### PR TITLE
[codex] Implement platform IAM root scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ venv/
 # Logs
 *.log
 log/
+output/
 
 # Caches
 .cache/

--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -1067,10 +1067,21 @@ export const i18nResources = {
           headerEmail: 'E-Mail',
           headerRole: 'Rolle',
           headerStatus: 'Status',
+          headerKeycloak: 'Keycloak',
           headerLastLogin: 'Letzter Login',
           headerActions: 'Aktionen',
           selectAll: 'Alle Nutzer markieren',
           selectOne: 'Nutzer {{name}} markieren',
+        },
+        mapping: {
+          mapped: 'Zugeordnet',
+          unmapped: 'Nicht zugeordnet',
+          manualReview: 'Manuell prüfen',
+        },
+        editability: {
+          editable: 'Bearbeitbar',
+          readOnly: 'Read-only',
+          blocked: 'Blockiert',
         },
         actions: {
           create: 'Nutzer anlegen',
@@ -1208,6 +1219,8 @@ export const i18nResources = {
             '{{checkedCount}} geprüft: {{correctedCount}} korrigiert, {{manualReviewCount}} manuell prüfen. {{importedCount}} importiert, {{updatedCount}} aktualisiert, {{skippedCount}} ohne passenden Instanzkontext übersprungen.',
           syncDiagnostics:
             'Realm {{authRealm}}, Quelle {{providerSource}}. {{matchedWithoutInstanceAttributeCount}} Benutzer ohne `instanceId` wurden über den Realm-Kontext zugeordnet.',
+          syncObjectDiagnostics: '{{count}} Benutzerobjekte mit Diagnose: {{codes}}',
+          diagnosticCodes: 'Diagnose: {{codes}}',
           syncOutcome: {
             success: 'Der Sync wurde deterministisch ohne offenen Nachlauf abgeschlossen.',
             partialFailure: 'Der Sync wurde mit teilweisen Fehlern oder manuellem Nachlauf abgeschlossen.',
@@ -1394,7 +1407,13 @@ export const i18nResources = {
           systemRole: 'Systemrolle',
           customRole: 'Benutzerdefinierte Rolle',
           externalRole: 'Externe Rolle',
+          builtInRole: 'Keycloak-Built-in-Rolle',
           temporaryNotice: 'Rollen sind vorläufig und werden weiterentwickelt.',
+        },
+        editability: {
+          editable: 'Bearbeitbar',
+          readOnly: 'Read-only',
+          blocked: 'Blockiert',
         },
         permissionActions: {
           read: 'Lesen',
@@ -1454,6 +1473,7 @@ export const i18nResources = {
           error: 'Rollen konnten nicht geladen werden.',
           permissionsEmpty: 'Keine Berechtigungen zugeordnet.',
           syncErrorCode: 'Synchronisierungsfehlercode: {{code}}',
+          diagnosticCodes: 'Diagnose: {{codes}}',
           lastSyncedAt: 'Zuletzt synchronisiert: {{value}}',
           noDescription: 'Keine Beschreibung',
           externalRoleName: 'Externer Rollenname: {{value}}',
@@ -1461,6 +1481,7 @@ export const i18nResources = {
           roleLevel: 'Rollenlevel: {{value}}',
           reconcileSummary:
             'Reconcile abgeschlossen. Geprüft: {{checked}}, korrigiert: {{corrected}}, fehlgeschlagen: {{failed}}, manuell prüfen: {{manual}}.',
+          reconcileObjectDiagnostics: '{{count}} Rollenobjekte mit Diagnose: {{codes}}',
           reconcileOutcome: {
             success: 'Der Abgleich wurde deterministisch ohne offenen Nachlauf abgeschlossen.',
             partialFailure: 'Der Abgleich wurde mit fehlgeschlagenen oder manuell zu prüfenden Einträgen abgeschlossen.',
@@ -2984,10 +3005,21 @@ export const i18nResources = {
           headerEmail: 'Email',
           headerRole: 'Role',
           headerStatus: 'Status',
+          headerKeycloak: 'Keycloak',
           headerLastLogin: 'Last login',
           headerActions: 'Actions',
           selectAll: 'Select all users',
           selectOne: 'Select user {{name}}',
+        },
+        mapping: {
+          mapped: 'Mapped',
+          unmapped: 'Unmapped',
+          manualReview: 'Manual review',
+        },
+        editability: {
+          editable: 'Editable',
+          readOnly: 'Read-only',
+          blocked: 'Blocked',
         },
         actions: {
           create: 'Create user',
@@ -3126,6 +3158,8 @@ export const i18nResources = {
             'Checked {{checkedCount}} users: {{correctedCount}} corrected, {{manualReviewCount}} require manual review. {{importedCount}} imported, {{updatedCount}} updated, {{skippedCount}} skipped without matching instance context.',
           syncDiagnostics:
             'Realm {{authRealm}}, source {{providerSource}}. {{matchedWithoutInstanceAttributeCount}} users without `instanceId` were matched by realm scope.',
+          syncObjectDiagnostics: '{{count}} user objects with diagnostics: {{codes}}',
+          diagnosticCodes: 'Diagnostics: {{codes}}',
           syncOutcome: {
             success: 'The sync completed deterministically without remaining follow-up.',
             partialFailure: 'The sync completed with partial failures or manual follow-up items.',
@@ -3312,7 +3346,13 @@ export const i18nResources = {
           systemRole: 'System role',
           customRole: 'Custom role',
           externalRole: 'External role',
+          builtInRole: 'Keycloak built-in role',
           temporaryNotice: 'Role names are temporary and will evolve.',
+        },
+        editability: {
+          editable: 'Editable',
+          readOnly: 'Read-only',
+          blocked: 'Blocked',
         },
         permissionActions: {
           read: 'Read',
@@ -3372,6 +3412,7 @@ export const i18nResources = {
           error: 'Roles could not be loaded.',
           permissionsEmpty: 'No permissions assigned.',
           syncErrorCode: 'Sync error code: {{code}}',
+          diagnosticCodes: 'Diagnostics: {{codes}}',
           lastSyncedAt: 'Last synced: {{value}}',
           noDescription: 'No description',
           externalRoleName: 'External role name: {{value}}',
@@ -3379,6 +3420,7 @@ export const i18nResources = {
           roleLevel: 'Role level: {{value}}',
           reconcileSummary:
             'Reconcile finished. Checked: {{checked}}, corrected: {{corrected}}, failed: {{failed}}, manual review: {{manual}}.',
+          reconcileObjectDiagnostics: '{{count}} role objects with diagnostics: {{codes}}',
           reconcileOutcome: {
             success: 'The reconcile completed deterministically without remaining follow-up.',
             partialFailure: 'The reconcile completed with failed or manually reviewable items.',

--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -1055,10 +1055,14 @@ export const i18nResources = {
         page: {
           title: 'Benutzerverwaltung',
           subtitle: 'Benutzerkonten suchen, filtern und verwalten',
+          platformTitle: 'Plattform-Benutzer',
+          platformSubtitle: 'Root-Benutzer aus dem Plattform-Realm suchen, filtern und synchronisieren',
         },
         table: {
           caption: 'Tabelle mit allen Benutzern in der aktuellen Instanz',
+          platformCaption: 'Tabelle mit allen Benutzern im Plattform-Realm',
           ariaLabel: 'Benutzertabelle',
+          platformAriaLabel: 'Plattform-Benutzertabelle',
           headerName: 'Name',
           headerEmail: 'E-Mail',
           headerRole: 'Rolle',
@@ -1214,6 +1218,7 @@ export const i18nResources = {
             instance: 'Instanz-Realm',
             global: 'globaler Realm',
             fallback_global: 'globaler Fallback-Realm',
+            platform: 'Plattform-Realm',
           },
         },
         errors: {
@@ -1354,10 +1359,14 @@ export const i18nResources = {
         page: {
           title: 'Rollenverwaltung',
           subtitle: 'System- und benutzerdefinierte Rollen verwalten',
+          platformTitle: 'Plattform-Rollen',
+          platformSubtitle: 'Root-Rollen und Plattform-Berechtigungen aus dem Plattform-Realm prüfen',
         },
         table: {
           caption: 'Tabelle aller Rollen mit Einstieg in die Rollen-Detailansicht',
+          platformCaption: 'Tabelle aller Plattform-Rollen aus dem Plattform-Realm',
           ariaLabel: 'Rollen-Tabelle',
+          platformAriaLabel: 'Plattform-Rollen-Tabelle',
           headerName: 'Rolle',
           headerType: 'Typ',
           headerSync: 'Synchronisierung',
@@ -1372,6 +1381,7 @@ export const i18nResources = {
           delete: 'Rolle löschen',
           reconcile: 'Abgleich starten',
           importFromKeycloak: 'Bereits in Keycloak angelegte Rollen importieren',
+          reconcilePlatform: 'Plattform-Rollen abgleichen',
           retrySync: 'Erneut synchronisieren',
           sort: 'Sortierung wechseln',
           retry: 'Erneut versuchen',
@@ -2962,10 +2972,14 @@ export const i18nResources = {
         page: {
           title: 'User Management',
           subtitle: 'Search, filter and manage user accounts',
+          platformTitle: 'Platform Users',
+          platformSubtitle: 'Search, filter and synchronize root users from the platform realm',
         },
         table: {
           caption: 'Table of all users in the current instance',
+          platformCaption: 'Table of all users in the platform realm',
           ariaLabel: 'Users table',
+          platformAriaLabel: 'Platform users table',
           headerName: 'Name',
           headerEmail: 'Email',
           headerRole: 'Role',
@@ -3122,6 +3136,7 @@ export const i18nResources = {
             instance: 'instance realm',
             global: 'global realm',
             fallback_global: 'global fallback realm',
+            platform: 'platform realm',
           },
         },
         errors: {
@@ -3262,10 +3277,14 @@ export const i18nResources = {
         page: {
           title: 'Role Management',
           subtitle: 'Manage system and custom roles',
+          platformTitle: 'Platform Roles',
+          platformSubtitle: 'Inspect root roles and platform permissions from the platform realm',
         },
         table: {
           caption: 'Role table with access to the role detail view',
+          platformCaption: 'Table of all platform roles from the platform realm',
           ariaLabel: 'Roles table',
+          platformAriaLabel: 'Platform roles table',
           headerName: 'Role',
           headerType: 'Type',
           headerSync: 'Sync',
@@ -3280,6 +3299,7 @@ export const i18nResources = {
           delete: 'Delete role',
           reconcile: 'Run reconcile',
           importFromKeycloak: 'Import roles already created in Keycloak',
+          reconcilePlatform: 'Reconcile platform roles',
           retrySync: 'Retry sync',
           sort: 'Toggle sorting',
           retry: 'Retry',

--- a/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.tsx
@@ -65,9 +65,12 @@ const STATUS_LABEL_KEYS = {
 
 const statusLabel = (syncState: 'synced' | 'pending' | 'failed'): string => t(STATUS_LABEL_KEYS[syncState]);
 
-const roleTypeLabel = (role: { isSystemRole: boolean; managedBy: 'studio' | 'external' }): string => {
+const roleTypeLabel = (role: { isSystemRole: boolean; managedBy: 'studio' | 'external' | 'keycloak_builtin' }): string => {
   if (role.isSystemRole) {
     return t('admin.roles.labels.systemRole');
+  }
+  if (role.managedBy === 'keycloak_builtin') {
+    return t('admin.roles.labels.builtInRole');
   }
   if (role.managedBy === 'external') {
     return t('admin.roles.labels.externalRole');

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.test.tsx
@@ -146,6 +146,48 @@ describe('RolesPage', () => {
     expect(reconcile).toHaveBeenCalledTimes(1);
   });
 
+  it('shows built-in role diagnostics as read-only state', () => {
+    useRolesMock.mockReturnValue({
+      roles: [
+        {
+          id: 'realm:default-roles',
+          roleKey: 'default-roles-de-musterhausen',
+          roleName: 'default-roles-de-musterhausen',
+          externalRoleName: 'default-roles-de-musterhausen',
+          managedBy: 'keycloak_builtin',
+          description: 'Default roles',
+          isSystemRole: false,
+          roleLevel: 0,
+          memberCount: 0,
+          syncState: 'synced',
+          editability: 'read_only',
+          diagnostics: [{ code: 'built_in_role', objectId: 'realm:default-roles', objectType: 'role' }],
+          permissions: [],
+        },
+      ],
+      isLoading: false,
+      error: null,
+      mutationError: null,
+      reconcileReport: null,
+      refetch: vi.fn(),
+      clearMutationError: vi.fn(),
+      createRole: vi.fn(),
+      updateRole: vi.fn(),
+      deleteRole: vi.fn(),
+      retryRoleSync: vi.fn(),
+      reconcile: vi.fn(),
+    });
+
+    render(<RolesPage />);
+
+    expect(screen.getAllByText('Keycloak-Built-in-Rolle').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Read-only').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Diagnose: built_in_role').length).toBeGreaterThan(0);
+    screen
+      .getAllByRole('button', { name: 'Rolle löschen' })
+      .forEach((button) => expect(button.hasAttribute('disabled')).toBe(true));
+  });
+
   it('triggers delete confirmation for custom roles', () => {
     const deleteRole = vi.fn().mockResolvedValue(true);
 
@@ -226,6 +268,46 @@ describe('RolesPage', () => {
     expect(screen.getByText('Empfohlene Aktion: Rollenabgleich prüfen')).toBeTruthy();
     expect(screen.getByText('Sync-Fehlercode: IDP_UNAVAILABLE')).toBeTruthy();
     expect(screen.getByText('Request-ID: req-role-list-7')).toBeTruthy();
+  });
+
+  it('renders object diagnostics from reconcile reports', () => {
+    useRolesMock.mockReturnValue({
+      roles: [],
+      isLoading: false,
+      error: null,
+      mutationError: null,
+      reconcileReport: {
+        outcome: 'partial_failure',
+        checkedCount: 2,
+        correctedCount: 1,
+        failedCount: 1,
+        manualReviewCount: 1,
+        requiresManualActionCount: 1,
+        roles: [
+          {
+            externalRoleName: 'default-roles-de-musterhausen',
+            action: 'report',
+            status: 'requires_manual_action',
+            errorCode: 'IDP_FORBIDDEN',
+            diagnostics: [{ code: 'forbidden_role_mapping', objectId: 'role-1', objectType: 'role' }],
+          },
+        ],
+      },
+      refetch: vi.fn(),
+      clearMutationError: vi.fn(),
+      createRole: vi.fn(),
+      updateRole: vi.fn(),
+      deleteRole: vi.fn(),
+      retryRoleSync: vi.fn(),
+      reconcile: vi.fn(),
+    });
+
+    render(<RolesPage />);
+
+    expect(screen.getByText(/Reconcile abgeschlossen\. Geprüft: 2, korrigiert: 1/i)).toBeTruthy();
+    expect(
+      screen.getByText('1 Rollenobjekte mit Diagnose: IDP_FORBIDDEN, forbidden_role_mapping')
+    ).toBeTruthy();
   });
 
   it('renders platform roles on root scope without tenant mutations', () => {

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { RolesPage } from './-roles-page';
 
 const useRolesMock = vi.fn();
+const useAuthMock = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
@@ -39,9 +40,15 @@ vi.mock('../../../hooks/use-roles', () => ({
   useRoles: () => useRolesMock(),
 }));
 
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
 describe('RolesPage', () => {
   beforeEach(() => {
     useRolesMock.mockReset();
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ user: { id: 'user-admin', instanceId: 'de-musterhausen', roles: ['system_admin'] } });
   });
 
   afterEach(() => {
@@ -219,5 +226,47 @@ describe('RolesPage', () => {
     expect(screen.getByText('Empfohlene Aktion: Rollenabgleich prüfen')).toBeTruthy();
     expect(screen.getByText('Sync-Fehlercode: IDP_UNAVAILABLE')).toBeTruthy();
     expect(screen.getByText('Request-ID: req-role-list-7')).toBeTruthy();
+  });
+
+  it('renders platform roles on root scope without tenant mutations', () => {
+    const reconcile = vi.fn();
+    useAuthMock.mockReturnValue({ user: { id: 'platform-admin', roles: ['system_admin'] } });
+    useRolesMock.mockReturnValue({
+      roles: [
+        {
+          id: 'platform:system_admin',
+          roleKey: 'system_admin',
+          roleName: 'system_admin',
+          externalRoleName: 'system_admin',
+          managedBy: 'external',
+          description: 'Platform admin',
+          isSystemRole: true,
+          roleLevel: 100,
+          memberCount: 0,
+          syncState: 'synced',
+          permissions: [],
+        },
+      ],
+      isLoading: false,
+      error: null,
+      mutationError: null,
+      reconcileReport: null,
+      refetch: vi.fn(),
+      clearMutationError: vi.fn(),
+      createRole: vi.fn(),
+      updateRole: vi.fn(),
+      deleteRole: vi.fn(),
+      retryRoleSync: vi.fn(),
+      reconcile,
+    });
+
+    render(<RolesPage />);
+
+    expect(screen.getByRole('heading', { name: 'Plattform-Rollen' })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Rolle anlegen' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Rolle bearbeiten' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Rolle löschen' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Plattform-Rollen abgleichen' }));
+    expect(reconcile).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
@@ -11,6 +11,7 @@ import { Card } from '../../../components/ui/card';
 import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
 import { useRoles } from '../../../hooks/use-roles';
+import { useAuth } from '../../../providers/auth-provider';
 import { t } from '../../../i18n';
 import type { TranslationKey } from '../../../i18n/translate';
 import type { IamHttpError, RoleReconcileReport } from '../../../lib/iam-api';
@@ -83,6 +84,8 @@ const roleErrorMessage = (error: IamHttpError | null, fallbackKey: TranslationKe
 
 export const RolesPage = () => {
   const rolesApi = useRoles();
+  const { user } = useAuth();
+  const isPlatformScope = !user?.instanceId;
 
   const [search, setSearch] = React.useState('');
   const [deleteRoleId, setDeleteRoleId] = React.useState<string | null>(null);
@@ -177,25 +180,27 @@ export const RolesPage = () => {
   return (
     <section className="space-y-5" aria-busy={rolesApi.isLoading}>
       <StudioListPageTemplate
-        title={t('admin.roles.page.title')}
-        description={t('admin.roles.page.subtitle')}
+        title={t(isPlatformScope ? 'admin.roles.page.platformTitle' : 'admin.roles.page.title')}
+        description={t(isPlatformScope ? 'admin.roles.page.platformSubtitle' : 'admin.roles.page.subtitle')}
         primaryAction={{
-          label: t('admin.roles.actions.create'),
+          label: t(isPlatformScope ? 'admin.roles.actions.reconcilePlatform' : 'admin.roles.actions.create'),
           render: (
             <div className="flex flex-wrap gap-2">
               <Button type="button" variant="secondary" onClick={() => void rolesApi.reconcile()}>
-                {t('admin.roles.actions.importFromKeycloak')}
+                {t(isPlatformScope ? 'admin.roles.actions.reconcilePlatform' : 'admin.roles.actions.importFromKeycloak')}
               </Button>
-              <Button asChild type="button">
-                <Link to="/admin/roles/new">{t('admin.roles.actions.create')}</Link>
-              </Button>
+              {isPlatformScope ? null : (
+                <Button asChild type="button">
+                  <Link to="/admin/roles/new">{t('admin.roles.actions.create')}</Link>
+                </Button>
+              )}
             </div>
           ),
         }}
       >
         <StudioDataTable
-          ariaLabel={t('admin.roles.table.ariaLabel')}
-          caption={t('admin.roles.table.caption')}
+          ariaLabel={t(isPlatformScope ? 'admin.roles.table.platformAriaLabel' : 'admin.roles.table.ariaLabel')}
+          caption={t(isPlatformScope ? 'admin.roles.table.platformCaption' : 'admin.roles.table.caption')}
           data={filteredRoles}
           columns={roleColumns}
           getRowId={(role) => role.id}
@@ -219,6 +224,9 @@ export const RolesPage = () => {
             </div>
           }
           rowActions={(role) => {
+            if (isPlatformScope) {
+              return null;
+            }
             const isReadOnly = role.isSystemRole || role.managedBy !== 'studio';
 
             return (

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
@@ -223,10 +223,7 @@ export const RolesPage = () => {
               />
             </div>
           }
-          rowActions={(role) => {
-            if (isPlatformScope) {
-              return null;
-            }
+          rowActions={isPlatformScope ? undefined : (role) => {
             const isReadOnly = role.isSystemRole || role.managedBy !== 'studio';
 
             return (

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
@@ -1,3 +1,4 @@
+import type { IamKeycloakObjectDiagnostic } from '@sva/core';
 import React from 'react';
 import { Link } from '@tanstack/react-router';
 
@@ -36,20 +37,45 @@ const STATUS_LABEL_KEYS = {
 const RECONCILE_OUTCOME_LABEL_KEYS = {
   success: 'admin.roles.messages.reconcileOutcome.success',
   partial_failure: 'admin.roles.messages.reconcileOutcome.partialFailure',
+  blocked: 'admin.roles.messages.reconcileOutcome.blocked',
   failed: 'admin.roles.messages.reconcileOutcome.failed',
 } as const satisfies Record<RoleReconcileReport['outcome'], TranslationKey>;
 
 const statusLabel = (syncState: 'synced' | 'pending' | 'failed'): string => t(STATUS_LABEL_KEYS[syncState]);
 
-const roleTypeLabel = (role: { isSystemRole: boolean; managedBy: 'studio' | 'external' }): string => {
+const roleTypeLabel = (role: { isSystemRole: boolean; managedBy: 'studio' | 'external' | 'keycloak_builtin' }): string => {
   if (role.isSystemRole) {
     return t('admin.roles.labels.systemRole');
+  }
+  if (role.managedBy === 'keycloak_builtin') {
+    return t('admin.roles.labels.builtInRole');
   }
   if (role.managedBy === 'external') {
     return t('admin.roles.labels.externalRole');
   }
   return t('admin.roles.labels.customRole');
 };
+
+const editabilityClassByValue = {
+  editable: 'border-primary/40 bg-primary/10 text-primary',
+  read_only: 'border-secondary/40 bg-secondary/10 text-secondary',
+  blocked: 'border-destructive/40 bg-destructive/10 text-destructive',
+} as const;
+
+const editabilityLabelKey = {
+  editable: 'admin.roles.editability.editable',
+  read_only: 'admin.roles.editability.readOnly',
+  blocked: 'admin.roles.editability.blocked',
+} as const;
+
+const renderDiagnosticCodes = (diagnostics: readonly IamKeycloakObjectDiagnostic[] | undefined) =>
+  diagnostics && diagnostics.length > 0 ? (
+    <p className="mt-2 text-xs text-muted-foreground">
+      {t('admin.roles.messages.diagnosticCodes', {
+        codes: diagnostics.map((diagnostic) => diagnostic.code).join(', '),
+      })}
+    </p>
+  ) : null;
 
 const roleErrorMessage = (error: IamHttpError | null, fallbackKey: TranslationKey): string => {
   if (!error) {
@@ -123,7 +149,18 @@ export const RolesPage = () => {
       {
         id: 'type',
         header: t('admin.roles.table.headerType'),
-        cell: (role) => roleTypeLabel(role),
+        cell: (role) => {
+          const editability = role.editability ?? 'editable';
+          return (
+            <div className="space-y-2">
+              <span className="block">{roleTypeLabel(role)}</span>
+              <Badge className={`rounded-full ${editabilityClassByValue[editability]}`} variant="outline">
+                {t(editabilityLabelKey[editability])}
+              </Badge>
+              {renderDiagnosticCodes(role.diagnostics)}
+            </div>
+          );
+        },
       },
       {
         id: 'sync',
@@ -278,6 +315,21 @@ export const RolesPage = () => {
             <span className="text-xs text-muted-foreground">
               {t(RECONCILE_OUTCOME_LABEL_KEYS[rolesApi.reconcileReport.outcome])}
             </span>
+            {rolesApi.reconcileReport.roles.length > 0 ? (
+              <span className="text-xs text-muted-foreground">
+                {t('admin.roles.messages.reconcileObjectDiagnostics', {
+                  count: rolesApi.reconcileReport.roles.length,
+                  codes: Array.from(
+                    new Set(
+                      rolesApi.reconcileReport.roles.flatMap((entry) => [
+                        ...(entry.errorCode ? [entry.errorCode] : []),
+                        ...(entry.diagnostics?.map((diagnostic) => diagnostic.code) ?? []),
+                      ])
+                    )
+                  ).join(', '),
+                })}
+              </span>
+            ) : null}
           </AlertDescription>
         </Alert>
       ) : null}

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
@@ -85,7 +85,7 @@ const roleErrorMessage = (error: IamHttpError | null, fallbackKey: TranslationKe
 export const RolesPage = () => {
   const rolesApi = useRoles();
   const { user } = useAuth();
-  const isPlatformScope = !user?.instanceId;
+  const isPlatformScope = user !== null && !user.instanceId;
 
   const [search, setSearch] = React.useState('');
   const [deleteRoleId, setDeleteRoleId] = React.useState<string | null>(null);

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
@@ -100,6 +100,39 @@ describe('UserListPage', () => {
     expect(screen.getAllByRole('link', { name: 'Bearbeiten' })[0]!.getAttribute('href')).toBe('/admin/users/$userId');
   });
 
+  it('shows Keycloak mapping diagnostics and disables blocked row actions', () => {
+    useUsersMock.mockReturnValue(
+      createUsersApiState({
+        users: [
+          {
+            id: 'keycloak:subject-unmapped',
+            keycloakSubject: 'subject-unmapped',
+            displayName: 'Unmapped User',
+            email: 'unmapped@example.com',
+            status: 'active',
+            mappingStatus: 'manual_review',
+            editability: 'blocked',
+            diagnostics: [{ code: 'missing_instance_attribute', objectId: 'subject-unmapped', objectType: 'user' }],
+            roles: [],
+          },
+        ],
+      })
+    );
+
+    render(<UserListPage />);
+
+    expect(screen.getAllByText('Manuell prüfen').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Blockiert').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Diagnose: missing_instance_attribute').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('link', { name: 'Bearbeiten' })).toBeNull();
+    screen
+      .getAllByRole('button', { name: 'Bearbeiten' })
+      .forEach((button) => expect(button.hasAttribute('disabled')).toBe(true));
+    screen
+      .getAllByRole('button', { name: 'Deaktivieren' })
+      .forEach((button) => expect(button.hasAttribute('disabled')).toBe(true));
+  });
+
   it('updates filters and pagination controls', () => {
     const setSearch = vi.fn();
     const setStatus = vi.fn();
@@ -148,6 +181,13 @@ describe('UserListPage', () => {
           providerSource: 'instance',
           matchedWithoutInstanceAttributeCount: 2,
         },
+        objects: [
+          {
+            keycloakSubject: 'subject-2',
+            mappingStatus: 'manual_review',
+            diagnostics: [{ code: 'missing_instance_attribute', objectId: 'subject-2', objectType: 'user' }],
+          },
+        ],
       },
     });
 
@@ -172,6 +212,7 @@ describe('UserListPage', () => {
         screen.getByText(/Realm de-musterhausen, Quelle Instanz-Realm\. 2 Benutzer ohne `instanceId`/i)
       ).toBeTruthy()
     );
+    expect(screen.getByText('1 Benutzerobjekte mit Diagnose: missing_instance_attribute')).toBeTruthy();
     expect(screen.getByText(/teilweisen Fehlern oder manuellem Nachlauf/i)).toBeTruthy();
   });
 

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
@@ -6,6 +6,7 @@ import { UserListPage } from './-user-list-page';
 
 const useUsersMock = vi.fn();
 const isIamBulkEnabledMock = vi.fn();
+const useAuthMock = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ to, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
@@ -21,6 +22,10 @@ vi.mock('../../../hooks/use-users', () => ({
 
 vi.mock('../../../lib/iam-admin-access', () => ({
   isIamBulkEnabled: () => isIamBulkEnabledMock(),
+}));
+
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => useAuthMock(),
 }));
 
 const createUsersApiState = (overrides: Record<string, unknown> = {}) => ({
@@ -81,6 +86,8 @@ describe('UserListPage', () => {
     useUsersMock.mockReset();
     isIamBulkEnabledMock.mockReset();
     isIamBulkEnabledMock.mockReturnValue(true);
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ user: { id: 'user-admin', instanceId: 'de-musterhausen', roles: ['system_admin'] } });
   });
 
   it('renders list actions and uses route links for create and edit', () => {
@@ -225,5 +232,18 @@ describe('UserListPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Deaktivieren' }));
 
     await waitFor(() => expect(deactivateUser).toHaveBeenCalledWith('user-1'));
+  });
+
+  it('renders platform user management on root scope without tenant mutations', () => {
+    useAuthMock.mockReturnValue({ user: { id: 'platform-admin', roles: ['system_admin'] } });
+    useUsersMock.mockReturnValue(createUsersApiState());
+
+    render(<UserListPage />);
+
+    expect(screen.getByRole('heading', { name: 'Plattform-Benutzer' })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Nutzer anlegen' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Bearbeiten' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Deaktivieren' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Aus Keycloak synchronisieren' })).toBeTruthy();
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -47,7 +47,7 @@ export const UserListPage = () => {
   const [syncResult, setSyncResult] = React.useState<IamUserImportSyncReport | null>(null);
   const [syncError, setSyncError] = React.useState<Parameters<typeof userErrorMessage>[0]>(null);
   const { user } = useAuth();
-  const isPlatformScope = !user?.instanceId;
+  const isPlatformScope = user !== null && !user.instanceId;
 
   const onConfirmDeactivate = async () => {
     const action = deactivateDialog;

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -78,16 +78,7 @@ export const UserListPage = () => {
       return;
     }
 
-    setSyncResult({
-      outcome: result.report.outcome,
-      checkedCount: result.report.checkedCount,
-      correctedCount: result.report.correctedCount,
-      manualReviewCount: result.report.manualReviewCount,
-      importedCount: result.report.importedCount,
-      updatedCount: result.report.updatedCount,
-      skippedCount: result.report.skippedCount,
-      diagnostics: result.report.diagnostics,
-    });
+    setSyncResult(result.report);
     setSyncStatus(
       result.report.importedCount === 0 &&
         result.report.updatedCount === 0 &&

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -244,19 +244,17 @@ export const UserListPage = () => {
               </Button>
             </>
           }
-          rowActions={(user) => (
-            isPlatformScope ? null : (
-              <>
-                <Button asChild size="sm" variant="outline">
-                  <Link to="/admin/users/$userId" params={{ userId: user.id }}>
-                    {t('admin.users.actions.edit')}
-                  </Link>
-                </Button>
-                <Button type="button" size="sm" variant="destructive" onClick={() => setDeactivateDialog({ mode: 'single', userId: user.id })}>
-                  {t('admin.users.actions.deactivate')}
-                </Button>
-              </>
-            )
+          rowActions={isPlatformScope ? undefined : (user) => (
+            <>
+              <Button asChild size="sm" variant="outline">
+                <Link to="/admin/users/$userId" params={{ userId: user.id }}>
+                  {t('admin.users.actions.edit')}
+                </Link>
+              </Button>
+              <Button type="button" size="sm" variant="destructive" onClick={() => setDeactivateDialog({ mode: 'single', userId: user.id })}>
+                {t('admin.users.actions.deactivate')}
+              </Button>
+            </>
           )}
         />
       </StudioListPageTemplate>

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -1,4 +1,9 @@
-import type { IamUserImportSyncReport } from '@sva/core';
+import type {
+  IamKeycloakMappingStatus,
+  IamKeycloakObjectDiagnostic,
+  IamKeycloakObjectEditability,
+  IamUserImportSyncReport,
+} from '@sva/core';
 import { Link } from '@tanstack/react-router';
 import React from 'react';
 
@@ -34,8 +39,36 @@ const statusTranslationKeyByValue = {
 const syncOutcomeTranslationKey = {
   success: 'admin.users.messages.syncOutcome.success',
   partial_failure: 'admin.users.messages.syncOutcome.partialFailure',
+  blocked: 'admin.users.messages.syncOutcome.blocked',
   failed: 'admin.users.messages.syncOutcome.failed',
 } as const;
+
+const mappingStatusTranslationKey: Record<IamKeycloakMappingStatus, string> = {
+  mapped: 'admin.users.mapping.mapped',
+  unmapped: 'admin.users.mapping.unmapped',
+  manual_review: 'admin.users.mapping.manualReview',
+};
+
+const editabilityTranslationKey: Record<IamKeycloakObjectEditability, string> = {
+  editable: 'admin.users.editability.editable',
+  read_only: 'admin.users.editability.readOnly',
+  blocked: 'admin.users.editability.blocked',
+};
+
+const editabilityClassByValue: Record<IamKeycloakObjectEditability, string> = {
+  editable: 'border-primary/40 bg-primary/10 text-primary',
+  read_only: 'border-secondary/40 bg-secondary/10 text-secondary',
+  blocked: 'border-destructive/40 bg-destructive/10 text-destructive',
+};
+
+const renderDiagnosticCodes = (diagnostics: readonly IamKeycloakObjectDiagnostic[] | undefined) =>
+  diagnostics && diagnostics.length > 0 ? (
+    <span className="block text-xs text-muted-foreground">
+      {t('admin.users.messages.diagnosticCodes', {
+        codes: diagnostics.map((diagnostic) => diagnostic.code).join(', '),
+      })}
+    </span>
+  ) : null;
 
 export const UserListPage = () => {
   const usersApi = useUsers();
@@ -48,6 +81,7 @@ export const UserListPage = () => {
   const [syncError, setSyncError] = React.useState<Parameters<typeof userErrorMessage>[0]>(null);
   const { user } = useAuth();
   const isPlatformScope = user !== null && !user.instanceId;
+  const isAuthLoading = user === null;
 
   const onConfirmDeactivate = async () => {
     const action = deactivateDialog;
@@ -124,6 +158,29 @@ export const UserListPage = () => {
         sortValue: (user) => user.status,
       },
       {
+        id: 'keycloak',
+        header: t('admin.users.table.headerKeycloak'),
+        cell: (user) => {
+          const mappingStatus = user.mappingStatus ?? 'mapped';
+          const editability = user.editability ?? 'editable';
+          return (
+            <div className="space-y-2">
+              <div className="flex flex-wrap gap-2">
+                <Badge className="rounded-full" variant="outline">
+                  {t(mappingStatusTranslationKey[mappingStatus])}
+                </Badge>
+                <Badge className={`rounded-full ${editabilityClassByValue[editability]}`} variant="outline">
+                  {t(editabilityTranslationKey[editability])}
+                </Badge>
+              </div>
+              {renderDiagnosticCodes(user.diagnostics)}
+            </div>
+          );
+        },
+        sortable: true,
+        sortValue: (user) => `${user.mappingStatus ?? 'mapped'}:${user.editability ?? 'editable'}`,
+      },
+      {
         id: 'lastLoginAt',
         header: t('admin.users.table.headerLastLogin'),
         cell: (user) => user.lastLoginAt ?? '-',
@@ -140,7 +197,7 @@ export const UserListPage = () => {
         title={t(isPlatformScope ? 'admin.users.page.platformTitle' : 'admin.users.page.title')}
         description={t(isPlatformScope ? 'admin.users.page.platformSubtitle' : 'admin.users.page.subtitle')}
         primaryAction={
-          isPlatformScope
+          isPlatformScope || isAuthLoading
             ? undefined
             : {
                 label: t('admin.users.actions.create'),
@@ -222,14 +279,26 @@ export const UserListPage = () => {
               </Button>
             </>
           }
-          rowActions={isPlatformScope ? undefined : (user) => (
+          rowActions={isPlatformScope || isAuthLoading ? undefined : (user) => (
             <>
-              <Button asChild size="sm" variant="outline">
-                <Link to="/admin/users/$userId" params={{ userId: user.id }}>
+              {user.editability === 'blocked' ? (
+                <Button size="sm" variant="outline" disabled>
                   {t('admin.users.actions.edit')}
-                </Link>
-              </Button>
-              <Button type="button" size="sm" variant="destructive" onClick={() => setDeactivateDialog({ mode: 'single', userId: user.id })}>
+                </Button>
+              ) : (
+                <Button asChild size="sm" variant="outline">
+                  <Link to="/admin/users/$userId" params={{ userId: user.id }}>
+                    {t('admin.users.actions.edit')}
+                  </Link>
+                </Button>
+              )}
+              <Button
+                type="button"
+                size="sm"
+                variant="destructive"
+                disabled={user.editability === 'blocked' || user.editability === 'read_only'}
+                onClick={() => setDeactivateDialog({ mode: 'single', userId: user.id })}
+              >
                 {t('admin.users.actions.deactivate')}
               </Button>
             </>
@@ -272,6 +341,20 @@ export const UserListPage = () => {
                   matchedWithoutInstanceAttributeCount: String(
                     syncResult.diagnostics.matchedWithoutInstanceAttributeCount ?? 0
                   ),
+                })}
+              </span>
+            ) : null}
+            {syncResult.objects && syncResult.objects.length > 0 ? (
+              <span className="block text-xs text-muted-foreground">
+                {t('admin.users.messages.syncObjectDiagnostics', {
+                  count: syncResult.objects.length,
+                  codes: Array.from(
+                    new Set(
+                      syncResult.objects.flatMap((entry) =>
+                        entry.diagnostics.map((diagnostic) => diagnostic.code)
+                      )
+                    )
+                  ).join(', '),
                 })}
               </span>
             ) : null}

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -1,3 +1,4 @@
+import type { IamUserImportSyncReport } from '@sva/core';
 import { Link } from '@tanstack/react-router';
 import React from 'react';
 
@@ -43,21 +44,7 @@ export const UserListPage = () => {
     null
   );
   const [syncStatus, setSyncStatus] = React.useState<'idle' | 'pending' | 'success' | 'empty' | 'error'>('idle');
-  const [syncResult, setSyncResult] = React.useState<{
-    outcome: 'success' | 'partial_failure' | 'failed';
-    checkedCount: number;
-    correctedCount: number;
-    manualReviewCount: number;
-    importedCount: number;
-    updatedCount: number;
-    skippedCount: number;
-    diagnostics?: {
-      authRealm: string;
-      providerSource: 'instance' | 'global' | 'fallback_global' | 'platform';
-      matchedWithoutInstanceAttributeCount?: number;
-      skippedInstanceIds?: readonly string[];
-    };
-  } | null>(null);
+  const [syncResult, setSyncResult] = React.useState<IamUserImportSyncReport | null>(null);
   const [syncError, setSyncError] = React.useState<Parameters<typeof userErrorMessage>[0]>(null);
   const { user } = useAuth();
   const isPlatformScope = !user?.instanceId;

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -13,6 +13,7 @@ import { Label } from '../../../components/ui/label';
 import { Select } from '../../../components/ui/select';
 import { useUsers } from '../../../hooks/use-users';
 import { isIamBulkEnabled } from '../../../lib/iam-admin-access';
+import { useAuth } from '../../../providers/auth-provider';
 import { t } from '../../../i18n';
 import { IamRuntimeDiagnosticDetails } from '../-iam-runtime-diagnostic-details';
 import { userErrorMessage } from './-user-error-message';
@@ -52,12 +53,14 @@ export const UserListPage = () => {
     skippedCount: number;
     diagnostics?: {
       authRealm: string;
-      providerSource: 'instance' | 'global' | 'fallback_global';
+      providerSource: 'instance' | 'global' | 'fallback_global' | 'platform';
       matchedWithoutInstanceAttributeCount?: number;
       skippedInstanceIds?: readonly string[];
     };
   } | null>(null);
   const [syncError, setSyncError] = React.useState<Parameters<typeof userErrorMessage>[0]>(null);
+  const { user } = useAuth();
+  const isPlatformScope = !user?.instanceId;
 
   const onConfirmDeactivate = async () => {
     const action = deactivateDialog;
@@ -156,20 +159,24 @@ export const UserListPage = () => {
   return (
     <section className="space-y-5" aria-busy={usersApi.isLoading}>
       <StudioListPageTemplate
-        title={t('admin.users.page.title')}
-        description={t('admin.users.page.subtitle')}
-        primaryAction={{
-          label: t('admin.users.actions.create'),
-          render: (
-            <Button asChild type="button">
-              <Link to="/admin/users/new">{t('admin.users.actions.create')}</Link>
-            </Button>
-          ),
-        }}
+        title={t(isPlatformScope ? 'admin.users.page.platformTitle' : 'admin.users.page.title')}
+        description={t(isPlatformScope ? 'admin.users.page.platformSubtitle' : 'admin.users.page.subtitle')}
+        primaryAction={
+          isPlatformScope
+            ? undefined
+            : {
+                label: t('admin.users.actions.create'),
+                render: (
+                  <Button asChild type="button">
+                    <Link to="/admin/users/new">{t('admin.users.actions.create')}</Link>
+                  </Button>
+                ),
+              }
+        }
       >
         <StudioDataTable
-          ariaLabel={t('admin.users.table.ariaLabel')}
-          caption={t('admin.users.table.caption')}
+          ariaLabel={t(isPlatformScope ? 'admin.users.table.platformAriaLabel' : 'admin.users.table.ariaLabel')}
+          caption={t(isPlatformScope ? 'admin.users.table.platformCaption' : 'admin.users.table.caption')}
           data={usersApi.users}
           columns={userColumns}
           getRowId={(user) => user.id}
@@ -181,7 +188,7 @@ export const UserListPage = () => {
             </Card>
           }
           bulkActions={
-            isIamBulkEnabled()
+            isIamBulkEnabled() && !isPlatformScope
               ? [
                   {
                     id: 'bulk-deactivate',
@@ -238,16 +245,18 @@ export const UserListPage = () => {
             </>
           }
           rowActions={(user) => (
-            <>
-              <Button asChild size="sm" variant="outline">
-                <Link to="/admin/users/$userId" params={{ userId: user.id }}>
-                  {t('admin.users.actions.edit')}
-                </Link>
-              </Button>
-              <Button type="button" size="sm" variant="destructive" onClick={() => setDeactivateDialog({ mode: 'single', userId: user.id })}>
-                {t('admin.users.actions.deactivate')}
-              </Button>
-            </>
+            isPlatformScope ? null : (
+              <>
+                <Button asChild size="sm" variant="outline">
+                  <Link to="/admin/users/$userId" params={{ userId: user.id }}>
+                    {t('admin.users.actions.edit')}
+                  </Link>
+                </Button>
+                <Button type="button" size="sm" variant="destructive" onClick={() => setDeactivateDialog({ mode: 'single', userId: user.id })}>
+                  {t('admin.users.actions.deactivate')}
+                </Button>
+              </>
+            )
           )}
         />
       </StudioListPageTemplate>
@@ -281,7 +290,9 @@ export const UserListPage = () => {
                       ? t('admin.users.messages.syncProviderSource.instance')
                       : syncResult.diagnostics.providerSource === 'fallback_global'
                         ? t('admin.users.messages.syncProviderSource.fallback_global')
-                        : t('admin.users.messages.syncProviderSource.global'),
+                        : syncResult.diagnostics.providerSource === 'platform'
+                          ? t('admin.users.messages.syncProviderSource.platform')
+                          : t('admin.users.messages.syncProviderSource.global'),
                   matchedWithoutInstanceAttributeCount: String(
                     syncResult.diagnostics.matchedWithoutInstanceAttributeCount ?? 0
                   ),

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -115,6 +115,7 @@ Referenzen:
 
 - User-Sync und Rollen-Reconcile werden als fachlich deterministische Laufzeitverträge behandelt und nicht mehr nur als technische Admin-Hilfsaktionen.
 - Führend ist ein gemeinsamer Projektionskern von Keycloak-Identität (`sub`), tenant-spezifischem Auth-Scope (`instanceId` aus Host/Registry/Realm), IAM-User und Membership bis zur Darstellung in `/auth/me`, `/account`, `/admin/users` und `/admin/roles`.
+- Auf dem Root-Host wird derselbe IAM-v1-Routenvertrag im `platform`-Scope ausgewertet; Plattform-User und Plattform-Rollen stammen aus dem Plattform-Realm und benötigen keine tenantgebundene `instanceId`.
 - Tenant-Admin-abhängige Reconcile- und Sync-Pfade reagieren fail-closed, sobald blockerrelevanter Drift in Registry oder Provisioning erkannt wird.
 - `manual_review` bleibt bewusst ein fachlicher Restzustand für nicht deterministisch behebbaren Abgleich; technische Fehler wie `IDP_UNAVAILABLE` und `IDP_FORBIDDEN` bleiben getrennt sichtbar.
 - Browser- und UI-Verträge behalten `classification`, `requestId` und `safeDetails` vollständig, damit Diagnose, Operator-Handlung und Fachzustand nicht auseinanderlaufen.

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -117,6 +117,13 @@ Referenzen:
 - Führend ist ein gemeinsamer Projektionskern von Keycloak-Identität (`sub`), tenant-spezifischem Auth-Scope (`instanceId` aus Host/Registry/Realm), IAM-User und Membership bis zur Darstellung in `/auth/me`, `/account`, `/admin/users` und `/admin/roles`.
 - Auf dem Root-Host wird derselbe IAM-v1-Routenvertrag im `platform`-Scope ausgewertet; Plattform-User und Plattform-Rollen stammen aus dem Plattform-Realm und benötigen keine tenantgebundene `instanceId`.
 - Tenant-Admin-abhängige Reconcile- und Sync-Pfade reagieren fail-closed, sobald blockerrelevanter Drift in Registry oder Provisioning erkannt wird.
+
+### Fortschreibung 2026-04: Studio als Keycloak-first Admin-UI
+
+- Studio wird für Benutzer, Realm-Rollen und Rollenzuordnungen als auditierte Admin-UI über Keycloak positioniert; Keycloak bleibt System of Record.
+- Platform-Scope und Tenant-Scope sind strategisch getrennte Admin-Pfade: Platform-Scope nutzt ausschließlich den Platform-Admin-Keycloak-Client, Tenant-Scope ausschließlich den Tenant-Admin-Keycloak-Client der Instanz.
+- Tenant-Listen folgen dem Keycloak-Realm als Benutzergrenze. Fehlende Studio-Zuordnungen werden nicht versteckt, sondern über `mappingStatus`, `editability` und stabile Diagnosecodes angezeigt.
+- Mutationen sind Keycloak-first. Studio-Read-Models werden nachgelagert synchronisiert oder als Drift/Diagnose sichtbar gemacht.
 - `manual_review` bleibt bewusst ein fachlicher Restzustand für nicht deterministisch behebbaren Abgleich; technische Fehler wie `IDP_UNAVAILABLE` und `IDP_FORBIDDEN` bleiben getrennt sichtbar.
 - Browser- und UI-Verträge behalten `classification`, `requestId` und `safeDetails` vollständig, damit Diagnose, Operator-Handlung und Fachzustand nicht auseinanderlaufen.
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -123,6 +123,19 @@ Abhängigkeiten des aktuellen Systems.
 - Der SVA-Mainserver bleibt fachliche Source of Truth für seine GraphQL-Daten; Studio hält nur Endpunktkonfiguration und kurzlebige Laufzeit-Caches für Credentials und Access-Tokens.
 - Fachmodule konsumieren zentrale IAM-Entscheidungen und duplizieren keine eigene Berechtigungsauflösung gegen IAM-Tabellen.
 
+### Fortschreibung 2026-04: Keycloak-Admin-UI-Bausteine
+
+1. `@sva/core`
+   - Definiert additive Verträge für `mappingStatus`, `editability`, objektbezogene Diagnosecodes und Sync-/Reconcile-Objektlisten.
+2. `packages/auth/src/identity-provider-port.ts`
+   - Kapselt Keycloak-nahe Listen-, Count-, Mutations- und explizite Role-Assignment-Operationen.
+3. `packages/auth/src/keycloak-admin-client`
+   - Implementiert serverseitige Pagination/Count für Realm-Rollen und User sowie differenzierte Fehlerabbildung für Keycloak-Admin-Aufrufe.
+4. `packages/auth/src/iam-account-management`
+   - Trennt Platform-Admin-Client, Tenant-Admin-Client, Keycloak-first Mutationen, Read-Model-Synchronisation und Drift-/Diagnoseprojektion.
+5. `apps/sva-studio-react/src/routes/admin/users` und `apps/sva-studio-react/src/routes/admin/roles`
+   - Rendern Mappingstatus, Bearbeitbarkeit und Diagnosecodes; blockierte oder read-only Aktionen bleiben sichtbar, aber deaktiviert.
+
 ### Fortschreibung 2026-04: Diagnosegrenzen im IAM-Pfad
 
 - `packages/data` liefert tenant- und registrynahe Drift- und Fallback-Signale, insbesondere in der Host-Auflösung.

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -341,6 +341,7 @@ Neu hinzugekommene Bausteine im Change `add-iam-organization-management-hierarch
 
 1. `packages/auth/src/iam-account-management/user-import-sync-handler.ts`
    - Führt einen expliziten Admin-Sync aus, liest Keycloak-Benutzer seitenweise aus dem aktiven Tenant-Realm, akzeptiert Benutzer ohne `instanceId`-Attribut und spiegelt Basisdaten idempotent nach `iam.accounts`; widersprüchliche Attribute bleiben als Diagnose sichtbar.
+   - Auf dem Root-Host führt derselbe Endpunkt einen Platform-Sync über den Plattform-Realm aus und meldet `executionMode=platform_admin`, ohne eine Pseudo-Instanz anzulegen.
 2. `packages/auth/src/identity-provider-port.ts`
    - Erweitert die IdP-Abstraktion um typisierte User-Listing-Operationen für administrative Import- und Reconcile-Flows.
 3. `packages/routing/src/auth.routes.server.ts` und `packages/auth/src/routes.shared.ts`

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -134,7 +134,7 @@ Fehlerpfad:
 ### Szenario 2e: Deterministischer User-Sync und Rollen-Reconcile
 
 1. Ein Administrator startet in `/admin/users` den Keycloak-User-Sync oder in `/admin/roles` den Rollen-Reconcile.
-2. Der Server lädt den Instanzkontext und prüft vor jeder tenantlokalen Admin-Mutation blockerrelevanten Drift aus Registry, Preflight und Provisioning-Plan.
+2. Der Server unterscheidet Root-Host-Platform-Scope und Tenant-Instance-Scope. Im Platform-Scope nutzt er den Plattform-Realm ohne `instanceId`; im Tenant-Scope lädt er den Instanzkontext und prüft vor jeder tenantlokalen Admin-Mutation blockerrelevanten Drift aus Registry, Preflight und Provisioning-Plan.
 3. Beim Keycloak-User-Sync ist der aktive Tenant-Realm die führende Benutzergrenze; fehlende `instanceId`-Attribute blockieren den Import nicht.
 4. Liegt ein Blocker vor, endet der Lauf sofort fail-closed mit technischem Fehlervertrag inklusive `classification`, `requestId` und freigegebenen Safe-Details.
 5. Ohne Blocker führt `packages/auth` den Sync oder Reconcile deterministisch aus und trennt pro Eintrag zwischen korrigiert, fehlgeschlagen und fachlichem Restzustand `manual_review`.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -147,6 +147,23 @@ Fehlerpfad:
 - `IDP_FORBIDDEN` und `IDP_UNAVAILABLE` bleiben als technische oder Berechtigungsfehler sichtbar und werden nicht als `manual_review` kaschiert.
 - einzelne fachlich mehrdeutige Fälle können in `manual_review` enden, ohne dass der Gesamt-Request hängen bleibt.
 
+### Szenario 2f: Keycloak-first User- und Rollenverwaltung
+
+1. `/admin/users` und `/admin/roles` laden Listen über den aktiven Keycloak-Admin-Pfad.
+2. Im Platform-Scope wird nur der Platform-Admin-Keycloak-Client verwendet.
+3. Im Tenant-Scope wird nur der Tenant-Admin-Keycloak-Client der Instanz verwendet; fehlt dieser, endet der Request mit `tenant_admin_client_not_configured`.
+4. Tenant-Userlisten lesen den vollständigen Realm-Ausschnitt aus Keycloak und verbinden ihn anschließend mit Studio-Read-Models.
+5. Keycloak-Objekte ohne Studio-Zuordnung bleiben als `unmapped` oder `manual_review` sichtbar.
+6. Mutierende Aktionen schreiben zuerst Keycloak, synchronisieren anschließend Studio-Read-Models und erzeugen Audit-Events.
+7. Read-only- oder blockierte Objekte werden in der UI mit Diagnosecode angezeigt und serverseitig erneut vor der Mutation geprüft.
+
+Fehlerpfad:
+
+- Keycloak `403` wird als `IDP_FORBIDDEN` beziehungsweise `idp_forbidden` eingeordnet.
+- föderierte oder profilrichtliniengeschützte Felder werden als `read_only_federated_field` sichtbar und nicht überschrieben.
+- verbotene Rollenzuordnungen werden als `forbidden_role_mapping` sichtbar.
+- Built-in-Rollen bleiben als Rollenobjekt read-only, dürfen aber abhängig von der aktiven Rechte-Matrix zugewiesen oder entfernt werden.
+
 ### Szenario 2b: Forced Reauth für einen Benutzer
 
 1. Ein interner Serverpfad ruft `forceReauthUser({ userId, mode, reason })` auf.

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -81,6 +81,9 @@ gleichzeitig beeinflussen.
 - Instanzverwaltung ist nur auf dem Root-Host zulässig; Tenant-Hosts rendern keine globale Control Plane
 - Normale Tenant-Administration nutzt ausschließlich einen tenantlokalen Keycloak-Adminpfad; Plattform-/Root-Credentials sind dafür kein zulässiger Fallback
 - Root-/Plattform-Zugriff umfasst Instanz-Lifecycle, Provisioning, Platform-User, Platform-Rollen, Platform-Sync und explizites Break-Glass; tenantlokale Daten bleiben davon getrennt
+- User-, Rollen- und Rollenzuordnungsänderungen folgen einem Keycloak-first-Vertrag. Studio schreibt erst Keycloak, synchronisiert danach die lokalen Read-Models und macht Abweichungen über `mappingStatus`, `editability` und Diagnosecodes sichtbar.
+- Tenant-Userlisten richten sich nach dem Tenant-Realm in Keycloak; ungemappte oder mehrdeutige Benutzer werden als `unmapped` beziehungsweise `manual_review` angezeigt.
+- Keycloak-Built-in-Rollen bleiben als Rollenobjekte read-only, werden aber in Listen nicht ausgeblendet.
 - Keycloak-Provisioning für Instanzen ist ein expliziter mehrstufiger Root-Host-Workflow aus Preflight, Plan, Ausführung und persistiertem Schrittprotokoll
 - Registry-Daten und Keycloak-Mutation sind getrennte Aktionen; ein Speichern von Instanzdaten führt keine implizite Keycloak-Änderung aus
 - Registry-Lookups verwenden einen kurzen In-Process-L1-Cache mit expliziter Invalidation, aber ohne Stale-Serve-Strategie
@@ -116,6 +119,8 @@ gleichzeitig beeinflussen.
 - Der Sync-Report darf additive, nicht-sensitive Diagnosefelder wie `authRealm`, `providerSource`, `executionMode`, `matchedWithoutInstanceAttributeCount` und `skippedInstanceIds` zurückgeben, damit UI und Doctor Realm-/Instanz-Drift ohne `kcadm.sh` eingrenzen können
 - Role-Sync- und Reconcile-Pfade verwenden ausschließlich den SDK-Logger; `console.*` ist serverseitig ausgeschlossen
 - Role-Sync-Audit nutzt ein einheitliches Schema mit `workspace_id`, `operation`, `result`, `error_code?`, `request_id`, `trace_id?`, `span_id?`
+- Keycloak-Admin-UI-Diagnosen verwenden stabile objektbezogene Codes wie `missing_instance_attribute`, `mapping_missing`, `forbidden_role_mapping`, `read_only_federated_field` und `idp_forbidden`.
+- Sync- und Reconcile-Reports dürfen betroffene Objektlisten enthalten; öffentliche Payloads bleiben auf nicht-sensitive IDs, Zähler, Codes und Korrelationsdaten begrenzt.
 - Zusätzliche Metriken für den Rollenpfad: `iam_role_sync_operations_total` und `iam_role_drift_backlog`
 - Zusätzliche Cache-Metriken für IAM: `sva_iam_cache_lookup_total`, `sva_iam_cache_invalidation_duration_ms`, `sva_iam_cache_stale_entry_rate`
 - Redis-Infrastrukturmetriken werden über `redis-exporter` in denselben Monitoring-Stack eingespeist und mit den IAM-Cache-Metriken korreliert

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -80,7 +80,7 @@ gleichzeitig beeinflussen.
 - Globale Instanzmutationen verwenden die dedizierte Plattformrolle `instance_registry_admin`
 - Instanzverwaltung ist nur auf dem Root-Host zulässig; Tenant-Hosts rendern keine globale Control Plane
 - Normale Tenant-Administration nutzt ausschließlich einen tenantlokalen Keycloak-Adminpfad; Plattform-/Root-Credentials sind dafür kein zulässiger Fallback
-- Root-/Plattform-Zugriff bleibt auf Instanz-Lifecycle, Provisioning, Reconcile und explizites Break-Glass begrenzt
+- Root-/Plattform-Zugriff umfasst Instanz-Lifecycle, Provisioning, Platform-User, Platform-Rollen, Platform-Sync und explizites Break-Glass; tenantlokale Daten bleiben davon getrennt
 - Keycloak-Provisioning für Instanzen ist ein expliziter mehrstufiger Root-Host-Workflow aus Preflight, Plan, Ausführung und persistiertem Schrittprotokoll
 - Registry-Daten und Keycloak-Mutation sind getrennte Aktionen; ein Speichern von Instanzdaten führt keine implizite Keycloak-Änderung aus
 - Registry-Lookups verwenden einen kurzen In-Process-L1-Cache mit expliziter Invalidation, aber ohne Stale-Serve-Strategie

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -77,6 +77,11 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
   - degradierte und Recovery-nahe Zustände dürfen nicht implizit als vollständig gesund dargestellt werden
   - Reconcile- und Sync-Responses müssen deterministische Abschlusszustände und die Zählwerte `checked`, `corrected`, `failed`, `manualReview` stabil serialisieren
   - blockerrelevanter Drift muss User-Sync und Rollen-Reconcile fail-closed blockieren und darf nicht als scheinbarer Erfolg in UI oder Audit erscheinen
+- IAM Keycloak-Admin-UI:
+  - `/admin/users` und `/admin/roles` müssen Mappingstatus, Bearbeitbarkeit und Diagnosecodes aus dem IAM-v1-Vertrag anzeigen
+  - Tenant-Scope darf nie auf Platform- oder globale Keycloak-Admin-Credentials zurückfallen
+  - Keycloak-Count/Pagination für User und Rollen muss serverseitig testbar bleiben
+  - read-only oder blockierte Aktionen müssen in UI und Serverprüfung konsistent deaktiviert beziehungsweise abgewiesen werden
 - IAM Redis-Betrieb:
   - Session-Store folgt dem Plattform-RTO `<= 2h`
   - Permission-Snapshots sind rekonstruierbar und müssen operativ innerhalb von `15 min` wieder in `ready|degraded` überführt werden

--- a/docs/development/runtime-profile-betrieb.md
+++ b/docs/development/runtime-profile-betrieb.md
@@ -290,10 +290,13 @@ Fuer `studio` gilt bei Tenant-Smokes zusaetzlich:
 Zusatzvertrag fuer den Root-Host:
 
 - `/admin/instances` ist die fuehrende Control Plane fuer tenant-spezifische Realm-Basisdaten
+- `/admin/users` und `/admin/roles` laufen auf dem Root-Host im Platform-Scope und lesen Plattform-User bzw. Plattform-Rollen aus dem Plattform-Realm; diese Pfade duerfen keine tenantgebundene `instanceId` voraussetzen
+- `POST /api/v1/iam/users/sync-keycloak` nutzt auf dem Root-Host `executionMode=platform_admin`; derselbe Endpunkt nutzt auf Tenant-Hosts weiter `executionMode=tenant_admin`
 - dort werden `authRealm`, `authClientId`, `tenantAdminClient.clientId`, optional `authIssuerUrl`, das tenant-spezifische OIDC-Client-Secret, das Tenant-Admin-Client-Secret und die Tenant-Admin-Stammdaten gepflegt
 - das Client-Secret ist write-only; im UI wird nur angezeigt, ob es bereits konfiguriert ist
 - Realm-/Login-Client-/Tenant-Admin-Client-/Mapper-/Tenant-Admin-Abgleich erfolgt explizit ueber den Keycloak-Reconcile-Pfad der Instanzverwaltung
 - tenant-lokale `system_admin`s duerfen diese globale Root-Host-Verwaltung nicht sehen oder mutieren
+- Tenant-Smokes werden separat gegen echte Tenant-Hosts ausgefuehrt; `partial_failure` beim Tenant-User-Sync ist ein fachlich offener Befund, aber kein Nachweis fuer einen Browser- oder Seitenabsturz
 
 `smoke` validiert zusätzlich den kritischen IAM-Schema-Stand. Fehlende Tabellen, Indizes oder RLS-Policies gelten als deterministischer Fehler und werden als maschinenlesbarer Drift gemeldet.
 

--- a/docs/guides/iam-service-api-dokumentation.md
+++ b/docs/guides/iam-service-api-dokumentation.md
@@ -57,6 +57,8 @@ Diese Anleitung beschreibt die aktuell stabilen IAM-v1-Endpunkte, Response-Envel
 
 - `GET /api/v1/iam/users`
   - Query: `page`, `pageSize`, `status`, `role`, `search`
+  - Tenant-Scope lädt die Benutzer führend aus dem Tenant-Realm in Keycloak. Fehlende Studio-Read-Model-Zuordnungen bleiben sichtbar und werden nicht herausgefiltert.
+  - Listeneinträge können additiv `mappingStatus`, `editability` und `diagnostics[]` enthalten.
 - `GET /api/v1/iam/users/{userId}`
   - enthält additiv `groups[]` mit `groupId`, `groupKey`, `displayName`, `groupType`, `origin`, `validFrom`, `validTo`
 - `POST /api/v1/iam/users`
@@ -70,6 +72,9 @@ Diese Anleitung beschreibt die aktuell stabilen IAM-v1-Endpunkte, Response-Envel
 ### Roles
 
 - `GET /api/v1/iam/roles`
+  - Rollenlisten verwenden Keycloak-Pagination und Keycloak-Count, wenn der aktive Scope das unterstützt.
+  - Keycloak-Built-in-Rollen bleiben sichtbar, werden aber als Rollenobjekte read-only markiert.
+  - Listeneinträge können additiv `editability` und `diagnostics[]` enthalten.
 - `POST /api/v1/iam/roles`
 - `PATCH /api/v1/iam/roles/{roleId}`
 - `DELETE /api/v1/iam/roles/{roleId}`
@@ -116,7 +121,19 @@ Diese Anleitung beschreibt die aktuell stabilen IAM-v1-Endpunkte, Response-Envel
 - `self_protection`
 - `feature_disabled`
 - `conflict`
+- `tenant_admin_client_not_configured`
 - `internal_error`
+
+## Keycloak-first Admin-Vertrag
+
+- Keycloak ist für Benutzer, Realm-Rollen und Rollenzuordnungen die führende Quelle. Studio mutiert zuerst Keycloak und synchronisiert danach die Studio-Read-Models.
+- Root-/Platform-Scope nutzt ausschließlich den Platform-Admin-Keycloak-Client. Tenant-Scope nutzt ausschließlich den Tenant-Admin-Keycloak-Client der Instanz; ein Fallback auf Platform- oder globale Admin-Credentials ist nicht zulässig.
+- `user === null` im Frontend ist ein Loading-/Unknown-Zustand und darf keinen Platform-Scope auslösen.
+- `mappingStatus` hat die stabilen Werte `mapped`, `unmapped` und `manual_review`.
+- `editability` hat die stabilen Werte `editable`, `read_only` und `blocked`.
+- Objektbezogene Diagnosen werden als stabile Codes übertragen, zum Beispiel `missing_instance_attribute`, `mapping_missing`, `forbidden_role_mapping`, `read_only_federated_field` und `idp_forbidden`.
+- Sync- und Reconcile-Reports verwenden die Abschlusszustände `success`, `partial_failure`, `blocked` und `failed` und dürfen betroffene Objektlisten sowie Zähler additiv enthalten.
+- Keycloak-Fehler werden differenziert gemappt; insbesondere `403` aus Keycloak wird als IdP-Berechtigungsproblem (`IDP_FORBIDDEN` beziehungsweise API-Diagnose `idp_forbidden`) sichtbar.
 
 ## Wichtige Vertragszusagen für Gruppen
 

--- a/docs/guides/keycloak-rollen-sync-runbook.md
+++ b/docs/guides/keycloak-rollen-sync-runbook.md
@@ -79,8 +79,19 @@ Häufige Fehlercodes:
 1. `iam_role_sync_operations_total` nach `operation`, `result` und `error_code` auswerten.
 2. Prüfen, ob die Fehler nur den `retry`-Pfad oder alle Write-Operationen betreffen.
 3. `iam_keycloak_request_duration_seconds` und `iam_circuit_breaker_state` parallel prüfen.
-4. Bei `IDP_FORBIDDEN` sofort die Rollenmatrix des Service-Accounts gegen `docs/guides/keycloak-service-account-setup-iam.md` prüfen.
-5. Bei `DB_WRITE_FAILED` Postgres-Verfügbarkeit und Migration `0007_iam_role_catalog_sync.sql` verifizieren.
+4. Bei `IDP_FORBIDDEN` zuerst den Scope bestimmen:
+   - Root-Host/Platform-Scope: Plattform-Service-Account und Plattform-Realm prüfen.
+   - Tenant-Host/Instance-Scope: `tenantAdminClient.clientId`, Tenant-Admin-Client-Secret, Realm-Zuordnung und Rechte im Tenant-Realm prüfen.
+5. Bei Tenant-`IDP_FORBIDDEN` keinen Fallback auf globale Plattform-Credentials verwenden; stattdessen Tenant-Admin-Client über die Instanzverwaltung neu provisionieren, Secret rotieren oder den Tenant-Admin zurücksetzen.
+6. Die Rollenmatrix des betroffenen Service-Accounts gegen `docs/guides/keycloak-service-account-setup-iam.md` prüfen.
+7. Bei `DB_WRITE_FAILED` Postgres-Verfügbarkeit und Migration `0007_iam_role_catalog_sync.sql` verifizieren.
+
+### Tenant-User-Sync liefert `partial_failure`
+
+1. `manualReviewCount`, `updatedCount`, `skippedCount`, `totalKeycloakUsers` und `diagnostics.executionMode` aus dem Sync-Report sichern.
+2. Bei `executionMode=tenant_admin` fehlende Profilfelder, widersprüchliche `instanceId`-Attribute und übersprungene Fremdinstanz-Attribute prüfen.
+3. Ein HTTP-200-`partial_failure` ist kein UI-Crash; er bleibt ein fachlicher Nachlauf, bis die manuell zu prüfenden Keycloak-Profile bereinigt sind.
+4. Bei Root-Host-Sync muss `executionMode=platform_admin` erscheinen; andernfalls liegt eine Scope-Auflösungslücke vor.
 
 ### Drift-Backlog erhöht
 

--- a/docs/guides/keycloak-service-account-setup-iam.md
+++ b/docs/guides/keycloak-service-account-setup-iam.md
@@ -4,6 +4,7 @@
 
 Diese Anleitung beschreibt die minimale Keycloak-Konfiguration für den IAM-Service des SVA Studio (`sva-studio-iam-service`).
 Sie deckt sowohl User-Management als auch den Studio-verwalteten Rollen-Katalog-Sync nach Keycloak ab.
+Studio ist für Benutzer, Rollen und Rollenzuordnungen eine auditierte Admin-UI über Keycloak: Keycloak bleibt System of Record, Studio schreibt Keycloak-first und aktualisiert anschließend seine Read-Models.
 
 Der fachliche Sollzustand tenant-spezifischer Realms, inklusive `sva-studio`-Client, `instanceId`-Claim, Protocol Mappern und minimalen Tenant-Admin-Rollen, ist separat unter [Keycloak-Tenant-Realm-Bootstrap für Studio](./keycloak-tenant-realm-bootstrap.md) dokumentiert.
 Der vollständige Root-Host-Betriebspfad für Preflight, Plan und Provisioning-Läufe ist unter [Instanzverwaltung als Keycloak-Control-Plane](./instance-keycloak-provisioning.md) beschrieben.
@@ -45,6 +46,13 @@ Explizit verboten:
 - `manage-identity-providers`
 - `manage-events`
 - zusätzliche globale Admin-Rollen außerhalb von `realm-management`
+
+Für Tenant-Hosts gilt zusätzlich:
+
+- Studio verwendet ausschließlich den in der Instanz-Registry hinterlegten Tenant-Admin-Client.
+- Ein fehlender Tenant-Admin-Client oder ein fehlendes Tenant-Admin-Secret führt fail-closed zu `tenant_admin_client_not_configured`.
+- Platform- oder globale Admin-Credentials dürfen tenantlokale User-, Rollen- oder Rollenzuordnungsoperationen nicht ersetzen.
+- Built-in-/Default-Rollen aus Keycloak dürfen sichtbar und abhängig von der Rechte-Matrix zuweisbar sein; ihre Rollenobjekte selbst bleiben read-only.
 
 ## 3. Secret-Handling
 
@@ -100,5 +108,7 @@ Die Rotation erfolgt spätestens alle 90 Tage (BSI-Grundschutz ORP.4) im Dual-Se
 - IAM-Health-Check (`/health/ready`) meldet Keycloak als `healthy`.
 - `POST /api/v1/iam/roles`, `PATCH /api/v1/iam/roles/:id` und `DELETE /api/v1/iam/roles/:id` liefern keinen `keycloak_unavailable`-Fehler.
 - `POST /api/v1/iam/admin/reconcile` erzeugt keinen Berechtigungsfehler im Keycloak-Adapter.
+- `GET /api/v1/iam/users` listet im Tenant-Scope Keycloak-Benutzer auch dann, wenn die Studio-Zuordnung fehlt; solche Objekte müssen als `unmapped` oder `manual_review` sichtbar sein.
+- `GET /api/v1/iam/roles` zeigt Built-in-Rollen als read-only und enthält bei Drift stabile Diagnosecodes.
 - Keine `401`/`403`-Fehler bei Keycloak-Admin-Aufrufen.
 - Keine Secrets oder Tokens in Logs; Audit-Events enthalten nur `workspace_id`, `operation`, `result`, `error_code?`, `request_id`, `trace_id?`, `span_id?`.

--- a/docs/staging/2026-04/pr-302-post-merge-deploy-testliste.md
+++ b/docs/staging/2026-04/pr-302-post-merge-deploy-testliste.md
@@ -1,0 +1,113 @@
+# PR 302: Post-Merge- und Post-Deploy-Testliste
+
+Diese grobe Testliste bündelt die wichtigsten Prüfungen nach Merge und Deploy von PR 302.
+
+## 1. CI und Release
+
+- Neuer Push auf `main`: GitHub Actions laufen ohne Nx-Cloud-Warnungen oder `nx fix-ci`.
+- Studio-Image-Build läuft durch.
+- Deploy zieht das neue Image/Artifact.
+- Runtime startet ohne Server-ESM- oder Importfehler.
+
+## 2. Login, Session und Logout
+
+- Plattform-Login auf Root-/Canonical-Host.
+- Tenant-Login über Tenant-Host/Realm ohne `instanceId`-Claim.
+- Tenant-Login mit passendem `instanceId`-Claim.
+- Tenant-Login mit widersprüchlichem `instanceId`-Claim: muss fail-closed sein.
+- Session-Cookie löschen ohne Logout: User sieht Hinweis und Login-Link führt zurück zur ursprünglichen Seite.
+- Header-Logout: muss Browser-Navigation/IdP-End-Session auslösen.
+- Logout aus Rechtstext-Dialog.
+- Nach Logout darf Silent-SSO nicht sofort wieder einloggen.
+
+## 3. Tenant, Keycloak und Provisioning
+
+- Root-Host `studio.smart-village.app`: `/admin/users` und `/admin/roles` laufen im Platform-Scope und dürfen kein `invalid_instance_id` liefern.
+- Root-Host Keycloak-User-Sync: Button auf `/admin/users` nutzt den Plattform-Realm und meldet `executionMode=platform_admin`.
+- Bestehender Tenant-Realm: Login funktioniert weiter.
+- Neuer Tenant-Realm: Bootstrap/Provisioning prüfen.
+- Tenant-lokaler User ohne `instanceId`-Attribut wird akzeptiert/importiert.
+- Tenant-lokaler User mit fremdem `instanceId`-Attribut wird übersprungen/diagnostiziert.
+- Keycloak-Checkliste: fehlender `instanceId`-Mapper ist Warnung, kein Login-Blocker.
+- Tenant-User-Sync: HTTP 200 mit `partial_failure` ist kein Browser-Crash, aber ein fachlich offener Befund; Zähler für `manualReviewCount`, `updatedCount`, `skippedCount` und `totalKeycloakUsers` dokumentieren.
+- Tenant-Rollen-Reconcile: `IDP_FORBIDDEN` gegen Tenant-Admin-Client-Rechte, Realm-Zuordnung und Secret-Ausrichtung prüfen; kein Fallback auf globale Plattform-Credentials.
+
+## 4. Admin-Routing
+
+- `/admin/content` funktioniert als kanonische Content-Route.
+- Legacy `/content`, `/content/new`, `/content/:id` redirecten korrekt.
+- Core-Admin-Routen funktionieren:
+  - `/admin/users`
+  - `/admin/organizations`
+  - `/admin/roles`
+  - `/admin/instances`
+- Detailseiten mit korrekten Param-Namen laden:
+  - User
+  - Organization
+  - Role
+  - Instance
+- Keine Plugin/Admin-Resource darf Core-Pfade wie `users`, `roles`, `organizations` shadowen.
+
+## 5. Navigation und UI
+
+- Sidebar zeigt Content/Admin-Einstiege korrekt.
+- Breadcrumbs für `/admin/content` und Detailseiten.
+- Header zeigt Login, Logout und Konto korrekt.
+- Home-Seite zeigt Session-Expired-Hinweis korrekt.
+- Keine kaputten Links zu alten `/content*`-Zielen außer Redirect-Kompatibilität.
+
+## 6. Plugin-Verträge und Namespacing
+
+- Plugin-News lädt und registriert sich korrekt.
+- Plugin-Identifier/Namespaces werden validiert.
+- Ungültige Plugin-IDs, Content-Types, Admin-Resource-IDs oder Audit-Events fail-fast.
+- Kollisionen zwischen Host- und Plugin-Registrierungen werden deterministisch abgelehnt.
+
+## 7. News-Plugin und Content
+
+- Bestehende alte News mit `contentType: "news"` bleiben sichtbar.
+- Alte News können bearbeitet werden und werden serverseitig validiert/sanitized.
+- Neue News werden als `news.article` erstellt.
+- News-Liste, Erstellen, Bearbeiten und Löschen im UI prüfen.
+- E2E: News-Plugin Smoke-Test gegen deployte Umgebung.
+
+## 8. Content-Management allgemein
+
+- Content-Liste unter `/admin/content`.
+- Content-Editor für neue und bestehende Einträge.
+- Berechtigungen für Content-Zugriff.
+- Fehlerfälle:
+  - ungültiger Payload
+  - fehlender CSRF/Idempotency-Key
+  - nicht berechtigt
+
+## 9. Rechte, Rollen und Guards
+
+- Nicht eingeloggter Zugriff auf geschützte Routen leitet zu Login mit `returnTo`.
+- User ohne Rolle bekommt klaren Fehler.
+- Editor/Admin/System-Admin sehen erwartete Bereiche.
+- Tenant-User sieht nur tenant-relevante Daten.
+
+## 10. Observability und Diagnose
+
+- Auth-Logs enthalten Scope/Instance-Kontext ohne PII.
+- Tenant-Scope-Konflikt hat `reason_code=tenant_scope_conflict`.
+- Logout-Logs enthalten keine sensiblen Redirect-Querys.
+- Routing-/Plugin-Konflikte werden strukturiert geloggt.
+
+## 11. OpenSpec und Docs-Sanity
+
+- Relevante Guides stimmen mit deploytem Verhalten überein.
+- Keycloak-Doku: Mapper als Warnung/Interop, nicht als Pflicht.
+- Plugin-Development-Guide passt zu Namespacing-Regeln.
+
+## Empfohlene Reihenfolge
+
+1. Deploy/Health
+2. Root-Login und Platform-IAM (`/admin/instances`, `/admin/users`, `/admin/roles`, Platform-User-Sync)
+3. Login/Logout
+4. Tenant-Login
+5. Tenant-Admin-Routing
+6. Content/News
+7. Provisioning/Keycloak inkl. Tenant-User-Sync und Rollen-Reconcile
+8. Observability

--- a/openspec/changes/update-platform-iam-root-scope/design.md
+++ b/openspec/changes/update-platform-iam-root-scope/design.md
@@ -1,0 +1,18 @@
+# Design: Platform-IAM Root Scope
+
+## Context
+
+ADR-032 trennt `platform` und `instance`: `instanceId` bleibt tenantgebunden, der Root-Host läuft ohne `instanceId`. Für Root-IAM werden vorhandene IAM-v1-Routen beibehalten, aber anhand der Session (`ctx.user.instanceId`) verzweigt.
+
+## Decisions
+
+- Bestehende Routen bleiben stabil: `/api/v1/iam/users`, `/api/v1/iam/roles`, `/api/v1/iam/users/sync-keycloak`.
+- Root-Requests ohne `ctx.user.instanceId` verwenden `resolveIdentityProvider()` mit `executionMode=platform_admin`.
+- Tenant-Requests mit `ctx.user.instanceId` verwenden weiter `resolveActorInfo()` und tenantlokale DB/Keycloak-Pfade.
+- Platform-Listen sind v1 read-first: User/Rollen werden aus Keycloak projiziert; tenantgebundene Mutationen bleiben tenant-only, bis ein persistentes Platform-IAM-Modell erweitert wird.
+- `partial_failure` bleibt ein fachlicher Restzustand. `IDP_FORBIDDEN` bleibt ein Keycloak-Rechte-/Konfigurationsbefund und wird nicht durch globale Fallback-Rechte kaschiert.
+
+## Risks
+
+- Platform-Keycloak-User/Rollen haben weniger lokale Metadaten als Tenant-IAM-DB-Objekte.
+- Bestehende UI-Detailseiten erwarten UUID-basierte lokale IDs; Platform-Detail-/Mutationspfade müssen deshalb entweder deaktiviert oder separat umgesetzt werden.

--- a/openspec/changes/update-platform-iam-root-scope/proposal.md
+++ b/openspec/changes/update-platform-iam-root-scope/proposal.md
@@ -1,0 +1,18 @@
+# Change: Platform-IAM auf dem Root-Host
+
+## Why
+
+`studio.smart-village.app` ist der kanonische Platform-/Root-Host, verwendet aber noch tenantgebundene IAM-Handler, die ohne `instanceId` mit `invalid_instance_id` abbrechen. Gleichzeitig müssen Root-User, Root-Rollen und Root-Sync fachlich im Platform-Scope verwaltbar sein.
+
+## What Changes
+
+- IAM-v1-User- und Rollen-Endpunkte werden scope-aware: Root nutzt `platform`, Tenant-Hosts nutzen weiter `instance`.
+- Platform-User/Rollen werden über den Plattform-Keycloak-Adminpfad gelesen und synchronisiert, ohne Pseudo-Instanz in `iam.instances`.
+- Tenant-Sync-Befunde (`partial_failure`, `IDP_FORBIDDEN`) werden in Doku, Diagnose und Testliste explizit getrennt nach User-Sync und Rollen-Reconcile behandelt.
+- Root- und Tenant-Smokes werden dokumentiert getrennt.
+
+## Impact
+
+- Affected specs: `iam-core`, `iam-access-control`, `deployment-topology`, `app-e2e-integration-testing`
+- Affected code: IAM Account-Management-Handler, React Admin-User-/Rollenlisten, IAM API-Typen und Doku
+- Affected arc42 sections: `04-solution-strategy`, `05-building-block-view`, `06-runtime-view`, `08-cross-cutting-concepts`, `10-quality-requirements`

--- a/openspec/changes/update-platform-iam-root-scope/specs/app-e2e-integration-testing/spec.md
+++ b/openspec/changes/update-platform-iam-root-scope/specs/app-e2e-integration-testing/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Live IAM Smoke Coverage
+
+Live IAM smoke tests SHALL distinguish platform-scope results from tenant-scope results and preserve diagnostic evidence for sync outcomes.
+
+#### Scenario: Platform smoke has no invalid instance failure
+- **WHEN** a root-host smoke opens `/admin/users` and `/admin/roles`
+- **THEN** no `invalid_instance_id` response is accepted as a passing result
+
+#### Scenario: Tenant sync partial failure remains visible
+- **WHEN** tenant Keycloak user sync returns HTTP 200 with `partial_failure`
+- **THEN** the smoke records the counters and treats the finding as fachlich offen rather than a browser crash

--- a/openspec/changes/update-platform-iam-root-scope/specs/deployment-topology/spec.md
+++ b/openspec/changes/update-platform-iam-root-scope/specs/deployment-topology/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Root and Tenant Host Smoke Separation
+
+Deployment verification SHALL test the root platform host separately from tenant hosts.
+
+#### Scenario: Root smoke validates platform IAM
+- **WHEN** post-deploy smoke tests run against `studio.smart-village.app`
+- **THEN** they validate platform login, instance management, platform users, platform roles, account page, and platform user sync
+
+#### Scenario: Tenant smoke validates tenant IAM
+- **WHEN** post-deploy smoke tests run against tenant hosts
+- **THEN** they validate tenant login, tenant user sync, tenant role reconcile, content access, and no browser crash

--- a/openspec/changes/update-platform-iam-root-scope/specs/iam-access-control/spec.md
+++ b/openspec/changes/update-platform-iam-root-scope/specs/iam-access-control/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Platform and Tenant Admin Permissions
+
+The system SHALL keep platform IAM administration and tenant IAM administration as separate authorization scopes while reusing stable IAM-v1 route paths.
+
+#### Scenario: Platform admin accesses root IAM lists
+- **WHEN** a user with a platform admin role accesses root-host `/admin/users` or `/admin/roles`
+- **THEN** the API evaluates platform roles and returns platform data
+
+#### Scenario: Tenant admin cannot fall back to platform admin
+- **WHEN** tenant-local Keycloak role reconciliation fails with `IDP_FORBIDDEN`
+- **THEN** the system reports the tenant admin permission failure
+- **AND** it does not retry the tenant operation with global platform credentials

--- a/openspec/changes/update-platform-iam-root-scope/specs/iam-core/spec.md
+++ b/openspec/changes/update-platform-iam-root-scope/specs/iam-core/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: IAM Account Management Scope Resolution
+
+IAM Account Management SHALL resolve each authenticated IAM-v1 request as either `platform` or `instance` scope before reading or mutating users, roles, permissions, or sync state.
+
+#### Scenario: Root-host user list uses platform scope
+- **WHEN** an authenticated platform admin without `instanceId` calls `GET /api/v1/iam/users`
+- **THEN** the system returns platform users from the platform identity provider
+- **AND** it does not require or synthesize a tenant `instanceId`
+
+#### Scenario: Tenant user list remains instance-scoped
+- **WHEN** an authenticated tenant admin with `instanceId` calls `GET /api/v1/iam/users`
+- **THEN** the system uses the existing tenant IAM read model for that `instanceId`
+
+### Requirement: Keycloak User Synchronization Scope
+
+The system SHALL run Keycloak user synchronization with the identity provider administration mode that matches the active scope.
+
+#### Scenario: Root sync uses platform admin
+- **WHEN** a platform admin starts `POST /api/v1/iam/users/sync-keycloak`
+- **THEN** the system lists platform Keycloak users using `platform_admin`
+- **AND** the response includes `executionMode=platform_admin` in diagnostics
+
+#### Scenario: Tenant sync keeps tenant admin
+- **WHEN** a tenant admin starts `POST /api/v1/iam/users/sync-keycloak`
+- **THEN** the system continues to use `tenant_admin`

--- a/openspec/changes/update-platform-iam-root-scope/tasks.md
+++ b/openspec/changes/update-platform-iam-root-scope/tasks.md
@@ -1,0 +1,28 @@
+## 1. Specification
+
+- [x] 1.1 OpenSpec-Deltas für Platform-IAM und getrennte Smokes ergänzen
+- [x] 1.2 OpenSpec strict validieren
+
+## 2. Backend
+
+- [x] 2.1 Platform-Userliste aus Plattform-Keycloak über bestehende IAM-v1-Route bereitstellen
+- [x] 2.2 Platform-Rollenliste aus Plattform-Keycloak über bestehende IAM-v1-Route bereitstellen
+- [x] 2.3 Platform-Keycloak-User-Sync über bestehende Sync-Route bereitstellen
+- [x] 2.4 Tenant-Verhalten unverändert absichern
+
+## 3. Frontend
+
+- [x] 3.1 Root-Userliste als Plattform-Benutzer kennzeichnen und nicht unterstützte Row-Mutationen ausblenden
+- [x] 3.2 Root-Rollenliste als Plattform-Rollen kennzeichnen und nicht unterstützte Row-Mutationen ausblenden
+- [x] 3.3 Sync-/Reconcile-Diagnostik um Platform-Quelle ergänzen
+
+## 4. Documentation
+
+- [x] 4.1 PR-302-Testliste aktualisieren
+- [x] 4.2 Runtime- und Keycloak-Runbooks um Platform-vs-Tenant-Sync ergänzen
+
+## 5. Verification
+
+- [x] 5.1 Backend-Tests für Platform-User/Rollen/Synchronisation
+- [x] 5.2 Frontend-Tests für Root-/Tenant-Labeling
+- [x] 5.3 Gezielte Nx-Unit-/Type-Checks ausführen

--- a/openspec/changes/update-studio-keycloak-admin-ui/design.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/design.md
@@ -1,0 +1,42 @@
+## Context
+
+PR #303 macht den Root-Host platform-scope-fähig. Die neue Zielsetzung geht darüber hinaus: Studio soll für IAM-Alltagsaufgaben als alternative UI zu Keycloak nutzbar sein. Damit reicht eine reine Projektion oder ein partieller Sync nicht mehr aus.
+
+## Goals / Non-Goals
+
+- Goal: Alle administrativ relevanten Keycloak-User und -Rollen im passenden Studio-Scope sichtbar machen.
+- Goal: User- und Rollenänderungen über Studio ausführen, auditieren und mit Keycloak synchron halten.
+- Goal: `partial_failure` und `IDP_FORBIDDEN` so darstellen, dass Admins die betroffenen Objekte und Ursachen sehen.
+- Goal: Keycloak-Listen skalierbar über serverseitige Filter, Pagination und Count-/Cursor-Mechanismen laden.
+- Non-Goal: Keycloak vollständig ersetzen oder Realm-/Client-Administration außerhalb von Usern, Rollen und Rollenzuordnungen übernehmen.
+- Non-Goal: Globale Admin-Rechte als Fallback für Tenant-Operationen verwenden.
+
+## Decisions
+
+- Decision: Keycloak bleibt System of Record für Identitäten und Realm-Rollen; Studio ist Admin-UI und synchronisierte Fachansicht.
+- Decision: Mutationen laufen Keycloak-first und aktualisieren danach Studio-Read-Models oder markieren Sync-Drift.
+- Decision: Root verwendet `platform_admin`; Tenant-Hosts verwenden `tenant_admin`. Cross-Scope-Fallbacks bleiben verboten.
+- Decision: Listen-Endpunkte müssen serverseitige Keycloak-Filter und Count-/Cursor-Daten verwenden. Vollständige Realm-Scans sind nur für explizite Sync-/Reconcile-Jobs zulässig.
+- Decision: Built-in- und Systemrollen bleiben sichtbar, aber mit Bearbeitbarkeitsstatus (`read_only`, `studio_managed`, `external_managed`) gekennzeichnet.
+
+## Risks / Trade-offs
+
+- Risk: Keycloak-Admin-API-Rechte sind tenantweise inkonsistent. Mitigation: Diagnosecodes, Provisioning-Checks und Runbook-Aktionen für fehlende Realm-/Client-Rollen.
+- Risk: Große Realms erzeugen hohe Latenzen. Mitigation: serverseitige Pagination, Count-Endpunkte, gedrosselte Rollenprojektion und Hintergrund-Sync für schwere Abgleiche.
+- Risk: Studio-Read-Models können von Keycloak abweichen. Mitigation: sichtbarer Drift-Status, Reconcile-Aktionen und Audit-Events.
+- Risk: Bearbeitung von extern gemanagten Rollen kann fachliche Integrationen stören. Mitigation: explizite Bearbeitbarkeitsmatrix und blockierte Mutationen mit Diagnose.
+
+## Migration Plan
+
+1. Keycloak-Admin-Port um Count-, Paging-, User-/Role-Mutation- und Assignment-Operationen erweitern.
+2. Root- und Tenant-Listen auf serverseitige Keycloak-Filter/Pagination umstellen.
+3. Bearbeitbarkeitsmatrix für User, Rollen und Rollenzuordnungen implementieren.
+4. UI-Detailseiten für Keycloak-first User-/Rollenbearbeitung freischalten.
+5. Sync-/Reconcile-Reports um objektbezogene Diagnosen erweitern.
+6. E2E-Smokes für Root und Tenant mit echten Keycloak-Objekten ergänzen.
+
+## Open Questions
+
+- Welche Keycloak-Built-in-Rollen sollen nur sichtbar sein und welche dürfen über Studio zugewiesen werden?
+- Sollen Tenant-Hosts ausschließlich User mit Tenant-Zuordnung zeigen oder alle User des Tenant-Realms, inklusive noch nicht gemappter User?
+- Welche Felder gelten als Studio-bearbeitbar, wenn Keycloak über Föderation/LDAP angebunden ist?

--- a/openspec/changes/update-studio-keycloak-admin-ui/proposal.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/proposal.md
@@ -1,0 +1,20 @@
+# Change: Studio als Keycloak-Admin-UI
+
+## Why
+
+Das Studio soll nicht nur tenantgebundene IAM-Daten verwalten, sondern als fachlich nutzbare Alternative zur Keycloak-Admin-Konsole dienen. Administratoren müssen deshalb alle relevanten Keycloak-User und -Rollen im Studio sehen, filtern, synchronisieren und bearbeiten können, ohne für Standardaufgaben in Keycloak wechseln zu müssen.
+
+## What Changes
+
+- Root-/Platform-IAM wird von einer read-or-sync Projektion zu einer bearbeitbaren Keycloak-Admin-Oberfläche erweitert.
+- Tenant-IAM zeigt alle tenantrelevanten Keycloak-User und -Rollen, einschließlich erklärbarer Mapping- und Sync-Zustände.
+- Studio wird Keycloak-first für User- und Rollenänderungen: Änderungen werden gegen Keycloak ausgeführt und anschließend in Studio-Read-Models synchronisiert.
+- Sync- und Reconcile-Ergebnisse unterscheiden vollständig zwischen `success`, `partial_failure`, `blocked` und `failed` und zeigen betroffene User/Rollen mit Diagnosecodes.
+- Pagination, Suche, Statusfilter und Rollenzuordnung müssen über Keycloak-Admin-APIs skalieren und dürfen nicht pro Request den gesamten Realm unkontrolliert laden.
+- Bearbeitbarkeit bleibt an klare Platform- und Tenant-Admin-Rechte, Audit-Logs und Least-Privilege-Service-Accounts gebunden.
+
+## Impact
+
+- Affected specs: `iam-core`, `iam-access-control`, `account-ui`, `app-e2e-integration-testing`, `architecture-documentation`
+- Affected code: Keycloak Admin Client, `IdentityProviderPort`, IAM Account-Management-Handler, Sync-/Reconcile-Services, React Admin-User-/Rollenlisten und Detailseiten
+- Affected arc42 sections: `04-solution-strategy`, `05-building-block-view`, `06-runtime-view`, `08-cross-cutting-concepts`, `10-quality-requirements`

--- a/openspec/changes/update-studio-keycloak-admin-ui/specs/account-ui/spec.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/specs/account-ui/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Studio Keycloak Admin UI
+
+The Studio admin UI SHALL allow authorized platform and tenant admins to use Studio as an alternative UI for Keycloak user and role administration.
+
+#### Scenario: Complete user list with edit affordances
+- **WHEN** ein Admin `/admin/users` öffnet
+- **THEN** zeigt die UI alle im aktiven Scope relevanten Keycloak-User mit Such-, Status-, Rollen- und Mapping-Filtern
+- **AND** zeigt pro User, ob Bearbeitung, Deaktivierung und Rollenzuordnung möglich, read-only oder blockiert ist
+
+#### Scenario: Complete role list with edit affordances
+- **WHEN** ein Admin `/admin/roles` öffnet
+- **THEN** zeigt die UI alle im aktiven Scope relevanten Keycloak-Rollen mit Such-, Typ- und Bearbeitbarkeitsfiltern
+- **AND** unterscheidet Built-in-, externe und Studio-managed Rollen sichtbar
+
+#### Scenario: Sync diagnostics are actionable
+- **WHEN** ein Sync oder Reconcile `partial_failure`, `blocked` oder `failed` meldet
+- **THEN** zeigt die UI Zähler, Diagnosecodes und betroffene User/Rollen
+- **AND** bietet nur Aktionen an, die im aktiven Scope und laut Bearbeitbarkeitsmatrix erlaubt sind

--- a/openspec/changes/update-studio-keycloak-admin-ui/specs/app-e2e-integration-testing/spec.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/specs/app-e2e-integration-testing/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Live IAM Smoke Coverage
+
+Live IAM smoke tests SHALL verify that Studio can be used as a practical Keycloak-admin UI for supported user and role workflows in both platform and tenant scopes.
+
+#### Scenario: Root smoke validates editable platform IAM
+- **WHEN** post-deploy smoke tests against `studio.smart-village.app` run
+- **THEN** they verify Platform user listing, filtering, detail loading, role listing, and at least one non-destructive editable workflow
+- **AND** they record Sync/Reconcile diagnostics without accepting hidden `invalid_instance_id` failures
+
+#### Scenario: Tenant smoke validates tenant Keycloak administration
+- **WHEN** post-deploy smoke tests against tenant hosts run
+- **THEN** they verify tenant user listing, mapping visibility, role listing, and role reconcile
+- **AND** `partial_failure` results are recorded with object counts and diagnosis instead of being treated as browser crashes
+
+#### Scenario: Forbidden tenant admin rights are diagnosable
+- **WHEN** a tenant role operation returns `IDP_FORBIDDEN`
+- **THEN** the smoke captures the visible diagnosis and confirms the page remains usable

--- a/openspec/changes/update-studio-keycloak-admin-ui/specs/architecture-documentation/spec.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/specs/architecture-documentation/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+
+### Requirement: arc42 documentation reflects implemented architecture
+
+Die arc42-Dokumentation SHALL Studio als alternative Keycloak-Admin-UI, Keycloak-first Mutationen und die Scope-Trennung zwischen Platform und Tenant beschreiben.
+
+#### Scenario: Architecture docs cover Keycloak-first IAM
+- **WHEN** der Change umgesetzt wird
+- **THEN** dokumentieren die betroffenen arc42-Abschnitte System-of-Record, Read-Models, Sync-/Reconcile-Flows, Bearbeitbarkeitsmatrix und Audit-Verhalten
+- **AND** die Doku nennt die Grenzen gegenüber vollständiger Keycloak-Realm-/Client-Administration

--- a/openspec/changes/update-studio-keycloak-admin-ui/specs/iam-access-control/spec.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/specs/iam-access-control/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Platform and Tenant Admin Permissions
+
+The system SHALL authorize Studio-based Keycloak administration separately for platform and tenant scopes and SHALL never use broader credentials as an implicit fallback for a narrower tenant operation.
+
+#### Scenario: Platform admin edits platform identities
+- **WHEN** ein Platform-Admin einen Platform-User oder eine Platform-Rolle im Root-Host bearbeitet
+- **THEN** prüft das System Platform-Admin-Rechte
+- **AND** verwendet ausschließlich den Platform-Admin-Keycloak-Client
+- **AND** schreibt ein Audit-Event mit Actor, Scope, Zielobjekt und Ergebnis
+
+#### Scenario: Tenant admin edits tenant identities
+- **WHEN** ein Tenant-Admin User, Rollen oder Rollenzuordnungen auf einem Tenant-Host bearbeitet
+- **THEN** prüft das System Tenant-Admin-Rechte für die aktive `instanceId`
+- **AND** verwendet ausschließlich den Tenant-Admin-Keycloak-Client
+- **AND** blockiert Cross-Tenant-Zugriffe
+
+#### Scenario: Tenant Keycloak rights are insufficient
+- **WHEN** Keycloak eine Tenant-Operation mit `IDP_FORBIDDEN` verweigert
+- **THEN** gibt das System einen stabilen Diagnosecode zurück
+- **AND** erklärt, welche Keycloak-Rechte oder Realm-/Client-Konfiguration fehlen
+- **AND** wiederholt die Operation nicht mit Platform- oder globalen Admin-Rechten
+
+### Requirement: Bearbeitbarkeitsmatrix für Keycloak-Objekte
+
+Das System SHALL für Keycloak-User, Rollen und Rollenzuordnungen vor jeder Mutation eine Bearbeitbarkeitsentscheidung berechnen.
+
+#### Scenario: Read-only object is visible but protected
+- **WHEN** ein Keycloak-Objekt sichtbar, aber nicht Studio-bearbeitbar ist
+- **THEN** zeigt die UI das Objekt mit `read_only`-Status
+- **AND** Server-Mutationen werden mit einem stabilen Diagnosecode blockiert
+
+#### Scenario: Federated user field is protected
+- **WHEN** ein User-Feld durch Föderation oder Keycloak-Policy nicht bearbeitbar ist
+- **THEN** deaktiviert die UI das Feld
+- **AND** der Server validiert denselben Zustand vor der Mutation

--- a/openspec/changes/update-studio-keycloak-admin-ui/specs/iam-core/spec.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/specs/iam-core/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Keycloak Admin API Integration
+
+Das System MUST über dedizierte Service-Accounts mit der Keycloak Admin REST API kommunizieren, um Benutzer, Rollen und Rollenzuordnungen im jeweiligen Platform- oder Tenant-Scope vollständig listen, bearbeiten und synchronisieren zu können. Keycloak bleibt System of Record für Identitäten und Realm-Rollen; Studio stellt eine auditierte Admin-UI und synchronisierte Fachansicht bereit.
+
+#### Scenario: Studio lists all platform Keycloak users
+- **WHEN** ein Platform-Admin die Root-Userliste öffnet
+- **THEN** lädt das System Platform-Realm-User über Keycloak-Admin-APIs mit serverseitiger Pagination, Suche und Count
+- **AND** jeder zurückgegebene User enthält Keycloak-ID, Status, Profilfelder, Rollenprojektion und Bearbeitbarkeitsstatus
+
+#### Scenario: Studio lists all tenant-relevant Keycloak users
+- **WHEN** ein Tenant-Admin die Tenant-Userliste öffnet
+- **THEN** lädt das System alle für den Tenant relevanten Keycloak-User
+- **AND** User ohne vollständiges Studio-Mapping werden sichtbar als `unmapped` oder `manual_review` markiert
+- **AND** die Liste bricht nicht wegen einzelner Mapping-Fehler ab
+
+#### Scenario: Keycloak-first user mutation
+- **WHEN** ein berechtigter Admin einen User im Studio erstellt, deaktiviert oder Profilfelder ändert
+- **THEN** führt das System die Mutation zuerst gegen Keycloak aus
+- **AND** synchronisiert anschließend das Studio-Read-Model
+- **AND** bei nachgelagertem Sync-Fehler bleibt der Keycloak-Zustand sichtbar und wird als Drift gemeldet
+
+#### Scenario: Studio lists all relevant Keycloak roles
+- **WHEN** ein Admin die Rollenliste öffnet
+- **THEN** lädt das System Realm-Rollen aus dem passenden Keycloak-Scope
+- **AND** Studio zeigt Built-in-, externe und Studio-managed Rollen mit Bearbeitbarkeitsstatus
+- **AND** read-only Rollen dürfen angezeigt und zugeordnet werden, wenn die Rechte-Matrix dies erlaubt
+
+#### Scenario: Keycloak-first role mutation
+- **WHEN** ein berechtigter Admin eine Studio-managed Rolle anlegt, ändert oder löscht
+- **THEN** führt das System die Änderung gegen Keycloak aus
+- **AND** synchronisiert anschließend Studio-Rollen- und Permission-Read-Models
+- **AND** blockiert Mutationen an read-only oder extern gemanagten Rollen mit stabilem Diagnosecode
+
+### Requirement: Keycloak User Synchronization Scope
+
+The system SHALL run Keycloak user synchronization as a reconciliation flow that explains differences between Keycloak and Studio instead of hiding unmapped or partially failed objects.
+
+#### Scenario: Sync reports unmapped users
+- **WHEN** ein User-Sync Keycloak-User findet, die nicht sauber einem Studio-Kontext zugeordnet werden können
+- **THEN** enthält der Sync-Report die Anzahl und Diagnosecodes dieser User
+- **AND** die betroffenen User bleiben in der Studio-UI sichtbar, sofern der aktive Scope dies erlaubt
+
+#### Scenario: Partial failure remains actionable
+- **WHEN** ein Sync mit `partial_failure` endet
+- **THEN** enthält der Report objektbezogene Ursachen wie `missing_instance_attribute`, `forbidden_role_mapping`, `read_only_federated_field` oder `idp_forbidden`
+- **AND** Admins können daraus Reconcile- oder Runbook-Aktionen ableiten

--- a/openspec/changes/update-studio-keycloak-admin-ui/tasks.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/tasks.md
@@ -1,0 +1,37 @@
+## 1. Specification
+
+- [ ] 1.1 OpenSpec-Deltas für Keycloak-first Admin-UI finalisieren
+- [ ] 1.2 Offene Fragen zu Built-in-Rollen, Tenant-Sichtbarkeit und föderierten User-Feldern klären
+- [ ] 1.3 `openspec validate update-studio-keycloak-admin-ui --strict` ausführen
+
+## 2. Backend
+
+- [ ] 2.1 `IdentityProviderPort` um Count-/Cursor-, User-Mutation-, Role-Mutation- und Role-Assignment-Operationen erweitern
+- [ ] 2.2 Keycloak-Admin-Client für serverseitige User-/Role-Pagination, Suche und Count absichern
+- [ ] 2.3 Root-/Platform-User und -Rollen vollständig aus Keycloak listen und bearbeitbar machen
+- [ ] 2.4 Tenant-User und -Rollen vollständig im Tenant-Scope sichtbar machen, inklusive ungemappter Keycloak-Objekte
+- [ ] 2.5 Keycloak-first Mutationen mit Studio-Read-Model-Sync und Drift-Status implementieren
+- [ ] 2.6 Diagnosecodes für `partial_failure`, `blocked`, `IDP_FORBIDDEN`, Read-only- und Föderationsfälle stabilisieren
+- [ ] 2.7 Audit-Events für User-/Rollenänderungen und Rollenzuordnungen ergänzen
+
+## 3. Frontend
+
+- [ ] 3.1 Root- und Tenant-Listen für alle Keycloak-User/-Rollen mit Bearbeitbarkeitsstatus erweitern
+- [ ] 3.2 User-Detail und Rollen-Detail für Keycloak-first Bearbeitung freischalten
+- [ ] 3.3 Rollenzuordnungen mit sichtbaren Blocked-/Read-only-Zuständen verwaltbar machen
+- [ ] 3.4 Sync-/Reconcile-Reports objektbezogen mit Zählern, Diagnosecodes und betroffenen Objekten anzeigen
+- [ ] 3.5 Loading-Zustände so absichern, dass `user === null` keinen falschen Platform-Scope rendert
+
+## 4. Documentation
+
+- [ ] 4.1 Keycloak-Runbooks um Studio als Admin-UI und Rechte-Matrix ergänzen
+- [ ] 4.2 Runtime-Doku um Keycloak-first Mutations- und Sync-Vertrag ergänzen
+- [ ] 4.3 Betroffene arc42-Abschnitte unter `docs/architecture/` aktualisieren
+
+## 5. Verification
+
+- [ ] 5.1 Unit-/Integrationstests für Keycloak-Count/Pagination, Mutationen und Drift-Diagnosen
+- [ ] 5.2 Frontend-Tests für vollständige Keycloak-Listen, Bearbeitbarkeit und Read-only-Zustände
+- [ ] 5.3 Tenant-Smokes gegen `bb-guben` und `hb-meinquartier` mit User-Sync und Rollen-Reconcile
+- [ ] 5.4 Root-Smoke gegen `studio.smart-village.app` mit Platform-User-/Rollenbearbeitung
+- [ ] 5.5 `pnpm test:pr` oder mindestens affected Unit/Types/Lint/E2E ausführen

--- a/openspec/changes/update-studio-keycloak-admin-ui/tasks.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Specification
 
-- [ ] 1.1 OpenSpec-Deltas für Keycloak-first Admin-UI finalisieren
-- [ ] 1.2 Offene Fragen zu Built-in-Rollen, Tenant-Sichtbarkeit und föderierten User-Feldern klären
-- [ ] 1.3 `openspec validate update-studio-keycloak-admin-ui --strict` ausführen
+- [x] 1.1 OpenSpec-Deltas für Keycloak-first Admin-UI finalisieren
+- [x] 1.2 Offene Fragen zu Built-in-Rollen, Tenant-Sichtbarkeit und föderierten User-Feldern klären
+- [x] 1.3 `openspec validate update-studio-keycloak-admin-ui --strict` ausführen
 
 ## 2. Backend
 
-- [ ] 2.1 `IdentityProviderPort` um Count-/Cursor-, User-Mutation-, Role-Mutation- und Role-Assignment-Operationen erweitern
-- [ ] 2.2 Keycloak-Admin-Client für serverseitige User-/Role-Pagination, Suche und Count absichern
-- [ ] 2.3 Root-/Platform-User und -Rollen vollständig aus Keycloak listen und bearbeitbar machen
-- [ ] 2.4 Tenant-User und -Rollen vollständig im Tenant-Scope sichtbar machen, inklusive ungemappter Keycloak-Objekte
-- [ ] 2.5 Keycloak-first Mutationen mit Studio-Read-Model-Sync und Drift-Status implementieren
-- [ ] 2.6 Diagnosecodes für `partial_failure`, `blocked`, `IDP_FORBIDDEN`, Read-only- und Föderationsfälle stabilisieren
-- [ ] 2.7 Audit-Events für User-/Rollenänderungen und Rollenzuordnungen ergänzen
+- [x] 2.1 `IdentityProviderPort` um Count-/Cursor-, User-Mutation-, Role-Mutation- und Role-Assignment-Operationen erweitern
+- [x] 2.2 Keycloak-Admin-Client für serverseitige User-/Role-Pagination, Suche und Count absichern
+- [x] 2.3 Root-/Platform-User und -Rollen vollständig aus Keycloak listen und bearbeitbar machen
+- [x] 2.4 Tenant-User und -Rollen vollständig im Tenant-Scope sichtbar machen, inklusive ungemappter Keycloak-Objekte
+- [x] 2.5 Keycloak-first Mutationen mit Studio-Read-Model-Sync und Drift-Status implementieren
+- [x] 2.6 Diagnosecodes für `partial_failure`, `blocked`, `IDP_FORBIDDEN`, Read-only- und Föderationsfälle stabilisieren
+- [x] 2.7 Audit-Events für User-/Rollenänderungen und Rollenzuordnungen ergänzen
 
 ## 3. Frontend
 
-- [ ] 3.1 Root- und Tenant-Listen für alle Keycloak-User/-Rollen mit Bearbeitbarkeitsstatus erweitern
-- [ ] 3.2 User-Detail und Rollen-Detail für Keycloak-first Bearbeitung freischalten
-- [ ] 3.3 Rollenzuordnungen mit sichtbaren Blocked-/Read-only-Zuständen verwaltbar machen
-- [ ] 3.4 Sync-/Reconcile-Reports objektbezogen mit Zählern, Diagnosecodes und betroffenen Objekten anzeigen
-- [ ] 3.5 Loading-Zustände so absichern, dass `user === null` keinen falschen Platform-Scope rendert
+- [x] 3.1 Root- und Tenant-Listen für alle Keycloak-User/-Rollen mit Bearbeitbarkeitsstatus erweitern
+- [x] 3.2 User-Detail und Rollen-Detail für Keycloak-first Bearbeitung freischalten
+- [x] 3.3 Rollenzuordnungen mit sichtbaren Blocked-/Read-only-Zuständen verwaltbar machen
+- [x] 3.4 Sync-/Reconcile-Reports objektbezogen mit Zählern, Diagnosecodes und betroffenen Objekten anzeigen
+- [x] 3.5 Loading-Zustände so absichern, dass `user === null` keinen falschen Platform-Scope rendert
 
 ## 4. Documentation
 
-- [ ] 4.1 Keycloak-Runbooks um Studio als Admin-UI und Rechte-Matrix ergänzen
-- [ ] 4.2 Runtime-Doku um Keycloak-first Mutations- und Sync-Vertrag ergänzen
-- [ ] 4.3 Betroffene arc42-Abschnitte unter `docs/architecture/` aktualisieren
+- [x] 4.1 Keycloak-Runbooks um Studio als Admin-UI und Rechte-Matrix ergänzen
+- [x] 4.2 Runtime-Doku um Keycloak-first Mutations- und Sync-Vertrag ergänzen
+- [x] 4.3 Betroffene arc42-Abschnitte unter `docs/architecture/` aktualisieren
 
 ## 5. Verification
 
-- [ ] 5.1 Unit-/Integrationstests für Keycloak-Count/Pagination, Mutationen und Drift-Diagnosen
-- [ ] 5.2 Frontend-Tests für vollständige Keycloak-Listen, Bearbeitbarkeit und Read-only-Zustände
-- [ ] 5.3 Tenant-Smokes gegen `bb-guben` und `hb-meinquartier` mit User-Sync und Rollen-Reconcile
-- [ ] 5.4 Root-Smoke gegen `studio.smart-village.app` mit Platform-User-/Rollenbearbeitung
-- [ ] 5.5 `pnpm test:pr` oder mindestens affected Unit/Types/Lint/E2E ausführen
+- [x] 5.1 Unit-/Integrationstests für Keycloak-Count/Pagination, Mutationen und Drift-Diagnosen
+- [x] 5.2 Frontend-Tests für vollständige Keycloak-Listen, Bearbeitbarkeit und Read-only-Zustände
+- [ ] 5.3 Tenant-Smokes gegen `bb-guben` und `hb-meinquartier` mit User-Sync und Rollen-Reconcile (nicht lokal ausgeführt)
+- [ ] 5.4 Root-Smoke gegen `studio.smart-village.app` mit Platform-User-/Rollenbearbeitung (nicht lokal ausgeführt)
+- [x] 5.5 `pnpm test:pr` oder mindestens affected Unit/Types/Lint/E2E ausführen

--- a/packages/auth/src/iam-account-management.contract.integration.test.ts
+++ b/packages/auth/src/iam-account-management.contract.integration.test.ts
@@ -334,6 +334,39 @@ vi.mock('@sva/sdk/server', async () => {
 
 vi.mock('./keycloak-admin-client', () => {
   class MockKeycloakAdminClient {
+    async listUsers(query: { first?: number; max?: number; search?: string; enabled?: boolean } = {}) {
+      const users = [
+        {
+          externalId: contractState.targetUser.keycloakSubject,
+          username: contractState.targetUser.email,
+          email: contractState.targetUser.email,
+          firstName: contractState.targetUser.firstName,
+          lastName: contractState.targetUser.lastName,
+          enabled: contractState.targetUser.status === 'active',
+          attributes: { instanceId: [INSTANCE_ID] },
+        },
+      ];
+      const filtered = users.filter((user) => {
+        if (typeof query.enabled === 'boolean' && user.enabled !== query.enabled) {
+          return false;
+        }
+        if (!query.search) {
+          return true;
+        }
+        const search = query.search.toLowerCase();
+        return [user.username, user.email, user.firstName, user.lastName].some((value) =>
+          value.toLowerCase().includes(search)
+        );
+      });
+      const first = query.first ?? 0;
+      const max = query.max ?? filtered.length;
+      return filtered.slice(first, first + max);
+    }
+
+    async countUsers(query: { search?: string; enabled?: boolean } = {}): Promise<number> {
+      return (await this.listUsers(query)).length;
+    }
+
     async listUserRoleNames(keycloakSubject: string): Promise<readonly string[]> {
       return contractState.syncedRoleNamesBySubject.get(keycloakSubject) ?? [];
     }
@@ -431,6 +464,15 @@ vi.mock('pg', () => ({
 
           if (text.includes('COUNT(DISTINCT a.id)::int AS total')) {
             return { rowCount: 1, rows: [{ total: 1 }] };
+          }
+
+          if (text.includes('WHERE a.keycloak_subject = ANY($2::text[])')) {
+            const instanceId = String(values?.[0]);
+            const subjects = new Set(((values?.[1] as readonly string[]) ?? []).map(String));
+            if (instanceId === INSTANCE_ID && subjects.has(contractState.targetUser.keycloakSubject)) {
+              return { rowCount: 1, rows: [toUserListRow(contractState.targetUser)] };
+            }
+            return { rowCount: 0, rows: [] };
           }
 
           if (text.includes('ORDER BY a.created_at DESC')) {

--- a/packages/auth/src/iam-account-management.integration.test.ts
+++ b/packages/auth/src/iam-account-management.integration.test.ts
@@ -109,7 +109,7 @@ describe('iam-account-management tenant isolation integration', () => {
     expect(payload.error.details?.reason_code).toBe('missing_actor_account');
   });
 
-  it('returns 200 for list users when instanceId matches own tenant', async () => {
+  it('returns 409 for list users when own tenant has no tenant-admin client', async () => {
     const response = await listUsersHandler(
       new Request('http://localhost/api/v1/iam/users?instanceId=de-musterhausen', {
         method: 'GET',
@@ -118,11 +118,12 @@ describe('iam-account-management tenant isolation integration', () => {
 
     const payload = (await response.json()) as {
       data?: unknown[];
-      error?: { code: string; message: string };
+      error?: { code: string; details?: { reason_code?: string }; message: string };
     };
-    expect(response.status).toBe(200);
-    expect(Array.isArray(payload.data)).toBe(true);
-    expect(payload.error).toBeUndefined();
+    expect(response.status).toBe(409);
+    expect(payload.data).toBeUndefined();
+    expect(payload.error?.code).toBe('tenant_admin_client_not_configured');
+    expect(payload.error?.details?.reason_code).toBe('tenant_admin_client_not_configured');
   });
 
   it('returns 403 for get user when instanceId points to a foreign tenant', async () => {

--- a/packages/auth/src/iam-account-management.user-import-sync.test.ts
+++ b/packages/auth/src/iam-account-management.user-import-sync.test.ts
@@ -100,6 +100,81 @@ vi.mock('./iam-account-management/shared.js', async () => {
   };
 });
 
+describe('syncUsersFromKeycloakInternal platform scope', () => {
+  const platformCtx = {
+    user: {
+      id: 'kc-platform-admin',
+      roles: ['system_admin'],
+    },
+  } as never;
+
+  const platformSyncRequest = () =>
+    new Request('https://studio.smart-village.app/api/v1/iam/users/sync-keycloak', {
+      method: 'POST',
+      headers: {
+        origin: 'https://studio.smart-village.app',
+        'x-requested-with': 'XMLHttpRequest',
+      },
+    });
+
+  beforeEach(() => {
+    state.listUsersImpl = null;
+    state.identityProviderRealm = 'platform';
+    state.identityProviderSource = 'global';
+    state.identityProviderExecutionMode = 'platform_admin';
+  });
+
+  it('runs the platform Keycloak user sync without tenant persistence', async () => {
+    state.listUsersImpl = () => [
+      {
+        externalId: 'kc-platform',
+        username: 'platform.admin',
+        email: 'platform.admin@example.com',
+        enabled: true,
+        attributes: {},
+      },
+    ];
+
+    const { syncUsersFromKeycloakInternal } = await import('./iam-account-management/user-import-sync-handler.js');
+
+    const response = await syncUsersFromKeycloakInternal(platformSyncRequest(), platformCtx);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        outcome: 'success',
+        totalKeycloakUsers: 1,
+        diagnostics: {
+          providerSource: 'platform',
+          executionMode: 'platform_admin',
+        },
+      },
+    });
+  });
+
+  it('maps platform Keycloak sync failures to keycloak_unavailable diagnostics', async () => {
+    state.listUsersImpl = () => {
+      throw new Error('keycloak unavailable');
+    };
+
+    const { syncUsersFromKeycloakInternal } = await import('./iam-account-management/user-import-sync-handler.js');
+
+    const response = await syncUsersFromKeycloakInternal(platformSyncRequest(), platformCtx);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'keycloak_unavailable',
+        details: {
+          dependency: 'keycloak',
+          reason_code: 'platform_keycloak_unavailable',
+          scope_kind: 'platform',
+        },
+      },
+    });
+  });
+});
+
 describe('runKeycloakUserImportSync', () => {
   const originalEnv = {
     IAM_PII_ACTIVE_KEY_ID: process.env.IAM_PII_ACTIVE_KEY_ID,

--- a/packages/auth/src/iam-account-management.user-import-sync.test.ts
+++ b/packages/auth/src/iam-account-management.user-import-sync.test.ts
@@ -18,6 +18,23 @@ const state = vi.hoisted(() => ({
   identityProviderRealm: 'de-musterhausen',
   identityProviderSource: 'instance' as 'instance' | 'global',
   identityProviderExecutionMode: 'tenant_admin' as 'platform_admin' | 'tenant_admin' | 'break_glass',
+  platformSyncError: null as Error | null,
+  platformSyncReport: {
+    outcome: 'success',
+    checkedCount: 1,
+    correctedCount: 0,
+    failedCount: 0,
+    requiresManualActionCount: 0,
+    importedCount: 0,
+    updatedCount: 0,
+    skippedCount: 0,
+    totalKeycloakUsers: 1,
+    diagnostics: {
+      authRealm: 'platform',
+      providerSource: 'platform',
+      executionMode: 'platform_admin',
+    },
+  },
   emitActivityLog: vi.fn(async () => undefined),
   logger: {
     isLevelEnabled: vi.fn(() => false),
@@ -100,6 +117,15 @@ vi.mock('./iam-account-management/shared.js', async () => {
   };
 });
 
+vi.mock('./iam-account-management/platform-iam.js', () => ({
+  runPlatformKeycloakUserSync: vi.fn(async () => {
+    if (state.platformSyncError) {
+      throw state.platformSyncError;
+    }
+    return state.platformSyncReport;
+  }),
+}));
+
 describe('syncUsersFromKeycloakInternal platform scope', () => {
   const platformCtx = {
     user: {
@@ -122,6 +148,7 @@ describe('syncUsersFromKeycloakInternal platform scope', () => {
     state.identityProviderRealm = 'platform';
     state.identityProviderSource = 'global';
     state.identityProviderExecutionMode = 'platform_admin';
+    state.platformSyncError = null;
   });
 
   it('runs the platform Keycloak user sync without tenant persistence', async () => {
@@ -153,9 +180,7 @@ describe('syncUsersFromKeycloakInternal platform scope', () => {
   });
 
   it('maps platform Keycloak sync failures to keycloak_unavailable diagnostics', async () => {
-    state.listUsersImpl = () => {
-      throw new Error('keycloak unavailable');
-    };
+    state.platformSyncError = new Error('keycloak unavailable');
 
     const { syncUsersFromKeycloakInternal } = await import('./iam-account-management/user-import-sync-handler.js');
 

--- a/packages/auth/src/iam-account-management/constants.ts
+++ b/packages/auth/src/iam-account-management/constants.ts
@@ -1,5 +1,6 @@
 export const ADMIN_ROLES = new Set(['system_admin', 'app_manager']);
 export const SYSTEM_ADMIN_ROLES = new Set(['system_admin']);
+export const PLATFORM_RATE_LIMIT_INSTANCE_ID = '__platform__';
 
 export const READ_RATE_LIMIT = 60;
 export const WRITE_RATE_LIMIT = 10;

--- a/packages/auth/src/iam-account-management/platform-iam-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-handlers.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  featureResponse: null as Response | null,
+  roleResponse: null as Response | null,
+  csrfResponse: null as Response | null,
+  rateLimitResponse: null as Response | null,
+  platformUsersResult: {
+    users: [{ id: 'platform:user-1', username: 'alice' }],
+    total: 1,
+  },
+  platformRolesResult: [{ id: 'platform:system_admin', roleName: 'system_admin' }],
+  platformReconcileResult: {
+    outcome: 'success',
+    checkedCount: 1,
+    correctedCount: 0,
+    failedCount: 0,
+    requiresManualActionCount: 0,
+    roles: [],
+  },
+  platformUserError: null as Error | null,
+  platformRoleError: null as Error | null,
+  platformReconcileError: null as Error | null,
+}));
+
+vi.mock('@sva/sdk/server', () => ({
+  getWorkspaceContext: () => ({ requestId: 'req-platform', traceId: 'trace-platform' }),
+}));
+
+vi.mock('../shared/db-helpers.js', () => ({
+  jsonResponse: (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } }),
+}));
+
+vi.mock('../shared/input-readers.js', () => ({
+  readString: (value: string | null) => value ?? undefined,
+}));
+
+vi.mock('./api-helpers.js', () => ({
+  asApiItem: (data: unknown, requestId?: string) => ({ data, requestId }),
+  asApiList: (items: unknown[], meta: unknown, requestId?: string) => ({ items, meta, requestId }),
+  createApiError: (
+    status: number,
+    code: string,
+    message: string,
+    requestId?: string,
+    details?: Readonly<Record<string, unknown>>
+  ) =>
+    new Response(JSON.stringify({ error: { code, message, details }, requestId }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  readPage: () => ({ page: 1, pageSize: 10 }),
+}));
+
+vi.mock('./feature-flags.js', () => ({
+  ensureFeature: vi.fn(() => state.featureResponse),
+  getFeatureFlags: vi.fn(() => ({})),
+}));
+
+vi.mock('./csrf.js', () => ({
+  validateCsrf: vi.fn(() => state.csrfResponse),
+}));
+
+vi.mock('./rate-limit.js', () => ({
+  consumeRateLimit: vi.fn(() => state.rateLimitResponse),
+}));
+
+vi.mock('./role-audit.js', () => ({
+  mapRoleSyncErrorCode: vi.fn(() => 'IDP_FORBIDDEN'),
+  sanitizeRoleErrorMessage: vi.fn((error: unknown) => (error instanceof Error ? error.message : String(error))),
+}));
+
+vi.mock('./shared.js', () => ({
+  logger: { error: vi.fn() },
+  requireRoles: vi.fn(() => state.roleResponse),
+}));
+
+vi.mock('./types.js', () => ({
+  USER_STATUS: ['active', 'inactive', 'pending'],
+}));
+
+vi.mock('./platform-iam.js', () => ({
+  listPlatformUsers: vi.fn(async () => {
+    if (state.platformUserError) {
+      throw state.platformUserError;
+    }
+    return state.platformUsersResult;
+  }),
+  listPlatformRoles: vi.fn(async () => {
+    if (state.platformRoleError) {
+      throw state.platformRoleError;
+    }
+    return state.platformRolesResult;
+  }),
+  runPlatformRoleReconcile: vi.fn(async () => {
+    if (state.platformReconcileError) {
+      throw state.platformReconcileError;
+    }
+    return state.platformReconcileResult;
+  }),
+}));
+
+import {
+  listPlatformRolesInternal,
+  listPlatformUsersInternal,
+  reconcilePlatformRolesInternal,
+} from './platform-iam-handlers.js';
+
+const ctx = { user: { id: 'kc-platform', roles: ['system_admin'] } } as never;
+
+describe('platform IAM handlers', () => {
+  beforeEach(() => {
+    state.featureResponse = null;
+    state.roleResponse = null;
+    state.csrfResponse = null;
+    state.rateLimitResponse = null;
+    state.platformUserError = null;
+    state.platformRoleError = null;
+    state.platformReconcileError = null;
+  });
+
+  it('lists platform users with filters', async () => {
+    const response = await listPlatformUsersInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/users?status=active&role=system_admin&search=alice'),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [{ id: 'platform:user-1', username: 'alice' }],
+      meta: { page: 1, pageSize: 10, total: 1 },
+      requestId: 'req-platform',
+    });
+  });
+
+  it('rejects invalid platform user filters and propagates platform dependency failures', async () => {
+    const invalidResponse = await listPlatformUsersInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/users?status=archived'),
+      ctx
+    );
+    expect(invalidResponse.status).toBe(400);
+
+    state.platformUserError = new Error('keycloak down');
+    const failureResponse = await listPlatformUsersInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/users'),
+      ctx
+    );
+    expect(failureResponse.status).toBe(503);
+    await expect(failureResponse.json()).resolves.toMatchObject({
+      error: {
+        code: 'keycloak_unavailable',
+        details: { reason_code: 'platform_keycloak_unavailable', scope_kind: 'platform' },
+      },
+    });
+  });
+
+  it('lists and reconciles platform roles', async () => {
+    const rolesResponse = await listPlatformRolesInternal(ctx, 'req-platform');
+    expect(rolesResponse.status).toBe(200);
+
+    const reconcileResponse = await reconcilePlatformRolesInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/admin/reconcile', { method: 'POST' }),
+      ctx,
+      'req-platform',
+      'trace-platform'
+    );
+    expect(reconcileResponse.status).toBe(200);
+  });
+
+  it('maps platform role failures and guard responses', async () => {
+    state.rateLimitResponse = new Response(JSON.stringify({ error: { code: 'rate_limited' } }), { status: 429 });
+    const limitedResponse = await listPlatformRolesInternal(ctx, 'req-platform');
+    expect(limitedResponse.status).toBe(429);
+
+    state.rateLimitResponse = null;
+    state.platformRoleError = new Error('keycloak denied');
+    const rolesFailure = await listPlatformRolesInternal(ctx, 'req-platform');
+    expect(rolesFailure.status).toBe(503);
+
+    state.platformReconcileError = new Error('forbidden');
+    const reconcileFailure = await reconcilePlatformRolesInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/admin/reconcile', { method: 'POST' }),
+      ctx,
+      'req-platform'
+    );
+    expect(reconcileFailure.status).toBe(503);
+    await expect(reconcileFailure.json()).resolves.toMatchObject({
+      error: {
+        code: 'keycloak_unavailable',
+        details: {
+          syncState: 'failed',
+          syncError: { code: 'IDP_FORBIDDEN' },
+          scope_kind: 'platform',
+        },
+      },
+    });
+  });
+});

--- a/packages/auth/src/iam-account-management/platform-iam-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-handlers.test.ts
@@ -106,6 +106,8 @@ import {
   listPlatformUsersInternal,
   reconcilePlatformRolesInternal,
 } from './platform-iam-handlers.js';
+import { consumeRateLimit } from './rate-limit.js';
+import { logger } from './shared.js';
 
 const ctx = { user: { id: 'kc-platform', roles: ['system_admin'] } } as never;
 
@@ -177,6 +179,27 @@ describe('platform IAM handlers', () => {
     state.platformRoleError = new Error('keycloak denied');
     const rolesFailure = await listPlatformRolesInternal(ctx, 'req-platform');
     expect(rolesFailure.status).toBe(503);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Platform role list failed',
+      expect.objectContaining({
+        operation: 'list_platform_roles',
+        request_id: 'req-platform',
+        scope_kind: 'platform',
+      })
+    );
+
+    state.platformRoleError = new Error('platform_identity_provider_not_configured');
+    const rolesConfigurationFailure = await listPlatformRolesInternal(ctx, 'req-platform');
+    expect(rolesConfigurationFailure.status).toBe(503);
+    await expect(rolesConfigurationFailure.json()).resolves.toMatchObject({
+      error: {
+        code: 'keycloak_unavailable',
+        details: {
+          reason_code: 'platform_identity_provider_not_configured',
+          scope_kind: 'platform',
+        },
+      },
+    });
 
     state.platformReconcileError = new Error('forbidden');
     const reconcileFailure = await reconcilePlatformRolesInternal(
@@ -220,6 +243,9 @@ describe('platform IAM handlers', () => {
       ctx
     );
     expect(userRateLimitResponse.status).toBe(429);
+    expect(consumeRateLimit).toHaveBeenLastCalledWith(
+      expect.objectContaining({ instanceId: '__platform__' })
+    );
 
     state.rateLimitResponse = null;
     state.csrfResponse = new Response(JSON.stringify({ error: { code: 'csrf_validation_failed' } }), { status: 403 });

--- a/packages/auth/src/iam-account-management/platform-iam-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-handlers.test.ts
@@ -196,4 +196,47 @@ describe('platform IAM handlers', () => {
       },
     });
   });
+
+  it('returns platform guard responses before dependency calls', async () => {
+    state.featureResponse = new Response(JSON.stringify({ error: { code: 'feature_disabled' } }), { status: 404 });
+    const featureResponse = await listPlatformUsersInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/users'),
+      ctx
+    );
+    expect(featureResponse.status).toBe(404);
+
+    state.featureResponse = null;
+    state.roleResponse = new Response(JSON.stringify({ error: { code: 'forbidden' } }), { status: 403 });
+    const roleResponse = await listPlatformUsersInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/users'),
+      ctx
+    );
+    expect(roleResponse.status).toBe(403);
+
+    state.roleResponse = null;
+    state.rateLimitResponse = new Response(JSON.stringify({ error: { code: 'rate_limited' } }), { status: 429 });
+    const userRateLimitResponse = await listPlatformUsersInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/users'),
+      ctx
+    );
+    expect(userRateLimitResponse.status).toBe(429);
+
+    state.rateLimitResponse = null;
+    state.csrfResponse = new Response(JSON.stringify({ error: { code: 'csrf_validation_failed' } }), { status: 403 });
+    const csrfResponse = await reconcilePlatformRolesInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/admin/reconcile', { method: 'POST' }),
+      ctx,
+      'req-platform'
+    );
+    expect(csrfResponse.status).toBe(403);
+
+    state.csrfResponse = null;
+    state.rateLimitResponse = new Response(JSON.stringify({ error: { code: 'rate_limited' } }), { status: 429 });
+    const reconcileRateLimitResponse = await reconcilePlatformRolesInternal(
+      new Request('https://studio.smart-village.app/api/v1/iam/admin/reconcile', { method: 'POST' }),
+      ctx,
+      'req-platform'
+    );
+    expect(reconcileRateLimitResponse.status).toBe(429);
+  });
 });

--- a/packages/auth/src/iam-account-management/platform-iam-handlers.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-handlers.ts
@@ -92,6 +92,9 @@ export const listPlatformUsersInternal = async (
       trace_id: requestContext.traceId,
       error: error instanceof Error ? error.message : String(error),
     });
+    if (isPlatformIdentityProviderConfigurationError(error)) {
+      return platformIdentityProviderConfigurationError(requestContext.requestId);
+    }
     return platformKeycloakError(
       'Plattform-Benutzer konnten nicht aus Keycloak geladen werden.',
       requestContext.requestId
@@ -116,7 +119,7 @@ export const listPlatformRolesInternal = async (
 
   try {
     const roles = await listPlatformRoles();
-    return jsonResponse(200, asApiList(roles, { page: 1, pageSize: Math.max(1, roles.length), total: roles.length }, requestId));
+    return jsonResponse(200, asApiList(roles, { page: 1, pageSize: roles.length, total: roles.length }, requestId));
   } catch (error) {
     logger.error('Platform role list failed', {
       operation: 'list_platform_roles',

--- a/packages/auth/src/iam-account-management/platform-iam-handlers.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-handlers.ts
@@ -5,7 +5,7 @@ import { jsonResponse } from '../shared/db-helpers.js';
 import { readString } from '../shared/input-readers.js';
 
 import { asApiItem, asApiList, createApiError, readPage } from './api-helpers.js';
-import { ADMIN_ROLES } from './constants.js';
+import { ADMIN_ROLES, PLATFORM_RATE_LIMIT_INSTANCE_ID } from './constants.js';
 import { validateCsrf } from './csrf.js';
 import { ensureFeature, getFeatureFlags } from './feature-flags.js';
 import { listPlatformRoles, listPlatformUsers, runPlatformRoleReconcile } from './platform-iam.js';
@@ -21,6 +21,22 @@ const platformKeycloakError = (message: string, requestId?: string): Response =>
     reason_code: 'platform_keycloak_unavailable',
     scope_kind: 'platform',
   });
+
+const isPlatformIdentityProviderConfigurationError = (error: unknown): boolean =>
+  error instanceof Error && error.message === 'platform_identity_provider_not_configured';
+
+const platformIdentityProviderConfigurationError = (requestId?: string): Response =>
+  createApiError(
+    503,
+    'keycloak_unavailable',
+    'Plattform-IAM ist nicht konfiguriert.',
+    requestId,
+    {
+      dependency: 'keycloak',
+      reason_code: 'platform_identity_provider_not_configured',
+      scope_kind: 'platform',
+    }
+  );
 
 export const listPlatformUsersInternal = async (
   request: Request,
@@ -42,7 +58,7 @@ export const listPlatformUsersInternal = async (
     return roleCheck;
   }
   const rateLimit = consumeRateLimit({
-    instanceId: 'platform',
+    instanceId: PLATFORM_RATE_LIMIT_INSTANCE_ID,
     actorKeycloakSubject: ctx.user.id,
     scope: 'read',
     requestId: requestContext.requestId,
@@ -85,10 +101,11 @@ export const listPlatformUsersInternal = async (
 
 export const listPlatformRolesInternal = async (
   ctx: AuthenticatedRequestContext,
-  requestId?: string
+  requestId?: string,
+  traceId?: string
 ): Promise<Response> => {
   const rateLimit = consumeRateLimit({
-    instanceId: 'platform',
+    instanceId: PLATFORM_RATE_LIMIT_INSTANCE_ID,
     actorKeycloakSubject: ctx.user.id,
     scope: 'read',
     requestId,
@@ -100,7 +117,17 @@ export const listPlatformRolesInternal = async (
   try {
     const roles = await listPlatformRoles();
     return jsonResponse(200, asApiList(roles, { page: 1, pageSize: Math.max(1, roles.length), total: roles.length }, requestId));
-  } catch {
+  } catch (error) {
+    logger.error('Platform role list failed', {
+      operation: 'list_platform_roles',
+      scope_kind: 'platform',
+      request_id: requestId,
+      trace_id: traceId,
+      error: sanitizeRoleErrorMessage(error),
+    });
+    if (isPlatformIdentityProviderConfigurationError(error)) {
+      return platformIdentityProviderConfigurationError(requestId);
+    }
     return platformKeycloakError('Plattform-Rollen konnten nicht aus Keycloak geladen werden.', requestId);
   }
 };
@@ -116,7 +143,7 @@ export const reconcilePlatformRolesInternal = async (
     return csrfError;
   }
   const rateLimit = consumeRateLimit({
-    instanceId: 'platform',
+    instanceId: PLATFORM_RATE_LIMIT_INSTANCE_ID,
     actorKeycloakSubject: ctx.user.id,
     scope: 'write',
     requestId,

--- a/packages/auth/src/iam-account-management/platform-iam-handlers.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-handlers.ts
@@ -1,0 +1,151 @@
+import { getWorkspaceContext } from '@sva/sdk/server';
+
+import type { AuthenticatedRequestContext } from '../middleware.server.js';
+import { jsonResponse } from '../shared/db-helpers.js';
+import { readString } from '../shared/input-readers.js';
+
+import { asApiItem, asApiList, createApiError, readPage } from './api-helpers.js';
+import { ADMIN_ROLES } from './constants.js';
+import { validateCsrf } from './csrf.js';
+import { ensureFeature, getFeatureFlags } from './feature-flags.js';
+import { listPlatformRoles, listPlatformUsers, runPlatformRoleReconcile } from './platform-iam.js';
+import { consumeRateLimit } from './rate-limit.js';
+import { mapRoleSyncErrorCode, sanitizeRoleErrorMessage } from './role-audit.js';
+import { logger, requireRoles } from './shared.js';
+import type { UserStatus } from './types.js';
+import { USER_STATUS } from './types.js';
+
+const platformKeycloakError = (message: string, requestId?: string): Response =>
+  createApiError(503, 'keycloak_unavailable', message, requestId, {
+    dependency: 'keycloak',
+    reason_code: 'platform_keycloak_unavailable',
+    scope_kind: 'platform',
+  });
+
+export const listPlatformUsersInternal = async (
+  request: Request,
+  ctx: AuthenticatedRequestContext
+): Promise<Response> => {
+  const { page, pageSize } = readPage(request);
+  const url = new URL(request.url);
+  const status = readString(url.searchParams.get('status')) as UserStatus | undefined;
+  const role = readString(url.searchParams.get('role'));
+  const search = readString(url.searchParams.get('search'));
+  const requestContext = getWorkspaceContext();
+
+  const featureCheck = ensureFeature(getFeatureFlags(), 'iam_admin', requestContext.requestId);
+  if (featureCheck) {
+    return featureCheck;
+  }
+  const roleCheck = requireRoles(ctx, ADMIN_ROLES, requestContext.requestId);
+  if (roleCheck) {
+    return roleCheck;
+  }
+  const rateLimit = consumeRateLimit({
+    instanceId: 'platform',
+    actorKeycloakSubject: ctx.user.id,
+    scope: 'read',
+    requestId: requestContext.requestId,
+  });
+  if (rateLimit) {
+    return rateLimit;
+  }
+  if (status && !USER_STATUS.includes(status)) {
+    return createApiError(400, 'invalid_request', 'Ungültiger Status-Filter.', requestContext.requestId);
+  }
+
+  try {
+    const resolved = await listPlatformUsers({
+      page,
+      pageSize,
+      status,
+      role: role ?? undefined,
+      search: search ?? undefined,
+      requestId: requestContext.requestId,
+      traceId: requestContext.traceId,
+    });
+    return jsonResponse(
+      200,
+      asApiList(resolved.users, { page, pageSize, total: resolved.total }, requestContext.requestId)
+    );
+  } catch (error) {
+    logger.error('Platform user list failed', {
+      operation: 'list_platform_users',
+      scope_kind: 'platform',
+      request_id: requestContext.requestId,
+      trace_id: requestContext.traceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return platformKeycloakError(
+      'Plattform-Benutzer konnten nicht aus Keycloak geladen werden.',
+      requestContext.requestId
+    );
+  }
+};
+
+export const listPlatformRolesInternal = async (
+  ctx: AuthenticatedRequestContext,
+  requestId?: string
+): Promise<Response> => {
+  const rateLimit = consumeRateLimit({
+    instanceId: 'platform',
+    actorKeycloakSubject: ctx.user.id,
+    scope: 'read',
+    requestId,
+  });
+  if (rateLimit) {
+    return rateLimit;
+  }
+
+  try {
+    const roles = await listPlatformRoles();
+    return jsonResponse(200, asApiList(roles, { page: 1, pageSize: Math.max(1, roles.length), total: roles.length }, requestId));
+  } catch {
+    return platformKeycloakError('Plattform-Rollen konnten nicht aus Keycloak geladen werden.', requestId);
+  }
+};
+
+export const reconcilePlatformRolesInternal = async (
+  request: Request,
+  ctx: AuthenticatedRequestContext,
+  requestId?: string,
+  traceId?: string
+): Promise<Response> => {
+  const csrfError = validateCsrf(request, requestId);
+  if (csrfError) {
+    return csrfError;
+  }
+  const rateLimit = consumeRateLimit({
+    instanceId: 'platform',
+    actorKeycloakSubject: ctx.user.id,
+    scope: 'write',
+    requestId,
+  });
+  if (rateLimit) {
+    return rateLimit;
+  }
+
+  try {
+    const report = await runPlatformRoleReconcile();
+    return jsonResponse(200, asApiItem(report, requestId));
+  } catch (error) {
+    logger.error('Platform role reconciliation failed', {
+      operation: 'reconcile_platform_roles',
+      scope_kind: 'platform',
+      request_id: requestId,
+      trace_id: traceId,
+      error: sanitizeRoleErrorMessage(error),
+    });
+    return createApiError(
+      503,
+      'keycloak_unavailable',
+      'Plattform-Rollen konnten nicht aus Keycloak abgeglichen werden.',
+      requestId,
+      {
+        syncState: 'failed',
+        syncError: { code: mapRoleSyncErrorCode(error) },
+        scope_kind: 'platform',
+      }
+    );
+  }
+};

--- a/packages/auth/src/iam-account-management/platform-iam-roles.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-roles.ts
@@ -1,0 +1,95 @@
+import type { IamRoleListItem } from '@sva/core';
+
+import type { IdentityRole } from '../identity-provider-port.js';
+
+import { logger, trackKeycloakCall } from './shared-observability.js';
+import { resolveIdentityProvider } from './shared-runtime.js';
+
+export const PLATFORM_ROLE_LEVEL_BY_NAME: Readonly<Record<string, number>> = {
+  system_admin: 100,
+  instance_registry_admin: 90,
+};
+
+const BUILTIN_REALM_ROLE_NAMES = new Set(['offline_access', 'uma_authorization']);
+
+const readRoleAttribute = (
+  attributes: Readonly<Record<string, readonly string[]>> | undefined,
+  key: string
+): string | undefined => {
+  const value = attributes?.[key]?.[0]?.trim();
+  return value && value.length > 0 ? value : undefined;
+};
+
+const isBuiltInRealmRole = (role: IdentityRole): boolean =>
+  BUILTIN_REALM_ROLE_NAMES.has(role.externalName) || role.externalName.startsWith('default-roles-');
+
+const isStudioManagedRole = (role: IdentityRole): boolean =>
+  readRoleAttribute(role.attributes, 'managed_by') === 'studio';
+
+const mapPlatformRole = (role: IdentityRole): IamRoleListItem => {
+  const roleKey = readRoleAttribute(role.attributes, 'role_key') ?? role.externalName;
+  const displayName = readRoleAttribute(role.attributes, 'display_name') ?? role.externalName;
+  const roleLevelRaw = readRoleAttribute(role.attributes, 'role_level');
+  const parsedRoleLevel = roleLevelRaw ? Number(roleLevelRaw) : PLATFORM_ROLE_LEVEL_BY_NAME[role.externalName] ?? 0;
+
+  return {
+    id: role.id ?? `platform:${role.externalName}`,
+    roleKey,
+    roleName: displayName,
+    externalRoleName: role.externalName,
+    managedBy: isStudioManagedRole(role) ? 'studio' : 'external',
+    description: role.description,
+    isSystemRole: role.externalName in PLATFORM_ROLE_LEVEL_BY_NAME,
+    roleLevel: Number.isFinite(parsedRoleLevel) ? parsedRoleLevel : 0,
+    memberCount: 0,
+    syncState: 'synced',
+    permissions: [],
+  };
+};
+
+export const listPlatformRoles = async (): Promise<readonly IamRoleListItem[]> => {
+  const identityProvider = resolveIdentityProvider();
+  if (!identityProvider) {
+    throw new Error('platform_identity_provider_not_configured');
+  }
+
+  const roles = await trackKeycloakCall('list_platform_roles', () => identityProvider.provider.listRoles());
+  return roles
+    .filter((role) => !isBuiltInRealmRole(role))
+    .map(mapPlatformRole)
+    .sort((left, right) => right.roleLevel - left.roleLevel || left.roleName.localeCompare(right.roleName, 'de'));
+};
+
+export const runPlatformRoleReconcile = async (): Promise<{
+  outcome: 'success';
+  checkedCount: number;
+  correctedCount: 0;
+  failedCount: 0;
+  manualReviewCount: 0;
+  requiresManualActionCount: 0;
+  roles: readonly {
+    externalRoleName: string;
+    action: 'noop';
+    status: 'synced';
+  }[];
+}> => {
+  const roles = await listPlatformRoles();
+  logger.info('reconcile_platform_roles_completed', {
+    operation: 'reconcile_platform_roles',
+    scope_kind: 'platform',
+    checked_count: roles.length,
+  });
+  return {
+    outcome: 'success',
+    checkedCount: roles.length,
+    correctedCount: 0,
+    failedCount: 0,
+    manualReviewCount: 0,
+    requiresManualActionCount: 0,
+    roles: roles.map((role) => ({
+      externalRoleName: role.externalRoleName,
+      action: 'noop',
+      status: 'synced',
+    })),
+  };
+};

--- a/packages/auth/src/iam-account-management/platform-iam-roles.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-roles.ts
@@ -31,15 +31,26 @@ const mapPlatformRole = (role: IdentityRole): IamRoleListItem => {
   const displayName = readRoleAttribute(role.attributes, 'display_name') ?? role.externalName;
   const roleLevelRaw = readRoleAttribute(role.attributes, 'role_level');
   const parsedRoleLevel = roleLevelRaw ? Number(roleLevelRaw) : PLATFORM_ROLE_LEVEL_BY_NAME[role.externalName] ?? 0;
+  const builtIn = isBuiltInRealmRole(role);
+  const systemRole = role.externalName in PLATFORM_ROLE_LEVEL_BY_NAME;
+  const managedBy = builtIn ? 'keycloak_builtin' : isStudioManagedRole(role) ? 'studio' : 'external';
 
   return {
     id: role.id ?? `platform:${role.externalName}`,
     roleKey,
     roleName: displayName,
     externalRoleName: role.externalName,
-    managedBy: isStudioManagedRole(role) ? 'studio' : 'external',
+    managedBy,
     description: role.description,
-    isSystemRole: role.externalName in PLATFORM_ROLE_LEVEL_BY_NAME,
+    isSystemRole: systemRole,
+    editability: managedBy === 'studio' && !systemRole ? 'editable' : 'read_only',
+    diagnostics: builtIn
+      ? [{ code: 'built_in_role', objectId: role.externalName, objectType: 'role' }]
+      : systemRole
+        ? [{ code: 'system_role', objectId: role.externalName, objectType: 'role' }]
+        : managedBy === 'external'
+          ? [{ code: 'external_managed', objectId: role.externalName, objectType: 'role' }]
+          : undefined,
     roleLevel: Number.isFinite(parsedRoleLevel) ? parsedRoleLevel : 0,
     memberCount: 0,
     syncState: 'synced',
@@ -55,7 +66,6 @@ export const listPlatformRoles = async (): Promise<readonly IamRoleListItem[]> =
 
   const roles = await trackKeycloakCall('list_platform_roles', () => identityProvider.provider.listRoles());
   return roles
-    .filter((role) => !isBuiltInRealmRole(role))
     .map(mapPlatformRole)
     .sort((left, right) => right.roleLevel - left.roleLevel || left.roleName.localeCompare(right.roleName, 'de'));
 };

--- a/packages/auth/src/iam-account-management/platform-iam-sync.ts
+++ b/packages/auth/src/iam-account-management/platform-iam-sync.ts
@@ -1,0 +1,34 @@
+import type { IamUserImportSyncReport } from '@sva/core';
+
+import { listAllPlatformUsers } from './platform-iam.js';
+import { logger } from './shared-observability.js';
+
+export const runPlatformKeycloakUserSync = async (input: {
+  readonly requestId?: string;
+  readonly traceId?: string;
+}): Promise<IamUserImportSyncReport> => {
+  const { realm, users } = await listAllPlatformUsers();
+  logger.info('sync_platform_keycloak_users_completed', {
+    operation: 'sync_platform_keycloak_users',
+    scope_kind: 'platform',
+    auth_realm: realm,
+    request_id: input.requestId,
+    trace_id: input.traceId,
+    checked_count: users.length,
+  });
+  return {
+    outcome: 'success',
+    checkedCount: users.length,
+    correctedCount: 0,
+    manualReviewCount: 0,
+    importedCount: 0,
+    updatedCount: 0,
+    skippedCount: 0,
+    totalKeycloakUsers: users.length,
+    diagnostics: {
+      authRealm: realm,
+      providerSource: 'platform',
+      executionMode: 'platform_admin',
+    },
+  };
+};

--- a/packages/auth/src/iam-account-management/platform-iam.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.test.ts
@@ -226,6 +226,14 @@ describe('platform IAM projection', () => {
     });
   });
 
+  it('returns an empty platform user page for pending status without querying Keycloak', async () => {
+    await expect(listPlatformUsers({ page: 1, pageSize: 25, status: 'pending' })).resolves.toEqual({
+      users: [],
+      total: 0,
+    });
+    expect(state.listUsersCalls).toEqual([]);
+  });
+
   it('maps platform role attributes and reconcile summaries', async () => {
     state.roles = [
       {

--- a/packages/auth/src/iam-account-management/platform-iam.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({
+  providerEnabled: true,
   users: [
     {
       externalId: 'kc-platform-1',
@@ -11,7 +12,7 @@ const state = vi.hoisted(() => ({
       enabled: true,
     },
   ],
-  rolesByUser: new Map<string, readonly string[]>([['kc-platform-1', ['system_admin']]]),
+  rolesByUser: new Map<string, readonly string[] | Error>([['kc-platform-1', ['system_admin']]]),
   roles: [
     {
       id: 'role-system-admin',
@@ -26,19 +27,28 @@ const state = vi.hoisted(() => ({
 }));
 
 vi.mock('./shared-runtime.js', () => ({
-  resolveIdentityProvider: () => ({
-    provider: {
-      listUsers: async ({ first = 0, max = 100 }: { first?: number; max?: number } = {}) =>
-        state.users.slice(first, first + max),
-      listUserRoleNames: async (externalId: string) => state.rolesByUser.get(externalId) ?? [],
-      listRoles: async () => state.roles,
-    },
-    realm: 'sva-studio',
-    source: 'global',
-    clientId: 'platform-admin',
-    adminRealm: 'sva-studio',
-    executionMode: 'platform_admin',
-  }),
+  resolveIdentityProvider: () =>
+    state.providerEnabled
+      ? {
+          provider: {
+            listUsers: async ({ first = 0, max = 100 }: { first?: number; max?: number } = {}) =>
+              state.users.slice(first, first + max),
+            listUserRoleNames: async (externalId: string) => {
+              const roles = state.rolesByUser.get(externalId);
+              if (roles instanceof Error) {
+                throw roles;
+              }
+              return roles ?? [];
+            },
+            listRoles: async () => state.roles,
+          },
+          realm: 'sva-studio',
+          source: 'global',
+          clientId: 'platform-admin',
+          adminRealm: 'sva-studio',
+          executionMode: 'platform_admin',
+        }
+      : null,
 }));
 
 vi.mock('./shared-observability.js', () => ({
@@ -49,10 +59,16 @@ vi.mock('./shared-observability.js', () => ({
   trackKeycloakCall: vi.fn(async (_operation: string, execute: () => Promise<unknown>) => execute()),
 }));
 
-import { listPlatformRoles, listPlatformUsers, runPlatformKeycloakUserSync } from './platform-iam';
+import {
+  listPlatformRoles,
+  listPlatformUsers,
+  runPlatformKeycloakUserSync,
+  runPlatformRoleReconcile,
+} from './platform-iam';
 
 describe('platform IAM projection', () => {
   beforeEach(() => {
+    state.providerEnabled = true;
     state.users = [
       {
         externalId: 'kc-platform-1',
@@ -63,7 +79,7 @@ describe('platform IAM projection', () => {
         enabled: true,
       },
     ];
-    state.rolesByUser = new Map<string, readonly string[]>([['kc-platform-1', ['system_admin']]]);
+    state.rolesByUser = new Map<string, readonly string[] | Error>([['kc-platform-1', ['system_admin']]]);
     state.roles = [
       {
         id: 'role-system-admin',
@@ -124,5 +140,112 @@ describe('platform IAM projection', () => {
         }),
       })
     );
+  });
+
+  it('applies platform user filters and tolerates degraded role projection', async () => {
+    state.users = [
+      {
+        externalId: 'kc-platform-1',
+        username: 'platform-admin',
+        email: 'platform@example.org',
+        firstName: 'Platform',
+        lastName: 'Admin',
+        enabled: true,
+      },
+      {
+        externalId: 'kc-platform-2',
+        username: 'registry-admin',
+        email: 'registry@example.org',
+        enabled: false,
+      },
+      {
+        externalId: 'kc-platform-3',
+        enabled: true,
+      },
+    ];
+    state.rolesByUser = new Map<string, readonly string[] | Error>([
+      ['kc-platform-1', ['system_admin']],
+      ['kc-platform-2', ['instance_registry_admin']],
+      ['kc-platform-3', new Error('roles unavailable')],
+    ]);
+
+    await expect(
+      listPlatformUsers({ page: 1, pageSize: 25, status: 'inactive', role: 'instance_registry_admin', search: 'registry' })
+    ).resolves.toMatchObject({
+      total: 1,
+      users: [expect.objectContaining({ displayName: 'registry-admin', status: 'inactive' })],
+    });
+    await expect(
+      listPlatformUsers({ page: 1, pageSize: 25, role: 'missing_role' })
+    ).resolves.toMatchObject({ total: 0 });
+    await expect(
+      listPlatformUsers({ page: 1, pageSize: 25, search: 'kc-platform-3' })
+    ).resolves.toMatchObject({
+      total: 1,
+      users: [expect.objectContaining({ displayName: 'kc-platform-3', roles: [] })],
+    });
+  });
+
+  it('maps platform role attributes and reconcile summaries', async () => {
+    state.roles = [
+      {
+        externalName: 'custom_admin',
+        description: 'Custom admin',
+        attributes: {
+          managed_by: ['studio'],
+          role_key: ['custom.admin'],
+          display_name: ['Custom Admin'],
+          role_level: ['77'],
+        },
+      },
+      {
+        externalName: 'external_role',
+        attributes: {
+          role_level: ['not-a-number'],
+        },
+      },
+      {
+        externalName: 'offline_access',
+      },
+      {
+        externalName: 'uma_authorization',
+      },
+    ];
+
+    const roles = await listPlatformRoles();
+
+    expect(roles).toEqual([
+      expect.objectContaining({
+        id: 'platform:custom_admin',
+        roleKey: 'custom.admin',
+        roleName: 'Custom Admin',
+        managedBy: 'studio',
+        roleLevel: 77,
+      }),
+      expect.objectContaining({
+        id: 'platform:external_role',
+        roleKey: 'external_role',
+        managedBy: 'external',
+        roleLevel: 0,
+      }),
+    ]);
+    await expect(runPlatformRoleReconcile()).resolves.toMatchObject({
+      outcome: 'success',
+      checkedCount: 2,
+      roles: [
+        { externalRoleName: 'custom_admin', action: 'noop', status: 'synced' },
+        { externalRoleName: 'external_role', action: 'noop', status: 'synced' },
+      ],
+    });
+  });
+
+  it('fails when the platform identity provider is not configured', async () => {
+    state.providerEnabled = false;
+
+    await expect(listPlatformUsers({ page: 1, pageSize: 25 })).rejects.toThrow(
+      'platform_identity_provider_not_configured'
+    );
+    await expect(listPlatformRoles()).rejects.toThrow('platform_identity_provider_not_configured');
+    await expect(runPlatformKeycloakUserSync({})).rejects.toThrow('platform_identity_provider_not_configured');
   });
 });

--- a/packages/auth/src/iam-account-management/platform-iam.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({
   providerEnabled: true,
+  listUsersCalls: [] as Array<{ first?: number; max?: number; enabled?: boolean }>,
   users: [
     {
       externalId: 'kc-platform-1',
@@ -31,8 +32,13 @@ vi.mock('./shared-runtime.js', () => ({
     state.providerEnabled
       ? {
           provider: {
-            listUsers: async ({ first = 0, max = 100 }: { first?: number; max?: number } = {}) =>
-              state.users.slice(first, first + max),
+            listUsers: async ({ first = 0, max = 100, enabled }: { first?: number; max?: number; enabled?: boolean } = {}) => {
+              state.listUsersCalls.push({ first, max, enabled });
+              const filteredUsers = typeof enabled === 'boolean'
+                ? state.users.filter((user) => (user.enabled !== false) === enabled)
+                : state.users;
+              return filteredUsers.slice(first, first + max);
+            },
             listUserRoleNames: async (externalId: string) => {
               const roles = state.rolesByUser.get(externalId);
               if (roles instanceof Error) {
@@ -69,6 +75,7 @@ import {
 describe('platform IAM projection', () => {
   beforeEach(() => {
     state.providerEnabled = true;
+    state.listUsersCalls = [];
     state.users = [
       {
         externalId: 'kc-platform-1',
@@ -175,6 +182,7 @@ describe('platform IAM projection', () => {
       total: 1,
       users: [expect.objectContaining({ displayName: 'registry-admin', status: 'inactive' })],
     });
+    expect(state.listUsersCalls.at(-1)).toMatchObject({ enabled: false });
     await expect(
       listPlatformUsers({ page: 1, pageSize: 25, role: 'missing_role' })
     ).resolves.toMatchObject({ total: 0 });

--- a/packages/auth/src/iam-account-management/platform-iam.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.test.ts
@@ -138,17 +138,27 @@ describe('platform IAM projection', () => {
     );
   });
 
-  it('filters built-in roles from platform role lists', async () => {
+  it('keeps built-in roles visible as read-only platform roles', async () => {
     const roles = await listPlatformRoles();
 
-    expect(roles).toHaveLength(1);
+    expect(roles).toHaveLength(2);
     expect(roles[0]).toEqual(
       expect.objectContaining({
         id: 'role-system-admin',
         roleKey: 'system_admin',
         roleName: 'system_admin',
         isSystemRole: true,
+        editability: 'read_only',
         roleLevel: 100,
+      })
+    );
+    expect(roles[1]).toEqual(
+      expect.objectContaining({
+        id: 'role-default',
+        roleKey: 'default-roles-sva-studio',
+        managedBy: 'keycloak_builtin',
+        editability: 'read_only',
+        diagnostics: [expect.objectContaining({ code: 'built_in_role' })],
       })
     );
   });
@@ -250,21 +260,33 @@ describe('platform IAM projection', () => {
         roleKey: 'custom.admin',
         roleName: 'Custom Admin',
         managedBy: 'studio',
+        editability: 'editable',
         roleLevel: 77,
       }),
       expect.objectContaining({
         id: 'platform:external_role',
         roleKey: 'external_role',
         managedBy: 'external',
+        editability: 'read_only',
         roleLevel: 0,
+      }),
+      expect.objectContaining({
+        id: 'platform:offline_access',
+        managedBy: 'keycloak_builtin',
+      }),
+      expect.objectContaining({
+        id: 'platform:uma_authorization',
+        managedBy: 'keycloak_builtin',
       }),
     ]);
     await expect(runPlatformRoleReconcile()).resolves.toMatchObject({
       outcome: 'success',
-      checkedCount: 2,
+      checkedCount: 4,
       roles: [
         { externalRoleName: 'custom_admin', action: 'noop', status: 'synced' },
         { externalRoleName: 'external_role', action: 'noop', status: 'synced' },
+        { externalRoleName: 'offline_access', action: 'noop', status: 'synced' },
+        { externalRoleName: 'uma_authorization', action: 'noop', status: 'synced' },
       ],
     });
   });

--- a/packages/auth/src/iam-account-management/platform-iam.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({
   providerEnabled: true,
-  listUsersCalls: [] as Array<{ first?: number; max?: number; enabled?: boolean }>,
+  listUsersCalls: [] as Array<{ first?: number; max?: number; enabled?: boolean; search?: string }>,
   users: [
     {
       externalId: 'kc-platform-1',
@@ -32,13 +32,35 @@ vi.mock('./shared-runtime.js', () => ({
     state.providerEnabled
       ? {
           provider: {
-            listUsers: async ({ first = 0, max = 100, enabled }: { first?: number; max?: number; enabled?: boolean } = {}) => {
-              state.listUsersCalls.push({ first, max, enabled });
-              const filteredUsers = typeof enabled === 'boolean'
-                ? state.users.filter((user) => (user.enabled !== false) === enabled)
-                : state.users;
+            listUsers: async ({ first = 0, max = 100, enabled, search }: { first?: number; max?: number; enabled?: boolean; search?: string } = {}) => {
+              state.listUsersCalls.push({ first, max, enabled, search });
+              const filteredUsers = state.users.filter((user) => {
+                if (typeof enabled === 'boolean' && (user.enabled !== false) !== enabled) {
+                  return false;
+                }
+                if (!search) {
+                  return true;
+                }
+                const query = search.toLowerCase();
+                return [user.externalId, user.username, user.email, user.firstName, user.lastName]
+                  .filter((value): value is string => typeof value === 'string')
+                  .some((value) => value.toLowerCase().includes(query));
+              });
               return filteredUsers.slice(first, first + max);
             },
+            countUsers: async ({ enabled, search }: { enabled?: boolean; search?: string } = {}) =>
+              state.users.filter((user) => {
+                if (typeof enabled === 'boolean' && (user.enabled !== false) !== enabled) {
+                  return false;
+                }
+                if (!search) {
+                  return true;
+                }
+                const query = search.toLowerCase();
+                return [user.externalId, user.username, user.email, user.firstName, user.lastName]
+                  .filter((value): value is string => typeof value === 'string')
+                  .some((value) => value.toLowerCase().includes(query));
+              }).length,
             listUserRoleNames: async (externalId: string) => {
               const roles = state.rolesByUser.get(externalId);
               if (roles instanceof Error) {

--- a/packages/auth/src/iam-account-management/platform-iam.test.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  users: [
+    {
+      externalId: 'kc-platform-1',
+      username: 'platform-admin',
+      email: 'platform@example.org',
+      firstName: 'Platform',
+      lastName: 'Admin',
+      enabled: true,
+    },
+  ],
+  rolesByUser: new Map<string, readonly string[]>([['kc-platform-1', ['system_admin']]]),
+  roles: [
+    {
+      id: 'role-system-admin',
+      externalName: 'system_admin',
+      description: 'System admin',
+    },
+    {
+      id: 'role-default',
+      externalName: 'default-roles-sva-studio',
+    },
+  ],
+}));
+
+vi.mock('./shared-runtime.js', () => ({
+  resolveIdentityProvider: () => ({
+    provider: {
+      listUsers: async ({ first = 0, max = 100 }: { first?: number; max?: number } = {}) =>
+        state.users.slice(first, first + max),
+      listUserRoleNames: async (externalId: string) => state.rolesByUser.get(externalId) ?? [],
+      listRoles: async () => state.roles,
+    },
+    realm: 'sva-studio',
+    source: 'global',
+    clientId: 'platform-admin',
+    adminRealm: 'sva-studio',
+    executionMode: 'platform_admin',
+  }),
+}));
+
+vi.mock('./shared-observability.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+  trackKeycloakCall: vi.fn(async (_operation: string, execute: () => Promise<unknown>) => execute()),
+}));
+
+import { listPlatformRoles, listPlatformUsers, runPlatformKeycloakUserSync } from './platform-iam';
+
+describe('platform IAM projection', () => {
+  beforeEach(() => {
+    state.users = [
+      {
+        externalId: 'kc-platform-1',
+        username: 'platform-admin',
+        email: 'platform@example.org',
+        firstName: 'Platform',
+        lastName: 'Admin',
+        enabled: true,
+      },
+    ];
+    state.rolesByUser = new Map<string, readonly string[]>([['kc-platform-1', ['system_admin']]]);
+    state.roles = [
+      {
+        id: 'role-system-admin',
+        externalName: 'system_admin',
+        description: 'System admin',
+      },
+      {
+        id: 'role-default',
+        externalName: 'default-roles-sva-studio',
+      },
+    ];
+  });
+
+  it('lists platform users without an instance id', async () => {
+    const result = await listPlatformUsers({ page: 1, pageSize: 25 });
+
+    expect(result.total).toBe(1);
+    expect(result.users[0]).toEqual(
+      expect.objectContaining({
+        id: 'platform:kc-platform-1',
+        keycloakSubject: 'kc-platform-1',
+        displayName: 'Platform Admin',
+        email: 'platform@example.org',
+        status: 'active',
+        roles: [expect.objectContaining({ roleKey: 'system_admin', roleLevel: 100 })],
+      })
+    );
+  });
+
+  it('filters built-in roles from platform role lists', async () => {
+    const roles = await listPlatformRoles();
+
+    expect(roles).toHaveLength(1);
+    expect(roles[0]).toEqual(
+      expect.objectContaining({
+        id: 'role-system-admin',
+        roleKey: 'system_admin',
+        roleName: 'system_admin',
+        isSystemRole: true,
+        roleLevel: 100,
+      })
+    );
+  });
+
+  it('reports platform sync diagnostics without tenant persistence', async () => {
+    const report = await runPlatformKeycloakUserSync({ requestId: 'req-platform-sync' });
+
+    expect(report).toEqual(
+      expect.objectContaining({
+        outcome: 'success',
+        checkedCount: 1,
+        correctedCount: 0,
+        totalKeycloakUsers: 1,
+        diagnostics: expect.objectContaining({
+          authRealm: 'sva-studio',
+          providerSource: 'platform',
+          executionMode: 'platform_admin',
+        }),
+      })
+    );
+  });
+});

--- a/packages/auth/src/iam-account-management/platform-iam.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.ts
@@ -1,0 +1,241 @@
+import type { IamRoleListItem, IamUserImportSyncReport, IamUserListItem } from '@sva/core';
+
+import type { IdentityListedUser, IdentityRole } from '../identity-provider-port.js';
+
+import { resolveIdentityProvider } from './shared-runtime.js';
+import { logger, trackKeycloakCall } from './shared-observability.js';
+import type { UserStatus } from './types.js';
+
+const PLATFORM_KEYCLOAK_PAGE_SIZE = 100;
+const PLATFORM_ROLE_LEVEL_BY_NAME: Readonly<Record<string, number>> = {
+  system_admin: 100,
+  instance_registry_admin: 90,
+};
+
+const BUILTIN_REALM_ROLE_NAMES = new Set(['offline_access', 'uma_authorization']);
+
+const readRoleAttribute = (
+  attributes: Readonly<Record<string, readonly string[]>> | undefined,
+  key: string
+): string | undefined => {
+  const value = attributes?.[key]?.[0]?.trim();
+  return value && value.length > 0 ? value : undefined;
+};
+
+const resolveDisplayName = (user: IdentityListedUser): string => {
+  const fullName = [user.firstName, user.lastName]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .trim();
+
+  return fullName || user.username || user.email || user.externalId;
+};
+
+const mapUserStatus = (user: IdentityListedUser): IamUserListItem['status'] =>
+  user.enabled === false ? 'inactive' : 'active';
+
+const matchesUserFilters = (
+  user: IamUserListItem,
+  filters: {
+    readonly status?: UserStatus;
+    readonly role?: string;
+    readonly search?: string;
+  }
+): boolean => {
+  if (filters.status && user.status !== filters.status) {
+    return false;
+  }
+  if (filters.role && !user.roles.some((role) => role.roleKey === filters.role || role.roleName === filters.role)) {
+    return false;
+  }
+  if (!filters.search) {
+    return true;
+  }
+
+  const query = filters.search.toLowerCase();
+  return [user.displayName, user.email, user.keycloakSubject]
+    .filter((value): value is string => typeof value === 'string')
+    .some((value) => value.toLowerCase().includes(query));
+};
+
+const isBuiltInRealmRole = (role: IdentityRole): boolean =>
+  BUILTIN_REALM_ROLE_NAMES.has(role.externalName) || role.externalName.startsWith('default-roles-');
+
+const isStudioManagedRole = (role: IdentityRole): boolean =>
+  readRoleAttribute(role.attributes, 'managed_by') === 'studio';
+
+const mapPlatformRole = (role: IdentityRole): IamRoleListItem => {
+  const roleKey = readRoleAttribute(role.attributes, 'role_key') ?? role.externalName;
+  const displayName = readRoleAttribute(role.attributes, 'display_name') ?? role.externalName;
+  const roleLevelRaw = readRoleAttribute(role.attributes, 'role_level');
+  const parsedRoleLevel = roleLevelRaw ? Number(roleLevelRaw) : PLATFORM_ROLE_LEVEL_BY_NAME[role.externalName] ?? 0;
+
+  return {
+    id: role.id ?? `platform:${role.externalName}`,
+    roleKey,
+    roleName: displayName,
+    externalRoleName: role.externalName,
+    managedBy: isStudioManagedRole(role) ? 'studio' : 'external',
+    description: role.description,
+    isSystemRole: role.externalName in PLATFORM_ROLE_LEVEL_BY_NAME,
+    roleLevel: Number.isFinite(parsedRoleLevel) ? parsedRoleLevel : 0,
+    memberCount: 0,
+    syncState: 'synced',
+    permissions: [],
+  };
+};
+
+const listAllPlatformUsers = async (): Promise<{
+  readonly realm: string;
+  readonly users: readonly IdentityListedUser[];
+}> => {
+  const identityProvider = resolveIdentityProvider();
+  if (!identityProvider) {
+    throw new Error('platform_identity_provider_not_configured');
+  }
+
+  const users: IdentityListedUser[] = [];
+  for (let first = 0; ; first += PLATFORM_KEYCLOAK_PAGE_SIZE) {
+    const page = await trackKeycloakCall('list_platform_users', () =>
+      identityProvider.provider.listUsers({ first, max: PLATFORM_KEYCLOAK_PAGE_SIZE })
+    );
+    users.push(...page);
+    if (page.length < PLATFORM_KEYCLOAK_PAGE_SIZE) {
+      return { realm: identityProvider.realm, users };
+    }
+  }
+};
+
+export const listPlatformUsers = async (input: {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly status?: UserStatus;
+  readonly role?: string;
+  readonly search?: string;
+  readonly requestId?: string;
+  readonly traceId?: string;
+}): Promise<{ readonly users: readonly IamUserListItem[]; readonly total: number }> => {
+  const identityProvider = resolveIdentityProvider();
+  if (!identityProvider) {
+    throw new Error('platform_identity_provider_not_configured');
+  }
+
+  const { users: listedUsers } = await listAllPlatformUsers();
+  const roleNamesBySubject = new Map<string, readonly string[]>();
+  await Promise.all(
+    listedUsers.map(async (user) => {
+      try {
+        roleNamesBySubject.set(
+          user.externalId,
+          await trackKeycloakCall('list_platform_user_roles', () =>
+            identityProvider.provider.listUserRoleNames(user.externalId)
+          )
+        );
+      } catch (error) {
+        logger.warn('Platform user role projection degraded', {
+          operation: 'list_platform_users',
+          request_id: input.requestId,
+          trace_id: input.traceId,
+          user_ref: user.externalId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        roleNamesBySubject.set(user.externalId, []);
+      }
+    })
+  );
+
+  const projectedUsers = listedUsers
+    .map<IamUserListItem>((user) => ({
+      id: `platform:${user.externalId}`,
+      keycloakSubject: user.externalId,
+      displayName: resolveDisplayName(user),
+      email: user.email,
+      status: mapUserStatus(user),
+      roles: (roleNamesBySubject.get(user.externalId) ?? []).map((roleName) => ({
+        roleId: `platform:${roleName}`,
+        roleKey: roleName,
+        roleName,
+        roleLevel: PLATFORM_ROLE_LEVEL_BY_NAME[roleName] ?? 0,
+      })),
+    }))
+    .filter((user) => matchesUserFilters(user, input))
+    .sort((left, right) => left.displayName.localeCompare(right.displayName, 'de'));
+
+  const start = Math.max(0, (input.page - 1) * input.pageSize);
+  return {
+    users: projectedUsers.slice(start, start + input.pageSize),
+    total: projectedUsers.length,
+  };
+};
+
+export const listPlatformRoles = async (): Promise<readonly IamRoleListItem[]> => {
+  const identityProvider = resolveIdentityProvider();
+  if (!identityProvider) {
+    throw new Error('platform_identity_provider_not_configured');
+  }
+
+  const roles = await trackKeycloakCall('list_platform_roles', () => identityProvider.provider.listRoles());
+  return roles
+    .filter((role) => !isBuiltInRealmRole(role))
+    .map(mapPlatformRole)
+    .sort((left, right) => right.roleLevel - left.roleLevel || left.roleName.localeCompare(right.roleName, 'de'));
+};
+
+export const runPlatformKeycloakUserSync = async (input: {
+  readonly requestId?: string;
+  readonly traceId?: string;
+}): Promise<IamUserImportSyncReport> => {
+  const { realm, users } = await listAllPlatformUsers();
+  logger.info('sync_platform_keycloak_users_completed', {
+    operation: 'sync_platform_keycloak_users',
+    scope_kind: 'platform',
+    auth_realm: realm,
+    request_id: input.requestId,
+    trace_id: input.traceId,
+    checked_count: users.length,
+  });
+  return {
+    outcome: 'success',
+    checkedCount: users.length,
+    correctedCount: 0,
+    manualReviewCount: 0,
+    importedCount: 0,
+    updatedCount: 0,
+    skippedCount: 0,
+    totalKeycloakUsers: users.length,
+    diagnostics: {
+      authRealm: realm,
+      providerSource: 'platform',
+      executionMode: 'platform_admin',
+    },
+  };
+};
+
+export const runPlatformRoleReconcile = async (): Promise<{
+  outcome: 'success';
+  checkedCount: number;
+  correctedCount: 0;
+  failedCount: 0;
+  manualReviewCount: 0;
+  requiresManualActionCount: 0;
+  roles: readonly {
+    externalRoleName: string;
+    action: 'noop';
+    status: 'synced';
+  }[];
+}> => {
+  const roles = await listPlatformRoles();
+  return {
+    outcome: 'success',
+    checkedCount: roles.length,
+    correctedCount: 0,
+    failedCount: 0,
+    manualReviewCount: 0,
+    requiresManualActionCount: 0,
+    roles: roles.map((role) => ({
+      externalRoleName: role.externalRoleName,
+      action: 'noop',
+      status: 'synced',
+    })),
+  };
+};

--- a/packages/auth/src/iam-account-management/platform-iam.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.ts
@@ -201,6 +201,9 @@ export const listPlatformUsers = async (input: {
   if (!identityProvider) {
     throw new Error('platform_identity_provider_not_configured');
   }
+  if (input.status === 'pending') {
+    return { users: [], total: 0 };
+  }
 
   const keycloakQuery: Omit<IdentityUserListQuery, 'first' | 'max'> = {
     ...(input.search ? { search: input.search } : {}),

--- a/packages/auth/src/iam-account-management/platform-iam.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.ts
@@ -1,4 +1,4 @@
-import type { IamUserImportSyncReport, IamUserListItem } from '@sva/core';
+import type { IamUserListItem } from '@sva/core';
 
 import type { IdentityListedUser, IdentityUserListQuery } from '../identity-provider-port.js';
 
@@ -8,6 +8,7 @@ import { logger, trackKeycloakCall } from './shared-observability.js';
 import type { UserStatus } from './types.js';
 
 export { listPlatformRoles, runPlatformRoleReconcile } from './platform-iam-roles.js';
+export { runPlatformKeycloakUserSync } from './platform-iam-sync.js';
 
 const PLATFORM_KEYCLOAK_PAGE_SIZE = 100;
 const PLATFORM_USER_ROLE_PROJECTION_CONCURRENCY = 5;
@@ -59,7 +60,7 @@ const matchesUserSearchFilter = (user: IamUserListItem, search?: string): boolea
     .some((value) => value.toLowerCase().includes(query));
 };
 
-const listAllPlatformUsers = async (
+export const listAllPlatformUsers = async (
   query: Omit<IdentityUserListQuery, 'first' | 'max'> = {}
 ): Promise<{
   readonly realm: string;
@@ -156,6 +157,37 @@ const resolvePlatformUserRoleNames = async (
   return roleNamesBySubject;
 };
 
+const listPlatformUsersPage = async (input: {
+  readonly provider: {
+    readonly listUsers: (query?: IdentityUserListQuery) => Promise<readonly IdentityListedUser[]>;
+    readonly listUserRoleNames: (externalId: string) => Promise<readonly string[]>;
+    readonly countUsers?: (query?: Omit<IdentityUserListQuery, 'first' | 'max'>) => Promise<number>;
+  };
+  readonly query: Omit<IdentityUserListQuery, 'first' | 'max'>;
+  readonly first: number;
+  readonly max: number;
+  readonly requestId?: string;
+  readonly traceId?: string;
+}): Promise<{ readonly users: readonly IamUserListItem[]; readonly total: number }> => {
+  const [listedUsers, countedUsers] = await Promise.all([
+    trackKeycloakCall('list_platform_users', () =>
+      input.provider.listUsers({ ...input.query, first: input.first, max: input.max })
+    ),
+    countPlatformUsers(input.provider, input.query),
+  ]);
+  const roleNamesBySubject = await resolvePlatformUserRoleNames({
+    users: listedUsers,
+    provider: input.provider,
+    requestId: input.requestId,
+    traceId: input.traceId,
+  });
+  const users = listedUsers
+    .map((user) => mapPlatformUser(user, roleNamesBySubject.get(user.externalId) ?? []))
+    .sort((left, right) => left.displayName.localeCompare(right.displayName, 'de'));
+
+  return { users, total: countedUsers ?? users.length };
+};
+
 export const listPlatformUsers = async (input: {
   readonly page: number;
   readonly pageSize: number;
@@ -181,35 +213,17 @@ export const listPlatformUsers = async (input: {
   const start = Math.max(0, (input.page - 1) * input.pageSize);
 
   if (!input.role) {
-    const [listedUsers, countedUsers] = await Promise.all([
-      trackKeycloakCall('list_platform_users', () =>
-        identityProvider.provider.listUsers({ ...keycloakQuery, first: start, max: input.pageSize })
-      ),
-      countPlatformUsers(identityProvider.provider, keycloakQuery),
-    ]);
-    const roleNamesBySubject = await resolvePlatformUserRoleNames({
-      users: listedUsers,
+    return listPlatformUsersPage({
       provider: identityProvider.provider,
+      query: keycloakQuery,
+      first: start,
+      max: input.pageSize,
       requestId: input.requestId,
       traceId: input.traceId,
     });
-    const projectedUsers = listedUsers
-      .map((user) => mapPlatformUser(user, roleNamesBySubject.get(user.externalId) ?? []))
-      .sort((left, right) => left.displayName.localeCompare(right.displayName, 'de'));
-
-    return {
-      users: projectedUsers,
-      total: countedUsers ?? projectedUsers.length,
-    };
   }
 
-  const roleFilterQuery: Omit<IdentityUserListQuery, 'first' | 'max'> =
-    input.status === 'active'
-      ? { ...keycloakQuery, enabled: true }
-      : input.status === 'inactive'
-        ? { ...keycloakQuery, enabled: false }
-        : keycloakQuery;
-  const { users: listedUsers } = await listAllPlatformUsers(roleFilterQuery);
+  const { users: listedUsers } = await listAllPlatformUsers(keycloakQuery);
   const listedUserBySubject = new Map(listedUsers.map((user) => [user.externalId, user]));
 
   const projectedUsersWithoutRoles = listedUsers
@@ -217,13 +231,8 @@ export const listPlatformUsers = async (input: {
     .filter((user) => matchesUserSearchFilter(user, input.search))
     .sort((left, right) => left.displayName.localeCompare(right.displayName, 'de'));
 
-  const visibleSubjects = new Set(
-    projectedUsersWithoutRoles.slice(start, start + input.pageSize).map((user) => user.keycloakSubject)
-  );
   const searchedSubjects = new Set(projectedUsersWithoutRoles.map((user) => user.keycloakSubject));
-  const roleProjectionCandidates = input.role
-    ? listedUsers.filter((user) => searchedSubjects.has(user.externalId))
-    : listedUsers.filter((user) => visibleSubjects.has(user.externalId));
+  const roleProjectionCandidates = listedUsers.filter((user) => searchedSubjects.has(user.externalId));
   const roleNamesBySubject = await resolvePlatformUserRoleNames({
     users: roleProjectionCandidates,
     provider: identityProvider.provider,
@@ -242,35 +251,5 @@ export const listPlatformUsers = async (input: {
   return {
     users: projectedUsers.slice(start, start + input.pageSize),
     total: projectedUsers.length,
-  };
-};
-
-export const runPlatformKeycloakUserSync = async (input: {
-  readonly requestId?: string;
-  readonly traceId?: string;
-}): Promise<IamUserImportSyncReport> => {
-  const { realm, users } = await listAllPlatformUsers();
-  logger.info('sync_platform_keycloak_users_completed', {
-    operation: 'sync_platform_keycloak_users',
-    scope_kind: 'platform',
-    auth_realm: realm,
-    request_id: input.requestId,
-    trace_id: input.traceId,
-    checked_count: users.length,
-  });
-  return {
-    outcome: 'success',
-    checkedCount: users.length,
-    correctedCount: 0,
-    manualReviewCount: 0,
-    importedCount: 0,
-    updatedCount: 0,
-    skippedCount: 0,
-    totalKeycloakUsers: users.length,
-    diagnostics: {
-      authRealm: realm,
-      providerSource: 'platform',
-      executionMode: 'platform_admin',
-    },
   };
 };

--- a/packages/auth/src/iam-account-management/platform-iam.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.ts
@@ -82,6 +82,19 @@ const listAllPlatformUsers = async (
   }
 };
 
+const countPlatformUsers = async (
+  provider: {
+    readonly countUsers?: (query?: Omit<IdentityUserListQuery, 'first' | 'max'>) => Promise<number>;
+  },
+  query: Omit<IdentityUserListQuery, 'first' | 'max'>
+): Promise<number | null> => {
+  if (!provider.countUsers) {
+    return null;
+  }
+
+  return trackKeycloakCall('count_platform_users', () => provider.countUsers?.(query) ?? Promise.resolve(null));
+};
+
 const mapPlatformUser = (
   user: IdentityListedUser,
   roleNames: readonly string[] = []
@@ -157,13 +170,46 @@ export const listPlatformUsers = async (input: {
     throw new Error('platform_identity_provider_not_configured');
   }
 
-  const keycloakQuery: Omit<IdentityUserListQuery, 'first' | 'max'> =
-    input.status === 'active'
+  const keycloakQuery: Omit<IdentityUserListQuery, 'first' | 'max'> = {
+    ...(input.search ? { search: input.search } : {}),
+    ...(input.status === 'active'
       ? { enabled: true }
       : input.status === 'inactive'
         ? { enabled: false }
-        : {};
-  const { users: listedUsers } = await listAllPlatformUsers(keycloakQuery);
+        : {}),
+  };
+  const start = Math.max(0, (input.page - 1) * input.pageSize);
+
+  if (!input.role) {
+    const [listedUsers, countedUsers] = await Promise.all([
+      trackKeycloakCall('list_platform_users', () =>
+        identityProvider.provider.listUsers({ ...keycloakQuery, first: start, max: input.pageSize })
+      ),
+      countPlatformUsers(identityProvider.provider, keycloakQuery),
+    ]);
+    const roleNamesBySubject = await resolvePlatformUserRoleNames({
+      users: listedUsers,
+      provider: identityProvider.provider,
+      requestId: input.requestId,
+      traceId: input.traceId,
+    });
+    const projectedUsers = listedUsers
+      .map((user) => mapPlatformUser(user, roleNamesBySubject.get(user.externalId) ?? []))
+      .sort((left, right) => left.displayName.localeCompare(right.displayName, 'de'));
+
+    return {
+      users: projectedUsers,
+      total: countedUsers ?? projectedUsers.length,
+    };
+  }
+
+  const roleFilterQuery: Omit<IdentityUserListQuery, 'first' | 'max'> =
+    input.status === 'active'
+      ? { ...keycloakQuery, enabled: true }
+      : input.status === 'inactive'
+        ? { ...keycloakQuery, enabled: false }
+        : keycloakQuery;
+  const { users: listedUsers } = await listAllPlatformUsers(roleFilterQuery);
   const listedUserBySubject = new Map(listedUsers.map((user) => [user.externalId, user]));
 
   const projectedUsersWithoutRoles = listedUsers
@@ -171,7 +217,6 @@ export const listPlatformUsers = async (input: {
     .filter((user) => matchesUserSearchFilter(user, input.search))
     .sort((left, right) => left.displayName.localeCompare(right.displayName, 'de'));
 
-  const start = Math.max(0, (input.page - 1) * input.pageSize);
   const visibleSubjects = new Set(
     projectedUsersWithoutRoles.slice(start, start + input.pageSize).map((user) => user.keycloakSubject)
   );

--- a/packages/auth/src/iam-account-management/platform-iam.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.ts
@@ -1,12 +1,13 @@
 import type { IamRoleListItem, IamUserImportSyncReport, IamUserListItem } from '@sva/core';
 
-import type { IdentityListedUser, IdentityRole } from '../identity-provider-port.js';
+import type { IdentityListedUser, IdentityRole, IdentityUserListQuery } from '../identity-provider-port.js';
 
 import { resolveIdentityProvider } from './shared-runtime.js';
 import { logger, trackKeycloakCall } from './shared-observability.js';
 import type { UserStatus } from './types.js';
 
 const PLATFORM_KEYCLOAK_PAGE_SIZE = 100;
+const PLATFORM_USER_ROLE_PROJECTION_CONCURRENCY = 5;
 const PLATFORM_ROLE_LEVEL_BY_NAME: Readonly<Record<string, number>> = {
   system_admin: 100,
   instance_registry_admin: 90,
@@ -58,6 +59,17 @@ const matchesUserFilters = (
     .some((value) => value.toLowerCase().includes(query));
 };
 
+const matchesUserSearchFilter = (user: IamUserListItem, search?: string): boolean => {
+  if (!search) {
+    return true;
+  }
+
+  const query = search.toLowerCase();
+  return [user.displayName, user.email, user.keycloakSubject]
+    .filter((value): value is string => typeof value === 'string')
+    .some((value) => value.toLowerCase().includes(query));
+};
+
 const isBuiltInRealmRole = (role: IdentityRole): boolean =>
   BUILTIN_REALM_ROLE_NAMES.has(role.externalName) || role.externalName.startsWith('default-roles-');
 
@@ -85,7 +97,9 @@ const mapPlatformRole = (role: IdentityRole): IamRoleListItem => {
   };
 };
 
-const listAllPlatformUsers = async (): Promise<{
+const listAllPlatformUsers = async (
+  query: Omit<IdentityUserListQuery, 'first' | 'max'> = {}
+): Promise<{
   readonly realm: string;
   readonly users: readonly IdentityListedUser[];
 }> => {
@@ -97,13 +111,74 @@ const listAllPlatformUsers = async (): Promise<{
   const users: IdentityListedUser[] = [];
   for (let first = 0; ; first += PLATFORM_KEYCLOAK_PAGE_SIZE) {
     const page = await trackKeycloakCall('list_platform_users', () =>
-      identityProvider.provider.listUsers({ first, max: PLATFORM_KEYCLOAK_PAGE_SIZE })
+      identityProvider.provider.listUsers({ ...query, first, max: PLATFORM_KEYCLOAK_PAGE_SIZE })
     );
     users.push(...page);
     if (page.length < PLATFORM_KEYCLOAK_PAGE_SIZE) {
       return { realm: identityProvider.realm, users };
     }
   }
+};
+
+const mapPlatformUser = (
+  user: IdentityListedUser,
+  roleNames: readonly string[] = []
+): IamUserListItem => ({
+  id: `platform:${user.externalId}`,
+  keycloakSubject: user.externalId,
+  displayName: resolveDisplayName(user),
+  email: user.email,
+  status: mapUserStatus(user),
+  roles: roleNames.map((roleName) => ({
+    roleId: `platform:${roleName}`,
+    roleKey: roleName,
+    roleName,
+    roleLevel: PLATFORM_ROLE_LEVEL_BY_NAME[roleName] ?? 0,
+  })),
+});
+
+const resolvePlatformUserRoleNames = async (
+  input: {
+    readonly users: readonly IdentityListedUser[];
+    readonly provider: {
+      readonly listUserRoleNames: (externalId: string) => Promise<readonly string[]>;
+    };
+    readonly requestId?: string;
+    readonly traceId?: string;
+  }
+): Promise<ReadonlyMap<string, readonly string[]>> => {
+  const roleNamesBySubject = new Map<string, readonly string[]>();
+  const workers = Array.from(
+    { length: Math.min(PLATFORM_USER_ROLE_PROJECTION_CONCURRENCY, input.users.length) },
+    async (_, workerIndex) => {
+      for (let index = workerIndex; index < input.users.length; index += PLATFORM_USER_ROLE_PROJECTION_CONCURRENCY) {
+        const user = input.users[index];
+        if (!user) {
+          continue;
+        }
+        try {
+          roleNamesBySubject.set(
+            user.externalId,
+            await trackKeycloakCall('list_platform_user_roles', () =>
+              input.provider.listUserRoleNames(user.externalId)
+            )
+          );
+        } catch (error) {
+          logger.warn('Platform user role projection degraded', {
+            operation: 'list_platform_users',
+            request_id: input.requestId,
+            trace_id: input.traceId,
+            user_ref: user.externalId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          roleNamesBySubject.set(user.externalId, []);
+        }
+      }
+    }
+  );
+
+  await Promise.all(workers);
+  return roleNamesBySubject;
 };
 
 export const listPlatformUsers = async (input: {
@@ -120,48 +195,43 @@ export const listPlatformUsers = async (input: {
     throw new Error('platform_identity_provider_not_configured');
   }
 
-  const { users: listedUsers } = await listAllPlatformUsers();
-  const roleNamesBySubject = new Map<string, readonly string[]>();
-  await Promise.all(
-    listedUsers.map(async (user) => {
-      try {
-        roleNamesBySubject.set(
-          user.externalId,
-          await trackKeycloakCall('list_platform_user_roles', () =>
-            identityProvider.provider.listUserRoleNames(user.externalId)
-          )
-        );
-      } catch (error) {
-        logger.warn('Platform user role projection degraded', {
-          operation: 'list_platform_users',
-          request_id: input.requestId,
-          trace_id: input.traceId,
-          user_ref: user.externalId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        roleNamesBySubject.set(user.externalId, []);
-      }
-    })
-  );
+  const keycloakQuery: Omit<IdentityUserListQuery, 'first' | 'max'> =
+    input.status === 'active'
+      ? { enabled: true }
+      : input.status === 'inactive'
+        ? { enabled: false }
+        : {};
+  const { users: listedUsers } = await listAllPlatformUsers(keycloakQuery);
+  const listedUserBySubject = new Map(listedUsers.map((user) => [user.externalId, user]));
 
-  const projectedUsers = listedUsers
-    .map<IamUserListItem>((user) => ({
-      id: `platform:${user.externalId}`,
-      keycloakSubject: user.externalId,
-      displayName: resolveDisplayName(user),
-      email: user.email,
-      status: mapUserStatus(user),
-      roles: (roleNamesBySubject.get(user.externalId) ?? []).map((roleName) => ({
-        roleId: `platform:${roleName}`,
-        roleKey: roleName,
-        roleName,
-        roleLevel: PLATFORM_ROLE_LEVEL_BY_NAME[roleName] ?? 0,
-      })),
-    }))
-    .filter((user) => matchesUserFilters(user, input))
+  const projectedUsersWithoutRoles = listedUsers
+    .map((user) => mapPlatformUser(user))
+    .filter((user) => matchesUserSearchFilter(user, input.search))
     .sort((left, right) => left.displayName.localeCompare(right.displayName, 'de'));
 
   const start = Math.max(0, (input.page - 1) * input.pageSize);
+  const visibleSubjects = new Set(
+    projectedUsersWithoutRoles.slice(start, start + input.pageSize).map((user) => user.keycloakSubject)
+  );
+  const searchedSubjects = new Set(projectedUsersWithoutRoles.map((user) => user.keycloakSubject));
+  const roleProjectionCandidates = input.role
+    ? listedUsers.filter((user) => searchedSubjects.has(user.externalId))
+    : listedUsers.filter((user) => visibleSubjects.has(user.externalId));
+  const roleNamesBySubject = await resolvePlatformUserRoleNames({
+    users: roleProjectionCandidates,
+    provider: identityProvider.provider,
+    requestId: input.requestId,
+    traceId: input.traceId,
+  });
+  const projectedUsers = projectedUsersWithoutRoles
+    .map((user) =>
+      mapPlatformUser(
+        listedUserBySubject.get(user.keycloakSubject) ?? { externalId: user.keycloakSubject },
+        roleNamesBySubject.get(user.keycloakSubject) ?? []
+      )
+    )
+    .filter((user) => matchesUserFilters(user, input));
+
   return {
     users: projectedUsers.slice(start, start + input.pageSize),
     total: projectedUsers.length,

--- a/packages/auth/src/iam-account-management/platform-iam.ts
+++ b/packages/auth/src/iam-account-management/platform-iam.ts
@@ -1,27 +1,16 @@
-import type { IamRoleListItem, IamUserImportSyncReport, IamUserListItem } from '@sva/core';
+import type { IamUserImportSyncReport, IamUserListItem } from '@sva/core';
 
-import type { IdentityListedUser, IdentityRole, IdentityUserListQuery } from '../identity-provider-port.js';
+import type { IdentityListedUser, IdentityUserListQuery } from '../identity-provider-port.js';
 
+import { PLATFORM_ROLE_LEVEL_BY_NAME } from './platform-iam-roles.js';
 import { resolveIdentityProvider } from './shared-runtime.js';
 import { logger, trackKeycloakCall } from './shared-observability.js';
 import type { UserStatus } from './types.js';
 
+export { listPlatformRoles, runPlatformRoleReconcile } from './platform-iam-roles.js';
+
 const PLATFORM_KEYCLOAK_PAGE_SIZE = 100;
 const PLATFORM_USER_ROLE_PROJECTION_CONCURRENCY = 5;
-const PLATFORM_ROLE_LEVEL_BY_NAME: Readonly<Record<string, number>> = {
-  system_admin: 100,
-  instance_registry_admin: 90,
-};
-
-const BUILTIN_REALM_ROLE_NAMES = new Set(['offline_access', 'uma_authorization']);
-
-const readRoleAttribute = (
-  attributes: Readonly<Record<string, readonly string[]>> | undefined,
-  key: string
-): string | undefined => {
-  const value = attributes?.[key]?.[0]?.trim();
-  return value && value.length > 0 ? value : undefined;
-};
 
 const resolveDisplayName = (user: IdentityListedUser): string => {
   const fullName = [user.firstName, user.lastName]
@@ -68,33 +57,6 @@ const matchesUserSearchFilter = (user: IamUserListItem, search?: string): boolea
   return [user.displayName, user.email, user.keycloakSubject]
     .filter((value): value is string => typeof value === 'string')
     .some((value) => value.toLowerCase().includes(query));
-};
-
-const isBuiltInRealmRole = (role: IdentityRole): boolean =>
-  BUILTIN_REALM_ROLE_NAMES.has(role.externalName) || role.externalName.startsWith('default-roles-');
-
-const isStudioManagedRole = (role: IdentityRole): boolean =>
-  readRoleAttribute(role.attributes, 'managed_by') === 'studio';
-
-const mapPlatformRole = (role: IdentityRole): IamRoleListItem => {
-  const roleKey = readRoleAttribute(role.attributes, 'role_key') ?? role.externalName;
-  const displayName = readRoleAttribute(role.attributes, 'display_name') ?? role.externalName;
-  const roleLevelRaw = readRoleAttribute(role.attributes, 'role_level');
-  const parsedRoleLevel = roleLevelRaw ? Number(roleLevelRaw) : PLATFORM_ROLE_LEVEL_BY_NAME[role.externalName] ?? 0;
-
-  return {
-    id: role.id ?? `platform:${role.externalName}`,
-    roleKey,
-    roleName: displayName,
-    externalRoleName: role.externalName,
-    managedBy: isStudioManagedRole(role) ? 'studio' : 'external',
-    description: role.description,
-    isSystemRole: role.externalName in PLATFORM_ROLE_LEVEL_BY_NAME,
-    roleLevel: Number.isFinite(parsedRoleLevel) ? parsedRoleLevel : 0,
-    memberCount: 0,
-    syncState: 'synced',
-    permissions: [],
-  };
 };
 
 const listAllPlatformUsers = async (
@@ -238,19 +200,6 @@ export const listPlatformUsers = async (input: {
   };
 };
 
-export const listPlatformRoles = async (): Promise<readonly IamRoleListItem[]> => {
-  const identityProvider = resolveIdentityProvider();
-  if (!identityProvider) {
-    throw new Error('platform_identity_provider_not_configured');
-  }
-
-  const roles = await trackKeycloakCall('list_platform_roles', () => identityProvider.provider.listRoles());
-  return roles
-    .filter((role) => !isBuiltInRealmRole(role))
-    .map(mapPlatformRole)
-    .sort((left, right) => right.roleLevel - left.roleLevel || left.roleName.localeCompare(right.roleName, 'de'));
-};
-
 export const runPlatformKeycloakUserSync = async (input: {
   readonly requestId?: string;
   readonly traceId?: string;
@@ -278,34 +227,5 @@ export const runPlatformKeycloakUserSync = async (input: {
       providerSource: 'platform',
       executionMode: 'platform_admin',
     },
-  };
-};
-
-export const runPlatformRoleReconcile = async (): Promise<{
-  outcome: 'success';
-  checkedCount: number;
-  correctedCount: 0;
-  failedCount: 0;
-  manualReviewCount: 0;
-  requiresManualActionCount: 0;
-  roles: readonly {
-    externalRoleName: string;
-    action: 'noop';
-    status: 'synced';
-  }[];
-}> => {
-  const roles = await listPlatformRoles();
-  return {
-    outcome: 'success',
-    checkedCount: roles.length,
-    correctedCount: 0,
-    failedCount: 0,
-    manualReviewCount: 0,
-    requiresManualActionCount: 0,
-    roles: roles.map((role) => ({
-      externalRoleName: role.externalRoleName,
-      action: 'noop',
-      status: 'synced',
-    })),
   };
 };

--- a/packages/auth/src/iam-account-management/reconcile-handler.internal.test.ts
+++ b/packages/auth/src/iam-account-management/reconcile-handler.internal.test.ts
@@ -29,6 +29,12 @@ const state = vi.hoisted(() => ({
 }));
 
 vi.mock('@sva/sdk/server', () => ({
+  createSdkLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
   getWorkspaceContext: () => ({ requestId: 'req-reconcile' }),
 }));
 
@@ -59,6 +65,10 @@ vi.mock('./feature-flags.js', () => ({
 
 vi.mock('./rate-limit.js', () => ({
   consumeRateLimit: vi.fn(() => null),
+}));
+
+vi.mock('./platform-iam-handlers.js', () => ({
+  reconcilePlatformRolesInternal: vi.fn(),
 }));
 
 vi.mock('./shared.js', () => ({
@@ -118,6 +128,7 @@ import { runRoleCatalogReconciliation } from './reconcile-core';
 const ctx = {
   user: {
     id: 'kc-1',
+    instanceId: 'de-musterhausen',
     roles: ['system_admin'],
   },
 } as never;

--- a/packages/auth/src/iam-account-management/reconcile-handler.internal.test.ts
+++ b/packages/auth/src/iam-account-management/reconcile-handler.internal.test.ts
@@ -277,4 +277,24 @@ describe('iam-account-management/reconcile-handler internals', () => {
       requestId: 'req-reconcile',
     });
   });
+
+  it('delegates platform reconciliation without tenant actor resolution', async () => {
+    const { reconcilePlatformRolesInternal } = await import('./platform-iam-handlers.js');
+    const { resolveActorInfo } = await import('./shared.js');
+    const platformResponse = new Response(JSON.stringify({ data: { outcome: 'success' } }), { status: 200 });
+    vi.mocked(reconcilePlatformRolesInternal).mockResolvedValueOnce(platformResponse);
+    const platformCtx = {
+      user: {
+        id: 'kc-platform-admin',
+        roles: ['system_admin'],
+      },
+    } as never;
+    const request = new Request('http://localhost/api/v1/iam/admin/reconcile', { method: 'POST' });
+
+    const response = await reconcilePlaceholderInternal(request, platformCtx);
+
+    expect(response).toBe(platformResponse);
+    expect(reconcilePlatformRolesInternal).toHaveBeenCalledWith(request, platformCtx, 'req-reconcile', undefined);
+    expect(resolveActorInfo).not.toHaveBeenCalled();
+  });
 });

--- a/packages/auth/src/iam-account-management/reconcile-handler.ts
+++ b/packages/auth/src/iam-account-management/reconcile-handler.ts
@@ -7,7 +7,7 @@ import { SYSTEM_ADMIN_ROLES } from './constants.js';
 import { asApiItem, createApiError } from './api-helpers.js';
 import { ensureFeature, getFeatureFlags } from './feature-flags.js';
 import { consumeRateLimit } from './rate-limit.js';
-import { runPlatformRoleReconcile } from './platform-iam.js';
+import { reconcilePlatformRolesInternal } from './platform-iam-handlers.js';
 import { runRoleCatalogReconciliation } from './reconcile-core.js';
 import { logger, requireRoles, resolveActorInfo } from './shared.js';
 import { validateCsrf } from './csrf.js';
@@ -27,42 +27,7 @@ export const reconcilePlaceholderInternal = async (
     return roleCheck;
   }
   if (!ctx.user.instanceId) {
-    const csrfError = validateCsrf(request, requestContext.requestId);
-    if (csrfError) {
-      return csrfError;
-    }
-    const rateLimit = consumeRateLimit({
-      instanceId: 'platform',
-      actorKeycloakSubject: ctx.user.id,
-      scope: 'write',
-      requestId: requestContext.requestId,
-    });
-    if (rateLimit) {
-      return rateLimit;
-    }
-    try {
-      const report = await runPlatformRoleReconcile();
-      return jsonResponse(200, asApiItem(report, requestContext.requestId));
-    } catch (error) {
-      logger.error('Platform role reconciliation failed', {
-        operation: 'reconcile_platform_roles',
-        scope_kind: 'platform',
-        request_id: requestContext.requestId,
-        trace_id: requestContext.traceId,
-        error: sanitizeRoleErrorMessage(error),
-      });
-      return createApiError(
-        503,
-        'keycloak_unavailable',
-        'Plattform-Rollen konnten nicht aus Keycloak abgeglichen werden.',
-        requestContext.requestId,
-        {
-          syncState: 'failed',
-          syncError: { code: mapRoleSyncErrorCode(error) },
-          scope_kind: 'platform',
-        }
-      );
-    }
+    return reconcilePlatformRolesInternal(request, ctx, requestContext.requestId, requestContext.traceId);
   }
   const actorResolution = await resolveActorInfo(request, ctx, { requireActorMembership: true });
   if ('error' in actorResolution) {

--- a/packages/auth/src/iam-account-management/reconcile-handler.ts
+++ b/packages/auth/src/iam-account-management/reconcile-handler.ts
@@ -7,6 +7,7 @@ import { SYSTEM_ADMIN_ROLES } from './constants.js';
 import { asApiItem, createApiError } from './api-helpers.js';
 import { ensureFeature, getFeatureFlags } from './feature-flags.js';
 import { consumeRateLimit } from './rate-limit.js';
+import { runPlatformRoleReconcile } from './platform-iam.js';
 import { runRoleCatalogReconciliation } from './reconcile-core.js';
 import { logger, requireRoles, resolveActorInfo } from './shared.js';
 import { validateCsrf } from './csrf.js';
@@ -24,6 +25,44 @@ export const reconcilePlaceholderInternal = async (
   const roleCheck = requireRoles(ctx, SYSTEM_ADMIN_ROLES, requestContext.requestId);
   if (roleCheck) {
     return roleCheck;
+  }
+  if (!ctx.user.instanceId) {
+    const csrfError = validateCsrf(request, requestContext.requestId);
+    if (csrfError) {
+      return csrfError;
+    }
+    const rateLimit = consumeRateLimit({
+      instanceId: 'platform',
+      actorKeycloakSubject: ctx.user.id,
+      scope: 'write',
+      requestId: requestContext.requestId,
+    });
+    if (rateLimit) {
+      return rateLimit;
+    }
+    try {
+      const report = await runPlatformRoleReconcile();
+      return jsonResponse(200, asApiItem(report, requestContext.requestId));
+    } catch (error) {
+      logger.error('Platform role reconciliation failed', {
+        operation: 'reconcile_platform_roles',
+        scope_kind: 'platform',
+        request_id: requestContext.requestId,
+        trace_id: requestContext.traceId,
+        error: sanitizeRoleErrorMessage(error),
+      });
+      return createApiError(
+        503,
+        'keycloak_unavailable',
+        'Plattform-Rollen konnten nicht aus Keycloak abgeglichen werden.',
+        requestContext.requestId,
+        {
+          syncState: 'failed',
+          syncError: { code: mapRoleSyncErrorCode(error) },
+          scope_kind: 'platform',
+        }
+      );
+    }
   }
   const actorResolution = await resolveActorInfo(request, ctx, { requireActorMembership: true });
   if ('error' in actorResolution) {

--- a/packages/auth/src/iam-account-management/role-audit.ts
+++ b/packages/auth/src/iam-account-management/role-audit.ts
@@ -113,6 +113,18 @@ export const mapRoleListItem = (row: {
   managedBy: row.managed_by,
   description: row.description ?? undefined,
   isSystemRole: row.is_system_role,
+  editability:
+    row.is_system_role || row.managed_by !== 'studio'
+      ? 'read_only'
+      : 'editable',
+  diagnostics:
+    row.is_system_role
+      ? [{ code: 'system_role', objectId: row.id, objectType: 'role' }]
+      : row.managed_by === 'keycloak_builtin'
+        ? [{ code: 'built_in_role', objectId: row.id, objectType: 'role' }]
+        : row.managed_by === 'external'
+          ? [{ code: 'external_managed', objectId: row.id, objectType: 'role' }]
+          : undefined,
   roleLevel: row.role_level,
   memberCount: row.member_count,
   syncState: row.sync_state,

--- a/packages/auth/src/iam-account-management/roles-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/roles-handlers.test.ts
@@ -96,6 +96,10 @@ vi.mock('./rate-limit.js', () => ({
   consumeRateLimit: vi.fn(() => null),
 }));
 
+vi.mock('./platform-iam-handlers.js', () => ({
+  listPlatformRolesInternal: vi.fn(),
+}));
+
 vi.mock('./shared-actor-resolution.js', () => ({
   requireRoles: vi.fn(() => null),
   resolveActorInfo: vi.fn(async () => state.actorResolution),
@@ -139,6 +143,7 @@ import { createRoleInternal, listPermissionsInternal, listRolesInternal, updateR
 const ctx = {
   user: {
     id: 'kc-1',
+    instanceId: 'de-musterhausen',
     roles: ['system_admin'],
   },
 } as never;

--- a/packages/auth/src/iam-account-management/roles-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/roles-handlers.test.ts
@@ -351,6 +351,25 @@ describe('iam-account-management/roles-handlers internals', () => {
     expect(response.status).toBe(429);
   });
 
+  it('delegates role listing to the platform admin client without tenant actor resolution', async () => {
+    const { listPlatformRolesInternal } = await import('./platform-iam-handlers.js');
+    const { resolveActorInfo } = await import('./shared-actor-resolution.js');
+    const platformResponse = new Response(JSON.stringify({ data: [] }), { status: 200 });
+    vi.mocked(listPlatformRolesInternal).mockResolvedValueOnce(platformResponse);
+
+    const response = await listRolesInternal(new Request('http://localhost/api/v1/iam/roles'), {
+      user: { id: 'kc-platform-admin', roles: ['system_admin'] },
+    } as never);
+
+    expect(response).toBe(platformResponse);
+    expect(listPlatformRolesInternal).toHaveBeenCalledWith(
+      { user: { id: 'kc-platform-admin', roles: ['system_admin'] } },
+      'req-roles',
+      undefined
+    );
+    expect(resolveActorInfo).not.toHaveBeenCalled();
+  });
+
   it('lists permissions and keeps page size at least one for empty result sets', async () => {
     const { withInstanceScopedDb } = await import('./shared-runtime.js');
     const { asApiList } = await import('./api-helpers.js');

--- a/packages/auth/src/iam-account-management/roles-handlers.ts
+++ b/packages/auth/src/iam-account-management/roles-handlers.ts
@@ -8,6 +8,7 @@ import { ADMIN_ROLES } from './constants.js';
 import { asApiList, createApiError } from './api-helpers.js';
 import { classifyIamDiagnosticError } from './diagnostics.js';
 import { ensureFeature, getFeatureFlags } from './feature-flags.js';
+import { listPlatformRoles } from './platform-iam.js';
 import { consumeRateLimit } from './rate-limit.js';
 import { loadRoleListItems } from './role-query.js';
 import { requireRoles, resolveActorInfo } from './shared-actor-resolution.js';
@@ -56,6 +57,36 @@ export const listRolesInternal = async (
   const roleCheck = requireRoles(ctx, ADMIN_ROLES, requestContext.requestId);
   if (roleCheck) {
     return roleCheck;
+  }
+  if (!ctx.user.instanceId) {
+    const rateLimit = consumeRateLimit({
+      instanceId: 'platform',
+      actorKeycloakSubject: ctx.user.id,
+      scope: 'read',
+      requestId: requestContext.requestId,
+    });
+    if (rateLimit) {
+      return rateLimit;
+    }
+    try {
+      const roles = await listPlatformRoles();
+      return jsonResponse(
+        200,
+        asApiList(roles, { page: 1, pageSize: Math.max(1, roles.length), total: roles.length }, requestContext.requestId)
+      );
+    } catch {
+      return createApiError(
+        503,
+        'keycloak_unavailable',
+        'Plattform-Rollen konnten nicht aus Keycloak geladen werden.',
+        requestContext.requestId,
+        {
+          dependency: 'keycloak',
+          reason_code: 'platform_keycloak_unavailable',
+          scope_kind: 'platform',
+        }
+      );
+    }
   }
   const actorResolution = await resolveActorInfo(request, ctx, { requireActorMembership: true });
   if ('error' in actorResolution) {

--- a/packages/auth/src/iam-account-management/roles-handlers.ts
+++ b/packages/auth/src/iam-account-management/roles-handlers.ts
@@ -8,7 +8,7 @@ import { ADMIN_ROLES } from './constants.js';
 import { asApiList, createApiError } from './api-helpers.js';
 import { classifyIamDiagnosticError } from './diagnostics.js';
 import { ensureFeature, getFeatureFlags } from './feature-flags.js';
-import { listPlatformRoles } from './platform-iam.js';
+import { listPlatformRolesInternal } from './platform-iam-handlers.js';
 import { consumeRateLimit } from './rate-limit.js';
 import { loadRoleListItems } from './role-query.js';
 import { requireRoles, resolveActorInfo } from './shared-actor-resolution.js';
@@ -59,34 +59,7 @@ export const listRolesInternal = async (
     return roleCheck;
   }
   if (!ctx.user.instanceId) {
-    const rateLimit = consumeRateLimit({
-      instanceId: 'platform',
-      actorKeycloakSubject: ctx.user.id,
-      scope: 'read',
-      requestId: requestContext.requestId,
-    });
-    if (rateLimit) {
-      return rateLimit;
-    }
-    try {
-      const roles = await listPlatformRoles();
-      return jsonResponse(
-        200,
-        asApiList(roles, { page: 1, pageSize: Math.max(1, roles.length), total: roles.length }, requestContext.requestId)
-      );
-    } catch {
-      return createApiError(
-        503,
-        'keycloak_unavailable',
-        'Plattform-Rollen konnten nicht aus Keycloak geladen werden.',
-        requestContext.requestId,
-        {
-          dependency: 'keycloak',
-          reason_code: 'platform_keycloak_unavailable',
-          scope_kind: 'platform',
-        }
-      );
-    }
+    return listPlatformRolesInternal(ctx, requestContext.requestId);
   }
   const actorResolution = await resolveActorInfo(request, ctx, { requireActorMembership: true });
   if ('error' in actorResolution) {

--- a/packages/auth/src/iam-account-management/roles-handlers.ts
+++ b/packages/auth/src/iam-account-management/roles-handlers.ts
@@ -59,7 +59,7 @@ export const listRolesInternal = async (
     return roleCheck;
   }
   if (!ctx.user.instanceId) {
-    return listPlatformRolesInternal(ctx, requestContext.requestId);
+    return listPlatformRolesInternal(ctx, requestContext.requestId, requestContext.traceId);
   }
   const actorResolution = await resolveActorInfo(request, ctx, { requireActorMembership: true });
   if ('error' in actorResolution) {

--- a/packages/auth/src/iam-account-management/tenant-keycloak-user-projection.ts
+++ b/packages/auth/src/iam-account-management/tenant-keycloak-user-projection.ts
@@ -1,0 +1,79 @@
+import type { IamKeycloakObjectDiagnostic, IamUserListItem } from '@sva/core';
+
+import type { IdentityListedUser } from '../identity-provider-port.js';
+
+import type { UserStatus } from './types.js';
+
+const readSingleAttribute = (
+  attributes: Readonly<Record<string, readonly string[]>> | undefined,
+  key: string
+): string | undefined => {
+  const value = attributes?.[key]?.[0]?.trim();
+  return value && value.length > 0 ? value : undefined;
+};
+
+const resolveDisplayName = (user: IdentityListedUser): string => {
+  const explicitDisplayName = readSingleAttribute(user.attributes, 'displayName');
+  if (explicitDisplayName) {
+    return explicitDisplayName;
+  }
+
+  const fullName = [user.firstName, user.lastName]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .trim();
+
+  return fullName || user.username || user.email || user.externalId;
+};
+
+const mapKeycloakUserStatus = (user: IdentityListedUser): UserStatus => (user.enabled === false ? 'inactive' : 'active');
+
+export const mapUnmappedKeycloakUser = (
+  user: IdentityListedUser,
+  roleNames: readonly string[] | null,
+  instanceId: string
+): IamUserListItem => {
+  const configuredInstanceIds = user.attributes?.instanceId ?? [];
+  const missingInstanceAttribute = configuredInstanceIds.length === 0;
+  const wrongInstanceAttribute = configuredInstanceIds.length > 0 && !configuredInstanceIds.includes(instanceId);
+  const diagnostics: IamKeycloakObjectDiagnostic[] = [];
+  if (missingInstanceAttribute) {
+    diagnostics.push({ code: 'missing_instance_attribute', objectId: user.externalId, objectType: 'user' });
+  } else if (wrongInstanceAttribute) {
+    diagnostics.push({ code: 'mapping_incomplete', objectId: user.externalId, objectType: 'user' });
+  } else {
+    diagnostics.push({ code: 'mapping_missing', objectId: user.externalId, objectType: 'user' });
+  }
+  if (roleNames === null) {
+    diagnostics.push({ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' });
+  }
+
+  return {
+    id: `keycloak:${user.externalId}`,
+    keycloakSubject: user.externalId,
+    displayName: resolveDisplayName(user),
+    email: user.email,
+    status: mapKeycloakUserStatus(user),
+    mappingStatus: missingInstanceAttribute || wrongInstanceAttribute ? 'manual_review' : 'unmapped',
+    editability: 'blocked',
+    diagnostics,
+    roles: [],
+  };
+};
+
+export const mergeMappedUserWithKeycloak = (
+  mapped: IamUserListItem,
+  user: IdentityListedUser,
+  roleNames: readonly string[] | null
+): IamUserListItem => ({
+  ...mapped,
+  displayName: mapped.displayName || resolveDisplayName(user),
+  email: mapped.email ?? user.email,
+  status: mapKeycloakUserStatus(user),
+  mappingStatus: roleNames === null ? 'manual_review' : 'mapped',
+  editability: roleNames === null ? 'blocked' : 'editable',
+  diagnostics:
+    roleNames === null
+      ? [{ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' }]
+      : mapped.diagnostics,
+});

--- a/packages/auth/src/iam-account-management/tenant-keycloak-user-query.ts
+++ b/packages/auth/src/iam-account-management/tenant-keycloak-user-query.ts
@@ -1,0 +1,107 @@
+import type { IamUserListItem } from '@sva/core';
+
+import type { QueryClient } from '../shared/db-helpers.js';
+
+import { mapUserRowToListItem } from './user-mapping.js';
+import type { IamRoleRow, UserStatus } from './types.js';
+
+type AccountProjectionRow = {
+  id: string;
+  keycloak_subject: string;
+  display_name_ciphertext: string | null;
+  first_name_ciphertext: string | null;
+  last_name_ciphertext: string | null;
+  email_ciphertext: string | null;
+  position: string | null;
+  department: string | null;
+  status: UserStatus;
+  last_login_at: string | null;
+  role_rows: Array<{
+    id: string;
+    role_key: string;
+    role_name: string;
+    display_name: string | null;
+    external_role_name: string | null;
+    role_level: number;
+    is_system_role: boolean;
+  }> | null;
+};
+
+const mapRoleRows = (roleRows: AccountProjectionRow['role_rows']): readonly IamRoleRow[] =>
+  roleRows?.map((entry) => ({
+    id: entry.id,
+    role_key: entry.role_key,
+    role_name: entry.role_name,
+    display_name: entry.display_name,
+    external_role_name: entry.external_role_name,
+    role_level: Number(entry.role_level),
+    is_system_role: Boolean(entry.is_system_role),
+  })) ?? [];
+
+export const loadMappedUsersBySubject = async (
+  client: QueryClient,
+  input: { instanceId: string; subjects: readonly string[] }
+): Promise<ReadonlyMap<string, IamUserListItem>> => {
+  if (input.subjects.length === 0) {
+    return new Map();
+  }
+
+  const result = await client.query<AccountProjectionRow>(
+    `
+SELECT
+  a.id,
+  a.keycloak_subject,
+  a.display_name_ciphertext,
+  a.first_name_ciphertext,
+  a.last_name_ciphertext,
+  a.email_ciphertext,
+  a.position,
+  a.department,
+  a.status,
+  MAX(al.created_at)::text AS last_login_at,
+  COALESCE(
+    json_agg(
+      DISTINCT jsonb_build_object(
+        'id', r.id,
+        'role_key', r.role_key,
+        'role_name', r.role_name,
+        'display_name', r.display_name,
+        'external_role_name', r.external_role_name,
+        'role_level', r.role_level,
+        'is_system_role', r.is_system_role
+      )
+    ) FILTER (WHERE r.id IS NOT NULL),
+    '[]'::json
+  ) AS role_rows
+FROM iam.accounts a
+JOIN iam.instance_memberships im
+  ON im.account_id = a.id
+ AND im.instance_id = $1
+LEFT JOIN iam.account_roles ar
+  ON ar.instance_id = im.instance_id
+ AND ar.account_id = im.account_id
+ AND ar.valid_from <= NOW()
+ AND (ar.valid_to IS NULL OR ar.valid_to > NOW())
+LEFT JOIN iam.roles r
+  ON r.instance_id = ar.instance_id
+ AND r.id = ar.role_id
+LEFT JOIN iam.activity_logs al
+  ON al.instance_id = im.instance_id
+ AND al.account_id = a.id
+ AND al.event_type = 'login'
+WHERE a.keycloak_subject = ANY($2::text[])
+GROUP BY a.id;
+`,
+    [input.instanceId, input.subjects]
+  );
+
+  return new Map(
+    result.rows.map((row) => [
+      row.keycloak_subject,
+      mapUserRowToListItem({
+        ...row,
+        roles: mapRoleRows(row.role_rows),
+      }),
+    ])
+  );
+};

--- a/packages/auth/src/iam-account-management/tenant-keycloak-users.test.ts
+++ b/packages/auth/src/iam-account-management/tenant-keycloak-users.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  provider: {
+    listUsers: vi.fn(),
+    countUsers: vi.fn(),
+    listUserRoleNames: vi.fn(),
+  },
+}));
+
+vi.mock('./shared-runtime.js', () => ({
+  resolveIdentityProviderForInstance: vi.fn(async () => ({
+    provider: state.provider,
+  })),
+}));
+
+vi.mock('./shared-observability.js', () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+  trackKeycloakCall: vi.fn(async (_operation: string, execute: () => Promise<unknown>) => execute()),
+}));
+
+vi.mock('./tenant-keycloak-user-query.js', () => ({
+  loadMappedUsersBySubject: vi.fn(async () => new Map()),
+}));
+
+import { resolveTenantKeycloakUsersWithPagination } from './tenant-keycloak-users';
+
+describe('tenant Keycloak user listing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.provider.listUsers.mockResolvedValue([
+      {
+        externalId: 'kc-user-1',
+        username: 'alice',
+        enabled: true,
+      },
+    ]);
+    state.provider.countUsers.mockResolvedValue(1);
+    state.provider.listUserRoleNames.mockResolvedValue([]);
+  });
+
+  it('returns an empty page for pending status without querying Keycloak users', async () => {
+    await expect(
+      resolveTenantKeycloakUsersWithPagination({
+        client: {} as never,
+        instanceId: 'de-musterhausen',
+        page: 1,
+        pageSize: 25,
+        status: 'pending',
+      })
+    ).resolves.toEqual({
+      users: [],
+      total: 0,
+      keycloakRoleNamesBySubject: new Map(),
+    });
+
+    expect(state.provider.listUsers).not.toHaveBeenCalled();
+    expect(state.provider.countUsers).not.toHaveBeenCalled();
+    expect(state.provider.listUserRoleNames).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-Keycloak role projection failures', async () => {
+    state.provider.listUserRoleNames.mockRejectedValueOnce(new TypeError('projection bug'));
+
+    await expect(
+      resolveTenantKeycloakUsersWithPagination({
+        client: {} as never,
+        instanceId: 'de-musterhausen',
+        page: 1,
+        pageSize: 25,
+      })
+    ).rejects.toThrow('projection bug');
+  });
+});

--- a/packages/auth/src/iam-account-management/tenant-keycloak-users.ts
+++ b/packages/auth/src/iam-account-management/tenant-keycloak-users.ts
@@ -1,37 +1,16 @@
-import type { IamKeycloakObjectDiagnostic, IamUserListItem } from '@sva/core';
+import type { IamUserListItem } from '@sva/core';
 
 import type { IdentityListedUser, IdentityProviderPort, IdentityUserListQuery } from '../identity-provider-port.js';
 import type { QueryClient } from '../shared/db-helpers.js';
 
-import { mapUserRowToListItem } from './user-mapping.js';
 import { resolveIdentityProviderForInstance } from './shared-runtime.js';
 import { logger, trackKeycloakCall } from './shared-observability.js';
-import type { IamRoleRow, UserStatus } from './types.js';
+import { loadMappedUsersBySubject } from './tenant-keycloak-user-query.js';
+import { mapUnmappedKeycloakUser, mergeMappedUserWithKeycloak } from './tenant-keycloak-user-projection.js';
+import type { UserStatus } from './types.js';
 
 const TENANT_KEYCLOAK_PAGE_SIZE = 100;
 const TENANT_USER_ROLE_PROJECTION_CONCURRENCY = 5;
-
-type AccountProjectionRow = {
-  id: string;
-  keycloak_subject: string;
-  display_name_ciphertext: string | null;
-  first_name_ciphertext: string | null;
-  last_name_ciphertext: string | null;
-  email_ciphertext: string | null;
-  position: string | null;
-  department: string | null;
-  status: UserStatus;
-  last_login_at: string | null;
-  role_rows: Array<{
-    id: string;
-    role_key: string;
-    role_name: string;
-    display_name: string | null;
-    external_role_name: string | null;
-    role_level: number;
-    is_system_role: boolean;
-  }> | null;
-};
 
 type TenantKeycloakUsersInput = {
   readonly client: QueryClient;
@@ -45,30 +24,6 @@ type TenantKeycloakUsersInput = {
   readonly traceId?: string;
 };
 
-const readSingleAttribute = (
-  attributes: Readonly<Record<string, readonly string[]>> | undefined,
-  key: string
-): string | undefined => {
-  const value = attributes?.[key]?.[0]?.trim();
-  return value && value.length > 0 ? value : undefined;
-};
-
-const resolveDisplayName = (user: IdentityListedUser): string => {
-  const explicitDisplayName = readSingleAttribute(user.attributes, 'displayName');
-  if (explicitDisplayName) {
-    return explicitDisplayName;
-  }
-
-  const fullName = [user.firstName, user.lastName]
-    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-    .join(' ')
-    .trim();
-
-  return fullName || user.username || user.email || user.externalId;
-};
-
-const mapKeycloakUserStatus = (user: IdentityListedUser): UserStatus => (user.enabled === false ? 'inactive' : 'active');
-
 const toKeycloakQuery = (
   input: Pick<TenantKeycloakUsersInput, 'search' | 'status'>
 ): Omit<IdentityUserListQuery, 'first' | 'max'> => ({
@@ -79,85 +34,6 @@ const toKeycloakQuery = (
       ? { enabled: false }
       : {}),
 });
-
-const mapRoleRows = (roleRows: AccountProjectionRow['role_rows']): readonly IamRoleRow[] =>
-  roleRows?.map((entry) => ({
-    id: entry.id,
-    role_key: entry.role_key,
-    role_name: entry.role_name,
-    display_name: entry.display_name,
-    external_role_name: entry.external_role_name,
-    role_level: Number(entry.role_level),
-    is_system_role: Boolean(entry.is_system_role),
-  })) ?? [];
-
-const loadMappedUsersBySubject = async (
-  client: QueryClient,
-  input: { instanceId: string; subjects: readonly string[] }
-): Promise<ReadonlyMap<string, IamUserListItem>> => {
-  if (input.subjects.length === 0) {
-    return new Map();
-  }
-
-  const result = await client.query<AccountProjectionRow>(
-    `
-SELECT
-  a.id,
-  a.keycloak_subject,
-  a.display_name_ciphertext,
-  a.first_name_ciphertext,
-  a.last_name_ciphertext,
-  a.email_ciphertext,
-  a.position,
-  a.department,
-  a.status,
-  MAX(al.created_at)::text AS last_login_at,
-  COALESCE(
-    json_agg(
-      DISTINCT jsonb_build_object(
-        'id', r.id,
-        'role_key', r.role_key,
-        'role_name', r.role_name,
-        'display_name', r.display_name,
-        'external_role_name', r.external_role_name,
-        'role_level', r.role_level,
-        'is_system_role', r.is_system_role
-      )
-    ) FILTER (WHERE r.id IS NOT NULL),
-    '[]'::json
-  ) AS role_rows
-FROM iam.accounts a
-JOIN iam.instance_memberships im
-  ON im.account_id = a.id
- AND im.instance_id = $1
-LEFT JOIN iam.account_roles ar
-  ON ar.instance_id = im.instance_id
- AND ar.account_id = im.account_id
- AND ar.valid_from <= NOW()
- AND (ar.valid_to IS NULL OR ar.valid_to > NOW())
-LEFT JOIN iam.roles r
-  ON r.instance_id = ar.instance_id
- AND r.id = ar.role_id
-LEFT JOIN iam.activity_logs al
-  ON al.instance_id = im.instance_id
- AND al.account_id = a.id
- AND al.event_type = 'login'
-WHERE a.keycloak_subject = ANY($2::text[])
-GROUP BY a.id;
-`,
-    [input.instanceId, input.subjects]
-  );
-
-  return new Map(
-    result.rows.map((row) => [
-      row.keycloak_subject,
-      mapUserRowToListItem({
-        ...row,
-        roles: mapRoleRows(row.role_rows),
-      }),
-    ])
-  );
-};
 
 const resolveRoleNamesForUsers = async (input: {
   readonly provider: IdentityProviderPort;
@@ -213,56 +89,6 @@ const listAllTenantUsers = async (
     }
   }
 };
-
-const mapUnmappedKeycloakUser = (
-  user: IdentityListedUser,
-  roleNames: readonly string[] | null,
-  instanceId: string
-): IamUserListItem => {
-  const configuredInstanceIds = user.attributes?.instanceId ?? [];
-  const missingInstanceAttribute = configuredInstanceIds.length === 0;
-  const wrongInstanceAttribute = configuredInstanceIds.length > 0 && !configuredInstanceIds.includes(instanceId);
-  const diagnostics: IamKeycloakObjectDiagnostic[] = [];
-  if (missingInstanceAttribute) {
-    diagnostics.push({ code: 'missing_instance_attribute', objectId: user.externalId, objectType: 'user' });
-  } else if (wrongInstanceAttribute) {
-    diagnostics.push({ code: 'mapping_incomplete', objectId: user.externalId, objectType: 'user' });
-  } else {
-    diagnostics.push({ code: 'mapping_missing', objectId: user.externalId, objectType: 'user' });
-  }
-  if (roleNames === null) {
-    diagnostics.push({ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' });
-  }
-
-  return {
-    id: `keycloak:${user.externalId}`,
-    keycloakSubject: user.externalId,
-    displayName: resolveDisplayName(user),
-    email: user.email,
-    status: mapKeycloakUserStatus(user),
-    mappingStatus: missingInstanceAttribute || wrongInstanceAttribute ? 'manual_review' : 'unmapped',
-    editability: 'blocked',
-    diagnostics,
-    roles: [],
-  };
-};
-
-const mergeMappedUserWithKeycloak = (
-  mapped: IamUserListItem,
-  user: IdentityListedUser,
-  roleNames: readonly string[] | null
-): IamUserListItem => ({
-  ...mapped,
-  displayName: mapped.displayName || resolveDisplayName(user),
-  email: mapped.email ?? user.email,
-  status: mapKeycloakUserStatus(user),
-  mappingStatus: roleNames === null ? 'manual_review' : 'mapped',
-  editability: roleNames === null ? 'blocked' : 'editable',
-  diagnostics:
-    roleNames === null
-      ? [{ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' }]
-      : mapped.diagnostics,
-});
 
 export const resolveTenantKeycloakUsersWithPagination = async (
   input: TenantKeycloakUsersInput

--- a/packages/auth/src/iam-account-management/tenant-keycloak-users.ts
+++ b/packages/auth/src/iam-account-management/tenant-keycloak-users.ts
@@ -1,0 +1,312 @@
+import type { IamKeycloakObjectDiagnostic, IamUserListItem } from '@sva/core';
+
+import type { IdentityListedUser, IdentityProviderPort, IdentityUserListQuery } from '../identity-provider-port.js';
+import type { QueryClient } from '../shared/db-helpers.js';
+
+import { mapUserRowToListItem } from './user-mapping.js';
+import { resolveIdentityProviderForInstance } from './shared-runtime.js';
+import { logger, trackKeycloakCall } from './shared-observability.js';
+import type { IamRoleRow, UserStatus } from './types.js';
+
+const TENANT_KEYCLOAK_PAGE_SIZE = 100;
+const TENANT_USER_ROLE_PROJECTION_CONCURRENCY = 5;
+
+type AccountProjectionRow = {
+  id: string;
+  keycloak_subject: string;
+  display_name_ciphertext: string | null;
+  first_name_ciphertext: string | null;
+  last_name_ciphertext: string | null;
+  email_ciphertext: string | null;
+  position: string | null;
+  department: string | null;
+  status: UserStatus;
+  last_login_at: string | null;
+  role_rows: Array<{
+    id: string;
+    role_key: string;
+    role_name: string;
+    display_name: string | null;
+    external_role_name: string | null;
+    role_level: number;
+    is_system_role: boolean;
+  }> | null;
+};
+
+type TenantKeycloakUsersInput = {
+  readonly client: QueryClient;
+  readonly instanceId: string;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly status?: UserStatus;
+  readonly role?: string;
+  readonly search?: string;
+  readonly requestId?: string;
+  readonly traceId?: string;
+};
+
+const readSingleAttribute = (
+  attributes: Readonly<Record<string, readonly string[]>> | undefined,
+  key: string
+): string | undefined => {
+  const value = attributes?.[key]?.[0]?.trim();
+  return value && value.length > 0 ? value : undefined;
+};
+
+const resolveDisplayName = (user: IdentityListedUser): string => {
+  const explicitDisplayName = readSingleAttribute(user.attributes, 'displayName');
+  if (explicitDisplayName) {
+    return explicitDisplayName;
+  }
+
+  const fullName = [user.firstName, user.lastName]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .trim();
+
+  return fullName || user.username || user.email || user.externalId;
+};
+
+const mapKeycloakUserStatus = (user: IdentityListedUser): UserStatus => (user.enabled === false ? 'inactive' : 'active');
+
+const toKeycloakQuery = (
+  input: Pick<TenantKeycloakUsersInput, 'search' | 'status'>
+): Omit<IdentityUserListQuery, 'first' | 'max'> => ({
+  ...(input.search ? { search: input.search } : {}),
+  ...(input.status === 'active'
+    ? { enabled: true }
+    : input.status === 'inactive'
+      ? { enabled: false }
+      : {}),
+});
+
+const mapRoleRows = (roleRows: AccountProjectionRow['role_rows']): readonly IamRoleRow[] =>
+  roleRows?.map((entry) => ({
+    id: entry.id,
+    role_key: entry.role_key,
+    role_name: entry.role_name,
+    display_name: entry.display_name,
+    external_role_name: entry.external_role_name,
+    role_level: Number(entry.role_level),
+    is_system_role: Boolean(entry.is_system_role),
+  })) ?? [];
+
+const loadMappedUsersBySubject = async (
+  client: QueryClient,
+  input: { instanceId: string; subjects: readonly string[] }
+): Promise<ReadonlyMap<string, IamUserListItem>> => {
+  if (input.subjects.length === 0) {
+    return new Map();
+  }
+
+  const result = await client.query<AccountProjectionRow>(
+    `
+SELECT
+  a.id,
+  a.keycloak_subject,
+  a.display_name_ciphertext,
+  a.first_name_ciphertext,
+  a.last_name_ciphertext,
+  a.email_ciphertext,
+  a.position,
+  a.department,
+  a.status,
+  MAX(al.created_at)::text AS last_login_at,
+  COALESCE(
+    json_agg(
+      DISTINCT jsonb_build_object(
+        'id', r.id,
+        'role_key', r.role_key,
+        'role_name', r.role_name,
+        'display_name', r.display_name,
+        'external_role_name', r.external_role_name,
+        'role_level', r.role_level,
+        'is_system_role', r.is_system_role
+      )
+    ) FILTER (WHERE r.id IS NOT NULL),
+    '[]'::json
+  ) AS role_rows
+FROM iam.accounts a
+JOIN iam.instance_memberships im
+  ON im.account_id = a.id
+ AND im.instance_id = $1
+LEFT JOIN iam.account_roles ar
+  ON ar.instance_id = im.instance_id
+ AND ar.account_id = im.account_id
+ AND ar.valid_from <= NOW()
+ AND (ar.valid_to IS NULL OR ar.valid_to > NOW())
+LEFT JOIN iam.roles r
+  ON r.instance_id = ar.instance_id
+ AND r.id = ar.role_id
+LEFT JOIN iam.activity_logs al
+  ON al.instance_id = im.instance_id
+ AND al.account_id = a.id
+ AND al.event_type = 'login'
+WHERE a.keycloak_subject = ANY($2::text[])
+GROUP BY a.id;
+`,
+    [input.instanceId, input.subjects]
+  );
+
+  return new Map(
+    result.rows.map((row) => [
+      row.keycloak_subject,
+      mapUserRowToListItem({
+        ...row,
+        roles: mapRoleRows(row.role_rows),
+      }),
+    ])
+  );
+};
+
+const resolveRoleNamesForUsers = async (input: {
+  readonly provider: IdentityProviderPort;
+  readonly users: readonly IdentityListedUser[];
+  readonly instanceId: string;
+  readonly requestId?: string;
+  readonly traceId?: string;
+}): Promise<ReadonlyMap<string, readonly string[] | null>> => {
+  const roleNamesBySubject = new Map<string, readonly string[] | null>();
+  const workers = Array.from(
+    { length: Math.min(TENANT_USER_ROLE_PROJECTION_CONCURRENCY, input.users.length) },
+    async (_, workerIndex) => {
+      for (let index = workerIndex; index < input.users.length; index += TENANT_USER_ROLE_PROJECTION_CONCURRENCY) {
+        const user = input.users[index];
+        if (!user) {
+          continue;
+        }
+        try {
+          roleNamesBySubject.set(
+            user.externalId,
+            await trackKeycloakCall('list_tenant_user_roles', () => input.provider.listUserRoleNames(user.externalId))
+          );
+        } catch (error) {
+          logger.warn('Tenant user role projection degraded', {
+            operation: 'list_tenant_keycloak_users',
+            instance_id: input.instanceId,
+            request_id: input.requestId,
+            trace_id: input.traceId,
+            user_ref: user.externalId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          roleNamesBySubject.set(user.externalId, null);
+        }
+      }
+    }
+  );
+  await Promise.all(workers);
+  return roleNamesBySubject;
+};
+
+const listAllTenantUsers = async (
+  provider: IdentityProviderPort,
+  query: Omit<IdentityUserListQuery, 'first' | 'max'>
+): Promise<readonly IdentityListedUser[]> => {
+  const users: IdentityListedUser[] = [];
+  for (let first = 0; ; first += TENANT_KEYCLOAK_PAGE_SIZE) {
+    const page = await trackKeycloakCall('list_tenant_users', () =>
+      provider.listUsers({ ...query, first, max: TENANT_KEYCLOAK_PAGE_SIZE })
+    );
+    users.push(...page);
+    if (page.length < TENANT_KEYCLOAK_PAGE_SIZE) {
+      return users;
+    }
+  }
+};
+
+const mapUnmappedKeycloakUser = (
+  user: IdentityListedUser,
+  roleNames: readonly string[] | null,
+  instanceId: string
+): IamUserListItem => {
+  const configuredInstanceIds = user.attributes?.instanceId ?? [];
+  const missingInstanceAttribute = configuredInstanceIds.length === 0;
+  const wrongInstanceAttribute = configuredInstanceIds.length > 0 && !configuredInstanceIds.includes(instanceId);
+  const diagnostics: IamKeycloakObjectDiagnostic[] = [];
+  if (missingInstanceAttribute) {
+    diagnostics.push({ code: 'missing_instance_attribute', objectId: user.externalId, objectType: 'user' });
+  } else if (wrongInstanceAttribute) {
+    diagnostics.push({ code: 'mapping_incomplete', objectId: user.externalId, objectType: 'user' });
+  } else {
+    diagnostics.push({ code: 'mapping_missing', objectId: user.externalId, objectType: 'user' });
+  }
+  if (roleNames === null) {
+    diagnostics.push({ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' });
+  }
+
+  return {
+    id: `keycloak:${user.externalId}`,
+    keycloakSubject: user.externalId,
+    displayName: resolveDisplayName(user),
+    email: user.email,
+    status: mapKeycloakUserStatus(user),
+    mappingStatus: missingInstanceAttribute || wrongInstanceAttribute ? 'manual_review' : 'unmapped',
+    editability: 'blocked',
+    diagnostics,
+    roles: [],
+  };
+};
+
+const mergeMappedUserWithKeycloak = (
+  mapped: IamUserListItem,
+  user: IdentityListedUser,
+  roleNames: readonly string[] | null
+): IamUserListItem => ({
+  ...mapped,
+  displayName: mapped.displayName || resolveDisplayName(user),
+  email: mapped.email ?? user.email,
+  status: mapKeycloakUserStatus(user),
+  mappingStatus: roleNames === null ? 'manual_review' : 'mapped',
+  editability: roleNames === null ? 'blocked' : 'editable',
+  diagnostics:
+    roleNames === null
+      ? [{ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' }]
+      : mapped.diagnostics,
+});
+
+export const resolveTenantKeycloakUsersWithPagination = async (
+  input: TenantKeycloakUsersInput
+): Promise<{ readonly users: readonly IamUserListItem[]; readonly total: number }> => {
+  const identityProvider = await resolveIdentityProviderForInstance(input.instanceId, { executionMode: 'tenant_admin' });
+  if (!identityProvider) {
+    throw new Error('tenant_admin_client_not_configured');
+  }
+
+  const query = toKeycloakQuery(input);
+  const first = Math.max(0, (input.page - 1) * input.pageSize);
+
+  const listedUsers = input.role
+    ? await listAllTenantUsers(identityProvider.provider, query)
+    : await trackKeycloakCall('list_tenant_users', () =>
+        identityProvider.provider.listUsers({ ...query, first, max: input.pageSize })
+      );
+  const roleNamesBySubject = await resolveRoleNamesForUsers({
+    provider: identityProvider.provider,
+    users: listedUsers,
+    instanceId: input.instanceId,
+    requestId: input.requestId,
+    traceId: input.traceId,
+  });
+  const roleFilteredUsers = input.role
+    ? listedUsers.filter((user) => roleNamesBySubject.get(user.externalId)?.includes(input.role as string))
+    : listedUsers;
+  const visibleUsers = input.role ? roleFilteredUsers.slice(first, first + input.pageSize) : roleFilteredUsers;
+  const mappedUsersBySubject = await loadMappedUsersBySubject(input.client, {
+    instanceId: input.instanceId,
+    subjects: visibleUsers.map((user) => user.externalId),
+  });
+
+  const users = visibleUsers.map((user) => {
+    const roleNames = roleNamesBySubject.get(user.externalId) ?? null;
+    const mapped = mappedUsersBySubject.get(user.externalId);
+    return mapped
+      ? mergeMappedUserWithKeycloak(mapped, user, roleNames)
+      : mapUnmappedKeycloakUser(user, roleNames, input.instanceId);
+  });
+
+  const total = input.role
+    ? roleFilteredUsers.length
+    : (await identityProvider.provider.countUsers?.(query)) ?? users.length;
+
+  return { users, total };
+};

--- a/packages/auth/src/iam-account-management/tenant-keycloak-users.ts
+++ b/packages/auth/src/iam-account-management/tenant-keycloak-users.ts
@@ -1,6 +1,10 @@
 import type { IamUserListItem } from '@sva/core';
 
 import type { IdentityListedUser, IdentityProviderPort, IdentityUserListQuery } from '../identity-provider-port.js';
+import {
+  KeycloakAdminRequestError,
+  KeycloakAdminUnavailableError,
+} from '../keycloak-admin-client.js';
 import type { QueryClient } from '../shared/db-helpers.js';
 
 import { resolveIdentityProviderForInstance } from './shared-runtime.js';
@@ -11,6 +15,12 @@ import type { UserStatus } from './types.js';
 
 const TENANT_KEYCLOAK_PAGE_SIZE = 100;
 const TENANT_USER_ROLE_PROJECTION_CONCURRENCY = 5;
+
+type TenantKeycloakUsersResult = {
+  readonly users: readonly IamUserListItem[];
+  readonly total: number;
+  readonly keycloakRoleNamesBySubject: ReadonlyMap<string, readonly string[] | null>;
+};
 
 type TenantKeycloakUsersInput = {
   readonly client: QueryClient;
@@ -57,6 +67,9 @@ const resolveRoleNamesForUsers = async (input: {
             await trackKeycloakCall('list_tenant_user_roles', () => input.provider.listUserRoleNames(user.externalId))
           );
         } catch (error) {
+          if (!(error instanceof KeycloakAdminRequestError) && !(error instanceof KeycloakAdminUnavailableError)) {
+            throw error;
+          }
           logger.warn('Tenant user role projection degraded', {
             operation: 'list_tenant_keycloak_users',
             instance_id: input.instanceId,
@@ -92,10 +105,13 @@ const listAllTenantUsers = async (
 
 export const resolveTenantKeycloakUsersWithPagination = async (
   input: TenantKeycloakUsersInput
-): Promise<{ readonly users: readonly IamUserListItem[]; readonly total: number }> => {
+): Promise<TenantKeycloakUsersResult> => {
   const identityProvider = await resolveIdentityProviderForInstance(input.instanceId, { executionMode: 'tenant_admin' });
   if (!identityProvider) {
     throw new Error('tenant_admin_client_not_configured');
+  }
+  if (input.status === 'pending') {
+    return { users: [], total: 0, keycloakRoleNamesBySubject: new Map() };
   }
 
   const query = toKeycloakQuery(input);
@@ -134,5 +150,9 @@ export const resolveTenantKeycloakUsersWithPagination = async (
     ? roleFilteredUsers.length
     : (await identityProvider.provider.countUsers?.(query)) ?? users.length;
 
-  return { users, total };
+  const visibleRoleNamesBySubject = new Map(
+    users.map((user) => [user.keycloakSubject, roleNamesBySubject.get(user.keycloakSubject) ?? null] as const)
+  );
+
+  return { users, total, keycloakRoleNamesBySubject: visibleRoleNamesBySubject };
 };

--- a/packages/auth/src/iam-account-management/types.ts
+++ b/packages/auth/src/iam-account-management/types.ts
@@ -43,7 +43,7 @@ export type IamRoleRow = {
   valid_to?: string | null;
 };
 
-export type ManagedBy = 'studio' | 'external';
+export type ManagedBy = 'studio' | 'external' | 'keycloak_builtin';
 
 export type RoleSyncErrorCode =
   | 'IDP_UNAVAILABLE'

--- a/packages/auth/src/iam-account-management/user-import-sync-handler.test.ts
+++ b/packages/auth/src/iam-account-management/user-import-sync-handler.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sva/sdk/server', () => ({
+  createSdkLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+  getWorkspaceContext: () => ({ requestId: 'req-platform-sync', traceId: 'trace-platform-sync' }),
+}));
+
+vi.mock('../shared/db-helpers.js', () => ({
+  jsonResponse: (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } }),
+}));
+
+vi.mock('./api-helpers.js', () => ({
+  asApiItem: (data: unknown, requestId?: string) => ({ data, ...(requestId ? { requestId } : {}) }),
+  createApiError: (
+    status: number,
+    code: string,
+    message: string,
+    requestId?: string,
+    details?: Record<string, unknown>
+  ) =>
+    new Response(
+      JSON.stringify({
+        error: { code, message, ...(details ? { details } : {}) },
+        ...(requestId ? { requestId } : {}),
+      }),
+      { status, headers: { 'content-type': 'application/json' } }
+    ),
+}));
+
+vi.mock('./csrf.js', () => ({
+  validateCsrf: vi.fn(() => null),
+}));
+
+vi.mock('./feature-flags.js', () => ({
+  ensureFeature: vi.fn(() => null),
+  getFeatureFlags: vi.fn(() => ({})),
+}));
+
+vi.mock('./platform-iam.js', () => ({
+  runPlatformKeycloakUserSync: vi.fn(async () => {
+    throw new Error('platform_identity_provider_not_configured');
+  }),
+}));
+
+vi.mock('./rate-limit.js', () => ({
+  consumeRateLimit: vi.fn(() => null),
+}));
+
+vi.mock('./shared.js', () => ({
+  emitActivityLog: vi.fn(),
+  iamUserOperationsCounter: { add: vi.fn() },
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  requireRoles: vi.fn(() => null),
+  resolveActorInfo: vi.fn(),
+  resolveIdentityProviderForInstance: vi.fn(),
+  trackKeycloakCall: vi.fn(async (_operation: string, execute: () => Promise<unknown>) => execute()),
+  withInstanceScopedDb: vi.fn(),
+}));
+
+import { syncUsersFromKeycloakInternal } from './user-import-sync-handler';
+
+describe('user import sync handler', () => {
+  it('maps missing platform admin identity provider to a setup diagnostic', async () => {
+    const response = await syncUsersFromKeycloakInternal(
+      new Request('http://localhost/api/v1/iam/users/sync-keycloak', { method: 'POST' }),
+      {
+        user: {
+          id: 'keycloak-platform-admin',
+          roles: ['system_admin'],
+        },
+      } as never
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'keycloak_unavailable',
+        message: 'Plattform-IAM ist nicht konfiguriert.',
+        details: {
+          dependency: 'keycloak',
+          reason_code: 'platform_identity_provider_not_configured',
+          scope_kind: 'platform',
+        },
+      },
+      requestId: 'req-platform-sync',
+    });
+    expect(response.status).toBe(503);
+  });
+});

--- a/packages/auth/src/iam-account-management/user-import-sync-handler.ts
+++ b/packages/auth/src/iam-account-management/user-import-sync-handler.ts
@@ -13,7 +13,7 @@ import { jsonResponse } from '../shared/db-helpers.js';
 import { buildLogContext } from '../shared/log-context.js';
 import { IamSchemaDriftError } from '../runtime-errors.js';
 
-import { ADMIN_ROLES } from './constants.js';
+import { ADMIN_ROLES, PLATFORM_RATE_LIMIT_INSTANCE_ID } from './constants.js';
 import { asApiItem, createApiError } from './api-helpers.js';
 import { validateCsrf } from './csrf.js';
 import { protectField } from './encryption.js';
@@ -770,7 +770,7 @@ export const syncUsersFromKeycloakInternal = async (
       return csrfError;
     }
     const rateLimit = consumeRateLimit({
-      instanceId: 'platform',
+      instanceId: PLATFORM_RATE_LIMIT_INSTANCE_ID,
       actorKeycloakSubject: ctx.user.id,
       scope: 'write',
       requestId: requestContext.requestId,

--- a/packages/auth/src/iam-account-management/user-import-sync-handler.ts
+++ b/packages/auth/src/iam-account-management/user-import-sync-handler.ts
@@ -18,6 +18,7 @@ import { asApiItem, createApiError } from './api-helpers.js';
 import { validateCsrf } from './csrf.js';
 import { protectField } from './encryption.js';
 import { ensureFeature, getFeatureFlags } from './feature-flags.js';
+import { runPlatformKeycloakUserSync } from './platform-iam.js';
 import { consumeRateLimit } from './rate-limit.js';
 import type { ActorInfo } from './types.js';
 import {
@@ -754,6 +755,59 @@ export const syncUsersFromKeycloakInternal = async (
   request: Request,
   ctx: AuthenticatedRequestContext
 ): Promise<Response> => {
+  if (!ctx.user.instanceId) {
+    const requestContext = getWorkspaceContext();
+    const featureCheck = ensureFeature(getFeatureFlags(), 'iam_admin', requestContext.requestId);
+    if (featureCheck) {
+      return featureCheck;
+    }
+    const roleCheck = requireRoles(ctx, ADMIN_ROLES, requestContext.requestId);
+    if (roleCheck) {
+      return roleCheck;
+    }
+    const csrfError = validateCsrf(request, requestContext.requestId);
+    if (csrfError) {
+      return csrfError;
+    }
+    const rateLimit = consumeRateLimit({
+      instanceId: 'platform',
+      actorKeycloakSubject: ctx.user.id,
+      scope: 'write',
+      requestId: requestContext.requestId,
+    });
+    if (rateLimit) {
+      return rateLimit;
+    }
+    try {
+      const report = await runPlatformKeycloakUserSync({
+        requestId: requestContext.requestId,
+        traceId: requestContext.traceId,
+      });
+      iamUserOperationsCounter.add(1, { action: 'sync_platform_keycloak_users', result: 'success' });
+      return jsonResponse(200, asApiItem(report, requestContext.requestId));
+    } catch (error) {
+      logger.error('Platform keycloak user sync failed', {
+        operation: 'sync_platform_keycloak_users',
+        scope_kind: 'platform',
+        request_id: requestContext.requestId,
+        trace_id: requestContext.traceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      iamUserOperationsCounter.add(1, { action: 'sync_platform_keycloak_users', result: 'failure' });
+      return createApiError(
+        503,
+        'keycloak_unavailable',
+        'Plattform-Benutzer konnten nicht aus Keycloak synchronisiert werden.',
+        requestContext.requestId,
+        {
+          dependency: 'keycloak',
+          reason_code: 'platform_keycloak_unavailable',
+          scope_kind: 'platform',
+        }
+      );
+    }
+  }
+
   const actorResolution = await resolveSyncActor(request, ctx);
   if ('error' in actorResolution) {
     return actorResolution.error;

--- a/packages/auth/src/iam-account-management/user-import-sync-handler.ts
+++ b/packages/auth/src/iam-account-management/user-import-sync-handler.ts
@@ -37,6 +37,9 @@ const KEYCLOAK_PAGE_SIZE = 100;
 const SKIPPED_USER_DEBUG_LOG_CAP = 20;
 const SKIPPED_USER_INSTANCE_SAMPLE_CAP = 5;
 
+const isPlatformIdentityProviderConfigurationError = (error: unknown): boolean =>
+  error instanceof Error && error.message === 'platform_identity_provider_not_configured';
+
 const readSingleAttribute = (
   attributes: Readonly<Record<string, readonly string[]>> | undefined,
   key: string
@@ -794,6 +797,19 @@ export const syncUsersFromKeycloakInternal = async (
         error: error instanceof Error ? error.message : String(error),
       });
       iamUserOperationsCounter.add(1, { action: 'sync_platform_keycloak_users', result: 'failure' });
+      if (isPlatformIdentityProviderConfigurationError(error)) {
+        return createApiError(
+          503,
+          'keycloak_unavailable',
+          'Plattform-IAM ist nicht konfiguriert.',
+          requestContext.requestId,
+          {
+            dependency: 'keycloak',
+            reason_code: 'platform_identity_provider_not_configured',
+            scope_kind: 'platform',
+          }
+        );
+      }
       return createApiError(
         503,
         'keycloak_unavailable',

--- a/packages/auth/src/iam-account-management/user-mapping.ts
+++ b/packages/auth/src/iam-account-management/user-mapping.ts
@@ -77,6 +77,8 @@ export const mapUserRowToListItem = (row: {
     displayName,
     email,
     status: row.status,
+    mappingStatus: 'mapped',
+    editability: 'editable',
     position: row.position ?? undefined,
     department: row.department ?? undefined,
     lastLoginAt: row.last_login_at ?? undefined,

--- a/packages/auth/src/iam-account-management/user-read-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.test.ts
@@ -127,6 +127,10 @@ vi.mock('./rate-limit.js', () => ({
   consumeRateLimit: vi.fn(() => state.rateLimitResult),
 }));
 
+vi.mock('./platform-iam-handlers.js', () => ({
+  listPlatformUsersInternal: vi.fn(),
+}));
+
 vi.mock('./types.js', () => ({
   USER_STATUS: ['active', 'inactive', 'pending'],
 }));
@@ -150,7 +154,7 @@ describe('user-read-handlers', () => {
       const { listUsersInternal } = await import('./user-read-handlers');
 
       const request = new Request('http://localhost/users?page=0&pageSize=10');
-      const ctx = { user: { id: 'actor-1' } } as any;
+      const ctx = { user: { id: 'actor-1', instanceId: 'test-instance' } } as any;
 
       const response = await listUsersInternal(request, ctx);
 
@@ -164,7 +168,7 @@ describe('user-read-handlers', () => {
       const { listUsersInternal } = await import('./user-read-handlers');
 
       const request = new Request('http://localhost/users?status=active');
-      const ctx = { user: { id: 'actor-1' } } as any;
+      const ctx = { user: { id: 'actor-1', instanceId: 'test-instance' } } as any;
 
       const response = await listUsersInternal(request, ctx);
 
@@ -175,7 +179,7 @@ describe('user-read-handlers', () => {
       const { listUsersInternal } = await import('./user-read-handlers');
 
       const request = new Request('http://localhost/users?status=invalid_status');
-      const ctx = { user: { id: 'actor-1' } } as any;
+      const ctx = { user: { id: 'actor-1', instanceId: 'test-instance' } } as any;
 
       const response = await listUsersInternal(request, ctx);
 
@@ -192,7 +196,7 @@ describe('user-read-handlers', () => {
       const { listUsersInternal } = await import('./user-read-handlers');
 
       const request = new Request('http://localhost/users');
-      const ctx = { user: { id: 'actor-1' } } as any;
+      const ctx = { user: { id: 'actor-1', instanceId: 'test-instance' } } as any;
 
       const response = await listUsersInternal(request, ctx);
 
@@ -205,7 +209,7 @@ describe('user-read-handlers', () => {
       const { getUserInternal } = await import('./user-read-handlers');
 
       const request = new Request('http://localhost/users/user-1');
-      const ctx = { user: { id: 'actor-1' } } as any;
+      const ctx = { user: { id: 'actor-1', instanceId: 'test-instance' } } as any;
 
       const response = await getUserInternal(request, ctx);
 
@@ -220,7 +224,7 @@ describe('user-read-handlers', () => {
       const { getUserInternal } = await import('./user-read-handlers');
 
       const request = new Request('http://localhost/users/nonexistent');
-      const ctx = { user: { id: 'actor-1' } } as any;
+      const ctx = { user: { id: 'actor-1', instanceId: 'test-instance' } } as any;
 
       const response = await getUserInternal(request, ctx);
 
@@ -245,7 +249,7 @@ describe('user-read-handlers', () => {
       const { getUserInternal } = await import('./user-read-handlers');
 
       const request = new Request('http://localhost/users/user-1');
-      const ctx = { user: { id: 'actor-1' } } as any;
+      const ctx = { user: { id: 'actor-1', instanceId: 'test-instance' } } as any;
 
       const response = await getUserInternal(request, ctx);
 

--- a/packages/auth/src/iam-account-management/user-read-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.test.ts
@@ -18,6 +18,10 @@ const state = vi.hoisted(() => ({
       { id: 'user-2', username: 'bob', email: 'bob@example.com' },
     ],
     total: 2,
+    keycloakRoleNamesBySubject: new Map<string, readonly string[] | null>([
+      ['kc-user-1', ['admin']],
+      ['kc-user-2', null],
+    ]),
   },
   userDetailResult: {
     id: 'user-1',
@@ -166,6 +170,12 @@ describe('user-read-handlers', () => {
       const data = await response.json();
       expect(data.data.items).toHaveLength(2);
       expect(data.data.items[0].roles).toEqual(['admin', 'user']);
+      const { applyCanonicalUserListProjection } = await import('./user-projection.js');
+      expect(applyCanonicalUserListProjection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keycloakRoleNamesBySubject: state.usersListResult.keycloakRoleNamesBySubject,
+        })
+      );
     });
 
     it('respects status filter parameter', async () => {

--- a/packages/auth/src/iam-account-management/user-read-handlers.test.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.test.ts
@@ -104,6 +104,10 @@ vi.mock('./user-list-query.js', () => ({
   resolveUsersWithPagination: vi.fn(async () => state.usersListResult),
 }));
 
+vi.mock('./tenant-keycloak-users.js', () => ({
+  resolveTenantKeycloakUsersWithPagination: vi.fn(async () => state.usersListResult),
+}));
+
 vi.mock('./user-projection.js', () => ({
   resolveKeycloakRoleNames: vi.fn(async () => state.keycloakRolesResult),
   resolveProjectedMainserverCredentialState: vi.fn(async () => state.mainserverCredentialResult),

--- a/packages/auth/src/iam-account-management/user-read-handlers.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.ts
@@ -1,10 +1,14 @@
 import type { IamUserDetail, IamUserListItem } from '@sva/core';
+import { getWorkspaceContext } from '@sva/sdk/server';
 
 import type { AuthenticatedRequestContext } from '../middleware.server.js';
 import { jsonResponse } from '../shared/db-helpers.js';
 import { readString } from '../shared/input-readers.js';
 
 import { asApiItem, asApiList, createApiError, readPage } from './api-helpers.js';
+import { ADMIN_ROLES } from './constants.js';
+import { ensureFeature, getFeatureFlags } from './feature-flags.js';
+import { listPlatformUsers } from './platform-iam.js';
 import { consumeRateLimit } from './rate-limit.js';
 import {
   createDatabaseApiError,
@@ -14,6 +18,7 @@ import {
 } from './user-read-shared.js';
 import {
   logger,
+  requireRoles,
   withInstanceScopedDb,
 } from './shared.js';
 import type { UserStatus } from './types.js';
@@ -81,6 +86,70 @@ export const listUsersInternal = async (
   request: Request,
   ctx: AuthenticatedRequestContext
 ): Promise<Response> => {
+  const { page, pageSize } = readPage(request);
+  const url = new URL(request.url);
+  const status = readString(url.searchParams.get('status')) as UserStatus | undefined;
+  const role = readString(url.searchParams.get('role'));
+  const search = readString(url.searchParams.get('search'));
+
+  if (!ctx.user.instanceId) {
+    const requestContext = getWorkspaceContext();
+    const featureCheck = ensureFeature(getFeatureFlags(), 'iam_admin', requestContext.requestId);
+    if (featureCheck) {
+      return featureCheck;
+    }
+    const roleCheck = requireRoles(ctx, ADMIN_ROLES, requestContext.requestId);
+    if (roleCheck) {
+      return roleCheck;
+    }
+    const rateLimit = consumeRateLimit({
+      instanceId: 'platform',
+      actorKeycloakSubject: ctx.user.id,
+      scope: 'read',
+      requestId: requestContext.requestId,
+    });
+    if (rateLimit) {
+      return rateLimit;
+    }
+    if (status && !USER_STATUS.includes(status)) {
+      return createApiError(400, 'invalid_request', 'Ungültiger Status-Filter.', requestContext.requestId);
+    }
+    try {
+      const resolved = await listPlatformUsers({
+        page,
+        pageSize,
+        status,
+        role: role ?? undefined,
+        search: search ?? undefined,
+        requestId: requestContext.requestId,
+        traceId: requestContext.traceId,
+      });
+      return jsonResponse(
+        200,
+        asApiList(resolved.users, { page, pageSize, total: resolved.total }, requestContext.requestId)
+      );
+    } catch (error) {
+      logger.error('Platform user list failed', {
+        operation: 'list_platform_users',
+        scope_kind: 'platform',
+        request_id: requestContext.requestId,
+        trace_id: requestContext.traceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return createApiError(
+        503,
+        'keycloak_unavailable',
+        'Plattform-Benutzer konnten nicht aus Keycloak geladen werden.',
+        requestContext.requestId,
+        {
+          dependency: 'keycloak',
+          reason_code: 'platform_keycloak_unavailable',
+          scope_kind: 'platform',
+        }
+      );
+    }
+  }
+
   const access = await resolveUserReadAccess(request, ctx);
   if (access.response) {
     return access.response;
@@ -94,11 +163,6 @@ export const listUsersInternal = async (
   if (rateLimit) {
     return rateLimit;
   }
-  const { page, pageSize } = readPage(request);
-  const url = new URL(request.url);
-  const status = readString(url.searchParams.get('status')) as UserStatus | undefined;
-  const role = readString(url.searchParams.get('role'));
-  const search = readString(url.searchParams.get('search'));
 
   if (status && !USER_STATUS.includes(status)) {
     return createApiError(400, 'invalid_request', 'Ungültiger Status-Filter.', access.actor.requestId);

--- a/packages/auth/src/iam-account-management/user-read-handlers.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.ts
@@ -80,15 +80,15 @@ export const listUsersInternal = async (
   request: Request,
   ctx: AuthenticatedRequestContext
 ): Promise<Response> => {
+  if (!ctx.user.instanceId) {
+    return listPlatformUsersInternal(request, ctx);
+  }
+
   const { page, pageSize } = readPage(request);
   const url = new URL(request.url);
   const status = readString(url.searchParams.get('status')) as UserStatus | undefined;
   const role = readString(url.searchParams.get('role'));
   const search = readString(url.searchParams.get('search'));
-
-  if (!ctx.user.instanceId) {
-    return listPlatformUsersInternal(request, ctx);
-  }
 
   const access = await resolveUserReadAccess(request, ctx);
   if (access.response) {

--- a/packages/auth/src/iam-account-management/user-read-handlers.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.ts
@@ -62,6 +62,7 @@ const listTenantUsersWithCanonicalProjection = async (input: {
       client,
       instanceId: input.instanceId,
       users: resolved.users,
+      keycloakRoleNamesBySubject: resolved.keycloakRoleNamesBySubject,
     })
   );
 

--- a/packages/auth/src/iam-account-management/user-read-handlers.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.ts
@@ -27,6 +27,47 @@ import {
 } from './user-projection.js';
 import { resolveUserTimeline } from './user-timeline-query.js';
 
+const createTenantAdminClientNotConfiguredResponse = (actor: {
+  readonly instanceId: string;
+  readonly requestId?: string;
+}): Response =>
+  createApiError(
+    409,
+    'tenant_admin_client_not_configured',
+    'Tenant-lokale Keycloak-Administration ist nicht konfiguriert.',
+    actor.requestId,
+    {
+      dependency: 'keycloak',
+      execution_mode: 'tenant_admin',
+      instance_id: actor.instanceId,
+      reason_code: 'tenant_admin_client_not_configured',
+    }
+  );
+
+const listTenantUsersWithCanonicalProjection = async (input: {
+  readonly instanceId: string;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly status?: UserStatus;
+  readonly role?: string;
+  readonly search?: string;
+  readonly requestId?: string;
+  readonly traceId?: string;
+}) => {
+  const resolved = await withInstanceScopedDb(input.instanceId, (client) =>
+    resolveTenantKeycloakUsersWithPagination({ client, ...input })
+  );
+  const users = await withInstanceScopedDb(input.instanceId, (client) =>
+    applyCanonicalUserListProjection({
+      client,
+      instanceId: input.instanceId,
+      users: resolved.users,
+    })
+  );
+
+  return { users, total: resolved.total };
+};
+
 export const listUsersInternal = async (
   request: Request,
   ctx: AuthenticatedRequestContext
@@ -60,30 +101,20 @@ export const listUsersInternal = async (
   }
 
   try {
-    const resolved = await withInstanceScopedDb(access.actor.instanceId, (client) =>
-      resolveTenantKeycloakUsersWithPagination({
-        client,
-        instanceId: access.actor.instanceId,
-        page,
-        pageSize,
-        status,
-        role: role ?? undefined,
-        search: search ?? undefined,
-        requestId: access.actor.requestId,
-        traceId: access.actor.traceId,
-      })
-    );
-    const users = await withInstanceScopedDb(access.actor.instanceId, (client) =>
-      applyCanonicalUserListProjection({
-        client,
-        instanceId: access.actor.instanceId,
-        users: resolved.users,
-      })
-    );
+    const resolved = await listTenantUsersWithCanonicalProjection({
+      instanceId: access.actor.instanceId,
+      page,
+      pageSize,
+      status,
+      role: role ?? undefined,
+      search: search ?? undefined,
+      requestId: access.actor.requestId,
+      traceId: access.actor.traceId,
+    });
 
     return jsonResponse(
       200,
-      asApiList(users, { page, pageSize, total: resolved.total }, access.actor.requestId)
+      asApiList(resolved.users, { page, pageSize, total: resolved.total }, access.actor.requestId)
     );
   } catch (error) {
     logger.error('IAM user list failed', {
@@ -94,18 +125,7 @@ export const listUsersInternal = async (
       error: error instanceof Error ? error.message : String(error),
     });
     if (error instanceof Error && error.message === 'tenant_admin_client_not_configured') {
-      return createApiError(
-        409,
-        'tenant_admin_client_not_configured',
-        'Tenant-lokale Keycloak-Administration ist nicht konfiguriert.',
-        access.actor.requestId,
-        {
-          dependency: 'keycloak',
-          execution_mode: 'tenant_admin',
-          instance_id: access.actor.instanceId,
-          reason_code: 'tenant_admin_client_not_configured',
-        }
-      );
+      return createTenantAdminClientNotConfiguredResponse(access.actor);
     }
     return createDatabaseApiError(error, access.actor.requestId);
   }

--- a/packages/auth/src/iam-account-management/user-read-handlers.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.ts
@@ -1,4 +1,4 @@
-import type { IamUserDetail, IamUserListItem } from '@sva/core';
+import type { IamUserDetail } from '@sva/core';
 import type { AuthenticatedRequestContext } from '../middleware.server.js';
 import { jsonResponse } from '../shared/db-helpers.js';
 import { readString } from '../shared/input-readers.js';
@@ -6,6 +6,7 @@ import { readString } from '../shared/input-readers.js';
 import { asApiItem, asApiList, createApiError, readPage } from './api-helpers.js';
 import { listPlatformUsersInternal } from './platform-iam-handlers.js';
 import { consumeRateLimit } from './rate-limit.js';
+import { resolveTenantKeycloakUsersWithPagination } from './tenant-keycloak-users.js';
 import {
   createDatabaseApiError,
   logUserProjectionDegraded,
@@ -18,63 +19,13 @@ import {
 } from './shared.js';
 import { USER_STATUS, type UserStatus } from './types.js';
 import { resolveUserDetail } from './user-detail-query.js';
-import { resolveUsersWithPagination } from './user-list-query.js';
 import {
   applyCanonicalUserDetailProjection,
   applyCanonicalUserListProjection,
-  isRecoverableUserProjectionError,
   resolveKeycloakRoleNames,
   resolveProjectedMainserverCredentialState,
 } from './user-projection.js';
 import { resolveUserTimeline } from './user-timeline-query.js';
-
-const USER_LIST_ROLE_PROJECTION_CONCURRENCY = 5;
-
-const resolveListProjectionInputs = async (input: {
-  actor: {
-    instanceId: string;
-    requestId?: string;
-    traceId?: string;
-  };
-  users: readonly IamUserListItem[];
-}) =>
-  {
-    const keycloakRoleNamesBySubject = new Map<string, readonly string[] | null>();
-    const workers = Array.from(
-      { length: Math.min(USER_LIST_ROLE_PROJECTION_CONCURRENCY, input.users.length) },
-      async (_, workerIndex) => {
-        for (let index = workerIndex; index < input.users.length; index += USER_LIST_ROLE_PROJECTION_CONCURRENCY) {
-          const user = input.users[index];
-          if (!user) {
-            continue;
-          }
-          try {
-            keycloakRoleNamesBySubject.set(
-              user.keycloakSubject,
-              await resolveKeycloakRoleNames(input.actor.instanceId, user.keycloakSubject)
-            );
-          } catch (error) {
-            if (!isRecoverableUserProjectionError(error)) {
-              throw error;
-            }
-            logger.warn('IAM user list role projection degraded', {
-              operation: 'list_users',
-              instance_id: input.actor.instanceId,
-              request_id: input.actor.requestId,
-              trace_id: input.actor.traceId,
-              user_id: user.id,
-              error: error.message,
-            });
-            keycloakRoleNamesBySubject.set(user.keycloakSubject, null);
-          }
-        }
-      }
-    );
-
-    await Promise.all(workers);
-
-    return keycloakRoleNamesBySubject;
-  };
 
 export const listUsersInternal = async (
   request: Request,
@@ -110,25 +61,23 @@ export const listUsersInternal = async (
 
   try {
     const resolved = await withInstanceScopedDb(access.actor.instanceId, (client) =>
-      resolveUsersWithPagination(client, {
+      resolveTenantKeycloakUsersWithPagination({
+        client,
         instanceId: access.actor.instanceId,
         page,
         pageSize,
         status,
         role: role ?? undefined,
         search: search ?? undefined,
+        requestId: access.actor.requestId,
+        traceId: access.actor.traceId,
       })
     );
-    const keycloakRoleNamesBySubject = await resolveListProjectionInputs({
-      actor: access.actor,
-      users: resolved.users,
-    });
     const users = await withInstanceScopedDb(access.actor.instanceId, (client) =>
       applyCanonicalUserListProjection({
         client,
         instanceId: access.actor.instanceId,
         users: resolved.users,
-        keycloakRoleNamesBySubject,
       })
     );
 
@@ -144,6 +93,20 @@ export const listUsersInternal = async (
       trace_id: access.actor.traceId,
       error: error instanceof Error ? error.message : String(error),
     });
+    if (error instanceof Error && error.message === 'tenant_admin_client_not_configured') {
+      return createApiError(
+        409,
+        'tenant_admin_client_not_configured',
+        'Tenant-lokale Keycloak-Administration ist nicht konfiguriert.',
+        access.actor.requestId,
+        {
+          dependency: 'keycloak',
+          execution_mode: 'tenant_admin',
+          instance_id: access.actor.instanceId,
+          reason_code: 'tenant_admin_client_not_configured',
+        }
+      );
+    }
     return createDatabaseApiError(error, access.actor.requestId);
   }
 };

--- a/packages/auth/src/iam-account-management/user-read-handlers.ts
+++ b/packages/auth/src/iam-account-management/user-read-handlers.ts
@@ -1,14 +1,10 @@
 import type { IamUserDetail, IamUserListItem } from '@sva/core';
-import { getWorkspaceContext } from '@sva/sdk/server';
-
 import type { AuthenticatedRequestContext } from '../middleware.server.js';
 import { jsonResponse } from '../shared/db-helpers.js';
 import { readString } from '../shared/input-readers.js';
 
 import { asApiItem, asApiList, createApiError, readPage } from './api-helpers.js';
-import { ADMIN_ROLES } from './constants.js';
-import { ensureFeature, getFeatureFlags } from './feature-flags.js';
-import { listPlatformUsers } from './platform-iam.js';
+import { listPlatformUsersInternal } from './platform-iam-handlers.js';
 import { consumeRateLimit } from './rate-limit.js';
 import {
   createDatabaseApiError,
@@ -18,11 +14,9 @@ import {
 } from './user-read-shared.js';
 import {
   logger,
-  requireRoles,
   withInstanceScopedDb,
 } from './shared.js';
-import type { UserStatus } from './types.js';
-import { USER_STATUS } from './types.js';
+import { USER_STATUS, type UserStatus } from './types.js';
 import { resolveUserDetail } from './user-detail-query.js';
 import { resolveUsersWithPagination } from './user-list-query.js';
 import {
@@ -93,61 +87,7 @@ export const listUsersInternal = async (
   const search = readString(url.searchParams.get('search'));
 
   if (!ctx.user.instanceId) {
-    const requestContext = getWorkspaceContext();
-    const featureCheck = ensureFeature(getFeatureFlags(), 'iam_admin', requestContext.requestId);
-    if (featureCheck) {
-      return featureCheck;
-    }
-    const roleCheck = requireRoles(ctx, ADMIN_ROLES, requestContext.requestId);
-    if (roleCheck) {
-      return roleCheck;
-    }
-    const rateLimit = consumeRateLimit({
-      instanceId: 'platform',
-      actorKeycloakSubject: ctx.user.id,
-      scope: 'read',
-      requestId: requestContext.requestId,
-    });
-    if (rateLimit) {
-      return rateLimit;
-    }
-    if (status && !USER_STATUS.includes(status)) {
-      return createApiError(400, 'invalid_request', 'Ungültiger Status-Filter.', requestContext.requestId);
-    }
-    try {
-      const resolved = await listPlatformUsers({
-        page,
-        pageSize,
-        status,
-        role: role ?? undefined,
-        search: search ?? undefined,
-        requestId: requestContext.requestId,
-        traceId: requestContext.traceId,
-      });
-      return jsonResponse(
-        200,
-        asApiList(resolved.users, { page, pageSize, total: resolved.total }, requestContext.requestId)
-      );
-    } catch (error) {
-      logger.error('Platform user list failed', {
-        operation: 'list_platform_users',
-        scope_kind: 'platform',
-        request_id: requestContext.requestId,
-        trace_id: requestContext.traceId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return createApiError(
-        503,
-        'keycloak_unavailable',
-        'Plattform-Benutzer konnten nicht aus Keycloak geladen werden.',
-        requestContext.requestId,
-        {
-          dependency: 'keycloak',
-          reason_code: 'platform_keycloak_unavailable',
-          scope_kind: 'platform',
-        }
-      );
-    }
+    return listPlatformUsersInternal(request, ctx);
   }
 
   const access = await resolveUserReadAccess(request, ctx);

--- a/packages/auth/src/identity-provider-port.ts
+++ b/packages/auth/src/identity-provider-port.ts
@@ -67,6 +67,12 @@ export type IdentityRole = {
   readonly containerId?: string;
 };
 
+export type IdentityRoleListQuery = {
+  readonly first?: number;
+  readonly max?: number;
+  readonly search?: string;
+};
+
 export type IdentityUserAttributes = Readonly<Record<string, readonly string[]>>;
 
 export interface IdentityProviderPort {
@@ -76,9 +82,12 @@ export interface IdentityProviderPort {
   listUsers(query?: IdentityUserListQuery): Promise<readonly IdentityListedUser[]>;
   getUserAttributes(externalId: string, attributeNames?: readonly string[]): Promise<IdentityUserAttributes>;
   syncRoles(externalId: string, roles: readonly string[]): Promise<void>;
+  assignRealmRoles?(externalId: string, roles: readonly string[]): Promise<void>;
+  removeRealmRoles?(externalId: string, roles: readonly string[]): Promise<void>;
   listUserRoleNames(externalId: string): Promise<readonly string[]>;
   countUsers?(query?: Omit<IdentityUserListQuery, 'first' | 'max'>): Promise<number>;
-  listRoles(): Promise<readonly IdentityRole[]>;
+  listRoles(query?: IdentityRoleListQuery): Promise<readonly IdentityRole[]>;
+  countRoles?(query?: Omit<IdentityRoleListQuery, 'first' | 'max'>): Promise<number>;
   getRoleByName(externalName: string): Promise<IdentityRole | null>;
   createRole(input: CreateIdentityRoleInput): Promise<IdentityRole>;
   updateRole(externalName: string, input: UpdateIdentityRoleInput): Promise<IdentityRole>;

--- a/packages/auth/src/identity-provider-port.ts
+++ b/packages/auth/src/identity-provider-port.ts
@@ -77,6 +77,7 @@ export interface IdentityProviderPort {
   getUserAttributes(externalId: string, attributeNames?: readonly string[]): Promise<IdentityUserAttributes>;
   syncRoles(externalId: string, roles: readonly string[]): Promise<void>;
   listUserRoleNames(externalId: string): Promise<readonly string[]>;
+  countUsers?(query?: Omit<IdentityUserListQuery, 'first' | 'max'>): Promise<number>;
   listRoles(): Promise<readonly IdentityRole[]>;
   getRoleByName(externalName: string): Promise<IdentityRole | null>;
   createRole(input: CreateIdentityRoleInput): Promise<IdentityRole>;

--- a/packages/auth/src/keycloak-admin-client.test.ts
+++ b/packages/auth/src/keycloak-admin-client.test.ts
@@ -609,6 +609,61 @@ describe('KeycloakAdminClient', () => {
     );
   });
 
+  it('lists and counts roles with server-side filters', async () => {
+    const { fetchImpl, calls } = createFetchStub([
+      createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }),
+      createJsonResponse(200, [{ id: 'role-editor', name: 'editor' }]),
+      createJsonResponse(200, { count: 1 }),
+    ]);
+
+    const client = new KeycloakAdminClient({
+      baseUrl: 'https://keycloak.example.com',
+      realm: 'demo',
+      clientId: 'svc-client',
+      clientSecret: 'svc-secret',
+      fetchImpl,
+    });
+
+    await expect(client.listRoles({ first: 5, max: 10, search: 'edit' })).resolves.toEqual([
+      expect.objectContaining({ id: 'role-editor', externalName: 'editor' }),
+    ]);
+    await expect(client.countRoles({ search: 'edit' })).resolves.toBe(1);
+    expect(String(calls[1]?.input)).toBe(
+      'https://keycloak.example.com/admin/realms/demo/roles?first=5&max=10&search=edit'
+    );
+    expect(String(calls[2]?.input)).toBe('https://keycloak.example.com/admin/realms/demo/roles/count?search=edit');
+  });
+
+  it('assigns and removes explicit realm role mappings', async () => {
+    const { fetchImpl, calls } = createFetchStub([
+      createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }),
+      createJsonResponse(200, [{ id: 'role-editor', name: 'editor' }]),
+      createTextResponse(204, ''),
+      createJsonResponse(200, [{ id: 'role-editor', name: 'editor' }]),
+      createTextResponse(204, ''),
+    ]);
+
+    const client = new KeycloakAdminClient({
+      baseUrl: 'https://keycloak.example.com',
+      realm: 'demo',
+      clientId: 'svc-client',
+      clientSecret: 'svc-secret',
+      fetchImpl,
+    });
+
+    await client.assignRealmRoles('user-1', ['editor']);
+    await client.removeRealmRoles('user-1', ['editor']);
+
+    const addCall = calls.find(
+      (entry) => String(entry.input).includes('/users/user-1/role-mappings/realm') && entry.init?.method === 'POST'
+    );
+    const removeCall = calls.find(
+      (entry) => String(entry.input).includes('/users/user-1/role-mappings/realm') && entry.init?.method === 'DELETE'
+    );
+    expect(JSON.parse(String(addCall?.init?.body))).toEqual([expect.objectContaining({ id: 'role-editor', name: 'editor' })]);
+    expect(JSON.parse(String(removeCall?.init?.body))).toEqual([expect.objectContaining({ id: 'role-editor', name: 'editor' })]);
+  });
+
   it('fails fast after a retryable listRoles error', async () => {
     const { fetchImpl } = createFetchStub([
       createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }),

--- a/packages/auth/src/keycloak-admin-client.test.ts
+++ b/packages/auth/src/keycloak-admin-client.test.ts
@@ -587,6 +587,28 @@ describe('KeycloakAdminClient', () => {
     ).rejects.toBeInstanceOf(KeycloakAdminRequestError);
   });
 
+  it('counts users with server-side filters', async () => {
+    const { fetchImpl, calls } = createFetchStub([
+      createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }),
+      createJsonResponse(200, 7),
+    ]);
+
+    const client = new KeycloakAdminClient({
+      baseUrl: 'https://keycloak.example.com',
+      realm: 'demo',
+      clientId: 'svc-client',
+      clientSecret: 'svc-secret',
+      fetchImpl,
+    });
+
+    await expect(
+      client.countUsers({ search: 'alice', email: 'a@example.com', username: 'alice', enabled: true })
+    ).resolves.toBe(7);
+    expect(String(calls[1]?.input)).toBe(
+      'https://keycloak.example.com/admin/realms/demo/users/count?enabled=true&search=alice&email=a%40example.com&username=alice'
+    );
+  });
+
   it('fails fast after a retryable listRoles error', async () => {
     const { fetchImpl } = createFetchStub([
       createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }),

--- a/packages/auth/src/keycloak-admin-client/core.ts
+++ b/packages/auth/src/keycloak-admin-client/core.ts
@@ -597,6 +597,49 @@ export class KeycloakAdminClient implements IdentityProviderPort {
     }
   }
 
+  async countUsers(query?: Omit<KeycloakListUsersQuery, 'first' | 'max'>): Promise<number> {
+    if (this.isCircuitOpen()) {
+      logger.error('Keycloak read blocked because circuit breaker is open', {
+        operation: 'count_users',
+        mode: 'fail_fast',
+      });
+      throw new KeycloakAdminUnavailableError('Keycloak unavailable; user count cannot be loaded.');
+    }
+
+    const searchParams = new URLSearchParams();
+    if (query?.enabled !== undefined) {
+      searchParams.set('enabled', String(query.enabled));
+    }
+    for (const [key, value] of [
+      ['search', query?.search],
+      ['email', query?.email],
+      ['username', query?.username],
+    ] as const) {
+      if (value) {
+        searchParams.set(key, value);
+      }
+    }
+
+    const querySuffix = searchParams.size > 0 ? `?${searchParams.toString()}` : '';
+    try {
+      const count = await this.executeWithResilience<number>({
+        method: 'GET',
+        path: `/admin/realms/${encodePathSegment(this.realm)}/users/count${querySuffix}`,
+        operation: 'count_users',
+      });
+      return count;
+    } catch (error) {
+      if (this.isRetryableError(error)) {
+        logger.error('Keycloak read failed without fallback', {
+          operation: 'count_users',
+          mode: 'fail_fast',
+          reason: toRetryLogReason(error),
+        });
+      }
+      throw error;
+    }
+  }
+
   private async readUserRoleMappings(
     externalId: string,
     operation: string

--- a/packages/auth/src/keycloak-admin-client/core.ts
+++ b/packages/auth/src/keycloak-admin-client/core.ts
@@ -7,6 +7,7 @@ import type {
   IdentityUserAttributes,
   CreateIdentityUserInput,
   IdentityRole,
+  IdentityRoleListQuery,
   IdentityProviderPort,
   IdentityUser,
   IdentityUserListQuery,
@@ -101,6 +102,7 @@ type KeycloakUserCreateResponse = {
 };
 
 export type KeycloakListUsersQuery = IdentityUserListQuery;
+export type KeycloakListRolesQuery = IdentityRoleListQuery;
 
 export type KeycloakAdminUser = {
   readonly id: string;
@@ -526,6 +528,65 @@ export class KeycloakAdminClient implements IdentityProviderPort {
     }
   }
 
+  async assignRealmRoles(externalId: string, roles: readonly string[]): Promise<void> {
+    await this.assertWriteAvailability();
+    const uniqueRoleNames = [...new Set(roles)];
+    if (uniqueRoleNames.length === 0) {
+      return;
+    }
+    const availableRoles = await this.listRoles();
+    const availableByName = new Map(availableRoles.map((role) => [role.externalName, role]));
+    const roleMappings = uniqueRoleNames.map((roleName) => availableByName.get(roleName));
+    const missingRoles = uniqueRoleNames.filter((roleName, index) => !roleMappings[index]);
+    if (missingRoles.length > 0) {
+      throw new KeycloakAdminRequestError({
+        message: `Unknown Keycloak roles: ${missingRoles.join(', ')}`,
+        statusCode: 400,
+        code: 'unknown_role',
+        retryable: false,
+      });
+    }
+
+    await this.executeWithResilience<void>({
+      method: 'POST',
+      path: `/admin/realms/${encodePathSegment(this.realm)}/users/${encodePathSegment(externalId)}/role-mappings/realm`,
+      body: JSON.stringify(
+        roleMappings
+          .filter((role): role is IdentityRole => role !== undefined)
+          .map((role): KeycloakRealmRole => ({
+            id: role.id ?? role.externalName,
+            name: role.externalName,
+            description: role.description,
+            attributes: role.attributes,
+            composite: role.composite,
+            clientRole: role.clientRole,
+            containerId: role.containerId,
+          }))
+      ),
+      operation: 'assign_realm_roles',
+    });
+  }
+
+  async removeRealmRoles(externalId: string, roles: readonly string[]): Promise<void> {
+    await this.assertWriteAvailability();
+    const roleNames = new Set(roles);
+    if (roleNames.size === 0) {
+      return;
+    }
+    const currentRoleMappings = await this.readUserRoleMappings(externalId, 'remove_realm_roles_read_current');
+    const toRemove = currentRoleMappings.filter((role) => roleNames.has(role.name));
+    if (toRemove.length === 0) {
+      return;
+    }
+
+    await this.executeWithResilience<void>({
+      method: 'DELETE',
+      path: `/admin/realms/${encodePathSegment(this.realm)}/users/${encodePathSegment(externalId)}/role-mappings/realm`,
+      body: JSON.stringify(toRemove),
+      operation: 'remove_realm_roles',
+    });
+  }
+
   async listUserRoleNames(externalId: string): Promise<readonly string[]> {
     const currentRoleMappings = await this.readUserRoleMappings(externalId, 'list_user_roles');
     return currentRoleMappings.map((role) => role.name);
@@ -655,7 +716,7 @@ export class KeycloakAdminClient implements IdentityProviderPort {
     });
   }
 
-  async listRoles(): Promise<readonly IdentityRole[]> {
+  async listRoles(query?: KeycloakListRolesQuery): Promise<readonly IdentityRole[]> {
     if (this.isCircuitOpen()) {
       logger.error('Keycloak read blocked because circuit breaker is open', {
         operation: 'list_roles',
@@ -664,10 +725,24 @@ export class KeycloakAdminClient implements IdentityProviderPort {
       throw new KeycloakAdminUnavailableError('Keycloak unavailable; role list cannot be loaded.');
     }
 
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of [
+      ['first', query?.first],
+      ['max', query?.max],
+    ] as const) {
+      if (value !== undefined) {
+        searchParams.set(key, String(value));
+      }
+    }
+    if (query?.search) {
+      searchParams.set('search', query.search);
+    }
+    const querySuffix = searchParams.size > 0 ? `?${searchParams.toString()}` : '';
+
     try {
       const roles = await this.executeWithResilience<KeycloakRealmRole[]>({
         method: 'GET',
-        path: `/admin/realms/${encodePathSegment(this.realm)}/roles`,
+        path: `/admin/realms/${encodePathSegment(this.realm)}/roles${querySuffix}`,
         operation: 'list_roles',
       });
       return roles.map(mapKeycloakRole);
@@ -681,6 +756,29 @@ export class KeycloakAdminClient implements IdentityProviderPort {
       }
       throw error;
     }
+  }
+
+  async countRoles(query?: Omit<KeycloakListRolesQuery, 'first' | 'max'>): Promise<number> {
+    if (this.isCircuitOpen()) {
+      logger.error('Keycloak read blocked because circuit breaker is open', {
+        operation: 'count_roles',
+        mode: 'fail_fast',
+      });
+      throw new KeycloakAdminUnavailableError('Keycloak unavailable; role count cannot be loaded.');
+    }
+
+    const searchParams = new URLSearchParams();
+    if (query?.search) {
+      searchParams.set('search', query.search);
+    }
+    const querySuffix = searchParams.size > 0 ? `?${searchParams.toString()}` : '';
+    const response = await this.executeWithResilience<number | { count?: number }>({
+      method: 'GET',
+      path: `/admin/realms/${encodePathSegment(this.realm)}/roles/count${querySuffix}`,
+      operation: 'count_roles',
+    });
+
+    return typeof response === 'number' ? response : response.count ?? 0;
   }
 
   async getRoleByName(externalName: string): Promise<IdentityRole | null> {

--- a/packages/core/src/iam/account-management-contract.test.ts
+++ b/packages/core/src/iam/account-management-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  type IamKeycloakObjectDiagnostic,
   iamRuntimeDiagnosticClassifications,
   iamRuntimeDiagnosticStatuses,
   iamRuntimeRecommendedActions,
@@ -39,5 +40,19 @@ describe('account-management-contract runtime diagnostics exports', () => {
       'manuell_pruefen',
       'support_kontaktieren',
     ]);
+  });
+
+  it('allows object-level Keycloak diagnostics for admin UI projections', () => {
+    const diagnostic: IamKeycloakObjectDiagnostic = {
+      code: 'missing_instance_attribute',
+      objectId: 'kc-user-1',
+      objectType: 'user',
+    };
+
+    expect(diagnostic).toEqual({
+      code: 'missing_instance_attribute',
+      objectId: 'kc-user-1',
+      objectType: 'user',
+    });
   });
 });

--- a/packages/core/src/iam/account-management-contract.ts
+++ b/packages/core/src/iam/account-management-contract.ts
@@ -137,6 +137,8 @@ export type IamUserRoleAssignment = {
   readonly roleKey: string;
   readonly roleName: string;
   readonly roleLevel: number;
+  readonly editability?: IamKeycloakObjectEditability;
+  readonly diagnostics?: readonly IamKeycloakObjectDiagnostic[];
   readonly validFrom?: string;
   readonly validTo?: string;
 };
@@ -191,6 +193,9 @@ export type IamUserListItem = {
   readonly displayName: string;
   readonly email?: string;
   readonly status: 'active' | 'inactive' | 'pending';
+  readonly mappingStatus?: IamKeycloakMappingStatus;
+  readonly editability?: IamKeycloakObjectEditability;
+  readonly diagnostics?: readonly IamKeycloakObjectDiagnostic[];
   readonly position?: string;
   readonly department?: string;
   readonly lastLoginAt?: string;
@@ -212,10 +217,47 @@ export type IamUserDetail = IamUserListItem & {
   readonly groups?: readonly IamUserGroupAssignment[];
   readonly mainserverUserApplicationId?: string;
   readonly mainserverUserApplicationSecretSet: boolean;
+  readonly fieldEditability?: IamKeycloakUserFieldEditability;
+};
+
+export type IamKeycloakMappingStatus = 'mapped' | 'unmapped' | 'manual_review';
+
+export type IamKeycloakObjectEditability = 'editable' | 'read_only' | 'blocked';
+
+export type IamKeycloakObjectDiagnosticCode =
+  | 'missing_instance_attribute'
+  | 'forbidden_role_mapping'
+  | 'read_only_federated_field'
+  | 'idp_forbidden'
+  | 'mapping_missing'
+  | 'mapping_incomplete'
+  | 'keycloak_projection_degraded'
+  | 'tenant_admin_client_not_configured'
+  | 'external_managed'
+  | 'built_in_role'
+  | 'system_role';
+
+export type IamKeycloakObjectDiagnostic = {
+  readonly code: IamKeycloakObjectDiagnosticCode;
+  readonly message?: string;
+  readonly objectId?: string;
+  readonly objectType?: 'user' | 'role' | 'role_assignment';
+};
+
+export type IamKeycloakUserFieldEditability = {
+  readonly profile: IamKeycloakObjectEditability;
+  readonly status: IamKeycloakObjectEditability;
+  readonly roles: IamKeycloakObjectEditability;
+};
+
+export type IamUserSyncObjectDiagnostic = {
+  readonly keycloakSubject: string;
+  readonly mappingStatus: IamKeycloakMappingStatus;
+  readonly diagnostics: readonly IamKeycloakObjectDiagnostic[];
 };
 
 export type IamUserImportSyncReport = {
-  readonly outcome: 'success' | 'partial_failure' | 'failed';
+  readonly outcome: 'success' | 'partial_failure' | 'blocked' | 'failed';
   readonly checkedCount: number;
   readonly correctedCount: number;
   readonly manualReviewCount: number;
@@ -224,6 +266,7 @@ export type IamUserImportSyncReport = {
   readonly repairedProfileCount?: number;
   readonly skippedCount: number;
   readonly totalKeycloakUsers: number;
+  readonly objects?: readonly IamUserSyncObjectDiagnostic[];
   readonly diagnostics?: {
     readonly authRealm: string;
     readonly providerSource: 'instance' | 'global' | 'fallback_global' | 'platform';
@@ -238,9 +281,11 @@ export type IamRoleListItem = {
   readonly roleKey: string;
   readonly roleName: string;
   readonly externalRoleName: string;
-  readonly managedBy: 'studio' | 'external';
+  readonly managedBy: 'studio' | 'external' | 'keycloak_builtin';
   readonly description?: string;
   readonly isSystemRole: boolean;
+  readonly editability?: IamKeycloakObjectEditability;
+  readonly diagnostics?: readonly IamKeycloakObjectDiagnostic[];
   readonly roleLevel: number;
   readonly memberCount: number;
   readonly syncState: IamRoleSyncState;
@@ -260,10 +305,11 @@ export type IamRoleReconcileEntry = {
   readonly action: 'noop' | 'create' | 'update' | 'report';
   readonly status: 'synced' | 'corrected' | 'failed' | 'requires_manual_action';
   readonly errorCode?: string;
+  readonly diagnostics?: readonly IamKeycloakObjectDiagnostic[];
 };
 
 export type IamRoleReconcileReport = {
-  readonly outcome: 'success' | 'partial_failure' | 'failed';
+  readonly outcome: 'success' | 'partial_failure' | 'blocked' | 'failed';
   readonly checkedCount: number;
   readonly correctedCount: number;
   readonly failedCount: number;

--- a/packages/core/src/iam/account-management-contract.ts
+++ b/packages/core/src/iam/account-management-contract.ts
@@ -226,7 +226,7 @@ export type IamUserImportSyncReport = {
   readonly totalKeycloakUsers: number;
   readonly diagnostics?: {
     readonly authRealm: string;
-    readonly providerSource: 'instance' | 'global' | 'fallback_global';
+    readonly providerSource: 'instance' | 'global' | 'fallback_global' | 'platform';
     readonly executionMode?: 'platform_admin' | 'tenant_admin' | 'break_glass';
     readonly matchedWithoutInstanceAttributeCount?: number;
     readonly skippedInstanceIds?: readonly string[];

--- a/packages/core/src/iam/index.ts
+++ b/packages/core/src/iam/index.ts
@@ -15,6 +15,11 @@ export type {
   IamGroupListItem,
   IamGroupMembershipOrigin,
   IamGroupType,
+  IamKeycloakMappingStatus,
+  IamKeycloakObjectDiagnostic,
+  IamKeycloakObjectDiagnosticCode,
+  IamKeycloakObjectEditability,
+  IamKeycloakUserFieldEditability,
   IamInstanceAuditEvent,
   IamInstanceDetail,
   IamInstanceKeycloakPlan,
@@ -51,6 +56,7 @@ export type {
   IamUserPermissionTraceSourceKind,
   IamUserPermissionTraceStatus,
   IamUserRoleAssignment,
+  IamUserSyncObjectDiagnostic,
 } from './account-management-contract.js';
 export { deriveIamRuntimeDiagnostics } from './runtime-diagnostics.js';
 export type {


### PR DESCRIPTION
## Summary

- makes IAM v1 user, role, sync and reconcile handlers scope-aware for the root Platform host
- renders root admin user/role pages with Platform-specific labels and hides unsupported tenant mutations
- adds OpenSpec deltas and updates PR-302/runtime/Keycloak documentation for Platform-vs-Tenant smokes and sync triage

## Validation

- openspec validate update-platform-iam-root-scope --strict
- pnpm nx run core:build
- pnpm nx run auth:test:types
- pnpm nx run auth:test:unit -- platform-iam.test.ts
- pnpm nx run sva-studio-react:test -- --run src/routes/admin/users/-user-list-page.test.tsx src/routes/admin/roles/-roles-page.test.tsx
- pnpm nx run sva-studio-react:test
- pnpm check:server-runtime
- pnpm nx run sva-studio-react:typecheck
- pnpm nx run auth:lint
- pnpm nx run sva-studio-react:lint

## Notes

- `studio.smart-village.app` remains the canonical Root/Platform host.
- `.gitignore` has a pre-existing local `output/` change and is intentionally not part of this PR.
- Live production smokes still need to run after deployment.