### PR TITLE
[codex] fix instance config status and repair flows

### DIFF
--- a/apps/sva-studio-react/e2e/account-admin-ui.spec.ts
+++ b/apps/sva-studio-react/e2e/account-admin-ui.spec.ts
@@ -712,7 +712,7 @@ test('direct access to admin users redirects unauthenticated clients to login', 
 
   expect([302, 303, 307, 308]).toContain(response.status());
   expect(response.headers().location).toMatch(
-    /(\/auth\/login\?redirect=%2Fadmin%2Fusers|\/protocol\/openid-connect\/auth\?|accounts\.google\.com\/(signin\/oauth\/error|o\/oauth2\/v2\/auth))/
+    /(\/auth\/login\?returnTo=%2Fadmin%2Fusers|\/protocol\/openid-connect\/auth\?|accounts\.google\.com\/(signin\/oauth\/error|o\/oauth2\/v2\/auth))/
   );
 });
 

--- a/apps/sva-studio-react/e2e/news-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/news-plugin.spec.ts
@@ -327,7 +327,7 @@ test.describe('news plugin', () => {
     await page.goto('/');
     await navigateClientSide(page, '/plugins/news');
 
-    await expect(page).toHaveURL(/\/auth\/login\?redirect=%2Fplugins%2Fnews/);
+    await expect(page).toHaveURL(/\/auth\/login\?returnTo=%2Fplugins%2Fnews/);
   });
 
   test('stays free of serious accessibility violations on news views', async ({ page }) => {

--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -830,6 +830,14 @@ export const i18nResources = {
             blocked: 'Der Client konnte wegen fehlendem Keycloak-Zugriff noch nicht geprüft werden.',
             pending: 'Der Tenant-Client sollte per Vorschau oder Statuslauf geprüft werden.',
           },
+          tenantAdminClient: {
+            title: 'Tenant-Admin-Client prüfen',
+            notConfigured: 'In der Registry ist noch kein Tenant-Admin-Client hinterlegt.',
+            secretMissing: 'Der Tenant-Admin-Client ist in der Registry vorhanden, aber der Secret-Vertrag ist noch unvollständig.',
+            ready: 'Tenant-Admin-Client und Secret-Vertrag entsprechen dem erwarteten Zustand.',
+            blocked: 'Der Tenant-Admin-Client konnte wegen fehlendem Keycloak-Zugriff noch nicht geprüft werden.',
+            pending: 'Der Tenant-Admin-Client sollte jetzt per Provisioning geprüft oder abgeglichen werden.',
+          },
           mapper: {
             title: 'instanceId-Mapper prüfen',
             ready: 'Der instanceId-Mapper ist vorhanden.',

--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -549,6 +549,14 @@ export const i18nResources = {
           authClientSecretHint: 'Leer lassen, um das bestehende Secret unverändert zu lassen.',
           authClientSecretGeneratedHint: 'Bei neuen Realms wird das Secret beim Provisioning automatisch erzeugt und danach in Studio gespeichert.',
           authClientSecretGeneratedDuringProvisioning: 'Wird beim Provisioning automatisch erzeugt',
+          tenantAdminClientTitle: 'Tenant-Admin-Client',
+          tenantAdminClientSubtitle: 'Client-Vertrag und Secret für tenant-spezifische Verwaltungsoperationen.',
+          tenantAdminClientId: 'Tenant-Admin-Client-ID',
+          tenantAdminClientSecret: 'Tenant-Admin-Client-Secret',
+          tenantAdminClientSecretConfigured: 'Secret bereits konfiguriert',
+          tenantAdminClientSecretMissing: 'Secret fehlt noch',
+          tenantAdminClientSecretHint:
+            'Leer lassen, um das bestehende Tenant-Admin-Client-Secret unverändert zu lassen.',
           tenantAdminTitle: 'Initialer Tenant-Admin',
           tenantAdminSubtitle: 'Diese Daten werden für den Bootstrap des Realm-Admins genutzt.',
           tenantAdminUsername: 'Admin-Benutzername',
@@ -599,6 +607,7 @@ export const i18nResources = {
           checkKeycloakStatus: 'Keycloak-Status prüfen',
           planProvisioning: 'Provisioning-Vorschau laden',
           executeProvisioning: 'Provisioning ausführen',
+          provisionAdminClient: 'Tenant-Admin-Client bereitstellen',
           reconcileKeycloak: 'Realm anwenden',
           resetTenantAdmin: 'Tenant-Admin neu setzen',
           rotateClientSecret: 'Client-Secret rotieren',
@@ -744,6 +753,22 @@ export const i18nResources = {
             impact:
               'Bei bestehenden Realms blockiert ein fehlendes Secret Secret-Checks und Teile des Provisioning-/Drift-Abgleichs. Bei neuen Realms wird es nach dem Provisioning automatisch gespeichert.',
           },
+          tenantAdminClientId: {
+            title: 'Tenant-Admin-Client-ID',
+            what: 'OIDC-Client für tenant-spezifische Verwaltungs- und Bootstrap-Vorgänge.',
+            value: 'Den erwarteten Client-Namen eintragen, z. B. "sva-studio-admin".',
+            source: 'Kommt aus dem Tenant-Realm in Keycloak oder aus dem vorgesehenen Provisioning-Vertrag.',
+            impact: 'Ohne korrekte Client-ID bleiben tenant-spezifische Verwaltungsaktionen und Teile der Benutzerverwaltung blockiert.',
+            defaultHint: 'Falls der Client noch nicht existiert, kann Studio ihn über das Provisioning bereitstellen.',
+          },
+          tenantAdminClientSecret: {
+            title: 'Tenant-Admin-Client-Secret',
+            what: 'Secret des Tenant-Admin-Clients, das Studio verschlüsselt speichert und für Verwaltungsoperationen nutzt.',
+            value: 'Bei bestehenden Realms das aktuelle Secret des Tenant-Admin-Clients eintragen.',
+            source: 'Kommt aus den Client-Credentials des Tenant-Admin-Clients in Keycloak.',
+            impact:
+              'Ein fehlendes oder falsches Secret blockiert Verwaltungsoperationen, Rollenpflege und den Abgleich des Tenant-Admin-Clients.',
+          },
           tenantAdminUsername: {
             title: 'Admin-Benutzername',
             what: 'Technischer Benutzername des Tenant-Admins für Bootstrap oder Reset.',
@@ -871,6 +896,42 @@ export const i18nResources = {
           },
           keycloakUnavailable: 'Die Detailseite bleibt bedienbar, aber Keycloak-Aktionen und Prüfungen sind aktuell blockiert. Prüfen Sie Erreichbarkeit und Credentials.',
         },
+        configuration: {
+          title: 'Konfigurationsstatus',
+          labels: {
+            lifecycle: 'Lifecycle',
+            requirements: 'Erfüllte Anforderungen',
+            requirementsValue: '{{satisfied}} / {{total}} Anforderungen erfüllt',
+            blockingIssues: 'Konkrete Blocker',
+            warnings: 'Hinweise',
+          },
+          overall: {
+            complete: 'Vollständig',
+            degraded: 'Mit Hinweisen',
+            incomplete: 'Unvollständig',
+            unknown: 'Ungeprüft',
+          },
+          summary: {
+            complete: {
+              title: 'Konfiguration vollständig',
+              body: 'Alle kanonischen Keycloak-Anforderungen für diese Instanz sind aktuell erfüllt.',
+            },
+            degraded: {
+              title: 'Konfiguration betriebsfähig mit Hinweisen',
+              body: 'Die Pflichtanforderungen sind erfüllt, aber es bestehen noch betriebliche Hinweise oder Abweichungen.',
+            },
+            incomplete: {
+              title: 'Konfiguration unvollständig',
+              body: 'Es sind noch {{count}} kanonische Anforderungen offen oder fehlerhaft.',
+            },
+            unknown: {
+              title: 'Konfigurationsstatus nicht verifiziert',
+              body: 'Die kanonischen Anforderungen wurden noch nicht vollständig gegen Keycloak geprüft.',
+              keycloakUnavailable:
+                'Die kanonischen Anforderungen konnten aktuell nicht zuverlässig gegen Keycloak geprüft werden.',
+            },
+          },
+        },
         keycloakStatus: {
           ok: 'OK',
           missing: 'Fehlt',
@@ -914,6 +975,10 @@ export const i18nResources = {
           conflict: 'Die gewünschte Änderung steht im Konflikt mit dem aktuellen Instanzstatus.',
           databaseUnavailable: 'Die Registry konnte wegen eines Datenbankproblems nicht verarbeitet werden.',
           tenantAuthClientSecretMissing: 'Für diese Instanz ist noch kein Tenant-Client-Secret hinterlegt.',
+          tenantAdminClientNotConfigured:
+            'Für diese Instanz ist noch kein Tenant-Admin-Client hinterlegt. Pflegen Sie den Client-Vertrag und speichern Sie die Instanz.',
+          tenantAdminClientSecretMissing:
+            'Für diese Instanz fehlt noch das Tenant-Admin-Client-Secret. Hinterlegen Sie es in der Detailseite und speichern Sie erneut.',
           keycloakUnavailable: 'Keycloak konnte nicht erreicht oder nicht abgeglichen werden.',
           encryptionNotConfigured: 'Die notwendige Feldverschlüsselung für Tenant-Secrets ist nicht konfiguriert.',
         },
@@ -2302,6 +2367,14 @@ export const i18nResources = {
           authClientSecretGeneratedHint:
             'For new realms, the secret is generated automatically during provisioning and stored in Studio afterwards.',
           authClientSecretGeneratedDuringProvisioning: 'Generated automatically during provisioning',
+          tenantAdminClientTitle: 'Tenant admin client',
+          tenantAdminClientSubtitle: 'Client contract and secret for tenant-specific administrative operations.',
+          tenantAdminClientId: 'Tenant admin client id',
+          tenantAdminClientSecret: 'Tenant admin client secret',
+          tenantAdminClientSecretConfigured: 'Secret already configured',
+          tenantAdminClientSecretMissing: 'Secret still missing',
+          tenantAdminClientSecretHint:
+            'Leave empty to keep the existing tenant admin client secret unchanged.',
           tenantAdminTitle: 'Initial tenant admin',
           tenantAdminSubtitle: 'These values are used for tenant realm bootstrap.',
           tenantAdminUsername: 'Admin username',
@@ -2352,6 +2425,7 @@ export const i18nResources = {
           checkKeycloakStatus: 'Check Keycloak status',
           planProvisioning: 'Load provisioning preview',
           executeProvisioning: 'Execute provisioning',
+          provisionAdminClient: 'Provision tenant admin client',
           reconcileKeycloak: 'Apply realm',
           resetTenantAdmin: 'Reset tenant admin',
           rotateClientSecret: 'Rotate client secret',
@@ -2499,6 +2573,22 @@ export const i18nResources = {
             impact:
               'For existing realms, missing the secret blocks secret checks and parts of provisioning/drift reconciliation. For new realms, it is stored automatically after provisioning.',
           },
+          tenantAdminClientId: {
+            title: 'Tenant admin client id',
+            what: 'OIDC client for tenant-specific administrative and bootstrap operations.',
+            value: 'Enter the expected client name, for example "sva-studio-admin".',
+            source: 'Comes from the tenant realm in Keycloak or from the intended provisioning contract.',
+            impact: 'Without the correct client id, tenant-specific administration and parts of user management stay blocked.',
+            defaultHint: 'If the client does not exist yet, Studio can provision it.',
+          },
+          tenantAdminClientSecret: {
+            title: 'Tenant admin client secret',
+            what: 'Secret of the tenant admin client that Studio stores encrypted and uses for administrative operations.',
+            value: 'For existing realms, enter the current secret of the tenant admin client.',
+            source: 'Comes from the client credentials of the tenant admin client in Keycloak.',
+            impact:
+              'A missing or wrong secret blocks administrative operations, role management, and reconciliation of the tenant admin client.',
+          },
           tenantAdminUsername: {
             title: 'Admin username',
             what: 'Technical username of the tenant admin for bootstrap or reset.',
@@ -2559,6 +2649,14 @@ export const i18nResources = {
             ready: 'The expected tenant client was found.',
             blocked: 'The client could not be checked yet because Keycloak access is blocked.',
             pending: 'The tenant client should be checked through preview or a status run.',
+          },
+          tenantAdminClient: {
+            title: 'Check tenant admin client',
+            notConfigured: 'No tenant admin client is stored in the registry yet.',
+            secretMissing: 'The tenant admin client exists in the registry, but its secret contract is still incomplete.',
+            ready: 'The tenant admin client and its secret contract match the expected state.',
+            blocked: 'The tenant admin client could not be checked yet because Keycloak access is blocked.',
+            pending: 'The tenant admin client should now be verified or reconciled through provisioning.',
           },
           mapper: {
             title: 'Check instanceId mapper',
@@ -2627,6 +2725,42 @@ export const i18nResources = {
           },
           keycloakUnavailable: 'The detail page remains usable, but Keycloak actions and checks are currently blocked. Verify reachability and credentials.',
         },
+        configuration: {
+          title: 'Configuration status',
+          labels: {
+            lifecycle: 'Lifecycle',
+            requirements: 'Satisfied requirements',
+            requirementsValue: '{{satisfied}} / {{total}} requirements satisfied',
+            blockingIssues: 'Blocking issues',
+            warnings: 'Warnings',
+          },
+          overall: {
+            complete: 'Complete',
+            degraded: 'Warnings',
+            incomplete: 'Incomplete',
+            unknown: 'Unchecked',
+          },
+          summary: {
+            complete: {
+              title: 'Configuration complete',
+              body: 'All canonical Keycloak requirements for this instance are currently satisfied.',
+            },
+            degraded: {
+              title: 'Configuration operational with warnings',
+              body: 'All required checks pass, but operational warnings or deviations remain.',
+            },
+            incomplete: {
+              title: 'Configuration incomplete',
+              body: '{{count}} canonical requirements are still missing or incorrect.',
+            },
+            unknown: {
+              title: 'Configuration status not verified',
+              body: 'The canonical requirements have not been checked against Keycloak completely yet.',
+              keycloakUnavailable:
+                'The canonical requirements could not be checked against Keycloak reliably at the moment.',
+            },
+          },
+        },
         keycloakStatus: {
           ok: 'OK',
           missing: 'Missing',
@@ -2670,6 +2804,10 @@ export const i18nResources = {
           conflict: 'The requested change conflicts with the current instance state.',
           databaseUnavailable: 'The registry could not be processed because of a database problem.',
           tenantAuthClientSecretMissing: 'No tenant client secret has been stored for this instance yet.',
+          tenantAdminClientNotConfigured:
+            'No tenant admin client has been stored for this instance yet. Enter the client contract and save the instance.',
+          tenantAdminClientSecretMissing:
+            'The tenant admin client secret is still missing for this instance. Enter it on the detail page and save again.',
           keycloakUnavailable: 'Keycloak could not be reached or reconciled.',
           encryptionNotConfigured: 'Field encryption required for tenant secrets is not configured.',
         },

--- a/apps/sva-studio-react/src/lib/iam-api.ts
+++ b/apps/sva-studio-react/src/lib/iam-api.ts
@@ -365,6 +365,10 @@ export type CreateInstancePayload = {
   readonly authClientId: string;
   readonly authIssuerUrl?: string;
   readonly authClientSecret?: string;
+  readonly tenantAdminClient?: {
+    readonly clientId: string;
+    readonly secret?: string;
+  };
   readonly tenantAdminBootstrap?: {
     readonly username: string;
     readonly email?: string;
@@ -384,6 +388,10 @@ export type UpdateInstancePayload = {
   readonly authClientId: string;
   readonly authIssuerUrl?: string;
   readonly authClientSecret?: string;
+  readonly tenantAdminClient?: {
+    readonly clientId: string;
+    readonly secret?: string;
+  };
   readonly tenantAdminBootstrap?: {
     readonly username: string;
     readonly email?: string;
@@ -401,7 +409,7 @@ export type ReconcileInstanceKeycloakPayload = {
 };
 
 export type ExecuteInstanceKeycloakProvisioningPayload = {
-  readonly intent: 'provision' | 'reset_tenant_admin' | 'rotate_client_secret';
+  readonly intent: 'provision' | 'provision_admin_client' | 'reset_tenant_admin' | 'rotate_client_secret';
   readonly tenantAdminTemporaryPassword?: string;
 };
 

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { t } from '../../../i18n';
 import { InstanceDetailPage } from './-instance-detail-page';
 
 const useInstancesMock = vi.fn();
@@ -165,12 +166,19 @@ describe('InstanceDetailPage', () => {
     render(<InstanceDetailPage instanceId="demo" />);
 
     await waitFor(() => {
-    expect(loadInstance).toHaveBeenCalledWith('demo');
+      expect(loadInstance).toHaveBeenCalledWith('demo');
     });
 
-    expect(screen.getByText('Konfigurationsstatus')).toBeTruthy();
-    expect(screen.getByText('Konfiguration vollständig')).toBeTruthy();
-    expect(screen.getByText('13 / 13 Anforderungen erfüllt')).toBeTruthy();
+    expect(screen.getByText(t('admin.instances.configuration.title'))).toBeTruthy();
+    expect(screen.getByText(t('admin.instances.configuration.summary.complete.title'))).toBeTruthy();
+    expect(
+      screen.getByText(
+        t('admin.instances.configuration.labels.requirementsValue', {
+          satisfied: 13,
+          total: 13,
+        })
+      )
+    ).toBeTruthy();
     expect(screen.getByText('Instanz gespeichert, aber noch nicht betriebsbereit')).toBeTruthy();
     expect(screen.getByText('Was ist noch offen?')).toBeTruthy();
     expect(screen.getByText('Provisioning ist erfolgreich. Die Instanz kann jetzt aktiviert werden.')).toBeTruthy();

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -28,6 +28,10 @@ const createSelectedInstance = (overrides: Record<string, unknown> = {}) => ({
   authRealm: 'demo',
   authClientId: 'sva-studio',
   authClientSecretConfigured: true,
+  tenantAdminClient: {
+    clientId: 'sva-studio-admin',
+    secretConfigured: true,
+  },
   hostnames: [],
   provisioningRuns: [],
   auditEvents: [],
@@ -67,6 +71,7 @@ const createSelectedInstance = (overrides: Record<string, unknown> = {}) => ({
   keycloakStatus: {
     realmExists: true,
     clientExists: true,
+    tenantAdminClientExists: true,
     instanceIdMapperExists: true,
     tenantAdminExists: true,
     tenantAdminHasSystemAdmin: true,
@@ -78,6 +83,9 @@ const createSelectedInstance = (overrides: Record<string, unknown> = {}) => ({
     clientSecretConfigured: true,
     tenantClientSecretReadable: true,
     clientSecretAligned: true,
+    tenantAdminClientSecretConfigured: true,
+    tenantAdminClientSecretReadable: true,
+    tenantAdminClientSecretAligned: true,
     runtimeSecretSource: 'tenant',
   },
   latestKeycloakProvisioningRun: {
@@ -157,9 +165,12 @@ describe('InstanceDetailPage', () => {
     render(<InstanceDetailPage instanceId="demo" />);
 
     await waitFor(() => {
-      expect(loadInstance).toHaveBeenCalledWith('demo');
+    expect(loadInstance).toHaveBeenCalledWith('demo');
     });
 
+    expect(screen.getByText('Konfigurationsstatus')).toBeTruthy();
+    expect(screen.getByText('Konfiguration vollständig')).toBeTruthy();
+    expect(screen.getByText('13 / 13 Anforderungen erfüllt')).toBeTruthy();
     expect(screen.getByText('Instanz gespeichert, aber noch nicht betriebsbereit')).toBeTruthy();
     expect(screen.getByText('Was ist noch offen?')).toBeTruthy();
     expect(screen.getByText('Provisioning ist erfolgreich. Die Instanz kann jetzt aktiviert werden.')).toBeTruthy();
@@ -183,6 +194,12 @@ describe('InstanceDetailPage', () => {
     fireEvent.change(screen.getByLabelText('Tenant-Client-Secret', { selector: '#detail-auth-client-secret' }), {
       target: { value: ' test-client-secret ' },
     });
+    fireEvent.change(screen.getByLabelText('Tenant-Admin-Client-ID', { selector: '#detail-tenant-admin-client-id' }), {
+      target: { value: ' tenant-admin-client ' },
+    });
+    fireEvent.change(screen.getByLabelText('Tenant-Admin-Client-Secret', { selector: '#detail-tenant-admin-client-secret' }), {
+      target: { value: ' test-admin-client-secret ' },
+    });
     fireEvent.change(screen.getByLabelText('Admin-Benutzername', { selector: '#detail-admin-username' }), {
       target: { value: ' updated-admin ' },
     });
@@ -200,6 +217,10 @@ describe('InstanceDetailPage', () => {
         authClientId: 'tenant-client',
         authIssuerUrl: 'https://issuer.example.org',
         authClientSecret: 'test-client-secret',
+        tenantAdminClient: {
+          clientId: 'tenant-admin-client',
+          secret: 'test-admin-client-secret',
+        },
         tenantAdminBootstrap: {
           username: 'updated-admin',
           email: 'demo@example.org',
@@ -213,12 +234,17 @@ describe('InstanceDetailPage', () => {
       expect(
         (screen.getByLabelText('Tenant-Client-Secret', { selector: '#detail-auth-client-secret' }) as HTMLInputElement).value
       ).toBe('');
+      expect(
+        (screen.getByLabelText('Tenant-Admin-Client-Secret', { selector: '#detail-tenant-admin-client-secret' }) as HTMLInputElement)
+          .value
+      ).toBe('');
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Vorbedingungen prüfen' })[0]);
     fireEvent.click(screen.getAllByRole('button', { name: 'Keycloak-Status prüfen' })[0]);
     fireEvent.click(screen.getAllByRole('button', { name: 'Provisioning-Vorschau laden' })[0]);
     fireEvent.click(screen.getAllByRole('button', { name: 'Provisioning ausführen' }).at(-1)!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Tenant-Admin-Client bereitstellen' }).at(-1)!);
     fireEvent.click(screen.getAllByRole('button', { name: 'Tenant-Admin neu setzen' }).at(-1)!);
     fireEvent.click(screen.getAllByRole('button', { name: 'Client-Secret rotieren' }).at(-1)!);
     fireEvent.click(screen.getByRole('button', { name: 'Aktivieren' }));
@@ -234,6 +260,13 @@ describe('InstanceDetailPage', () => {
             'demo',
             {
               intent: 'provision',
+              tenantAdminTemporaryPassword: 'test-temp-password',
+            },
+          ],
+          [
+            'demo',
+            {
+              intent: 'provision_admin_client',
               tenantAdminTemporaryPassword: 'test-temp-password',
             },
           ],
@@ -296,6 +329,7 @@ describe('InstanceDetailPage', () => {
           keycloakStatus: {
             realmExists: false,
             clientExists: false,
+            tenantAdminClientExists: false,
             instanceIdMapperExists: false,
             tenantAdminExists: false,
             tenantAdminHasSystemAdmin: false,
@@ -307,7 +341,10 @@ describe('InstanceDetailPage', () => {
             clientSecretConfigured: false,
             tenantClientSecretReadable: false,
             clientSecretAligned: false,
-            runtimeSecretSource: 'instance',
+            tenantAdminClientSecretConfigured: false,
+            tenantAdminClientSecretReadable: false,
+            tenantAdminClientSecretAligned: false,
+            runtimeSecretSource: 'global',
           },
           latestKeycloakProvisioningRun: undefined,
         }),
@@ -325,6 +362,47 @@ describe('InstanceDetailPage', () => {
     expect(
       screen.getByText('Bei neuen Realms wird das Secret beim Provisioning automatisch erzeugt und danach in Studio gespeichert.')
     ).toBeTruthy();
+  });
+
+  it('shows blocking configuration issues when the tenant admin client contract is incomplete', () => {
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        selectedInstance: createSelectedInstance({
+          status: 'active',
+          tenantAdminClient: {
+            clientId: 'demo-admin-client',
+            secretConfigured: false,
+          },
+          keycloakStatus: {
+            realmExists: true,
+            clientExists: true,
+            tenantAdminClientExists: false,
+            instanceIdMapperExists: true,
+            tenantAdminExists: true,
+            tenantAdminHasSystemAdmin: true,
+            tenantAdminHasInstanceRegistryAdmin: false,
+            tenantAdminInstanceIdMatches: true,
+            redirectUrisMatch: true,
+            logoutUrisMatch: true,
+            webOriginsMatch: true,
+            clientSecretConfigured: true,
+            tenantClientSecretReadable: true,
+            clientSecretAligned: true,
+            tenantAdminClientSecretConfigured: false,
+            tenantAdminClientSecretReadable: false,
+            tenantAdminClientSecretAligned: false,
+            runtimeSecretSource: 'tenant',
+          },
+        }),
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    expect(screen.getByText('Konfiguration unvollständig')).toBeTruthy();
+    expect(screen.getByText('Konkrete Blocker')).toBeTruthy();
+    expect(screen.getByText('Tenant-Admin-Client vorhanden')).toBeTruthy();
+    expect(screen.getByText('Tenant-Admin-Client-Secret mit Keycloak abgeglichen')).toBeTruthy();
   });
 
   it('renders non-keycloak mutation errors', () => {

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -128,7 +128,13 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
   };
 
   const triggerWorkflowAction = async (
-    action: 'check_preflight' | 'check_keycloak_status' | 'plan_provisioning' | 'execute_provisioning' | 'activate_instance'
+    action:
+      | 'check_preflight'
+      | 'check_keycloak_status'
+      | 'plan_provisioning'
+      | 'execute_provisioning'
+      | 'provision_admin_client'
+      | 'activate_instance'
   ) => {
     if (!selectedInstance) {
       return;
@@ -146,6 +152,9 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
         return;
       case 'execute_provisioning':
         await executeProvisioning('provision');
+        return;
+      case 'provision_admin_client':
+        await executeProvisioning('provision_admin_client');
         return;
       case 'activate_instance':
         await instancesApi.activateInstance(selectedInstance.instanceId);

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -10,7 +10,9 @@ import { useInstances } from '../../../hooks/use-instances';
 import { t } from '../../../i18n';
 import { FieldHelp } from './-field-help';
 import {
+  ConfigurationStatusBadge,
   createDetailForm,
+  evaluateInstanceConfiguration,
   getErrorMessage,
   getKeycloakStatusEntries,
   getSetupWorkflowSteps,
@@ -55,6 +57,7 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
 
   const selectedInstance = instancesApi.selectedInstance?.instanceId === instanceId ? instancesApi.selectedInstance : null;
   const tenantSecretUserInputRequired = selectedInstance ? isTenantSecretUserInputRequired(selectedInstance.realmMode) : true;
+  const configurationAssessment = selectedInstance ? evaluateInstanceConfiguration(selectedInstance, instancesApi.mutationError) : null;
 
   React.useEffect(() => {
     if (!selectedInstance) {
@@ -79,6 +82,12 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
       authClientId: detailFormValues.authClientId.trim(),
       authIssuerUrl: detailFormValues.authIssuerUrl.trim() || undefined,
       authClientSecret: detailFormValues.authClientSecret.trim() || undefined,
+      tenantAdminClient: detailFormValues.tenantAdminClient.clientId.trim()
+        ? {
+            clientId: detailFormValues.tenantAdminClient.clientId.trim(),
+            secret: detailFormValues.tenantAdminClient.secret.trim() || undefined,
+          }
+        : undefined,
       tenantAdminBootstrap: detailFormValues.tenantAdminBootstrap.username.trim()
         ? {
             username: detailFormValues.tenantAdminBootstrap.username.trim(),
@@ -89,10 +98,23 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
         : undefined,
     });
 
-    setDetailFormValues((current) => (current ? { ...current, authClientSecret: '' } : current));
+    setDetailFormValues((current) =>
+      current
+        ? {
+            ...current,
+            authClientSecret: '',
+            tenantAdminClient: {
+              ...current.tenantAdminClient,
+              secret: '',
+            },
+          }
+        : current
+    );
   };
 
-  const executeProvisioning = async (intent: 'provision' | 'reset_tenant_admin' | 'rotate_client_secret') => {
+  const executeProvisioning = async (
+    intent: 'provision' | 'provision_admin_client' | 'reset_tenant_admin' | 'rotate_client_secret'
+  ) => {
     if (!selectedInstance || !detailFormValues) {
       return;
     }
@@ -159,6 +181,63 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
                 <div>{t('admin.instances.detail.parentDomain', { value: selectedInstance.parentDomain })}</div>
                 <div>{t('admin.instances.detail.status', { value: t(INSTANCE_STATUS_LABELS[selectedInstance.status]) })}</div>
               </div>
+              {configurationAssessment ? (
+                <div className="rounded-lg border border-border p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="font-medium text-foreground">{t('admin.instances.configuration.title')}</div>
+                      <p className="text-sm text-muted-foreground">{configurationAssessment.title}</p>
+                    </div>
+                    <ConfigurationStatusBadge status={configurationAssessment.overallStatus} />
+                  </div>
+                  <div className="mt-3 grid gap-2 text-sm md:grid-cols-2">
+                    <div className="rounded-md border border-border bg-muted/20 p-3">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {t('admin.instances.configuration.labels.lifecycle')}
+                      </div>
+                      <div className="mt-1 font-medium text-foreground">
+                        {t(INSTANCE_STATUS_LABELS[selectedInstance.status])}
+                      </div>
+                    </div>
+                    <div className="rounded-md border border-border bg-muted/20 p-3">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {t('admin.instances.configuration.labels.requirements')}
+                      </div>
+                      <div className="mt-1 font-medium text-foreground">
+                        {t('admin.instances.configuration.labels.requirementsValue', {
+                          satisfied: configurationAssessment.satisfiedRequirements,
+                          total: configurationAssessment.totalRequirements,
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">{configurationAssessment.body}</p>
+                  {configurationAssessment.blockingIssues.length > 0 ? (
+                    <div className="mt-3 space-y-2">
+                      <div className="text-sm font-medium text-foreground">
+                        {t('admin.instances.configuration.labels.blockingIssues')}
+                      </div>
+                      <ul className="space-y-1 text-sm text-muted-foreground">
+                        {configurationAssessment.blockingIssues.map((issue) => (
+                          <li key={issue.key}>• {issue.label}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                  {configurationAssessment.warningIssues.length > 0 ? (
+                    <div className="mt-3 space-y-2">
+                      <div className="text-sm font-medium text-foreground">
+                        {t('admin.instances.configuration.labels.warnings')}
+                      </div>
+                      <ul className="space-y-1 text-sm text-muted-foreground">
+                        {configurationAssessment.warningIssues.map((issue) => (
+                          <li key={issue.key}>• {issue.label}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
               <div className="rounded-lg border border-border bg-muted/30 p-3">
                 <div className="font-medium text-foreground">{getStatusGuidance(selectedInstance).title}</div>
                 <p className="mt-1 text-sm text-muted-foreground">{getStatusGuidance(selectedInstance).body}</p>
@@ -332,6 +411,62 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
                 </div>
 
                 <div className="space-y-1">
+                  <h2 className="text-sm font-medium text-foreground">{t('admin.instances.form.tenantAdminClientTitle')}</h2>
+                  <p className="text-xs text-muted-foreground">{t('admin.instances.form.tenantAdminClientSubtitle')}</p>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div className="space-y-1">
+                    <FormLabelWithHelp
+                      htmlFor="detail-tenant-admin-client-id"
+                      label={t('admin.instances.form.tenantAdminClientId')}
+                      helpKey="tenantAdminClientId"
+                    />
+                    <Input
+                      id="detail-tenant-admin-client-id"
+                      value={detailFormValues.tenantAdminClient.clientId}
+                      onChange={(event) =>
+                        setDetailFormValues((current) =>
+                          current
+                            ? {
+                                ...current,
+                                tenantAdminClient: { ...current.tenantAdminClient, clientId: event.target.value },
+                              }
+                            : current
+                        )
+                      }
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <FormLabelWithHelp
+                      htmlFor="detail-tenant-admin-client-secret"
+                      label={t('admin.instances.form.tenantAdminClientSecret')}
+                      helpKey="tenantAdminClientSecret"
+                    />
+                    <Input
+                      id="detail-tenant-admin-client-secret"
+                      type="password"
+                      placeholder={
+                        selectedInstance.tenantAdminClient?.secretConfigured
+                          ? t('admin.instances.form.tenantAdminClientSecretConfigured')
+                          : t('admin.instances.form.tenantAdminClientSecretMissing')
+                      }
+                      value={detailFormValues.tenantAdminClient.secret}
+                      onChange={(event) =>
+                        setDetailFormValues((current) =>
+                          current
+                            ? {
+                                ...current,
+                                tenantAdminClient: { ...current.tenantAdminClient, secret: event.target.value },
+                              }
+                            : current
+                        )
+                      }
+                    />
+                    <p className="text-xs text-muted-foreground">{t('admin.instances.form.tenantAdminClientSecretHint')}</p>
+                  </div>
+                </div>
+
+                <div className="space-y-1">
                   <h2 className="text-sm font-medium text-foreground">{t('admin.instances.form.tenantAdminTitle')}</h2>
                   <p className="text-xs text-muted-foreground">{t('admin.instances.form.tenantAdminSubtitle')}</p>
                 </div>
@@ -451,6 +586,9 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
               <div className="flex flex-wrap gap-2">
                 <Button type="button" onClick={() => void executeProvisioning('provision')}>
                   {t('admin.instances.actions.executeProvisioning')}
+                </Button>
+                <Button type="button" variant="outline" onClick={() => void executeProvisioning('provision_admin_client')}>
+                  {t('admin.instances.actions.provisionAdminClient')}
                 </Button>
                 <Button type="button" variant="outline" onClick={() => void executeProvisioning('reset_tenant_admin')}>
                   {t('admin.instances.actions.resetTenantAdmin')}

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -134,6 +134,7 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
       | 'plan_provisioning'
       | 'execute_provisioning'
       | 'provision_admin_client'
+      | 'reset_tenant_admin'
       | 'activate_instance'
   ) => {
     if (!selectedInstance) {
@@ -155,6 +156,9 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
         return;
       case 'provision_admin_client':
         await executeProvisioning('provision_admin_client');
+        return;
+      case 'reset_tenant_admin':
+        await executeProvisioning('reset_tenant_admin');
         return;
       case 'activate_instance':
         await instancesApi.activateInstance(selectedInstance.instanceId);

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
@@ -280,9 +280,9 @@ describe('instances shared helpers', () => {
     );
 
     expect(assessment.overallStatus).toBe('incomplete');
-    expect(assessment.blockingIssues.map((issue) => issue.label)).toEqual([
-      'Tenant-Admin-Client vorhanden',
-      'Tenant-Admin-Client-Secret mit Keycloak abgeglichen',
+    expect(assessment.blockingIssues.map((issue) => issue.key)).toEqual([
+      'tenant_admin_client',
+      'tenant_admin_client_secret',
     ]);
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
@@ -226,6 +226,63 @@ describe('instances shared helpers', () => {
     ]);
   });
 
+  it('uses intent-specific workflow actions for tenant admin client and tenant admin steps', () => {
+    const workflow = getSetupWorkflowSteps(
+      {
+        instanceId: 'demo',
+        displayName: 'Demo',
+        status: 'requested',
+        featureFlags: {},
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        parentDomain: 'studio.example.org',
+        primaryHostname: 'demo.studio.example.org',
+        realmMode: 'existing',
+        authRealm: 'demo',
+        authClientId: 'sva-studio',
+        authClientSecretConfigured: true,
+        tenantAdminClient: {
+          clientId: 'demo-admin-client',
+          secretConfigured: false,
+        },
+        hostnames: [],
+        provisioningRuns: [],
+        auditEvents: [],
+        keycloakPreflight: undefined,
+        keycloakPlan: undefined,
+        keycloakProvisioningRuns: [],
+        tenantAdminBootstrap: {
+          username: 'demo-admin',
+        },
+        keycloakStatus: {
+          realmExists: true,
+          clientExists: true,
+          tenantAdminClientExists: false,
+          instanceIdMapperExists: true,
+          tenantAdminExists: false,
+          tenantAdminHasSystemAdmin: false,
+          tenantAdminHasInstanceRegistryAdmin: false,
+          tenantAdminInstanceIdMatches: false,
+          redirectUrisMatch: true,
+          logoutUrisMatch: true,
+          webOriginsMatch: true,
+          clientSecretConfigured: true,
+          tenantClientSecretReadable: true,
+          clientSecretAligned: true,
+          tenantAdminClientSecretConfigured: false,
+          tenantAdminClientSecretReadable: false,
+          tenantAdminClientSecretAligned: false,
+          runtimeSecretSource: 'tenant',
+        },
+        latestKeycloakProvisioningRun: undefined,
+      } as const,
+      null
+    );
+
+    expect(workflow.find((step) => step.key === 'tenantAdminClient')?.action).toBe('provision_admin_client');
+    expect(workflow.find((step) => step.key === 'tenantAdmin')?.action).toBe('reset_tenant_admin');
+  });
+
   it('evaluates the configuration as incomplete when canonical requirements are missing', () => {
     const assessment = evaluateInstanceConfiguration(
       {

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createEmptyCreateForm,
+  evaluateInstanceConfiguration,
   getCreateReadinessChecks,
   getErrorMessage,
   getCreateStepValidationMessages,
@@ -182,6 +183,7 @@ describe('instances shared helpers', () => {
       ['keycloakAccess', 'blocked'],
       ['realm', 'blocked'],
       ['client', 'blocked'],
+      ['tenantAdminClient', 'blocked'],
       ['mapper', 'blocked'],
       ['tenantSecret', 'blocked'],
       ['tenantAdmin', 'blocked'],
@@ -221,6 +223,66 @@ describe('instances shared helpers', () => {
     expect(entries).toContainEqual([
       'admin.instances.keycloakStatus.tenantAdminHasInstanceRegistryAdmin',
       true,
+    ]);
+  });
+
+  it('evaluates the configuration as incomplete when canonical requirements are missing', () => {
+    const assessment = evaluateInstanceConfiguration(
+      {
+        instanceId: 'demo',
+        displayName: 'Demo',
+        status: 'active',
+        featureFlags: {},
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        parentDomain: 'studio.example.org',
+        primaryHostname: 'demo.studio.example.org',
+        realmMode: 'existing',
+        authRealm: 'demo',
+        authClientId: 'sva-studio',
+        authClientSecretConfigured: true,
+        tenantAdminClient: {
+          clientId: 'demo-admin-client',
+          secretConfigured: false,
+        },
+        hostnames: [],
+        provisioningRuns: [],
+        auditEvents: [],
+        keycloakPreflight: undefined,
+        keycloakPlan: undefined,
+        keycloakProvisioningRuns: [],
+        tenantAdminBootstrap: {
+          username: 'demo-admin',
+        },
+        keycloakStatus: {
+          realmExists: true,
+          clientExists: true,
+          tenantAdminClientExists: false,
+          instanceIdMapperExists: true,
+          tenantAdminExists: true,
+          tenantAdminHasSystemAdmin: true,
+          tenantAdminHasInstanceRegistryAdmin: false,
+          tenantAdminInstanceIdMatches: true,
+          redirectUrisMatch: true,
+          logoutUrisMatch: true,
+          webOriginsMatch: true,
+          clientSecretConfigured: true,
+          tenantClientSecretReadable: true,
+          clientSecretAligned: true,
+          tenantAdminClientSecretConfigured: false,
+          tenantAdminClientSecretReadable: false,
+          tenantAdminClientSecretAligned: false,
+          runtimeSecretSource: 'tenant',
+        },
+        latestKeycloakProvisioningRun: undefined,
+      } as const,
+      null
+    );
+
+    expect(assessment.overallStatus).toBe('incomplete');
+    expect(assessment.blockingIssues.map((issue) => issue.label)).toEqual([
+      'Tenant-Admin-Client vorhanden',
+      'Tenant-Admin-Client-Secret mit Keycloak abgeglichen',
     ]);
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
@@ -48,7 +48,13 @@ export type SetupWorkflowStep = {
   readonly description: string;
   readonly status: WorkflowStepState;
   readonly actionLabel?: string;
-  readonly action?: 'check_preflight' | 'check_keycloak_status' | 'plan_provisioning' | 'execute_provisioning' | 'activate_instance';
+  readonly action?:
+    | 'check_preflight'
+    | 'check_keycloak_status'
+    | 'plan_provisioning'
+    | 'execute_provisioning'
+    | 'provision_admin_client'
+    | 'activate_instance';
 };
 
 export type InstanceConfigurationIssue = {
@@ -91,7 +97,11 @@ const KEYCLOAK_STATUS_LABELS = {
   redirectUrisMatch: 'admin.instances.keycloakStatus.redirectUrisMatch',
   logoutUrisMatch: 'admin.instances.keycloakStatus.logoutUrisMatch',
   webOriginsMatch: 'admin.instances.keycloakStatus.webOriginsMatch',
+  clientSecretConfigured: 'admin.instances.keycloakStatus.clientSecretConfigured',
+  tenantClientSecretReadable: 'admin.instances.keycloakStatus.tenantClientSecretReadable',
   clientSecretAligned: 'admin.instances.keycloakStatus.clientSecretAligned',
+  tenantAdminClientSecretConfigured: 'admin.instances.keycloakStatus.tenantAdminClientSecretConfigured',
+  tenantAdminClientSecretReadable: 'admin.instances.keycloakStatus.tenantAdminClientSecretReadable',
   tenantAdminClientSecretAligned: 'admin.instances.keycloakStatus.tenantAdminClientSecretAligned',
 } as const satisfies Record<InstanceKeycloakStatusField, string>;
 
@@ -587,8 +597,8 @@ export const getSetupWorkflowSteps = (
             : keycloakUnavailable
               ? 'blocked'
               : 'current',
-      actionLabel: t('admin.instances.actions.executeProvisioning'),
-      action: 'execute_provisioning',
+      actionLabel: t('admin.instances.actions.provisionAdminClient'),
+      action: 'provision_admin_client',
     }),
     createWorkflowStep({
       key: 'mapper',

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
@@ -69,6 +69,31 @@ export type InstanceConfigurationAssessment = {
 };
 
 type IamInstanceKeycloakStatus = NonNullable<IamInstanceDetail['keycloakStatus']>;
+type InstanceKeycloakRequirement = (typeof INSTANCE_KEYCLOAK_REQUIREMENTS)[number];
+type InstanceKeycloakStatusField = InstanceKeycloakRequirement['statusField'];
+
+const CONFIGURATION_STATUS_LABELS = {
+  complete: 'admin.instances.configuration.overall.complete',
+  degraded: 'admin.instances.configuration.overall.degraded',
+  incomplete: 'admin.instances.configuration.overall.incomplete',
+  unknown: 'admin.instances.configuration.overall.unknown',
+} as const satisfies Record<InstanceConfigurationOverallStatus, string>;
+
+const KEYCLOAK_STATUS_LABELS = {
+  realmExists: 'admin.instances.keycloakStatus.realmExists',
+  clientExists: 'admin.instances.keycloakStatus.clientExists',
+  tenantAdminClientExists: 'admin.instances.keycloakStatus.tenantAdminClientExists',
+  instanceIdMapperExists: 'admin.instances.keycloakStatus.instanceIdMapperExists',
+  tenantAdminExists: 'admin.instances.keycloakStatus.tenantAdminExists',
+  tenantAdminHasSystemAdmin: 'admin.instances.keycloakStatus.tenantAdminHasSystemAdmin',
+  tenantAdminHasInstanceRegistryAdmin: 'admin.instances.keycloakStatus.tenantAdminHasInstanceRegistryAdmin',
+  tenantAdminInstanceIdMatches: 'admin.instances.keycloakStatus.tenantAdminInstanceIdMatches',
+  redirectUrisMatch: 'admin.instances.keycloakStatus.redirectUrisMatch',
+  logoutUrisMatch: 'admin.instances.keycloakStatus.logoutUrisMatch',
+  webOriginsMatch: 'admin.instances.keycloakStatus.webOriginsMatch',
+  clientSecretAligned: 'admin.instances.keycloakStatus.clientSecretAligned',
+  tenantAdminClientSecretAligned: 'admin.instances.keycloakStatus.tenantAdminClientSecretAligned',
+} as const satisfies Record<InstanceKeycloakStatusField, string>;
 
 export const isTenantSecretUserInputRequired = (realmMode: 'new' | 'existing') => realmMode === 'existing';
 
@@ -368,7 +393,7 @@ const findPreflightCheck = (preflight: IamInstanceKeycloakPreflight | undefined,
 const createWorkflowStep = (input: SetupWorkflowStep): SetupWorkflowStep => input;
 
 const translateConfigurationStatus = (status: InstanceConfigurationOverallStatus) =>
-  t(`admin.instances.configuration.overall.${status}`);
+  t(CONFIGURATION_STATUS_LABELS[status]);
 
 const readRequirementGroupSatisfied = (
   keycloakStatus: IamInstanceKeycloakStatus | undefined,
@@ -402,7 +427,7 @@ export const evaluateInstanceConfiguration = (
       : [];
   const blockingIssues: InstanceConfigurationIssue[] = failingRequirements.map((requirement) => ({
     key: requirement.key,
-    label: t(`admin.instances.keycloakStatus.${requirement.statusField}` as never),
+    label: t(KEYCLOAK_STATUS_LABELS[requirement.statusField]),
     severity: 'blocking',
   }));
 
@@ -700,7 +725,7 @@ export const getKeycloakStatusEntries = (selectedInstance: NonNullable<ReturnTyp
 
   return [
     ...INSTANCE_KEYCLOAK_REQUIREMENTS.map((requirement) => [
-      `admin.instances.keycloakStatus.${requirement.statusField}`,
+      KEYCLOAK_STATUS_LABELS[requirement.statusField],
       isInstanceKeycloakRequirementSatisfied(status, requirement),
     ] as const),
     ['admin.instances.keycloakStatus.clientSecretConfigured', status.clientSecretConfigured],

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
@@ -54,6 +54,7 @@ export type SetupWorkflowStep = {
     | 'plan_provisioning'
     | 'execute_provisioning'
     | 'provision_admin_client'
+    | 'reset_tenant_admin'
     | 'activate_instance';
 };
 
@@ -511,6 +512,8 @@ export const getSetupWorkflowSteps = (
   const tenantAdminConfigured = Boolean(instance.tenantAdminBootstrap?.username);
   const tenantAdminClientConfigured = Boolean(instance.tenantAdminClient?.clientId);
   const tenantAdminClientSecretConfigured = instance.tenantAdminClient?.secretConfigured === true;
+  const tenantAdminClientReady =
+    instance.keycloakStatus !== undefined && readRequirementGroupSatisfied(instance.keycloakStatus, 'tenantAdminClient');
 
   return [
     createWorkflowStep({
@@ -581,7 +584,7 @@ export const getSetupWorkflowSteps = (
       title: t('admin.instances.workflow.tenantAdminClient.title'),
       description: !tenantAdminClientConfigured
         ? t('admin.instances.workflow.tenantAdminClient.notConfigured')
-        : readRequirementGroupSatisfied(instance.keycloakStatus, 'tenantAdminClient')
+        : tenantAdminClientReady
           ? t('admin.instances.workflow.tenantAdminClient.ready')
           : !tenantAdminClientSecretConfigured
             ? t('admin.instances.workflow.tenantAdminClient.secretMissing')
@@ -590,7 +593,7 @@ export const getSetupWorkflowSteps = (
               : t('admin.instances.workflow.tenantAdminClient.pending'),
       status: !tenantAdminClientConfigured
         ? 'blocked'
-        : readRequirementGroupSatisfied(instance.keycloakStatus, 'tenantAdminClient')
+        : tenantAdminClientReady
           ? 'done'
           : !tenantAdminClientSecretConfigured
             ? 'blocked'
@@ -654,7 +657,7 @@ export const getSetupWorkflowSteps = (
             ? 'blocked'
             : 'current',
       actionLabel: t('admin.instances.actions.resetTenantAdmin'),
-      action: 'execute_provisioning',
+      action: 'reset_tenant_admin',
     }),
     createWorkflowStep({
       key: 'provisioning',

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
@@ -30,6 +30,8 @@ export type InstanceFieldHelpKey =
   | 'authClientId'
   | 'authIssuerUrl'
   | 'authClientSecret'
+  | 'tenantAdminClientId'
+  | 'tenantAdminClientSecret'
   | 'tenantAdminUsername'
   | 'tenantAdminEmail'
   | 'tenantAdminFirstName'
@@ -38,6 +40,7 @@ export type InstanceFieldHelpKey =
 export type CreateFormValues = ReturnType<typeof createEmptyCreateForm>;
 
 export type WorkflowStepState = 'done' | 'current' | 'blocked' | 'pending';
+export type InstanceConfigurationOverallStatus = 'complete' | 'degraded' | 'incomplete' | 'unknown';
 
 export type SetupWorkflowStep = {
   readonly key: string;
@@ -46,6 +49,23 @@ export type SetupWorkflowStep = {
   readonly status: WorkflowStepState;
   readonly actionLabel?: string;
   readonly action?: 'check_preflight' | 'check_keycloak_status' | 'plan_provisioning' | 'execute_provisioning' | 'activate_instance';
+};
+
+export type InstanceConfigurationIssue = {
+  readonly key: string;
+  readonly label: string;
+  readonly severity: 'blocking' | 'warning';
+};
+
+export type InstanceConfigurationAssessment = {
+  readonly overallStatus: InstanceConfigurationOverallStatus;
+  readonly title: string;
+  readonly body: string;
+  readonly statusLabel: string;
+  readonly satisfiedRequirements: number;
+  readonly totalRequirements: number;
+  readonly blockingIssues: readonly InstanceConfigurationIssue[];
+  readonly warningIssues: readonly InstanceConfigurationIssue[];
 };
 
 type IamInstanceKeycloakStatus = NonNullable<IamInstanceDetail['keycloakStatus']>;
@@ -84,6 +104,10 @@ export const getErrorMessage = (error: IamHttpError | null) => {
       return t('admin.instances.errors.databaseUnavailable');
     case 'tenant_auth_client_secret_missing':
       return t('admin.instances.errors.tenantAuthClientSecretMissing');
+    case 'tenant_admin_client_not_configured':
+      return t('admin.instances.errors.tenantAdminClientNotConfigured');
+    case 'tenant_admin_client_secret_missing':
+      return t('admin.instances.errors.tenantAdminClientSecretMissing');
     case 'keycloak_unavailable':
       return t('admin.instances.errors.keycloakUnavailable');
     case 'encryption_not_configured':
@@ -120,6 +144,10 @@ export const createDetailForm = (instance: NonNullable<ReturnType<typeof useInst
   authClientId: instance.authClientId,
   authIssuerUrl: instance.authIssuerUrl ?? '',
   authClientSecret: '',
+  tenantAdminClient: {
+    clientId: instance.tenantAdminClient?.clientId ?? '',
+    secret: '',
+  },
   tenantAdminBootstrap: {
     username: instance.tenantAdminBootstrap?.username ?? '',
     email: instance.tenantAdminBootstrap?.email ?? '',
@@ -223,6 +251,21 @@ export const INSTANCE_FIELD_HELP: Record<
     source: t('admin.instances.help.authClientSecret.source'),
     impact: t('admin.instances.help.authClientSecret.impact'),
   },
+  tenantAdminClientId: {
+    title: t('admin.instances.help.tenantAdminClientId.title'),
+    what: t('admin.instances.help.tenantAdminClientId.what'),
+    value: t('admin.instances.help.tenantAdminClientId.value'),
+    source: t('admin.instances.help.tenantAdminClientId.source'),
+    impact: t('admin.instances.help.tenantAdminClientId.impact'),
+    defaultHint: t('admin.instances.help.tenantAdminClientId.defaultHint'),
+  },
+  tenantAdminClientSecret: {
+    title: t('admin.instances.help.tenantAdminClientSecret.title'),
+    what: t('admin.instances.help.tenantAdminClientSecret.what'),
+    value: t('admin.instances.help.tenantAdminClientSecret.value'),
+    source: t('admin.instances.help.tenantAdminClientSecret.source'),
+    impact: t('admin.instances.help.tenantAdminClientSecret.impact'),
+  },
   tenantAdminUsername: {
     title: t('admin.instances.help.tenantAdminUsername.title'),
     what: t('admin.instances.help.tenantAdminUsername.what'),
@@ -324,6 +367,9 @@ const findPreflightCheck = (preflight: IamInstanceKeycloakPreflight | undefined,
 
 const createWorkflowStep = (input: SetupWorkflowStep): SetupWorkflowStep => input;
 
+const translateConfigurationStatus = (status: InstanceConfigurationOverallStatus) =>
+  t(`admin.instances.configuration.overall.${status}`);
+
 const readRequirementGroupSatisfied = (
   keycloakStatus: IamInstanceKeycloakStatus | undefined,
   uiStepKey: string
@@ -334,6 +380,86 @@ const readRequirementGroupSatisfied = (
         isInstanceKeycloakRequirementSatisfied(keycloakStatus, requirement)
       )
   );
+
+export const evaluateInstanceConfiguration = (
+  instance: IamInstanceDetail,
+  mutationError: IamHttpError | null
+): InstanceConfigurationAssessment => {
+  const keycloakStatus = instance.keycloakStatus;
+  const keycloakUnavailable = mutationError?.code === 'keycloak_unavailable';
+  const failingRequirements = keycloakStatus
+    ? INSTANCE_KEYCLOAK_REQUIREMENTS.filter((requirement) => !isInstanceKeycloakRequirementSatisfied(keycloakStatus, requirement))
+    : [];
+  const warningIssues: InstanceConfigurationIssue[] =
+    keycloakStatus && keycloakStatus.runtimeSecretSource !== 'tenant'
+      ? [
+          {
+            key: 'runtime_secret_source',
+            label: t('admin.instances.keycloakStatus.runtimeSecretSourceTenant'),
+            severity: 'warning',
+          },
+        ]
+      : [];
+  const blockingIssues: InstanceConfigurationIssue[] = failingRequirements.map((requirement) => ({
+    key: requirement.key,
+    label: t(`admin.instances.keycloakStatus.${requirement.statusField}` as never),
+    severity: 'blocking',
+  }));
+
+  if (keycloakUnavailable || !keycloakStatus) {
+    return {
+      overallStatus: 'unknown',
+      title: t('admin.instances.configuration.summary.unknown.title'),
+      body: keycloakUnavailable
+        ? t('admin.instances.configuration.summary.unknown.keycloakUnavailable')
+        : t('admin.instances.configuration.summary.unknown.body'),
+      statusLabel: translateConfigurationStatus('unknown'),
+      satisfiedRequirements: keycloakStatus ? INSTANCE_KEYCLOAK_REQUIREMENTS.length - failingRequirements.length : 0,
+      totalRequirements: INSTANCE_KEYCLOAK_REQUIREMENTS.length,
+      blockingIssues,
+      warningIssues,
+    };
+  }
+
+  if (blockingIssues.length > 0) {
+    return {
+      overallStatus: 'incomplete',
+      title: t('admin.instances.configuration.summary.incomplete.title'),
+      body: t('admin.instances.configuration.summary.incomplete.body', {
+        count: blockingIssues.length,
+      }),
+      statusLabel: translateConfigurationStatus('incomplete'),
+      satisfiedRequirements: INSTANCE_KEYCLOAK_REQUIREMENTS.length - blockingIssues.length,
+      totalRequirements: INSTANCE_KEYCLOAK_REQUIREMENTS.length,
+      blockingIssues,
+      warningIssues,
+    };
+  }
+
+  if (warningIssues.length > 0) {
+    return {
+      overallStatus: 'degraded',
+      title: t('admin.instances.configuration.summary.degraded.title'),
+      body: t('admin.instances.configuration.summary.degraded.body'),
+      statusLabel: translateConfigurationStatus('degraded'),
+      satisfiedRequirements: INSTANCE_KEYCLOAK_REQUIREMENTS.length,
+      totalRequirements: INSTANCE_KEYCLOAK_REQUIREMENTS.length,
+      blockingIssues,
+      warningIssues,
+    };
+  }
+
+  return {
+    overallStatus: 'complete',
+    title: t('admin.instances.configuration.summary.complete.title'),
+    body: t('admin.instances.configuration.summary.complete.body'),
+    statusLabel: translateConfigurationStatus('complete'),
+    satisfiedRequirements: INSTANCE_KEYCLOAK_REQUIREMENTS.length,
+    totalRequirements: INSTANCE_KEYCLOAK_REQUIREMENTS.length,
+    blockingIssues,
+    warningIssues,
+  };
+};
 
 export const getSetupWorkflowSteps = (
   instance: IamInstanceDetail,
@@ -348,6 +474,8 @@ export const getSetupWorkflowSteps = (
   const provisioningFailed = latestKeycloakRun?.overallStatus === 'failed';
   const provisioningRunning = latestKeycloakRun?.overallStatus === 'running';
   const tenantAdminConfigured = Boolean(instance.tenantAdminBootstrap?.username);
+  const tenantAdminClientConfigured = Boolean(instance.tenantAdminClient?.clientId);
+  const tenantAdminClientSecretConfigured = instance.tenantAdminClient?.secretConfigured === true;
 
   return [
     createWorkflowStep({
@@ -412,6 +540,30 @@ export const getSetupWorkflowSteps = (
           : 'pending',
       actionLabel: t('admin.instances.actions.planProvisioning'),
       action: 'plan_provisioning',
+    }),
+    createWorkflowStep({
+      key: 'tenantAdminClient',
+      title: t('admin.instances.workflow.tenantAdminClient.title'),
+      description: !tenantAdminClientConfigured
+        ? t('admin.instances.workflow.tenantAdminClient.notConfigured')
+        : readRequirementGroupSatisfied(instance.keycloakStatus, 'tenantAdminClient')
+          ? t('admin.instances.workflow.tenantAdminClient.ready')
+          : !tenantAdminClientSecretConfigured
+            ? t('admin.instances.workflow.tenantAdminClient.secretMissing')
+            : keycloakUnavailable
+              ? t('admin.instances.workflow.tenantAdminClient.blocked')
+              : t('admin.instances.workflow.tenantAdminClient.pending'),
+      status: !tenantAdminClientConfigured
+        ? 'blocked'
+        : readRequirementGroupSatisfied(instance.keycloakStatus, 'tenantAdminClient')
+          ? 'done'
+          : !tenantAdminClientSecretConfigured
+            ? 'blocked'
+            : keycloakUnavailable
+              ? 'blocked'
+              : 'current',
+      actionLabel: t('admin.instances.actions.executeProvisioning'),
+      action: 'execute_provisioning',
     }),
     createWorkflowStep({
       key: 'mapper',
@@ -564,6 +716,11 @@ export const KeycloakStatusBadge = ({ ready }: { ready: boolean }) => (
     {ready ? t('admin.instances.keycloakStatus.ok') : t('admin.instances.keycloakStatus.missing')}
   </Badge>
 );
+
+export const ConfigurationStatusBadge = ({ status }: { status: InstanceConfigurationOverallStatus }) => {
+  const variant = status === 'complete' ? 'secondary' : 'outline';
+  return <Badge variant={variant}>{translateConfigurationStatus(status)}</Badge>;
+};
 
 export const WorkflowStatusBadge = ({ status }: { status: WorkflowStepState }) => {
   const labelMap: Record<WorkflowStepState, string> = {

--- a/packages/auth/src/iam-instance-registry/http.test.ts
+++ b/packages/auth/src/iam-instance-registry/http.test.ts
@@ -98,7 +98,7 @@ describe('iam-instance-registry http helpers', () => {
     expect(result.success).toBe(false);
   });
 
-  it('requires a tenant admin client contract on create requests', () => {
+  it('allows create requests without a tenant admin client contract', () => {
     const result = createInstanceSchema.safeParse({
       instanceId: 'de-test',
       displayName: 'Demo',
@@ -108,7 +108,7 @@ describe('iam-instance-registry http helpers', () => {
       authClientId: 'sva-studio',
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it('extracts keycloak run ids from nested run routes', () => {

--- a/packages/auth/src/iam-instance-registry/http.ts
+++ b/packages/auth/src/iam-instance-registry/http.ts
@@ -37,7 +37,8 @@ const tenantAdminClientSchema = z
   .object({
     clientId: z.string().trim().min(1),
     secret: z.string().trim().min(1).optional(),
-  });
+  })
+  .optional();
 
 export const listQuerySchema = z.object({
   search: z.string().trim().min(1).optional(),

--- a/packages/auth/src/routes/handlers.test.ts
+++ b/packages/auth/src/routes/handlers.test.ts
@@ -190,6 +190,36 @@ describe('routes/handlers', () => {
     );
   });
 
+  it('accepts legacy redirect query params for post-login navigation', async () => {
+    createLoginUrlMock.mockResolvedValue({
+      url: 'https://issuer.example/auth',
+      state: 'state-legacy-redirect',
+      loginState: {
+        codeVerifier: 'verifier-legacy-redirect',
+        nonce: 'nonce-legacy-redirect',
+        createdAt: Date.now(),
+        returnTo: '/admin/instances',
+        silent: false,
+      },
+    });
+
+    const { loginHandler } = await import('./handlers.js');
+
+    const response = await loginHandler(new Request('http://localhost/auth/login?redirect=%2Fadmin%2Finstances'));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://issuer.example/auth');
+    const encodedCookie = (response.headers.get('set-cookie') ?? '').split(';')[0]?.split('=')[1];
+    const encodedPayload = encodedCookie?.split('.')[0];
+    const decodedPayload = encodedPayload ? JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) : null;
+
+    expect(decodedPayload).toEqual(
+      expect.objectContaining({
+        returnTo: '/admin/instances',
+      })
+    );
+  });
+
   it('logs the resolved auth config for login requests', async () => {
     resolvedAuthConfigState.kind = 'instance';
     resolvedAuthConfigState.instanceId = 'bb-guben';

--- a/packages/auth/src/routes/handlers.ts
+++ b/packages/auth/src/routes/handlers.ts
@@ -374,7 +374,9 @@ export const loginHandler = async (request?: Request): Promise<Response> => {
       const authConfig = request ? await resolveAuthConfigForRequest(request) : getAuthConfig();
       const authScope = getScopeFromAuthConfig(authConfig);
       const { loginStateCookieName, loginStateSecret } = authConfig;
-      const returnTo = request ? await sanitizeReturnTo(request, url?.searchParams.get('returnTo')) : DEFAULT_POST_LOGIN_REDIRECT;
+      const returnTo = request
+        ? await sanitizeReturnTo(request, url?.searchParams.get('returnTo') ?? url?.searchParams.get('redirect'))
+        : DEFAULT_POST_LOGIN_REDIRECT;
       const { url: authorizationUrl, state, loginState } = await createLoginUrl({
         returnTo,
         silent: isSilent,

--- a/packages/routing/src/account-ui.routes.test.ts
+++ b/packages/routing/src/account-ui.routes.test.ts
@@ -19,7 +19,7 @@ const invoke = async (guard: Guard, roles: readonly string[] | null, href: strin
 describe('accountUiRouteGuards', () => {
   it('redirects account route to login when unauthenticated', async () => {
     await expect(invoke(accountUiRouteGuards.account, null, '/account')).rejects.toMatchObject(
-      redirect({ href: '/auth/login?redirect=%2Faccount' })
+      redirect({ href: '/auth/login?returnTo=%2Faccount' })
     );
   });
 

--- a/packages/routing/src/protected.routes.test.ts
+++ b/packages/routing/src/protected.routes.test.ts
@@ -27,7 +27,7 @@ describe('protected routes', () => {
     } catch (error) {
       expect(isRedirect(error)).toBe(true);
       if (isRedirect(error)) {
-        expect(error.options.href).toBe('/auth/login?redirect=%2Fadmin%2Fusers%3Fpage%3D2');
+        expect(error.options.href).toBe('/auth/login?returnTo=%2Fadmin%2Fusers%3Fpage%3D2');
       }
     }
   });
@@ -70,7 +70,7 @@ describe('protected routes', () => {
     } catch (error) {
       expect(isRedirect(error)).toBe(true);
       if (isRedirect(error)) {
-        expect(error.options.href).toBe('/auth/login?redirect=%2F');
+        expect(error.options.href).toBe('/auth/login?returnTo=%2F');
       }
     }
   });

--- a/packages/routing/src/protected.routes.ts
+++ b/packages/routing/src/protected.routes.ts
@@ -40,7 +40,7 @@ const normalizeInternalPath = (value: string, fallbackPath: string): string => {
 
 const buildLoginHref = (loginPath: string, returnTo: string) => {
   const url = new URL(normalizeInternalPath(loginPath, DEFAULT_LOGIN_PATH), INTERNAL_REDIRECT_BASE);
-  url.searchParams.set('redirect', normalizeInternalPath(returnTo, DEFAULT_FALLBACK_PATH));
+  url.searchParams.set('returnTo', normalizeInternalPath(returnTo, DEFAULT_FALLBACK_PATH));
   return `${url.pathname}${url.search}`;
 };
 


### PR DESCRIPTION
## What changed
- unify protected-route login redirects on `returnTo` and keep the auth handler backward-compatible with legacy `redirect`
- add a canonical instance configuration assessment on the admin detail page so lifecycle and actual Keycloak completeness are shown separately
- add tenant admin client fields and a dedicated provisioning action so detected configuration gaps can be corrected directly in the UI

## Why
- `/admin/instances` could lose its post-login destination because the router emitted `redirect` while the login flow only read `returnTo`
- the instance detail page showed conflicting signals like `Active` and `Done` even when canonical Keycloak requirements were still missing
- tenant admin client drift was diagnosable, but not directly fixable from the UI

## Impact
- protected admin routes preserve the intended return path after login
- operators can immediately see whether an instance is fully configured, incomplete, degraded, or not yet verified
- tenant admin client contract data can be edited and provisioned directly from the instance detail page

## Validation
- `pnpm nx run routing:test:unit -- src/protected.routes.test.ts src/account-ui.routes.test.ts`
- `pnpm nx run auth:test:unit -- src/routes/handlers.test.ts`
- `pnpm nx run auth:test:types`
- `pnpm exec vitest run src/routes/admin/instances/-instances-shared.test.tsx src/routes/admin/instances/-instance-detail-page.test.tsx src/i18n/translate.test.ts`
- `pnpm nx run sva-studio-react:typecheck`
