### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,15 +12,9 @@
       "@nx/vitest": "22.5.4"
     }
   },
-  "workspaceLayout": {
-    "appsDir": "apps",
-    "libsDir": "packages"
-  },
+  "workspaceLayout": { "appsDir": "apps", "libsDir": "packages" },
   "targetDefaults": {
-    "test:unit": {
-      "cache": true,
-      "inputs": ["default", "^production", "testing"]
-    },
+    "test:unit": { "cache": true, "inputs": ["default", "^production", "testing"] },
     "test:coverage": {
       "cache": true,
       "inputs": [
@@ -57,22 +51,11 @@
       "{projectRoot}/tsconfig.json",
       "{projectRoot}/package.json"
     ],
-    "frontendEnvBuild": [
-      {
-        "env": "CODECOV_TOKEN"
-      }
-    ],
-    "frontendEnvServe": [
-      {
-        "env": "TSS_DEV_SERVER"
-      }
-    ],
-    "frontendEnvE2E": [
-      {
-        "env": "CI"
-      }
-    ],
+    "frontendEnvBuild": [{ "env": "CODECOV_TOKEN" }],
+    "frontendEnvServe": [{ "env": "TSS_DEV_SERVER" }],
+    "frontendEnvE2E": [{ "env": "CI" }],
     "sharedGlobals": ["{workspaceRoot}/tsconfig.base.json", "{workspaceRoot}/pnpm-lock.yaml"]
   },
-  "analytics": false
+  "analytics": false,
+  "nxCloudId": "69e4e2584679d3b4b2845b37"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/69e4e2190680f8c80c4202dd/workspaces/69e4e2584679d3b4b2845b37

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.