### PR TITLE
docs(adr): ADR-008 zum Einsatz von Codecov zur Entscheidung vorlegen

### DIFF
--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -40,9 +40,11 @@ Architekturprinzipien auf IST-Basis.
 - Plugin-Architektur: `ADR-002`
 - Monitoring-Stack: `ADR-004`
 - Logging-Pipeline und Label-Policy: `ADR-006`, `ADR-007`
+- Coverage-Reporting mit externem Transparenz-Layer: `ADR-008`
 
 Referenzen:
 
 - `./decisions/ADR-001-frontend-framework-selection.md`
 - `./decisions/ADR-002-plugin-architecture-pattern.md`
 - `./decisions/ADR-004-monitoring-stack-loki-grafana-prometheus.md`
+- `./decisions/ADR-008-codecov-coverage-reporting-and-gates.md`

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -22,6 +22,7 @@ mit Bezug auf die arc42-Abschnitte.
 - `ADR-005-observability-module-ownership.md`
 - `ADR-006-logging-pipeline-strategy.md`
 - `ADR-007-label-schema-and-pii-policy.md`
+- `ADR-008-codecov-coverage-reporting-and-gates.md`
 
 ### Zuordnung zu arc42-Abschnitten
 
@@ -29,7 +30,7 @@ mit Bezug auf die arc42-Abschnitte.
 - Abschnitt 05 (Bausteinsicht): ADR-001, ADR-002, ADR-005
 - Abschnitt 06/07 (Laufzeit/Deployment): ADR-004, ADR-006
 - Abschnitt 08 (Querschnitt): ADR-005, ADR-006, ADR-007
-- Abschnitt 10/11 (Qualitaet/Risiken): ADR-004, ADR-007
+- Abschnitt 10/11 (Qualitaet/Risiken): ADR-004, ADR-007, ADR-008
 
 ### Pflege-Regel
 

--- a/docs/architecture/decisions/ADR-008-codecov-coverage-reporting-and-gates.md
+++ b/docs/architecture/decisions/ADR-008-codecov-coverage-reporting-and-gates.md
@@ -1,0 +1,114 @@
+# ADR-008: Codecov für Coverage-Reporting und PR-Transparenz
+
+**Datum:** 18. Februar 2026
+**Status:** 📋 Offen
+**Kontext:** Test-Coverage Governance (CI-Gates, Reporting, Pull-Request-Feedback)
+**Entscheider:** Philipp & Daniel
+
+---
+
+## Entscheidung
+
+Wir nutzen **Codecov** als zusätzliche Sicht auf unsere Testqualität.
+Die verbindliche Freigabe bleibt aber weiterhin intern.
+
+Konkret:
+
+- **Test-Coverage** (Anteil des Codes, der durch automatisierte Tests ausgeführt wird) wird weiterhin in der **CI** (Continuous Integration, automatische Prüfung bei jedem Code-Update) erzeugt.
+- Das verbindliche **Quality Gate** (Regel, die vor Freigabe zwingend erfüllt sein muss) bleibt `pnpm coverage-gate` im **Repository** (zentraler Speicherort für den Quellcode).
+- Ergebnisse werden zusaetzlich an Codecov gesendet, damit Änderungen in einem **Pull Request** (Vorschlag, Änderungen in den Hauptzweig zu übernehmen) schneller sichtbar sind.
+- Wenn Codecov kurzfristig nicht verfügbar ist, bleibt die Freigabelogik stabil (`fail_ci_if_error: false`), weil die interne Bewertung weiterläuft.
+
+---
+
+## Kontext und Problem
+
+Unser **Monorepo** hat bereits eine interne **Governance** für Coverage.
+Diese Regeln sind für Freigaben verlässlich, aber in Reviews oder für Externe nicht immer nachvollziehbar.
+
+Insbesondere fehlte eine durchgängige Sicht auf:
+
+- Coverage-Trends über Zeit
+- schnelle Rückmeldung direkt im Pull Request
+- zentrale Vergleichbarkeit über mehrere Packages
+
+Die internen Regeln nutzen bereits eine **Baseline** (Referenzwert als Ausgangspunkt) und **Floors** (Mindestwerte, die nicht unterschritten werden dürfen).
+Ohne zusätzliche Visualisierung bleiben diese Werte korrekt, aber für nicht-täglich technische Stakeholder schwerer einzuordnen.
+
+---
+
+## Was ist Codecov?
+
+Codecov ist ein externer Dienst, der Coverage-Ergebnisse aus CI-Läufen aufbereitet und visuell darstellt.
+Im Projekt ist Codecov damit ein Transparenz- und Analysewerkzeug, nicht die Instanz für finale Freigaben.
+
+Funktional bedeutet das:
+
+- Anzeige von Coverage-Änderungen pro Pull Request.
+- Historische Trends und Vergleichbarkeit über mehrere Ausführungen hinweg.
+- Zentrale Darstellung aggregierter **LCOV**-Reports (Standard-Dateiformat für Coverage-Ergebnisse) aus App- und Package-Targets.
+
+Die bindende Qualitätsentscheidung bleibt weiterhin bei der internen Governance (`coverage-gate`), damit Freigaberegeln unabhängig von externer Verfügbarkeit bleiben.
+
+---
+
+## Betrachtete Optionen
+
+| Option | Kriterien | Bewertung | Kommentar |
+|---|---|---|---|
+| **A: Interne Gates + Codecov (empfohlen)** | Verbindlichkeit, Transparenz, Integrationsaufwand | 9/10 | Klare Trennung von Freigaberegeln und Reporting, gute PR-Sichtbarkeit |
+| B: Nur interne Gates und Artefakte | Robustheit, Einfachheit | 7/10 | Weniger externer Aufwand, aber schwache Trend-/PR-Visualisierung |
+| C: Externe Plattform als alleiniges Gate | Zentralisierung | 5/10 | Höhere Abhängigkeit von einem einzelnen Anbieter, weniger Kontrolle im Repo |
+
+### Warum Option A?
+
+- ✅ **Verlässliche Entscheidungshoheit im Repo:** Baselines/Floors bleiben in Versionierung und Review.
+- ✅ **Bessere Nachvollziehbarkeit im Review:** Pull Requests erhalten zusätzliche Coverage-Transparenz.
+- ✅ **Niedriges Ausfallrisiko:** Externer Upload ist hilfreich, aber nicht kritisch für Gate-Entscheidungen.
+- ✅ **Skalierbar für Monorepo:** Mehrere LCOV-Quellen können konsistent aggregiert werden.
+
+---
+
+## Trade-offs & Limitierungen
+
+### Pros
+- ✅ Bessere Sichtbarkeit auf Coverage-Trends und Auswirkungen einzelner Pull Requests.
+- ✅ Klare Trennung zwischen internen Freigaberegeln und externer Visualisierung.
+- ✅ Geringe Umstellung, da bestehende Coverage-Targets unverändert bleiben.
+
+### Cons
+- ❌ Zusätzliche externe Abhängigkeit (Service + Zugangsverwaltung).
+- ❌ Potentielle Verwirrung, wenn Codecov-Darstellung und interne Gate-Werte unterschiedlich wirken.
+- ❌ Wartungsaufwand für Workflow-/Codecov-Konfiguration.
+
+**Mitigation:** In Doku und CI bleibt klar dokumentiert, dass `pnpm coverage-gate` das bindende Merge-Kriterium ist.
+
+---
+
+## Implementierung / Ausblick
+
+- [x] CI erzeugt Coverage-Reports via `test:coverage`/`nx affected --target=test:coverage`.
+- [x] Upload zu Codecov erfolgt in `.github/workflows/test-coverage.yml`.
+- [x] Grundkonfiguration liegt in `codecov.yml`.
+- [ ] Reviewer-Leitfaden um explizite Codecov-Interpretation ergänzen (Änderung je Pull Request vs. Gesamtwert).
+- [ ] Halbjährliche Evaluation: Nutzen, Fehlalarme, Lock-in-Risiken.
+
+---
+
+## Migration / Exit-Strategie
+
+Bei Abkehr von Codecov bleibt die Kern-Governance unverändert:
+
+1. Codecov-Upload-Step aus Workflow entfernen.
+2. Optional alternative Reporting-Plattform anbinden.
+3. Interne Gates (`coverage-gate`, Policy/Baseline) unverändert weiter nutzen.
+
+Damit ist ein Exit ohne Änderungen an den Test-Targets oder den Governance-Regeln möglich.
+
+---
+
+**Links:**
+- [Coverage Workflow](../../../.github/workflows/test-coverage.yml)
+- [Codecov Konfiguration](../../../codecov.yml)
+- [Testing & Coverage Governance](../../development/testing-coverage.md)
+- [OpenSpec: Enhance Test Coverage Tooling](../../../openspec/changes/enhance-test-coverage-tooling/proposal.md)

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -47,6 +47,7 @@ Architecture Decision Records dokumentieren **wichtige technische Entscheidungen
 | 005 | Observability Module Ownership | 📋 | 2026-02-06 | Observability |
 | 006 | Logging Pipeline Strategy | 📋 | 2026-02-06 | Observability |
 | 007 | Label Schema & PII Policy | 📋 | 2026-02-06 | Security/Observability |
+| 008 | Codecov fuer Coverage-Reporting und PR-Transparenz | 📋 | 2026-02-18 | Qualitaet/CI |
 
 ---
 


### PR DESCRIPTION
## Ziel
Diese PR legt **ADR-008** vor, damit wir den Einsatz von **Codecov** als Reporting-/Transparenz-Layer bewusst entscheiden können.

## Inhalt
- neue ADR-Datei: `docs/architecture/decisions/ADR-008-codecov-coverage-reporting-and-gates.md`
- Verlinkung in der Architekturübersicht:
  - `docs/architecture/04-solution-strategy.md`
  - `docs/architecture/09-architecture-decisions.md`
  - `docs/architecture/decisions/README.md`

## Entscheidungsrahmen (für Review)
Bitte im Review insbesondere diese Punkte bewerten:
1. Soll Codecov als **ergänzender Reporting-Layer** eingeführt werden?
2. Soll das **verbindliche Merge-Gate** weiterhin ausschließlich intern über `coverage-gate` laufen?
3. Sind Trade-offs, Exit-Strategie und Zuständigkeiten in der ADR ausreichend klar?

## Wichtig
- ADR-Status ist aktuell auf **📋 Offen** gesetzt.
- Mit einem positiven Review kann der Status auf **✅ Accepted** geändert werden.

## Scope
Diese PR enthält nur Dokumentationsänderungen zur Architekturentscheidung (keine neue Runtime-Logik).
