### PR TITLE
Fix lint blockers in test files

### DIFF
--- a/packages/auth/src/iam-authorization.listener.test.ts
+++ b/packages/auth/src/iam-authorization.listener.test.ts
@@ -36,8 +36,6 @@ vi.mock('@opentelemetry/api', () => ({
 
 vi.mock('pg', () => ({
   Pool: class MockPool {
-    public constructor(_config: unknown) {}
-
     public async connect() {
       return {
         query: async (text: string, values?: readonly unknown[]) => {

--- a/packages/sdk/tests/check-file-placement.test.ts
+++ b/packages/sdk/tests/check-file-placement.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 import { describe, expect, it } from 'vitest';
 
 import { findFilePlacementViolations, getTrackedFiles } from '../../../scripts/ci/check-file-placement.ts';

--- a/packages/sdk/tests/check-openapi-iam.test.ts
+++ b/packages/sdk/tests/check-openapi-iam.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 import { describe, expect, it } from 'vitest';
 
 import { requiredPaths, requiredSchemas, validateOpenApiDocument } from '../../../scripts/ci/check-openapi-iam.ts';


### PR DESCRIPTION
## Summary
- remove the empty mocked Pool constructor in the auth listener test to satisfy @typescript-eslint/no-empty-function
- allow the two SDK CI-script tests to import scripts/ci/* using the same local module-boundary exception already used by the existing complexity-gate test
- keep the change set scoped to the three failing lint blockers only

## Testing
- pnpm test:unit
- pnpm test:types
- pnpm test:eslint
- pnpm test:e2e

## Notes
- pnpm test:e2e passed but logged existing React hydration mismatch warnings in the app shell; no new failure was introduced by this change.