### PR TITLE
docs(arc42): Arc42-Architekturdokumentation für main übernehmen

### DIFF
--- a/docs/architecture/01-introduction-and-goals.md
+++ b/docs/architecture/01-introduction-and-goals.md
@@ -1,69 +1,70 @@
-# 01 Einführung und Ziele
+# 01 Einfuehrung und Ziele
 
 ## Zweck
 
 SVA Studio ist eine TanStack-Start-basierte Webanwendung im Nx-Monorepo, die
-als modulares Studio für Content- und Systemfunktionen aufgebaut wird.
-Der aktuelle Repo-Stand fokussiert auf:
+als modulares Studio fuer Content- und Systemfunktionen aufgebaut wird.
+Der aktuelle Stand fokussiert auf:
 
-- Typsicheres Routing mit Core- und Plugin-Route-Factories
-- Demo-Routen mit TanStack Start Server Functions
-- Grundlagenpakete für Core, Data, SDK und Plugin-Integration
-- Monorepo-Governance für Build/Test/Qualität
+- Typsicheres Routing mit Core- und Plugin-Routen
+- OIDC-Login mit Session-Verwaltung (Redis)
+- Strukturiertes Server-Logging mit OTEL-Pipeline
+- Monorepo-Governance fuer Build/Test/Qualitaet
 
 Referenzen:
 
 - `apps/sva-studio-react/src/router.tsx`
-- `apps/sva-studio-react/src/routes/-core-routes.tsx`
-- `packages/core/src/routing/registry.ts`
-- `packages/data/src/index.ts`
+- `packages/routing/src/index.ts`
+- `packages/auth/src/routes.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
 
 ## Mindestinhalte
 
-Mindestinhalte für diesen Abschnitt:
+Mindestinhalte fuer diesen Abschnitt:
 
-- Systemkontext in 3-5 Sätzen
-- Primäre Stakeholder und deren wichtigste Bedürfnisse
-- Top-3 Architekturziele mit Priorität
+- Systemkontext in 3-5 Saetzen
+- Primaere Stakeholder und deren wichtigste Beduerfnisse
+- Top-3 Architekturziele mit Prioritaet
 
 ## Aktueller Stand
 
 ### Produkt- und Problemkontext (ohne Feature-Commitment)
 
-SVA Studio ist das technische Fundament für ein Redaktions- und Verwaltungsstudio im Smart-Village-Umfeld.
+SVA Studio ist das technische Fundament fuer ein Redaktions- und Verwaltungsstudio im Smart-Village-Umfeld.
 Der fachliche Hintergrund (Warum/wer/Rahmenbedingungen) ist im Konzept unter `concepts/konzeption-cms-v2/` beschrieben.
-Dieses Repository implementiert aktuell vor allem technische Enabler für Routing, UI-Demos und Paketstruktur.
+Dieses Repository dokumentiert und implementiert aktuell vor allem technische Enabler (Routing, Auth, Observability, Monorepo-Governance).
 
-Wichtig: Das Konzept enthält auch Roadmap-/Milestone-Inhalte; diese gelten nicht als dokumentierter Ist-Stand dieses Repos.
+Wichtig: Das Konzept enthaelt auch Roadmap-/Milestone-Inhalte; diese gelten nicht als dokumentierter Ist-Stand dieses Repos.
 
 ### Stakeholder (technisch)
 
 - Produkt-/Architektur-Team: stabile Zielarchitektur und nachvollziehbare Entscheidungen
 - Entwickler:innen: hohe Typsicherheit, klare Modulgrenzen, reproduzierbare Workflows
-- Betrieb/SRE: standardisierte Build-/Test-Pipelines
+- Betrieb/SRE: beobachtbares und betreibbares System inkl. Logging/Monitoring
 
 ### Stakeholder (fachlich / Nutzerrollen)
 
-Die folgenden Rollen stammen aus dem Konzept und dienen hier als Kontext für Architekturentscheidungen.
+Die folgenden Rollen stammen aus dem Konzept und dienen hier als Kontext fuer Architekturentscheidungen.
 Sie sind nicht als bereits umgesetzte Feature-Liste zu verstehen.
 
-- System-Administrator:innen
-- App-Manager:innen
-- Feature-Manager:innen
-- Designer:innen
-- Schnittstellen-Manager:innen
-- Redakteur:innen/Inhaltsersteller:innen
+- System-Administrator:innen: Betrieb, Sicherheit, Rollen/Rechte, Observability
+- App-Manager:innen: Konfiguration und Steuerung (aus fachlicher Sicht)
+- Feature-Manager:innen: fachliche Verantwortung fuer einzelne Inhalts-/Modulbereiche
+- Designer:innen: Corporate Design, UI-Konsistenz
+- Schnittstellen-Manager:innen: Integrationen, Datenfluesse, Fehlertransparenz
+- Redakteur:innen/Inhaltsersteller:innen: effiziente Inhaltspflege
 
 ### Top-3 Architekturziele (priorisiert)
 
-1. Typsichere, erweiterbare Routing-Architektur (Core + Plugins)
-2. Klare Paketgrenzen mit framework-agnostischer Kernlogik
-3. Nachvollziehbare Qualitäts-Governance über Nx-/CI-Workflows und Doku
+1. Typsichere, erweiterbare Modul- und Routing-Architektur (Core + Plugins)
+2. Sichere Authentifizierung und Session-Management fuer Web-Workflows
+3. Einheitliche, PII-sichere Observability ueber OTEL -> Collector -> Loki
 
 ### Systemgrenze (Kurzfassung)
 
-In diesem Repo liegen die Web-App, gemeinsame Pakete (`core`, `data`, `sdk`, `plugin-example`)
-und die Doku-/Governance-Artefakte.
-Externe Fachsysteme werden konzeptionell adressiert, sind aber nicht Teil des aktuellen Codes.
+In diesem Repo liegen Frontend, Routing-Layer, Auth-BFF-Funktionen,
+SDK/Observability sowie lokale Betriebsartefakte.
+Externe Systeme (IdP/Keycloak, ggf. weitere Backends) werden integriert, aber
+nicht in diesem Repository betrieben.
 
 Konzept-Referenz (Kontext): `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md`

--- a/docs/architecture/02-constraints.md
+++ b/docs/architecture/02-constraints.md
@@ -17,8 +17,9 @@ im IST-System direkt beeinflussen.
 
 - Node.js `>=22.12.0`, pnpm `>=9.12.2` (`package.json`)
 - Nx-Monorepo mit standardisierten Targets (`build`, `lint`, `test:unit`)
-- TanStack Start/Router für die Web-App
-- Package-Abhängigkeiten intern über `workspace:*`
+- TanStack Start/Router fuer App und Server-Routen
+- Redis als Session-Store, lokal via Docker Compose
+- OTEL-basierte Logging-/Metrikpipeline ueber Collector
 
 ### Organisatorische Randbedingungen
 
@@ -28,14 +29,13 @@ im IST-System direkt beeinflussen.
 
 ### Regulatorische/Qualitaets-Randbedingungen
 
+- PII-Schutz im Logging (Redaction + Label-Whitelist)
 - Security- und Accessibility-Regeln aus `DEVELOPMENT_RULES.md`
 - Nachweisbare Test-/Lint-/Type-Checks im Entwicklungsworkflow
-- PR-Checks für Coverage und Integration über GitHub Actions
 
 Referenzen:
 
 - `package.json`
-- `pnpm-workspace.yaml`
 - `openspec/AGENTS.md`
 - `scripts/ci/check-file-placement.mjs`
-- `.github/workflows/test-coverage.yml`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -15,39 +15,40 @@ aktuellen fachlich-technischen Scope.
 
 ### Fachlicher Kontext (nur Kontext)
 
-Im Produktkontext adressiert SVA Studio die Verwaltung strukturierter Inhalte und Konfigurationen für die Smart Village App und angrenzende Kanäle (Headless/API-first).
-Im aktuellen Repo-Ist-Stand sind primär technische Grundlagen für Routing, Demo-Flows und Paketstruktur umgesetzt.
+Im Produktkontext adressiert SVA Studio die Verwaltung strukturierter Inhalte und Konfigurationen fuer die Smart Village App und angrenzende Kanaele (Headless/API-first).
+Im aktuellen Repo-Ist-Stand sind davon primaer die technischen Grundlagen umgesetzt (Routing, Auth, Observability, lokale Betriebsartefakte).
 
 ### In Scope (IST)
 
 - Web-App `sva-studio-react` mit TanStack Start
-- Routing-Komposition über `@sva/core` und `@sva/plugin-example`
-- Demo-Server-Functions in der App (`createServerFn`)
-- Einfacher DataClient mit In-Memory-Cache in `@sva/data`
-- Architektur- und Governance-Dokumentation unter `docs/` und `openspec/`
+- Zentrales Routing (`@sva/core`, `@sva/routing`, Plugin-Routen)
+- Auth-BFF-Endpunkte (`/auth/login`, `/auth/callback`, `/auth/me`, `/auth/logout`)
+- Session-Verwaltung mit Redis (inkl. optionaler Token-Verschluesselung)
+- SDK Logger + OTEL Monitoring Client + lokale Monitoring-Stacks
 
 ### Out of Scope (in diesem Repo)
 
-- Betrieb und Quellcode eines externen IdP
-- Produktive Auth-/Session-Implementierung als stabiles Paket
-- Produktiver Monitoring-Stack (Collector/Loki/Prometheus/Grafana) im Repository
-- Vollständige Fachverfahren-Integrationen
+- Betrieb und Quellcode des externen IdP (Keycloak Realm/Server)
+- Mobile App / externe Konsumenten
+- Vollstaendige Fachverfahren-Integrationen
+- Produkt-/Fachmodule (z. B. konkrete CMS-Content-Modelle) sind im Code derzeit nicht als stabile API/Implementierung vorhanden
 
 ### Externe Nachbarsysteme
 
-- HTTP-Backends, die vom DataClient aufgerufen werden
-- Externe Plattformen für CI/CD und Code-Hosting (GitHub)
+- OIDC Provider (per `openid-client`)
+- Redis (lokal/extern)
+- OTEL Collector, Loki, Prometheus, Grafana, Alertmanager
 
 Konzept-Referenz (Kontext): `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md`
 
 ### Verantwortungsgrenzen
 
-- Repo verantwortet App-, Paket-, Build-/Test- und Doku-Logik
-- Externe Dienste werden angebunden, aber nicht in diesem Repository betrieben
+- Repo verantwortet App-, Routing-, Auth-, SDK- und Doku-Logik
+- Externe Dienste werden angebunden, aber nicht hier implementiert
 
 Referenzen:
 
-- `apps/sva-studio-react/src/router.tsx`
-- `apps/sva-studio-react/src/routes/-core-routes.tsx`
-- `packages/data/src/index.ts`
-- `.github/workflows/test-coverage.yml`
+- `packages/auth/src/oidc.server.ts`
+- `packages/auth/src/redis.server.ts`
+- `docker-compose.yml`
+- `docker-compose.monitoring.yml`

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -1,4 +1,4 @@
-# 04 Lösungsstrategie
+# 04 Loesungsstrategie
 
 ## Zweck
 
@@ -15,31 +15,34 @@ Architekturprinzipien auf IST-Basis.
 
 ### Leitprinzipien
 
-- Monorepo mit klaren Paketgrenzen und Workspace-Abhängigkeiten (`workspace:*`)
-- Framework-agnostische Kernlogik in `@sva/core`, Integration in der App-Ebene
-- Route-Komposition über Factory-Pattern (`mergeRouteFactories`, `buildRouteTree`)
+- Monorepo mit klaren Paketgrenzen und Workspace-Abhaengigkeiten (`workspace:*`)
+- Framework-agnostische Kernlogik in `@sva/core`, Integration in App-Ebene
+- Trennung von client-sicheren und serverseitigen Routen/Handlern
+- Observability ueber OTEL-Standards statt vendor-spezifischer App-Anbindung
 - Doku-getriebene Architekturpflege (arc42 + OpenSpec + ADR)
 
 ### Architekturtreiber
 
 - Hohe Typsicherheit und Wartbarkeit bei wachsender Modulanzahl
 - Erweiterbarkeit durch Plugins und zentrale Route-Registry
-- Reproduzierbarkeit über standardisierte Nx-/pnpm-Workflows
+- Betriebsfaehigkeit mit strukturierter Telemetrie
+- Security/Privacy-Anforderungen an Auth und Logging
 
 ### Zielkonflikte (aktuell sichtbar)
 
-- Hohe Flexibilität (code-based + file-based Routing) vs. Komplexität
-- Schneller Dev-Flow vs. Governance-Anforderungen in CI
-- Multi-Tooling (Nx, TanStack, pnpm) vs. Einarbeitungsaufwand
+- Hohe Flexibilitaet (code-based + file-based Routing) vs. Komplexitaet
+- Schneller Dev-Flow vs. strenge Security-/PII-Kontrollen
+- Multi-Tooling (Nx, TanStack, OTEL) vs. Einarbeitungsaufwand
 
 ### Strategische Entscheidungen (Auswahl)
 
 - Frontend-Framework: `ADR-001`
 - Plugin-Architektur: `ADR-002`
-- Design-Token-Architektur: `ADR-003`
+- Monitoring-Stack: `ADR-004`
+- Logging-Pipeline und Label-Policy: `ADR-006`, `ADR-007`
 
 Referenzen:
 
 - `./decisions/ADR-001-frontend-framework-selection.md`
 - `./decisions/ADR-002-plugin-architecture-pattern.md`
-- `./decisions/ADR-003-design-token-architecture.md`
+- `./decisions/ADR-004-monitoring-stack-loki-grafana-prometheus.md`

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -3,12 +3,12 @@
 ## Zweck
 
 Dieser Abschnitt beschreibt statische Bausteine, Verantwortlichkeiten und
-Abhängigkeiten des aktuellen Systems.
+Abhaengigkeiten des aktuellen Systems.
 
 ## Mindestinhalte
 
 - Hauptbausteine mit Verantwortung
-- Schnittstellen und Abhängigkeiten zwischen Bausteinen
+- Schnittstellen und Abhaengigkeiten zwischen Bausteinen
 - Grenzen zwischen framework-agnostischer Kernlogik und Bindings
 
 ## Aktueller Stand
@@ -18,31 +18,38 @@ Abhängigkeiten des aktuellen Systems.
 1. App (`apps/sva-studio-react`)
    - TanStack Start App, UI, Root-Shell, Router-Erzeugung
 2. Core (`packages/core`)
-   - generische Route-Registry-Utilities (`mergeRouteFactories`, `buildRouteTree`)
-3. Data (`packages/data`)
-   - einfacher HTTP DataClient mit In-Memory-Cache
-4. SDK (`packages/sdk`)
-   - gemeinsamer Einstiegspunkt für paketübergreifende Utilities
-5. Plugin Example (`packages/plugin-example`)
-   - Beispielroute für Plugin-Erweiterbarkeit
+   - generische Route-Registry Utilities (`mergeRouteFactories`, `buildRouteTree`)
+3. Routing (`packages/routing`)
+   - zentrale Route-Factories (client + server)
+4. Auth (`packages/auth`)
+   - OIDC-Flows, Session-Store, auth HTTP-Handler
+5. SDK (`packages/sdk`)
+   - Logger, Context-Propagation, OTEL-Bootstrap
+6. Monitoring Client (`packages/monitoring-client`)
+   - OTEL SDK Setup, Exporter, Log-Redaction-Processor
+7. Data (`packages/data`)
+   - einfacher HTTP DataClient mit In-Memory Cache
+8. Plugin Example (`packages/plugin-example`)
+   - Beispielroute fuer Plugin-Erweiterbarkeit
 
-### Abhängigkeiten (vereinfacht)
+### Abhaengigkeiten (vereinfacht)
 
-- `apps/sva-studio-react` -> `@sva/core`, `@sva/plugin-example`
-- `@sva/data` -> `@sva/core`
-- `@sva/sdk` -> `@sva/core`
-- `@sva/plugin-example` -> `@sva/core`
+- App -> `@sva/core`, `@sva/routing`, `@sva/auth`, `@sva/plugin-example`
+- `@sva/routing` -> `@sva/auth`, `@sva/core`
+- `@sva/auth` -> `@sva/sdk`
+- `@sva/sdk` -> `@sva/core`, `@sva/monitoring-client`
+- `@sva/monitoring-client` -> OTEL Libraries, `@sva/sdk` Context API
 
 ### Boundary Core vs. Framework Binding
 
 - Framework-agnostisch:
-  - `packages/core`, `packages/data`, `packages/sdk`
+  - `packages/core`, Teile von `packages/data`, SDK Context APIs
 - Framework-/Runtime-gebunden:
-  - `apps/sva-studio-react`, `packages/plugin-example` (React Router Route-Definitionen)
+  - `apps/sva-studio-react`, TanStack-Route-Definitionen, Auth-Handler fuer Start
 
 Referenzen:
 
-- `apps/sva-studio-react/src/router.tsx`
 - `packages/core/src/routing/registry.ts`
-- `packages/data/src/index.ts`
-- `packages/plugin-example/src/routes.tsx`
+- `packages/routing/src/index.ts`
+- `packages/auth/src/index.server.ts`
+- `packages/sdk/src/server.ts`

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -8,44 +8,52 @@ Dieser Abschnitt beschreibt kritische Laufzeitszenarien und Interaktionen.
 
 - Mindestens 3 kritische End-to-End-Szenarien
 - Sequenz der beteiligten Bausteine pro Szenario
-- Fehler- und Ausnahmeverhalten für kritische Flows
+- Fehler- und Ausnahmeverhalten fuer kritische Flows
 
 ## Aktueller Stand
 
 ### Szenario 1: App-Start + Route-Komposition
 
-1. App lädt `getRouter()` in `apps/sva-studio-react/src/router.tsx`
-2. Core- und Plugin-Route-Factories werden zusammengeführt
-3. `buildRouteTree(...)` erzeugt den Runtime-RouteTree
-4. Router wird mit RouteTree und Kontext erstellt
+1. App laedt `getRouter()` in `apps/sva-studio-react/src/router.tsx`
+2. Core-Route-Factories werden client- oder serverseitig geladen
+3. Plugin-Route-Factories werden mit Core-Factories gemerged
+4. `buildRouteTree(...)` erzeugt Runtime-RouteTree
+5. Router wird mit RouteTree und SSR-Kontext erstellt
 
 Fehlerpfad:
 
-- Fehlerhafte Route-Factory oder falscher Import kann Build/Runtime brechen.
+- Fehlerhafte Route-Factory oder server-only Import im Client kann Build/Runtime brechen.
 
-### Szenario 2: Plugin-Route-Navigation
+### Szenario 2: OIDC Login-Flow
 
-1. Eine Plugin-Route wird in `packages/plugin-example/src/routes.tsx` definiert
-2. Die Route-Factory wird beim Router-Build registriert
-3. Navigation auf `/plugins/example` rendert die Plugin-Komponente
-
-Fehlerpfad:
-
-- Bei fehlerhafter Factory-Signatur wird die Route nicht korrekt gebaut.
-
-### Szenario 3: Server Function innerhalb der App
-
-1. Client triggert eine Aktion in einer Demo-Route
-2. `createServerFn` verarbeitet den Request serverseitig
-3. Ergebnis wird an den Client zurückgegeben und in der UI gerendert
+1. Browser ruft `/auth/login` auf
+2. `loginHandler()` erstellt PKCE-LoginState, setzt signiertes State-Cookie und redirectet zum IdP
+3. IdP redirectet nach `/auth/callback?code=...&state=...`
+4. `callbackHandler()` validiert State, tauscht Code gegen Tokens und erstellt Redis-Session
+5. Session-Cookie wird gesetzt, Redirect zur App
+6. App ruft `/auth/me` fuer User-Kontext
 
 Fehlerpfad:
 
-- Ungültige Eingaben liefern einen Fallback-Wert statt Hard-Fail.
+- Fehlender/abgelaufener State -> Redirect mit Fehlerstatus
+- Token-/Refresh-Fehler -> Session invalidiert oder unauthorized Antwort
+
+### Szenario 3: Logging/Observability bei Server-Requests
+
+1. Server-Code loggt via `createSdkLogger(...)`
+2. Context (workspace/request) wird ueber AsyncLocalStorage injiziert
+3. Direct OTEL Transport emittiert LogRecords an globalen LoggerProvider
+4. OTEL Processor redacted und filtert Labels
+5. Export via OTLP an Collector -> Loki/Prometheus
+
+Fehlerpfad:
+
+- OTEL nicht initialisiert: Console-Fallback bleibt aktiv
+- fehlender LoggerProvider: OTEL-Emission no-op, App bleibt lauffaehig
 
 Referenzen:
 
 - `apps/sva-studio-react/src/router.tsx`
-- `apps/sva-studio-react/src/routes/-core-routes.tsx`
-- `packages/core/src/routing/registry.ts`
-- `packages/plugin-example/src/routes.tsx`
+- `packages/auth/src/routes.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -8,37 +8,44 @@ Laufzeitknoten auf Basis des aktuellen Repos.
 ## Mindestinhalte
 
 - Deployment-Topologie (lokal, CI, staging, production)
-- Abhängigkeiten zu externen Diensten
+- Abhaengigkeiten zu externen Diensten (z. B. Redis, OTEL, Loki)
 - Sicherheits- und Betriebsaspekte je Umgebung
 
 ## Aktueller Stand
 
 ### Lokale Entwicklungsverteilung
 
-- App: `pnpm nx run sva-studio-react:serve` auf `localhost:3000`
-- Workspace-Pakete werden über `workspace:*` aufgelöst
-- Es gibt aktuell keine verbindlichen Compose-Manifeste für Runtime-Services in diesem Branch
-
-### CI-Verteilung
-
-- Pull Requests: Coverage und Integration laufen über GitHub Actions
-- Coverage auf PRs wird mit `nx affected` gegen den Base-Branch berechnet
-- Main/Schedule fuehren die komplette Coverage-Suite aus
+- App: `nx run sva-studio-react:serve` auf `localhost:3000`
+- Redis: `docker-compose.yml` (`6379`, optional TLS `6380`)
+- Monitoring Stack: `docker-compose.monitoring.yml`
+  - Collector: `4317`, `4318`, `13133`
+  - Loki: `3100`
+  - Prometheus: `9090`
+  - Grafana: `3001`
+  - Promtail: `3101`
+  - Alertmanager: `9093`
 
 ### Deployment-Bausteine (logisch)
 
 - Web-App Runtime (TanStack Start / Node)
-- Nx-/pnpm-basierte Build- und Test-Pipeline
-- Externe Plattform (GitHub Actions) für CI-Ausführung
+- Redis Session Store
+- OTEL Collector als Telemetrie-Hub
+- Loki/Prometheus als Storage, Grafana fuer Auswertung
+
+### Sicherheits-/Betriebsaspekte
+
+- Monitoring-Ports in Compose explizit auf `127.0.0.1` gebunden
+- Redis TLS-Unterstuetzung vorhanden, in local Dev optional
+- Healthchecks fuer zentrale Monitoring-Services konfiguriert
+- Graceful OTEL Shutdown im SDK vorgesehen
 
 ### Noch offen (Stand heute)
 
-- Produktions-Topologie (z. B. K8s vs. VM) ist nicht repo-verbindlich dokumentiert
-- Betriebsdokumentation für produktive Infrastruktur ist als Folgeschritt vorgesehen
+- Produktions-Topologie (z. B. K8s vs. VM) ist noch nicht repo-verbindlich definiert
+- HA-/Skalierungsdetails fuer produktiven Betrieb sind nur teilweise als ADR/Doku beschrieben
 
 Referenzen:
 
-- `.github/workflows/test-coverage.yml`
-- `apps/sva-studio-react/package.json`
-- `pnpm-workspace.yaml`
-- `nx.json`
+- `docker-compose.yml`
+- `docker-compose.monitoring.yml`
+- `packages/sdk/src/server/bootstrap.server.ts`

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -2,7 +2,7 @@
 
 ## Zweck
 
-Dieser Abschnitt sammelt übergreifende Konzepte, die mehrere Bausteine
+Dieser Abschnitt sammelt uebergreifende Konzepte, die mehrere Bausteine
 gleichzeitig beeinflussen.
 
 ## Mindestinhalte
@@ -15,30 +15,33 @@ gleichzeitig beeinflussen.
 
 ### Security und Privacy
 
-- Sicherheits- und Datenschutzanforderungen sind als verbindliche Entwicklungsregeln dokumentiert
-- Der Branch enthält aktuell keine produktive Auth-/Session-Implementierung im Code
-- Architektur- und Security-Reviews sind über Agenten-Templates als Governance verankert
+- OIDC Authorization Code Flow mit PKCE
+- Signiertes Login-State-Cookie (HMAC)
+- Session-Cookies: `httpOnly`, `sameSite=lax`, `secure` in Production
+- Optionale Verschluesselung von Tokens im Redis-Store via `ENCRYPTION_KEY`
+- Redaction sensibler Logfelder im SDK und im OTEL Processor
 
 ### Logging und Observability
 
-- Es existieren Architekturleitlinien in `docs/architecture/logging-architecture.md`
-- Eine produktive OTEL-Pipeline ist in diesem Branch nicht als laufende Implementierung enthalten
-- Observability wird daher als Zielbild dokumentiert, nicht als vollständiger IST-Flow
+- Einheitlicher Server-Logger ueber `@sva/sdk/server`
+- AsyncLocalStorage fuer `workspace_id`/request context
+- OTEL Pipeline fuer Logs + Metrics
+- Label-Whitelist und PII-Blockliste in OTEL/Promtail
 
 ### Fehlerbehandlung und Resilienz
 
-- `@sva/data` gibt bei HTTP-Fehlern klare Fehler zurück (`throw new Error(...)`)
-- Der DataClient nutzt einen TTL-basierten In-Memory-Cache zur Lastreduktion
-- CI-Prüfungen sichern Build-/Test-Basis regelmäßig ab
+- OTEL-Init ist fehlertolerant (App laeuft weiter ohne Telemetrie)
+- Redis-Reconnect mit Backoff und Max-Retry Logik
+- Auth-Flow mit klaren Redirect-Fehlerpfaden (`auth=error`, `auth=state-expired`)
 
 ### i18n und Accessibility
 
-- i18n- und A11y-Anforderungen sind in `DEVELOPMENT_RULES.md` und Review-Templates festgelegt
-- Vollständige technische Durchsetzung ist projektweit noch nicht abgeschlossen
+- UI-Texte sind derzeit ueberwiegend direkt im Code und noch nicht durchgaengig i18n-basiert
+- A11y wird pro Review/Template eingefordert, aber noch nicht zentral automatisiert
 
 Referenzen:
 
-- `DEVELOPMENT_RULES.md`
-- `docs/architecture/logging-architecture.md`
-- `packages/data/src/index.ts`
-- `.github/agents/templates/architecture-review.md`
+- `packages/auth/src/routes.server.ts`
+- `packages/auth/src/redis-session.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -8,8 +8,8 @@ mit Bezug auf die arc42-Abschnitte.
 ## Mindestinhalte
 
 - Liste relevanter ADRs mit Status
-- Kurzbegründung und Auswirkungen pro Entscheidung
-- Verknüpfung zu betroffenen arc42-Abschnitten
+- Kurzbegruendung und Auswirkungen pro Entscheidung
+- Verknuepfung zu betroffenen arc42-Abschnitten
 
 ## Aktueller Stand
 
@@ -18,14 +18,18 @@ mit Bezug auf die arc42-Abschnitte.
 - `ADR-001-frontend-framework-selection.md`
 - `ADR-002-plugin-architecture-pattern.md`
 - `ADR-003-design-token-architecture.md`
+- `ADR-004-monitoring-stack-loki-grafana-prometheus.md`
+- `ADR-005-observability-module-ownership.md`
+- `ADR-006-logging-pipeline-strategy.md`
+- `ADR-007-label-schema-and-pii-policy.md`
 
 ### Zuordnung zu arc42-Abschnitten
 
-- Abschnitt 04 (Lösungsstrategie): ADR-001, ADR-002, ADR-003
-- Abschnitt 05 (Bausteinsicht): ADR-001, ADR-002
-- Abschnitt 06/07 (Laufzeit/Deployment): aktuell keine dedizierte ADR im Verzeichnis
-- Abschnitt 08 (Querschnitt): ADR-003
-- Abschnitt 10/11 (Qualität/Risiken): aktuell keine dedizierte ADR im Verzeichnis
+- Abschnitt 04 (Loesungsstrategie): ADR-001, ADR-002, ADR-004
+- Abschnitt 05 (Bausteinsicht): ADR-001, ADR-002, ADR-005
+- Abschnitt 06/07 (Laufzeit/Deployment): ADR-004, ADR-006
+- Abschnitt 08 (Querschnitt): ADR-005, ADR-006, ADR-007
+- Abschnitt 10/11 (Qualitaet/Risiken): ADR-004, ADR-007
 
 ### Pflege-Regel
 
@@ -37,7 +41,5 @@ Bei Architekturentscheidungen in OpenSpec-Changes:
 
 Referenzen:
 
-- `./decisions/ADR-001-frontend-framework-selection.md`
-- `./decisions/ADR-002-plugin-architecture-pattern.md`
-- `./decisions/ADR-003-design-token-architecture.md`
+- `./decisions/README.md`
 - `openspec/AGENTS.md`

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -1,23 +1,23 @@
-# 10 Qualitätsanforderungen
+# 10 Qualitaetsanforderungen
 
 ## Zweck
 
-Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
+Dieser Abschnitt beschreibt messbare Qualitaetsziele auf aktuellem Stand.
 
 ## Mindestinhalte
 
-- Qualitätsziele (z. B. Sicherheit, Wartbarkeit, Verfügbarkeit)
+- Qualitaetsziele (z. B. Sicherheit, Wartbarkeit, Verfuegbarkeit)
 - Priorisierung und messbare Akzeptanzkriterien
 - Bezug zu Tests, Monitoring und Quality Gates
 
 ## Aktueller Stand
 
-### Priorisierte Qualitätsziele
+### Priorisierte Qualitaetsziele
 
-1. Wartbarkeit und Nachvollziehbarkeit
-2. Typsicherheit und Integrationsstabilität
-3. Reproduzierbare CI-Qualitätsprüfungen
-4. Security-/Privacy-Governance
+1. Sicherheit/Datenschutz
+2. Wartbarkeit und Nachvollziehbarkeit
+3. Beobachtbarkeit und Betrieb
+4. Typsicherheit und Integrationsstabilitaet
 
 ### Messbare Kriterien (IST)
 
@@ -32,13 +32,13 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
 - Coverage Governance:
   - Gate-Logik und Baselines in `scripts/ci/coverage-gate.ts` und `tooling/testing/*`
 
-### Observability-Qualität
+### Observability-Qualitaet
 
-- Architekturziele für Logging/Observability sind dokumentiert
-- Eine vollständige Monitoring-Implementierung ist in diesem Branch nicht enthalten
-- CI-Artefakte (`coverage-summary.json`, `lcov.info`) dienen als verifizierbare Qualitätsnachweise
+- Strukturierte Logs mit Pflichtfeldern (`component`, `environment`, `workspace_id`)
+- Label-Whitelist und PII-Redaction entlang der OTEL-Pipeline
+- Healthchecks fuer lokale Monitoring-Dienste in Compose
 
-### Aktuelle Lücken
+### Aktuelle Luecken
 
 - Nicht alle Projekte haben vollwertige Unit/Coverage-Suites (teils exempt)
 - App-Tests laufen derzeit mit `--passWithNoTests`, daher eingeschraenkte Aussagekraft
@@ -47,4 +47,4 @@ Referenzen:
 
 - `../development/testing-coverage.md`
 - `scripts/ci/coverage-gate.ts`
-- `.github/workflows/test-coverage.yml`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/11-risks-and-technical-debt.md
+++ b/docs/architecture/11-risks-and-technical-debt.md
@@ -8,7 +8,7 @@ Schulden auf IST-Basis.
 ## Mindestinhalte
 
 - Priorisierte Risiko-/Schuldenliste
-- Auswirkungen, Eintrittswahrscheinlichkeit, Gegenmaßnahmen
+- Auswirkungen, Eintrittswahrscheinlichkeit, Gegenmassnahmen
 - Verantwortliche und Zieltermine
 
 ## Aktueller Stand
@@ -18,33 +18,33 @@ Schulden auf IST-Basis.
 1. Geheimnisse in lokalen Env-Dateien
    - Impact: hoch (Credential Leak Risiko)
    - Wahrscheinlichkeit: mittel
-   - Maßnahme: Secrets rotieren, lokale Env-Dateien strikt aus VCS halten, Secret-Scan in CI
+   - Massnahme: Secrets rotieren, lokale Env-Dateien strikt aus VCS halten, Secret-Scan in CI
 
 2. Uneinheitliche Testabdeckung
-   - Impact: mittel bis hoch (Regressionen spät erkannt)
+   - Impact: mittel bis hoch (Regressionen spaet erkannt)
    - Wahrscheinlichkeit: hoch
-   - Maßnahme: Exempt-Projekte schrittweise abbauen, Coverage-Floors erhöhen
+   - Massnahme: Exempt-Projekte schrittweise abbauen, Coverage-Floors erhoehen
 
-3. Routing-Komplexität durch dualen Ansatz (file-based + code-based)
+3. Routing-Komplexitaet durch dualen Ansatz (file-based + code-based)
    - Impact: mittel (Fehlkonfiguration/Bundling-Fehler)
    - Wahrscheinlichkeit: mittel
-   - Maßnahme: klare Source-of-Truth Regeln und mehr Routing-Tests
+   - Massnahme: klare Source-of-Truth Regeln und mehr Routing-Tests
 
-4. Observability-Abhängigkeit von korrekter Initialisierung
+4. Observability-Abhaengigkeit von korrekter Initialisierung
    - Impact: mittel (blinde Flecken im Betrieb)
    - Wahrscheinlichkeit: mittel
-   - Maßnahme: robuste Startup-Checks und automatische Verifikation der OTEL-Pipeline
+   - Massnahme: robuste Startup-Checks und automatische Verifikation der OTEL-Pipeline
 
 5. Dokumentationsdrift bei schnell wandelnden Architekturteilen
    - Impact: mittel
    - Wahrscheinlichkeit: hoch
-   - Maßnahme: Doku-Agent Reviews bei Proposal/PR verpflichtend nutzen
+   - Massnahme: Doku-Agent Reviews bei Proposal/PR verpflichtend nutzen
 
 ### Technische Schulden (Auswahl)
 
 - Teilweise No-Op Testtargets in Libraries
 - Historisch gewachsene Doku mit gemischter Tiefe
-- Offene Produktionsentscheidungen für Deployment/HA
+- Offene Produktionsentscheidungen fuer Deployment/HA
 
 ### Nachverfolgung
 

--- a/docs/architecture/12-glossary.md
+++ b/docs/architecture/12-glossary.md
@@ -2,7 +2,7 @@
 
 ## Zweck
 
-Dieser Abschnitt führt einheitliche Begriffe und Abkürzungen für
+Dieser Abschnitt fuehrt einheitliche Begriffe und Abkuerzungen fuer
 Architektur und Betrieb.
 
 ## Mindestinhalte
@@ -15,13 +15,19 @@ Architektur und Betrieb.
 
 | Begriff | Definition | Bezug |
 | --- | --- | --- |
-| arc42 | Strukturrahmen für Architekturdokumentation mit 12 Abschnitten | `docs/architecture/README.md` |
-| ADR | Architecture Decision Record für nachvollziehbare Entscheidungen | `docs/architecture/decisions/` |
+| arc42 | Strukturrahmen fuer Architekturdokumentation mit 12 Abschnitten | `docs/architecture/README.md` |
+| ADR | Architecture Decision Record fuer nachvollziehbare Entscheidungen | `docs/architecture/decisions/` |
 | Kommune | Organisations-/Mandanteneinheit im Smart-Village-Kontext (fachlicher Begriff) | `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md` |
+| Mandant | Isolierter Betriebs-/Datenkontext (Tenant); wird im Code u. a. ueber `workspace_id` abgebildet | `packages/sdk/src/observability/context.server.ts` |
+| workspace_id | Identifier zur Kontext-Korrelation (z. B. Tenant/Workspace) in Logs/Telemetry | `docs/architecture/logging-architecture.md` |
 | Core Route Factory | Funktion, die aus `rootRoute` eine Route erzeugt | `packages/core/src/routing/registry.ts` |
 | Plugin Route Factory | Route-Factory aus Plugins, die mit Core-Factories gemerged wird | `packages/plugin-example/src/routes.tsx` |
-| Route Registry | Zusammenführung und Aufbau des finalen Route-Trees | `packages/core/src/routing/registry.ts` |
-| DataClient | Einfacher HTTP-Client mit In-Memory-Cache und TTL | `packages/data/src/index.ts` |
-| Server Function | Serverseitige Funktion in TanStack Start (`createServerFn`) | `apps/sva-studio-react/src/routes/-core-routes.tsx` |
-| workspace:* | pnpm-Mechanismus für interne Paketabhängigkeiten im Monorepo | `pnpm-workspace.yaml` |
-| Coverage Exempt | Projekt, das temporär nicht in Coverage-Gates eingeht | `tooling/testing/coverage-policy.json` |
+| OIDC | OpenID Connect fuer Authentifizierung gegen externen IdP | `packages/auth/src/oidc.server.ts` |
+| IdP | Identity Provider (OIDC-Provider) fuer Authentifizierung, extern betrieben | `packages/auth/src/oidc.server.ts` |
+| PKCE | Security-Mechanismus im Authorization Code Flow | `packages/auth/src/auth.server.ts` |
+| Session Cookie | HttpOnly-Cookie mit Session-ID fuer Auth-Kontext | `packages/auth/src/routes.server.ts` |
+| AsyncLocalStorage Context | Request-/Workspace-Kontext fuer Logging und Korrelation | `packages/sdk/src/observability/context.server.ts` |
+| OTEL | OpenTelemetry Standard fuer Logs/Metriken/Tracing | `packages/monitoring-client/src/otel.server.ts` |
+| OTLP | OpenTelemetry Protocol fuer Export an Collector | `packages/monitoring-client/src/otel.server.ts` |
+| Label Whitelist | erlaubte Log-Labels (`workspace_id`, `component`, `environment`, `level`) | `packages/monitoring-client/src/otel.server.ts` |
+| Coverage Exempt | Projekt, das temporaer nicht in Coverage-Gates eingeht | `tooling/testing/coverage-policy.json` |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,29 +1,29 @@
-# Architekturübersicht (arc42)
+# Architekturuebersicht (arc42)
 
-Diese Übersicht ist der verpflichtende Einstiegspunkt für Architektur- und Systemdokumentation.
+Diese Uebersicht ist der verpflichtende Einstiegspunkt fuer Architektur- und Systemdokumentation.
 Alle Architekturinformationen werden arc42-konform in den Abschnitten 1-12 gepflegt.
 
 ## Arc42-Struktur
 
 | Abschnitt | Datei | Mindestinhalte | Pflege-Trigger |
 | --- | --- | --- | --- |
-| 1. Einführung und Ziele | `./01-introduction-and-goals.md` | Systemzweck, Stakeholder, Top-3 Architekturziele | Änderung von Produktzielen, Scope oder Zielgruppen |
+| 1. Einfuehrung und Ziele | `./01-introduction-and-goals.md` | Systemzweck, Stakeholder, Top-3 Architekturziele | Aenderung von Produktzielen, Scope oder Zielgruppen |
 | 2. Randbedingungen | `./02-constraints.md` | Technische, organisatorische, regulatorische Constraints | Neue Vorgaben (Security, Compliance, Plattform, Budget) |
-| 3. Kontext und Scope | `./03-context-and-scope.md` | Systemkontext, externe Schnittstellen, fachliche Grenzen | Neue Integrationen, geänderte Verantwortungsgrenzen |
-| 4. Lösungsstrategie | `./04-solution-strategy.md` | Leitprinzipien, Architekturtreiber, strategische Entscheidungen | Neue Leitentscheidungen oder geänderte Zielarchitektur |
-| 5. Bausteinsicht | `./05-building-block-view.md` | Module/Packages, Verantwortlichkeiten, Abhängigkeiten | Neue Module, geänderte Modulgrenzen |
-| 6. Laufzeitsicht | `./06-runtime-view.md` | Wichtige Szenarien/Sequenzen, Request-Flows | Geänderte Flows, neue kritische Laufzeitszenarien |
-| 7. Verteilungssicht | `./07-deployment-view.md` | Deployment-Topologie, Umgebungen, Betriebsgrenzen | Neue Laufzeitumgebungen, Infra- oder Deployment-Änderungen |
-| 8. Querschnittliche Konzepte | `./08-cross-cutting-concepts.md` | Security, Logging, Fehlerbehandlung, i18n, A11y | Änderung cross-cutting Policies oder Patterns |
+| 3. Kontext und Scope | `./03-context-and-scope.md` | Systemkontext, externe Schnittstellen, fachliche Grenzen | Neue Integrationen, geaenderte Verantwortungsgrenzen |
+| 4. Loesungsstrategie | `./04-solution-strategy.md` | Leitprinzipien, Architekturtreiber, strategische Entscheidungen | Neue Leitentscheidungen oder geaenderte Zielarchitektur |
+| 5. Bausteinsicht | `./05-building-block-view.md` | Module/Packages, Verantwortlichkeiten, Abhaengigkeiten | Neue Module, geaenderte Modulgrenzen |
+| 6. Laufzeitsicht | `./06-runtime-view.md` | Wichtige Szenarien/Sequenzen, Request-Flows | Geaenderte Flows, neue kritische Laufzeitszenarien |
+| 7. Verteilungssicht | `./07-deployment-view.md` | Deployment-Topologie, Umgebungen, Betriebsgrenzen | Neue Laufzeitumgebungen, Infra- oder Deployment-Aenderungen |
+| 8. Querschnittliche Konzepte | `./08-cross-cutting-concepts.md` | Security, Logging, Observability, Fehlerbehandlung, i18n, A11y | Aenderung cross-cutting Policies oder Patterns |
 | 9. Architekturentscheidungen | `./09-architecture-decisions.md` | Relevante ADR-Liste, Status und Verweise | Neue/aktualisierte ADRs |
-| 10. Qualitätsanforderungen | `./10-quality-requirements.md` | Qualitätsziele, Szenarien, Metriken | Neue Qualitätsziele oder geänderte Priorisierung |
-| 11. Risiken und technische Schulden | `./11-risks-and-technical-debt.md` | Architektur-Risiken, Schulden, Gegenmaßnahmen | Neue Risiken, geänderte Risikobewertung |
-| 12. Glossar | `./12-glossary.md` | Einheitliche Begriffe, Abkürzungen, Definitionen | Neue zentrale Begriffe oder uneinheitliche Terminologie |
+| 10. Qualitaetsanforderungen | `./10-quality-requirements.md` | Qualitaetsziele, Szenarien, Metriken | Neue Qualitaetsziele oder geaenderte Priorisierung |
+| 11. Risiken und technische Schulden | `./11-risks-and-technical-debt.md` | Architektur-Risiken, Schulden, Gegenmassnahmen | Neue Risiken, geaenderte Risikobewertung |
+| 12. Glossar | `./12-glossary.md` | Einheitliche Begriffe, Abkuerzungen, Definitionen | Neue zentrale Begriffe oder uneinheitliche Terminologie |
 
 ## Pflege-Regeln
 
-- Architektur- oder Systemänderungen in PRs müssen die betroffenen arc42-Abschnitte aktualisieren oder eine begründete Abweichung dokumentieren.
-- OpenSpec-Changes mit Architekturwirkung müssen betroffene arc42-Abschnitte in `proposal.md` und `tasks.md` referenzieren.
+- Architektur- oder Systemaenderungen in PRs muessen die betroffenen arc42-Abschnitte aktualisieren oder eine begruendete Abweichung dokumentieren.
+- OpenSpec-Changes mit Architekturwirkung muessen betroffene arc42-Abschnitte in `proposal.md` und `tasks.md` referenzieren.
 - Architekturentscheidungen werden als ADR unter `./decisions/` dokumentiert und in Abschnitt 9 verlinkt.
 - Referenzen sollen konsistent und klickbar sein (Dateipfade statt Freitext).
 
@@ -31,4 +31,5 @@ Alle Architekturinformationen werden arc42-konform in den Abschnitten 1-12 gepfl
 
 - Routing: `./routing-architecture.md`
 - Logging und Observability: `./logging-architecture.md`
-- ADRs: `./decisions/ADR-001-frontend-framework-selection.md`, `./decisions/ADR-002-plugin-architecture-pattern.md`, `./decisions/ADR-003-design-token-architecture.md`
+- Session-Analyse: `./session-management-analysis.md`
+- ADRs: `./decisions/README.md`

--- a/docs/architecture/decisions/ADR-000-template.md
+++ b/docs/architecture/decisions/ADR-000-template.md
@@ -1,0 +1,56 @@
+# ADR-[Nummer]: [Kurzer Titel]
+
+**Datum:** YYYY-MM-DD
+**Status:** ✅ Accepted | ⏳ Proposed | 🟡 Superseded
+**Kontext:** [Kurzbeschreibung des Bereichs, z. B. „Monitoring & Observability“]
+**Entscheider:** [Team/Stakeholder]
+
+---
+
+## Entscheidung
+
+[Kurze, klare Aussage, was entschieden wurde.]
+
+## Kontext und Problem
+
+[Warum ist die Entscheidung nötig? Anforderungen, Constraints, Risiken, Abhängigkeiten.]
+
+## Betrachtete Optionen
+
+| Option | Kriterien | Bewertung | Kommentar |
+|---|---|---|---|
+| **Option A** | [z. B. Type Safety, Performance, Betrieb] | [z. B. 8/10] | [Kurzbegründung] |
+| Option B |  |  |  |
+| Option C |  |  |  |
+
+### Warum die gewählte Option?
+
+- ✅ [Hauptargument 1]
+- ✅ [Hauptargument 2]
+- ✅ [Hauptargument 3]
+
+## Trade-offs & Limitierungen
+
+### Pros
+- ✅ [Vorteil 1]
+- ✅ [Vorteil 2]
+
+### Cons
+- ❌ [Nachteil 1]
+- ❌ [Nachteil 2]
+
+## Implementierung / Ausblick
+
+- [ ] [Schritt 1]
+- [ ] [Schritt 2]
+- [ ] [Validierung/Erfolgskriterien]
+
+## Migration / Exit-Strategie (optional)
+
+[Wie könnte die Entscheidung rückgängig gemacht werden?]
+
+---
+
+**Links:**
+- [Relevante Doku/Specs]
+- [Weitere ADRs]

--- a/docs/architecture/decisions/ADR-004-monitoring-stack-loki-grafana-prometheus.md
+++ b/docs/architecture/decisions/ADR-004-monitoring-stack-loki-grafana-prometheus.md
@@ -1,0 +1,378 @@
+# ADR-004: Monitoring Stack – Loki, Grafana & Prometheus
+
+**Datum:** 5. Februar 2026
+**Status:** ✅ Accepted
+**Kontext:** System Monitoring, Logging & Observability für SVA Studio CMS 2.0
+**Entscheider:** SVA Studio Team
+
+---
+
+## Entscheidung
+
+Wir implementieren einen integrierten Observability Stack aus:
+- **Prometheus** für Metriken und System-KPIs
+- **Loki** für strukturierte Logs
+- **Grafana** als zentale Visualisierungs- und Alerting-Plattform
+
+---
+
+## Kontext und Problem
+
+**Architektur-Überblick:**
+- **Betrieb durch Dienstleister:** Prometheus + Loki + Grafana laufen auf Dienstleister-Infrastruktur (zentral betrieben)
+- **Kommunen erhalten vereinfachte Ansichten:** Im SVA Studio CMS gibt es Simple Dashboards/Logs, NICHT direkter Zugriff auf Grafana
+- **Strikte Multi-Tenancy:** Kommunen können ihre Daten nicht gegenseitig sehen
+
+Der Dienstleister benötigt umfassende Überwachung für:
+- **System Health:** CPU, RAM, Disk, Netzwerk, DB-Performance (alle Kommunen, zentral)
+- **Application Logging:** Strukturierte JSON-Logs mit Kontextinformationen (User-ID, Request-ID, Session-ID, Workspace-ID)
+- **Audit Trails:** Vollständige Protokollierung kritischer Aktionen (Append-Only, unveränderlich, 2 Jahre Retention)
+- **Performance Monitoring:** Response-Zeiten, Error-Rates, Cache-Hit-Rates pro Workspace
+- **Anomalie-Erkennung:** Automatische Baselines und Abweichungserkennung für Capacity Planning
+- **Alert Management:** Rule-basierte Alerts für kritische Fehler (E-Mail an Support-Team)
+- **Multi-Tenant Isolation:** Strikte Daten-Trennung zwischen Kommunen auf Label-Ebene
+- **Compliance:** DSGVO-konform (Anonymisierung, Datenschutz, Right-to-Deletion), 90 Tage Standard / bis 2 Jahre konfigurierbar
+
+**Technische Anforderungen (Dienstleister-Seite):**
+- High-Volume Log Ingestion (Millionen Events/Tag über alle Kommunen)
+- Sub-Sekunden Query Performance für Echtzeit-Dashboards (Dienstleister, Kommunen mit Caching)
+- Cost-Efficient Storage (Time-Series + Log Compression, zentrale Kostenoptimierung)
+- Sichere Isolation: Prometheus/Loki nur für Dienstleister erreichbar (nicht öffentlich)
+- Native Support für Labels/Tags zur Datenorganisation (workspace_id, tenant_id, component, etc.)
+- **Kein direkter Kommunen-Zugriff:** Grafana ist Dienstleister-Tool, Kommunen nutzen vereinfachte SVA Studio Endpoints
+
+**Kommune-Sicht (im SVA Studio CMS):**
+- REST-API für Logs/Metriken (vereinfachte Queries, keine PromQL/LogQL-Exposure)
+- Vordefinierte Dashboards (System-Health, Error-Übersicht, Nutzungsstatistiken)
+- Einfache Visualisierungen (Charts, Tables, Alerts)
+- Kein Zugriff auf andere Kommunen oder System-Metriken
+
+---
+
+## Betrachtete Optionen
+
+| Stack | Logs | Metriken | Dashboards | Type Safety | Operator-Freundlich | Cost | Bewertung |
+|---|---|---|---|---|---|---|---|
+| **Prometheus + Loki + Grafana** | ✅ Loki | ✅ Prometheus | ✅ Grafana | 9/10 | 9/10 | 10/10 | **9.3/10** ✅ |
+| ELK Stack (Elasticsearch) | ✅ (teuer) | 🟡 Metriken-Plugin | ✅ Kibana | 7/10 | 7/10 | 5/10 | 6.7/10 |
+| Datadog | ✅ All-in-One | ✅ All-in-One | ✅ All-in-One | 8/10 | 10/10 | 3/10 (SaaS) | 7/10 |
+| Splunk | ✅ (sehr teuer) | 🟡 Add-ons | ✅ Dashboards | 6/10 | 6/10 | 2/10 | 4.7/10 |
+| New Relic | ✅ All-in-One | ✅ All-in-One | ✅ All-in-One | 7/10 | 9/10 | 4/10 (SaaS) | 6.7/10 |
+
+### Warum Prometheus + Loki + Grafana?
+
+#### **1. Perfekte Komplementarität:**
+```
+Prometheus (Metriken)
+├── Time-Series DB optimiert für numerische Daten
+├── PromQL für flexible Queries und Aggregationen
+├── Built-in Alerting Rules
+└── Native Exporters für Standard-Services
+
+Loki (Logs)
+├── Log-Indexierung optimiert für Labels, nicht volltext
+├── LogQL (Prometheus-ähnlich) für konsistentes Querying
+├── Hohe Compression (Log-Daten bis 10x komprimierbar)
+└── Label-basierte Multi-Tenancy (Workspace/Kommune Isolation)
+
+Grafana (Visualization & Alerting)
+├── Unterstützt Prometheus, Loki, SQL, CloudWatch nativ
+├── Unified Dashboards (Metriken + Logs zusammen)
+├── Advanced Alerting (Multi-Channel: E-Mail, Slack, Webhook, SMS)
+└── Plugin-Ökosystem für Erweiterungen
+```
+
+#### **2. Cost-Efficiency:**
+```
+Datadog (SaaS):
+├── Logs: $0.70 pro GB/Monat → 100GB = $70/Monat
+├── Metriken: $0.05 pro Metric/Monat → 1000 Metrics = $50/Monat
+└── Total: ~$120-200/Monat für Small-Mid Setup
+
+ELK Stack (Self-Hosted):
+├── Elasticsearch (Speicher-hungrig): 16GB RAM + 500GB Storage
+├── Logstash (CPU-intensiv): 4+ CPU Cores
+├── Kibana (einfach): 2GB RAM
+└── Total: ~$400-600/Monat Infrastruktur-Kosten
+
+Prometheus + Loki + Grafana (Self-Hosted):
+├── Prometheus: 2GB RAM, 100GB Storage (komprimiert)
+├── Loki: 2GB RAM, 200GB Storage (Indexes leicht)
+├── Grafana: 512MB RAM, minimal Speicher
+└── Total: ~$100-150/Monat Infrastruktur-Kosten (75% günstiger als ELK)
+```
+
+#### **3. Developer Experience:**
+- **Konsistente Query-Sprachen:** PromQL (Metriken) und LogQL (Logs) ähnliche Syntax
+- **Native Integrations:** Winston/Pino für Logs, prom-client für Metriken
+- **Unified Dashboards:** Metriken + Logs in einem Grafana-View (Korrelation)
+
+#### **4. OpenTelemetry-Integration (Zukunftssicherheit):**
+
+**Strategie:** Applikationen nutzen **OpenTelemetry SDK** statt direkter Prometheus/Loki-Clients.
+
+**Begründung:**
+- **Vendor-Neutralität:** App-Code unabhängig vom Backend (Prometheus/Loki/Datadog/...)
+- **Standards-Compliance:** W3C Trace Context, OpenMetrics, OTLP Protocol
+- **Migration-Sicherheit:** Backend-Wechsel = Config-Änderung (2-3 Tage), nicht Code-Refactoring (3-4 Wochen)
+- **Unified Observability:** Traces + Metrics + Logs mit einem SDK, automatische Korrelation
+- **TanStack Start Kompatibilität:** OTEL SDK funktioniert mit Server Functions und Middleware
+
+**Praktischer Vorteil:**
+```
+Migration zu Datadog (falls nötig):
+├── Mit OTEL: 0 Code-Änderungen, nur OTEL Collector Config swap
+├── Ohne OTEL: 3-4 Wochen App-Code Refactoring, 2-3 Tage Downtime
+└── Fazit: OTEL reduziert Lock-in-Risiko massiv
+```
+
+#### **5. Kubernetes-Native:**
+- **Service Discovery:** Prometheus Operator + ServiceMonitors (automatische Target-Erkennung)
+- **DaemonSet Deployment:** Promtail auf jedem K8s-Node (Log-Collection)
+- **Helm Charts:** Offizielle Charts für Prometheus, Loki, Grafana (Infrastructure-as-Code)
+
+#### **6. Multi-Tenant Isolation (Dienstleister-Betrieb):**
+```
+Prometheus Labels (Metriken)
+├── workspace_id: "Kommune_A"      // MANDATORY Label
+├── environment: "production"
+├── service: "sva-studio-backend"
+└── Nur Dienstleister sieht alle Metriken
+
+Loki Labels (Logs)
+├── workspace_id: "Kommune_A"      // MANDATORY, garantiert Isolation
+├── component: "auth"
+├── level: "error"
+└── LogQL-Queries im Grafana: {workspace_id="Kommune_A"} filters strict by Dienstleister
+
+Grafana (Dienstleister-Tool)
+├── Multi-Workspace Dashboards (Dienstleister-View)
+├── Alert Rules pro Workspace (z.B. hohe Error-Rate in Kommune_A)
+├── Support-Team hat Zugriff auf alle Daten für Debugging
+└── Rollenbasiert: Admin, Operator, Viewer (kein Zugriff auf andere Workspaces)
+
+SVA Studio CMS (Kommune-View, vereinfacht)
+├── REST-Endpoint: GET /api/admin/monitoring/dashboard
+├── Rückgabe: {errorRate, avgResponseTime, activeUsers, lastErrors}
+├── Keine Rohdaten, nur aggregierte Metriken
+├── Streng isoliert: Queries intern mit workspace_id gefiltert
+└── Rate-Limiting: 1 Request/Sekunde pro Kommune (DDoS-Schutz)
+```
+
+---
+
+## Trade-offs & Limitierungen
+
+### Pros
+- ✅ **Cost-Efficient:** ~75% günstiger als ELK oder Datadog (Self-Hosted)
+- ✅ **Open Source:** Keine Vendor Lock-in, vollständige Kontrolle
+- ✅ **Highly Scalable:** Prometheus verarbeitet Millionen Metrics/Min, Loki Billionen Logs/Tag
+- ✅ **Unified Platform:** Ein Dashboard für Logs + Metriken + Alerting
+- ✅ **Developer-Friendly:** PromQL + LogQL sind konsistent, einfach zu lernen
+- ✅ **Kubernetes-Native:** Service Discovery, Helm Charts, Prometheus Operator
+- ✅ **DSGVO-Konform:** Self-Hosted, vollständige Datenkontrolle, einfache Anonymisierung
+- ✅ **Rich Ecosystem:** 1000+ Exporters, Grafana Plugins, Community Support
+
+### Cons
+- ❌ **Dienstleister-Maintenance:** Require Operations Knowledge (höhere Anforderung an Support-Team)
+- ❌ **Storage Management:** Retention-Policies müssen zentral gepflegt werden (Multi-Tenant Komplexität)
+- ❌ **Cardinality Issues:** Hohe Label-Cardinality über viele Kommunen ⇒ Storage-Explosion (z.B. User-IDs als Labels)
+- ❌ **Full-Text Search Limitation:** LogQL optimiert für Labels, nicht für komplexe Log-Suche
+- ❌ **Beta Features:** Some Loki features (wie Patterns) sind noch nicht stabilisiert
+- ❌ **HA Komplexität:** Single Prometheus/Loki = Single Point of Failure (backup strategy nötig)
+
+### Mitigationen
+```
+❌ Dienstleister-Maintenance
+└─ Mitigation: Infrastructure-as-Code (Terraform/Helm), dokumentierte Runbooks, SLA für Response-Zeit
+
+❌ Storage Management (Multi-Tenant)
+└─ Mitigation: Loki Table Manager für automatische Retention pro Workspace, Quotas pro Kommune
+   └─ z.B. Kommune_A: max 500GB Logs, 90 Tage Retention
+
+❌ Cardinality Issues
+└─ Mitigation: Strict Label Guidelines (keine User-IDs/unique values als Labels)
+   ├─ ALLOWED: workspace_id, component, level, status_code
+   └─ FORBIDDEN: user_id, session_id, email
+   └─ Cardinality Monitoring: Alert bei > 100k unique metric combinations
+
+❌ Full-Text Search
+└─ Mitigation: Für Audit-Logs Elasticsearch als optionales Backup
+   └─ Loki = primary (schnell, kosteneffizient), ES = archival (Compliance)
+
+❌ HA/Disaster Recovery
+└─ Mitigation:
+   ├─ Prometheus + Loki: 2 replicas behind Load Balancer
+   ├─ Persistent Volume mit Backup (daily, 7 Tage retention)
+   ├─ RPO (Recovery Point Objective): 1 Hour
+   ├─ RTO (Recovery Time Objective): 15 Minuten
+   └─ Test DR monatlich
+```
+
+---
+
+## Sicherheit & Compliance
+
+### Technische Komponenten
+- **Prometheus:** Metrics Collection + AlertManager
+- **Loki:** Log Aggregation + Promtail (Collector)
+- **Grafana:** Visualisierung + LDAP/SAML Auth
+- **External Monitoring:** UptimeRobot (SPOF-Überwachung)
+
+### Multi-Tenancy & Isolation
+- **Label-Enforcement:** `workspace_id` MANDATORY für alle Logs/Metriken (sonst Rejection)
+- **Zugriffskontrolle:** Prometheus/Loki nur Dienstleister-intern, Kommunen via REST-API
+- **Rate-Limiting:** 1000 logs/sec pro Workspace, 100 API-Requests/min
+
+### DSGVO-Compliance
+- **Anonymisierung:** IP-Adressen (letztes Oktett), User-Agent normalisiert
+- **Retention:** 90 Tage Standard, 2 Jahre Audit-Logs
+- **Right-to-Erasure:** Automatische Löschung auf Anfrage (30 Tage Bestätigung)
+
+## Rahmenbedingungen für Umsetzung
+
+### Label-Schema (Pflicht)
+**Erlaubte Labels** (Low Cardinality): `workspace_id`, `component`, `environment`, `status_code`, `level`
+**Verbotene Labels** (High Cardinality): `user_id`, `session_id`, `email`, `request_id`
+
+### Cardinality-Limits
+- Prometheus: Max 50k metric combinations pro Workspace
+- Loki: Max 1k label combinations pro Stream
+- Enforcement: OTEL SDK Whitelisting + Relabeling Rules
+
+### Verantwortlichkeiten
+**Dienstleister:** Stack-Betrieb (SLA 99.5%), Alert Response (< 15 Min), Backup-Tests
+**Kommunen:** Dashboard-Zugriff via CMS, Support via Ticket-System
+
+---
+
+## Skalierung & Capacity Planning
+
+### Auslegung (150 Kommunen)
+- **Prometheus:** 1.125M Metrics, 500 IOPS SSD, Cardinality-Monitoring
+- **Loki:** 5000 logs/sec (HA: 10k logs/sec), 30GB/day Storage (komprimiert)
+- **Grafana:** 50 concurrent users, 500+ Dashboards
+
+### Scale-Trigger
+- **Scale UP:** Cardinality > 80%, Loki ingestion > 7000 logs/sec, Query Latency > 2sec
+- **Scale OUT:** Latency p99 > 500ms (regionale Instanzen)
+
+---
+
+## Alerting & Verfügbarkeit
+
+### Alert-Kategorien
+- **Critical (< 5 Min):** Prometheus/Loki/Grafana Down, Cardinality-Explosion
+- **Warning (< 15 Min):** Disk > 85%, Query Latency > 2sec, Backup Failed
+- **Info:** Retention Cleanup, neue Labels erkannt
+
+### External Monitoring
+- **Tool:** UptimeRobot (oder Pingdom)
+- **Zweck:** SPOF-Überwachung (wenn interne Alerts ausfallen)
+- **Checks:** Health-Endpoints für Prometheus/Loki/Grafana alle 5 Min
+- **Action:** Email + PagerDuty bei Ausfall
+
+## High Availability
+
+### HA-Setup
+- **Prometheus:** 2 Replicas (active-active), S3 Snapshots, RPO 10min, RTO 15-30min
+- **Loki:** 2 Replicas (stateless via S3), Redis Cache, RPO 0, RTO < 5min
+- **AlertManager:** Gossip Cluster (2 Instances), 0 Alert Loss
+
+### Backup-Strategie
+- **Daily S3 Snapshots** (Prometheus TSDB)
+- **S3 Lifecycle Policies** (Loki Retention)
+- **Monatliche Restore-Tests**
+
+---
+
+## Implementierung / Roadmap
+
+### Phase 1: Foundation (Woche 1-4, nicht 1-3)
+- [ ] Prometheus Setup (HA with 2 replicas, Persistent Volumes, AlertManager)
+- [ ] Loki Setup (HA 2 replicas, S3 backend storage, Redis cache)
+- [ ] Grafana Setup + LDAP/SAML Integration + HA setup
+- [ ] Firewall-Konfiguration (nur Dienstleister-Access)
+- [ ] Backup-Strategie (daily S3 snapshots, 7 Tage retention)
+- [ ] Disaster Recovery Test (restore from backup, record RTO)
+- [ ] **UptimeRobot Setup**: Health-Check Endpoints, Email + Webhook alerts
+- [ ] **AlertManager Config**: Critical/Warning/Info rules defined
+
+### Phase 2: Application Integration (Woche 5-7, nicht 4-6)
+- [ ] Structured Logging (Winston/Pino mit workspace_id Injection)
+- [ ] Custom Metrics (API Response Times, Business Events)
+- [ ] Audit Log Pipeline (Application → Loki mit Append-Only)
+- [ ] Error Tracking (Errors → Grafana Alerts → Dienstleister-Email)
+- [ ] Retention Policies (90 Tage default, konfigurierbar pro Workspace)
+- [ ] **Label Validation**: workspace_id MANDATORY, return 400 if missing
+- [ ] **Promtail Deployment**: DaemonSet per K8s Node, local buffering
+
+### Phase 3: Kommune-Integration (Woche 8-9, nicht 7-8)
+- [ ] REST-API für Logs/Metrics (vereinfachte Queries, workspace_id enforcement)
+- [ ] SVA Studio CMS: Dashboard Integration
+- [ ] Vordefinierte Charts (Error-Rate, Response-Time, User-Count)
+- [ ] Alert-Notification im CMS (kritische Events)
+- [ ] Rate-Limiting & Security Headers (100 req/min per workspace)
+- [ ] **Data Export API**: GET /api/admin/monitoring/export (JSON, CSV)
+
+### Phase 4: DSGVO & Testing & Production Hardening (Woche 10-13, nicht 9-10)
+- [ ] Anonymization Filters (IP, User-Agent, PII)
+- [ ] Right-to-Erasure Implementation & Testing
+- [ ] DSGVO Compliance-Report Generator (monthly)
+- [ ] Load Test: 150M logs/day, 5000 logs/sec sustained, verify limits
+- [ ] HA Failover Test (each component individually + combined)
+- [ ] **Cardinality Load Test**: 150 Workspaces × 7500 Metrics = 1.125M metrics
+- [ ] **UptimeRobot Response Time**: Verify < 5sec health-checks
+- [ ] Stress Test Alerting: 1000 alerts/min, verify no loss
+- [ ] Backup & Restore Drill: Restore from S3, verify data integrity
+
+### Validierung & SLOs
+- [ ] Verfügbarkeit: 99.5% (Dienstleister-Stack), 99% (Kommune-API)
+- [ ] Query Performance: Grafana Dashboards < 2 Sekunden, CMS-API < 1 Sekunde
+- [ ] Alert Response: Kritische Alerts < 60 Sekunden, Email Versand < 120 Sekunden
+- [ ] Data Loss: RPO 1 Hour, RTO 15 Minuten
+- [ ] DSGVO Audit: Anonymisierung, Retention, Löschung funktionieren
+- [ ] Cardinality Monitoring: Kein unkontrolliertes Wachstum
+
+---
+
+## Exit-Strategie
+
+### Migration-Optionen
+**Zu ELK Stack (3 Wochen):**
+- **Trigger:** Cardinality > 1.5M oder Full-Text Search benötigt
+- **Vorteil OTEL:** Nur OTEL Collector Config ändern, kein App-Code Refactoring
+
+**Zu Datadog (2 Wochen):**
+- **Trigger:** Ops-Aufwand > 20h/Monat, Budget verfügbar
+- **Vorteil OTEL:** 0 Code-Änderungen, Parallel-Betrieb möglich
+
+### Review-Zeitplan
+- **6 Monate:** Kosten, Ops-Aufwand, Cardinality evaluieren
+- **12 Monate:** Stack-Fitness Review
+
+**Nicht zu migrierende Komponente:**
+- SVA Studio CMS API bleibt gleich (kommunen-facing API ist abstrahiert)
+- Nur Dienstleister-interne Stack austauschbar
+
+---
+
+## Validierung & SLOs (finalisiert)
+- [ ] Verfügbarkeit: 99.5% (Dienstleister-Stack), 99% (Kommune-API)
+- [ ] Query Performance: Grafana Dashboards < 2 Sekunden, CMS-API < 1 Sekunde
+- [ ] Alert Response: Kritische Alerts < 60 Sekunden, Email Versand < 120 Sekunden
+- [ ] Data Loss: RPO 1 Hour (Prometheus), RPO 0 (Loki via S3), RTO 15 Minuten
+- [ ] External Monitoring: UptimeRobot alerts within 5 minutes of outage
+- [ ] DSGVO Audit: Anonymisierung, Retention, Löschung funktionieren
+- [ ] Cardinality Limits: Max 1M metrics (150 Workspaces × 7.5k metrics), alert at 80%
+- [ ] Label Validation: 100% of logs have workspace_id, < 0.1% validation errors
+- [ ] HA Test Results: All components recover < 15 min after single/double failures
+
+---
+
+**Links:**
+- [Monitoring.md Requirements](../../../concepts/konzeption-cms-v2/02_Anforderungen/02_01_Funktional/Monitoring.md)
+- [Prometheus Documentation](https://prometheus.io/docs/)
+- [Loki Documentation](https://grafana.com/docs/loki/latest/)
+- [Grafana Documentation](https://grafana.com/docs/grafana/)
+- [ADR-001: Frontend Framework Selection](ADR-001-frontend-framework-selection.md)

--- a/docs/architecture/decisions/ADR-005-observability-module-ownership.md
+++ b/docs/architecture/decisions/ADR-005-observability-module-ownership.md
@@ -1,0 +1,86 @@
+# ADR-005: Observability Module Ownership
+
+**Datum:** 6. Februar 2026
+**Status:** ⏳ Proposed
+**Kontext:** Observability & Modulgrenzen (Core, SDK, Monitoring-Client)
+**Entscheider:** SVA Studio Team
+
+---
+
+## Entscheidung
+
+Die Observability-Implementierung wird in **drei klar getrennte Schichten** aufgeteilt:
+
+1. **packages/core/** bleibt **observability-neutral** und enthält keine OTEL-, Logger- oder Monitoring-Abhängigkeiten.
+2. **packages/sdk/** stellt **framework-agnostische Logger- und Context-Utilities** bereit (z. B. strukturierter Logger, Request-Context, PII-Redaction Hooks).
+3. **packages/monitoring-client/** bündelt die **OpenTelemetry SDK-Konfiguration**, Exporter, Collector-Endpoints und Entwicklungs-Dashboards.
+
+Damit bleibt die Kernlogik minimal und stabil, während Observability als **optional, austauschbar und erweiterbar** umgesetzt wird.
+
+---
+
+## Kontext und Problem
+
+Für den Docker-basierten Monitoring-Stack (Prometheus + Loki + Grafana + OTEL Collector) müssen **Logs, Metrics und Traces** in der Entwicklung wie in der Produktion konsistent erfasst werden. Gleichzeitig gilt:
+
+- **Core bleibt framework-agnostisch** und darf keine Infrastruktur-Details erzwingen.
+- **SDK soll app-agnostische Utilities bündeln**, damit Plugins und Apps einen gemeinsamen Logging-Standard nutzen.
+- **Monitoring-Setup ist optional** (Dev-Stack), darf also nicht zwingend alle Apps/Packages referenzieren.
+- **Dependency Hygiene** (workspace-Protokoll, geringe Transitivität) ist entscheidend für Build-Zeit und Wartbarkeit.
+
+Die Entscheidung muss sicherstellen, dass Observability **leicht aktivierbar**, aber **klar gekapselt** ist.
+
+---
+
+## Betrachtete Optionen
+
+| Option | Kriterien | Bewertung | Kommentar |
+|---|---|---|---|
+| **A: Monitoring-Client Package + SDK Logger (empfohlen)** | Saubere Modulgrenzen, optional, austauschbar | 9/10 | Klarer Ownership-Schnitt, geringe Core-Kopplung ✅ |
+| B: Alles in `core` bündeln | Minimale Package-Anzahl | 4/10 | Vermischt Domäne & Infrastruktur, schwer austauschbar |
+| C: Alles in `sdk` bündeln | Zentraler Einstiegspunkt | 6/10 | SDK wird zu schwergewichtig, OTEL-Abhängigkeiten überall |
+| D: App-spezifische Implementierung | Maximale Flexibilität | 5/10 | Inkonsistente Standards, hoher Pflegeaufwand |
+
+### Warum Option A?
+
+- ✅ **Separation of Concerns:** Core bleibt stabil, Observability bleibt optional.
+- ✅ **Austauschbarkeit:** OTEL Collector oder Backend-Wechsel erfordern keine Core-Änderung.
+- ✅ **Developer Experience:** SDK bietet konsistente Logger-API, Monitoring-Client kapselt OTEL-Setup.
+- ✅ **Build-Performance:** Keine OTEL-Abhängigkeiten in core → geringere Bundle- und Testkosten.
+
+---
+
+## Trade-offs & Limitierungen
+
+### Pros
+- ✅ Klare Verantwortlichkeiten zwischen Core, SDK und Monitoring-Client.
+- ✅ Einfache Aktivierung/Deaktivierung per Import im App-Entry.
+- ✅ Unterstützung von alternativen Backends (z. B. Datadog) ohne Core-Schnittstellenänderung.
+
+### Cons
+- ❌ Zusätzliche Packages erhöhen organisatorischen Overhead.
+- ❌ App-Teams müssen zwei Packages kennen (`sdk` + `monitoring-client`).
+- ❌ Mehrerlei Konfigurationen können Inkonsistenzen verursachen, wenn nicht dokumentiert.
+
+**Mitigation:** Gemeinsame Default-Konfiguration in `monitoring-client` und klare README-Dokumentation.
+
+---
+
+## Implementierung / Ausblick
+
+- [ ] `packages/sdk/src/logger/` erstellt einen strukturierten Logger mit PII-Redaction-Hooks.
+- [ ] `packages/monitoring-client/src/otel.ts` enthält OTEL SDK Setup (Exporter, Resource, Instrumentation).
+- [ ] `packages/monitoring-client/` enthält Dev-Dashboards und Collector-Konfiguration.
+- [ ] Apps aktivieren Observability via explizitem Import (kein implicit side-effect in Core).
+
+---
+
+## Migration / Exit-Strategie
+
+Falls ein anderer Observability-Stack genutzt wird, wird nur `monitoring-client` ausgetauscht. SDK-Logger bleibt stabil, Core bleibt unverändert.
+
+---
+
+**Links:**
+- [ADR-004: Monitoring Stack – Loki, Grafana & Prometheus](ADR-004-monitoring-stack-loki-grafana-prometheus.md)
+- [Design: Docker-basierter Monitoring Stack](../../../openspec/changes/add-docker-monitoring-dev-stack/design.md)

--- a/docs/architecture/decisions/ADR-006-logging-pipeline-strategy.md
+++ b/docs/architecture/decisions/ADR-006-logging-pipeline-strategy.md
@@ -1,0 +1,85 @@
+# ADR-006: Logging Pipeline Strategy
+
+**Datum:** 6. Februar 2026
+**Status:** ⏳ Proposed
+**Kontext:** Logging-Pipeline (OTEL vs. Logger vs. Promtail)
+**Entscheider:** SVA Studio Team
+
+---
+
+## Entscheidung
+
+Die **primäre Logging-Pipeline** läuft über **OpenTelemetry SDK → OTEL Collector → Loki**.
+
+- **App-Logs:** Strukturierte JSON-Logs im App-Code (SDK-Logger), Export via OTEL (OTLP/HTTP).
+- **Container-Logs:** **Promtail** sammelt stdout/stderr als **Fallback** (für Dienste ohne OTEL).
+- **Kein direktes Loki-SDK** in Apps; OTEL bleibt der zentrale Integrationspunkt.
+
+Damit entsteht eine **einheitliche, zukunftssichere Pipeline**, die Backend-Wechsel ermöglicht und konsistente Kontext-Korrelation erlaubt.
+
+---
+
+## Kontext und Problem
+
+Im lokalen Monitoring-Stack müssen Logs zuverlässig, konsistent und mit Kontext (workspace_id, component, level) erfasst werden. Gleichzeitig:
+
+- Es gibt **mehrere potenzielle Pipelines** (Promtail-only, direkter Loki-Client, OTEL).
+- **Multi-Tenancy** erfordert strikte Label- und PII-Regeln.
+- Die Lösung muss **Developer-freundlich** sein und **keine Hard-Lock-ins** erzeugen.
+
+Ziel ist eine Pipeline, die **Entwicklung, Tests und späteren Betrieb** konsistent unterstützt.
+
+---
+
+## Betrachtete Optionen
+
+| Option | Kriterien | Bewertung | Kommentar |
+|---|---|---|---|
+| **A: OTEL SDK → Collector → Loki (empfohlen)** | Standardisierung, Korrelation, Future-Proof | 9/10 | Einheitlicher Weg für Logs + Metrics ✅ |
+| B: Promtail-only (stdout) | Einfachheit, keine App-Änderung | 6/10 | Kein strukturiertes Context-Management |
+| C: Direkter Loki-Client in Apps | Direkter Weg | 5/10 | Starker Lock-in, geringe Flexibilität |
+| D: Logger-only (File/Console) | Minimal | 3/10 | Keine zentrale Observability, keine Dashboards |
+
+### Warum Option A?
+
+- ✅ **Standards-Compliance:** OTLP ist vendor-neutral und etabliert.
+- ✅ **Korrelation:** Logs, Metrics und Traces mit gemeinsamen Resource-Attributen.
+- ✅ **Backend-Flexibilität:** Loki kann später ersetzt werden, ohne App-Code zu ändern.
+- ✅ **Observability-Consistency:** Gleiches Setup für lokale Entwicklung und Produktion.
+
+---
+
+## Trade-offs & Limitierungen
+
+### Pros
+- ✅ Vereinheitlichte Pipeline (ein Exporter, ein Collector).
+- ✅ Bessere Korrelation zwischen Log-Events und Metriken.
+- ✅ Skalierbar: OTEL Collector als zentraler Hub.
+
+### Cons
+- ❌ Zusätzliche Komplexität (Collector + Exporter).
+- ❌ Höherer Setup-Aufwand für Entwickler.
+- ❌ Doppelpfad möglich (Promtail + OTEL) → Risiko von Duplikaten.
+
+**Mitigation:** Promtail dient nur als Fallback für nicht-OTEL-fähige Services; OTEL-Logs werden bevorzugt. Duplikate werden via Label oder Pipeline-Filter verhindert.
+
+---
+
+## Implementierung / Ausblick
+
+- [ ] SDK-Logger schreibt strukturierte JSON-Logs (timestamp, level, workspace_id, component).
+- [ ] OTEL SDK exportiert Logs per OTLP/HTTP an den Collector.
+- [ ] Promtail sammelt Container-stdout für Legacy/Third-Party Services.
+- [ ] Label-Whitelist & PII-Redaction greifen vor dem Export.
+
+---
+
+## Migration / Exit-Strategie
+
+Bei Wechsel zu z. B. Datadog oder ELK bleibt der App-Code gleich; nur der OTEL Collector und die Exporter-Konfiguration werden angepasst.
+
+---
+
+**Links:**
+- [ADR-004: Monitoring Stack – Loki, Grafana & Prometheus](ADR-004-monitoring-stack-loki-grafana-prometheus.md)
+- [Design: Docker-basierter Monitoring Stack](../../../openspec/changes/add-docker-monitoring-dev-stack/design.md)

--- a/docs/architecture/decisions/ADR-007-label-schema-and-pii-policy.md
+++ b/docs/architecture/decisions/ADR-007-label-schema-and-pii-policy.md
@@ -1,0 +1,97 @@
+# ADR-007: Label Schema & PII Policy
+
+**Datum:** 6. Februar 2026
+**Status:** ⏳ Proposed
+**Kontext:** Label-Standards, PII-Redaction & Retention
+**Entscheider:** SVA Studio Team
+
+---
+
+## Entscheidung
+
+Wir definieren ein **striktes Label-Schema** mit **Whitelist**, **PII-Redaction** und **Retention-Regeln**:
+
+**Erlaubte Labels (Low Cardinality):**
+- `workspace_id` (mandatory)
+- `component`
+- `environment`
+- `level`
+- `status_code`
+
+**Verbotene Labels (High Cardinality / PII):**
+- `user_id`, `session_id`, `email`, `request_id`, `token`, `ip`
+
+**PII Policy:**
+- PII wird **vor Export** redacted (Logger + OTEL Processor).
+- PII darf **nur im Payload** auftauchen, nie als Label.
+- E-Mail-Masking und Secret-Redaction sind verpflichtend.
+
+**Retention:**
+- **Development:** 7 Tage (lokaler Stack)
+- **Production:** 90 Tage Standard, Audit-Logs bis 2 Jahre
+
+---
+
+## Kontext und Problem
+
+Multi-Tenancy und DSGVO erfordern **strikte Trennung und Minimierung**. Labels sind indexiert und führen bei hoher Kardinalität zu Performance- und Kostenproblemen. Ohne klare Regeln drohen:
+
+- **Daten-Leaks** zwischen Workspaces
+- **Kostenexplosion** durch hohe Label-Kardinalität
+- **DSGVO-Verstöße** durch Speicherung personenbezogener Daten in Labels
+
+Die Entscheidung legt daher verbindliche Regeln fest, die **technisch durchgesetzt** werden.
+
+---
+
+## Betrachtete Optionen
+
+| Option | Kriterien | Bewertung | Kommentar |
+|---|---|---|---|
+| **A: Strikte Label-Whitelist + Redaction (empfohlen)** | Sicherheit, DSGVO, Skalierung | 9/10 | Klare Regeln, sicher und stabil ✅ |
+| B: Freies Labeling | Flexibilität | 3/10 | Hohe Kardinalität, Security-Risiko |
+| C: Partielles Labeling (Guidelines ohne Enforcement) | Einfach | 5/10 | Regelbruch schwer erkennbar |
+
+### Warum Option A?
+
+- ✅ **Sicherheit:** Keine PII in Labels → minimiertes Leak-Risiko.
+- ✅ **Performance:** Begrenzte Label-Cardinality.
+- ✅ **Compliance:** DSGVO-konform durch Redaction und Retention.
+- ✅ **Observability-Qualität:** Einheitliche Filterbarkeit nach workspace_id.
+
+---
+
+## Trade-offs & Limitierungen
+
+### Pros
+- ✅ Klare Regeln für Entwickler und Ops.
+- ✅ Skalierbarkeit durch stabile Label-Kardinalität.
+- ✅ Einfache Multi-Tenancy-Isolation.
+
+### Cons
+- ❌ Weniger Flexibilität bei Ad-hoc-Labels.
+- ❌ Zusätzlicher Implementierungsaufwand (Processor + Tests).
+
+**Mitigation:** Standardisierte Payload-Felder ermöglichen Details ohne Indexierung (z. B. `user_id` als Feld).
+
+---
+
+## Implementierung / Ausblick
+
+- [ ] Logger-Redaction-Filter für `password`, `token`, `authorization`, `api_key`, `secret`.
+- [ ] OTEL Processor mit Label-Whitelist und Drop-Policy.
+- [ ] Promtail Relabeling Rules zur Entfernung verbotener Labels.
+- [ ] Tests für Label-Validation & PII-Redaction.
+- [ ] Dokumentation des Schemas in `docs/development/monitoring-stack.md`.
+
+---
+
+## Migration / Exit-Strategie
+
+Die Policy ist stack-agnostisch und kann bei Backend-Wechsel unverändert übernommen werden. Änderungen sind versionierbar über ADR-Supersedes.
+
+---
+
+**Links:**
+- [ADR-004: Monitoring Stack – Loki, Grafana & Prometheus](ADR-004-monitoring-stack-loki-grafana-prometheus.md)
+- [Design: Docker-basierter Monitoring Stack](../../../openspec/changes/add-docker-monitoring-dev-stack/design.md)

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,336 @@
+# Architecture Decision Records (ADRs)
+
+Zentrale Dokumentation aller technischen und architektonischen Entscheidungen im SVA Studio Projekt.
+
+## Was sind ADRs?
+
+Architecture Decision Records dokumentieren **wichtige technische Entscheidungen**, die langfristige Auswirkungen auf das Projekt haben. Sie speichern:
+
+- **Kontext:** Warum musste eine Entscheidung getroffen werden?
+- **Entscheidung:** Was wurde entschieden?
+- **Begründung:** Warum diese Option?
+- **Konsequenzen:** Welche positiven und negativen Folgen hat das?
+- **Alternativen:** Welche anderen Optionen wurden erwogen?
+
+### Warum ADRs wichtig sind
+
+- 📚 **Wissenserhalt:** Neuen Team-Mitgliedern das "Warum" erklären
+- 🧠 **Kontext-Bewahrung:** In 6 Monaten erinnert sich niemand, warum React gewählt wurde
+- 🤝 **Transparenz:** Community sieht, wie Entscheidungen getroffen werden
+- 🔄 **Rückverfolgung:** Wenn etwas schiefgeht, können wir nachsehen, was übersehen wurde
+- 📋 **Governance:** Open-Source-Projekte profitieren von dokumentierten Entscheidungen
+
+---
+
+## Übersicht aller ADRs
+
+### Status-Legende
+
+| Symbol | Bedeutung |
+|---|---|
+| ✅ | Accepted – Aktuelle, gültige Entscheidung |
+| 📋 | Proposed – Unter Diskussion, Abstimmung ausstehend |
+| 🔄 | Superseded – Durch neuere ADR ersetzt |
+| ❌ | Deprecated – Nicht mehr relevant |
+
+---
+
+### ADR-Liste
+
+| # | Titel | Status | Entscheidungsdatum | Thema |
+|---|---|---|---|---|
+| 000 | ADR Template | 📋 | - | Dokumentation |
+| 001 | Frontend Framework Selection | ✅ | 2026-01-18 | Architektur |
+| 002 | Plugin Architecture Pattern | ✅ | 2026-01-18 | Architektur |
+| 003 | Design Token Architecture | ✅ | 2026-01-18 | UI/Design System |
+| 004 | Monitoring Stack – Loki, Grafana & Prometheus | ✅ | 2026-02-05 | Observability |
+| 005 | Observability Module Ownership | 📋 | 2026-02-06 | Observability |
+| 006 | Logging Pipeline Strategy | 📋 | 2026-02-06 | Observability |
+| 007 | Label Schema & PII Policy | 📋 | 2026-02-06 | Security/Observability |
+
+---
+
+## ADR-Lebenszyklus
+
+```
+Issue                PR              Merged              Review
+(Discussion)        (ADR-File)      to main             (6 Monate später)
+   │                   │               │                    │
+   v                   v               v                    v
+[Propose]──────→[Review & Draft]──→[Accept]────────→[Evaluate & Update]
+   7 Tage         3-5 Reviews       1 Merge             oder Supersede
+```
+
+### Phasen erklärt
+
+#### 1. **Proposed Phase** (Issue)
+- **Dauer:** ~7 Tage
+- **Wo:** GitHub Issue (Label: `adr`, `decision-required`)
+- **Ziel:** Team & Community einbinden
+- **Beispiel-Frage:** "Sollen wir React oder Vue verwenden?"
+
+#### 2. **Review Phase** (PR)
+- **Dauer:** 3-5 Tage
+- **Wo:** GitHub PR mit ADR-Datei (Label: `adr`)
+- **Review:** Min. 2 Approvals von Senior-Entwicklern
+- **Format:** Nutze ADR-000-template.md
+
+#### 3. **Accepted Phase**
+- **Dauer:** Unbegrenzt (bis superseded)
+- **Wo:** docs/adr/ADR-XXX.md im main-Branch
+- **Status:** Aktive Entscheidung, die Entwicklung leitet
+
+#### 4. **Evaluation Phase** (Optional)
+- **Dauer:** Nach 6-12 Monaten (regelmäßige Reviews)
+- **Frage:** "War diese Entscheidung richtig? Sollten wir sie ändern?"
+- **Outcome:** Accept (weiterhin gültig) oder Supersede (neue ADR erstellen)
+
+---
+
+## Wie erstelle ich eine ADR?
+
+### Schritt 1: Issue erstellen (Discussion)
+
+```bash
+gh issue create \
+  --title "[ADR] Entscheidung: Welches Frontend-Framework?" \
+  --label "adr,decision-required,discussion" \
+  --body "## Kontext
+Wir müssen ein Frontend-Framework wählen.
+
+## Optionen
+- React 18
+- Vue 3
+- Svelte
+
+## Diskussionspunkte
+1. Team-Erfahrung?
+2. Performance-Anforderungen?
+3. A11y-Support?
+
+## Timeline
+Abstimmung bis [Datum]"
+```
+
+**Dauer:** ~7 Tage Discussion
+
+---
+
+### Schritt 2: ADR schreiben (Draft)
+
+Erstelle Datei `docs/adr/ADR-001-frontend-framework.md`:
+
+```bash
+cp docs/adr/ADR-000-template.md docs/adr/ADR-001-frontend-framework.md
+```
+
+Editiere die Datei und fülle folgende Sektionen aus:
+- ✅ Kontext
+- ✅ Entscheidung
+- ✅ Begründung
+- ✅ Alternativen
+- ✅ Konsequenzen + Mitigationen
+- ✅ Implementierungs-Roadmap
+
+---
+
+### Schritt 3: PR erstellen (Review)
+
+```bash
+git add docs/adr/ADR-001-frontend-framework.md
+git commit -m "docs(adr): ADR-001 – Frontend Framework Entscheidung"
+git push origin feature/adr-001-frontend-framework
+gh pr create \
+  --title "docs(adr): ADR-001 – Frontend Framework auswählen" \
+  --body "Dokumentiert die Entscheidung für React 18 basierend auf Issue #XYZ Diskussion." \
+  --label "adr,documentation" \
+  --draft
+```
+
+**PR-Checkliste:**
+- [ ] Issue-Nummer verlinkt
+- [ ] Diskussions-Ergebnisse dokumentiert
+- [ ] Alternativen fair dargestellt
+- [ ] Konsequenzen realistisch
+- [ ] Min. 2 Reviews erforderlich
+
+---
+
+### Schritt 4: Merge & Accept
+
+Nach Approvals:
+
+```bash
+gh pr merge <PR-Number> --squash
+```
+
+**Update ADR-Status:** `Proposed` → `Accepted`
+
+---
+
+## Best Practices
+
+### ✅ DO
+
+- ✅ **ADR für große Entscheidungen:** Tech-Stack, Architektur, Patterns
+- ✅ **Neutral schreiben:** Alle Optionen fair bewerten
+- ✅ **Konkret sein:** Keine vagen Aussagen ("wahrscheinlich besser")
+- ✅ **Konsequenzen dokumentieren:** Positive UND Negative
+- ✅ **Regelmäßig reviewen:** Nach 6-12 Monaten überprüfen
+- ✅ **Updaten bei Änderungen:** Wenn sich etwas fundamental ändert
+
+### ❌ DON'T
+
+- ❌ **ADR statt schneller Bugs:** Nicht für jeden kleinen Fix
+- ❌ **Zu kurz:** Mindestens 300 Wörter, erklärbar ohne Vorwissen
+- ❌ **Voreingenommenheit:** Eine Option von Anfang an kritisieren
+- ❌ **"Entschieden von oben":** ADRs sind Team-Entscheidungen
+- ❌ **Vergessen:** ADRs müssen gelebt und evaluiert werden
+
+---
+
+## Konvention
+
+### Datei-Naming
+
+```
+ADR-<Nummer>-<kurzer-beschreibung>.md
+
+Beispiele:
+- ADR-001-frontend-framework.md
+- ADR-002-state-management.md
+- ADR-003-testing-framework.md
+```
+
+### Nummering
+
+- Laufende Nummern: ADR-001, ADR-002, ...
+- Nicht reusable Nummern (Lücken sind OK)
+- Neue ADR = nächste höchste Nummer
+
+### Titel-Format im GitHub Issue
+
+```
+[ADR] <Entscheidungsgegenstand>
+```
+
+Beispiele:
+- `[ADR] Frontend Framework – React vs. Vue vs. Svelte`
+- `[ADR] State Management Library auswählen`
+
+---
+
+## Integration mit Projektmanagement
+
+### Issue-Labels
+
+| Label | Bedeutung |
+|---|---|
+| `adr` | Architecture Decision Record |
+| `decision-required` | Entscheidung ausstehend |
+| `discussion` | Offene Diskussion |
+| `blocked` | Andere ADR blockiert diese |
+
+### Linking
+
+**In Issue-Body:**
+```markdown
+Abhängig von: #XYZ (ADR für Basis-Framework)
+Blockt: #ABC (ADR für State Management)
+```
+
+---
+
+## Beispiel-ADR (komplett)
+
+Siehe [ADR-001-frontend-framework.md](./ADR-001-frontend-framework.md) (wird später erstellt)
+
+---
+
+## Häufig gestellte Fragen (FAQ)
+
+### F: Wann sollte ich eine ADR erstellen?
+
+**A:** Wenn die Entscheidung:
+- Die Architektur prägt (> 6 Monate Gültigkeit)
+- Mehrere Team-Mitglieder betrifft
+- Schwer zu rückgängig zu machen ist
+- Langfristige Kosten/Nutzen hat
+
+**Nicht für:**
+- Kleine Bug-Fixes
+- Unbedeutende Library-Wahl
+- Tägliche Entwicklungs-Entscheidungen
+
+### F: Kann ich eine ADR ändern?
+
+**A:** Ja, aber:
+1. Wenn nur Klarstellung: Update direkt
+2. Wenn fundamentale Änderung: Neue ADR erstellen, alte als "Superseded" markieren
+
+Beispiel: Wenn React-Decision später zu Vue wechselt:
+```markdown
+**Status:** Superseded by ADR-006
+```
+
+### F: Wie lange sollte ich diskutieren?
+
+**A:** Standard: ~7 Tage
+- Einfache Entscheidung: 3-5 Tage
+- Komplexe Entscheidung: 2 Wochen
+- Kritische Entscheidung: 3 Wochen
+
+### F: Wer kann eine ADR schreiben?
+
+**A:** Jeder im Team! Aber:
+- Idealerweise jemand mit Kontext
+- Review von mindestens 1 Senior-Dev
+- Genehmigung durch BDFL oder Tech Lead
+
+### F: Sind ADRs bindend?
+
+**A:** **Ja, solange sie "Accepted" sind.** Sie können nicht einfach ignoriert werden. Wenn jemand ein Problem mit einer ADR hat:
+1. Diskutiert im Team
+2. Neue ADR schreiben, die alte superseded
+3. Implementierung anpassen
+
+---
+
+## Tools & Automation
+
+### ADR-Generierung
+
+Verwende das Template `ADR-000-template.md` als Basis für neue ADRs:
+
+```bash
+cp docs/adr/ADR-000-template.md docs/adr/ADR-XXX-your-decision.md
+```
+
+### Validierung (geplant)
+
+- GitHub Action zur Syntax-Validierung
+- Checklist für Merge
+- Lint-Rule für Template-Erfüllung
+
+---
+
+## Kontakt & Fragen
+
+Hast du Fragen zu ADRs?
+- **Discord:** #architecture-decisions
+- **GitHub:** Öffne Issue mit Label `adr`
+- **Docs:** Siehe [ARCHITECTURE.md](../ARCHITECTURE.md)
+
+---
+
+## Verwandte Ressourcen
+
+- [ADR GitHub Repository](https://adr.github.io/)
+- [MADR – Markdown ADR](https://adr.github.io/madr/)
+- [Architecture Decision Record (ADR) – Examples](https://github.com/joelparkerhenderson/architecture_decision_record)
+- [Documenting Architecture Decisions – Michael Nygard](http://thinkrelevant.com/blog/2011/11/15/documenting-architecture-decisions/)
+
+---
+
+**Letzte Aktualisierung:** 2026-01-08
+**Nächste Überprüfung:** 2026-07-08 (6 Monate)

--- a/docs/architecture/routing-architecture.md
+++ b/docs/architecture/routing-architecture.md
@@ -99,7 +99,7 @@ Definierte Pfade:
 
 - erstellt Routen mit `component: () => null`
 - **keine** Server-Handler
-- geeignet für clientseitige Route-Struktur/Linkbarkeit
+- geeignet fuer clientseitige Route-Struktur/Linkbarkeit
 
 #### Server-Variante (`auth.routes.server.ts`)
 
@@ -133,7 +133,7 @@ Server-Kombination:
 
 Export:
 
-- `coreRouteFactories` (serverfähige Endfassung für die App)
+- `coreRouteFactories` (serverfähige Endfassung fuer die App)
 
 ### 6) Router-Instanz (`apps/sva-studio-react/src/router.tsx`)
 
@@ -161,7 +161,7 @@ Beispiel in `packages/plugin-example/src/routes.tsx`:
 
 Damit kann jedes Plugin isoliert eigene Routen beitragen, ohne den App-Router direkt zu editieren.
 
-## Request/Response Routing für Auth
+## Request/Response Routing fuer Auth
 
 Auth-Endpunkte werden als TanStack Server Route Handler registriert und delegieren in `@sva/auth/server`:
 
@@ -186,7 +186,7 @@ Regeln:
 
 1. Server-Handler nur in `@sva/routing/server` und `.server.tsx` Pfaden verwenden.
 2. Keine server-only Imports in client-exponierten Route-Dateien.
-3. Lazy imports für Auth-Handler verhindern versehentliche Client-Bundle-Leaks.
+3. Lazy imports fuer Auth-Handler verhindern versehentliche Client-Bundle-Leaks.
 
 ## Beziehung zu `routeTree.gen.ts`
 
@@ -195,10 +195,10 @@ Regeln:
 Wichtig:
 
 - Runtime-Komposition erfolgt hier primär code-basiert via `buildRouteTree(...)`.
-- Das generierte File bleibt relevant für TanStack Start Typ-Registrierung/Integration.
+- Das generierte File bleibt relevant fuer TanStack Start Typ-Registrierung/Integration.
 - Bei refactors muss darauf geachtet werden, dass file-based und code-based Sicht konsistent bleiben.
 
-## Aktuelle Route-Sources (übersichtlich)
+## Aktuelle Route-Sources (uebersichtlich)
 
 1. File Routes:
   - `routes/__root.tsx`
@@ -210,7 +210,7 @@ Wichtig:
   - `@sva/routing`
   - `@sva/plugin-example`
 
-## Konventionen für neue Routen
+## Konventionen fuer neue Routen
 
 ### Do
 
@@ -228,7 +228,7 @@ Wichtig:
 ## Bekannte Trade-offs
 
 1. **Dualer Ansatz (file-based + code-based)** erhöht Flexibilität, aber auch Komplexität.
-2. Debug/Admin-Test-Routen können Route-Tree-Sicht erweitern, obwohl sie nicht Teil des Core-Flows sind.
+2. Debug/Admin-Test-Routen koennen Route-Tree-Sicht erweitern, obwohl sie nicht Teil des Core-Flows sind.
 3. Strikte Import-Disziplin ist entscheidend; sonst drohen Bundling-/Hydration-Probleme.
 
 ## Referenzen

--- a/docs/architecture/session-management-analysis.md
+++ b/docs/architecture/session-management-analysis.md
@@ -1,0 +1,560 @@
+# Session Management: Analyse & Handlungsempfehlung
+
+**Erstellt:** 2026-02-04
+**Status:** Vorschlag für Architekturentscheidung
+**Kontext:** [Issue zur Auth-Implementierung] & Milestone 1
+
+---
+
+## 1. Problem: Aktuelle Situation
+
+### 1.1 Ist-Zustand
+
+Die aktuelle Auth-Implementierung (`packages/auth`) nutzt **In-Memory-Session-Storage**:
+
+```typescript
+// packages/auth/src/session.ts
+const sessions = new Map<string, Session>();
+const loginStates = new Map<string, LoginState>();
+```
+
+**Probleme:**
+- ❌ Sessions gehen bei Server-Restart/HMR verloren
+- ❌ Nicht skalierbar (nur ein Prozess/Server)
+- ❌ Keine Persistenz bei Deployment/Rollouts
+- ❌ Kein Cluster-Betrieb möglich
+
+### 1.2 Symptom
+
+Nach Login-Redirect von Keycloak wird die Session initial erstellt, aber:
+1. Bei Dev-Server-Reload (HMR) ist die Map leer
+2. User sieht "Nicht eingeloggt", obwohl Cookie gesetzt wurde
+3. Callback-Flow funktioniert grundsätzlich, aber Session-Persistenz fehlt
+
+---
+
+## 2. Anforderungen aus Projektkontext
+
+### 2.1 Funktionale Anforderungen
+
+- **Multi-Mandanten-Fähigkeit**: Verschiedene Organisationen mit isolierten Sessions
+- **Skalierbarkeit**: Horizontal skalierbar (mehrere Backend-Instanzen)
+- **Performance**: Berechtigungsprüfung < 50 ms (laut Konzeption)
+- **OIDC/Keycloak-Integration**: Access Token, Refresh Token, ID Token verwalten
+- **Session-Refresh**: Automatisches Token-Refresh ohne Neuanmeldung
+
+### 2.2 Nicht-funktionale Anforderungen
+
+**Sicherheit & Compliance:**
+- DSGVO-konform (Datenminimierung, Verschlüsselung)
+- BSI-Grundschutz
+- HttpOnly, Secure, SameSite Cookies
+- Session-Timeout & Auto-Logout
+
+**Betrieb & Wartbarkeit:**
+- Open Source First (keine proprietären Cloud-Dienste zwingend)
+- Self-Hosted-Fähigkeit für Kommunen
+- Monitoring & Observability
+- Disaster Recovery & Backup
+
+**Performance:**
+- Session-Lookup < 10 ms
+- Berechtigungsprüfung < 50 ms (mit Caching)
+- Keine blockierenden Disk-I/O im Request-Path
+
+---
+
+## 3. Lösungsoptionen: Vergleich
+
+### 3.1 Option A: Cookie-basierte Sessions (verschlüsselt)
+
+**Konzept:**
+- Session-Daten vollständig im Cookie (JWE/signed)
+- Kein Server-Side-Storage nötig
+- Stateless
+
+**Vorteile:**
+- ✅ Keine externe Abhängigkeit (Redis, DB)
+- ✅ Horizontal skalierbar (stateless)
+- ✅ Einfaches Deployment
+- ✅ Schnell (keine DB-Abfrage)
+
+**Nachteile:**
+- ❌ Cookie-Größenlimit (~4 KB)
+- ❌ Sensitive Daten im Browser (verschlüsselt, aber risiko)
+- ❌ Kein serverseitiges Session-Revoke (nur über Token-Blacklist)
+- ❌ Größere Tokens bei vielen Rollen/Orgs
+
+**Bewertung:**
+Gut für **einfache Use-Cases**, aber problematisch bei:
+- Vielen Organisationszugehörigkeiten
+- Komplexen Berechtigungsstrukturen (siehe 7-Personas-System)
+- Impersonation/Support-Sessions
+
+---
+
+### 3.2 Option B: Redis Session Store
+
+**Konzept:**
+- Session-ID im Cookie
+- Session-Daten in Redis (Key-Value)
+- TTL-basierte Auto-Expiration
+
+**Vorteile:**
+- ✅ Sehr schnell (< 1 ms Latenz)
+- ✅ Horizontal skalierbar (Redis Cluster)
+- ✅ TTL/Expiration eingebaut
+- ✅ Session-Revoke möglich (DELETE key)
+- ✅ Pub/Sub für Cache-Invalidierung
+
+**Nachteile:**
+- ⚠️ Externe Abhängigkeit (Redis-Server)
+- ⚠️ Keine Persistenz bei Redis-Restart (außer RDB/AOF)
+- ⚠️ Zusätzlicher Infrastruktur-Komponente
+
+**Bewertung:**
+**Empfohlene Lösung** für Phase 1–2, weil:
+- Passt zur Konzeption (Redis bereits für Permission-Cache geplant)
+- Ausgezeichnetes Performance-Profil
+- Bewährte Technologie (express-session, connect-redis)
+
+---
+
+### 3.3 Option C: Datenbank-basierte Sessions
+
+**Konzept:**
+- Session-ID im Cookie
+- Session-Daten in Postgres-Tabelle
+- Cleanup via Cron-Job oder TTL-Extension (pg_cron)
+
+**Vorteile:**
+- ✅ Vollständige Persistenz
+- ✅ Transaktionale Konsistenz mit User-Daten
+- ✅ Einfaches Backup/Recovery
+- ✅ Audit-Trail möglich (Session-History)
+- ✅ Keine zusätzliche Infrastruktur (wenn Postgres schon da)
+
+**Nachteile:**
+- ❌ Langsamer als Redis (5–20 ms statt < 1 ms)
+- ❌ Höhere DB-Last bei vielen Sessions
+- ❌ Connection-Pool-Overhead
+
+**Bewertung:**
+Sinnvoll für **langfristige Architektur** oder wenn:
+- Keine Redis-Infrastruktur gewünscht
+- Sessions mit User-Änderungen transaktional verknüpft werden sollen
+- Maximale Daten-Persistenz erforderlich
+
+---
+
+### 3.4 Option D: Hybrid-Ansatz (Redis + DB)
+
+**Konzept:**
+- **Hot Storage**: Aktive Sessions in Redis (< 1 h)
+- **Cold Storage**: Ältere Sessions in DB (für Audit)
+- Automatisches Tiering
+
+**Vorteile:**
+- ✅ Beste Performance für aktive Sessions
+- ✅ Audit-Fähigkeit durch DB-Persistenz
+- ✅ Session-History für Compliance
+
+**Nachteile:**
+- ⚠️ Höhere Komplexität (2 Stores)
+- ⚠️ Sync-Mechanismus nötig
+
+**Bewertung:**
+Für **spätere Phasen** relevant, wenn:
+- Umfangreiches Session-Audit erforderlich
+- Langzeit-Analyse von Login-Mustern
+- Forensik/Compliance-Anforderungen steigen
+
+---
+
+## 4. Handlungsempfehlung
+
+### 4.1 Kurz- bis Mittelfrist (Milestone 1–3): **Redis Session Store**
+
+**Begründung:**
+1. **Projektkonzeption passt**: Redis bereits für Permission-Cache vorgesehen
+2. **Performance-Ziele erfüllbar**: < 50 ms Berechtigungsprüfung nur mit Caching realistisch
+3. **Skalierbarkeit**: Horizontal skalierbar, Cloud-Ready
+4. **Einfache Migration**: Von In-Memory zu Redis ist straightforward
+5. **Open Source**: Redis ist FOSS, self-hosted möglich
+
+**Umsetzungsschritte:**
+
+#### Phase 1: Redis-Integration (Milestone 1)
+```typescript
+// packages/auth/src/session.redis.ts
+import { createClient } from 'redis';
+
+const redis = createClient({
+  url: process.env.REDIS_URL || 'redis://localhost:6379'
+});
+
+export const createSession = async (session: Session) => {
+  const ttl = 60 * 60 * 24 * 7; // 7 Tage
+  await redis.setEx(
+    `session:${session.id}`,
+    ttl,
+    JSON.stringify(session)
+  );
+};
+
+export const getSession = async (sessionId: string): Promise<Session | null> => {
+  const data = await redis.get(`session:${sessionId}`);
+  return data ? JSON.parse(data) : null;
+};
+
+export const deleteSession = async (sessionId: string) => {
+  await redis.del(`session:${sessionId}`);
+};
+```
+
+#### Phase 2: Permission-Cache nutzen (Milestone 2)
+- Session-User-Permissions aus Permission-Engine cachen
+- Invalidierung via Pub/Sub
+- Shared Cache für Sessions + Permissions
+
+#### Phase 3: Cluster-Setup (Milestone 3+)
+- Redis Sentinel oder Cluster für HA
+- Session-Replikation
+- Monitoring (Redis Insights, Prometheus)
+
+---
+
+### 4.2 Langfristig (Milestone 4+): **Hybrid Redis + DB**
+
+**Wann relevant?**
+- Audit-Trail-Anforderungen steigen
+- DSGVO-Auskunftsanfragen (welche Sessions hatte User X?)
+- Forensik nach Security-Incident
+- Langzeit-Analyse von Login-Mustern
+
+**Umsetzung:**
+```typescript
+// Schreibe aktive Session in Redis + DB
+await Promise.all([
+  redis.setEx(`session:${id}`, ttl, JSON.stringify(session)),
+  db.sessions.create({ ...session, expiresAt: new Date(Date.now() + ttl * 1000) })
+]);
+
+// Cleanup alter DB-Sessions via Cron
+await db.sessions.deleteMany({
+  expiresAt: { lt: new Date() },
+  createdAt: { lt: subMonths(new Date(), 3) } // 3-Monats-Retention
+});
+```
+
+---
+
+### 4.3 Alternative für Self-Hosted ohne Redis: **DB-Only**
+
+**Falls Kommune Redis ablehnt:**
+- Postgres-Session-Store nutzen
+- Query-Optimierung (Index auf session_id + expires_at)
+- Connection-Pooling optimieren
+- Eventuell: pgBouncer für Session-Pooling
+
+**Performance-Tuning:**
+```sql
+CREATE INDEX idx_sessions_lookup ON iam.sessions(id, expires_at)
+WHERE expires_at > NOW();
+
+-- Partitionierung nach Monat für große Installationen
+CREATE TABLE iam.sessions_2026_02 PARTITION OF iam.sessions
+FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+```
+
+---
+
+## 5. Technische Spezifikation: Redis-Implementierung
+
+### 5.1 Session-Schema in Redis
+
+**Key-Pattern:**
+```
+session:{sessionId}           -> JSON Session-Objekt
+session:user:{userId}:active  -> Set von Session-IDs (für Multi-Device)
+session:state:{state}         -> Login-State (PKCE, nur 10 min TTL)
+```
+
+**Session-Objekt:**
+```typescript
+interface Session {
+  id: string;
+  user: SessionUser;
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+  expiresAt?: number;
+  createdAt: number;
+  lastActivity: number;
+  ipAddress?: string;
+  userAgent?: string;
+  // Für Impersonation/Support
+  impersonatedBy?: string;
+  originalUserId?: string;
+}
+```
+
+### 5.2 Security-Features
+
+**Encryption at Rest:**
+```typescript
+import { createCipheriv, createDecipheriv } from 'crypto';
+
+const encrypt = (data: string): string => {
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  // ... Verschlüsselung
+};
+
+await redis.setEx(
+  `session:${id}`,
+  ttl,
+  encrypt(JSON.stringify(session))
+);
+```
+
+**Session-Fixation-Schutz:**
+```typescript
+// Bei Login: Neue Session-ID generieren
+const newSessionId = randomUUID();
+await deleteSession(oldSessionId); // Alte Session löschen
+await createSession({ ...session, id: newSessionId });
+```
+
+**IP-Binding (optional):**
+```typescript
+const session = await getSession(sessionId);
+if (session.ipAddress !== request.ip) {
+  throw new Error('Session IP mismatch');
+}
+```
+
+### 5.3 Monitoring & Observability
+
+**Metriken (Prometheus):**
+- `session_create_total` (Counter)
+- `session_get_duration_seconds` (Histogram)
+- `session_active_total` (Gauge)
+- `session_expired_total` (Counter)
+
+**Health-Check:**
+```typescript
+export const healthCheck = async () => {
+  try {
+    await redis.ping();
+    return { status: 'healthy', latency: latency };
+  } catch (error) {
+    return { status: 'unhealthy', error };
+  }
+};
+```
+
+---
+
+## 6. Migrations-Pfad
+
+### 6.1 Phase 1: Redis lokal (Development)
+
+```bash
+# Docker Compose für lokale Entwicklung
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+```
+
+**Code-Änderungen:**
+1. `pnpm add redis` in `packages/auth`
+2. `session.ts` → `session.redis.ts` mit async Funktionen
+3. `auth.server.ts`: Alle Session-Calls `await`
+4. `.env.local`: `REDIS_URL=redis://localhost:6379`
+
+### 6.2 Phase 2: Staging (Redis Cloud/Managed)
+
+**Optionen:**
+- **Redis Cloud** (free tier für testing)
+- **AWS ElastiCache** (wenn AWS-Hosting)
+- **Self-Hosted** (Redis auf VM, Ansible-Playbook)
+
+**Config:**
+```env
+REDIS_URL=redis://:password@redis.staging.sva-studio.de:6379
+REDIS_TLS=true
+REDIS_CLUSTER_MODE=true
+```
+
+### 6.3 Phase 3: Production (HA-Setup)
+
+**Redis Sentinel:**
+```yaml
+services:
+  redis-master:
+    image: redis:7-alpine
+  redis-replica-1:
+    image: redis:7-alpine
+    command: redis-server --replicaof redis-master 6379
+  sentinel:
+    image: redis:7-alpine
+    command: redis-sentinel /etc/redis/sentinel.conf
+```
+
+**Client-Code:**
+```typescript
+import { createClient } from 'redis';
+
+const client = createClient({
+  socket: {
+    host: process.env.REDIS_SENTINEL_HOST,
+    port: 26379
+  },
+  sentinel: {
+    name: 'mymaster',
+    sentinelPassword: process.env.REDIS_SENTINEL_PASSWORD
+  }
+});
+```
+
+---
+
+## 7. Alternativen & Trade-offs
+
+### 7.1 Warum nicht Keycloak-Sessions direkt nutzen?
+
+**Idee:** Keycloak als einzige Session-Authority.
+
+**Contra:**
+- Keycloak-Sessions sind für SSO optimiert, nicht für App-State
+- Keine feingranularen CMS-spezifischen Session-Daten
+- Performance-Overhead (HTTP-Call zu Keycloak bei jedem Request)
+- Vendor Lock-in (schwer zu migrieren)
+
+**Fazit:** Keycloak für **Authentifizierung**, CMS für **Session-State**.
+
+---
+
+### 7.2 Warum nicht Supabase Auth?
+
+**Idee:** Supabase hat eingebautes Auth-System.
+
+**Contra:**
+- Wir nutzen bereits Keycloak (Projektanforderung)
+- Supabase Auth ist weniger flexibel für Custom-Flows
+- Keine Passkeys/FIDO2-Unterstützung (Stand 2026)
+
+**Fazit:** Supabase nur als **Datenbank**, Keycloak als **IdP**.
+
+---
+
+### 7.3 Warum nicht JWT-only (stateless)?
+
+**Idee:** Nur Access Token, kein Session-Store.
+
+**Contra:**
+- Kein Session-Revoke (Logout wirkt erst nach Token-Expiry)
+- Refresh-Token-Rotation kompliziert
+- Impersonation/Support-Sessions schwierig
+- Token-Größe bei vielen Claims (Permissions, Orgs)
+
+**Fazit:** **Hybrid-Ansatz**: Short-Lived Access Token (15 min) + Server-Side-Session für Refresh Token.
+
+---
+
+## 8. Offene Fragen & Next Steps
+
+### 8.1 Zu klären
+
+1. **Redis-Hosting-Strategie:**
+   - Managed Service (Redis Cloud, AWS) vs. Self-Hosted?
+   - Budget-Freigabe nötig?
+
+2. **Backup & Recovery:**
+   - RDB-Snapshots täglich?
+   - AOF für Point-in-Time-Recovery?
+
+3. **Monitoring-Stack:**
+   - Prometheus + Grafana bereits vorhanden?
+   - Alert-Regeln für Session-Store-Ausfälle?
+
+4. **DSGVO-Retention:**
+   - Session-Daten nach 30 Tagen löschen?
+   - Audit-Log in DB für 90 Tage behalten?
+
+### 8.2 Action Items
+
+- [ ] Redis-Setup in `docker-compose.yml` für lokale Dev
+- [ ] `packages/auth/src/session.redis.ts` implementieren
+- [ ] Integration-Tests mit Testcontainers
+- [ ] Staging-Deployment mit Redis Cloud (Free Tier)
+- [ ] Performance-Benchmarks (Session-Lookup < 10 ms)
+- [ ] Security-Review (Encryption, Session-Fixation)
+- [ ] Dokumentation für Deployment-Team
+
+---
+
+## 9. Fazit & Empfehlung
+
+**Für SVA Studio empfehle ich:**
+
+1. **Jetzt (Milestone 1):** Redis Session Store implementieren
+   - Schnell, bewährt, passt zur Architektur
+   - Minimale Infrastruktur-Änderung (Redis lokal/Docker)
+   - Basis für späteren Permission-Cache
+
+2. **Später (Milestone 3+):** Hybrid Redis + DB
+   - Für Audit-Trail & Compliance
+   - Session-History für DSGVO-Auskunft
+   - Forensik nach Security-Incidents
+
+3. **Fallback:** DB-Only für Self-Hosted ohne Redis
+   - Performance-Tuning erforderlich
+   - Aber funktional vollständig
+
+**Vorteile für Projekt:**
+- ✅ Open Source (Redis ist FOSS)
+- ✅ Self-Hosted-fähig (keine Cloud-Pflicht)
+- ✅ Skalierbar (Cluster-Mode)
+- ✅ DSGVO-konform (Data Residency)
+- ✅ BSI-konform (Verschlüsselung, Monitoring)
+- ✅ Community-Standard (express-session, connect-redis)
+
+---
+
+**Nächster Schritt:** Implementierungs-Ticket erstellen + Tech-Review im Team.
+
+---
+
+## 10. Stellungnahme (Security & Privacy)
+
+Aus Security-Sicht ist die Redis-Strategie grundsätzlich passend und skalierbar. Vor Umsetzung müssen jedoch Key-Management (KMS/Rotation), Token-Schutz im Session-Store sowie ein verbindliches Retention-/Löschkonzept festgelegt werden, um DSGVO/BSI-Anforderungen zu erfüllen.
+
+---
+
+## 11. Stellungnahme (UX & Accessibility)
+
+**Statement (UX & Accessibility Reviewer):** Die Analyse adressiert UX/A11y nur indirekt. Für die Umsetzung sollten klare Session-Timeout- und Re-Login-Flows mit barrierefreien Hinweisen (Screenreader-Text, Fokus-Management, eindeutige Fehlermeldungen) verbindlich ergänzt werden, damit Nutzer:innen nicht unerwartet aus Sitzungen fallen.
+
+---
+
+## 12. Stellungnahme (Operations & Reliability)
+
+**Statement (Operations & Reliability Reviewer):** Die Analyse benennt Redis als zentrale Betriebsabhängigkeit, aber es fehlen konkrete Runbooks, RTO/RPO‑Ziele, Backup/Restore‑Verfahren und ein belastbarer HA‑Plan (Sentinel/Cluster) inkl. Monitoring/Alerting. Für einen 24/7‑Betrieb müssen diese Punkte verbindlich festgelegt und getestet werden (insb. Failover‑Tests, Restore‑Drills, Ressourcen‑Sizing).
+
+---
+
+## 13. Stellungnahme (Interoperabilität & Daten)
+
+**Statement (Interoperability & Data Reviewer):** Die Analyse ist technisch schlüssig, adressiert aber Interoperabilität nur indirekt. Für Wechsel- und Migrationsfähigkeit fehlen klare Vorgaben zu Export/Import von Sessions/Audit-Daten, Versionierung der Auth-API sowie ein dokumentierter Deprecation‑Pfad. Ohne diese Standards ist die Exit‑Fähigkeit eingeschränkt und ein Anbieterwechsel risikobehaftet.
+
+---
+
+## 14. Stellungnahme (Architektur & FIT)
+
+**Statement (Architecture & FIT Compliance Reviewer):** Die Redis-Empfehlung ist aus Skalierungs- und API‑First‑Sicht plausibel und kompatibel mit dem Headless‑Ansatz. Für FIT‑Konformität fehlen jedoch explizite ADRs zur Abgrenzung Keycloak vs. CMS‑IAM, zum Vendor‑Lock‑in‑Risiko (Redis/Keycloak) sowie zu offenen Standards (OIDC/SAML/SCIM‑Erweiterungen). Diese Entscheidungen sollten dokumentiert werden, um Abweichungen nachvollziehbar zu machen.


### PR DESCRIPTION
## Zusammenfassung
Diese PR übernimmt die Arc42-Architekturdokumentation aus dem bisherigen Arbeitsstand in einen sauberen, auf `main` basierenden Branch.

## Enthaltene Änderungen
- Aktualisierung der Arc42-Kapitel unter `docs/architecture/01-12`
- Aktualisierung von `docs/architecture/README.md`
- Ergänzung von Architektur-Entscheidungen:
  - `ADR-004-monitoring-stack-loki-grafana-prometheus.md`
  - `ADR-005-observability-module-ownership.md`
  - `ADR-006-logging-pipeline-strategy.md`
  - `ADR-007-label-schema-and-pii-policy.md`
  - `ADR-000-template.md` und `docs/architecture/decisions/README.md`
- Ergänzung von `docs/architecture/session-management-analysis.md`
- Aktualisierung von `docs/architecture/routing-architecture.md`

## Abgrenzung
Diese PR enthält ausschließlich Arc42-/Architektur-Dokumentation und keine fachlichen Code-Änderungen.

## Nachgelagerte Aufräumarbeiten
Nach Merge soll der alte Branch `docs/arc42-setup` gelöscht/geschlossen werden.