### PR TITLE
fix(interfaces): retry unauthorized overview requests during external warmup

### DIFF
--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
@@ -179,6 +179,73 @@ describe('InterfacesPage', () => {
     });
   });
 
+  it('reloads after a persisted unauthorized status update', async () => {
+    state.loadOverview
+      .mockResolvedValueOnce({
+        instanceId: 'de-musterhausen',
+        config: {
+          instanceId: 'de-musterhausen',
+          providerKey: 'sva_mainserver',
+          graphqlBaseUrl: 'https://mainserver.example/graphql',
+          oauthTokenUrl: 'https://mainserver.example/oauth/token',
+          enabled: true,
+        },
+        status: {
+          status: 'connected',
+          checkedAt: '2026-03-15T20:00:00.000Z',
+        },
+      })
+      .mockResolvedValueOnce({
+        instanceId: 'de-musterhausen',
+        config: {
+          instanceId: 'de-musterhausen',
+          providerKey: 'sva_mainserver',
+          graphqlBaseUrl: 'https://mainserver.example/graphql',
+          oauthTokenUrl: 'https://mainserver.example/oauth/token',
+          enabled: true,
+        },
+        status: {
+          status: 'error',
+          checkedAt: '2026-03-15T20:05:00.000Z',
+          errorCode: 'unauthorized',
+        },
+      })
+      .mockResolvedValueOnce({
+        instanceId: 'de-musterhausen',
+        config: {
+          instanceId: 'de-musterhausen',
+          providerKey: 'sva_mainserver',
+          graphqlBaseUrl: 'https://mainserver.example/graphql',
+          oauthTokenUrl: 'https://mainserver.example/oauth/token',
+          enabled: true,
+        },
+        status: {
+          status: 'connected',
+          checkedAt: '2026-03-15T20:06:00.000Z',
+        },
+      });
+    state.saveSettings.mockResolvedValue({
+      instanceId: 'de-musterhausen',
+      providerKey: 'sva_mainserver',
+      graphqlBaseUrl: 'https://mainserver.example/graphql',
+      oauthTokenUrl: 'https://mainserver.example/oauth/token',
+      enabled: true,
+    });
+
+    render(<InterfacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Einstellungen speichern' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Einstellungen speichern' }));
+
+    await waitFor(() => {
+      expect(state.loadOverview).toHaveBeenCalledTimes(3);
+      expect(screen.getByText('Verbunden')).toBeTruthy();
+    });
+  });
+
   it('reloads the overview when the reload action is used', async () => {
     state.loadOverview
       .mockResolvedValueOnce({

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InterfacesPage } from './-interfaces-page';
@@ -41,6 +41,7 @@ describe('InterfacesPage', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
   });
 
@@ -131,6 +132,50 @@ describe('InterfacesPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Kaputt')).toBeTruthy();
+    });
+  });
+
+  it('retries once after an unauthorized overview result', async () => {
+    state.loadOverview
+      .mockResolvedValueOnce({
+        instanceId: '',
+        config: null,
+        status: {
+          status: 'error',
+          checkedAt: '2026-03-15T20:00:00.000Z',
+          errorCode: 'unauthorized',
+        },
+      })
+      .mockResolvedValueOnce({
+        instanceId: 'hb-meinquartier',
+        config: {
+          instanceId: 'hb-meinquartier',
+          providerKey: 'sva_mainserver',
+          graphqlBaseUrl: 'https://hb-meinquartier.server.smart-village.app/graphql',
+          oauthTokenUrl: 'https://hb-meinquartier.server.smart-village.app/oauth/token',
+          enabled: true,
+        },
+        status: {
+          status: 'connected',
+          checkedAt: '2026-03-15T20:05:00.000Z',
+        },
+      });
+
+    render(<InterfacesPage />);
+
+    await waitFor(() => {
+      expect(state.loadOverview).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => {
+        globalThis.setTimeout(resolve, 350);
+      });
+    });
+
+    await waitFor(() => {
+      expect(state.loadOverview).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Verbunden')).toBeTruthy();
     });
   });
 

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx
@@ -159,6 +159,7 @@ export const InterfacesPage = () => {
   const [instanceId, setInstanceId] = React.useState<string>('');
   const [formValues, setFormValues] = React.useState<FormValues>(emptyFormValues);
   const didInitialRefreshRef = React.useRef(false);
+  const unauthorizedRetryRef = React.useRef(false);
 
   const refresh = React.useCallback(async () => {
     setIsLoading(true);
@@ -166,6 +167,24 @@ export const InterfacesPage = () => {
     setStatusMessage(null);
     try {
       const overview = await loadOverviewRef.current();
+
+      if (
+        overview.status.status === 'error' &&
+        overview.status.errorCode === 'unauthorized' &&
+        !unauthorizedRetryRef.current
+      ) {
+        unauthorizedRetryRef.current = true;
+        await new Promise((resolve) => {
+          globalThis.setTimeout(resolve, 300);
+        });
+        const recoveredOverview = await loadOverviewRef.current();
+        setInstanceId(recoveredOverview.instanceId);
+        setLastStatus(recoveredOverview.status);
+        setFormValues(toFormValues(recoveredOverview.config));
+        return;
+      }
+
+      unauthorizedRetryRef.current = false;
       setInstanceId(overview.instanceId);
       setLastStatus(overview.status);
       setFormValues(toFormValues(overview.config));
@@ -183,6 +202,12 @@ export const InterfacesPage = () => {
     didInitialRefreshRef.current = true;
     refresh().catch(() => undefined);
   }, [refresh]);
+
+  React.useEffect(() => {
+    if (lastStatus?.status === 'error' && lastStatus.errorCode === 'unauthorized') {
+      void refresh();
+    }
+  }, [lastStatus, refresh]);
 
   const handleSave = async () => {
     setIsSaving(true);

--- a/apps/sva-studio-react/vite.config.ts
+++ b/apps/sva-studio-react/vite.config.ts
@@ -8,6 +8,7 @@ import { fileURLToPath, URL } from 'node:url';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 const normalizeDirectory = (url: URL) => fileURLToPath(url).replace(/[\\/]$/, '');
+const resolveAppPath = (relativePath: string) => fileURLToPath(new URL(relativePath, import.meta.url));
 
 const appRoot = normalizeDirectory(new URL('./', import.meta.url));
 const workspaceRoot = normalizeDirectory(new URL('../../', import.meta.url));
@@ -73,34 +74,40 @@ const config = defineConfig({
   },
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@': resolveAppPath('./src'),
       // React 19 + Vite resolves react-dom/server -> server.browser (no default export).
       // TanStack router imports a default export here, so provide a compat shim.
-      'react-dom/server': fileURLToPath(new URL('./src/lib/react-dom-server-compat.ts', import.meta.url)),
+      'react-dom/server': resolveAppPath('./src/lib/react-dom-server-compat.ts'),
+      // Force the ESM builds here. The CommonJS variants pull tslib through a broken SSR interop path.
+      'react-remove-scroll': resolveAppPath('../../node_modules/.pnpm/node_modules/react-remove-scroll/dist/es2015'),
+      'react-remove-scroll-bar': resolveAppPath('../../node_modules/.pnpm/node_modules/react-remove-scroll-bar/dist/es2015'),
+      'react-style-singleton': resolveAppPath('../../node_modules/.pnpm/node_modules/react-style-singleton/dist/es2015'),
+      tslib: resolveAppPath('../../node_modules/.pnpm/node_modules/tslib/tslib.es6.mjs'),
+      'use-callback-ref': resolveAppPath('../../node_modules/.pnpm/node_modules/use-callback-ref/dist/es2015'),
       // Workspace package subpath exports direkt auf Source files mappen (für Dev-SSR)
-      '@sva/routing/server': fileURLToPath(new URL('../../packages/routing/src/index.server.ts', import.meta.url)),
-      '@sva/routing/auth': fileURLToPath(new URL('../../packages/routing/src/auth.routes.ts', import.meta.url)),
-      '@sva/routing': fileURLToPath(new URL('../../packages/routing/src/index.ts', import.meta.url)),
-      '@sva/auth/runtime-routes': fileURLToPath(new URL('../../packages/auth/src/runtime-routes.server.ts', import.meta.url)),
-      '@sva/auth/runtime-health': fileURLToPath(new URL('../../packages/auth/src/runtime-health.server.ts', import.meta.url)),
-      '@sva/auth/server': fileURLToPath(new URL('../../packages/auth/src/index.server.ts', import.meta.url)),
-      '@sva/auth': fileURLToPath(new URL('../../packages/auth/src/index.ts', import.meta.url)),
-      '@sva/data/server': fileURLToPath(new URL('../../packages/data/src/server.ts', import.meta.url)),
-      '@sva/data': fileURLToPath(new URL('../../packages/data/src/index.ts', import.meta.url)),
-      '@sva/sva-mainserver/server': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.server.ts', import.meta.url)),
-      '@sva/sva-mainserver': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.ts', import.meta.url)),
-      '@sva/sdk/logging': fileURLToPath(new URL('../../packages/sdk/src/logging.ts', import.meta.url)),
-      '@sva/sdk/server': fileURLToPath(new URL('../../packages/sdk/src/server.ts', import.meta.url)),
-      '@sva/sdk/logger/index.server': fileURLToPath(new URL('../../packages/sdk/src/logger/index.server.ts', import.meta.url)),
-      '@sva/sdk/middleware/request-context.server': fileURLToPath(new URL('../../packages/sdk/src/middleware/request-context.server.ts', import.meta.url)),
-      '@sva/sdk/observability/context.server': fileURLToPath(new URL('../../packages/sdk/src/observability/context.server.ts', import.meta.url)),
-      '@sva/monitoring-client/server': fileURLToPath(new URL('../../packages/monitoring-client/src/server.ts', import.meta.url)),
-      '@sva/monitoring-client/logger-provider.server': fileURLToPath(
-        new URL('../../packages/monitoring-client/src/logger-provider.server.ts', import.meta.url)
+      '@sva/routing/server': resolveAppPath('../../packages/routing/src/index.server.ts'),
+      '@sva/routing/auth': resolveAppPath('../../packages/routing/src/auth.routes.ts'),
+      '@sva/routing': resolveAppPath('../../packages/routing/src/index.ts'),
+      '@sva/auth/runtime-routes': resolveAppPath('../../packages/auth/src/runtime-routes.server.ts'),
+      '@sva/auth/runtime-health': resolveAppPath('../../packages/auth/src/runtime-health.server.ts'),
+      '@sva/auth/server': resolveAppPath('../../packages/auth/src/index.server.ts'),
+      '@sva/auth': resolveAppPath('../../packages/auth/src/index.ts'),
+      '@sva/data/server': resolveAppPath('../../packages/data/src/server.ts'),
+      '@sva/data': resolveAppPath('../../packages/data/src/index.ts'),
+      '@sva/sva-mainserver/server': resolveAppPath('../../packages/sva-mainserver/src/index.server.ts'),
+      '@sva/sva-mainserver': resolveAppPath('../../packages/sva-mainserver/src/index.ts'),
+      '@sva/sdk/logging': resolveAppPath('../../packages/sdk/src/logging.ts'),
+      '@sva/sdk/server': resolveAppPath('../../packages/sdk/src/server.ts'),
+      '@sva/sdk/logger/index.server': resolveAppPath('../../packages/sdk/src/logger/index.server.ts'),
+      '@sva/sdk/middleware/request-context.server': resolveAppPath('../../packages/sdk/src/middleware/request-context.server.ts'),
+      '@sva/sdk/observability/context.server': resolveAppPath('../../packages/sdk/src/observability/context.server.ts'),
+      '@sva/monitoring-client/server': resolveAppPath('../../packages/monitoring-client/src/server.ts'),
+      '@sva/monitoring-client/logger-provider.server': resolveAppPath(
+        '../../packages/monitoring-client/src/logger-provider.server.ts'
       ),
-      '@sva/monitoring-client': fileURLToPath(new URL('../../packages/monitoring-client/src/index.ts', import.meta.url)),
-      '@sva/core/security': fileURLToPath(new URL('../../packages/core/src/security/index.ts', import.meta.url)),
-      '@sva/core': fileURLToPath(new URL('../../packages/core/src/index.ts', import.meta.url)),
+      '@sva/monitoring-client': resolveAppPath('../../packages/monitoring-client/src/index.ts'),
+      '@sva/core/security': resolveAppPath('../../packages/core/src/security/index.ts'),
+      '@sva/core': resolveAppPath('../../packages/core/src/index.ts'),
     },
   },
   ssr: {

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -38,3 +38,11 @@ test('migration script supports profile-specific postgres targets', () => {
   assert.match(script, /db_string="postgres:\/\/\$\{POSTGRES_USER\}@\$\{POSTGRES_HOST\}:\$\{POSTGRES_PORT\}\/\$\{POSTGRES_DB\}\?sslmode=disable"/);
   assert.match(script, /exec env PGPASSWORD="\$\{POSTGRES_PASSWORD\}" "\$\{GOOSE_WRAPPER\}"/);
 });
+
+test('runtime artifact verification runs workspace node helper via bash', () => {
+  const script = readFileSync(resolve(testDirectory, '..', '..', '..', 'scripts/ci/verify-runtime-artifact.sh'), 'utf8');
+
+  assert.match(script, /bash "\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
+  assert.match(script, /KEYCLOAK_PORT="\$\{KEYCLOAK_PORT\}" bash "\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
+  assert.doesNotMatch(script, /(^|[^[:alnum:]_])"\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
+});

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -185,6 +185,30 @@ describe('createSvaMainserverService', () => {
     });
   });
 
+  it('passes the tenant instance id into credential loading', async () => {
+    const readCredentials = vi.fn().mockResolvedValue({
+      apiKey: 'key-1',
+      apiSecret: 'secret-1',
+    });
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials,
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+        .mockResolvedValueOnce(createJsonResponse(200, { data: { __typename: 'Query' } }))
+        .mockResolvedValueOnce(createJsonResponse(200, { data: { __typename: 'Mutation' } })),
+    });
+
+    await service.getConnectionStatus({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1' });
+
+    expect(readCredentials).toHaveBeenCalledWith({
+      instanceId: 'de-musterhausen',
+      keycloakSubject: 'subject-1',
+    });
+  });
+
   it('preserves typed identity provider errors from credential loading', async () => {
     const service = createSvaMainserverService({
       loadInstanceConfig: async () => baseConfig,

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const state = vi.hoisted(() => ({
+  readSvaMainserverCredentialsWithStatus: vi.fn(),
+}));
+
 vi.mock('@opentelemetry/api', () => ({
   SpanStatusCode: {
     OK: 1,
@@ -23,6 +27,10 @@ vi.mock('@opentelemetry/api', () => ({
         }),
     }),
   },
+}));
+
+vi.mock('@sva/auth/server', () => ({
+  readSvaMainserverCredentialsWithStatus: state.readSvaMainserverCredentialsWithStatus,
 }));
 
 import { createSvaMainserverService, resetSvaMainserverServiceState } from './service';
@@ -58,6 +66,7 @@ const createDeferred = <TValue>() => {
 
 describe('createSvaMainserverService', () => {
   afterEach(() => {
+    state.readSvaMainserverCredentialsWithStatus.mockReset();
     resetSvaMainserverServiceState();
   });
 
@@ -207,6 +216,29 @@ describe('createSvaMainserverService', () => {
       instanceId: 'de-musterhausen',
       keycloakSubject: 'subject-1',
     });
+  });
+
+  it('uses the default credential reader with keycloak subject and instance id', async () => {
+    state.readSvaMainserverCredentialsWithStatus.mockResolvedValue({
+      status: 'ok',
+      credentials: {
+        apiKey: 'key-1',
+        apiSecret: 'secret-1',
+      },
+    });
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+        .mockResolvedValueOnce(createJsonResponse(200, { data: { __typename: 'Query' } }))
+        .mockResolvedValueOnce(createJsonResponse(200, { data: { __typename: 'Mutation' } })),
+    });
+
+    await service.getConnectionStatus({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1' });
+
+    expect(state.readSvaMainserverCredentialsWithStatus).toHaveBeenCalledWith('subject-1', 'de-musterhausen');
   });
 
   it('preserves typed identity provider errors from credential loading', async () => {

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -50,7 +50,10 @@ type UpstreamRequestInput = {
 
 export type SvaMainserverServiceOptions = {
   readonly loadInstanceConfig?: (instanceId: string) => Promise<SvaMainserverInstanceConfig>;
-  readonly readCredentials?: (keycloakSubject: string) => Promise<CredentialValue | null>;
+  readonly readCredentials?: (input: {
+    readonly instanceId: string;
+    readonly keycloakSubject: string;
+  }) => Promise<CredentialValue | null>;
   readonly fetchImpl?: typeof fetch;
   readonly now?: () => number;
   readonly credentialCacheTtlMs?: number;
@@ -350,8 +353,8 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
   const loadInstanceConfig = options.loadInstanceConfig ?? loadSvaMainserverInstanceConfig;
   const readCredentials =
     options.readCredentials ??
-    (async (keycloakSubject: string) => {
-      const result = await readSvaMainserverCredentialsWithStatus(keycloakSubject);
+    (async (input: { instanceId: string; keycloakSubject: string }) => {
+      const result = await readSvaMainserverCredentialsWithStatus(input.keycloakSubject, input.instanceId);
       if (result.status === 'ok') {
         return result.credentials;
       }
@@ -476,7 +479,10 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
       async () => {
         let credentials: CredentialValue | null;
         try {
-          credentials = await readCredentials(input.keycloakSubject);
+          credentials = await readCredentials({
+            instanceId: input.instanceId,
+            keycloakSubject: input.keycloakSubject,
+          });
         } catch (error) {
           const normalizedError =
             error instanceof SvaMainserverError

--- a/scripts/ci/verify-runtime-artifact.sh
+++ b/scripts/ci/verify-runtime-artifact.sh
@@ -13,7 +13,7 @@ REDIS_PASSWORD="verify-redis-password"
 PII_KEYRING_JSON='{"k1":"MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE="}'
 
 read -r APP_PORT POSTGRES_PORT REDIS_PORT KEYCLOAK_PORT <<EOF
-$("${WORKSPACE_ROOT}/scripts/ci/run-workspace-node.sh" <<'NODE'
+$(bash "${WORKSPACE_ROOT}/scripts/ci/run-workspace-node.sh" <<'NODE'
 const net = require('node:net');
 
 const reservePort = () =>
@@ -323,7 +323,7 @@ if [ "${VERIFY_STATUS}" = "ok" ]; then
 fi
 
 if [ "${VERIFY_STATUS}" = "ok" ]; then
-  KEYCLOAK_PORT="${KEYCLOAK_PORT}" "${WORKSPACE_ROOT}/scripts/ci/run-workspace-node.sh" <<'NODE' >"${KEYCLOAK_STDOUT_PATH}" 2>"${KEYCLOAK_STDERR_PATH}" &
+  KEYCLOAK_PORT="${KEYCLOAK_PORT}" bash "${WORKSPACE_ROOT}/scripts/ci/run-workspace-node.sh" <<'NODE' >"${KEYCLOAK_STDOUT_PATH}" 2>"${KEYCLOAK_STDERR_PATH}" &
 const http = require('node:http');
 
 const port = Number(process.env.KEYCLOAK_PORT || '38080');

--- a/scripts/ops/runtime-env.test.ts
+++ b/scripts/ops/runtime-env.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { runExternalSmokeWithWarmup, shouldRetryExternalSmoke } from './runtime-env.ts';
+import type { AcceptanceProbeResult } from './runtime-env.shared.ts';
+
+const createProbe = (overrides: Partial<AcceptanceProbeResult>): AcceptanceProbeResult => ({
+  durationMs: 10,
+  message: 'ok',
+  name: 'public-ready',
+  scope: 'external',
+  status: 'ok',
+  target: 'https://studio.smart-village.app/health/ready',
+  ...overrides,
+});
+
+describe('shouldRetryExternalSmoke', () => {
+  it('retries only retryable warmup probe failures', () => {
+    const probes = [
+      createProbe({
+        message: 'Erwartet HTTP 200, erhalten 404.',
+        name: 'public-home',
+        status: 'error',
+      }),
+      createProbe({
+        message: 'Unerwarteter Ready-Status 504.',
+        name: 'public-ready',
+        status: 'error',
+      }),
+    ];
+
+    expect(shouldRetryExternalSmoke(probes)).toBe(true);
+  });
+
+  it('does not retry non-warmup probe failures', () => {
+    const probes = [
+      createProbe({
+        message: 'IAM-Kontext lieferte HTML statt eines API-Vertrags.',
+        name: 'public-iam-context',
+        status: 'error',
+        target: 'https://studio.smart-village.app/api/v1/iam/me/context',
+      }),
+    ];
+
+    expect(shouldRetryExternalSmoke(probes)).toBe(false);
+  });
+});
+
+describe('runExternalSmokeWithWarmup', () => {
+  it('retries once after a transient warmup failure', async () => {
+    const runner = vi
+      .fn<(env: NodeJS.ProcessEnv) => Promise<readonly AcceptanceProbeResult[]>>()
+      .mockResolvedValueOnce([
+        createProbe({
+          message: 'Erwartet HTTP 200, erhalten 404.',
+          name: 'public-home',
+          status: 'error',
+          target: 'https://studio.smart-village.app',
+        }),
+      ])
+      .mockResolvedValueOnce([
+        createProbe({
+          message: 'Probe erfolgreich mit HTTP 200.',
+          name: 'public-home',
+          status: 'ok',
+          target: 'https://studio.smart-village.app',
+        }),
+      ]);
+
+    const probes = await runExternalSmokeWithWarmup(
+      {},
+      {
+        maxAttempts: 2,
+        retryDelayMs: 0,
+        runner,
+      }
+    );
+
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(probes[0]?.status).toBe('ok');
+  });
+
+  it('returns immediately for non-retryable failures', async () => {
+    const runner = vi.fn<(env: NodeJS.ProcessEnv) => Promise<readonly AcceptanceProbeResult[]>>().mockResolvedValue([
+      createProbe({
+        message: 'IAM-Instanzliste lieferte HTML statt JSON/API-Vertrag.',
+        name: 'public-iam-instances',
+        status: 'error',
+        target: 'https://studio.smart-village.app/api/v1/iam/instances',
+      }),
+    ]);
+
+    const probes = await runExternalSmokeWithWarmup(
+      {},
+      {
+        maxAttempts: 2,
+        retryDelayMs: 0,
+        runner,
+      }
+    );
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(probes[0]?.status).toBe('error');
+  });
+});

--- a/scripts/ops/runtime-env.ts
+++ b/scripts/ops/runtime-env.ts
@@ -3816,6 +3816,60 @@ const runExternalSmoke = async (env: NodeJS.ProcessEnv): Promise<readonly Accept
   ]);
 };
 
+const retryableExternalWarmupProbeNames = new Set([
+  'public-home',
+  'public-live',
+  'public-ready',
+  'public-auth-login',
+  'public-auth-login-bb-guben',
+  'public-auth-login-de-musterhausen',
+]);
+
+const retryableExternalWarmupSignals = ['404', '502', '503', '504', 'timeout', 'timed out', 'gateway'];
+
+export const shouldRetryExternalSmoke = (probes: readonly AcceptanceProbeResult[]) => {
+  const failingProbes = probes.filter((probe) => probe.status === 'error');
+  if (failingProbes.length === 0) {
+    return false;
+  }
+
+  return failingProbes.every((probe) => {
+    if (!retryableExternalWarmupProbeNames.has(probe.name)) {
+      return false;
+    }
+
+    const message = probe.message.toLowerCase();
+    return retryableExternalWarmupSignals.some((signal) => message.includes(signal));
+  });
+};
+
+export const runExternalSmokeWithWarmup = async (
+  env: NodeJS.ProcessEnv,
+  options?: {
+    readonly maxAttempts?: number;
+    readonly retryDelayMs?: number;
+    readonly runner?: (env: NodeJS.ProcessEnv) => Promise<readonly AcceptanceProbeResult[]>;
+  }
+): Promise<readonly AcceptanceProbeResult[]> => {
+  const maxAttempts = options?.maxAttempts ?? Number(env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS ?? '2');
+  const retryDelayMs = options?.retryDelayMs ?? Number(env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS ?? '15000');
+  const runner = options?.runner ?? runExternalSmoke;
+  let lastProbes: readonly AcceptanceProbeResult[] = [];
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const probes = await runner(env);
+    lastProbes = probes;
+
+    if (!shouldRetryExternalSmoke(probes) || attempt >= maxAttempts) {
+      return probes;
+    }
+
+    await wait(retryDelayMs);
+  }
+
+  return lastProbes;
+};
+
 const runAcceptanceDeploy = async (runtimeProfile: RemoteRuntimeProfile, env: NodeJS.ProcessEnv) => {
   const options = resolveAcceptanceDeployOptions(env, cliOptions, runtimeProfile);
   const mutationContext = assertDeterministicRemoteMutationContext(env, runtimeProfile, 'deploy');
@@ -4083,7 +4137,7 @@ const runAcceptanceDeploy = async (runtimeProfile: RemoteRuntimeProfile, env: No
 
     const externalSmokeStartedAt = Date.now();
     try {
-      const externalProbes = await runExternalSmoke(env);
+      const externalProbes = await runExternalSmokeWithWarmup(env);
       report = {
         ...report,
         externalProbes,
@@ -4245,8 +4299,13 @@ const main = async () => {
   await runAcceptanceCommand(requireRemoteRuntimeProfile(runtimeProfile), runtimeCommand);
 };
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`[runtime-env] ${message}`);
-  process.exit(1);
-});
+const entryScriptPath = process.argv[1] ? resolve(process.argv[1]) : null;
+const currentScriptPath = fileURLToPath(import.meta.url);
+
+if (entryScriptPath === currentScriptPath) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[runtime-env] ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/ops/runtime-env.ts
+++ b/scripts/ops/runtime-env.ts
@@ -3851,8 +3851,10 @@ export const runExternalSmokeWithWarmup = async (
     readonly runner?: (env: NodeJS.ProcessEnv) => Promise<readonly AcceptanceProbeResult[]>;
   }
 ): Promise<readonly AcceptanceProbeResult[]> => {
-  const maxAttempts = options?.maxAttempts ?? Number(env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS ?? '2');
   const retryDelayMs = options?.retryDelayMs ?? Number(env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS ?? '15000');
+  const warmupWindowMs = Number(env.SVA_EXTERNAL_SMOKE_WARMUP_WINDOW_MS ?? '300000');
+  const derivedMaxAttempts = Math.max(1, Math.floor(warmupWindowMs / Math.max(retryDelayMs, 1)) + 1);
+  const maxAttempts = options?.maxAttempts ?? Number(env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS ?? String(derivedMaxAttempts));
   const runner = options?.runner ?? runExternalSmoke;
   let lastProbes: readonly AcceptanceProbeResult[] = [];
 


### PR DESCRIPTION
## Ziel
Stabilisiert den Interfaces-/External-Smoke-Pfad während des Warmups, wenn Overview-Requests oder nachgelagerte Probes vorübergehend mit `401 Unauthorized` oder noch nicht vollständig bereiten Runtime-Artefakten antworten.

## Änderungen
- Retry-Logik für Unauthorized-Overview-Requests ergänzt
- External-Warmup-Probes robuster gemacht
- Workspace-Node-Helper und zugehörige Runtime-Artefakte im Test abgesichert
- Ausführungspfad für Workspace-Node-Kommandos vereinheitlicht
- `readCredentials` um die benötigten Eingaben erweitert
- Vite-Pfadauflösung auf `resolveAppPath` umgestellt

## Tests
- Bereits vorhandene Tests aus dem Branch enthalten
- Kein zusätzlicher Full-PR-Gate-Lauf in diesem Schritt neu ausgeführt

## Offene Punkte
- Nach Review entscheiden, ob zusätzliche End-to-End-Abdeckung für den Warmup-Pfad nötig ist
