### PR TITLE
docs(arc42): Basisstruktur der Arc42-Architekturdokumentation einführen

### DIFF
--- a/docs/architecture/01-introduction-and-goals.md
+++ b/docs/architecture/01-introduction-and-goals.md
@@ -1,69 +1,70 @@
-# 01 Einführung und Ziele
+# 01 Einfuehrung und Ziele
 
 ## Zweck
 
 SVA Studio ist eine TanStack-Start-basierte Webanwendung im Nx-Monorepo, die
-als modulares Studio für Content- und Systemfunktionen aufgebaut wird.
-Der aktuelle Repo-Stand fokussiert auf:
+als modulares Studio fuer Content- und Systemfunktionen aufgebaut wird.
+Der aktuelle Stand fokussiert auf:
 
-- Typsicheres Routing mit Core- und Plugin-Route-Factories
-- Demo-Routen mit TanStack Start Server Functions
-- Grundlagenpakete für Core, Data, SDK und Plugin-Integration
-- Monorepo-Governance für Build/Test/Qualität
+- Typsicheres Routing mit Core- und Plugin-Routen
+- OIDC-Login mit Session-Verwaltung (Redis)
+- Strukturiertes Server-Logging mit OTEL-Pipeline
+- Monorepo-Governance fuer Build/Test/Qualitaet
 
 Referenzen:
 
 - `apps/sva-studio-react/src/router.tsx`
-- `apps/sva-studio-react/src/routes/-core-routes.tsx`
-- `packages/core/src/routing/registry.ts`
-- `packages/data/src/index.ts`
+- `packages/routing/src/index.ts`
+- `packages/auth/src/routes.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
 
 ## Mindestinhalte
 
-Mindestinhalte für diesen Abschnitt:
+Mindestinhalte fuer diesen Abschnitt:
 
-- Systemkontext in 3-5 Sätzen
-- Primäre Stakeholder und deren wichtigste Bedürfnisse
-- Top-3 Architekturziele mit Priorität
+- Systemkontext in 3-5 Saetzen
+- Primaere Stakeholder und deren wichtigste Beduerfnisse
+- Top-3 Architekturziele mit Prioritaet
 
 ## Aktueller Stand
 
 ### Produkt- und Problemkontext (ohne Feature-Commitment)
 
-SVA Studio ist das technische Fundament für ein Redaktions- und Verwaltungsstudio im Smart-Village-Umfeld.
+SVA Studio ist das technische Fundament fuer ein Redaktions- und Verwaltungsstudio im Smart-Village-Umfeld.
 Der fachliche Hintergrund (Warum/wer/Rahmenbedingungen) ist im Konzept unter `concepts/konzeption-cms-v2/` beschrieben.
-Dieses Repository implementiert aktuell vor allem technische Enabler für Routing, UI-Demos und Paketstruktur.
+Dieses Repository dokumentiert und implementiert aktuell vor allem technische Enabler (Routing, Auth, Observability, Monorepo-Governance).
 
-Wichtig: Das Konzept enthält auch Roadmap-/Milestone-Inhalte; diese gelten nicht als dokumentierter Ist-Stand dieses Repos.
+Wichtig: Das Konzept enthaelt auch Roadmap-/Milestone-Inhalte; diese gelten nicht als dokumentierter Ist-Stand dieses Repos.
 
 ### Stakeholder (technisch)
 
 - Produkt-/Architektur-Team: stabile Zielarchitektur und nachvollziehbare Entscheidungen
 - Entwickler:innen: hohe Typsicherheit, klare Modulgrenzen, reproduzierbare Workflows
-- Betrieb/SRE: standardisierte Build-/Test-Pipelines
+- Betrieb/SRE: beobachtbares und betreibbares System inkl. Logging/Monitoring
 
 ### Stakeholder (fachlich / Nutzerrollen)
 
-Die folgenden Rollen stammen aus dem Konzept und dienen hier als Kontext für Architekturentscheidungen.
+Die folgenden Rollen stammen aus dem Konzept und dienen hier als Kontext fuer Architekturentscheidungen.
 Sie sind nicht als bereits umgesetzte Feature-Liste zu verstehen.
 
-- System-Administrator:innen
-- App-Manager:innen
-- Feature-Manager:innen
-- Designer:innen
-- Schnittstellen-Manager:innen
-- Redakteur:innen/Inhaltsersteller:innen
+- System-Administrator:innen: Betrieb, Sicherheit, Rollen/Rechte, Observability
+- App-Manager:innen: Konfiguration und Steuerung (aus fachlicher Sicht)
+- Feature-Manager:innen: fachliche Verantwortung fuer einzelne Inhalts-/Modulbereiche
+- Designer:innen: Corporate Design, UI-Konsistenz
+- Schnittstellen-Manager:innen: Integrationen, Datenfluesse, Fehlertransparenz
+- Redakteur:innen/Inhaltsersteller:innen: effiziente Inhaltspflege
 
 ### Top-3 Architekturziele (priorisiert)
 
-1. Typsichere, erweiterbare Routing-Architektur (Core + Plugins)
-2. Klare Paketgrenzen mit framework-agnostischer Kernlogik
-3. Nachvollziehbare Qualitäts-Governance über Nx-/CI-Workflows und Doku
+1. Typsichere, erweiterbare Modul- und Routing-Architektur (Core + Plugins)
+2. Sichere Authentifizierung und Session-Management fuer Web-Workflows
+3. Einheitliche, PII-sichere Observability ueber OTEL -> Collector -> Loki
 
 ### Systemgrenze (Kurzfassung)
 
-In diesem Repo liegen die Web-App, gemeinsame Pakete (`core`, `data`, `sdk`, `plugin-example`)
-und die Doku-/Governance-Artefakte.
-Externe Fachsysteme werden konzeptionell adressiert, sind aber nicht Teil des aktuellen Codes.
+In diesem Repo liegen Frontend, Routing-Layer, Auth-BFF-Funktionen,
+SDK/Observability sowie lokale Betriebsartefakte.
+Externe Systeme (IdP/Keycloak, ggf. weitere Backends) werden integriert, aber
+nicht in diesem Repository betrieben.
 
 Konzept-Referenz (Kontext): `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md`

--- a/docs/architecture/02-constraints.md
+++ b/docs/architecture/02-constraints.md
@@ -17,8 +17,9 @@ im IST-System direkt beeinflussen.
 
 - Node.js `>=22.12.0`, pnpm `>=9.12.2` (`package.json`)
 - Nx-Monorepo mit standardisierten Targets (`build`, `lint`, `test:unit`)
-- TanStack Start/Router für die Web-App
-- Package-Abhängigkeiten intern über `workspace:*`
+- TanStack Start/Router fuer App und Server-Routen
+- Redis als Session-Store, lokal via Docker Compose
+- OTEL-basierte Logging-/Metrikpipeline ueber Collector
 
 ### Organisatorische Randbedingungen
 
@@ -28,14 +29,13 @@ im IST-System direkt beeinflussen.
 
 ### Regulatorische/Qualitaets-Randbedingungen
 
+- PII-Schutz im Logging (Redaction + Label-Whitelist)
 - Security- und Accessibility-Regeln aus `DEVELOPMENT_RULES.md`
 - Nachweisbare Test-/Lint-/Type-Checks im Entwicklungsworkflow
-- PR-Checks für Coverage und Integration über GitHub Actions
 
 Referenzen:
 
 - `package.json`
-- `pnpm-workspace.yaml`
 - `openspec/AGENTS.md`
 - `scripts/ci/check-file-placement.mjs`
-- `.github/workflows/test-coverage.yml`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -15,39 +15,40 @@ aktuellen fachlich-technischen Scope.
 
 ### Fachlicher Kontext (nur Kontext)
 
-Im Produktkontext adressiert SVA Studio die Verwaltung strukturierter Inhalte und Konfigurationen für die Smart Village App und angrenzende Kanäle (Headless/API-first).
-Im aktuellen Repo-Ist-Stand sind primär technische Grundlagen für Routing, Demo-Flows und Paketstruktur umgesetzt.
+Im Produktkontext adressiert SVA Studio die Verwaltung strukturierter Inhalte und Konfigurationen fuer die Smart Village App und angrenzende Kanaele (Headless/API-first).
+Im aktuellen Repo-Ist-Stand sind davon primaer die technischen Grundlagen umgesetzt (Routing, Auth, Observability, lokale Betriebsartefakte).
 
 ### In Scope (IST)
 
 - Web-App `sva-studio-react` mit TanStack Start
-- Routing-Komposition über `@sva/core` und `@sva/plugin-example`
-- Demo-Server-Functions in der App (`createServerFn`)
-- Einfacher DataClient mit In-Memory-Cache in `@sva/data`
-- Architektur- und Governance-Dokumentation unter `docs/` und `openspec/`
+- Zentrales Routing (`@sva/core`, `@sva/routing`, Plugin-Routen)
+- Auth-BFF-Endpunkte (`/auth/login`, `/auth/callback`, `/auth/me`, `/auth/logout`)
+- Session-Verwaltung mit Redis (inkl. optionaler Token-Verschluesselung)
+- SDK Logger + OTEL Monitoring Client + lokale Monitoring-Stacks
 
 ### Out of Scope (in diesem Repo)
 
-- Betrieb und Quellcode eines externen IdP
-- Produktive Auth-/Session-Implementierung als stabiles Paket
-- Produktiver Monitoring-Stack (Collector/Loki/Prometheus/Grafana) im Repository
-- Vollständige Fachverfahren-Integrationen
+- Betrieb und Quellcode des externen IdP (Keycloak Realm/Server)
+- Mobile App / externe Konsumenten
+- Vollstaendige Fachverfahren-Integrationen
+- Produkt-/Fachmodule (z. B. konkrete CMS-Content-Modelle) sind im Code derzeit nicht als stabile API/Implementierung vorhanden
 
 ### Externe Nachbarsysteme
 
-- HTTP-Backends, die vom DataClient aufgerufen werden
-- Externe Plattformen für CI/CD und Code-Hosting (GitHub)
+- OIDC Provider (per `openid-client`)
+- Redis (lokal/extern)
+- OTEL Collector, Loki, Prometheus, Grafana, Alertmanager
 
 Konzept-Referenz (Kontext): `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md`
 
 ### Verantwortungsgrenzen
 
-- Repo verantwortet App-, Paket-, Build-/Test- und Doku-Logik
-- Externe Dienste werden angebunden, aber nicht in diesem Repository betrieben
+- Repo verantwortet App-, Routing-, Auth-, SDK- und Doku-Logik
+- Externe Dienste werden angebunden, aber nicht hier implementiert
 
 Referenzen:
 
-- `apps/sva-studio-react/src/router.tsx`
-- `apps/sva-studio-react/src/routes/-core-routes.tsx`
-- `packages/data/src/index.ts`
-- `.github/workflows/test-coverage.yml`
+- `packages/auth/src/oidc.server.ts`
+- `packages/auth/src/redis.server.ts`
+- `docker-compose.yml`
+- `docker-compose.monitoring.yml`

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -1,4 +1,4 @@
-# 04 Lösungsstrategie
+# 04 Loesungsstrategie
 
 ## Zweck
 
@@ -15,31 +15,34 @@ Architekturprinzipien auf IST-Basis.
 
 ### Leitprinzipien
 
-- Monorepo mit klaren Paketgrenzen und Workspace-Abhängigkeiten (`workspace:*`)
-- Framework-agnostische Kernlogik in `@sva/core`, Integration in der App-Ebene
-- Route-Komposition über Factory-Pattern (`mergeRouteFactories`, `buildRouteTree`)
+- Monorepo mit klaren Paketgrenzen und Workspace-Abhaengigkeiten (`workspace:*`)
+- Framework-agnostische Kernlogik in `@sva/core`, Integration in App-Ebene
+- Trennung von client-sicheren und serverseitigen Routen/Handlern
+- Observability ueber OTEL-Standards statt vendor-spezifischer App-Anbindung
 - Doku-getriebene Architekturpflege (arc42 + OpenSpec + ADR)
 
 ### Architekturtreiber
 
 - Hohe Typsicherheit und Wartbarkeit bei wachsender Modulanzahl
 - Erweiterbarkeit durch Plugins und zentrale Route-Registry
-- Reproduzierbarkeit über standardisierte Nx-/pnpm-Workflows
+- Betriebsfaehigkeit mit strukturierter Telemetrie
+- Security/Privacy-Anforderungen an Auth und Logging
 
 ### Zielkonflikte (aktuell sichtbar)
 
-- Hohe Flexibilität (code-based + file-based Routing) vs. Komplexität
-- Schneller Dev-Flow vs. Governance-Anforderungen in CI
-- Multi-Tooling (Nx, TanStack, pnpm) vs. Einarbeitungsaufwand
+- Hohe Flexibilitaet (code-based + file-based Routing) vs. Komplexitaet
+- Schneller Dev-Flow vs. strenge Security-/PII-Kontrollen
+- Multi-Tooling (Nx, TanStack, OTEL) vs. Einarbeitungsaufwand
 
 ### Strategische Entscheidungen (Auswahl)
 
 - Frontend-Framework: `ADR-001`
 - Plugin-Architektur: `ADR-002`
-- Design-Token-Architektur: `ADR-003`
+- Monitoring-Stack: `ADR-004`
+- Logging-Pipeline und Label-Policy: `ADR-006`, `ADR-007`
 
 Referenzen:
 
 - `./decisions/ADR-001-frontend-framework-selection.md`
 - `./decisions/ADR-002-plugin-architecture-pattern.md`
-- `./decisions/ADR-003-design-token-architecture.md`
+- `./decisions/ADR-004-monitoring-stack-loki-grafana-prometheus.md`

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -3,12 +3,12 @@
 ## Zweck
 
 Dieser Abschnitt beschreibt statische Bausteine, Verantwortlichkeiten und
-Abhängigkeiten des aktuellen Systems.
+Abhaengigkeiten des aktuellen Systems.
 
 ## Mindestinhalte
 
 - Hauptbausteine mit Verantwortung
-- Schnittstellen und Abhängigkeiten zwischen Bausteinen
+- Schnittstellen und Abhaengigkeiten zwischen Bausteinen
 - Grenzen zwischen framework-agnostischer Kernlogik und Bindings
 
 ## Aktueller Stand
@@ -18,31 +18,38 @@ Abhängigkeiten des aktuellen Systems.
 1. App (`apps/sva-studio-react`)
    - TanStack Start App, UI, Root-Shell, Router-Erzeugung
 2. Core (`packages/core`)
-   - generische Route-Registry-Utilities (`mergeRouteFactories`, `buildRouteTree`)
-3. Data (`packages/data`)
-   - einfacher HTTP DataClient mit In-Memory-Cache
-4. SDK (`packages/sdk`)
-   - gemeinsamer Einstiegspunkt für paketübergreifende Utilities
-5. Plugin Example (`packages/plugin-example`)
-   - Beispielroute für Plugin-Erweiterbarkeit
+   - generische Route-Registry Utilities (`mergeRouteFactories`, `buildRouteTree`)
+3. Routing (`packages/routing`)
+   - zentrale Route-Factories (client + server)
+4. Auth (`packages/auth`)
+   - OIDC-Flows, Session-Store, auth HTTP-Handler
+5. SDK (`packages/sdk`)
+   - Logger, Context-Propagation, OTEL-Bootstrap
+6. Monitoring Client (`packages/monitoring-client`)
+   - OTEL SDK Setup, Exporter, Log-Redaction-Processor
+7. Data (`packages/data`)
+   - einfacher HTTP DataClient mit In-Memory Cache
+8. Plugin Example (`packages/plugin-example`)
+   - Beispielroute fuer Plugin-Erweiterbarkeit
 
-### Abhängigkeiten (vereinfacht)
+### Abhaengigkeiten (vereinfacht)
 
-- `apps/sva-studio-react` -> `@sva/core`, `@sva/plugin-example`
-- `@sva/data` -> `@sva/core`
-- `@sva/sdk` -> `@sva/core`
-- `@sva/plugin-example` -> `@sva/core`
+- App -> `@sva/core`, `@sva/routing`, `@sva/auth`, `@sva/plugin-example`
+- `@sva/routing` -> `@sva/auth`, `@sva/core`
+- `@sva/auth` -> `@sva/sdk`
+- `@sva/sdk` -> `@sva/core`, `@sva/monitoring-client`
+- `@sva/monitoring-client` -> OTEL Libraries, `@sva/sdk` Context API
 
 ### Boundary Core vs. Framework Binding
 
 - Framework-agnostisch:
-  - `packages/core`, `packages/data`, `packages/sdk`
+  - `packages/core`, Teile von `packages/data`, SDK Context APIs
 - Framework-/Runtime-gebunden:
-  - `apps/sva-studio-react`, `packages/plugin-example` (React Router Route-Definitionen)
+  - `apps/sva-studio-react`, TanStack-Route-Definitionen, Auth-Handler fuer Start
 
 Referenzen:
 
-- `apps/sva-studio-react/src/router.tsx`
 - `packages/core/src/routing/registry.ts`
-- `packages/data/src/index.ts`
-- `packages/plugin-example/src/routes.tsx`
+- `packages/routing/src/index.ts`
+- `packages/auth/src/index.server.ts`
+- `packages/sdk/src/server.ts`

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -8,44 +8,52 @@ Dieser Abschnitt beschreibt kritische Laufzeitszenarien und Interaktionen.
 
 - Mindestens 3 kritische End-to-End-Szenarien
 - Sequenz der beteiligten Bausteine pro Szenario
-- Fehler- und Ausnahmeverhalten für kritische Flows
+- Fehler- und Ausnahmeverhalten fuer kritische Flows
 
 ## Aktueller Stand
 
 ### Szenario 1: App-Start + Route-Komposition
 
-1. App lädt `getRouter()` in `apps/sva-studio-react/src/router.tsx`
-2. Core- und Plugin-Route-Factories werden zusammengeführt
-3. `buildRouteTree(...)` erzeugt den Runtime-RouteTree
-4. Router wird mit RouteTree und Kontext erstellt
+1. App laedt `getRouter()` in `apps/sva-studio-react/src/router.tsx`
+2. Core-Route-Factories werden client- oder serverseitig geladen
+3. Plugin-Route-Factories werden mit Core-Factories gemerged
+4. `buildRouteTree(...)` erzeugt Runtime-RouteTree
+5. Router wird mit RouteTree und SSR-Kontext erstellt
 
 Fehlerpfad:
 
-- Fehlerhafte Route-Factory oder falscher Import kann Build/Runtime brechen.
+- Fehlerhafte Route-Factory oder server-only Import im Client kann Build/Runtime brechen.
 
-### Szenario 2: Plugin-Route-Navigation
+### Szenario 2: OIDC Login-Flow
 
-1. Eine Plugin-Route wird in `packages/plugin-example/src/routes.tsx` definiert
-2. Die Route-Factory wird beim Router-Build registriert
-3. Navigation auf `/plugins/example` rendert die Plugin-Komponente
-
-Fehlerpfad:
-
-- Bei fehlerhafter Factory-Signatur wird die Route nicht korrekt gebaut.
-
-### Szenario 3: Server Function innerhalb der App
-
-1. Client triggert eine Aktion in einer Demo-Route
-2. `createServerFn` verarbeitet den Request serverseitig
-3. Ergebnis wird an den Client zurückgegeben und in der UI gerendert
+1. Browser ruft `/auth/login` auf
+2. `loginHandler()` erstellt PKCE-LoginState, setzt signiertes State-Cookie und redirectet zum IdP
+3. IdP redirectet nach `/auth/callback?code=...&state=...`
+4. `callbackHandler()` validiert State, tauscht Code gegen Tokens und erstellt Redis-Session
+5. Session-Cookie wird gesetzt, Redirect zur App
+6. App ruft `/auth/me` fuer User-Kontext
 
 Fehlerpfad:
 
-- Ungültige Eingaben liefern einen Fallback-Wert statt Hard-Fail.
+- Fehlender/abgelaufener State -> Redirect mit Fehlerstatus
+- Token-/Refresh-Fehler -> Session invalidiert oder unauthorized Antwort
+
+### Szenario 3: Logging/Observability bei Server-Requests
+
+1. Server-Code loggt via `createSdkLogger(...)`
+2. Context (workspace/request) wird ueber AsyncLocalStorage injiziert
+3. Direct OTEL Transport emittiert LogRecords an globalen LoggerProvider
+4. OTEL Processor redacted und filtert Labels
+5. Export via OTLP an Collector -> Loki/Prometheus
+
+Fehlerpfad:
+
+- OTEL nicht initialisiert: Console-Fallback bleibt aktiv
+- fehlender LoggerProvider: OTEL-Emission no-op, App bleibt lauffaehig
 
 Referenzen:
 
 - `apps/sva-studio-react/src/router.tsx`
-- `apps/sva-studio-react/src/routes/-core-routes.tsx`
-- `packages/core/src/routing/registry.ts`
-- `packages/plugin-example/src/routes.tsx`
+- `packages/auth/src/routes.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -8,37 +8,44 @@ Laufzeitknoten auf Basis des aktuellen Repos.
 ## Mindestinhalte
 
 - Deployment-Topologie (lokal, CI, staging, production)
-- Abhängigkeiten zu externen Diensten
+- Abhaengigkeiten zu externen Diensten (z. B. Redis, OTEL, Loki)
 - Sicherheits- und Betriebsaspekte je Umgebung
 
 ## Aktueller Stand
 
 ### Lokale Entwicklungsverteilung
 
-- App: `pnpm nx run sva-studio-react:serve` auf `localhost:3000`
-- Workspace-Pakete werden über `workspace:*` aufgelöst
-- Es gibt aktuell keine verbindlichen Compose-Manifeste für Runtime-Services in diesem Branch
-
-### CI-Verteilung
-
-- Pull Requests: Coverage und Integration laufen über GitHub Actions
-- Coverage auf PRs wird mit `nx affected` gegen den Base-Branch berechnet
-- Main/Schedule fuehren die komplette Coverage-Suite aus
+- App: `nx run sva-studio-react:serve` auf `localhost:3000`
+- Redis: `docker-compose.yml` (`6379`, optional TLS `6380`)
+- Monitoring Stack: `docker-compose.monitoring.yml`
+  - Collector: `4317`, `4318`, `13133`
+  - Loki: `3100`
+  - Prometheus: `9090`
+  - Grafana: `3001`
+  - Promtail: `3101`
+  - Alertmanager: `9093`
 
 ### Deployment-Bausteine (logisch)
 
 - Web-App Runtime (TanStack Start / Node)
-- Nx-/pnpm-basierte Build- und Test-Pipeline
-- Externe Plattform (GitHub Actions) für CI-Ausführung
+- Redis Session Store
+- OTEL Collector als Telemetrie-Hub
+- Loki/Prometheus als Storage, Grafana fuer Auswertung
+
+### Sicherheits-/Betriebsaspekte
+
+- Monitoring-Ports in Compose explizit auf `127.0.0.1` gebunden
+- Redis TLS-Unterstuetzung vorhanden, in local Dev optional
+- Healthchecks fuer zentrale Monitoring-Services konfiguriert
+- Graceful OTEL Shutdown im SDK vorgesehen
 
 ### Noch offen (Stand heute)
 
-- Produktions-Topologie (z. B. K8s vs. VM) ist nicht repo-verbindlich dokumentiert
-- Betriebsdokumentation für produktive Infrastruktur ist als Folgeschritt vorgesehen
+- Produktions-Topologie (z. B. K8s vs. VM) ist noch nicht repo-verbindlich definiert
+- HA-/Skalierungsdetails fuer produktiven Betrieb sind nur teilweise als ADR/Doku beschrieben
 
 Referenzen:
 
-- `.github/workflows/test-coverage.yml`
-- `apps/sva-studio-react/package.json`
-- `pnpm-workspace.yaml`
-- `nx.json`
+- `docker-compose.yml`
+- `docker-compose.monitoring.yml`
+- `packages/sdk/src/server/bootstrap.server.ts`

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -2,7 +2,7 @@
 
 ## Zweck
 
-Dieser Abschnitt sammelt übergreifende Konzepte, die mehrere Bausteine
+Dieser Abschnitt sammelt uebergreifende Konzepte, die mehrere Bausteine
 gleichzeitig beeinflussen.
 
 ## Mindestinhalte
@@ -15,30 +15,33 @@ gleichzeitig beeinflussen.
 
 ### Security und Privacy
 
-- Sicherheits- und Datenschutzanforderungen sind als verbindliche Entwicklungsregeln dokumentiert
-- Der Branch enthält aktuell keine produktive Auth-/Session-Implementierung im Code
-- Architektur- und Security-Reviews sind über Agenten-Templates als Governance verankert
+- OIDC Authorization Code Flow mit PKCE
+- Signiertes Login-State-Cookie (HMAC)
+- Session-Cookies: `httpOnly`, `sameSite=lax`, `secure` in Production
+- Optionale Verschluesselung von Tokens im Redis-Store via `ENCRYPTION_KEY`
+- Redaction sensibler Logfelder im SDK und im OTEL Processor
 
 ### Logging und Observability
 
-- Es existieren Architekturleitlinien in `docs/architecture/logging-architecture.md`
-- Eine produktive OTEL-Pipeline ist in diesem Branch nicht als laufende Implementierung enthalten
-- Observability wird daher als Zielbild dokumentiert, nicht als vollständiger IST-Flow
+- Einheitlicher Server-Logger ueber `@sva/sdk/server`
+- AsyncLocalStorage fuer `workspace_id`/request context
+- OTEL Pipeline fuer Logs + Metrics
+- Label-Whitelist und PII-Blockliste in OTEL/Promtail
 
 ### Fehlerbehandlung und Resilienz
 
-- `@sva/data` gibt bei HTTP-Fehlern klare Fehler zurück (`throw new Error(...)`)
-- Der DataClient nutzt einen TTL-basierten In-Memory-Cache zur Lastreduktion
-- CI-Prüfungen sichern Build-/Test-Basis regelmäßig ab
+- OTEL-Init ist fehlertolerant (App laeuft weiter ohne Telemetrie)
+- Redis-Reconnect mit Backoff und Max-Retry Logik
+- Auth-Flow mit klaren Redirect-Fehlerpfaden (`auth=error`, `auth=state-expired`)
 
 ### i18n und Accessibility
 
-- i18n- und A11y-Anforderungen sind in `DEVELOPMENT_RULES.md` und Review-Templates festgelegt
-- Vollständige technische Durchsetzung ist projektweit noch nicht abgeschlossen
+- UI-Texte sind derzeit ueberwiegend direkt im Code und noch nicht durchgaengig i18n-basiert
+- A11y wird pro Review/Template eingefordert, aber noch nicht zentral automatisiert
 
 Referenzen:
 
-- `DEVELOPMENT_RULES.md`
-- `docs/architecture/logging-architecture.md`
-- `packages/data/src/index.ts`
-- `.github/agents/templates/architecture-review.md`
+- `packages/auth/src/routes.server.ts`
+- `packages/auth/src/redis-session.server.ts`
+- `packages/sdk/src/logger/index.server.ts`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -8,8 +8,8 @@ mit Bezug auf die arc42-Abschnitte.
 ## Mindestinhalte
 
 - Liste relevanter ADRs mit Status
-- Kurzbegründung und Auswirkungen pro Entscheidung
-- Verknüpfung zu betroffenen arc42-Abschnitten
+- Kurzbegruendung und Auswirkungen pro Entscheidung
+- Verknuepfung zu betroffenen arc42-Abschnitten
 
 ## Aktueller Stand
 
@@ -18,14 +18,18 @@ mit Bezug auf die arc42-Abschnitte.
 - `ADR-001-frontend-framework-selection.md`
 - `ADR-002-plugin-architecture-pattern.md`
 - `ADR-003-design-token-architecture.md`
+- `ADR-004-monitoring-stack-loki-grafana-prometheus.md`
+- `ADR-005-observability-module-ownership.md`
+- `ADR-006-logging-pipeline-strategy.md`
+- `ADR-007-label-schema-and-pii-policy.md`
 
 ### Zuordnung zu arc42-Abschnitten
 
-- Abschnitt 04 (Lösungsstrategie): ADR-001, ADR-002, ADR-003
-- Abschnitt 05 (Bausteinsicht): ADR-001, ADR-002
-- Abschnitt 06/07 (Laufzeit/Deployment): aktuell keine dedizierte ADR im Verzeichnis
-- Abschnitt 08 (Querschnitt): ADR-003
-- Abschnitt 10/11 (Qualität/Risiken): aktuell keine dedizierte ADR im Verzeichnis
+- Abschnitt 04 (Loesungsstrategie): ADR-001, ADR-002, ADR-004
+- Abschnitt 05 (Bausteinsicht): ADR-001, ADR-002, ADR-005
+- Abschnitt 06/07 (Laufzeit/Deployment): ADR-004, ADR-006
+- Abschnitt 08 (Querschnitt): ADR-005, ADR-006, ADR-007
+- Abschnitt 10/11 (Qualitaet/Risiken): ADR-004, ADR-007
 
 ### Pflege-Regel
 
@@ -37,7 +41,5 @@ Bei Architekturentscheidungen in OpenSpec-Changes:
 
 Referenzen:
 
-- `./decisions/ADR-001-frontend-framework-selection.md`
-- `./decisions/ADR-002-plugin-architecture-pattern.md`
-- `./decisions/ADR-003-design-token-architecture.md`
+- `./decisions/README.md`
 - `openspec/AGENTS.md`

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -1,23 +1,23 @@
-# 10 Qualitätsanforderungen
+# 10 Qualitaetsanforderungen
 
 ## Zweck
 
-Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
+Dieser Abschnitt beschreibt messbare Qualitaetsziele auf aktuellem Stand.
 
 ## Mindestinhalte
 
-- Qualitätsziele (z. B. Sicherheit, Wartbarkeit, Verfügbarkeit)
+- Qualitaetsziele (z. B. Sicherheit, Wartbarkeit, Verfuegbarkeit)
 - Priorisierung und messbare Akzeptanzkriterien
 - Bezug zu Tests, Monitoring und Quality Gates
 
 ## Aktueller Stand
 
-### Priorisierte Qualitätsziele
+### Priorisierte Qualitaetsziele
 
-1. Wartbarkeit und Nachvollziehbarkeit
-2. Typsicherheit und Integrationsstabilität
-3. Reproduzierbare CI-Qualitätsprüfungen
-4. Security-/Privacy-Governance
+1. Sicherheit/Datenschutz
+2. Wartbarkeit und Nachvollziehbarkeit
+3. Beobachtbarkeit und Betrieb
+4. Typsicherheit und Integrationsstabilitaet
 
 ### Messbare Kriterien (IST)
 
@@ -32,13 +32,13 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
 - Coverage Governance:
   - Gate-Logik und Baselines in `scripts/ci/coverage-gate.ts` und `tooling/testing/*`
 
-### Observability-Qualität
+### Observability-Qualitaet
 
-- Architekturziele für Logging/Observability sind dokumentiert
-- Eine vollständige Monitoring-Implementierung ist in diesem Branch nicht enthalten
-- CI-Artefakte (`coverage-summary.json`, `lcov.info`) dienen als verifizierbare Qualitätsnachweise
+- Strukturierte Logs mit Pflichtfeldern (`component`, `environment`, `workspace_id`)
+- Label-Whitelist und PII-Redaction entlang der OTEL-Pipeline
+- Healthchecks fuer lokale Monitoring-Dienste in Compose
 
-### Aktuelle Lücken
+### Aktuelle Luecken
 
 - Nicht alle Projekte haben vollwertige Unit/Coverage-Suites (teils exempt)
 - App-Tests laufen derzeit mit `--passWithNoTests`, daher eingeschraenkte Aussagekraft
@@ -47,4 +47,4 @@ Referenzen:
 
 - `../development/testing-coverage.md`
 - `scripts/ci/coverage-gate.ts`
-- `.github/workflows/test-coverage.yml`
+- `packages/monitoring-client/src/otel.server.ts`

--- a/docs/architecture/11-risks-and-technical-debt.md
+++ b/docs/architecture/11-risks-and-technical-debt.md
@@ -8,7 +8,7 @@ Schulden auf IST-Basis.
 ## Mindestinhalte
 
 - Priorisierte Risiko-/Schuldenliste
-- Auswirkungen, Eintrittswahrscheinlichkeit, Gegenmaßnahmen
+- Auswirkungen, Eintrittswahrscheinlichkeit, Gegenmassnahmen
 - Verantwortliche und Zieltermine
 
 ## Aktueller Stand
@@ -18,33 +18,33 @@ Schulden auf IST-Basis.
 1. Geheimnisse in lokalen Env-Dateien
    - Impact: hoch (Credential Leak Risiko)
    - Wahrscheinlichkeit: mittel
-   - Maßnahme: Secrets rotieren, lokale Env-Dateien strikt aus VCS halten, Secret-Scan in CI
+   - Massnahme: Secrets rotieren, lokale Env-Dateien strikt aus VCS halten, Secret-Scan in CI
 
 2. Uneinheitliche Testabdeckung
-   - Impact: mittel bis hoch (Regressionen spät erkannt)
+   - Impact: mittel bis hoch (Regressionen spaet erkannt)
    - Wahrscheinlichkeit: hoch
-   - Maßnahme: Exempt-Projekte schrittweise abbauen, Coverage-Floors erhöhen
+   - Massnahme: Exempt-Projekte schrittweise abbauen, Coverage-Floors erhoehen
 
-3. Routing-Komplexität durch dualen Ansatz (file-based + code-based)
+3. Routing-Komplexitaet durch dualen Ansatz (file-based + code-based)
    - Impact: mittel (Fehlkonfiguration/Bundling-Fehler)
    - Wahrscheinlichkeit: mittel
-   - Maßnahme: klare Source-of-Truth Regeln und mehr Routing-Tests
+   - Massnahme: klare Source-of-Truth Regeln und mehr Routing-Tests
 
-4. Observability-Abhängigkeit von korrekter Initialisierung
+4. Observability-Abhaengigkeit von korrekter Initialisierung
    - Impact: mittel (blinde Flecken im Betrieb)
    - Wahrscheinlichkeit: mittel
-   - Maßnahme: robuste Startup-Checks und automatische Verifikation der OTEL-Pipeline
+   - Massnahme: robuste Startup-Checks und automatische Verifikation der OTEL-Pipeline
 
 5. Dokumentationsdrift bei schnell wandelnden Architekturteilen
    - Impact: mittel
    - Wahrscheinlichkeit: hoch
-   - Maßnahme: Doku-Agent Reviews bei Proposal/PR verpflichtend nutzen
+   - Massnahme: Doku-Agent Reviews bei Proposal/PR verpflichtend nutzen
 
 ### Technische Schulden (Auswahl)
 
 - Teilweise No-Op Testtargets in Libraries
 - Historisch gewachsene Doku mit gemischter Tiefe
-- Offene Produktionsentscheidungen für Deployment/HA
+- Offene Produktionsentscheidungen fuer Deployment/HA
 
 ### Nachverfolgung
 

--- a/docs/architecture/12-glossary.md
+++ b/docs/architecture/12-glossary.md
@@ -2,7 +2,7 @@
 
 ## Zweck
 
-Dieser Abschnitt führt einheitliche Begriffe und Abkürzungen für
+Dieser Abschnitt fuehrt einheitliche Begriffe und Abkuerzungen fuer
 Architektur und Betrieb.
 
 ## Mindestinhalte
@@ -15,13 +15,19 @@ Architektur und Betrieb.
 
 | Begriff | Definition | Bezug |
 | --- | --- | --- |
-| arc42 | Strukturrahmen für Architekturdokumentation mit 12 Abschnitten | `docs/architecture/README.md` |
-| ADR | Architecture Decision Record für nachvollziehbare Entscheidungen | `docs/architecture/decisions/` |
+| arc42 | Strukturrahmen fuer Architekturdokumentation mit 12 Abschnitten | `docs/architecture/README.md` |
+| ADR | Architecture Decision Record fuer nachvollziehbare Entscheidungen | `docs/architecture/decisions/` |
 | Kommune | Organisations-/Mandanteneinheit im Smart-Village-Kontext (fachlicher Begriff) | `concepts/konzeption-cms-v2/01_Einleitung/Einleitung.md` |
+| Mandant | Isolierter Betriebs-/Datenkontext (Tenant); wird im Code u. a. ueber `workspace_id` abgebildet | `packages/sdk/src/observability/context.server.ts` |
+| workspace_id | Identifier zur Kontext-Korrelation (z. B. Tenant/Workspace) in Logs/Telemetry | `docs/architecture/logging-architecture.md` |
 | Core Route Factory | Funktion, die aus `rootRoute` eine Route erzeugt | `packages/core/src/routing/registry.ts` |
 | Plugin Route Factory | Route-Factory aus Plugins, die mit Core-Factories gemerged wird | `packages/plugin-example/src/routes.tsx` |
-| Route Registry | Zusammenführung und Aufbau des finalen Route-Trees | `packages/core/src/routing/registry.ts` |
-| DataClient | Einfacher HTTP-Client mit In-Memory-Cache und TTL | `packages/data/src/index.ts` |
-| Server Function | Serverseitige Funktion in TanStack Start (`createServerFn`) | `apps/sva-studio-react/src/routes/-core-routes.tsx` |
-| workspace:* | pnpm-Mechanismus für interne Paketabhängigkeiten im Monorepo | `pnpm-workspace.yaml` |
-| Coverage Exempt | Projekt, das temporär nicht in Coverage-Gates eingeht | `tooling/testing/coverage-policy.json` |
+| OIDC | OpenID Connect fuer Authentifizierung gegen externen IdP | `packages/auth/src/oidc.server.ts` |
+| IdP | Identity Provider (OIDC-Provider) fuer Authentifizierung, extern betrieben | `packages/auth/src/oidc.server.ts` |
+| PKCE | Security-Mechanismus im Authorization Code Flow | `packages/auth/src/auth.server.ts` |
+| Session Cookie | HttpOnly-Cookie mit Session-ID fuer Auth-Kontext | `packages/auth/src/routes.server.ts` |
+| AsyncLocalStorage Context | Request-/Workspace-Kontext fuer Logging und Korrelation | `packages/sdk/src/observability/context.server.ts` |
+| OTEL | OpenTelemetry Standard fuer Logs/Metriken/Tracing | `packages/monitoring-client/src/otel.server.ts` |
+| OTLP | OpenTelemetry Protocol fuer Export an Collector | `packages/monitoring-client/src/otel.server.ts` |
+| Label Whitelist | erlaubte Log-Labels (`workspace_id`, `component`, `environment`, `level`) | `packages/monitoring-client/src/otel.server.ts` |
+| Coverage Exempt | Projekt, das temporaer nicht in Coverage-Gates eingeht | `tooling/testing/coverage-policy.json` |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,29 +1,29 @@
-# Architekturübersicht (arc42)
+# Architekturuebersicht (arc42)
 
-Diese Übersicht ist der verpflichtende Einstiegspunkt für Architektur- und Systemdokumentation.
+Diese Uebersicht ist der verpflichtende Einstiegspunkt fuer Architektur- und Systemdokumentation.
 Alle Architekturinformationen werden arc42-konform in den Abschnitten 1-12 gepflegt.
 
 ## Arc42-Struktur
 
 | Abschnitt | Datei | Mindestinhalte | Pflege-Trigger |
 | --- | --- | --- | --- |
-| 1. Einführung und Ziele | `./01-introduction-and-goals.md` | Systemzweck, Stakeholder, Top-3 Architekturziele | Änderung von Produktzielen, Scope oder Zielgruppen |
+| 1. Einfuehrung und Ziele | `./01-introduction-and-goals.md` | Systemzweck, Stakeholder, Top-3 Architekturziele | Aenderung von Produktzielen, Scope oder Zielgruppen |
 | 2. Randbedingungen | `./02-constraints.md` | Technische, organisatorische, regulatorische Constraints | Neue Vorgaben (Security, Compliance, Plattform, Budget) |
-| 3. Kontext und Scope | `./03-context-and-scope.md` | Systemkontext, externe Schnittstellen, fachliche Grenzen | Neue Integrationen, geänderte Verantwortungsgrenzen |
-| 4. Lösungsstrategie | `./04-solution-strategy.md` | Leitprinzipien, Architekturtreiber, strategische Entscheidungen | Neue Leitentscheidungen oder geänderte Zielarchitektur |
-| 5. Bausteinsicht | `./05-building-block-view.md` | Module/Packages, Verantwortlichkeiten, Abhängigkeiten | Neue Module, geänderte Modulgrenzen |
-| 6. Laufzeitsicht | `./06-runtime-view.md` | Wichtige Szenarien/Sequenzen, Request-Flows | Geänderte Flows, neue kritische Laufzeitszenarien |
-| 7. Verteilungssicht | `./07-deployment-view.md` | Deployment-Topologie, Umgebungen, Betriebsgrenzen | Neue Laufzeitumgebungen, Infra- oder Deployment-Änderungen |
-| 8. Querschnittliche Konzepte | `./08-cross-cutting-concepts.md` | Security, Logging, Fehlerbehandlung, i18n, A11y | Änderung cross-cutting Policies oder Patterns |
+| 3. Kontext und Scope | `./03-context-and-scope.md` | Systemkontext, externe Schnittstellen, fachliche Grenzen | Neue Integrationen, geaenderte Verantwortungsgrenzen |
+| 4. Loesungsstrategie | `./04-solution-strategy.md` | Leitprinzipien, Architekturtreiber, strategische Entscheidungen | Neue Leitentscheidungen oder geaenderte Zielarchitektur |
+| 5. Bausteinsicht | `./05-building-block-view.md` | Module/Packages, Verantwortlichkeiten, Abhaengigkeiten | Neue Module, geaenderte Modulgrenzen |
+| 6. Laufzeitsicht | `./06-runtime-view.md` | Wichtige Szenarien/Sequenzen, Request-Flows | Geaenderte Flows, neue kritische Laufzeitszenarien |
+| 7. Verteilungssicht | `./07-deployment-view.md` | Deployment-Topologie, Umgebungen, Betriebsgrenzen | Neue Laufzeitumgebungen, Infra- oder Deployment-Aenderungen |
+| 8. Querschnittliche Konzepte | `./08-cross-cutting-concepts.md` | Security, Logging, Observability, Fehlerbehandlung, i18n, A11y | Aenderung cross-cutting Policies oder Patterns |
 | 9. Architekturentscheidungen | `./09-architecture-decisions.md` | Relevante ADR-Liste, Status und Verweise | Neue/aktualisierte ADRs |
-| 10. Qualitätsanforderungen | `./10-quality-requirements.md` | Qualitätsziele, Szenarien, Metriken | Neue Qualitätsziele oder geänderte Priorisierung |
-| 11. Risiken und technische Schulden | `./11-risks-and-technical-debt.md` | Architektur-Risiken, Schulden, Gegenmaßnahmen | Neue Risiken, geänderte Risikobewertung |
-| 12. Glossar | `./12-glossary.md` | Einheitliche Begriffe, Abkürzungen, Definitionen | Neue zentrale Begriffe oder uneinheitliche Terminologie |
+| 10. Qualitaetsanforderungen | `./10-quality-requirements.md` | Qualitaetsziele, Szenarien, Metriken | Neue Qualitaetsziele oder geaenderte Priorisierung |
+| 11. Risiken und technische Schulden | `./11-risks-and-technical-debt.md` | Architektur-Risiken, Schulden, Gegenmassnahmen | Neue Risiken, geaenderte Risikobewertung |
+| 12. Glossar | `./12-glossary.md` | Einheitliche Begriffe, Abkuerzungen, Definitionen | Neue zentrale Begriffe oder uneinheitliche Terminologie |
 
 ## Pflege-Regeln
 
-- Architektur- oder Systemänderungen in PRs müssen die betroffenen arc42-Abschnitte aktualisieren oder eine begründete Abweichung dokumentieren.
-- OpenSpec-Changes mit Architekturwirkung müssen betroffene arc42-Abschnitte in `proposal.md` und `tasks.md` referenzieren.
+- Architektur- oder Systemaenderungen in PRs muessen die betroffenen arc42-Abschnitte aktualisieren oder eine begruendete Abweichung dokumentieren.
+- OpenSpec-Changes mit Architekturwirkung muessen betroffene arc42-Abschnitte in `proposal.md` und `tasks.md` referenzieren.
 - Architekturentscheidungen werden als ADR unter `./decisions/` dokumentiert und in Abschnitt 9 verlinkt.
 - Referenzen sollen konsistent und klickbar sein (Dateipfade statt Freitext).
 
@@ -31,4 +31,5 @@ Alle Architekturinformationen werden arc42-konform in den Abschnitten 1-12 gepfl
 
 - Routing: `./routing-architecture.md`
 - Logging und Observability: `./logging-architecture.md`
-- ADRs: `./decisions/ADR-001-frontend-framework-selection.md`, `./decisions/ADR-002-plugin-architecture-pattern.md`, `./decisions/ADR-003-design-token-architecture.md`
+- Session-Analyse: `./session-management-analysis.md`
+- ADRs: `./decisions/README.md`


### PR DESCRIPTION
## Ziel
Diese PR führt die Basisstruktur der Arc42-Architekturdokumentation ein.

## Umfang
- Aktualisierung der Arc42-Kapitel `docs/architecture/01-12`
- Aktualisierung von `docs/architecture/README.md`
- Inhalte sind bewusst als vorläufiger Stand gedacht und werden iterativ weiterentwickelt.

## Abgrenzung
- Keine ADR-Inhalte in dieser PR.
- ADRs werden jeweils in eigenen, separaten PRs behandelt.