### PR TITLE
docs(arc42): clean develop scope for architecture docs and doc governance

### DIFF
--- a/.agents/skills/auth-implementation-patterns/SKILL.md
+++ b/.agents/skills/auth-implementation-patterns/SKILL.md
@@ -18,6 +18,10 @@ Build secure, scalable authentication and authorization systems using industry-s
 - Debugging auth issues
 - Implementing SSO or multi-tenancy
 
+## Repo-Konventionen (SVA Studio)
+
+- Wenn Auth-Aenderungen Architektur, Trust Boundaries oder Session-/Token-Flows wesentlich beeinflussen, aktualisiere die betroffenen arc42-Abschnitte unter `docs/architecture/` (Einstiegspunkt: `docs/architecture/README.md`) und referenziere (oder ergaenze) passende ADRs unter `docs/architecture/decisions/`.
+
 ## Core Concepts
 
 ### 1. Authentication vs Authorization

--- a/.agents/skills/deployment-pipeline-design/SKILL.md
+++ b/.agents/skills/deployment-pipeline-design/SKILL.md
@@ -19,6 +19,10 @@ Design robust, secure deployment pipelines that balance speed with safety throug
 - Establish deployment best practices
 - Implement progressive delivery
 
+## Repo-Konventionen (SVA Studio)
+
+- Wenn Pipeline-/Deployment-Aenderungen die Laufzeit- oder Deployment-Sicht wesentlich veraendern, dokumentiere die betroffenen arc42-Abschnitte unter `docs/architecture/` (Einstiegspunkt: `docs/architecture/README.md`) und halte Entscheidungen als ADRs unter `docs/architecture/decisions/` fest.
+
 ## Pipeline Stages
 
 ### Standard Pipeline Flow

--- a/.agents/skills/monorepo-management/SKILL.md
+++ b/.agents/skills/monorepo-management/SKILL.md
@@ -18,6 +18,10 @@ Build efficient, scalable monorepos that enable code sharing, consistent tooling
 - Versioning and publishing packages
 - Debugging monorepo-specific issues
 
+## Repo-Konventionen (SVA Studio)
+
+- Wenn Monorepo-Aenderungen Architektur-/Systemgrenzen betreffen, dokumentiere die betroffenen arc42-Abschnitte unter `docs/architecture/` (Einstiegspunkt: `docs/architecture/README.md`) und verlinke relevante ADRs unter `docs/architecture/decisions/`.
+
 ## Core Concepts
 
 ### 1. Why Monorepos?

--- a/.agents/skills/secrets-management/SKILL.md
+++ b/.agents/skills/secrets-management/SKILL.md
@@ -19,6 +19,10 @@ Implement secure secrets management in CI/CD pipelines without hardcoding sensit
 - Rotate secrets automatically
 - Implement least-privilege access
 
+## Repo-Konventionen (SVA Studio)
+
+- Wenn Secrets-Handling (z. B. Vault/KeyVault/Rotation) die Systemarchitektur oder Betriebsmodelle veraendert, dokumentiere die betroffenen arc42-Abschnitte unter `docs/architecture/` (Einstiegspunkt: `docs/architecture/README.md`) und verweise auf relevante ADRs unter `docs/architecture/decisions/`.
+
 ## Secrets Management Tools
 
 ### HashiCorp Vault

--- a/.github/agents/architecture.agent.md
+++ b/.github/agents/architecture.agent.md
@@ -23,12 +23,13 @@ Du bist der Architekt mit Fokus auf FIT- und Zielarchitektur.
 - Benennung notwendiger ADRs
 - Technische Schulden mit Langzeitwirkung
 - Klare Empfehlung: akzeptieren / ändern / dokumentieren
+- Verweis auf betroffene arc42-Abschnitte unter `docs/architecture/` (und ob Updates fehlen)
 
 ### Regeln
 - Du bewertest Struktur, nicht Code-Stil
 - Du änderst keinen Code
 - Du darfst Konzept- und Dokumentationsdateien bearbeiten, wenn du explizit dazu aufgefordert wirst
-- Jede bewusste Abweichung braucht Dokumentation
+- Jede bewusste Abweichung braucht Dokumentation (bei Architektur-/Systemdoku: arc42-konform unter `docs/architecture/`)
 
 ### GitHub Issues erstellen
 

--- a/.github/agents/documentation.agent.md
+++ b/.github/agents/documentation.agent.md
@@ -1,0 +1,73 @@
+---
+name: Documentation Steward (Starfleet)
+description: Prueft, pflegt und verbessert Projekt-Dokumentation in Code, OpenSpec und PR/Proposal-Kontext
+tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'copilot-container-tools/*', 'nx-mcp-server/*', 'antfu/nuxt-mcp/*', 'sequentialthinking/*', 'agent', 'github.vscode-pull-request-github/copilotCodingAgent', 'github.vscode-pull-request-github/issue_fetch', 'github.vscode-pull-request-github/suggest-fix', 'github.vscode-pull-request-github/searchSyntax', 'github.vscode-pull-request-github/doSearch', 'github.vscode-pull-request-github/renderIssues', 'github.vscode-pull-request-github/activePullRequest', 'github.vscode-pull-request-github/openPullRequest', 'todo']
+---
+
+Du bist der Documentation Steward mit Fokus auf Doku-Qualitaet, Konsistenz und nachhaltige Pflege.
+Du bist freundlich, klar und ein Star-Trek-Nerd. Verwende sparsam passende Star-Trek-Anspielungen, ohne den Inhalt zu verwässern.
+
+### Mission
+- Halte die Projekt-Dokumentation aktuell, konsistent und handlungsleitend.
+- Pruefe bei Proposals, PRs und Code-Aenderungen, ob Doku korrekt mitgedacht wurde.
+- Raeume Doku-Strukturen auf, reduziere Duplikate und verbessere Auffindbarkeit.
+
+### Grundlage
+- `README.md`
+- `AGENTS.md`
+- `DEVELOPMENT_RULES.md`
+- `openspec/AGENTS.md`
+- `openspec/project.md`
+- `docs/architecture/README.md` (arc42 Einstiegspunkt)
+
+### Du pruefst insbesondere
+- Abdeckung: Sind geaenderte Features/Flows in Docs, OpenSpec und ADRs reflektiert?
+- Konsistenz: Stimmen Begriffe, Pfade, Linkziele, Prozesse und Verantwortlichkeiten?
+- Platzierung: Liegen Dokumente gem. Repo-Regeln am richtigen Ort?
+- Architekturbezug: Sind relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt?
+- Code-nahe Doku: Sind Docstrings, Kommentare und Inline-Doku korrekt und hilfreich?
+
+### Du lieferst IMMER
+- Doku-Reifegrad: [Low | Medium | High]
+- Konkrete Luecken (priorisiert) mit Dateireferenzen
+- Klare Handlungsempfehlung: direkt im PR fixen oder Follow-up Issue
+- Hinweis auf fehlende OpenSpec-/arc42-Verweise bei Architektur-/Systemaenderungen
+
+### Regeln
+- Du darfst Dokumentationsdateien bearbeiten.
+- Du darfst Codedateien nur fuer Doku-Verbesserungen bearbeiten (Kommentare, Docstrings, Erklaertexte).
+- Du darfst keinerlei funktionale Code-Logik aendern.
+- Bei Architektur-/Systemdoku immer arc42-konform arbeiten (Einstiegspunkt: `docs/architecture/README.md`).
+- Bei OpenSpec-Changes sicherstellen, dass betroffene arc42-Abschnitte referenziert sind.
+
+### Lernen und Selbstpflege
+- Du darfst deine eigenen Anweisungen erweitern, wenn neue wiederkehrende Doku-Aufgaben im Scope entstehen.
+- Jede Selbst-Erweiterung muss als kleine, nachvollziehbare Regel erfolgen.
+- Aendere dabei nur diesen Agenten oder zugehoerige Doku-Templates, nicht fachliche Code-Logik.
+
+### Erlaubte Aktionen
+- Issues erstellen (nach Duplikat-Pruefung)
+- Proposals kommentieren
+- PRs kommentieren
+- Dokumentation direkt verbessern
+- Inline-Doku im Code verbessern (ohne Logikaenderung)
+
+### GitHub Issues erstellen
+
+Wenn du ein Issue vorschlagen willst, **PRUEFE ZUERST auf Duplikate**:
+
+```bash
+gh issue list --search "KEYWORD in:title" --state all --json number,title,state
+
+# Beispiel: Documentation-Issues filtern
+gh issue list --search "label:documentation" --state all
+```
+
+**Wenn es ein Duplikat gibt**: Schließe es und verlinke zum Original  
+**Wenn es verwandt ist**: Verlinke es im neuen Issue
+
+Detaillierte Richtlinien: [./skills/ISSUE_CREATION_GUIDE.md](./skills/ISSUE_CREATION_GUIDE.md#-documentation-agent)
+
+### Review-Output (Template)
+
+Nutze das zentrale Template unter [templates/documentation-review.md](templates/documentation-review.md).

--- a/.github/agents/interoperability-data.agent.md
+++ b/.github/agents/interoperability-data.agent.md
@@ -26,12 +26,14 @@ Du bist verantwortlich für Integrations- und Datenfähigkeit.
 - Konkrete Integrationsrisiken
 - Hinweise auf fehlende Standards oder Doku
 - Empfehlungen für stabile APIs
+- Hinweis, ob betroffene arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt wurden (oder Abweichung begruendet ist)
 
 ### Regeln
 - Keine UX- oder Security-Diskussion
 - Fokus auf externe Systeme & Langzeitfähigkeit
 - Du änderst keinen Code
 - Du darfst Konzept- und Dokumentationsdateien bearbeiten, wenn du explizit dazu aufgefordert wirst
+- Bei Architektur-/Systemdoku immer arc42-konform arbeiten (Einstiegspunkt: `docs/architecture/README.md`)
 
 ### GitHub Issues erstellen
 

--- a/.github/agents/logging.agent.md
+++ b/.github/agents/logging.agent.md
@@ -36,9 +36,9 @@ Du bist verantwortlich fuer die Qualitaet der Logging-Implementierung und ihre D
 ```typescript
 import { createSdkLogger } from '@sva/sdk';
 
-const logger = createSdkLogger({ 
+const logger = createSdkLogger({
   component: 'auth-redis',  // Eindeutig pro Modul
-  level: 'info' 
+  level: 'info'
 });
 
 // ✅ Session-Operation
@@ -86,6 +86,7 @@ if (process.env.NODE_ENV !== 'production') {
 - Konkrete Luecken in Struktur, Korrelation oder Schutz sensibler Daten
 - Priorisierte Empfehlungen (kurz, umsetzbar)
 - Hinweis, ob ADRs oder Konventionen fehlen
+- Hinweis, ob die betroffenen Architektur-/Systemaspekte in der arc42-Doku unter `docs/architecture/` ergänzt/aktualisiert werden sollten
 
 ### Regeln
 - Keine Feature-Diskussion

--- a/.github/agents/operations-reliability.agent.md
+++ b/.github/agents/operations-reliability.agent.md
@@ -27,12 +27,14 @@ Du bist verantwortlich für Betriebsfähigkeit und Zuverlässigkeit.
 - Fehlende Runbooks oder Dokumentation
 - Risiken für Verfügbarkeit oder Datenverlust
 - Konkrete Empfehlungen (keine Theorie)
+- Hinweis, ob betroffene arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt wurden (oder Abweichung begruendet ist)
 
 ### Regeln
 - Keine Feature-Diskussion
 - Fokus auf reale Betriebsszenarien
 - Du änderst keinen Code
 - Du darfst Konzept- und Dokumentationsdateien bearbeiten, wenn du explizit dazu aufgefordert wirst
+- Bei Architektur-/Systemdoku immer arc42-konform arbeiten (Einstiegspunkt: `docs/architecture/README.md`)
 
 ### GitHub Issues erstellen
 

--- a/.github/agents/security-privacy.agent.md
+++ b/.github/agents/security-privacy.agent.md
@@ -26,6 +26,7 @@ Du bist der Security- und Datenschutz-Reviewer für das Projekt.
 - 🟢 OK / erfüllt
 - Konkrete Verbesserungsvorschläge
 - Hinweis, ob eine ADR oder Risikoakzeptanz nötig ist
+- Hinweis, ob Architektur-/Systemdoku (arc42 unter `docs/architecture/`) angepasst werden muss, wenn Security/Privacy-Architektur betroffen ist
 
 ### Regeln
 - Du änderst keinen Code

--- a/.github/agents/skills/ISSUE_CREATION_GUIDE.md
+++ b/.github/agents/skills/ISSUE_CREATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Agent Issue Creation Guide
 
-Alle 5 Reviewer-Agents können dir GitHub-CLI-Befehle (`gh issue create`) geben. Du führst sie manuell aus, damit du volle Kontrolle über die Issue-Erstellung hast. Dieses Dokument legt die Standards fest.
+Alle 6 Reviewer-Agents können dir GitHub-CLI-Befehle (`gh issue create`) geben. Du führst sie manuell aus, damit du volle Kontrolle über die Issue-Erstellung hast. Dieses Dokument legt die Standards fest.
 
 ## Duplikat-Prüfung (Kritisch!)
 
@@ -211,6 +211,35 @@ gh issue list --search "Authentication in:title" --state all
 - Screenreader-Inkompatibilität
 - Fehlende oder falsche Alt-Texte für Inhalte
 - Tastaturzugang nicht möglich
+
+---
+
+### 📚 Documentation Agent
+
+**Labels**:
+- `documentation` (immer)
+- `docs-quality` (Konsistenz/Struktur)
+- `docs-architecture` (arc42/OpenSpec/ADR-Bezug)
+- `tech-debt` (veraltete/duplizierte Doku)
+- `good-first-issue` (optional bei klar abgegrenzten Aufraeumarbeiten)
+
+**Issue-Titel-Format**:
+```
+[Docs] <Bereich>: <Massnahme>
+```
+
+**Beispiele**:
+```
+[Docs] Architecture: arc42 Abschnitt 06 Laufzeitsicht aktualisieren
+[Docs] OpenSpec: Proposal-Template um arc42-Referenzen ergaenzen
+[Docs] Inline Docs: Veraltete Docstrings im Auth-Modul bereinigen
+```
+
+**Wann erstellen?**
+- Proposal/PR hat fachliche oder architektonische Aenderung ohne passende Doku-Updates
+- arc42/OpenSpec/ADR-Verlinkung fehlt oder ist inkonsistent
+- Doku-Duplikate/Drift fuehren zu Fehlinterpretation
+- Umfangreiche Doku-Aufraeumarbeiten sind noetig und nicht sinnvoll im aktuellen PR
 
 ---
 

--- a/.github/agents/templates/architecture-review.md
+++ b/.github/agents/templates/architecture-review.md
@@ -31,6 +31,7 @@ Nutze dieses Template für Architektur-Reviews. Triff eine klare Entscheidung un
 - [ ] Offene Standards bevorzugt
 - [ ] Cloud-Portabilität (kein Hard-Lock-in)
 - [ ] Skalierbarkeit/Zukunftsfähigkeit
+- [ ] Relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt (oder Abweichung begründet)
 
 ## Anhänge
 - Eingesetzte Inputs: (Diagramme, ADRs, Specs)

--- a/.github/agents/templates/documentation-review.md
+++ b/.github/agents/templates/documentation-review.md
@@ -1,0 +1,43 @@
+# Documentation Review - Template
+
+Nutze dieses Template fuer Doku-Reviews. Fokus: Aktualitaet, Konsistenz, Vollstaendigkeit, Auffindbarkeit.
+
+## Entscheidung
+
+- Doku-Reifegrad: [Low | Medium | High]
+- Empfehlung: [Merge-OK | Merge mit Auflagen | Follow-up Issues]
+- Begruendung (1-2 Saetze):
+
+## Executive Summary (3-5 Punkte)
+
+- Punkt 1
+- Punkt 2
+- Punkt 3
+
+## Befunduebersicht
+
+| ID | Thema | Schwere | Bereich | Evidenz |
+|---:|-------|---------|---------|---------|
+
+## Detail-Findings
+
+### D1 - Kurztitel
+
+- Beschreibung: ...
+- Impact/Risiko (Onboarding, Wartbarkeit, Fehlbedienung): ...
+- Evidenz/Quelle: (Dateien, Abschnitte, PR-Diff)
+- Empfehlung/Abhilfe: ...
+- Direkt im PR fixbar? [Ja/Nein]
+
+## Checkliste (Status)
+
+- [ ] Geaenderte Features/Flows sind in relevanter Doku aktualisiert
+- [ ] Interne Links und Pfade sind gueltig und konsistent
+- [ ] OpenSpec-Change referenziert bei Architekturwirkung die betroffenen arc42-Abschnitte
+- [ ] Relevante arc42-Dateien unter `docs/architecture/` wurden aktualisiert/verlinkt (oder Abweichung begruendet)
+- [ ] Repo-File-Placement-Regeln fuer neue/verschobene Doku sind eingehalten
+- [ ] Inline-Doku in Code (Docstrings/Kommentare) ist korrekt und nicht veraltet
+
+## Anhaenge
+
+- Eingesetzte Inputs: (Docs, OpenSpec-Change, PR-Diff, ADRs)

--- a/.github/agents/templates/interoperability-review.md
+++ b/.github/agents/templates/interoperability-review.md
@@ -3,21 +3,25 @@
 Nutze dieses Template für Interop-/Daten-Reviews. Fokus: Versionierung, Migration, Standards.
 
 ## Entscheidung
+
 - Bewertung: [hoch | mittel | niedrig]
 - Begründung (1–2 Sätze):
 
 ## Executive Summary (3–5 Punkte)
+
 - Punkt 1
 - Punkt 2
 - Punkt 3
 
 ## Befundübersicht
-| ID | Thema | Schwere | Bereich | Evidenz |
-|---:|-------|---------|---------|---------|
-| I1 | …     | 🔴/🟡/🟢 | API/Schema | Link/Zitat |
+
+| ID | Thema | Schwere | Bereich    | Evidenz   |
+|---:|-------|---------|------------|-----------|
 
 ## Detail-Findings
+
 ### I1 – Kurztitel
+
 - Beschreibung: …
 - Impact/Risiko (Vendor-Wechsel, Datenverlust): …
 - Evidenz/Quelle: (OpenAPI/Schema/Dumps)
@@ -25,12 +29,15 @@ Nutze dieses Template für Interop-/Daten-Reviews. Fokus: Versionierung, Migrati
 - Empfehlung/Abhilfe: …
 
 ## Checkliste (Status)
+
 - [ ] API-Versionierung + Deprecation-Policy dokumentiert
 - [ ] Backward-Compatibility nachgewiesen (Contract-/Consumer-Tests)
 - [ ] Vollständiger Import/Export (inkl. Assets/Metadaten)
 - [ ] Offene Standards (JSON Schema, OpenAPI, DCAT, o.ä.)
 - [ ] Exit-Plan (vollständiger Dump + Wiederherstellung)
 - [ ] Schema-Evolution/Migrationen dokumentiert
+- [ ] Falls Architektur/System betroffen: relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt (oder Abweichung begründet)
 
 ## Anhänge
+
 - Eingesetzte Inputs: (OpenAPI, Schemas, Export-Dumps)

--- a/.github/agents/templates/logging-review.md
+++ b/.github/agents/templates/logging-review.md
@@ -3,21 +3,25 @@
 Nutze dieses Template fuer Logging-Reviews. Fokus: Debugging-Tauglichkeit, Struktur, Korrelation, Datenschutz.
 
 ## Entscheidung
+
 - Logging-Reifegrad: [Low | Medium | High]
 - Begruendung (1–2 Saetze):
 
 ## Executive Summary (3–5 Punkte)
+
 - Punkt 1
 - Punkt 2
 - Punkt 3
 
 ## Befunduebersicht
-| ID | Thema | Schwere | Bereich | Evidenz |
-|---:|-------|---------|---------|---------|
-| L1 | …     | 🔴/🟡/🟢 | Struktur/PII/Korrelation | Link/Zitat |
+
+| ID | Thema | Schwere | Bereich                  | Evidenz   |
+|---:|-------|---------|--------------------------|-----------|
 
 ## Detail-Findings
+
 ### L1 – Kurztitel
+
 - Beschreibung: …
 - Impact/Risiko (Debugging, Sicherheit, Compliance): …
 - Evidenz/Quelle: (Logs, Pipelines, Configs)
@@ -25,6 +29,7 @@ Nutze dieses Template fuer Logging-Reviews. Fokus: Debugging-Tauglichkeit, Struk
 - Empfehlung/Abhilfe: …
 
 ## Checkliste (Status)
+
 - [ ] Pipeline: OTEL SDK -> Collector -> Loki; Promtail nur Fallback
 - [ ] SDK Logger Pflicht; kein console.log
 - [ ] Strukturierte Logs (JSON) mit stabilen Feldern
@@ -36,6 +41,8 @@ Nutze dieses Template fuer Logging-Reviews. Fokus: Debugging-Tauglichkeit, Struk
 - [ ] Label-Whitelist in App und Promtail konsistent (labelkeep/labeldrop)
 - [ ] Sampling oder Rate-Limits bei High-Volume Logs
 - [ ] Retention und Zugriff (RBAC) dokumentiert
+- [ ] Falls Architektur/System betroffen: relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt (oder Abweichung begründet)
 
 ## Anhaenge
+
 - Eingesetzte Inputs: (Configs, Pipelines, Beispiel-Logs)

--- a/.github/agents/templates/operations-reliability-review.md
+++ b/.github/agents/templates/operations-reliability-review.md
@@ -3,21 +3,25 @@
 Nutze dieses Template für Betriebs-/Zuverlässigkeits-Reviews. Fokus: Deployments, Backups, Observability.
 
 ## Entscheidung
+
 - Betriebsreife: [Low | Medium | High]
 - Begründung (1–2 Sätze):
 
 ## Executive Summary (3–5 Punkte)
+
 - Punkt 1
 - Punkt 2
 - Punkt 3
 
 ## Befundübersicht
-| ID | Thema | Schwere | Bereich | Evidenz |
-|---:|-------|---------|---------|---------|
-| O1 | …     | 🔴/🟡/🟢 | Deploy/Backup/Monitor | Link/Zitat |
+
+| ID | Thema | Schwere | Bereich               | Evidenz   |
+|---:|-------|---------|-----------------------|-----------|
 
 ## Detail-Findings
+
 ### O1 – Kurztitel
+
 - Beschreibung: …
 - Impact/Risiko (Verfügbarkeit, Datenverlust, MTTR): …
 - Evidenz/Quelle: (Pipelines, Scripts, Dashboards)
@@ -25,6 +29,7 @@ Nutze dieses Template für Betriebs-/Zuverlässigkeits-Reviews. Fokus: Deploymen
 - Empfehlung/Abhilfe: …
 
 ## Checkliste (Status)
+
 - [ ] Installierbarkeit: Docker/Compose/K8s vorhanden + dokumentiert
 - [ ] Zero-Downtime-Deployments (Blue/Green, Rolling, Canary)
 - [ ] Rollback < X Minuten; Migrations rückwärtskompatibel
@@ -33,6 +38,8 @@ Nutze dieses Template für Betriebs-/Zuverlässigkeits-Reviews. Fokus: Deploymen
 - [ ] Wartungsmodus + Notfallszenarien (Runbooks, DR-Drills)
 - [ ] Ressourcenbedarf/Skalierung (Auto-Scaling, HPA, Limits)
 - [ ] SLO/SLA-Ziele (Uptime, MTTR) definiert
+- [ ] Falls Architektur/System betroffen: relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt (oder Abweichung begründet)
 
 ## Anhänge
+
 - Eingesetzte Inputs: (Deploy-Files, Backup-Configs, Dashboards)

--- a/.github/agents/templates/security-review.md
+++ b/.github/agents/templates/security-review.md
@@ -3,23 +3,27 @@
 Nutze dieses Template für jedes Review. Fülle alle relevanten Abschnitte aus und treffe eine klare Merge-Empfehlung.
 
 ## Entscheidung
+
 - Entscheidung: [Merge-OK | Merge-Blocker | Merge mit Auflagen]
 - Begründung (1-2 Sätze):
 
 ## Executive Summary (3–5 Punkte)
+
 - Punkt 1
 - Punkt 2
 - Punkt 3
 
 ## Risikoübersicht
-| ID | Titel | Schwere | CVSS (falls zutreffend) | Betroffene Bereiche | Evidenz |
-|---:|-------|---------|-------------------------|---------------------|---------|
-| R1 | …     | 🔴/🟡/🟢 | 8.1 (High)              | Auth, API           | Link/Zitat |
+
+| ID | Titel | Schwere | CVSS (falls zutreffend) | Betroffene Bereiche | Evidenz   |
+|---:|-------|---------|-------------------------|---------------------|-----------|
 
 Legende: 🔴 Kritisch (Merge-Blocker), 🟡 Mittel (mit Auflagen), 🟢 OK
 
 ## Detail-Findings
+
 ### R1 – Kurztitel
+
 - Beschreibung: …
 - Impact/Risiko: …
 - Evidenz/Quelle: (z. B. PR-Diff, Scan-Report, Log-Auszug)
@@ -29,9 +33,11 @@ Legende: 🔴 Kritisch (Merge-Blocker), 🟡 Mittel (mit Auflagen), 🟢 OK
 - Owner & Fälligkeitsdatum: …
 
 ### R2 – Kurztitel
+
 - …
 
 ## Checkliste (Status)
+
 - [ ] Authentifizierung & Autorisierung (RBAC/ABAC, Session-Handling, MFA)
 - [ ] Secrets-Handling (kein Hardcoding, Rotation, Secret-Manager)
 - [ ] Kryptografie (TLS-Versionen, at-rest-Encryption, KMS)
@@ -40,16 +46,20 @@ Legende: 🔴 Kritisch (Merge-Blocker), 🟡 Mittel (mit Auflagen), 🟢 OK
 - [ ] Dependencies & SBOM (CVE-Schwellen, Updates, Policy)
 - [ ] SAST/DAST/Container-Scan (Berichte geprüft)
 - [ ] Infra/Config (Least Privilege, sichere Defaults)
+- [ ] Falls Architektur/System betroffen: relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt (oder Abweichung begründet)
 
 ## Auflagen (falls „Merge mit Auflagen“)
+
 - Maßnahme | Verantwortlich | Frist | Nachweisart
 - …
 
 ## ADR / Risikoakzeptanz
+
 - ADR erforderlich? [Ja/Nein] – Thema: …
 - Risikoakzeptanz notwendig? [Ja/Nein] – Entscheidungsträger: …
 
 ## Anhänge
+
 - Eingesetzte Inputs: (PR-Diff, Lockfiles, SBOM, Reports)
 - Scope/Out-of-Scope: …
 - Änderungen seit letztem Review: …

--- a/.github/agents/templates/ux-accessibility-review.md
+++ b/.github/agents/templates/ux-accessibility-review.md
@@ -31,6 +31,7 @@ Nutze dieses Template für UX/Barrierefreiheit-Reviews. Fokus: WCAG 2.1 AA / BIT
 - [ ] Alt-Texte & Struktur (Headings, Listen, Landmark Regions, Skip Links)
 - [ ] Dynamische Inhalte: Live-Regionen/Statusmeldungen
 - [ ] Redaktions-Workflow unterstützt barrierefreie Inhalte
+- [ ] Falls Architektur/System betroffen: relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt (oder Abweichung begruendet)
 
 ## Anhänge
 - Eingesetzte Inputs: (Flows, Komponenten, Doku)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,5 @@
 # Copilot Custom Instructions
 
 Bitte antworte im Rahmen von Code‑Reviews ausschließlich auf Deutsch. Deine Kommentare sollen präzise, konstruktiv und freundlich formuliert sein. Konzentriere dich auf Lesbarkeit, Sicherheit, Wartbarkeit und Performance.
+
+Wenn du Architektur-/Systemdokumentation erstellst oder aktualisierst, strukturiere sie arc42-konform unter `docs/architecture/` (Abschnitte 1–12, Einstiegspunkt `docs/architecture/README.md`) und verweise im PR/Change auf die betroffenen Abschnitte.

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -38,11 +38,11 @@ jobs:
 
       - name: Ensure origin/main is available for affected
         if: github.event_name == 'pull_request'
-        run: git fetch origin main --no-tags --prune --depth=1
+        run: git fetch origin "${{ github.base_ref }}" --no-tags --prune --depth=1
 
       - name: Run affected coverage on PR
         if: github.event_name == 'pull_request'
-        run: pnpm test:coverage:affected
+        run: npx nx affected --target=test:coverage --base=origin/${{ github.base_ref }}
 
       - name: Run full coverage on main/schedule
         if: github.event_name != 'pull_request'

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,83 @@
+name: Wiki Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    env:
+      WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Clone wiki repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TOKEN="${WIKI_SYNC_TOKEN:-$GITHUB_TOKEN}"
+          WIKI_URL="https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git"
+
+          if ! git clone --depth 1 "$WIKI_URL" wiki; then
+            echo "Wiki clone failed."
+            echo "Bitte pruefen:"
+            echo "1) Wiki ist aktiviert und initialisiert (mindestens eine Seite vorhanden)."
+            echo "2) Optionales Secret WIKI_SYNC_TOKEN hat repo-Rechte (empfohlen bei privaten Repos)."
+            exit 1
+          fi
+
+      - name: Sync docs to wiki/docs
+        run: |
+          mkdir -p wiki/docs
+          rsync -a --delete docs/ wiki/docs/
+
+      - name: Generate wiki entry pages
+        run: |
+          cat > wiki/Home.md <<'EOF'
+          # SVA Studio Wiki
+
+          Diese Wiki-Inhalte werden automatisch aus `docs/` synchronisiert.
+
+          ## Einstieg
+
+          - [Architekturuebersicht (arc42)](docs/architecture/README.md)
+          - [Monorepo Struktur](docs/monorepo.md)
+          - [Routing](docs/routing.md)
+          - [Monitoring Stack](docs/development/monitoring-stack.md)
+          - [Testing & Coverage Governance](docs/development/testing-coverage.md)
+          EOF
+
+          cat > wiki/_Sidebar.md <<'EOF'
+          - [Home](Home)
+          - [Architektur (arc42)](docs/architecture/README.md)
+          - [Architekturentscheidungen (ADRs)](docs/architecture/decisions/README.md)
+          - [Monorepo](docs/monorepo.md)
+          - [Routing](docs/routing.md)
+          - [Monitoring](docs/development/monitoring-stack.md)
+          - [Testing/Coverage](docs/development/testing-coverage.md)
+          EOF
+
+      - name: Commit and push wiki changes
+        run: |
+          if [[ -z "$(git -C wiki status --porcelain)" ]]; then
+            echo "No wiki changes to commit."
+            exit 0
+          fi
+
+          git -C wiki config user.name "github-actions[bot]"
+          git -C wiki config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C wiki add .
+          git -C wiki commit -m "docs: sync wiki from docs/ (${GITHUB_SHA::7})"
+          git -C wiki push origin HEAD

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@
 - Vor dem Commit immer `pnpm test:eslint`, `pnpm test:types` und `pnpm test:unit` ausführen
 - Änderungen an den relevanten Stellen testen
 - Bei neuen Features die passende Doku im Verzeichnis `docs/` aktualisieren
+- Bei Architektur-/Systemänderungen die relevanten arc42-Abschnitte unter `docs/architecture/` aktualisieren und im PR verlinken
+- Einstiegspunkt fuer Architekturdoku ist `docs/architecture/README.md` (Abschnitte 1-12)
+- Fuer Doku-Qualitaet und Doku-Abdeckung bei Proposals/PRs steht der Agent `documentation.agent.md` unter `.github/agents/` bereit
 - Für jede Code-Änderung Tests hinzufügen oder anpassen
 - Interne Doku-Links relativ zum Ordner `docs/` schreiben (z. B. `./guide/data-loading`)
 
@@ -116,7 +119,7 @@ Behalte diesen verwalteten Block bei, damit 'openspec update' die Anweisungen ak
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
 
-# General Guidelines for working with Nx
+## General Guidelines for working with Nx
 
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
 - You have access to the Nx MCP server and its tools, use them to help the user

--- a/README.md
+++ b/README.md
@@ -78,3 +78,19 @@ Siehe [docs/development/monitoring-stack.md](docs/development/monitoring-stack.m
 
 **Verbotene Labels (PII / High Cardinality):**
 - `user_id`, `session_id`, `email`, `request_id`, `token`, `authorization`, `api_key`, `secret`, `ip`
+
+## Dokumentation
+
+- Architektur-Einstiegspunkt (arc42): [docs/architecture/README.md](docs/architecture/README.md)
+
+## Aktueller Implementierungsstand (Repo)
+
+Der aktuelle Code-Stand dieses Repos bildet vor allem technische Grundlagen ab:
+
+- TanStack Start App `apps/sva-studio-react`
+- Typsicheres Routing mit Core-/Plugin-Route-Factories
+- OIDC Login + Session-Verwaltung (Redis) ueber `packages/auth`
+- SDK Logger + OpenTelemetry Pipeline (lokaler Monitoring-Stack)
+
+Das beigefuegte Konzept unter `concepts/konzeption-cms-v2/` liefert den fachlichen Hintergrund.
+Roadmap-/Milestone-Inhalte daraus sind nicht automatisch als implementiert zu verstehen.

--- a/docs/architecture/01-introduction-and-goals.md
+++ b/docs/architecture/01-introduction-and-goals.md
@@ -1,0 +1,70 @@
+# 01 Einfuehrung und Ziele
+
+## Zweck
+
+SVA Studio ist eine TanStack-Start-basierte Webanwendung im Nx-Monorepo, die
+als modulares Studio fuer Content- und Systemfunktionen aufgebaut wird.
+Der aktuelle Stand fokussiert auf:
+
+- Typsicheres Routing mit Core- und Plugin-Routen
+- OIDC-Login mit Session-Verwaltung (Redis)
+- Strukturiertes Server-Logging mit OTEL-Pipeline
+- Monorepo-Governance fuer Build/Test/Qualitaet
+
+Referenzen:
+
+- `apps/sva-studio-react/src/router.tsx`
+- `packages/routing/src/index.ts`
+- `packages/auth/src/routes.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
+
+## Mindestinhalte
+
+Mindestinhalte fuer diesen Abschnitt:
+
+- Systemkontext in 3-5 Saetzen
+- Primaere Stakeholder und deren wichtigste Beduerfnisse
+- Top-3 Architekturziele mit Prioritaet
+
+## Aktueller Stand
+
+### Produkt- und Problemkontext (ohne Feature-Commitment)
+
+SVA Studio ist das technische Fundament fuer ein Redaktions- und Verwaltungsstudio im Smart-Village-Umfeld.
+Der fachliche Hintergrund (Warum/wer/Rahmenbedingungen) ist im Konzept unter `concepts/konzeption-cms-v2/` beschrieben.
+Dieses Repository dokumentiert und implementiert aktuell vor allem technische Enabler (Routing, Auth, Observability, Monorepo-Governance).
+
+Wichtig: Das Konzept enthaelt auch Roadmap-/Milestone-Inhalte; diese gelten nicht als dokumentierter Ist-Stand dieses Repos.
+
+### Stakeholder (technisch)
+
+- Produkt-/Architektur-Team: stabile Zielarchitektur und nachvollziehbare Entscheidungen
+- Entwickler:innen: hohe Typsicherheit, klare Modulgrenzen, reproduzierbare Workflows
+- Betrieb/SRE: beobachtbares und betreibbares System inkl. Logging/Monitoring
+
+### Stakeholder (fachlich / Nutzerrollen)
+
+Die folgenden Rollen stammen aus dem Konzept und dienen hier als Kontext fuer Architekturentscheidungen.
+Sie sind nicht als bereits umgesetzte Feature-Liste zu verstehen.
+
+- System-Administrator:innen: Betrieb, Sicherheit, Rollen/Rechte, Observability
+- App-Manager:innen: Konfiguration und Steuerung (aus fachlicher Sicht)
+- Feature-Manager:innen: fachliche Verantwortung fuer einzelne Inhalts-/Modulbereiche
+- Designer:innen: Corporate Design, UI-Konsistenz
+- Schnittstellen-Manager:innen: Integrationen, Datenfluesse, Fehlertransparenz
+- Redakteur:innen/Inhaltsersteller:innen: effiziente Inhaltspflege
+
+### Top-3 Architekturziele (priorisiert)
+
+1. Typsichere, erweiterbare Modul- und Routing-Architektur (Core + Plugins)
+2. Sichere Authentifizierung und Session-Management fuer Web-Workflows
+3. Einheitliche, PII-sichere Observability ueber OTEL -> Collector -> Loki
+
+### Systemgrenze (Kurzfassung)
+
+In diesem Repo liegen Frontend, Routing-Layer, Auth-BFF-Funktionen,
+SDK/Observability sowie lokale Betriebsartefakte.
+Externe Systeme (IdP/Keycloak, ggf. weitere Backends) werden integriert, aber
+nicht in diesem Repository betrieben.
+
+Konzept-Referenz (Kontext): `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md`

--- a/docs/architecture/02-constraints.md
+++ b/docs/architecture/02-constraints.md
@@ -1,0 +1,41 @@
+# 02 Randbedingungen
+
+## Zweck
+
+Dieser Abschnitt dokumentiert Rahmenbedingungen, die Architekturentscheidungen
+im IST-System direkt beeinflussen.
+
+## Mindestinhalte
+
+- Technische Constraints (Runtime, Plattformen, Infrastruktur)
+- Organisatorische Constraints (Team, Betrieb, Governance)
+- Regulatorische Constraints (DSGVO, BSI, BITV, FIT)
+
+## Aktueller Stand
+
+### Technische Randbedingungen
+
+- Node.js `>=22.12.0`, pnpm `>=9.12.2` (`package.json`)
+- Nx-Monorepo mit standardisierten Targets (`build`, `lint`, `test:unit`)
+- TanStack Start/Router fuer App und Server-Routen
+- Redis als Session-Store, lokal via Docker Compose
+- OTEL-basierte Logging-/Metrikpipeline ueber Collector
+
+### Organisatorische Randbedingungen
+
+- Architektur-/Systemdoku arc42-konform unter `docs/architecture/`
+- OpenSpec-gesteuerte Aenderungen mit Pflicht zur arc42-Referenzierung
+- Repo-File-Placement Regeln werden per CI-Skript erzwungen
+
+### Regulatorische/Qualitaets-Randbedingungen
+
+- PII-Schutz im Logging (Redaction + Label-Whitelist)
+- Security- und Accessibility-Regeln aus `DEVELOPMENT_RULES.md`
+- Nachweisbare Test-/Lint-/Type-Checks im Entwicklungsworkflow
+
+Referenzen:
+
+- `package.json`
+- `openspec/AGENTS.md`
+- `scripts/ci/check-file-placement.mjs`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -1,0 +1,54 @@
+# 03 Kontext und Scope
+
+## Zweck
+
+Dieser Abschnitt beschreibt Systemgrenzen, externe Schnittstellen und den
+aktuellen fachlich-technischen Scope.
+
+## Mindestinhalte
+
+- Fachlicher Scope und Out-of-Scope
+- Kontextsicht mit externen Systemen und Integrationen
+- Verantwortungsgrenzen (intern/extern)
+
+## Aktueller Stand
+
+### Fachlicher Kontext (nur Kontext)
+
+Im Produktkontext adressiert SVA Studio die Verwaltung strukturierter Inhalte und Konfigurationen fuer die Smart Village App und angrenzende Kanaele (Headless/API-first).
+Im aktuellen Repo-Ist-Stand sind davon primaer die technischen Grundlagen umgesetzt (Routing, Auth, Observability, lokale Betriebsartefakte).
+
+### In Scope (IST)
+
+- Web-App `sva-studio-react` mit TanStack Start
+- Zentrales Routing (`@sva/core`, `@sva/routing`, Plugin-Routen)
+- Auth-BFF-Endpunkte (`/auth/login`, `/auth/callback`, `/auth/me`, `/auth/logout`)
+- Session-Verwaltung mit Redis (inkl. optionaler Token-Verschluesselung)
+- SDK Logger + OTEL Monitoring Client + lokale Monitoring-Stacks
+
+### Out of Scope (in diesem Repo)
+
+- Betrieb und Quellcode des externen IdP (Keycloak Realm/Server)
+- Mobile App / externe Konsumenten
+- Vollstaendige Fachverfahren-Integrationen
+- Produkt-/Fachmodule (z. B. konkrete CMS-Content-Modelle) sind im Code derzeit nicht als stabile API/Implementierung vorhanden
+
+### Externe Nachbarsysteme
+
+- OIDC Provider (per `openid-client`)
+- Redis (lokal/extern)
+- OTEL Collector, Loki, Prometheus, Grafana, Alertmanager
+
+Konzept-Referenz (Kontext): `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md`
+
+### Verantwortungsgrenzen
+
+- Repo verantwortet App-, Routing-, Auth-, SDK- und Doku-Logik
+- Externe Dienste werden angebunden, aber nicht hier implementiert
+
+Referenzen:
+
+- `packages/auth/src/oidc.server.ts`
+- `packages/auth/src/redis.server.ts`
+- `docker-compose.yml`
+- `docker-compose.monitoring.yml`

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -1,0 +1,48 @@
+# 04 Loesungsstrategie
+
+## Zweck
+
+Dieser Abschnitt dokumentiert die strategischen Leitentscheidungen und
+Architekturprinzipien auf IST-Basis.
+
+## Mindestinhalte
+
+- Leitprinzipien (z. B. API-first, modulare Architektur)
+- Architekturtreiber und Zielkonflikte
+- Strategische Entscheidungen mit Verweisen auf ADRs
+
+## Aktueller Stand
+
+### Leitprinzipien
+
+- Monorepo mit klaren Paketgrenzen und Workspace-Abhaengigkeiten (`workspace:*`)
+- Framework-agnostische Kernlogik in `@sva/core`, Integration in App-Ebene
+- Trennung von client-sicheren und serverseitigen Routen/Handlern
+- Observability ueber OTEL-Standards statt vendor-spezifischer App-Anbindung
+- Doku-getriebene Architekturpflege (arc42 + OpenSpec + ADR)
+
+### Architekturtreiber
+
+- Hohe Typsicherheit und Wartbarkeit bei wachsender Modulanzahl
+- Erweiterbarkeit durch Plugins und zentrale Route-Registry
+- Betriebsfaehigkeit mit strukturierter Telemetrie
+- Security/Privacy-Anforderungen an Auth und Logging
+
+### Zielkonflikte (aktuell sichtbar)
+
+- Hohe Flexibilitaet (code-based + file-based Routing) vs. Komplexitaet
+- Schneller Dev-Flow vs. strenge Security-/PII-Kontrollen
+- Multi-Tooling (Nx, TanStack, OTEL) vs. Einarbeitungsaufwand
+
+### Strategische Entscheidungen (Auswahl)
+
+- Frontend-Framework: `ADR-001`
+- Plugin-Architektur: `ADR-002`
+- Monitoring-Stack: `ADR-004`
+- Logging-Pipeline und Label-Policy: `ADR-006`, `ADR-007`
+
+Referenzen:
+
+- `./decisions/ADR-001-frontend-framework-selection.md`
+- `./decisions/ADR-002-plugin-architecture-pattern.md`
+- `./decisions/ADR-004-monitoring-stack-loki-grafana-prometheus.md`

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -1,0 +1,55 @@
+# 05 Bausteinsicht
+
+## Zweck
+
+Dieser Abschnitt beschreibt statische Bausteine, Verantwortlichkeiten und
+Abhaengigkeiten des aktuellen Systems.
+
+## Mindestinhalte
+
+- Hauptbausteine mit Verantwortung
+- Schnittstellen und Abhaengigkeiten zwischen Bausteinen
+- Grenzen zwischen framework-agnostischer Kernlogik und Bindings
+
+## Aktueller Stand
+
+### Hauptbausteine
+
+1. App (`apps/sva-studio-react`)
+   - TanStack Start App, UI, Root-Shell, Router-Erzeugung
+2. Core (`packages/core`)
+   - generische Route-Registry Utilities (`mergeRouteFactories`, `buildRouteTree`)
+3. Routing (`packages/routing`)
+   - zentrale Route-Factories (client + server)
+4. Auth (`packages/auth`)
+   - OIDC-Flows, Session-Store, auth HTTP-Handler
+5. SDK (`packages/sdk`)
+   - Logger, Context-Propagation, OTEL-Bootstrap
+6. Monitoring Client (`packages/monitoring-client`)
+   - OTEL SDK Setup, Exporter, Log-Redaction-Processor
+7. Data (`packages/data`)
+   - einfacher HTTP DataClient mit In-Memory Cache
+8. Plugin Example (`packages/plugin-example`)
+   - Beispielroute fuer Plugin-Erweiterbarkeit
+
+### Abhaengigkeiten (vereinfacht)
+
+- App -> `@sva/core`, `@sva/routing`, `@sva/auth`, `@sva/plugin-example`
+- `@sva/routing` -> `@sva/auth`, `@sva/core`
+- `@sva/auth` -> `@sva/sdk`
+- `@sva/sdk` -> `@sva/core`, `@sva/monitoring-client`
+- `@sva/monitoring-client` -> OTEL Libraries, `@sva/sdk` Context API
+
+### Boundary Core vs. Framework Binding
+
+- Framework-agnostisch:
+  - `packages/core`, Teile von `packages/data`, SDK Context APIs
+- Framework-/Runtime-gebunden:
+  - `apps/sva-studio-react`, TanStack-Route-Definitionen, Auth-Handler fuer Start
+
+Referenzen:
+
+- `packages/core/src/routing/registry.ts`
+- `packages/routing/src/index.ts`
+- `packages/auth/src/index.server.ts`
+- `packages/sdk/src/server.ts`

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -1,0 +1,59 @@
+# 06 Laufzeitsicht
+
+## Zweck
+
+Dieser Abschnitt beschreibt kritische Laufzeitszenarien und Interaktionen.
+
+## Mindestinhalte
+
+- Mindestens 3 kritische End-to-End-Szenarien
+- Sequenz der beteiligten Bausteine pro Szenario
+- Fehler- und Ausnahmeverhalten fuer kritische Flows
+
+## Aktueller Stand
+
+### Szenario 1: App-Start + Route-Komposition
+
+1. App laedt `getRouter()` in `apps/sva-studio-react/src/router.tsx`
+2. Core-Route-Factories werden client- oder serverseitig geladen
+3. Plugin-Route-Factories werden mit Core-Factories gemerged
+4. `buildRouteTree(...)` erzeugt Runtime-RouteTree
+5. Router wird mit RouteTree und SSR-Kontext erstellt
+
+Fehlerpfad:
+
+- Fehlerhafte Route-Factory oder server-only Import im Client kann Build/Runtime brechen.
+
+### Szenario 2: OIDC Login-Flow
+
+1. Browser ruft `/auth/login` auf
+2. `loginHandler()` erstellt PKCE-LoginState, setzt signiertes State-Cookie und redirectet zum IdP
+3. IdP redirectet nach `/auth/callback?code=...&state=...`
+4. `callbackHandler()` validiert State, tauscht Code gegen Tokens und erstellt Redis-Session
+5. Session-Cookie wird gesetzt, Redirect zur App
+6. App ruft `/auth/me` fuer User-Kontext
+
+Fehlerpfad:
+
+- Fehlender/abgelaufener State -> Redirect mit Fehlerstatus
+- Token-/Refresh-Fehler -> Session invalidiert oder unauthorized Antwort
+
+### Szenario 3: Logging/Observability bei Server-Requests
+
+1. Server-Code loggt via `createSdkLogger(...)`
+2. Context (workspace/request) wird ueber AsyncLocalStorage injiziert
+3. Direct OTEL Transport emittiert LogRecords an globalen LoggerProvider
+4. OTEL Processor redacted und filtert Labels
+5. Export via OTLP an Collector -> Loki/Prometheus
+
+Fehlerpfad:
+
+- OTEL nicht initialisiert: Console-Fallback bleibt aktiv
+- fehlender LoggerProvider: OTEL-Emission no-op, App bleibt lauffaehig
+
+Referenzen:
+
+- `apps/sva-studio-react/src/router.tsx`
+- `packages/auth/src/routes.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -1,0 +1,51 @@
+# 07 Verteilungssicht
+
+## Zweck
+
+Dieser Abschnitt beschreibt die technische Verteilung auf Umgebungen und
+Laufzeitknoten auf Basis des aktuellen Repos.
+
+## Mindestinhalte
+
+- Deployment-Topologie (lokal, CI, staging, production)
+- Abhaengigkeiten zu externen Diensten (z. B. Redis, OTEL, Loki)
+- Sicherheits- und Betriebsaspekte je Umgebung
+
+## Aktueller Stand
+
+### Lokale Entwicklungsverteilung
+
+- App: `nx run sva-studio-react:serve` auf `localhost:3000`
+- Redis: `docker-compose.yml` (`6379`, optional TLS `6380`)
+- Monitoring Stack: `docker-compose.monitoring.yml`
+  - Collector: `4317`, `4318`, `13133`
+  - Loki: `3100`
+  - Prometheus: `9090`
+  - Grafana: `3001`
+  - Promtail: `3101`
+  - Alertmanager: `9093`
+
+### Deployment-Bausteine (logisch)
+
+- Web-App Runtime (TanStack Start / Node)
+- Redis Session Store
+- OTEL Collector als Telemetrie-Hub
+- Loki/Prometheus als Storage, Grafana fuer Auswertung
+
+### Sicherheits-/Betriebsaspekte
+
+- Monitoring-Ports in Compose explizit auf `127.0.0.1` gebunden
+- Redis TLS-Unterstuetzung vorhanden, in local Dev optional
+- Healthchecks fuer zentrale Monitoring-Services konfiguriert
+- Graceful OTEL Shutdown im SDK vorgesehen
+
+### Noch offen (Stand heute)
+
+- Produktions-Topologie (z. B. K8s vs. VM) ist noch nicht repo-verbindlich definiert
+- HA-/Skalierungsdetails fuer produktiven Betrieb sind nur teilweise als ADR/Doku beschrieben
+
+Referenzen:
+
+- `docker-compose.yml`
+- `docker-compose.monitoring.yml`
+- `packages/sdk/src/server/bootstrap.server.ts`

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -1,0 +1,47 @@
+# 08 Querschnittliche Konzepte
+
+## Zweck
+
+Dieser Abschnitt sammelt uebergreifende Konzepte, die mehrere Bausteine
+gleichzeitig beeinflussen.
+
+## Mindestinhalte
+
+- Security- und Privacy-Konzepte
+- Logging/Observability-Konzept
+- Fehlerbehandlung, Resilienz, i18n und Accessibility-Leitlinien
+
+## Aktueller Stand
+
+### Security und Privacy
+
+- OIDC Authorization Code Flow mit PKCE
+- Signiertes Login-State-Cookie (HMAC)
+- Session-Cookies: `httpOnly`, `sameSite=lax`, `secure` in Production
+- Optionale Verschluesselung von Tokens im Redis-Store via `ENCRYPTION_KEY`
+- Redaction sensibler Logfelder im SDK und im OTEL Processor
+
+### Logging und Observability
+
+- Einheitlicher Server-Logger ueber `@sva/sdk/server`
+- AsyncLocalStorage fuer `workspace_id`/request context
+- OTEL Pipeline fuer Logs + Metrics
+- Label-Whitelist und PII-Blockliste in OTEL/Promtail
+
+### Fehlerbehandlung und Resilienz
+
+- OTEL-Init ist fehlertolerant (App laeuft weiter ohne Telemetrie)
+- Redis-Reconnect mit Backoff und Max-Retry Logik
+- Auth-Flow mit klaren Redirect-Fehlerpfaden (`auth=error`, `auth=state-expired`)
+
+### i18n und Accessibility
+
+- UI-Texte sind derzeit ueberwiegend direkt im Code und noch nicht durchgaengig i18n-basiert
+- A11y wird pro Review/Template eingefordert, aber noch nicht zentral automatisiert
+
+Referenzen:
+
+- `packages/auth/src/routes.server.ts`
+- `packages/auth/src/redis-session.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -1,0 +1,45 @@
+# 09 Architekturentscheidungen
+
+## Zweck
+
+Dieser Abschnitt verlinkt und kontextualisiert Architekturentscheidungen (ADRs)
+mit Bezug auf die arc42-Abschnitte.
+
+## Mindestinhalte
+
+- Liste relevanter ADRs mit Status
+- Kurzbegruendung und Auswirkungen pro Entscheidung
+- Verknuepfung zu betroffenen arc42-Abschnitten
+
+## Aktueller Stand
+
+### Relevante ADRs (vorhanden)
+
+- `ADR-001-frontend-framework-selection.md`
+- `ADR-002-plugin-architecture-pattern.md`
+- `ADR-003-design-token-architecture.md`
+- `ADR-004-monitoring-stack-loki-grafana-prometheus.md`
+- `ADR-005-observability-module-ownership.md`
+- `ADR-006-logging-pipeline-strategy.md`
+- `ADR-007-label-schema-and-pii-policy.md`
+
+### Zuordnung zu arc42-Abschnitten
+
+- Abschnitt 04 (Loesungsstrategie): ADR-001, ADR-002, ADR-004
+- Abschnitt 05 (Bausteinsicht): ADR-001, ADR-002, ADR-005
+- Abschnitt 06/07 (Laufzeit/Deployment): ADR-004, ADR-006
+- Abschnitt 08 (Querschnitt): ADR-005, ADR-006, ADR-007
+- Abschnitt 10/11 (Qualitaet/Risiken): ADR-004, ADR-007
+
+### Pflege-Regel
+
+Bei Architekturentscheidungen in OpenSpec-Changes:
+
+1. betroffene arc42-Abschnitte referenzieren
+2. ADR erstellen/aktualisieren
+3. Entscheidung in diesem Abschnitt nachziehen
+
+Referenzen:
+
+- `./decisions/README.md`
+- `openspec/AGENTS.md`

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -1,0 +1,50 @@
+# 10 Qualitaetsanforderungen
+
+## Zweck
+
+Dieser Abschnitt beschreibt messbare Qualitaetsziele auf aktuellem Stand.
+
+## Mindestinhalte
+
+- Qualitaetsziele (z. B. Sicherheit, Wartbarkeit, Verfuegbarkeit)
+- Priorisierung und messbare Akzeptanzkriterien
+- Bezug zu Tests, Monitoring und Quality Gates
+
+## Aktueller Stand
+
+### Priorisierte Qualitaetsziele
+
+1. Sicherheit/Datenschutz
+2. Wartbarkeit und Nachvollziehbarkeit
+3. Beobachtbarkeit und Betrieb
+4. Typsicherheit und Integrationsstabilitaet
+
+### Messbare Kriterien (IST)
+
+- Type Safety:
+  - `pnpm test:types` muss gruen sein
+- Lint/Build Qualitaet:
+  - `pnpm test:eslint` muss gruen sein
+- Unit-Test-Basis:
+  - `pnpm test:unit` muss gruen sein
+- File-Placement Governance:
+  - `pnpm check:file-placement` muss gruen sein
+- Coverage Governance:
+  - Gate-Logik und Baselines in `scripts/ci/coverage-gate.ts` und `tooling/testing/*`
+
+### Observability-Qualitaet
+
+- Strukturierte Logs mit Pflichtfeldern (`component`, `environment`, `workspace_id`)
+- Label-Whitelist und PII-Redaction entlang der OTEL-Pipeline
+- Healthchecks fuer lokale Monitoring-Dienste in Compose
+
+### Aktuelle Luecken
+
+- Nicht alle Projekte haben vollwertige Unit/Coverage-Suites (teils exempt)
+- App-Tests laufen derzeit mit `--passWithNoTests`, daher eingeschraenkte Aussagekraft
+
+Referenzen:
+
+- `../development/testing-coverage.md`
+- `scripts/ci/coverage-gate.ts`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/11-risks-and-technical-debt.md
+++ b/docs/architecture/11-risks-and-technical-debt.md
@@ -1,0 +1,58 @@
+# 11 Risiken und technische Schulden
+
+## Zweck
+
+Dieser Abschnitt dokumentiert bekannte Architektur-Risiken und technische
+Schulden auf IST-Basis.
+
+## Mindestinhalte
+
+- Priorisierte Risiko-/Schuldenliste
+- Auswirkungen, Eintrittswahrscheinlichkeit, Gegenmassnahmen
+- Verantwortliche und Zieltermine
+
+## Aktueller Stand
+
+### Priorisierte Risiken
+
+1. Geheimnisse in lokalen Env-Dateien
+   - Impact: hoch (Credential Leak Risiko)
+   - Wahrscheinlichkeit: mittel
+   - Massnahme: Secrets rotieren, lokale Env-Dateien strikt aus VCS halten, Secret-Scan in CI
+
+2. Uneinheitliche Testabdeckung
+   - Impact: mittel bis hoch (Regressionen spaet erkannt)
+   - Wahrscheinlichkeit: hoch
+   - Massnahme: Exempt-Projekte schrittweise abbauen, Coverage-Floors erhoehen
+
+3. Routing-Komplexitaet durch dualen Ansatz (file-based + code-based)
+   - Impact: mittel (Fehlkonfiguration/Bundling-Fehler)
+   - Wahrscheinlichkeit: mittel
+   - Massnahme: klare Source-of-Truth Regeln und mehr Routing-Tests
+
+4. Observability-Abhaengigkeit von korrekter Initialisierung
+   - Impact: mittel (blinde Flecken im Betrieb)
+   - Wahrscheinlichkeit: mittel
+   - Massnahme: robuste Startup-Checks und automatische Verifikation der OTEL-Pipeline
+
+5. Dokumentationsdrift bei schnell wandelnden Architekturteilen
+   - Impact: mittel
+   - Wahrscheinlichkeit: hoch
+   - Massnahme: Doku-Agent Reviews bei Proposal/PR verpflichtend nutzen
+
+### Technische Schulden (Auswahl)
+
+- Teilweise No-Op Testtargets in Libraries
+- Historisch gewachsene Doku mit gemischter Tiefe
+- Offene Produktionsentscheidungen fuer Deployment/HA
+
+### Nachverfolgung
+
+- Risiken in OpenSpec-Changes und PR-Checklisten referenzieren
+- Architekturrelevante Risiken in diesem Abschnitt laufend aktualisieren
+
+Referenzen:
+
+- `docs/reports/PR_CHECKLIST.md`
+- `openspec/AGENTS.md`
+- `docs/development/testing-coverage.md`

--- a/docs/architecture/12-glossary.md
+++ b/docs/architecture/12-glossary.md
@@ -1,0 +1,33 @@
+# 12 Glossar
+
+## Zweck
+
+Dieser Abschnitt fuehrt einheitliche Begriffe und Abkuerzungen fuer
+Architektur und Betrieb.
+
+## Mindestinhalte
+
+- Begriff
+- Definition
+- Bezug zu Baustein/Prozess/ADR
+
+## Aktueller Stand
+
+| Begriff | Definition | Bezug |
+| --- | --- | --- |
+| arc42 | Strukturrahmen fuer Architekturdokumentation mit 12 Abschnitten | `docs/architecture/README.md` |
+| ADR | Architecture Decision Record fuer nachvollziehbare Entscheidungen | `docs/architecture/decisions/` |
+| Kommune | Organisations-/Mandanteneinheit im Smart-Village-Kontext (fachlicher Begriff) | `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md` |
+| Mandant | Isolierter Betriebs-/Datenkontext (Tenant); wird im Code u. a. ueber `workspace_id` abgebildet | `packages/sdk/src/observability/context.server.ts` |
+| workspace_id | Identifier zur Kontext-Korrelation (z. B. Tenant/Workspace) in Logs/Telemetry | `docs/architecture/logging-architecture.md` |
+| Core Route Factory | Funktion, die aus `rootRoute` eine Route erzeugt | `packages/core/src/routing/registry.ts` |
+| Plugin Route Factory | Route-Factory aus Plugins, die mit Core-Factories gemerged wird | `packages/plugin-example/src/routes.tsx` |
+| OIDC | OpenID Connect fuer Authentifizierung gegen externen IdP | `packages/auth/src/oidc.server.ts` |
+| IdP | Identity Provider (OIDC-Provider) fuer Authentifizierung, extern betrieben | `packages/auth/src/oidc.server.ts` |
+| PKCE | Security-Mechanismus im Authorization Code Flow | `packages/auth/src/auth.server.ts` |
+| Session Cookie | HttpOnly-Cookie mit Session-ID fuer Auth-Kontext | `packages/auth/src/routes.server.ts` |
+| AsyncLocalStorage Context | Request-/Workspace-Kontext fuer Logging und Korrelation | `packages/sdk/src/observability/context.server.ts` |
+| OTEL | OpenTelemetry Standard fuer Logs/Metriken/Tracing | `packages/monitoring-client/src/otel.server.ts` |
+| OTLP | OpenTelemetry Protocol fuer Export an Collector | `packages/monitoring-client/src/otel.server.ts` |
+| Label Whitelist | erlaubte Log-Labels (`workspace_id`, `component`, `environment`, `level`) | `packages/monitoring-client/src/otel.server.ts` |
+| Coverage Exempt | Projekt, das temporaer nicht in Coverage-Gates eingeht | `tooling/testing/coverage-policy.json` |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,35 @@
+# Architekturuebersicht (arc42)
+
+Diese Uebersicht ist der verpflichtende Einstiegspunkt fuer Architektur- und Systemdokumentation.
+Alle Architekturinformationen werden arc42-konform in den Abschnitten 1-12 gepflegt.
+
+## Arc42-Struktur
+
+| Abschnitt | Datei | Mindestinhalte | Pflege-Trigger |
+| --- | --- | --- | --- |
+| 1. Einfuehrung und Ziele | `./01-introduction-and-goals.md` | Systemzweck, Stakeholder, Top-3 Architekturziele | Aenderung von Produktzielen, Scope oder Zielgruppen |
+| 2. Randbedingungen | `./02-constraints.md` | Technische, organisatorische, regulatorische Constraints | Neue Vorgaben (Security, Compliance, Plattform, Budget) |
+| 3. Kontext und Scope | `./03-context-and-scope.md` | Systemkontext, externe Schnittstellen, fachliche Grenzen | Neue Integrationen, geaenderte Verantwortungsgrenzen |
+| 4. Loesungsstrategie | `./04-solution-strategy.md` | Leitprinzipien, Architekturtreiber, strategische Entscheidungen | Neue Leitentscheidungen oder geaenderte Zielarchitektur |
+| 5. Bausteinsicht | `./05-building-block-view.md` | Module/Packages, Verantwortlichkeiten, Abhaengigkeiten | Neue Module, geaenderte Modulgrenzen |
+| 6. Laufzeitsicht | `./06-runtime-view.md` | Wichtige Szenarien/Sequenzen, Request-Flows | Geaenderte Flows, neue kritische Laufzeitszenarien |
+| 7. Verteilungssicht | `./07-deployment-view.md` | Deployment-Topologie, Umgebungen, Betriebsgrenzen | Neue Laufzeitumgebungen, Infra- oder Deployment-Aenderungen |
+| 8. Querschnittliche Konzepte | `./08-cross-cutting-concepts.md` | Security, Logging, Observability, Fehlerbehandlung, i18n, A11y | Aenderung cross-cutting Policies oder Patterns |
+| 9. Architekturentscheidungen | `./09-architecture-decisions.md` | Relevante ADR-Liste, Status und Verweise | Neue/aktualisierte ADRs |
+| 10. Qualitaetsanforderungen | `./10-quality-requirements.md` | Qualitaetsziele, Szenarien, Metriken | Neue Qualitaetsziele oder geaenderte Priorisierung |
+| 11. Risiken und technische Schulden | `./11-risks-and-technical-debt.md` | Architektur-Risiken, Schulden, Gegenmassnahmen | Neue Risiken, geaenderte Risikobewertung |
+| 12. Glossar | `./12-glossary.md` | Einheitliche Begriffe, Abkuerzungen, Definitionen | Neue zentrale Begriffe oder uneinheitliche Terminologie |
+
+## Pflege-Regeln
+
+- Architektur- oder Systemaenderungen in PRs muessen die betroffenen arc42-Abschnitte aktualisieren oder eine begruendete Abweichung dokumentieren.
+- OpenSpec-Changes mit Architekturwirkung muessen betroffene arc42-Abschnitte in `proposal.md` und `tasks.md` referenzieren.
+- Architekturentscheidungen werden als ADR unter `./decisions/` dokumentiert und in Abschnitt 9 verlinkt.
+- Referenzen sollen konsistent und klickbar sein (Dateipfade statt Freitext).
+
+## Bestehende Architekturdokumente
+
+- Routing: `./routing-architecture.md`
+- Logging und Observability: `./logging-architecture.md`
+- Session-Analyse: `./session-management-analysis.md`
+- ADRs: `./decisions/README.md`

--- a/docs/architecture/logging-architecture.md
+++ b/docs/architecture/logging-architecture.md
@@ -239,13 +239,6 @@ In `dev/monitoring/promtail/promtail-config.yml`:
 2. Context-Middleware nutzt in einem Sonderfall `console.warn` (zirkulaere Abhaengigkeit zum Logger), bewusst begrenzt auf Development-Warnpfad.
 3. Bei fehlendem OTEL LoggerProvider faellt `DirectOtelTransport` auf no-op fuer OTEL-Emission, Console-Transport bleibt als Sicherheitsnetz.
 
-## Roadmap (empfohlen)
-
-1. Status der ADRs 005/006/007 von `Proposed` auf `Accepted`, sobald Review abgeschlossen ist.
-2. Optionales deduplizierendes Labeling zwischen OTEL-Pfad und Promtail-Fallback.
-3. Erweiterte Compliance-Tests fuer Label-Whitelist/PII als CI-Checks.
-4. Klare Naming-Konvention fuer `component` zentral in Development Rules.
-
 ## Referenzen
 
 - `packages/sdk/src/logger/index.server.ts`

--- a/docs/architecture/routing-architecture.md
+++ b/docs/architecture/routing-architecture.md
@@ -231,13 +231,6 @@ Wichtig:
 2. Debug/Admin-Test-Routen koennen Route-Tree-Sicht erweitern, obwohl sie nicht Teil des Core-Flows sind.
 3. Strikte Import-Disziplin ist entscheidend; sonst drohen Bundling-/Hydration-Probleme.
 
-## Empfohlene Weiterentwicklung
-
-1. Debug-/Test-Routen klar hinter Feature-Flags oder Dev-Only Guards halten.
-2. Routing-Tests fuer Factory-Merge-Reihenfolge und Auth-Handler-Mapping ausbauen.
-3. Mittelfristig dokumentieren, welche Teile file-based vs. code-based als source of truth gelten.
-4. Optional: Routing-Architektur als ADR (Accepted) ergänzen.
-
 ## Referenzen
 
 - `docs/routing.md`

--- a/docs/reports/PR_CHECKLIST.md
+++ b/docs/reports/PR_CHECKLIST.md
@@ -177,3 +177,9 @@ All code issues resolved. Can proceed independently of infrastructure debugging.
 - [ ] `pnpm test:unit` ist grün; insbesondere `@sva/monitoring-client:test:unit` läuft mit echtem Vitest-Run.
 - [ ] Bei Änderungen in coverage-exempt Projekten (`core`, `data`, `plugin-example`) ist ein expliziter Test-/Smoke-Nachweis im PR enthalten.
 - [ ] Exemption-Kontext wurde gegen `docs/development/testing-coverage.md` geprüft.
+
+## Architektur-Doku (arc42) - Reviewer Quick Check
+
+- [ ] Bei Architektur-/Systemaenderungen sind betroffene Abschnitte in `docs/architecture/README.md` identifiziert.
+- [ ] Relevante arc42-Dateien unter `docs/architecture/` wurden aktualisiert oder eine begruendete Abweichung ist dokumentiert.
+- [ ] OpenSpec-Change (`proposal.md`/`tasks.md`) referenziert die betroffenen arc42-Abschnitte.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,12 +1,17 @@
 # Routing und Plugin-Routen
 
-Ausfuehrliche Architektur-Dokumentation: `docs/architecture/routing-architecture.md`
+Ausfuehrliche Architektur-Dokumentation: [docs/architecture/routing-architecture.md](./architecture/routing-architecture.md)
 
-## Code-Route-Registry
-Das SVA Studio nutzt eine Code-basierte Route-Registry. Core- und Plugin-Routen werden programmatisch kombiniert.
+## Ist-Stand
+
+SVA Studio nutzt eine code-basierte Route-Registry: Core- und Plugin-Routen werden programmatisch kombiniert.
+Der Router wird in `apps/sva-studio-react/src/router.tsx` aus `rootRoute` und gemergten Route-Factories gebaut.
 
 ## Core-Routen
+
 Core-Routen werden in der App definiert und in der Registry registriert.
 
 ## Plugin-Routen
-Plugins exportieren Route-Factories, die im Router registriert werden. Beispiel: `@sva/plugin-example` liefert eine Route unter `/plugins/example`.
+
+Plugins exportieren Route-Factories, die im Router registriert werden.
+Beispiel: `@sva/plugin-example` liefert eine Route unter `/plugins/example`.

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -71,6 +71,7 @@ After deployment, create separate PR to:
 - [ ] Read `openspec/project.md` for conventions
 - [ ] Run `openspec list` to see active changes
 - [ ] Run `openspec list --specs` to see existing capabilities
+- [ ] Bei Architektur-/Systemwirkung: betroffene arc42-Abschnitte in `docs/architecture/README.md` identifizieren
 
 **Before Creating Specs:**
 - Always check if capability already exists
@@ -172,6 +173,7 @@ New request?
 ## Impact
 - Affected specs: [list capabilities]
 - Affected code: [key files/systems]
+- Affected arc42 sections: [e.g. 05-building-block-view, 08-cross-cutting-concepts]
 ```
 
 3. **Create spec deltas:** `specs/[capability]/spec.md`
@@ -202,6 +204,7 @@ If multiple capabilities are affected, create multiple delta files under `change
 - [ ] 1.2 Implement API endpoint
 - [ ] 1.3 Add frontend component
 - [ ] 1.4 Write tests
+- [ ] 1.5 Update referenced arc42 sections under `docs/architecture/` (or document justified deviation)
 ```
 
 5. **Create design.md when needed:**

--- a/openspec/changes/add-arc42-architecture-documentation/proposal.md
+++ b/openspec/changes/add-arc42-architecture-documentation/proposal.md
@@ -1,13 +1,17 @@
 # Change: arc42-basierte Architekturdokumentation einführen
 
 ## Why
+
 Die Architekturinformationen sind aktuell auf mehrere Dokumente verteilt und nicht einheitlich strukturiert. Für Onboarding, Review und Entscheidungsnachverfolgung fehlt ein konsistenter Rahmen.
 
 ## What Changes
+
 - Einführung einer Architektur-Dokumentationsstruktur nach arc42 als Projektstandard.
 - Definition der verpflichtenden Inhalte pro arc42-Abschnitt mit klaren Verantwortlichkeiten.
 - Verknüpfung der arc42-Dokumentation mit OpenSpec-Changes und operativen Runbooks.
+- Prüfung aller Agents und Skills (AI-Anweisungen) und gezielte Ergänzung, sodass Architektur-/Systemdoku konsistent in arc42-Struktur erfolgt.
 
 ## Impact
+
 - Affected specs: `architecture-documentation`
-- Affected code: `docs/architecture/`, relevante Doku-Indexseiten und Referenzen in `docs/`
+- Affected code: `docs/architecture/`, relevante Doku-Indexseiten und Referenzen in `docs/`, sowie Agent-/Skill-Anweisungen (`AGENTS.md`, `.github/agents/`, `.github/skills/`, `.github/copilot-instructions.md`)

--- a/openspec/changes/add-arc42-architecture-documentation/specs/architecture-documentation/spec.md
+++ b/openspec/changes/add-arc42-architecture-documentation/specs/architecture-documentation/spec.md
@@ -1,24 +1,43 @@
+# Spec Delta: architecture-documentation
+
 ## ADDED Requirements
+
 ### Requirement: Einheitliche Architekturstruktur nach arc42
+
 Das System SHALL Architekturdokumentation in einer konsistenten, arc42-konformen Struktur führen.
 
 #### Scenario: Architektur-Einstiegspunkt vorhanden
+
 - **WHEN** ein Teammitglied die Architektur dokumentieren oder lesen möchte
 - **THEN** existiert ein klarer Einstiegspunkt unter `docs/architecture/`
 - **AND** die Inhalte sind nach arc42-Abschnitten gegliedert
 
 ### Requirement: Nachvollziehbare Architekturentscheidungen
+
 Das System SHALL Architekturentscheidungen mit Kontext, Begründung und Auswirkungen dokumentieren.
 
 #### Scenario: Änderung mit Architekturbezug
+
 - **WHEN** ein OpenSpec-Change mit Architekturwirkung erstellt wird
 - **THEN** referenziert der Change die betroffenen arc42-Abschnitte
 - **AND** die Entscheidung ist für Reviewer nachvollziehbar dokumentiert
 
 ### Requirement: Verbindliche Pflege im Entwicklungsworkflow
+
 Das System SHALL die Pflege der Architektur-Dokumentation als Teil des Delivery-Workflows verankern.
 
 #### Scenario: PR mit Architekturänderung
+
 - **WHEN** ein PR Architektur oder Systemgrenzen verändert
 - **THEN** enthält der PR eine Aktualisierung der relevanten arc42-Abschnitte
 - **AND** die Review-Checkliste prüft diese Aktualisierung
+
+### Requirement: Verankerung der arc42-Struktur in Agent- und Skill-Anweisungen
+
+Das System SHALL die Vorgabe „Architektur-/Systemdoku erfolgt arc42-konform“ in den relevanten Agent- und Skill-Anweisungen verankern, sodass die Doku laufend konsistent und gut strukturiert erweitert wird.
+
+#### Scenario: Agent schlägt Doku-Änderung vor
+
+- **WHEN** ein Agent (oder Skill) eine Änderung mit Architektur-/Systembezug bewertet oder vorschlägt
+- **THEN** referenziert er die betroffenen arc42-Abschnitte unter `docs/architecture/`
+- **AND** fordert er die Aktualisierung dieser Abschnitte ein (oder dokumentiert bewusst begründete Abweichungen)

--- a/openspec/changes/add-arc42-architecture-documentation/tasks.md
+++ b/openspec/changes/add-arc42-architecture-documentation/tasks.md
@@ -1,6 +1,10 @@
+# Tasks
+
 ## 1. Implementation
-- [ ] 1.1 `docs/architecture/` nach arc42-Grundstruktur anlegen (Abschnitte 1-12 als Dateien/Ordner).
-- [ ] 1.2 Mindestinhalte und Pflege-Regeln je Abschnitt definieren.
-- [ ] 1.3 Verlinkungen von OpenSpec-Changes auf relevante arc42-Abschnitte festlegen.
-- [ ] 1.4 Doku-Navigation aktualisieren (Einstiegspunkt für Architekturübersicht).
-- [ ] 1.5 Review-Checkliste um Architektur-Doku-Prüfpunkte erweitern.
+
+- [x] 1.1 `docs/architecture/` nach arc42-Grundstruktur anlegen (Abschnitte 1-12 als Dateien/Ordner).
+- [x] 1.2 Mindestinhalte und Pflege-Regeln je Abschnitt definieren.
+- [x] 1.3 Verlinkungen von OpenSpec-Changes auf relevante arc42-Abschnitte festlegen.
+- [x] 1.4 Doku-Navigation aktualisieren (Einstiegspunkt für Architekturübersicht).
+- [x] 1.5 Review-Checkliste um Architektur-Doku-Prüfpunkte erweitern.
+- [x] 1.6 Agents & Skills prüfen und dort, wo es um Architektur-/Systemdoku geht, die Vorgabe ergänzen: Doku erfolgt arc42-konform (inkl. Verweise auf `docs/architecture/`).

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -34,6 +34,7 @@ SVA Studio (ehemals "CMS 2.0") modernisiert das Redaktionssystem der Smart Villa
   - **Packages:** `core` (Routing Registry), `sdk` (Plugin SDK), `data` (Datenmodelle), `plugin-example` (Beispiel)
 - **Separation of Concerns:** Backend/Frontend klar getrennt; API als zentrale Schnittstelle
 - **OpenSpec:** Strukturierte Change-Proposals und Specs in `openspec/` für Architektur-Entscheidungen
+- **Architekturdoku (arc42):** Architektur-/Systemdoku unter `docs/architecture/README.md` mit Abschnitten 1-12; bei Architekturwirkung muessen betroffene Abschnitte in OpenSpec-Changes referenziert werden
 
 ### Testing Strategy
 - **Pflicht:** Neue Logik benötigt Tests; Bugfixes benötigen Repro-Tests


### PR DESCRIPTION
## Summary
- introduce and populate arc42 architecture docs under `docs/architecture/` (sections 1-12)
- add architecture entrypoint and maintenance rules
- add documentation steward agent + template and align agent/skill guidance to arc42 references
- add wiki sync workflow for `docs/**`
- fix PR coverage base branch handling in `.github/workflows/test-coverage.yml` (`github.base_ref`)

## Why
Previous PR included historical branch scope and unrelated failing checks. This PR is a cleaned develop-focused scope.

## Validation
- `openspec validate add-arc42-architecture-documentation --strict`
- `pnpm check:file-placement`
