### PR TITLE
ci: sync docs to GitHub Wiki

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,71 @@
+name: Wiki Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Checkout wiki repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync docs to wiki/docs
+        run: |
+          mkdir -p wiki/docs
+          rsync -a --delete docs/ wiki/docs/
+
+      - name: Generate wiki entry pages
+        run: |
+          cat > wiki/Home.md <<'EOF'
+          # SVA Studio Wiki
+
+          Diese Wiki-Inhalte werden automatisch aus `docs/` synchronisiert.
+
+          ## Einstieg
+
+          - [Architekturuebersicht (arc42)](docs/architecture/README.md)
+          - [Monorepo Struktur](docs/monorepo.md)
+          - [Routing](docs/routing.md)
+          - [Monitoring Stack](docs/development/monitoring-stack.md)
+          - [Testing & Coverage Governance](docs/development/testing-coverage.md)
+          EOF
+
+          cat > wiki/_Sidebar.md <<'EOF'
+          - [Home](Home)
+          - [Architektur (arc42)](docs/architecture/README.md)
+          - [Architekturentscheidungen (ADRs)](docs/architecture/decisions/README.md)
+          - [Monorepo](docs/monorepo.md)
+          - [Routing](docs/routing.md)
+          - [Monitoring](docs/development/monitoring-stack.md)
+          - [Testing/Coverage](docs/development/testing-coverage.md)
+          EOF
+
+      - name: Commit and push wiki changes
+        run: |
+          if [[ -z "$(git -C wiki status --porcelain)" ]]; then
+            echo "No wiki changes to commit."
+            exit 0
+          fi
+
+          git -C wiki config user.name "github-actions[bot]"
+          git -C wiki config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C wiki add .
+          git -C wiki commit -m "docs: sync wiki from docs/ (${GITHUB_SHA::7})"
+          git -C wiki push


### PR DESCRIPTION
## Summary
- add workflow `.github/workflows/wiki-sync.yml`
- sync `docs/` to `${owner}/${repo}.wiki` on push to `main` (nur bei `docs/**` Änderungen) und per manueller Ausführung
- generate `Home.md` und `_Sidebar.md` im Wiki-Repo

## Why
Automatische Veröffentlichung der Repository-Dokumentation im GitHub Wiki.

## Validation
- `pnpm check:file-placement` ist grün
