### PR TITLE
[codex] Add Nx cache target defaults

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,18 @@
   },
   "workspaceLayout": { "appsDir": "apps", "libsDir": "packages" },
   "targetDefaults": {
+    "build": {
+      "cache": true,
+      "inputs": ["production", "^production"]
+    },
+    "check:runtime": {
+      "cache": true,
+      "inputs": ["production", "^production"]
+    },
+    "lint": {
+      "cache": true,
+      "inputs": ["default", "^production"]
+    },
     "test:unit": { "cache": true, "inputs": ["default", "^production", "testing"] },
     "test:coverage": {
       "cache": true,
@@ -25,6 +37,14 @@
         "{workspaceRoot}/vitest.workspace.ts"
       ],
       "outputs": ["{projectRoot}/coverage"]
+    },
+    "test:integration": {
+      "cache": true,
+      "inputs": ["default", "^production", "testing"]
+    },
+    "typecheck": {
+      "cache": true,
+      "inputs": ["production", "^production", "frontendTooling"]
     }
   },
   "namedInputs": {

--- a/nx.json
+++ b/nx.json
@@ -20,11 +20,11 @@
     },
     "check:runtime": {
       "cache": true,
-      "inputs": ["production", "^production"]
+      "inputs": ["production", "^production", "serverRuntimeTooling"]
     },
     "lint": {
       "cache": true,
-      "inputs": ["default", "^production"]
+      "inputs": ["default", "^production", "lintTooling"]
     },
     "test:unit": { "cache": true, "inputs": ["default", "^production", "testing"] },
     "test:coverage": {
@@ -39,7 +39,7 @@
       "outputs": ["{projectRoot}/coverage"]
     },
     "test:integration": {
-      "cache": true,
+      "cache": false,
       "inputs": ["default", "^production", "testing"]
     },
     "typecheck": {
@@ -74,6 +74,8 @@
     "frontendEnvBuild": [{ "env": "CODECOV_TOKEN" }],
     "frontendEnvServe": [{ "env": "TSS_DEV_SERVER" }],
     "frontendEnvE2E": [{ "env": "CI" }],
+    "lintTooling": ["{workspaceRoot}/eslint.config.mjs"],
+    "serverRuntimeTooling": ["{workspaceRoot}/scripts/ci/check-server-package-runtime.ts"],
     "sharedGlobals": ["{workspaceRoot}/tsconfig.base.json", "{workspaceRoot}/pnpm-lock.yaml"]
   },
   "analytics": false


### PR DESCRIPTION
## Summary

- Add Nx target defaults for build, runtime check, lint, integration test, and typecheck targets
- Keep the change scoped to `nx.json`; the old coverage workflow change is not included because `main` already skips Codecov bundle builds on PRs

## Why

This preserves the still-relevant part of the old CI cache hardening branch on top of current `main`. The defaults make common workspace gates cacheable with explicit input sets while project-specific target inputs continue to override where needed.

## Validation

- `node -e "JSON.parse(require('node:fs').readFileSync('nx.json','utf8')); console.log('nx.json ok')"`
- `pnpm nx show projects`
- `pnpm nx affected --target=typecheck --base=origin/main --output-style=stream`
- `git diff --check`
