### PR TITLE
[codex] Propose central media management

### DIFF
--- a/openspec/changes/add-media-management/design.md
+++ b/openspec/changes/add-media-management/design.md
@@ -1,0 +1,162 @@
+## Kontext
+
+Medienmanagement ist im Studio kein isoliertes Fachfeature, sondern eine hostseitige Querschnittsfunktion. Das Zielbild verlangt:
+
+- zentrale Wiederverwendbarkeit über mehrere Module und Instanzen hinweg
+- Trennung von fachlicher Nutzung und technischer Dateiausprägung
+- kontrollierte Variantenbildung und Auslieferung
+- Mandantenisolation, Rechte, Audit und Löschsicherheit
+
+Die bestehende Plugin-Architektur ist dafür nicht der richtige Ort. Plugins dürfen heute fachliche Erweiterungen auf Basis des SDK liefern, aber keine hostseitigen Storage-, Sicherheits- oder Routing-Bypässe etablieren. Medienmanagement muss deshalb als Capability des Hosts modelliert werden, mit optionalen Extension Points für Fachmodule.
+
+## Ziele
+
+- Medien als zentrale Assets mit stabiler Identität modellieren
+- Inhalte und Fachmodule an Medien über Referenzen und Rollen ankoppeln
+- technische Varianten zentral steuern, ohne Content-Modelle an Dateigrößen zu koppeln
+- Upload, Pflege, Löschung und Auslieferung über IAM und Audit absichern
+- spätere Erweiterungen für Video, Audio, KI-Analyse oder externe Quellen offenhalten
+
+## Nicht-Ziele für den ersten Schnitt
+
+- vollständiges Digital Asset Management mit Freigabeworkflows
+- komplexe Versionierung und Branching von Medien
+- generische Plugin-Eigenimplementierungen für Storage oder Variantengenerierung
+- unbegrenzte Suche oder Volltextsuche über Binärinhalte
+
+## Architekturentscheidung: Host-Capability mit eigenem Domänenpaket
+
+Der bevorzugte Zuschnitt ist ein eigenes hostseitiges Package `packages/media` für den kanonischen Medienvertrag. Dieses Package enthält keine UI, keine Datenbankzugriffe und keine runtime-spezifischen Adapter, sondern:
+
+- Domänentypen für `MediaAsset`, `MediaVariant`, `MediaReference`
+- Validierungs- und Statuslogik
+- Preset- und Rollenmodell
+- Regeln für Referenzierbarkeit, Ersetzbarkeit und Löschbarkeit
+
+Die Umsetzung bleibt schichtentreu:
+
+- `packages/media`: Domänenvertrag und framework-agnostische Logik
+- `packages/data`: Persistenz, Migrationen, Repositories, Such- und Nutzungsabfragen
+- `packages/auth`: serverseitige Rechte-, Upload-, Download- und Auditpfade
+- `apps/sva-studio-react`: Bibliothek, Picker, Metadatenpflege, Verwendungsnachweis
+- optional dedizierter Worker oder Job-Pfad für asynchrone Verarbeitung
+
+Falls das Team kein neues Package einführen will, ist `packages/core/src/media/*` die zweitbeste Variante. Nicht empfohlen ist ein monolithisches `packages/media`, das gleichzeitig Domain, Persistenz, API und UI enthält.
+
+## Domänenmodell
+
+### MediaAsset
+
+Repräsentiert das führende Originalmedium.
+
+Pflichtfelder im Zielbild:
+
+- `id`
+- `instanceId`
+- `storageKey`
+- `mediaType`
+- `mimeType`
+- `byteSize`
+- technische Metadaten wie Breite, Höhe, Dauer oder Seitenzahl soweit anwendbar
+- redaktionelle Metadaten wie Titel, Beschreibung, Alt-Text, Copyright, Lizenz
+- `visibility`
+- `processingStatus`
+
+### MediaVariant
+
+Repräsentiert eine abgeleitete technische Variante eines Assets.
+
+Pflichtfelder im Zielbild:
+
+- `id`
+- `assetId`
+- `variantKey`
+- `presetKey`
+- `format`
+- `width` und weitere transformationsrelevante Kennzeichen
+- `storageKey`
+- `generationStatus`
+
+### MediaReference
+
+Repräsentiert die fachliche Nutzung eines Assets durch einen anderen Domänenkontext.
+
+Pflichtfelder im Zielbild:
+
+- `id`
+- `assetId`
+- `targetType`
+- `targetId`
+- `role`
+- optional Sortierung oder Slot-Information
+
+## Referenzmodell und Content-Anbindung
+
+Inhalte und andere Module referenzieren Medien nie über rohe URLs oder Dateipfade. Sie referenzieren ein `MediaAsset` in einer fachlichen Rolle wie `teaser_image`, `header_image`, `gallery_item` oder `download`.
+
+Die Auswahl der konkreten technischen Variante erfolgt zentral über Presets und Ausgabeanforderungen. Dadurch bleiben Inhalte stabil, auch wenn Breitenstufen, Formate oder CDN-Regeln später angepasst werden.
+
+## Variantenstrategie
+
+Die Spezifikation soll keinen einzelnen Bild- oder Processing-Stack erzwingen, aber den Vertrag festlegen:
+
+- Original bleibt erhalten
+- Varianten sind ableitbar und ersetzbar
+- Presets werden zentral verwaltet
+- Breitenstufen unterstützen responsive Auslieferung
+- häufige Varianten dürfen eager erzeugt werden
+- seltene Varianten dürfen lazy erzeugt werden
+
+Empfohlen ist ein hybrider Ansatz aus eager und lazy generation, weil beim Upload die spätere Nutzung oft noch unbekannt ist.
+
+## Storage- und Auslieferungsvertrag
+
+Die Spezifikation benennt S3-kompatiblen Objektspeicher als Zielbild, ohne einen einzelnen Anbieter hart festzuschreiben. Wichtig ist der Vertrag:
+
+- Assets und Varianten werden mandantenfähig abgelegt
+- öffentliche und geschützte Medien sind unterscheidbar
+- öffentliche URLs bleiben stabil genug für CDN und Caching
+- geschützte Medien laufen über signierte oder anderweitig kontrollierte Zugriffspfade
+
+Die Storage-Schicht ist keine Plugin-Verantwortung. Sie liegt beim Host und muss in Deployment-, Security- und Observability-Dokumentation mitgeführt werden.
+
+## IAM und Audit
+
+Medienoperationen werden als eigene Fachrechte modelliert, mindestens für:
+
+- Lesen
+- Upload initialisieren
+- Metadaten pflegen
+- Referenzen verwalten
+- Löschen oder Archivieren
+- geschützte Auslieferung freigeben
+
+Löschungen müssen gegen aktive Referenzen, rechtliche Haltefristen oder geschützte Betriebszustände fail-closed sein. Alle sicherheits- und fachrelevanten Medienereignisse erzeugen Audit-Events.
+
+## Laufzeit- und Betriebswirkung
+
+Die Capability erzeugt neue Laufzeitpfade:
+
+- Upload initialisieren
+- Objekt hochladen
+- Metadaten extrahieren
+- Varianten generieren
+- Referenzen anlegen oder entfernen
+- Asset ausliefern
+- Verwendung nachweisen
+
+Damit sind mindestens Bausteinsicht, Laufzeitsicht, Verteilungssicht, Querschnittskonzepte, Qualitätsanforderungen und Risiken betroffen. Wahrscheinlich ist zusätzlich eine ADR nötig, weil eine neue hostseitige Infrastrukturgrenze eingeführt wird.
+
+## MVP-Empfehlung
+
+Für die erste Iteration:
+
+- Bilder zuerst
+- zentrale Bibliothek
+- Metadatenpflege
+- referenzbasierte Nutzung in `content-management`
+- Breitenstufen und wenige zentrale Presets
+- Verwendungsnachweis
+- einfache geschützte vs. öffentliche Sichtbarkeit
+
+Video, Audio, komplexe Freigaben und KI-Analysen bleiben explizit nachgelagert.

--- a/openspec/changes/add-media-management/proposal.md
+++ b/openspec/changes/add-media-management/proposal.md
@@ -1,0 +1,35 @@
+# Change: Zentrales Medienmanagement als hostseitige Capability
+
+## Why
+SVA Studio besitzt bereits ein kanonisches Inhaltsmodell, aber noch keinen verbindlichen Vertrag für Medien als wiederverwendbare, mandantenfähige und sicher auslieferbare Assets. Ein reiner Datei-Upload pro Fachmodul würde die Zielarchitektur des Studios unterlaufen: Medien würden dupliziert, Variantenlogik zerstreut, Rechte und Audit uneinheitlich umgesetzt und fachliche Referenzen direkt an technische Dateipfade gekoppelt.
+
+Benötigt wird deshalb eine eigenständige hostseitige Capability für Medienmanagement, die als zentrale Infrastruktur für Inhalte, Systemkonfigurationen und künftige Module dient. Diese Capability muss Originale, Varianten, Referenzen, Rechte, Mandantentrennung, Metadaten und Nutzungstransparenz konsistent modellieren, ohne die bestehende Plugin- und Content-Architektur zu brechen.
+
+## What Changes
+- Führt eine neue Capability `media-management` für Media Assets, Varianten, Referenzen, Metadaten, Verwendungsnachweise und kontrollierte Auslieferung ein
+- Verankert Medien als hostseitige Querschnittsfunktion und grenzt sie explizit gegen Fachplugins ab
+- Definiert ein fachliches Kernmodell mit `MediaAsset`, `MediaVariant`, `MediaReference` und zentral konfigurierbaren Nutzungsklassen bzw. Presets
+- Beschreibt die Trennung zwischen erhaltenem Original, abgeleiteten Varianten und fachlicher Nutzung über Rollen statt über direkte Dateipfade
+- Ergänzt `content-management` um die Anforderung, Medien referenzbasiert und rollenbasiert an Inhalte anzubinden
+- Ergänzt `iam-access-control` um rollenbasierte Medienrechte für Upload, Metadatenpflege, Referenzierung, Löschung und geschützte Auslieferung
+- Ergänzt `iam-auditing` um revisionssichere Audit-Events für Upload, Ersatz, Metadatenänderung, Variantenverarbeitung und Löschentscheidungen
+- Verankert die Architekturwirkung in arc42, insbesondere für Bausteinsicht, Laufzeitsicht, Verteilungssicht, Querschnittskonzepte, Qualitätsanforderungen, Risiken und ADR-Bedarf
+
+## Impact
+- Affected specs: `media-management`, `content-management`, `iam-access-control`, `iam-auditing`, `architecture-documentation`
+- Affected code:
+  - `packages/media/*` oder alternativ `packages/core/src/media/*` für den kanonischen Medienvertrag
+  - `packages/data/*` für Persistenz, Repositories und Migrationen
+  - `packages/auth/*` für serverseitige Rechte-, Upload- und Auslieferungspfade
+  - `apps/sva-studio-react/src/routes/media/*` und zugehörige UI-Bausteine
+  - optional Worker-/Processing-Bausteine für Metadaten-Extraktion und Variantengenerierung
+- Affected arc42 sections:
+  - `docs/architecture/03-context-and-scope.md` (S3-kompatibler Objektspeicher als neues externes System im Kontextdiagramm)
+  - `docs/architecture/04-solution-strategy.md` (Medienmanagement als hostseitige Querschnittsstrategie, prüfen)
+  - `docs/architecture/05-building-block-view.md`
+  - `docs/architecture/06-runtime-view.md`
+  - `docs/architecture/07-deployment-view.md`
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/09-architecture-decisions.md` (ADR-035 eintragen)
+  - `docs/architecture/10-quality-requirements.md`
+  - `docs/architecture/11-risks-and-technical-debt.md` (Async-Variantenpfad als bekannte technische Schuld, CDN/PII-Risiko)

--- a/openspec/changes/add-media-management/proposal.md
+++ b/openspec/changes/add-media-management/proposal.md
@@ -30,6 +30,6 @@ Benötigt wird deshalb eine eigenständige hostseitige Capability für Medienman
   - `docs/architecture/06-runtime-view.md`
   - `docs/architecture/07-deployment-view.md`
   - `docs/architecture/08-cross-cutting-concepts.md`
-  - `docs/architecture/09-architecture-decisions.md` (ADR-035 eintragen)
+  - `docs/architecture/09-architecture-decisions.md` (ADR-037 eintragen)
   - `docs/architecture/10-quality-requirements.md`
   - `docs/architecture/11-risks-and-technical-debt.md` (Async-Variantenpfad als bekannte technische Schuld, CDN/PII-Risiko)

--- a/openspec/changes/add-media-management/specs/architecture-documentation/spec.md
+++ b/openspec/changes/add-media-management/specs/architecture-documentation/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+### Requirement: Mandantenisolation von Medien-Assets zur Laufzeit
+
+Das System SHALL Media Assets strikt anhand ihrer `instanceId` isolieren.
+
+#### Scenario: Zugriff auf Asset einer fremden Instanz wird verhindert
+
+- **WHEN** ein Benutzer oder Dienst ein Media Asset anfragt
+- **THEN** prüft das System, ob das Asset zur aktiven Instanz des Aufrufers gehört
+- **AND** ein Asset einer anderen Instanz wird nicht zurückgegeben, auch wenn die Asset-ID bekannt ist
+
+### Requirement: Referenzintegrität beim Löschen von Assets
+
+Das System SHALL sicherstellen, dass ein Media Asset nicht gelöscht werden kann, solange aktive `MediaReference`-Einträge darauf verweisen.
+
+#### Scenario: Löschversuch bei aktivem Referenzbestand schlägt kontrolliert fehl
+
+- **WHEN** ein Benutzer ein Asset löschen will und mindestens eine aktive `MediaReference` auf dieses Asset verweist
+- **THEN** lehnt das System die Löschung fail-closed ab
+- **AND** die Ablehnung ist auditierbar und für den Benutzer nachvollziehbar
+
+### Requirement: Autorisierungspflicht für alle geschützten Auslieferungspfade
+
+Das System SHALL sicherstellen, dass geschützte Medien ausschließlich über autorisierte Pfade erreichbar sind.
+
+#### Scenario: Direktaufruf eines geschützten Mediums ohne gültigen Berechtigungsnachweis schlägt fehl
+
+- **WHEN** ein Zugriff auf ein als geschützt markiertes Medium ohne gültigen Berechtigungsnachweis erfolgt
+- **THEN** verweigert das System den Zugriff unabhängig davon, ob der Storage-Pfad bekannt ist
+- **AND** es werden keine Metadaten oder Vorschaudaten des Mediums offengelegt

--- a/openspec/changes/add-media-management/specs/architecture-documentation/spec.md
+++ b/openspec/changes/add-media-management/specs/architecture-documentation/spec.md
@@ -1,30 +1,28 @@
 ## ADDED Requirements
-### Requirement: Mandantenisolation von Medien-Assets zur Laufzeit
+### Requirement: Medienmanagement-Architektur in arc42 dokumentieren
 
-Das System SHALL Media Assets strikt anhand ihrer `instanceId` isolieren.
+Das System SHALL die Architekturwirkung des Medienmanagements in den betroffenen arc42-Abschnitten nachvollziehbar dokumentieren.
 
-#### Scenario: Zugriff auf Asset einer fremden Instanz wird verhindert
+#### Scenario: Externe Medieninfrastruktur ist im Systemkontext beschrieben
 
-- **WHEN** ein Benutzer oder Dienst ein Media Asset anfragt
-- **THEN** prüft das System, ob das Asset zur aktiven Instanz des Aufrufers gehört
-- **AND** ein Asset einer anderen Instanz wird nicht zurückgegeben, auch wenn die Asset-ID bekannt ist
+- **WHEN** Medienmanagement einen Objektspeicher, CDN- oder geschützte Auslieferungspfade einführt
+- **THEN** beschreiben die arc42-Abschnitte für Kontext, Deployment und Querschnitt die externen Systeme, Vertrauensgrenzen und Laufzeitverantwortlichkeiten
+- **AND** sie duplizieren keine fachlichen Laufzeitregeln aus den Capability-Spezifikationen
 
-### Requirement: Referenzintegrität beim Löschen von Assets
+#### Scenario: Medienbausteine sind in der Baustein- und Laufzeitsicht verortet
 
-Das System SHALL sicherstellen, dass ein Media Asset nicht gelöscht werden kann, solange aktive `MediaReference`-Einträge darauf verweisen.
+- **WHEN** die Medien-Capability umgesetzt wird
+- **THEN** dokumentiert die arc42-Bausteinsicht die hostseitigen Medienbausteine, Schnittstellen und Abhängigkeiten zu Content, IAM und Audit
+- **AND** die Laufzeitsicht beschreibt Upload, Variantenableitung, Verwendungsnachweis und kontrollierte Auslieferung auf Architektur-Ebene
 
-#### Scenario: Löschversuch bei aktivem Referenzbestand schlägt kontrolliert fehl
+#### Scenario: Querschnittliche Medienregeln referenzieren die fachlichen Specs
 
-- **WHEN** ein Benutzer ein Asset löschen will und mindestens eine aktive `MediaReference` auf dieses Asset verweist
-- **THEN** lehnt das System die Löschung fail-closed ab
-- **AND** die Ablehnung ist auditierbar und für den Benutzer nachvollziehbar
+- **WHEN** Mandantentrennung, Löschschutz, geschützte Auslieferung oder Audit im Architekturkapitel behandelt werden
+- **THEN** verweisen die Dokumentationsabschnitte auf `media-management`, `content-management`, `iam-access-control` und `iam-auditing`
+- **AND** die Laufzeitregeln bleiben in diesen fachlichen Spezifikationen führend
 
-### Requirement: Autorisierungspflicht für alle geschützten Auslieferungspfade
+#### Scenario: ADR für Package- und Storage-Entscheidungen ist verlinkt
 
-Das System SHALL sicherstellen, dass geschützte Medien ausschließlich über autorisierte Pfade erreichbar sind.
-
-#### Scenario: Direktaufruf eines geschützten Mediums ohne gültigen Berechtigungsnachweis schlägt fehl
-
-- **WHEN** ein Zugriff auf ein als geschützt markiertes Medium ohne gültigen Berechtigungsnachweis erfolgt
-- **THEN** verweigert das System den Zugriff unabhängig davon, ob der Storage-Pfad bekannt ist
-- **AND** es werden keine Metadaten oder Vorschaudaten des Mediums offengelegt
+- **WHEN** die Umsetzung startet
+- **THEN** dokumentiert ADR-037 Package-Zuschnitt, Storage-/Processing-Vertrag und Bezug zum Plugin-SDK-Vertrag aus ADR-034
+- **AND** `docs/architecture/09-architecture-decisions.md` referenziert diese Entscheidung

--- a/openspec/changes/add-media-management/specs/content-management/spec.md
+++ b/openspec/changes/add-media-management/specs/content-management/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+### Requirement: Inhalt ist ein erweiterbares Core-Element
+
+Das System MUST `Inhalt` als kanonisches Core-Element modellieren, das über definierte SDK-Erweiterungspunkte für spezielle Datentypen erweitert werden kann und referenzbasierte Mediennutzung unterstützt.
+
+#### Scenario: Core-Inhalt wird mit Basiskern angelegt
+
+- **WENN** ein Inhalt gespeichert oder geladen wird
+- **DANN** enthält er mindestens `contentType`, Titel, Veröffentlichungsdatum, Erstellungsdatum, Änderungsdatum, Autor, Payload, Status und Historie
+- **UND** diese Core-Felder bleiben unabhängig vom konkreten Inhaltstyp verfügbar
+
+#### Scenario: SDK erweitert einen speziellen Inhaltstyp
+
+- **WENN** für einen registrierten `contentType` eine SDK-Erweiterung vorhanden ist
+- **DANN** kann diese zusätzliche Validierung, UI-Bereiche, Tabelleninformationen oder Aktionen bereitstellen
+- **UND** der Core-Vertrag des Inhalts bleibt unverändert gültig
+
+#### Scenario: Plugin überschreibt den Core-Vertrag nicht
+
+- **WENN** ein Plugin oder SDK-Modul einen speziellen Inhaltstyp registriert
+- **DANN** darf es die Bedeutung oder Pflichtigkeit der Core-Felder nicht brechen
+- **UND** Statusmodell, Historie und Core-Metadaten bleiben systemweit konsistent
+
+#### Scenario: Inhalte binden Medien referenzbasiert an
+
+- **WENN** ein Inhalt ein Bild, Download oder anderes Medium benötigt
+- **DANN** referenziert der Inhalt Medien über die zentrale Medien-Capability und fachliche Rollen
+- **UND** der Inhalt speichert keine rohen Storage-Keys oder auslieferungsrelevanten Dateipfade als führenden Vertrag

--- a/openspec/changes/add-media-management/specs/iam-access-control/spec.md
+++ b/openspec/changes/add-media-management/specs/iam-access-control/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+### Requirement: Rollenbasierte Autorisierung für Medienmanagement
+
+Das System SHALL Medienmanagement über die zentrale IAM-Autorisierung absichern.
+
+#### Scenario: Zugriff auf Medienbibliothek ohne Leserecht
+
+- **WHEN** ein Benutzer die Medienbibliothek, einen Media-Picker oder eine Medien-Detailansicht aufruft
+- **AND** ihm im aktiven Kontext die Berechtigung `media.read` fehlt
+- **THEN** verweigert das System den Zugriff
+- **AND** es werden keine Medienmetadaten oder Vorschaudaten offengelegt
+
+#### Scenario: Upload erfordert eigene Medienberechtigung
+
+- **WHEN** ein Benutzer ein neues Medium hochladen oder einen Upload initialisieren will
+- **THEN** prüft das System eine dedizierte Berechtigung wie `media.create`
+- **AND** ein Benutzer mit reinem Leserecht darf keinen Uploadpfad nutzen
+
+#### Scenario: Metadatenpflege und Referenzverwaltung sind getrennt steuerbar
+
+- **WHEN** ein Benutzer Metadaten eines Assets ändern oder Referenzen eines Assets verwalten will
+- **THEN** prüft das System dafür passende Fachberechtigungen wie `media.update` und `media.reference.manage`
+- **AND** nicht autorisierte Änderungen werden serverseitig abgewiesen
+
+#### Scenario: Löschen oder Archivieren eines Assets ist gesondert geschützt
+
+- **WHEN** ein Benutzer ein Asset löschen, archivieren oder durch ein anderes Original ersetzen will
+- **THEN** prüft das System dafür eine dedizierte Berechtigung wie `media.delete`
+- **AND** die Freigabeentscheidung berücksichtigt aktive Referenzen und Scope-Grenzen fail-closed
+
+#### Scenario: Geschützte Auslieferung bleibt kontrolliert
+
+- **WHEN** ein nicht öffentliches Medium ausgeliefert werden soll
+- **THEN** prüft das System den aktiven Berechtigungskontext für den geschützten Zugriffspfad
+- **AND** direkte öffentliche Auslieferung ohne passende Berechtigung bleibt ausgeschlossen
+
+#### Scenario: Signierte Zugriffs-URLs haben eine begrenzte Gültigkeitsdauer
+
+- **WHEN** das System eine signierte URL für ein geschütztes Medium ausstellt
+- **THEN** hat die URL eine systemseitig konfigurierbare und nach oben begrenzte Gültigkeitsdauer
+- **AND** eine URL ohne Ablaufzeitpunkt oder mit einer die maximale Konfiguration überschreitenden Gültigkeitsdauer wird nicht ausgestellt

--- a/openspec/changes/add-media-management/specs/iam-auditing/spec.md
+++ b/openspec/changes/add-media-management/specs/iam-auditing/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+### Requirement: Revisionssichere Auditspur für Medienereignisse
+
+Das System SHALL für sicherheits- und fachrelevante Medienoperationen unveränderbare Audit-Events erzeugen.
+
+#### Scenario: Upload oder Asset-Anlage wird protokolliert
+
+- **WHEN** ein Medium hochgeladen oder als Asset registriert wird
+- **THEN** erzeugt das System ein Audit-Event mit Zeitpunkt, pseudonymisierter Actor-Referenz, Scope, Zielobjekt und Ergebnis
+- **AND** Klartext-PII oder geheime Zugangsartefakte werden nicht im Event gespeichert
+
+#### Scenario: Metadaten oder Sichtbarkeit eines Assets werden geändert
+
+- **WHEN** redaktionelle Metadaten, Sichtbarkeit oder fachliche Einordnung eines Assets geändert werden
+- **THEN** erzeugt das System ein Audit-Event mit Änderungsart und Ergebnis
+- **AND** das Event bleibt exportierbar und unveränderbar
+
+#### Scenario: Lösch- oder Ersetzungsentscheidung wird protokolliert
+
+- **WHEN** ein Asset gelöscht, archiviert oder durch ein neues Original ersetzt werden soll
+- **THEN** erzeugt das System ein Audit-Event mit Aktion, Ergebnis und referenzbezogenem Kontext
+- **AND** eine Blockierung wegen aktiver Nutzung bleibt ebenso nachvollziehbar auditierbar
+
+#### Scenario: Variantenverarbeitung bleibt nachvollziehbar
+
+- **WHEN** das System Varianten generiert, erneut erzeugt oder verwirft
+- **THEN** entstehen dafür nachvollziehbare Medienereignisse mit Ergebnis und technischem Status
+- **AND** operative Fehlerpfade bleiben redigiert und korrelierbar

--- a/openspec/changes/add-media-management/specs/media-management/spec.md
+++ b/openspec/changes/add-media-management/specs/media-management/spec.md
@@ -1,0 +1,145 @@
+## ADDED Requirements
+### Requirement: Medienmanagement als hostseitige Capability
+
+Das System SHALL Medienmanagement als zentrale hostseitige Capability und nicht als isoliertes Fachplugin bereitstellen.
+
+#### Scenario: Medienfunktion wird systemweit bereitgestellt
+
+- **WHEN** das Studio Medien hochlädt, verwaltet oder ausliefert
+- **THEN** erfolgt dies über eine zentrale Host-Capability mit gemeinsamem Domänenvertrag
+- **AND** Fachmodule konsumieren diese Capability über definierte Referenzen oder Extension Points
+- **AND** es entsteht keine konkurrierende Plugin-Eigenimplementierung für Storage, Varianten oder Sicherheitsgrenzen
+
+### Requirement: Trennung von Originalmedium, Varianten und Nutzung
+
+Das System SHALL Originalmedium, technische Varianten und fachliche Nutzung getrennt modellieren.
+
+#### Scenario: Originalmedium bleibt führend erhalten
+
+- **WHEN** ein Medium hochgeladen und später in mehreren Kontexten verwendet wird
+- **THEN** bleibt das Originalmedium als führendes Asset erhalten
+- **AND** technische Varianten werden davon abgeleitet
+- **AND** Fachobjekte referenzieren das Asset statt einer konkreten Variantendatei
+
+### Requirement: Kanonisches Medienmodell
+
+Das System SHALL ein kanonisches Medienmodell mit `MediaAsset`, `MediaVariant` und `MediaReference` bereitstellen.
+
+#### Scenario: Asset, Variante und Referenz sind getrennt identifizierbar
+
+- **WHEN** ein Medium gespeichert und in einem Fachobjekt verwendet wird
+- **THEN** existiert ein identifizierbares `MediaAsset` für das Original
+- **AND** abgeleitete Dateien werden als `MediaVariant` modelliert
+- **AND** die Nutzung durch Inhalte oder Konfigurationen wird als `MediaReference` gespeichert
+
+### Requirement: Referenzbasierte fachliche Nutzung über Rollen
+
+Das System SHALL Medien über fachliche Rollen statt über rohe Dateipfade anbinden.
+
+#### Scenario: Inhalt referenziert ein Medien-Asset in einer fachlichen Rolle
+
+- **WHEN** ein Inhalt ein Teaserbild oder ein Headerbild nutzt
+- **THEN** speichert das System eine Referenz auf ein `MediaAsset`
+- **AND** die Referenz enthält eine fachliche Rolle wie `teaser_image` oder `header_image`
+- **AND** die konkrete technische Ausprägung wird nicht im Content-Modell fest verdrahtet
+
+### Requirement: Zentrale Preset- und Variantensteuerung
+
+Das System SHALL Varianten und Nutzungsklassen zentral konfigurieren können.
+
+#### Scenario: Preset wird zentral angepasst
+
+- **WHEN** ein Team eine Nutzungsklasse wie `thumbnail` oder `hero` technisch anpasst
+- **THEN** erfolgt die Anpassung zentral
+- **AND** bestehende Inhalte oder Referenzen bleiben fachlich unverändert
+- **AND** es sind keine manuellen Content-Migrationen nur wegen geänderter Bildgrößen erforderlich
+
+### Requirement: Hybride Variantengenerierung
+
+Das System SHALL häufige Varianten direkt und seltene Varianten bei Bedarf generieren können.
+
+#### Scenario: Upload erzeugt häufige Varianten sofort
+
+- **WHEN** ein neues Bild hochgeladen wird
+- **THEN** darf das System definierte häufige Varianten unmittelbar erzeugen
+- **AND** kennzeichnet es weitere Varianten als später ableitbar
+
+#### Scenario: Seltene Variante wird bei Bedarf erzeugt
+
+- **WHEN** eine noch nicht vorhandene, erlaubte Variante erstmals benötigt wird
+- **THEN** darf das System diese Variante bedarfsgesteuert erzeugen
+- **AND** der ursprüngliche Asset-Vertrag bleibt unverändert
+
+### Requirement: Redaktionelle und technische Metadaten
+
+Das System SHALL technische und redaktionelle Metadaten getrennt, aber gemeinsam verwaltbar halten.
+
+#### Scenario: Redaktion pflegt Metadaten
+
+- **WHEN** ein Redakteur ein Medium im Studio bearbeitet
+- **THEN** kann er mindestens Titel, Beschreibung, Alt-Text, Copyright, Lizenz und Tags pflegen
+- **AND** technische Metadaten wie MIME-Type, Größe oder Abmessungen bleiben systemseitig nachvollziehbar
+
+### Requirement: Nutzungstransparenz vor Löschung
+
+Das System SHALL vor potenziell destruktiven Medienoperationen die aktuelle Verwendung des Assets nachvollziehbar machen.
+
+#### Scenario: Löschentscheidung prüft aktive Referenzen
+
+- **WHEN** ein Benutzer ein Asset löschen oder ersetzen will
+- **THEN** zeigt das System, in welchen Objekten und Rollen das Asset aktuell verwendet wird
+- **AND** eine Löschung mit aktiven, nicht explizit aufgelösten Referenzen wird fail-closed behandelt oder kontrolliert blockiert
+
+### Requirement: Mandantenfähige Storage- und Auslieferungsgrenze
+
+Das System SHALL Medien mandantenfähig speichern und öffentliche von geschützten Auslieferungspfaden trennen.
+
+#### Scenario: Geschütztes Medium wird nicht wie ein öffentliches Asset ausgeliefert
+
+- **WHEN** ein Medium als nicht öffentlich markiert ist
+- **THEN** liefert das System es nur über einen kontrollierten Zugriffspfad wie signierte URLs oder gleichwertige Freigabemechanismen aus
+- **AND** öffentliche Pfade oder Caches exponieren dieses Medium nicht unbegrenzt
+
+#### Scenario: Medien verschiedener Instanzen bleiben getrennt
+
+- **WHEN** Medien verschiedener Instanzen gespeichert oder abgefragt werden
+- **THEN** erzwingt das System eine Mandantentrennung im Speicher- und Metadatenmodell
+- **AND** organisations- oder instanzfremde Medien werden nicht offengelegt
+
+### Requirement: Erweiterbarer Medientypenpfad
+
+Das System SHALL den Vertrag so definieren, dass nachgelagerte Erweiterungen für weitere Medientypen möglich bleiben.
+
+#### Scenario: Erster Schnitt beschränkt sich auf Bilder
+
+- **WHEN** das System in einer ersten Iteration nur Bilder vollständig unterstützt
+- **THEN** bleibt der Medienvertrag trotzdem offen für spätere Typen wie PDF, Audio oder Video
+- **AND** der erste Schnitt zwingt keine Breaking Changes nur zur Erweiterung des Medientypenspektrums
+
+### Requirement: Serverseitige Upload-Validierung
+
+Das System SHALL jeden Datei-Upload serverseitig anhand des tatsächlichen Dateiinhalts validieren.
+
+#### Scenario: Upload mit ungültigem oder nicht erlaubtem Medientyp wird abgelehnt
+
+- **WHEN** ein Client eine Datei hochlädt
+- **THEN** prüft das System den tatsächlichen Dateiinhalt gegen eine Allowlist erlaubter Medientypen (z. B. über Magic-Bytes oder äquivalente Inhaltsprüfung)
+- **AND** der vom Client gesetzte `Content-Type`-Header wird nicht als vertrauenswürdig behandelt
+- **AND** eine Datei, deren Inhalt nicht dem deklarierten oder erlaubten Medientyp entspricht, wird abgelehnt
+
+#### Scenario: Upload über der konfigurierbaren Maximalgröße wird abgelehnt
+
+- **WHEN** ein Client eine Datei hochlädt, die die systemseitig konfigurierte maximale Dateigröße überschreitet
+- **THEN** lehnt das System den Upload mit einem klaren Fehlercode ab
+- **AND** es werden keine Teile der Datei persistent gespeichert
+
+### Requirement: Instanz-Speicherkontingent
+
+Das System SHALL den genutzten Speicher pro Instanz gegen ein konfigurierbares Kontingent prüfen.
+
+#### Scenario: Upload wird bei Kontingentüberschreitung abgelehnt
+
+- **WHEN** ein Upload das verbleibende Speicherkontingent der Instanz überschreiten würde
+- **THEN** lehnt das System den Upload mit einem eindeutigen Fehler ab
+- **AND** es werden keine Teile der Datei persistent gespeichert
+- **AND** bestehende Assets der Instanz bleiben unberührt

--- a/openspec/changes/add-media-management/tasks.md
+++ b/openspec/changes/add-media-management/tasks.md
@@ -3,7 +3,7 @@
 - [ ] 1.2 `content-management` um referenzbasierte Mediennutzung statt direkter Dateikopplung ergänzen
 - [ ] 1.3 `iam-access-control` um Medienrechte für Upload, Pflege, Referenzierung, Löschung und geschützte Auslieferung ergänzen
 - [ ] 1.4 `iam-auditing` um revisionssichere Auditspur für Medienereignisse ergänzen
-- [ ] 1.5 Technische Entscheidungen zu Package-Zuschnitt, Storage-Vertrag, Variantenstrategie, Referenzmodell und Worker-Schnitt in `design.md` dokumentieren; ADR-035 für Package-Zuschnitt und Storage-/Processing-Vertrag als Entwurf in `docs/adr/` anlegen (Querverweis zu ADR-034 herstellen) – **vor** Umsetzung in Abschnitt 2
+- [ ] 1.5 Technische Entscheidungen zu Package-Zuschnitt, Storage-Vertrag, Variantenstrategie, Referenzmodell und Worker-Schnitt in `design.md` dokumentieren; ADR-037 für Package-Zuschnitt und Storage-/Processing-Vertrag als Entwurf in `docs/adr/` anlegen (Querverweis zu ADR-034 herstellen) – **vor** Umsetzung in Abschnitt 2
 - [ ] 1.6 Architekturwirkung und betroffene arc42-Abschnitte im Change explizit referenzieren; dabei arc42-03 (S3-Objektspeicher als neues externes System im Kontextdiagramm) und arc42-04 (Medienmanagement als hostseitige Querschnittsstrategie) prüfen und ggf. ergänzen
 
 ## 2. Umsetzung
@@ -25,5 +25,5 @@
   - **Typ-Tests:** `MediaAsset`, `MediaVariant`, `MediaReference` als exportierte Typen aus `packages/media` über `test:types`
   - **E2E-MVP-Scope:** Upload-Flow (Bild hochladen, Metadaten pflegen) + Lösch-Blockierungs-Flow
 - [ ] 3.2 Relevante Dokumentation unter `docs/` sowie die betroffenen arc42-Abschnitte (03–11) aktualisieren; folgende Guides als Stubs anlegen: `docs/guides/media-management.md` (Zielgruppe: Redakteure – Upload, Rollen, Nutzungstransparenz) und bestehenden `docs/guides/plugin-development.md` um Medien-Extension-Points und verbotene Direktzugriffe ergänzen
-- [ ] 3.3 ADR-035 für Package-Zuschnitt `packages/media` und Storage-/Processing-Vertrag finalisieren (Entwurf aus Task 1.5); in `docs/architecture/09-architecture-decisions.md` verlinken; Querverweis zu ADR-034 (Plugin-SDK-Vertrag) sicherstellen
+- [ ] 3.3 ADR-037 für Package-Zuschnitt `packages/media` und Storage-/Processing-Vertrag finalisieren (Entwurf aus Task 1.5); in `docs/architecture/09-architecture-decisions.md` verlinken; Querverweis zu ADR-034 (Plugin-SDK-Vertrag) sicherstellen
 - [ ] 3.4 `openspec validate add-media-management --strict` ausführen

--- a/openspec/changes/add-media-management/tasks.md
+++ b/openspec/changes/add-media-management/tasks.md
@@ -15,7 +15,7 @@
 - [ ] 2.6 **MVP-Scope (Phase 1):** Metadaten-Extraktion synchron im Upload-Handler; Variantengenerierung lazy on-demand ohne Job-Queue-Infrastruktur; kein dedizierter async Worker in Phase 1. Async-Verarbeitungspfad als eigenständiger Folge-Change `add-media-async-processing` spezifizieren und als technische Schuld in `docs/architecture/11-risks-and-technical-debt.md` eintragen.
 - [ ] 2.7 Anbindung an `content-management` und mindestens ein Fachmodul über referenzbasierte Medienrollen herstellen
 - [ ] 2.8 Audit- und Historienpfad für Medienereignisse implementieren
-- [ ] 2.9 i18n-Keys für Medienbibliothek-UI, Media-Picker, Metadatenfelder, Rollennamen (z. B. `teaser_image`, `header_image`) und Fehlerzustände in `de` und `en` definieren; `check:i18n`-Gate muss grün bleiben
+- [ ] 2.9 i18n-Keys für Medienbibliothek-UI, Media-Picker, Metadatenfelder, Übersetzungen für Medienrollen (Rollen-IDs z. B. `teaser_image`, `header_image`; i18n-Keys gemäß Repo-Konvention in Dot-Notation, z. B. `media.roles.teaser_image`) und Fehlerzustände in `de` und `en` definieren; `check:i18n`-Gate muss grün bleiben
 
 ## 3. Qualität und Dokumentation
 - [ ] 3.1 Unit-, Typ-, Integrations- und UI-Tests für Referenzen, Varianten, Rechtepfade, Löschschutz und Auslieferung ergänzen. Folgende Hochrisiko-Pfade müssen explizit durch Tests abgedeckt sein:

--- a/openspec/changes/add-media-management/tasks.md
+++ b/openspec/changes/add-media-management/tasks.md
@@ -1,0 +1,29 @@
+## 1. Spezifikation
+- [ ] 1.1 Neue Capability `media-management` für Assets, Varianten, Referenzen, Metadaten, Nutzungstransparenz und Auslieferung spezifizieren
+- [ ] 1.2 `content-management` um referenzbasierte Mediennutzung statt direkter Dateikopplung ergänzen
+- [ ] 1.3 `iam-access-control` um Medienrechte für Upload, Pflege, Referenzierung, Löschung und geschützte Auslieferung ergänzen
+- [ ] 1.4 `iam-auditing` um revisionssichere Auditspur für Medienereignisse ergänzen
+- [ ] 1.5 Technische Entscheidungen zu Package-Zuschnitt, Storage-Vertrag, Variantenstrategie, Referenzmodell und Worker-Schnitt in `design.md` dokumentieren; ADR-035 für Package-Zuschnitt und Storage-/Processing-Vertrag als Entwurf in `docs/adr/` anlegen (Querverweis zu ADR-034 herstellen) – **vor** Umsetzung in Abschnitt 2
+- [ ] 1.6 Architekturwirkung und betroffene arc42-Abschnitte im Change explizit referenzieren; dabei arc42-03 (S3-Objektspeicher als neues externes System im Kontextdiagramm) und arc42-04 (Medienmanagement als hostseitige Querschnittsstrategie) prüfen und ggf. ergänzen
+
+## 2. Umsetzung
+- [ ] 2.1 Kanonischen Medienvertrag in einem hostseitigen Package modellieren (`packages/media` oder begründete Alternative im Core); `project.json` mit Scope-Tag `scope:core` versehen und `nx.json`-Modulgrenzen um `media`-Package erweitern – **kein Nachholen**, muss im selben PR erfolgen
+- [ ] 2.2 Persistenzmodell für Assets, Varianten, Referenzen und Nutzungsauswertung mit versionierten Migrationen implementieren
+- [ ] 2.3 Serverseitige Endpunkte für Upload-Initialisierung, Metadatenpflege, Referenzverwaltung, Verwendungsnachweis und kontrollierte Auslieferung implementieren
+- [ ] 2.4 Rollen- und Rechteprüfung für Medienoperationen serverseitig und in der UI integrieren
+- [ ] 2.5 Studio-UI für Medienbibliothek, Picker, Metadatenpflege und Nutzungsanzeige implementieren
+- [ ] 2.6 **MVP-Scope (Phase 1):** Metadaten-Extraktion synchron im Upload-Handler; Variantengenerierung lazy on-demand ohne Job-Queue-Infrastruktur; kein dedizierter async Worker in Phase 1. Async-Verarbeitungspfad als eigenständiger Folge-Change `add-media-async-processing` spezifizieren und als technische Schuld in `docs/architecture/11-risks-and-technical-debt.md` eintragen.
+- [ ] 2.7 Anbindung an `content-management` und mindestens ein Fachmodul über referenzbasierte Medienrollen herstellen
+- [ ] 2.8 Audit- und Historienpfad für Medienereignisse implementieren
+- [ ] 2.9 i18n-Keys für Medienbibliothek-UI, Media-Picker, Metadatenfelder, Rollennamen (z. B. `teaser_image`, `header_image`) und Fehlerzustände in `de` und `en` definieren; `check:i18n`-Gate muss grün bleiben
+
+## 3. Qualität und Dokumentation
+- [ ] 3.1 Unit-, Typ-, Integrations- und UI-Tests für Referenzen, Varianten, Rechtepfade, Löschschutz und Auslieferung ergänzen. Folgende Hochrisiko-Pfade müssen explizit durch Tests abgedeckt sein:
+  - **Löschblockierung:** Negativtest `GIVEN Asset mit N aktiven Referenzen WHEN delete THEN 4xx/blocked` (begleitend zu Task 2.7–2.8, nicht nachgelagert)
+  - **Mandantentrennung:** Repository-Isolation-Test – Asset einer Instanz ist von anderer Instanz nicht abrufbar (begleitend zu Task 2.2)
+  - **IAM-Negativpfade:** Serverseitige Middleware-Unit-Tests für `media.read`, `media.create`, `media.delete` je mit fehlendem Recht (begleitend zu Task 2.4)
+  - **Typ-Tests:** `MediaAsset`, `MediaVariant`, `MediaReference` als exportierte Typen aus `packages/media` über `test:types`
+  - **E2E-MVP-Scope:** Upload-Flow (Bild hochladen, Metadaten pflegen) + Lösch-Blockierungs-Flow
+- [ ] 3.2 Relevante Dokumentation unter `docs/` sowie die betroffenen arc42-Abschnitte (03–11) aktualisieren; folgende Guides als Stubs anlegen: `docs/guides/media-management.md` (Zielgruppe: Redakteure – Upload, Rollen, Nutzungstransparenz) und bestehenden `docs/guides/plugin-development.md` um Medien-Extension-Points und verbotene Direktzugriffe ergänzen
+- [ ] 3.3 ADR-035 für Package-Zuschnitt `packages/media` und Storage-/Processing-Vertrag finalisieren (Entwurf aus Task 1.5); in `docs/architecture/09-architecture-decisions.md` verlinken; Querverweis zu ADR-034 (Plugin-SDK-Vertrag) sicherstellen
+- [ ] 3.4 `openspec validate add-media-management --strict` ausführen

--- a/openspec/changes/add-media-management/tasks.md
+++ b/openspec/changes/add-media-management/tasks.md
@@ -12,7 +12,7 @@
 - [ ] 2.3 Serverseitige Endpunkte für Upload-Initialisierung, Metadatenpflege, Referenzverwaltung, Verwendungsnachweis und kontrollierte Auslieferung implementieren
 - [ ] 2.4 Rollen- und Rechteprüfung für Medienoperationen serverseitig und in der UI integrieren
 - [ ] 2.5 Studio-UI für Medienbibliothek, Picker, Metadatenpflege und Nutzungsanzeige implementieren
-- [ ] 2.6 **MVP-Scope (Phase 1):** Metadaten-Extraktion synchron im Upload-Handler; Variantengenerierung lazy on-demand ohne Job-Queue-Infrastruktur; kein dedizierter async Worker in Phase 1. Async-Verarbeitungspfad als eigenständiger Folge-Change `add-media-async-processing` spezifizieren und als technische Schuld in `docs/architecture/11-risks-and-technical-debt.md` eintragen.
+- [ ] 2.6 **MVP-Scope (Phase 1):** Metadaten-Extraktion und definierte häufige Varianten synchron im Upload-Handler erzeugen; seltene Varianten lazy on-demand ohne Job-Queue-Infrastruktur generieren; kein dedizierter async Worker in Phase 1. Async-Verarbeitungspfad als eigenständiger Folge-Change `add-media-async-processing` spezifizieren und als technische Schuld in `docs/architecture/11-risks-and-technical-debt.md` eintragen.
 - [ ] 2.7 Anbindung an `content-management` und mindestens ein Fachmodul über referenzbasierte Medienrollen herstellen
 - [ ] 2.8 Audit- und Historienpfad für Medienereignisse implementieren
 - [ ] 2.9 i18n-Keys für Medienbibliothek-UI, Media-Picker, Metadatenfelder, Übersetzungen für Medienrollen (Rollen-IDs z. B. `teaser_image`, `header_image`; i18n-Keys gemäß Repo-Konvention in Dot-Notation, z. B. `media.roles.teaser_image`) und Fehlerzustände in `de` und `en` definieren; `check:i18n`-Gate muss grün bleiben


### PR DESCRIPTION
## Summary

- Add OpenSpec change `add-media-management`
- Specify central media-management as a host-side capability for assets, variants, references, metadata, usage transparency, IAM, audit, and delivery
- Include architecture, content-management, access-control, auditing, and new `media-management` spec deltas

## Why

The branch only contains the proposal/specification work. It is now rebased onto current `main` so the change can be reviewed independently before implementation starts.

## Validation

- `openspec validate add-media-management --strict`
- `pnpm check:file-placement`
- `git diff --check`
