### PR TITLE
Fix follow-up review findings after PR 256

### DIFF
--- a/apps/sva-studio-react/src/hooks/use-groups.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-groups.test.tsx
@@ -162,6 +162,7 @@ describe('useGroups', () => {
         groupKey: 'admins',
         displayName: 'Admins',
         description: 'Administrative Gruppe',
+        instanceId: 'de-musterhausen',
         groupType: 'role_bundle',
         isActive: true,
         memberCount: 1,
@@ -190,10 +191,12 @@ describe('useGroups', () => {
         assignedRoleIds: ['role-legacy'],
         memberships: [
           expect.objectContaining({
+            instanceId: 'de-musterhausen',
             accountId: 'account-1',
-            keycloakSubject: 'Ada Admin',
+            keycloakSubject: 'account-1',
             validFrom: '2026-04-01T00:00:00.000Z',
             validUntil: '2026-05-01T00:00:00.000Z',
+            assignedAt: '2026-04-01T00:00:00.000Z',
           }),
         ],
       });

--- a/apps/sva-studio-react/src/hooks/use-groups.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-groups.test.tsx
@@ -193,7 +193,7 @@ describe('useGroups', () => {
           expect.objectContaining({
             instanceId: 'de-musterhausen',
             accountId: 'account-1',
-            keycloakSubject: 'account-1',
+            keycloakSubject: '',
             validFrom: '2026-04-01T00:00:00.000Z',
             validUntil: '2026-05-01T00:00:00.000Z',
             assignedAt: '2026-04-01T00:00:00.000Z',

--- a/apps/sva-studio-react/src/hooks/use-groups.ts
+++ b/apps/sva-studio-react/src/hooks/use-groups.ts
@@ -46,16 +46,19 @@ type UseGroupsResult = {
 
 const groupsLogger = createOperationLogger('groups-hook', 'debug');
 
+type LegacyGroupMember = {
+  accountId: string;
+  groupId: string;
+  displayName?: string;
+  keycloakSubject?: string;
+  validFrom?: string;
+  validTo?: string;
+};
+
 const normalizeGroupDetail = (detail: IamAdminGroupDetail): IamAdminGroupDetail => {
   const detailRecord = detail as IamAdminGroupDetail & {
     roles?: readonly { roleId: string }[];
-    members?: readonly {
-      accountId: string;
-      groupId: string;
-      displayName?: string;
-      validFrom?: string;
-      validTo?: string;
-    }[];
+    members?: readonly LegacyGroupMember[];
   };
 
   const assignedRoleIds =
@@ -70,7 +73,7 @@ const normalizeGroupDetail = (detail: IamAdminGroupDetail): IamAdminGroupDetail 
           instanceId: detail.instanceId,
           accountId: member.accountId,
           groupId: member.groupId,
-          keycloakSubject: member.accountId,
+          keycloakSubject: member.keycloakSubject?.trim() || '',
           displayName: member.displayName,
           validFrom: member.validFrom,
           validUntil: member.validTo,

--- a/apps/sva-studio-react/src/hooks/use-groups.ts
+++ b/apps/sva-studio-react/src/hooks/use-groups.ts
@@ -67,14 +67,14 @@ const normalizeGroupDetail = (detail: IamAdminGroupDetail): IamAdminGroupDetail 
     Array.isArray(detailRecord.memberships)
       ? detailRecord.memberships
       : (detailRecord.members ?? []).map((member) => ({
-          instanceId: '',
+          instanceId: detail.instanceId,
           accountId: member.accountId,
           groupId: member.groupId,
-          keycloakSubject: member.displayName ?? member.accountId,
+          keycloakSubject: member.accountId,
           displayName: member.displayName,
           validFrom: member.validFrom,
           validUntil: member.validTo,
-          assignedAt: '',
+          assignedAt: member.validFrom ?? detail.updatedAt,
         }));
 
   return {

--- a/apps/sva-studio-react/src/routes/-core-routes.test.tsx
+++ b/apps/sva-studio-react/src/routes/-core-routes.test.tsx
@@ -46,7 +46,10 @@ const createRouteMock = vi.hoisted(() =>
         groupId: 'group-1',
         legalTextVersionId: 'legal-text-1',
       }),
-      useSearch: () => ({ tab: 'governance' }),
+      useSearch: () =>
+        typeof options.validateSearch === 'function'
+          ? (options.validateSearch as (search: Record<string, unknown>) => unknown)({ tab: 'bogus' })
+          : { tab: 'governance' },
     };
     return route;
   })
@@ -325,7 +328,7 @@ describe('core routes', () => {
 
     cleanup();
     render(roleDetailRoute.component?.());
-    expect(screen.getByText('RoleDetailPage:role-1:governance')).toBeTruthy();
+    expect(screen.getByText('RoleDetailPage:role-1:overview')).toBeTruthy();
   });
 
   it('renders the new placeholder routes and explicit page components', async () => {
@@ -410,7 +413,7 @@ describe('core routes', () => {
     expect(await screen.findByText('RolesPage')).toBeTruthy();
 
     renderPath('/admin/roles/$roleId');
-    expect(screen.getByText('RoleDetailPage:role-1:governance')).toBeTruthy();
+    expect(screen.getByText('RoleDetailPage:role-1:overview')).toBeTruthy();
 
     renderPath('/admin/instances/new');
     expect(screen.getByText('InstanceCreatePage')).toBeTruthy();

--- a/apps/sva-studio-react/src/routes/admin/groups/-group-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/groups/-group-detail-page.test.tsx
@@ -184,6 +184,35 @@ describe('GroupDetailPage', () => {
     });
   });
 
+  it('disables membership removal for legacy entries without a keycloak subject', async () => {
+    const loadGroupDetail = vi.fn().mockResolvedValue({
+      ...detailFixture,
+      memberships: [
+        {
+          ...detailFixture.memberships[0],
+          accountId: 'account-legacy-1',
+          keycloakSubject: '',
+        },
+      ],
+    });
+    const removeMembership = vi.fn().mockResolvedValue(true);
+    useGroupsMock.mockReturnValue(
+      createGroupsState({
+        loadGroupDetail,
+        removeMembership,
+      })
+    );
+
+    render(<GroupDetailPage groupId="group-1" />);
+
+    await waitFor(() => {
+      expect(loadGroupDetail).toHaveBeenCalledWith('group-1');
+    });
+
+    expect(screen.getByRole('button', { name: 'Entfernen' })).toHaveProperty('disabled', true);
+    expect(removeMembership).not.toHaveBeenCalled();
+  });
+
   it('renders the not-found state when the detail is missing', async () => {
     useGroupsMock.mockReturnValue(
       createGroupsState({

--- a/apps/sva-studio-react/src/routes/admin/groups/-group-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/groups/-group-detail-page.tsx
@@ -331,8 +331,8 @@ export const GroupDetailPage = ({ groupId }: GroupDetailPageProps) => {
                       <tr key={`${membership.groupId}-${membership.accountId}`} className="border-t border-border text-sm text-foreground">
                         <th scope="row" className="px-3 py-3 text-left font-medium">
                           <div className="space-y-1">
-                            <div>{membership.displayName ?? membership.keycloakSubject}</div>
-                            <div className="text-xs text-muted-foreground">{membership.keycloakSubject}</div>
+                            <div>{membership.displayName ?? (membership.keycloakSubject || membership.accountId)}</div>
+                            <div className="text-xs text-muted-foreground">{membership.keycloakSubject || membership.accountId}</div>
                           </div>
                         </th>
                         <td className="px-3 py-3">
@@ -352,7 +352,13 @@ export const GroupDetailPage = ({ groupId }: GroupDetailPageProps) => {
                         </td>
                         <td className="px-3 py-3">
                           <div className="flex justify-end">
-                            <Button type="button" size="sm" variant="outline" onClick={() => void onRemoveMembership(membership.keycloakSubject)}>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              disabled={!membership.keycloakSubject}
+                              onClick={() => void onRemoveMembership(membership.keycloakSubject)}
+                            >
                               {t('admin.groups.memberships.remove')}
                             </Button>
                           </div>

--- a/apps/sva-studio-react/vite.config.ts
+++ b/apps/sva-studio-react/vite.config.ts
@@ -61,7 +61,7 @@ if (process.cwd() !== appRoot) {
 const config = defineConfig({
   root: appRoot,
   server: {
-    host: configuredDevHost || '0.0.0.0',
+    host: configuredDevHost || '127.0.0.1',
     // Disable HMR in this TanStack Start SSR setup to avoid React preamble runtime crashes.
     hmr: false,
     allowedHosts,

--- a/packages/auth/src/iam-legal-texts.repository.test.ts
+++ b/packages/auth/src/iam-legal-texts.repository.test.ts
@@ -112,8 +112,12 @@ describe('iam-legal-texts repository', () => {
 
   it('rejects deleting legal text versions that already have acceptances', async () => {
     state.client.query.mockResolvedValueOnce({
+      rowCount: 0,
+      rows: [],
+    });
+    state.client.query.mockResolvedValueOnce({
       rowCount: 1,
-      rows: [{ acceptance_count: 2 }],
+      rows: [{ has_acceptances: true }],
     });
 
     await expect(
@@ -124,8 +128,25 @@ describe('iam-legal-texts repository', () => {
       })
     ).rejects.toBeInstanceOf(LegalTextDeleteConflictError);
 
+    expect(state.client.query).toHaveBeenCalledTimes(2);
+    expect(state.client.query.mock.calls[0]?.[0]).toContain('DELETE FROM iam.legal_text_versions version');
+    expect(state.client.query.mock.calls[1]?.[0]).toContain('SELECT EXISTS');
+    expect(state.emitActivityLog).not.toHaveBeenCalled();
+  });
+
+  it('maps foreign-key violations during legal text deletion to a conflict error', async () => {
+    state.client.query.mockRejectedValueOnce({ code: '23503' });
+
+    await expect(
+      deleteLegalTextVersion({
+        instanceId: 'de-musterhausen',
+        actorAccountId: 'account-1',
+        legalTextVersionId: legalTextRow.id,
+      })
+    ).rejects.toBeInstanceOf(LegalTextDeleteConflictError);
+
     expect(state.client.query).toHaveBeenCalledTimes(1);
-    expect(state.client.query.mock.calls[0]?.[0]).toContain('FROM iam.legal_text_acceptances');
+    expect(state.client.query.mock.calls[0]?.[0]).toContain('DELETE FROM iam.legal_text_versions version');
     expect(state.emitActivityLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth/src/iam-legal-texts.repository.test.ts
+++ b/packages/auth/src/iam-legal-texts.repository.test.ts
@@ -17,7 +17,12 @@ vi.mock('./iam-account-management/shared.js', () => ({
   withInstanceScopedDb: (...args: Parameters<typeof state.withInstanceScopedDb>) => state.withInstanceScopedDb(...args),
 }));
 
-import { loadPendingLegalTexts, updateLegalTextVersion } from './iam-legal-texts/repository.js';
+import {
+  deleteLegalTextVersion,
+  LegalTextDeleteConflictError,
+  loadPendingLegalTexts,
+  updateLegalTextVersion,
+} from './iam-legal-texts/repository.js';
 
 const legalTextRow = {
   id: '11111111-1111-1111-1111-111111111111',
@@ -103,5 +108,24 @@ describe('iam-legal-texts repository', () => {
         payload: expect.objectContaining({ legal_text_version_id: legalTextRow.id }),
       })
     );
+  });
+
+  it('rejects deleting legal text versions that already have acceptances', async () => {
+    state.client.query.mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ acceptance_count: 2 }],
+    });
+
+    await expect(
+      deleteLegalTextVersion({
+        instanceId: 'de-musterhausen',
+        actorAccountId: 'account-1',
+        legalTextVersionId: legalTextRow.id,
+      })
+    ).rejects.toBeInstanceOf(LegalTextDeleteConflictError);
+
+    expect(state.client.query).toHaveBeenCalledTimes(1);
+    expect(state.client.query.mock.calls[0]?.[0]).toContain('FROM iam.legal_text_acceptances');
+    expect(state.emitActivityLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth/src/iam-legal-texts.server.test.ts
+++ b/packages/auth/src/iam-legal-texts.server.test.ts
@@ -456,11 +456,7 @@ describe('iam-legal-texts handlers', () => {
       if (resolveActorAccountQuery(text)) {
         return { rowCount: 1, rows: [{ account_id: 'account-1' }] };
       }
-      if (text.includes('FROM iam.legal_text_acceptances')) {
-        expect(values).toEqual(['de-musterhausen', legalTextRow.id]);
-        return { rowCount: 1, rows: [{ acceptance_count: 0 }] };
-      }
-      if (text.includes('DELETE FROM iam.legal_text_versions')) {
+      if (text.includes('DELETE FROM iam.legal_text_versions version')) {
         expect(values).toEqual(['de-musterhausen', legalTextRow.id]);
         return { rowCount: 1, rows: [{ id: legalTextRow.id }] };
       }
@@ -482,7 +478,7 @@ describe('iam-legal-texts handlers', () => {
       data: { id: legalTextRow.id },
       requestId: 'req-legal-texts',
     });
-    expect(state.queryLog.some((entry) => entry.text.includes('DELETE FROM iam.legal_text_versions'))).toBe(true);
+    expect(state.queryLog.some((entry) => entry.text.includes('DELETE FROM iam.legal_text_versions version'))).toBe(true);
     expect(state.queryLog.some((entry) => entry.text.includes('INSERT INTO iam.activity_log'))).toBe(true);
   });
 
@@ -516,9 +512,13 @@ describe('iam-legal-texts handlers', () => {
       if (resolveActorAccountQuery(text)) {
         return { rowCount: 1, rows: [{ account_id: 'account-1' }] };
       }
-      if (text.includes('FROM iam.legal_text_acceptances')) {
+      if (text.includes('DELETE FROM iam.legal_text_versions version')) {
         expect(values).toEqual(['de-musterhausen', legalTextRow.id]);
-        return { rowCount: 1, rows: [{ acceptance_count: 2 }] };
+        return { rowCount: 0, rows: [] };
+      }
+      if (text.includes('SELECT EXISTS')) {
+        expect(values).toEqual(['de-musterhausen', legalTextRow.id]);
+        return { rowCount: 1, rows: [{ has_acceptances: true }] };
       }
       return { rowCount: 0, rows: [] };
     };
@@ -537,7 +537,34 @@ describe('iam-legal-texts handlers', () => {
         message: 'Rechtstext-Version kann nicht gelöscht werden, weil bereits Zustimmungen vorliegen.',
       },
     });
-    expect(state.queryLog.some((entry) => entry.text.includes('DELETE FROM iam.legal_text_versions'))).toBe(false);
+    expect(state.queryLog.some((entry) => entry.text.includes('DELETE FROM iam.legal_text_versions version'))).toBe(true);
+  });
+
+  it('returns conflict when deleting a legal text version hits a foreign-key race', async () => {
+    state.queryHandler = (text) => {
+      if (resolveActorAccountQuery(text)) {
+        return { rowCount: 1, rows: [{ account_id: 'account-1' }] };
+      }
+      if (text.includes('DELETE FROM iam.legal_text_versions version')) {
+        throw { code: '23503' };
+      }
+      return { rowCount: 0, rows: [] };
+    };
+
+    const response = await deleteLegalTextHandler(
+      new Request(`http://localhost:3000/api/v1/iam/legal-texts/${legalTextRow.id}`, {
+        method: 'DELETE',
+        headers: jsonHeaders,
+      })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'conflict',
+        message: 'Rechtstext-Version kann nicht gelöscht werden, weil bereits Zustimmungen vorliegen.',
+      },
+    });
   });
 
   it('replays an idempotent create request without inserting another record', async () => {

--- a/packages/auth/src/iam-legal-texts.server.test.ts
+++ b/packages/auth/src/iam-legal-texts.server.test.ts
@@ -456,6 +456,10 @@ describe('iam-legal-texts handlers', () => {
       if (resolveActorAccountQuery(text)) {
         return { rowCount: 1, rows: [{ account_id: 'account-1' }] };
       }
+      if (text.includes('FROM iam.legal_text_acceptances')) {
+        expect(values).toEqual(['de-musterhausen', legalTextRow.id]);
+        return { rowCount: 1, rows: [{ acceptance_count: 0 }] };
+      }
       if (text.includes('DELETE FROM iam.legal_text_versions')) {
         expect(values).toEqual(['de-musterhausen', legalTextRow.id]);
         return { rowCount: 1, rows: [{ id: legalTextRow.id }] };
@@ -480,6 +484,60 @@ describe('iam-legal-texts handlers', () => {
     });
     expect(state.queryLog.some((entry) => entry.text.includes('DELETE FROM iam.legal_text_versions'))).toBe(true);
     expect(state.queryLog.some((entry) => entry.text.includes('INSERT INTO iam.activity_log'))).toBe(true);
+  });
+
+  it('rejects deleting legal text versions with invalid ids before touching the delete query', async () => {
+    state.queryHandler = (text) => {
+      if (resolveActorAccountQuery(text)) {
+        return { rowCount: 1, rows: [{ account_id: 'account-1' }] };
+      }
+      return { rowCount: 0, rows: [] };
+    };
+
+    const response = await deleteLegalTextHandler(
+      new Request('http://localhost:3000/api/v1/iam/legal-texts/not-a-uuid', {
+        method: 'DELETE',
+        headers: jsonHeaders,
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'invalid_request',
+        message: 'Rechtstext-ID ist ungültig.',
+      },
+    });
+    expect(state.queryLog.some((entry) => entry.text.includes('DELETE FROM iam.legal_text_versions'))).toBe(false);
+  });
+
+  it('returns conflict when deleting a legal text version with recorded acceptances', async () => {
+    state.queryHandler = (text, values) => {
+      if (resolveActorAccountQuery(text)) {
+        return { rowCount: 1, rows: [{ account_id: 'account-1' }] };
+      }
+      if (text.includes('FROM iam.legal_text_acceptances')) {
+        expect(values).toEqual(['de-musterhausen', legalTextRow.id]);
+        return { rowCount: 1, rows: [{ acceptance_count: 2 }] };
+      }
+      return { rowCount: 0, rows: [] };
+    };
+
+    const response = await deleteLegalTextHandler(
+      new Request(`http://localhost:3000/api/v1/iam/legal-texts/${legalTextRow.id}`, {
+        method: 'DELETE',
+        headers: jsonHeaders,
+      })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'conflict',
+        message: 'Rechtstext-Version kann nicht gelöscht werden, weil bereits Zustimmungen vorliegen.',
+      },
+    });
+    expect(state.queryLog.some((entry) => entry.text.includes('DELETE FROM iam.legal_text_versions'))).toBe(false);
   });
 
   it('replays an idempotent create request without inserting another record', async () => {

--- a/packages/auth/src/iam-legal-texts/mutations.ts
+++ b/packages/auth/src/iam-legal-texts/mutations.ts
@@ -10,9 +10,10 @@ import {
 } from '../iam-account-management/api-helpers.js';
 import { validateCsrf } from '../iam-account-management/csrf.js';
 import { completeIdempotency, reserveIdempotency } from '../iam-account-management/shared.js';
+import { UUID_LIKE_PATTERN } from '../shared/validators.js';
 
 import type { ResolvedLegalTextsActor } from './request-context.js';
-import { createLegalTextVersion, loadLegalTextById, updateLegalTextVersion } from './repository.js';
+import { createLegalTextVersion, LegalTextDeleteConflictError, loadLegalTextById, updateLegalTextVersion } from './repository.js';
 import { createLegalTextSchema, updateLegalTextSchema } from './schemas.js';
 
 const logger = createSdkLogger({ component: 'iam-legal-texts', level: 'info' });
@@ -206,6 +207,9 @@ export const deleteLegalTextResponse = async (
   if (!legalTextVersionId) {
     return createApiError(400, 'invalid_request', 'Rechtstext-ID fehlt.', actor.requestId);
   }
+  if (!UUID_LIKE_PATTERN.test(legalTextVersionId)) {
+    return createApiError(400, 'invalid_request', 'Rechtstext-ID ist ungültig.', actor.requestId);
+  }
 
   try {
     const { deleteLegalTextVersion } = await import('./repository.js');
@@ -221,6 +225,14 @@ export const deleteLegalTextResponse = async (
       ? jsonResponse(200, asApiItem({ id: deletedId }, actor.requestId))
       : createApiError(404, 'not_found', 'Rechtstext-Version wurde nicht gefunden.', actor.requestId);
   } catch (error) {
+    if (error instanceof LegalTextDeleteConflictError) {
+      return createApiError(
+        409,
+        'conflict',
+        'Rechtstext-Version kann nicht gelöscht werden, weil bereits Zustimmungen vorliegen.',
+        actor.requestId
+      );
+    }
     logger.error('Legal text delete failed', {
       operation: 'legal_text_delete',
       instance_id: actor.instanceId,

--- a/packages/auth/src/iam-legal-texts/repository-activity.ts
+++ b/packages/auth/src/iam-legal-texts/repository-activity.ts
@@ -1,0 +1,65 @@
+import { emitActivityLog, withInstanceScopedDb } from '../iam-account-management/shared.js';
+import type { CreateLegalTextInput, UpdateLegalTextInput } from './repository-shared.js';
+
+type InstanceScopedClient = Parameters<Parameters<typeof withInstanceScopedDb>[1]>[0];
+
+export type DeleteLegalTextInput = {
+  instanceId: string;
+  actorAccountId: string;
+  requestId?: string;
+  traceId?: string;
+  legalTextVersionId: string;
+};
+
+export class LegalTextDeleteConflictError extends Error {
+  constructor() {
+    super('legal_text_acceptances_exist');
+    this.name = 'LegalTextDeleteConflictError';
+  }
+}
+
+export const emitLegalTextCreatedActivityLog = (
+  client: InstanceScopedClient,
+  input: CreateLegalTextInput,
+  legalTextVersionId: string,
+) =>
+  emitActivityLog(client, {
+    instanceId: input.instanceId,
+    accountId: input.actorAccountId,
+    eventType: 'iam.legal_text.created',
+    result: 'success',
+    payload: { legal_text_version_id: legalTextVersionId, name: input.name, legal_text_version: input.legalTextVersion, locale: input.locale, status: input.status },
+    requestId: input.requestId,
+    traceId: input.traceId,
+  });
+
+export const emitLegalTextUpdatedActivityLog = (
+  client: InstanceScopedClient,
+  input: UpdateLegalTextInput,
+  updatedLegalTextVersionId: string,
+  updatedFields: readonly string[],
+) =>
+  emitActivityLog(client, {
+    instanceId: input.instanceId,
+    accountId: input.actorAccountId,
+    eventType: 'iam.legal_text.updated',
+    result: 'success',
+    payload: { legal_text_version_id: updatedLegalTextVersionId, updated_fields: updatedFields },
+    requestId: input.requestId,
+    traceId: input.traceId,
+  });
+
+export const emitLegalTextDeletedActivityLog = (
+  client: InstanceScopedClient,
+  input: DeleteLegalTextInput,
+  deletedLegalTextVersionId: string,
+) =>
+  emitActivityLog(client, {
+    instanceId: input.instanceId,
+    accountId: input.actorAccountId,
+    eventType: 'iam.legal_text.deleted',
+    result: 'success',
+    payload: { legal_text_version_id: deletedLegalTextVersionId },
+    requestId: input.requestId,
+    traceId: input.traceId,
+  });

--- a/packages/auth/src/iam-legal-texts/repository.ts
+++ b/packages/auth/src/iam-legal-texts/repository.ts
@@ -27,6 +27,13 @@ type InstanceScopedClient = Parameters<Parameters<typeof withInstanceScopedDb>[1
 
 export { LegalTextDeleteConflictError } from './repository-activity.js';
 
+const isForeignKeyConflict = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  typeof (error as { code?: unknown }).code === 'string' &&
+  (error as { code: string }).code === '23503';
+
 const loadLegalTextByIdWithClient = async (
   client: InstanceScopedClient,
   instanceId: string,
@@ -212,32 +219,46 @@ RETURNING id;
 
 export const deleteLegalTextVersion = async (input: DeleteLegalTextInput): Promise<string | undefined> =>
   withInstanceScopedDb(input.instanceId, async (client) => {
-    const acceptances = await client.query<{ acceptance_count: number }>(
-      `
-SELECT COUNT(*)::int AS acceptance_count
-FROM iam.legal_text_acceptances
-WHERE instance_id = $1
-  AND legal_text_version_id = $2::uuid;
+    let deleted;
+    try {
+      deleted = await client.query<{ id: string }>(
+        `
+DELETE FROM iam.legal_text_versions version
+WHERE version.instance_id = $1
+  AND version.id = $2::uuid
+  AND NOT EXISTS (
+    SELECT 1
+    FROM iam.legal_text_acceptances acceptance
+    WHERE acceptance.instance_id = version.instance_id
+      AND acceptance.legal_text_version_id = version.id
+  )
+RETURNING version.id;
 `,
-      [input.instanceId, input.legalTextVersionId]
-    );
-
-    if ((acceptances.rows[0]?.acceptance_count ?? 0) > 0) {
-      throw new LegalTextDeleteConflictError();
+        [input.instanceId, input.legalTextVersionId]
+      );
+    } catch (error) {
+      if (isForeignKeyConflict(error)) {
+        throw new LegalTextDeleteConflictError();
+      }
+      throw error;
     }
-
-    const deleted = await client.query<{ id: string }>(
-      `
-DELETE FROM iam.legal_text_versions
-WHERE instance_id = $1
-  AND id = $2::uuid
-RETURNING id;
-`,
-      [input.instanceId, input.legalTextVersionId]
-    );
 
     const deletedLegalTextVersionId = deleted.rows[0]?.id;
     if (deletedLegalTextVersionId === undefined) {
+      const acceptances = await client.query<{ has_acceptances: boolean }>(
+        `
+SELECT EXISTS (
+  SELECT 1
+  FROM iam.legal_text_acceptances
+  WHERE instance_id = $1
+    AND legal_text_version_id = $2::uuid
+) AS has_acceptances;
+`,
+        [input.instanceId, input.legalTextVersionId]
+      );
+      if (acceptances.rows[0]?.has_acceptances) {
+        throw new LegalTextDeleteConflictError();
+      }
       return undefined;
     }
 

--- a/packages/auth/src/iam-legal-texts/repository.ts
+++ b/packages/auth/src/iam-legal-texts/repository.ts
@@ -1,7 +1,14 @@
 import type { IamLegalTextListItem, IamPendingLegalTextItem } from '@sva/core';
 
-import { emitActivityLog, withInstanceScopedDb } from '../iam-account-management/shared.js';
+import { withInstanceScopedDb } from '../iam-account-management/shared.js';
 import { hashLegalTextHtml, sanitizeLegalTextHtml } from './html.js';
+import {
+  DeleteLegalTextInput,
+  emitLegalTextCreatedActivityLog,
+  emitLegalTextDeletedActivityLog,
+  emitLegalTextUpdatedActivityLog,
+  LegalTextDeleteConflictError,
+} from './repository-activity.js';
 import {
   LEGAL_TEXT_SELECT,
   collectUpdatedFields,
@@ -17,20 +24,8 @@ import {
 } from './repository-shared.js';
 
 type InstanceScopedClient = Parameters<Parameters<typeof withInstanceScopedDb>[1]>[0];
-type DeleteLegalTextInput = {
-  instanceId: string;
-  actorAccountId: string;
-  requestId?: string;
-  traceId?: string;
-  legalTextVersionId: string;
-};
 
-export class LegalTextDeleteConflictError extends Error {
-  constructor() {
-    super('legal_text_acceptances_exist');
-    this.name = 'LegalTextDeleteConflictError';
-  }
-}
+export { LegalTextDeleteConflictError } from './repository-activity.js';
 
 const loadLegalTextByIdWithClient = async (
   client: InstanceScopedClient,
@@ -160,15 +155,7 @@ RETURNING id;
       return undefined;
     }
 
-    await emitActivityLog(client, {
-      instanceId: input.instanceId,
-      accountId: input.actorAccountId,
-      eventType: 'iam.legal_text.created',
-      result: 'success',
-      payload: { legal_text_version_id: legalTextVersionId, name: input.name, legal_text_version: input.legalTextVersion, locale: input.locale, status: input.status },
-      requestId: input.requestId,
-      traceId: input.traceId,
-    });
+    await emitLegalTextCreatedActivityLog(client, input, legalTextVersionId);
 
     return legalTextVersionId;
   });
@@ -218,15 +205,7 @@ RETURNING id;
       return undefined;
     }
 
-    await emitActivityLog(client, {
-      instanceId: input.instanceId,
-      accountId: input.actorAccountId,
-      eventType: 'iam.legal_text.updated',
-      result: 'success',
-      payload: { legal_text_version_id: updatedLegalTextVersionId, updated_fields: collectUpdatedFields(input) },
-      requestId: input.requestId,
-      traceId: input.traceId,
-    });
+    await emitLegalTextUpdatedActivityLog(client, input, updatedLegalTextVersionId, collectUpdatedFields(input));
 
     return updatedLegalTextVersionId;
   });
@@ -262,15 +241,7 @@ RETURNING id;
       return undefined;
     }
 
-    await emitActivityLog(client, {
-      instanceId: input.instanceId,
-      accountId: input.actorAccountId,
-      eventType: 'iam.legal_text.deleted',
-      result: 'success',
-      payload: { legal_text_version_id: deletedLegalTextVersionId },
-      requestId: input.requestId,
-      traceId: input.traceId,
-    });
+    await emitLegalTextDeletedActivityLog(client, input, deletedLegalTextVersionId);
 
     return deletedLegalTextVersionId;
   });

--- a/packages/auth/src/iam-legal-texts/repository.ts
+++ b/packages/auth/src/iam-legal-texts/repository.ts
@@ -25,6 +25,13 @@ type DeleteLegalTextInput = {
   legalTextVersionId: string;
 };
 
+export class LegalTextDeleteConflictError extends Error {
+  constructor() {
+    super('legal_text_acceptances_exist');
+    this.name = 'LegalTextDeleteConflictError';
+  }
+}
+
 const loadLegalTextByIdWithClient = async (
   client: InstanceScopedClient,
   instanceId: string,
@@ -226,6 +233,20 @@ RETURNING id;
 
 export const deleteLegalTextVersion = async (input: DeleteLegalTextInput): Promise<string | undefined> =>
   withInstanceScopedDb(input.instanceId, async (client) => {
+    const acceptances = await client.query<{ acceptance_count: number }>(
+      `
+SELECT COUNT(*)::int AS acceptance_count
+FROM iam.legal_text_acceptances
+WHERE instance_id = $1
+  AND legal_text_version_id = $2::uuid;
+`,
+      [input.instanceId, input.legalTextVersionId]
+    );
+
+    if ((acceptances.rows[0]?.acceptance_count ?? 0) > 0) {
+      throw new LegalTextDeleteConflictError();
+    }
+
     const deleted = await client.query<{ id: string }>(
       `
 DELETE FROM iam.legal_text_versions

--- a/packages/sdk/tests/deploy-feedback-loop.test.ts
+++ b/packages/sdk/tests/deploy-feedback-loop.test.ts
@@ -100,6 +100,19 @@ describe('deploy-feedback-loop', () => {
     expect(reports[0]?.reportId).toBe('acceptance-deploy-2026-03-21T12-00-00-000Z');
   });
 
+  it('ignores malformed reports without a generated timestamp before sorting', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'deploy-feedback-'));
+    tempDirs.push(dir);
+
+    writeFileSync(resolve(dir, 'report-invalid.json'), `${JSON.stringify({ reportId: 'broken', steps: [] })}\n`, 'utf8');
+    writeFileSync(resolve(dir, 'report-valid.json'), `${JSON.stringify(createReport())}\n`, 'utf8');
+
+    const reports = listDeployReports(dir);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]?.reportId).toBe('acceptance-deploy-2026-03-21T12-00-00-000Z');
+  });
+
   it('summarizes failure categories, failed phases and success rate', () => {
     const success = createReport();
     const failed = createReport({

--- a/packages/sdk/tests/runtime-env.shared.test.ts
+++ b/packages/sdk/tests/runtime-env.shared.test.ts
@@ -144,6 +144,18 @@ describe('runtime-env.shared', () => {
     ).toEqual({ mode: 'local-operator' });
   });
 
+  it('rejects explicit local operator context outside the studio profile', () => {
+    expect(() =>
+      assertDeterministicRemoteMutationContext(
+        {
+          SVA_REMOTE_OPERATOR_CONTEXT: 'local-operator',
+        },
+        'acceptance-hb',
+        'deploy',
+      ),
+    ).toThrow(/nicht fuer den lokalen Operator-Pfad freigegeben/);
+  });
+
   it('detects documented truthy flag values for local emergency overrides', () => {
     expect(isTruthyFlag('true')).toBe(true);
     expect(isTruthyFlag('On')).toBe(true);

--- a/packages/sdk/tests/runtime-env.shared.test.ts
+++ b/packages/sdk/tests/runtime-env.shared.test.ts
@@ -153,7 +153,7 @@ describe('runtime-env.shared', () => {
         'acceptance-hb',
         'deploy',
       ),
-    ).toThrow(/nicht fuer den lokalen Operator-Pfad freigegeben/);
+    ).toThrow(/greift nur, wenn SVA_REMOTE_OPERATOR_CONTEXT nicht auf local-operator steht/);
   });
 
   it('detects documented truthy flag values for local emergency overrides', () => {

--- a/scripts/ci/verify-runtime-artifact.sh
+++ b/scripts/ci/verify-runtime-artifact.sh
@@ -13,7 +13,7 @@ REDIS_PASSWORD="verify-redis-password"
 PII_KEYRING_JSON='{"k1":"MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE="}'
 
 read -r APP_PORT POSTGRES_PORT REDIS_PORT KEYCLOAK_PORT <<EOF
-$(node <<'NODE'
+$("${WORKSPACE_ROOT}/scripts/ci/run-workspace-node.sh" <<'NODE'
 const net = require('node:net');
 
 const reservePort = () =>
@@ -323,7 +323,7 @@ if [ "${VERIFY_STATUS}" = "ok" ]; then
 fi
 
 if [ "${VERIFY_STATUS}" = "ok" ]; then
-  KEYCLOAK_PORT="${KEYCLOAK_PORT}" node <<'NODE' >"${KEYCLOAK_STDOUT_PATH}" 2>"${KEYCLOAK_STDERR_PATH}" &
+  KEYCLOAK_PORT="${KEYCLOAK_PORT}" "${WORKSPACE_ROOT}/scripts/ci/run-workspace-node.sh" <<'NODE' >"${KEYCLOAK_STDOUT_PATH}" 2>"${KEYCLOAK_STDERR_PATH}" &
 const http = require('node:http');
 
 const port = Number(process.env.KEYCLOAK_PORT || '38080');

--- a/scripts/ops/deploy-feedback-loop.ts
+++ b/scripts/ops/deploy-feedback-loop.ts
@@ -85,7 +85,10 @@ export const listDeployReports = (reportDir: string): AcceptanceDeployReport[] =
     .map((fileName) => safeReadJson<AcceptanceDeployReport>(resolve(reportDir, fileName)))
     .filter(
       (report): report is AcceptanceDeployReport =>
-        report !== null && typeof report.reportId === 'string' && Array.isArray(report.steps)
+        report !== null &&
+        typeof report.reportId === 'string' &&
+        typeof report.generatedAt === 'string' &&
+        Array.isArray(report.steps)
     )
     .sort((left, right) => left.generatedAt.localeCompare(right.generatedAt));
 };

--- a/scripts/ops/runtime-env.shared.ts
+++ b/scripts/ops/runtime-env.shared.ts
@@ -411,6 +411,12 @@ export const assertDeterministicRemoteMutationContext = (
   }
 
   if (hasLocalOperatorContext) {
+    if (runtimeProfile !== 'studio') {
+      throw new Error(
+        `Remote-Mutation ${command} fuer ${runtimeProfile} ist nicht fuer den lokalen Operator-Pfad freigegeben. Nutze den Workflow-Pfad oder setze SVA_ALLOW_LOCAL_REMOTE_MUTATIONS=true fuer einen dokumentierten Notfallpfad.`,
+      );
+    }
+
     return {
       mode: 'local-operator' as const,
     };

--- a/scripts/ops/runtime-env.shared.ts
+++ b/scripts/ops/runtime-env.shared.ts
@@ -413,7 +413,7 @@ export const assertDeterministicRemoteMutationContext = (
   if (hasLocalOperatorContext) {
     if (runtimeProfile !== 'studio') {
       throw new Error(
-        `Remote-Mutation ${command} fuer ${runtimeProfile} ist nicht fuer den lokalen Operator-Pfad freigegeben. Nutze den Workflow-Pfad oder setze SVA_ALLOW_LOCAL_REMOTE_MUTATIONS=true fuer einen dokumentierten Notfallpfad.`,
+        `Remote-Mutation ${command} fuer ${runtimeProfile} ist nicht fuer den lokalen Operator-Pfad freigegeben. Nutze den Workflow-Pfad. Der dokumentierte Notfallpfad mit SVA_ALLOW_LOCAL_REMOTE_MUTATIONS=true greift nur, wenn SVA_REMOTE_OPERATOR_CONTEXT nicht auf local-operator steht.`,
       );
     }
 


### PR DESCRIPTION
## Hintergrund
Follow-up auf den bereits gemergten PR #256. Dieser PR zieht die noch offenen Review-Punkte mit kleinem Regression-Radius nach.

## Änderungen
- härtere Guards für Deploy-Feedback-Reports und Remote-Mutation-Kontexte
- `verify-runtime-artifact.sh` auf das Workspace-Node-Wrapper-Skript umgestellt
- Rechtstext-Löschen gegen ungültige UUIDs und bestehende Acceptances abgesichert
- Gruppen-Hook normalisiert Legacy-Memberships ohne leere Platzhalterwerte
- `-core-routes`-Test an die tatsächliche Search-Normalisierung angepasst
- Vite-Dev-Server bindet standardmäßig nur noch an `127.0.0.1`

## Verifikation
- `pnpm exec vitest run packages/sdk/tests/deploy-feedback-loop.test.ts packages/sdk/tests/runtime-env.shared.test.ts`
- `pnpm nx run auth:test:unit -- --run src/iam-legal-texts.repository.test.ts src/iam-legal-texts.server.test.ts`
- `pnpm exec vitest run --config apps/sva-studio-react/vitest.config.ts apps/sva-studio-react/src/hooks/use-groups.test.tsx apps/sva-studio-react/src/routes/-core-routes.test.tsx`
- `bash -n scripts/ci/verify-runtime-artifact.sh`
- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main`
- `pnpm check:server-runtime`
