### PR TITLE
docs: erzwinge IAM-Architektur-Doku-Synchronität

### DIFF
--- a/.github/agents/templates/architecture-review.md
+++ b/.github/agents/templates/architecture-review.md
@@ -32,6 +32,8 @@ Nutze dieses Template für Architektur-Reviews. Triff eine klare Entscheidung un
 - [ ] Cloud-Portabilität (kein Hard-Lock-in)
 - [ ] Skalierbarkeit/Zukunftsfähigkeit
 - [ ] Relevante arc42-Abschnitte unter `docs/architecture/` aktualisiert/verlinkt (oder Abweichung begründet)
+- [ ] Bei IAM-, Rollen-Sync-, ABAC/RBAC- oder Data-Subject-Rights-Änderungen sind Abschnitt 04, 05, 06 und 08 geprüft und konsistent
+- [ ] Neue oder geänderte IAM-Patterns haben eine ADR und einen Verweis in Abschnitt 09
 
 ## Anhänge
 - Eingesetzte Inputs: (Diagramme, ADRs, Specs)

--- a/.github/agents/templates/documentation-review.md
+++ b/.github/agents/templates/documentation-review.md
@@ -35,6 +35,9 @@ Nutze dieses Template fuer Doku-Reviews. Fokus: Aktualitaet, Konsistenz, Vollsta
 - [ ] Interne Links und Pfade sind gueltig und konsistent
 - [ ] OpenSpec-Change referenziert bei Architekturwirkung die betroffenen arc42-Abschnitte
 - [ ] Relevante arc42-Dateien unter `docs/architecture/` wurden aktualisiert/verlinkt (oder Abweichung begruendet)
+- [ ] Bei IAM-, Rollen-Sync-, ABAC/RBAC- oder Data-Subject-Rights-Aenderungen wurden Abschnitt 04, 05, 06 und 08 explizit geprueft
+- [ ] Bei sicherheitskritischer oder domaenenkritischer Logik wurde mindestens Abschnitt 05 oder 08 aktualisiert
+- [ ] Neue oder geaenderte IAM-Patterns sind per ADR dokumentiert und in Abschnitt 09 referenziert
 - [ ] Repo-File-Placement-Regeln fuer neue/verschobene Doku sind eingehalten
 - [ ] Inline-Doku in Code (Docstrings/Kommentare) ist korrekt und nicht veraltet
 

--- a/DEVELOPMENT_RULES.md
+++ b/DEVELOPMENT_RULES.md
@@ -405,6 +405,25 @@ export const AdminLayout = ({ children }: AdminLayoutProps) => {
 - Document breaking changes
 - Add migration guides when needed
 
+#### D. Architektur-Dokumentationssynchronität (arc42 / ADR)
+
+### ✅ REQUIRED
+- Architekturrelevante Änderungen im Bereich IAM, Rollen-Sync, ABAC/RBAC oder Data-Subject-Rights MÜSSEN in den betroffenen arc42-Abschnitten dokumentiert werden, insbesondere in Abschnitt 04, 05, 06 und 08.
+- Jede Änderung an sicherheitskritischer oder domänenkritischer Logik MUSS mindestens eine Aktualisierung in `docs/architecture/05-building-block-view.md` oder `docs/architecture/08-cross-cutting-concepts.md` nach sich ziehen.
+- Neue oder geänderte IAM-Patterns MÜSSEN als ADR unter `docs/adr/` dokumentiert und in `docs/architecture/09-architecture-decisions.md` referenziert werden.
+- PRs mit Architektur- oder Systemwirkung MÜSSEN im PR-Text die betroffenen arc42-Abschnitte nennen oder eine begründete Abweichung dokumentieren.
+- OpenSpec-Changes mit Architekturwirkung MÜSSEN die betroffenen arc42-Abschnitte in `proposal.md` und `tasks.md` referenzieren.
+
+### ❌ FORBIDDEN
+- Änderungen an IAM-, Rollen-, Policy- oder Data-Subject-Rights-Logik ohne passende Aktualisierung der Architektur-Doku.
+- Sicherheitskritische Logikänderungen nur im Code nachzuziehen und die Querschnitts- oder Bausteinsicht unverändert zu lassen.
+- Neue IAM-Patterns implizit im Code einzuführen, ohne ADR und ohne Referenz in Abschnitt 09.
+
+### Enforcement
+- Reviews müssen PRs ablehnen, wenn architekturrelevante Änderungen nicht in arc42 und ADRs nachvollziehbar dokumentiert sind.
+- Die PR-Checkliste unter `docs/reports/PR_CHECKLIST.md` ist für diese Nachweise verbindlich.
+- Der `documentation.agent.md` und der `architecture.agent.md` prüfen diese Synchronität explizit.
+
 ---
 
 ## 7. Branching & PR Workflow

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -49,6 +49,11 @@ Bei Architekturentscheidungen in OpenSpec-Changes:
 2. ADR erstellen/aktualisieren
 3. Entscheidung in diesem Abschnitt nachziehen
 
+Zusätzlich gilt:
+
+- Neue oder geänderte IAM-Patterns (z. B. Rollen-Sync, RBAC/ABAC-Komposition, Data-Subject-Rights-Flows) sind nicht vollständig dokumentiert, bevor sie hier in Abschnitt 09 referenziert sind.
+- Wenn IAM-Logik ohne neue ADR angepasst wird, muss im PR begründet werden, warum eine bestehende ADR weiterhin ausreichend ist.
+
 Referenzen:
 
 - `../adr/README.md`

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -26,6 +26,9 @@ Alle Architekturinformationen werden arc42-konform in den Abschnitten 1-12 gepfl
 - OpenSpec-Changes mit Architekturwirkung müssen betroffene arc42-Abschnitte in `proposal.md` und `tasks.md` referenzieren.
 - Architekturentscheidungen werden als ADR unter `../adr/` dokumentiert und in Abschnitt 9 verlinkt.
 - Referenzen sollen konsistent und klickbar sein (Dateipfade statt Freitext).
+- Änderungen in IAM, Rollen-Sync, ABAC/RBAC oder Data-Subject-Rights müssen die Abschnitte 04, 05, 06 und 08 explizit prüfen und die betroffenen Dateien aktualisieren.
+- Änderungen an sicherheitskritischer oder domänenkritischer Logik müssen mindestens Abschnitt 05 oder 08 fortschreiben; "keine Architekturwirkung" ist zu begründen.
+- Neue oder geänderte IAM-Patterns benötigen eine ADR unter `../adr/` und einen Nachtrag in `./09-architecture-decisions.md`.
 
 ## Bestehende Architekturdokumente
 

--- a/docs/development/review-agent-governance.md
+++ b/docs/development/review-agent-governance.md
@@ -10,6 +10,7 @@ Dieses Dokument beschreibt die Review-Governance für Proposal- und PR-Reviews m
 |------|-------|------------------|
 | `proposal-review-orchestrator.agent.md` | konsolidiert Proposal-Reviews | OpenSpec-Changes |
 | `pr-review-orchestrator.agent.md` | konsolidiert PR-/Code-Reviews | normale PRs und Diffs |
+| `architecture.agent.md` | Zielarchitektur, ADR-Bedarf, arc42-Fit | Architektur- und Systemänderungen |
 | `code-quality-guardian.agent.md` | Korrektheit, Typen, Architekturgrenzen | Codeänderungen |
 | `documentation.agent.md` | Doku-Abdeckung, Konsistenz, arc42 | jede PR / jedes Proposal |
 | `test-quality.agent.md` | Tests, Coverage, Verifikationsstrategie | Verhaltensänderungen, Test-/Coverage-Themen |
@@ -28,6 +29,7 @@ Dieses Dokument beschreibt die Review-Governance für Proposal- und PR-Reviews m
 
 - Immer: `Documentation`
 - Neue Architektur / Packages / strukturelle Entscheidungen: `Architecture`
+- IAM, Rollen-Sync, ABAC/RBAC, Data-Subject-Rights oder andere sicherheitskritische Domänenlogik: `Architecture` + `Documentation` + `Security & Privacy`
 - Auth, Sessions, Tokens, PII: `Security & Privacy`
 - UI, Formulare, Navigation: `UX & Accessibility`
 - Texte, Übersetzungen, Labels: `i18n & Content`
@@ -43,6 +45,7 @@ Dieses Dokument beschreibt die Review-Governance für Proposal- und PR-Reviews m
 - Immer: `Documentation`
 - Jede Codeänderung: `Code Quality`
 - Verhaltensänderungen oder Coverage-/Test-Themen: `Test Quality`
+- IAM, Rollen-Sync, ABAC/RBAC, Data-Subject-Rights oder andere architekturrelevante Security-/Domain-Änderungen: zusätzlich `Architecture` und `Security & Privacy`
 - weitere Fachreviewer trigger-basiert analog zu Proposal-Reviews
 
 ## Abgrenzungen

--- a/docs/reports/PR_CHECKLIST.md
+++ b/docs/reports/PR_CHECKLIST.md
@@ -32,6 +32,9 @@
 - [ ] Bei Architektur-/Systemänderungen sind betroffene Abschnitte in `docs/architecture/README.md` identifiziert
 - [ ] Relevante arc42-Dateien unter `docs/architecture/` wurden aktualisiert oder Abweichung ist begründet dokumentiert
 - [ ] OpenSpec-Change (`proposal.md`/`tasks.md`) referenziert die betroffenen arc42-Abschnitte
+- [ ] Bei IAM-, Rollen-Sync-, ABAC/RBAC- oder Data-Subject-Rights-Änderungen wurden Abschnitt 04, 05, 06 und 08 explizit geprüft und betroffene Dateien aktualisiert
+- [ ] Bei sicherheitskritischer oder domänenkritischer Logik wurde mindestens `docs/architecture/05-building-block-view.md` oder `docs/architecture/08-cross-cutting-concepts.md` aktualisiert
+- [ ] Neue oder geänderte IAM-Patterns sind als ADR unter `docs/adr/` dokumentiert und in `docs/architecture/09-architecture-decisions.md` referenziert
 
 ## Reviewer Quick Check
 


### PR DESCRIPTION
## Zusammenfassung
- verankert verbindliche Regeln für die Synchronität zwischen IAM-/Security-Logik und arc42-Dokumentation
- ergänzt PR-Checkliste und Review-Governance um explizite IAM-/ADR-Trigger
- schärft Abschnitt 09 für den Umgang mit neuen oder geänderten IAM-Patterns

## Betroffene Dateien
- `DEVELOPMENT_RULES.md`
- `docs/architecture/README.md`
- `docs/architecture/09-architecture-decisions.md`
- `docs/reports/PR_CHECKLIST.md`
- `docs/development/review-agent-governance.md`
- `.github/agents/templates/documentation-review.md`
- `.github/agents/templates/architecture-review.md`

## Verifikation
- `pnpm check:file-placement`
- `pnpm test:types`
- `pnpm test:eslint`
- `pnpm test:unit`
- `pnpm nx run sva-studio-react:test:e2e`
