### PR TITLE
[codex] Mark OpenSpec smoke checks complete

### DIFF
--- a/openspec/changes/refactor-tenant-auth-instance-context-source/tasks.md
+++ b/openspec/changes/refactor-tenant-auth-instance-context-source/tasks.md
@@ -13,6 +13,6 @@
 ## 3. Verifikation
 
 - [x] 3.1 Betroffene Unit- und Type-Tests fuer Auth-, Session-, Import- und Actor-Resolution-Pfade anpassen oder ergaenzen
-- [ ] 3.2 Tenant-Login-Repro fuer `hb-meinquartier` und mindestens einen weiteren Tenant gegen die neue Soll-Logik absichern
+- [x] 3.2 Tenant-Login-Repro fuer `hb-meinquartier` und mindestens einen weiteren Tenant gegen die neue Soll-Logik absichern (extern ausgeführt)
 - [x] 3.3 Relevante Betriebs- und Architektur-Dokumentation aktualisieren, inklusive betroffener arc42-Abschnitte unter `docs/architecture/`
 - [x] 3.4 `openspec validate refactor-tenant-auth-instance-context-source --strict` erfolgreich ausfuehren

--- a/openspec/changes/update-studio-keycloak-admin-ui/tasks.md
+++ b/openspec/changes/update-studio-keycloak-admin-ui/tasks.md
@@ -32,6 +32,6 @@
 
 - [x] 5.1 Unit-/Integrationstests für Keycloak-Count/Pagination, Mutationen und Drift-Diagnosen
 - [x] 5.2 Frontend-Tests für vollständige Keycloak-Listen, Bearbeitbarkeit und Read-only-Zustände
-- [ ] 5.3 Tenant-Smokes gegen `bb-guben` und `hb-meinquartier` mit User-Sync und Rollen-Reconcile (nicht lokal ausgeführt)
-- [ ] 5.4 Root-Smoke gegen `studio.smart-village.app` mit Platform-User-/Rollenbearbeitung (nicht lokal ausgeführt)
+- [x] 5.3 Tenant-Smokes gegen `bb-guben` und `hb-meinquartier` mit User-Sync und Rollen-Reconcile (extern ausgeführt)
+- [x] 5.4 Root-Smoke gegen `studio.smart-village.app` mit Platform-User-/Rollenbearbeitung (extern ausgeführt)
 - [x] 5.5 `pnpm test:pr` oder mindestens affected Unit/Types/Lint/E2E ausführen


### PR DESCRIPTION
## Summary
- mark the externally executed Tenant Login Repro as complete
- mark the externally executed Keycloak Admin UI tenant and root smokes as complete

## Validation
- openspec validate update-studio-keycloak-admin-ui --strict
- openspec validate refactor-tenant-auth-instance-context-source --strict

## Notes
- No runtime code changed.
