### PR TITLE
[codex] Propose Keycloak provisioning run idempotency

### DIFF
--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/design.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Die ältere Instanz-Provisioning-Tabelle `iam.instance_provisioning_runs` besitzt bereits einen `idempotency_key` und dedupliziert nach `instance_id`, `operation` und Key. Der neuere Keycloak-Control-Plane-Pfad verwendet jedoch `iam.instance_keycloak_provisioning_runs`; dort werden Reconcile- und Execute-Aufträge als Worker-Runs persistiert, aber ohne Idempotenzspalte oder Payload-Fingerprint.
+
+Am API-Rand ist der Header bereits verpflichtend. Ohne persistente Nutzung des Keys bleibt der Schutz unvollständig: ein Browser-Retry, ein doppelter Button-Klick oder ein Gateway-Retry kann denselben Keycloak-Auftrag mehrfach einreihen.
+
+## Goals / Non-Goals
+
+Goals:
+- End-to-End-Idempotenz für Keycloak-Reconcile- und Execute-Run-Enqueue herstellen.
+- Doppelte Worker-Runs für denselben fachlichen Auftrag bei Retry verhindern.
+- Replay-Antworten deterministisch auf den bestehenden Run abbilden.
+- Key-Reuse mit abweichendem fachlichem Payload als Konflikt behandeln.
+
+Non-Goals:
+- Keine Änderung der Keycloak-Schrittlogik im Worker.
+- Keine Änderung der allgemeinen Instanzanlage über `iam.instance_provisioning_runs`.
+- Keine Einführung eines neuen Queue-Modells.
+- Keine Retention- oder Cleanup-Änderung außerhalb der neuen Idempotenzdaten.
+
+## Decisions
+
+- Decision: Der Deduplizierungs-Scope ist `instance_id + intent + idempotency_key`.
+  Alternatives considered: `instance_id + idempotency_key` wäre zu breit und könnte verschiedene Intents blockieren. `instance_id + step_key + idempotency_key` wäre zu eng, weil Reconcile/Execute den Run als Auftrag und nicht als einzelne Worker-Step-Mutation modellieren.
+
+- Decision: Der fachliche Payload-Fingerprint wird aus den enqueue-relevanten Eingaben gebildet.
+  Alternatives considered: Nur den Key speichern. Verworfen, weil wiederverwendete Keys mit anderer Payload sonst still denselben oder einen neuen Auftrag erzeugen könnten.
+
+- Decision: Replay liefert den bestehenden Run zurück; Payload-Mismatch liefert einen stabilen Konfliktfehler.
+  Alternatives considered: Replay als `202 Accepted` ohne Run-Body. Verworfen, weil Clients den bestehenden Run für Polling und UI-Status benötigen.
+
+## Risks / Trade-offs
+
+- Risk: Falsch definierter Payload-Fingerprint erzeugt Scheinkonflikte.
+  Mitigation: Fingerprint nur aus fachlich enqueue-relevanten Feldern bilden und Tests für optionale Felder ergänzen.
+
+- Risk: Migration auf bestehender Tabelle erfordert Backfill für vorhandene Runs.
+  Mitigation: Additive Migration mit nullable Backfill-Strategie oder sentinel-Werten für historische Runs; Unique Constraint erst für neue idempotente Runs wirksam machen.
+
+- Risk: Parallel eintreffende Requests können auf Constraint-Konflikte laufen.
+  Mitigation: Repository-Write-Pfad atomar per Insert/Upsert oder transaktionaler Konfliktauflösung implementieren.
+
+## Migration Plan
+
+1. DB-Migration für Idempotenzspalte(n), Payload-Fingerprint und eindeutige Deduplizierungsregel ergänzen.
+2. Service-Inputs für Reconcile/Execute um `idempotencyKey` erweitern.
+3. Repository-Create-Pfad auf atomare Deduplizierung umstellen.
+4. API-Fehlermapping für Payload-Mismatch und konkurrierende Requests ergänzen.
+5. Tests und betroffene Architektur-/Runbook-Dokumentation aktualisieren.

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/design.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/design.md
@@ -23,8 +23,8 @@ Non-Goals:
 - Decision: Der Deduplizierungs-Scope ist `instance_id + mutation + idempotency_key`, wobei `mutation` die stabile API-Mutation wie `reconcileKeycloak` oder `executeKeycloakProvisioning` bezeichnet.
   Alternatives considered: `instance_id + idempotency_key` wäre zu breit und könnte verschiedene Mutationen blockieren. `instance_id + intent + idempotency_key` wurde verworfen, weil der Reconcile-Intent aus veränderlichem Instanzzustand abgeleitet wird und ein Retry nach Zustandsänderung sonst einen zweiten Run erzeugen könnte. `instance_id + step_key + idempotency_key` wäre zu eng, weil Reconcile/Execute den Run als Auftrag und nicht als einzelne Worker-Step-Mutation modellieren.
 
-- Decision: Der fachliche Payload-Fingerprint wird aus den enqueue-relevanten Eingaben gebildet.
-  Alternatives considered: Nur den Key speichern. Verworfen, weil wiederverwendete Keys mit anderer Payload sonst still denselben oder einen neuen Auftrag erzeugen könnten. Für `reconcileKeycloak` wird der abgeleitete Intent im gespeicherten Run und im Fingerprint nachvollziehbar gehalten, aber nicht Teil des Deduplizierungs-Scopes.
+- Decision: Der fachliche Payload-Fingerprint wird nur aus stabilen Request-Eingaben gebildet.
+  Alternatives considered: Nur den Key speichern. Verworfen, weil wiederverwendete Keys mit anderer Payload sonst still denselben oder einen neuen Auftrag erzeugen könnten. Den abgeleiteten Reconcile-Intent in den Fingerprint aufzunehmen wurde verworfen, weil er von mutablem Instanzzustand abhängt und normale Retries nach Zustandsänderung sonst fälschlich als Konflikt erscheinen könnten. Für `reconcileKeycloak` wird der abgeleitete Intent im gespeicherten Run nachvollziehbar gehalten, aber weder Teil des Deduplizierungs-Scopes noch des Konflikt-Fingerprints.
 
 - Decision: Replay liefert den bestehenden Run zurück; Payload-Mismatch liefert einen stabilen Konfliktfehler.
   Alternatives considered: Replay als `202 Accepted` ohne Run-Body. Verworfen, weil Clients den bestehenden Run für Polling und UI-Status benötigen.
@@ -32,7 +32,7 @@ Non-Goals:
 ## Risks / Trade-offs
 
 - Risk: Falsch definierter Payload-Fingerprint erzeugt Scheinkonflikte.
-  Mitigation: Fingerprint nur aus fachlich enqueue-relevanten Feldern bilden und Tests für optionale Felder ergänzen.
+  Mitigation: Fingerprint nur aus stabilen Request-Feldern bilden, derived state explizit ausschließen und Tests für optionale Felder ergänzen.
 
 - Risk: Migration auf bestehender Tabelle erfordert Backfill für vorhandene Runs.
   Mitigation: Additive Migration mit nullable Backfill-Strategie oder sentinel-Werten für historische Runs; Unique Constraint erst für neue idempotente Runs wirksam machen.

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/design.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/design.md
@@ -20,11 +20,11 @@ Non-Goals:
 
 ## Decisions
 
-- Decision: Der Deduplizierungs-Scope ist `instance_id + intent + idempotency_key`.
-  Alternatives considered: `instance_id + idempotency_key` wäre zu breit und könnte verschiedene Intents blockieren. `instance_id + step_key + idempotency_key` wäre zu eng, weil Reconcile/Execute den Run als Auftrag und nicht als einzelne Worker-Step-Mutation modellieren.
+- Decision: Der Deduplizierungs-Scope ist `instance_id + mutation + idempotency_key`, wobei `mutation` die stabile API-Mutation wie `reconcileKeycloak` oder `executeKeycloakProvisioning` bezeichnet.
+  Alternatives considered: `instance_id + idempotency_key` wäre zu breit und könnte verschiedene Mutationen blockieren. `instance_id + intent + idempotency_key` wurde verworfen, weil der Reconcile-Intent aus veränderlichem Instanzzustand abgeleitet wird und ein Retry nach Zustandsänderung sonst einen zweiten Run erzeugen könnte. `instance_id + step_key + idempotency_key` wäre zu eng, weil Reconcile/Execute den Run als Auftrag und nicht als einzelne Worker-Step-Mutation modellieren.
 
 - Decision: Der fachliche Payload-Fingerprint wird aus den enqueue-relevanten Eingaben gebildet.
-  Alternatives considered: Nur den Key speichern. Verworfen, weil wiederverwendete Keys mit anderer Payload sonst still denselben oder einen neuen Auftrag erzeugen könnten.
+  Alternatives considered: Nur den Key speichern. Verworfen, weil wiederverwendete Keys mit anderer Payload sonst still denselben oder einen neuen Auftrag erzeugen könnten. Für `reconcileKeycloak` wird der abgeleitete Intent im gespeicherten Run und im Fingerprint nachvollziehbar gehalten, aber nicht Teil des Deduplizierungs-Scopes.
 
 - Decision: Replay liefert den bestehenden Run zurück; Payload-Mismatch liefert einen stabilen Konfliktfehler.
   Alternatives considered: Replay als `202 Accepted` ohne Run-Body. Verworfen, weil Clients den bestehenden Run für Polling und UI-Status benötigen.

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
@@ -5,7 +5,7 @@
 
 ## What Changes
 - Der validierte `Idempotency-Key` wird für Keycloak-Reconcile- und Execute-Mutationen bis in Service- und Repository-Schicht weitergereicht.
-- `iam.instance_keycloak_provisioning_runs` erhält einen persistenten Idempotenzbezug und eine eindeutige Deduplizierungsregel für denselben Instanz-/Mutation-/Key-Scope; mutable Reconcile-Intents bleiben Teil des fachlichen Payload-Fingerprints, aber nicht des Deduplizierungs-Scopes.
+- `iam.instance_keycloak_provisioning_runs` erhält einen persistenten Idempotenzbezug und eine eindeutige Deduplizierungsregel für denselben Instanz-/Mutation-/Key-Scope; mutable Reconcile-Intents werden am Run nachvollziehbar gespeichert, aber weder im Deduplizierungs-Scope noch im Konflikt-Fingerprint geführt.
 - Wiederholte Requests mit identischem Key und identischem fachlichem Payload erzeugen keinen zweiten Run und geben deterministisch die passende ursprüngliche Response-Form zurück: Reconcile liefert den bestehenden Status-/Snapshot-Pfad, Execute liefert den bestehenden Keycloak-Provisioning-Run.
 - Wiederverwendung eines Keys mit abweichendem fachlichem Payload wird als Konflikt behandelt und erzeugt keinen neuen Run.
 - API-, Service-, Repository- und Migrationstests decken Replay, Parallelität und Payload-Mismatch ab.

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
@@ -5,7 +5,7 @@
 
 ## What Changes
 - Der validierte `Idempotency-Key` wird für Keycloak-Reconcile- und Execute-Mutationen bis in Service- und Repository-Schicht weitergereicht.
-- `iam.instance_keycloak_provisioning_runs` erhält einen persistenten Idempotenzbezug und eine eindeutige Deduplizierungsregel für denselben Instanz-/Intent-/Key-Scope.
+- `iam.instance_keycloak_provisioning_runs` erhält einen persistenten Idempotenzbezug und eine eindeutige Deduplizierungsregel für denselben Instanz-/Mutation-/Key-Scope; mutable Reconcile-Intents bleiben Teil des fachlichen Payload-Fingerprints, aber nicht des Deduplizierungs-Scopes.
 - Wiederholte Requests mit identischem Key und identischem fachlichem Payload erzeugen keinen zweiten Run und geben deterministisch die passende ursprüngliche Response-Form zurück: Reconcile liefert den bestehenden Status-/Snapshot-Pfad, Execute liefert den bestehenden Keycloak-Provisioning-Run.
 - Wiederverwendung eines Keys mit abweichendem fachlichem Payload wird als Konflikt behandelt und erzeugt keinen neuen Run.
 - API-, Service-, Repository- und Migrationstests decken Replay, Parallelität und Payload-Mismatch ab.

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
@@ -1,12 +1,12 @@
 # Change: Keycloak-Provisioning-Run-Idempotenz nachziehen
 
 ## Why
-`reconcileKeycloak` und `executeKeycloakProvisioning` verlangen bereits einen `Idempotency-Key`, nutzen ihn aber im aktuellen Keycloak-Control-Plane-Pfad nicht zur persistenten Deduplizierung. Retries oder doppelte UI-Aktionen können dadurch mehrere `iam.instance_keycloak_provisioning_runs` für denselben fachlichen Auftrag anlegen.
+`reconcileKeycloak` und `executeKeycloakProvisioning` verlangen bereits den kanonischen Header `Idempotency-Key`, der fachlich dem in älteren Spezifikationen genannten `X-Idempotency-Key` entspricht. Im aktuellen Keycloak-Control-Plane-Pfad wird dieser Key aber nicht zur persistenten Deduplizierung genutzt. Retries oder doppelte UI-Aktionen können dadurch mehrere `iam.instance_keycloak_provisioning_runs` für denselben fachlichen Auftrag anlegen.
 
 ## What Changes
 - Der validierte `Idempotency-Key` wird für Keycloak-Reconcile- und Execute-Mutationen bis in Service- und Repository-Schicht weitergereicht.
 - `iam.instance_keycloak_provisioning_runs` erhält einen persistenten Idempotenzbezug und eine eindeutige Deduplizierungsregel für denselben Instanz-/Intent-/Key-Scope.
-- Wiederholte Requests mit identischem Key und identischem fachlichem Payload liefern deterministisch denselben Keycloak-Provisioning-Run zurück.
+- Wiederholte Requests mit identischem Key und identischem fachlichem Payload erzeugen keinen zweiten Run und geben deterministisch die passende ursprüngliche Response-Form zurück: Reconcile liefert den bestehenden Status-/Snapshot-Pfad, Execute liefert den bestehenden Keycloak-Provisioning-Run.
 - Wiederverwendung eines Keys mit abweichendem fachlichem Payload wird als Konflikt behandelt und erzeugt keinen neuen Run.
 - API-, Service-, Repository- und Migrationstests decken Replay, Parallelität und Payload-Mismatch ab.
 

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/proposal.md
@@ -1,0 +1,16 @@
+# Change: Keycloak-Provisioning-Run-Idempotenz nachziehen
+
+## Why
+`reconcileKeycloak` und `executeKeycloakProvisioning` verlangen bereits einen `Idempotency-Key`, nutzen ihn aber im aktuellen Keycloak-Control-Plane-Pfad nicht zur persistenten Deduplizierung. Retries oder doppelte UI-Aktionen können dadurch mehrere `iam.instance_keycloak_provisioning_runs` für denselben fachlichen Auftrag anlegen.
+
+## What Changes
+- Der validierte `Idempotency-Key` wird für Keycloak-Reconcile- und Execute-Mutationen bis in Service- und Repository-Schicht weitergereicht.
+- `iam.instance_keycloak_provisioning_runs` erhält einen persistenten Idempotenzbezug und eine eindeutige Deduplizierungsregel für denselben Instanz-/Intent-/Key-Scope.
+- Wiederholte Requests mit identischem Key und identischem fachlichem Payload liefern deterministisch denselben Keycloak-Provisioning-Run zurück.
+- Wiederverwendung eines Keys mit abweichendem fachlichem Payload wird als Konflikt behandelt und erzeugt keinen neuen Run.
+- API-, Service-, Repository- und Migrationstests decken Replay, Parallelität und Payload-Mismatch ab.
+
+## Impact
+- Affected specs: `instance-provisioning`
+- Affected code: `packages/auth/src/iam-instance-registry/core-mutations.ts`, `packages/auth/src/iam-instance-registry/mutation-types.ts`, `packages/auth/src/iam-instance-registry/service-keycloak*.ts`, `packages/data/src/instance-registry/index.ts`, `packages/data/migrations/*`, zugehörige Tests
+- Affected arc42 sections: `05-building-block-view`, `06-runtime-view`, `08-cross-cutting-concepts`

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
@@ -6,20 +6,20 @@ Das System SHALL Keycloak-Reconcile- und Execute-Mutationen end-to-end idempoten
 
 #### Scenario: Replay mit gleichem Key und gleicher Payload nutzt den bestehenden Run
 
-- **WHEN** ein berechtigter Client dieselbe Keycloak-Reconcile- oder Execute-Mutation für dieselbe Instanz, denselben Intent und denselben `Idempotency-Key` mit fachlich identischer Payload erneut sendet
+- **WHEN** ein berechtigter Client dieselbe Keycloak-Reconcile- oder Execute-Mutation für dieselbe Instanz und denselben `Idempotency-Key` mit fachlich identischer Payload erneut sendet
 - **THEN** erzeugt das System keinen zusätzlichen Keycloak-Provisioning-Run
 - **AND** liefert `reconcileKeycloak` deterministisch die bestehende Status-/Snapshot-Antwort aus dem ursprünglichen Auftrag zurück
 - **AND** liefert `executeKeycloakProvisioning` deterministisch den bereits vorhandenen Keycloak-Provisioning-Run zurück
 
 #### Scenario: Key-Reuse mit abweichender Payload wird abgelehnt
 
-- **WHEN** ein Client denselben `Idempotency-Key` im selben Scope aus Instanz und Intent wiederverwendet, aber eine fachlich abweichende Payload sendet
+- **WHEN** ein Client denselben `Idempotency-Key` im selben Scope aus Instanz und Mutation wiederverwendet, aber eine fachlich abweichende Payload oder einen abweichenden Reconcile-Intent-Fingerprint sendet
 - **THEN** lehnt das System den Request mit einem Konfliktfehler ab
 - **AND** erzeugt es keinen neuen Keycloak-Provisioning-Run
 
 #### Scenario: Parallele Requests mit gleichem Key werden atomar dedupliziert
 
-- **WHEN** zwei nahezu gleichzeitige Keycloak-Reconcile- oder Execute-Requests mit identischem Scope und identischem `Idempotency-Key` eingehen
+- **WHEN** zwei nahezu gleichzeitige Keycloak-Reconcile- oder Execute-Requests mit identischer Instanz, Mutation, identischem `Idempotency-Key` und identischem fachlichem Payload-Fingerprint eingehen
 - **THEN** bleibt die persistierte Run-Erzeugung effektiv genau einmalig
 - **AND** referenzieren alle erfolgreichen Execute-Antworten denselben Keycloak-Provisioning-Run
 - **AND** geben alle erfolgreichen Reconcile-Antworten denselben Status-/Snapshot-Zustand des deduplizierten Auftrags wieder

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
@@ -2,13 +2,14 @@
 
 ### Requirement: Keycloak-Provisioning-Run-Enqueue ist idempotent
 
-Das System SHALL Keycloak-Reconcile- und Execute-Mutationen end-to-end idempotent verarbeiten, indem der validierte `Idempotency-Key` bis zur persistenten Erzeugung von `iam.instance_keycloak_provisioning_runs` verwendet wird.
+Das System SHALL Keycloak-Reconcile- und Execute-Mutationen end-to-end idempotent verarbeiten, indem der validierte Header `Idempotency-Key` bis zur persistenten Erzeugung von `iam.instance_keycloak_provisioning_runs` verwendet wird. Dieser Header ist der kanonische Name für denselben Idempotenzvertrag, der in älteren IAM-Spezifikationen als `X-Idempotency-Key` beschrieben ist.
 
-#### Scenario: Replay mit gleichem Key und gleicher Payload liefert bestehenden Run
+#### Scenario: Replay mit gleichem Key und gleicher Payload nutzt den bestehenden Run
 
 - **WHEN** ein berechtigter Client dieselbe Keycloak-Reconcile- oder Execute-Mutation für dieselbe Instanz, denselben Intent und denselben `Idempotency-Key` mit fachlich identischer Payload erneut sendet
 - **THEN** erzeugt das System keinen zusätzlichen Keycloak-Provisioning-Run
-- **AND** liefert es deterministisch den bereits vorhandenen Run als Antwort zurück
+- **AND** liefert `reconcileKeycloak` deterministisch die bestehende Status-/Snapshot-Antwort aus dem ursprünglichen Auftrag zurück
+- **AND** liefert `executeKeycloakProvisioning` deterministisch den bereits vorhandenen Keycloak-Provisioning-Run zurück
 
 #### Scenario: Key-Reuse mit abweichender Payload wird abgelehnt
 
@@ -20,4 +21,5 @@ Das System SHALL Keycloak-Reconcile- und Execute-Mutationen end-to-end idempoten
 
 - **WHEN** zwei nahezu gleichzeitige Keycloak-Reconcile- oder Execute-Requests mit identischem Scope und identischem `Idempotency-Key` eingehen
 - **THEN** bleibt die persistierte Run-Erzeugung effektiv genau einmalig
-- **AND** referenzieren alle erfolgreichen Antworten denselben Keycloak-Provisioning-Run
+- **AND** referenzieren alle erfolgreichen Execute-Antworten denselben Keycloak-Provisioning-Run
+- **AND** geben alle erfolgreichen Reconcile-Antworten denselben Status-/Snapshot-Zustand des deduplizierten Auftrags wieder

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Keycloak-Provisioning-Run-Enqueue ist idempotent
+
+Das System SHALL Keycloak-Reconcile- und Execute-Mutationen end-to-end idempotent verarbeiten, indem der validierte `Idempotency-Key` bis zur persistenten Erzeugung von `iam.instance_keycloak_provisioning_runs` verwendet wird.
+
+#### Scenario: Replay mit gleichem Key und gleicher Payload liefert bestehenden Run
+
+- **WHEN** ein berechtigter Client dieselbe Keycloak-Reconcile- oder Execute-Mutation für dieselbe Instanz, denselben Intent und denselben `Idempotency-Key` mit fachlich identischer Payload erneut sendet
+- **THEN** erzeugt das System keinen zusätzlichen Keycloak-Provisioning-Run
+- **AND** liefert es deterministisch den bereits vorhandenen Run als Antwort zurück
+
+#### Scenario: Key-Reuse mit abweichender Payload wird abgelehnt
+
+- **WHEN** ein Client denselben `Idempotency-Key` im selben Scope aus Instanz und Intent wiederverwendet, aber eine fachlich abweichende Payload sendet
+- **THEN** lehnt das System den Request mit einem Konfliktfehler ab
+- **AND** erzeugt es keinen neuen Keycloak-Provisioning-Run
+
+#### Scenario: Parallele Requests mit gleichem Key werden atomar dedupliziert
+
+- **WHEN** zwei nahezu gleichzeitige Keycloak-Reconcile- oder Execute-Requests mit identischem Scope und identischem `Idempotency-Key` eingehen
+- **THEN** bleibt die persistierte Run-Erzeugung effektiv genau einmalig
+- **AND** referenzieren alle erfolgreichen Antworten denselben Keycloak-Provisioning-Run

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/specs/instance-provisioning/spec.md
@@ -13,7 +13,7 @@ Das System SHALL Keycloak-Reconcile- und Execute-Mutationen end-to-end idempoten
 
 #### Scenario: Key-Reuse mit abweichender Payload wird abgelehnt
 
-- **WHEN** ein Client denselben `Idempotency-Key` im selben Scope aus Instanz und Mutation wiederverwendet, aber eine fachlich abweichende Payload oder einen abweichenden Reconcile-Intent-Fingerprint sendet
+- **WHEN** ein Client denselben `Idempotency-Key` im selben Scope aus Instanz und Mutation wiederverwendet, aber eine fachlich abweichende stabile Request-Payload sendet
 - **THEN** lehnt das System den Request mit einem Konfliktfehler ab
 - **AND** erzeugt es keinen neuen Keycloak-Provisioning-Run
 

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Implementation
 - [ ] 1.1 `reconcileKeycloak` und `executeKeycloakProvisioning` reichen den validierten `idempotencyKey` bis in die Service-Inputs weiter.
 - [ ] 1.2 Service- und Repository-Typen für Keycloak-Provisioning-Runs nehmen `idempotencyKey` und einen fachlichen Payload-Fingerprint auf.
-- [ ] 1.3 Datenbank-Migration für `iam.instance_keycloak_provisioning_runs` ergänzt Idempotenzdaten und eine eindeutige Deduplizierungsregel für `instance_id + mutation + idempotency_key`; fachliche Intents werden über den Payload-Fingerprint verglichen, nicht als Unique-Scope geführt.
+- [ ] 1.3 Datenbank-Migration für `iam.instance_keycloak_provisioning_runs` ergänzt Idempotenzdaten und eine eindeutige Deduplizierungsregel für `instance_id + mutation + idempotency_key`; fachliche Payload-Fingerprints basieren nur auf stabilen Request-Eingaben, nicht auf aus Instanzzustand abgeleiteten Reconcile-Intents.
 - [ ] 1.4 Repository-Create-Pfad dedupliziert atomar und gibt bei Replay den bestehenden Run zurück.
 - [ ] 1.5 Payload-Mismatch wird deterministisch als Konfliktfehler gemappt und erzeugt keinen neuen Run.
 - [ ] 1.6 Tests für API-Weitergabe, Service-Enqueue, Repository-Replay, parallele Requests und Payload-Mismatch ergänzen.

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+- [ ] 1.1 `reconcileKeycloak` und `executeKeycloakProvisioning` reichen den validierten `idempotencyKey` bis in die Service-Inputs weiter.
+- [ ] 1.2 Service- und Repository-Typen für Keycloak-Provisioning-Runs nehmen `idempotencyKey` und einen fachlichen Payload-Fingerprint auf.
+- [ ] 1.3 Datenbank-Migration für `iam.instance_keycloak_provisioning_runs` ergänzt Idempotenzdaten und eine eindeutige Deduplizierungsregel für `instance_id + intent + idempotency_key`.
+- [ ] 1.4 Repository-Create-Pfad dedupliziert atomar und gibt bei Replay den bestehenden Run zurück.
+- [ ] 1.5 Payload-Mismatch wird deterministisch als Konfliktfehler gemappt und erzeugt keinen neuen Run.
+- [ ] 1.6 Tests für API-Weitergabe, Service-Enqueue, Repository-Replay, parallele Requests und Payload-Mismatch ergänzen.
+- [ ] 1.7 Betroffene arc42-Abschnitte unter `docs/architecture/` aktualisieren oder eine begründete Nicht-Änderung dokumentieren.
+
+## 2. Validation
+- [ ] 2.1 `pnpm nx run auth:test:unit`
+- [ ] 2.2 `pnpm nx run data:test:unit`
+- [ ] 2.3 `pnpm nx affected --target=typecheck --base=origin/main`
+- [ ] 2.4 `openspec validate update-keycloak-provisioning-run-idempotency --strict`

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Implementation
 - [ ] 1.1 `reconcileKeycloak` und `executeKeycloakProvisioning` reichen den validierten `idempotencyKey` bis in die Service-Inputs weiter.
 - [ ] 1.2 Service- und Repository-Typen für Keycloak-Provisioning-Runs nehmen `idempotencyKey` und einen fachlichen Payload-Fingerprint auf.
-- [ ] 1.3 Datenbank-Migration für `iam.instance_keycloak_provisioning_runs` ergänzt Idempotenzdaten und eine eindeutige Deduplizierungsregel für `instance_id + intent + idempotency_key`.
+- [ ] 1.3 Datenbank-Migration für `iam.instance_keycloak_provisioning_runs` ergänzt Idempotenzdaten und eine eindeutige Deduplizierungsregel für `instance_id + mutation + idempotency_key`; fachliche Intents werden über den Payload-Fingerprint verglichen, nicht als Unique-Scope geführt.
 - [ ] 1.4 Repository-Create-Pfad dedupliziert atomar und gibt bei Replay den bestehenden Run zurück.
 - [ ] 1.5 Payload-Mismatch wird deterministisch als Konfliktfehler gemappt und erzeugt keinen neuen Run.
 - [ ] 1.6 Tests für API-Weitergabe, Service-Enqueue, Repository-Replay, parallele Requests und Payload-Mismatch ergänzen.

--- a/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
+++ b/openspec/changes/update-keycloak-provisioning-run-idempotency/tasks.md
@@ -10,5 +10,5 @@
 ## 2. Validation
 - [ ] 2.1 `pnpm nx run auth:test:unit`
 - [ ] 2.2 `pnpm nx run data:test:unit`
-- [ ] 2.3 `pnpm nx affected --target=typecheck --base=origin/main`
+- [ ] 2.3 `pnpm test:types`
 - [ ] 2.4 `openspec validate update-keycloak-provisioning-run-idempotency --strict`


### PR DESCRIPTION
## Summary

- Add OpenSpec change `update-keycloak-provisioning-run-idempotency`
- Scope the old idempotency follow-up to the current Keycloak Control Plane run table
- Specify replay, payload-mismatch, and parallel-request behavior for `iam.instance_keycloak_provisioning_runs`

## Why

The old `chore/offene-sachen-2026-04-11` branch described a valid concern, but it targeted older provisioning context. Current `main` already has idempotency for `iam.instance_provisioning_runs`; the remaining gap is the newer Keycloak provisioning run enqueue path.

## Validation

- `openspec validate update-keycloak-provisioning-run-idempotency --strict`
- `pnpm check:file-placement`
- `git diff --check`
