### PR TITLE
[codex] Runtime-Artefakt-Builds härten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v5
 
-      - run: pnpm exec nx affected -t lint test build
+      - run: pnpm exec nx affected -t lint test:unit build

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Die drei offiziellen Laufzeitprofile werden zentral über `SVA_RUNTIME_PROFILE` 
 
 - `local-keycloak` für lokalen Betrieb auf `http://localhost:3000` mit Test-Realm
 - `local-builder` für lokalen Builder.io-Betrieb mit Mock-User
-- `acceptance-hb` für die HB-Abnahme auf `https://hb-meinquartier.studio.smart-village.app`
+- `studio` für den produktionsnahen Serverbetrieb auf `https://studio.smart-village.app`
 
 Kanonische Profildefinitionen liegen unter `config/runtime/`. Projektweite Start-, Stop-, Update-, Smoke- und Migrationskommandos sind in `docs/development/runtime-profile-betrieb.md` dokumentiert.
 

--- a/apps/sva-studio-react/src/components/StudioDataTable.test.tsx
+++ b/apps/sva-studio-react/src/components/StudioDataTable.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -58,6 +59,42 @@ describe('StudioDataTable', () => {
     fireEvent.click(screen.getByRole('button', { name: /Region/i }));
     rows = screen.getAllByRole('row');
     expect(rows[1]?.textContent).toContain('Prignitz');
+  });
+
+  it('keeps table data stable across parent rerenders while sorting', () => {
+    const CountingTable = () => {
+      const [, forceRerender] = React.useReducer((value: number) => value + 1, 0);
+      const rows = React.useMemo(
+        () => [
+          { id: '2', region: 'Prignitz', city: 'Pritzwalk' },
+          { id: '1', region: 'Barnim', city: 'Bernau' },
+        ],
+        []
+      );
+
+      return (
+        <>
+          <Button type="button" onClick={forceRerender}>
+            Neu rendern
+          </Button>
+          <StudioDataTable
+            ariaLabel="Abholorte"
+            data={rows}
+            columns={demoColumns}
+            emptyState={<div>leer</div>}
+            getRowId={(row) => row.id}
+          />
+        </>
+      );
+    };
+
+    render(<CountingTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Region/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Neu rendern' }));
+
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]?.textContent).toContain('Barnim');
   });
 
   it('supports row selection and bulk actions', () => {

--- a/apps/sva-studio-react/src/components/StudioDataTable.tsx
+++ b/apps/sva-studio-react/src/components/StudioDataTable.tsx
@@ -155,6 +155,8 @@ export function StudioDataTable<TData>({
     setRowSelection({});
   }, []);
 
+  const tableData = React.useMemo(() => [...data], [data]);
+
   const coreColumns = React.useMemo<ColumnDef<TData>[]>(() => {
     const tableColumns = columns.map<ColumnDef<TData>>((column) => ({
       id: column.id,
@@ -208,7 +210,7 @@ export function StudioDataTable<TData>({
   }, [ariaLabel, columns, rowActions, selectionMode]);
 
   const table = useReactTable({
-    data: [...data],
+    data: tableData,
     columns: coreColumns,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/apps/sva-studio-react/vite.config.ts
+++ b/apps/sva-studio-react/vite.config.ts
@@ -60,6 +60,17 @@ if (process.cwd() !== appRoot) {
 
 const config = defineConfig({
   root: appRoot,
+  esbuild: {
+    jsxDev: false,
+  },
+  oxc: {
+    jsx: {
+      runtime: 'automatic',
+      importSource: 'react',
+      development: false,
+      refresh: false,
+    },
+  },
   server: {
     host: configuredDevHost || '127.0.0.1',
     // Disable HMR in this TanStack Start SSR setup to avoid React preamble runtime crashes.

--- a/apps/sva-studio-react/vite.config.ts
+++ b/apps/sva-studio-react/vite.config.ts
@@ -60,9 +60,6 @@ if (process.cwd() !== appRoot) {
 
 const config = defineConfig({
   root: appRoot,
-  esbuild: {
-    jsxDev: false,
-  },
   oxc: {
     jsx: {
       runtime: 'automatic',

--- a/deploy/portainer/Dockerfile
+++ b/deploy/portainer/Dockerfile
@@ -18,6 +18,11 @@ COPY . .
 RUN find apps packages -name "*.tsbuildinfo" -type f -delete
 
 RUN pnpm install --frozen-lockfile
+
+# Keep devDependencies available for the build toolchain, but build the
+# deployable artifact under production runtime semantics.
+ENV NODE_ENV=production
+
 # Build workspace libraries in dependency order (Nx graph: core -> monitoring-client,sdk -> auth,routing -> app)
 # --skip-nx-cache ensures builds are never skipped due to a stale cache
 RUN pnpm nx run core:build --skip-nx-cache
@@ -74,6 +79,10 @@ for (const distRoot of distRoots) walk(distRoot);"
 # emits the client bundle for this TanStack Start app, while `vite build`
 # produces client, SSR service bundle and Nitro server output in one pass.
 RUN pnpm nx run sva-studio-react:build --skip-nx-cache
+RUN if grep -R -E 'jsxDEV|jsx-dev-runtime' /workspace/apps/sva-studio-react/.output/server; then \
+      echo "Docker production artifact must not contain React development JSX runtime." >&2; \
+      exit 1; \
+    fi
 RUN pnpm --filter sva-studio-react deploy --prod /workspace/.deploy/sva-studio-react
 
 # Copy built dist/ artifacts of workspace packages into deployed pnpm package locations.

--- a/deploy/portainer/Dockerfile
+++ b/deploy/portainer/Dockerfile
@@ -79,7 +79,13 @@ for (const distRoot of distRoots) walk(distRoot);"
 # emits the client bundle for this TanStack Start app, while `vite build`
 # produces client, SSR service bundle and Nitro server output in one pass.
 RUN pnpm nx run sva-studio-react:build --skip-nx-cache
-RUN if grep -R -E 'jsxDEV|jsx-dev-runtime' /workspace/apps/sva-studio-react/.output/server; then \
+RUN if grep -R -E -q \
+      --include='*.js' \
+      --include='*.mjs' \
+      --include='*.cjs' \
+      --exclude='*.map' \
+      --exclude-dir='node_modules' \
+      'jsxDEV|jsx-dev-runtime' /workspace/apps/sva-studio-react/.output/server; then \
       echo "Docker production artifact must not contain React development JSX runtime." >&2; \
       exit 1; \
     fi

--- a/nx.json
+++ b/nx.json
@@ -2,14 +2,14 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "main",
   "installation": {
-    "version": "22.5.4",
+    "version": "22.6.5",
     "plugins": {
-      "@nx/eslint": "22.5.4",
-      "@nx/eslint-plugin": "22.5.4",
-      "@nx/js": "22.5.4",
-      "@nx/playwright": "22.5.4",
-      "@nx/vite": "22.5.4",
-      "@nx/vitest": "22.5.4"
+      "@nx/eslint": "22.6.5",
+      "@nx/eslint-plugin": "22.6.5",
+      "@nx/js": "22.6.5",
+      "@nx/playwright": "22.6.5",
+      "@nx/vite": "22.6.5",
+      "@nx/vitest": "22.6.5"
     }
   },
   "workspaceLayout": { "appsDir": "apps", "libsDir": "packages" },

--- a/packages/auth/src/iam-account-management.handlers.test.ts
+++ b/packages/auth/src/iam-account-management.handlers.test.ts
@@ -59,6 +59,10 @@ const state = vi.hoisted(() => ({
     instanceId: 'de-musterhausen',
   },
   queryHandler: null as null | ((text: string, values?: readonly unknown[]) => { rowCount: number; rows: unknown[] }),
+  poolConnectAttempts: 0,
+  poolConnectFailuresRemaining: 0,
+  bootstrapStudioResult: false,
+  bootstrapStudioCalls: [] as Error[],
   redisAvailable: true,
   permissionCacheHealth: {
     status: 'ready',
@@ -211,6 +215,13 @@ vi.mock('./redis.server', () => ({
   isRedisAvailable: vi.fn(async () => state.redisAvailable),
 }));
 
+vi.mock('./postgres-app-user-bootstrap.server', () => ({
+  bootstrapStudioAppDbUserIfNeeded: vi.fn(async (error: Error) => {
+    state.bootstrapStudioCalls.push(error);
+    return state.bootstrapStudioResult;
+  }),
+}));
+
 vi.mock('./config.js', () => ({
   resolveAuthConfigForRequest: vi.fn(async () => ({
     authRealm: state.runtimeAuthRealm,
@@ -234,6 +245,12 @@ vi.mock('./iam-account-management/user-timeline-query', () => ({
 vi.mock('pg', () => ({
   Pool: class MockPool {
     async connect() {
+      state.poolConnectAttempts += 1;
+      if (state.poolConnectFailuresRemaining > 0) {
+        state.poolConnectFailuresRemaining -= 1;
+        throw new Error('password authentication failed for user "sva_app"');
+      }
+
       return {
         async query(text: string, values?: readonly unknown[]) {
           const isUserDetailSchemaSupportQuery =
@@ -552,6 +569,10 @@ describe('iam-account-management handlers (guards)', () => {
       }
       return { rowCount: 0, rows: [] };
     };
+    state.poolConnectAttempts = 0;
+    state.poolConnectFailuresRemaining = 0;
+    state.bootstrapStudioResult = false;
+    state.bootstrapStudioCalls = [];
     state.createRoleImpl = null;
     state.updateRoleImpl = null;
     state.deleteRoleImpl = null;
@@ -6054,6 +6075,73 @@ describe('iam-account-management additional handlers', () => {
         }),
       })
     );
+  });
+
+  it('bootstraps the studio app database user and retries readiness connection', async () => {
+    vi.resetModules();
+    state.redisAvailable = true;
+    state.listRolesImpl = async () => [];
+    state.poolConnectAttempts = 0;
+    state.poolConnectFailuresRemaining = 1;
+    state.bootstrapStudioResult = true;
+    state.bootstrapStudioCalls = [];
+    state.queryHandler = (text) => {
+      if (text.includes('SELECT 1;')) {
+        return { rowCount: 1, rows: [{ '?column?': 1 }] };
+      }
+      if (text.includes("to_regclass('iam.groups')")) {
+        return {
+          rowCount: 1,
+          rows: [
+            {
+              groups_exists: true,
+              group_roles_exists: true,
+              account_groups_exists: true,
+              account_groups_origin_column_exists: true,
+              activity_logs_exists: true,
+              platform_activity_logs_exists: true,
+              accounts_avatar_url_column_exists: true,
+              accounts_instance_id_column_exists: true,
+              accounts_username_ciphertext_column_exists: true,
+              accounts_notes_column_exists: true,
+              accounts_preferred_language_column_exists: true,
+              accounts_timezone_column_exists: true,
+              instance_hostnames_exists: true,
+              instance_hostnames_rls_disabled: true,
+              instances_primary_hostname_column_exists: true,
+              instances_auth_realm_column_exists: true,
+              instances_auth_client_id_column_exists: true,
+              instances_auth_issuer_url_column_exists: true,
+              instances_auth_client_secret_ciphertext_column_exists: true,
+              instances_rls_disabled: true,
+              instances_tenant_admin_username_column_exists: true,
+              instances_tenant_admin_email_column_exists: true,
+              instances_tenant_admin_first_name_column_exists: true,
+              instances_tenant_admin_last_name_column_exists: true,
+              instances_tenant_admin_client_id_column_exists: true,
+              instances_tenant_admin_client_secret_ciphertext_column_exists: true,
+              idx_accounts_kc_subject_instance_exists: true,
+              accounts_isolation_policy_matches: true,
+              instance_memberships_isolation_policy_matches: true,
+            },
+          ],
+        };
+      }
+      return { rowCount: 0, rows: [] };
+    };
+
+    const { healthReadyHandler: freshHealthReadyHandler } = await import('./iam-account-management.server');
+    const response = await freshHealthReadyHandler(
+      new Request('http://localhost/api/v1/iam/health/ready', { method: 'GET' })
+    );
+    const payload = (await response.json()) as { status: string; checks: { db: boolean } };
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe('ready');
+    expect(payload.checks.db).toBe(true);
+    expect(state.poolConnectAttempts).toBe(2);
+    expect(state.bootstrapStudioCalls).toHaveLength(1);
+    expect(state.bootstrapStudioCalls[0]?.message).toContain('password authentication failed');
   });
 
   it('returns degraded when authorization cache exceeds latency threshold', async () => {

--- a/packages/auth/src/iam-account-management/platform-handlers.ts
+++ b/packages/auth/src/iam-account-management/platform-handlers.ts
@@ -4,7 +4,7 @@ import { classifyHost, isTrafficEnabledInstanceStatus } from '@sva/core';
 import { loadInstanceByHostname } from '@sva/data/server';
 
 import { getPermissionCacheHealth } from '../iam-authorization/shared.js';
-import { bootstrapAcceptanceAppDbUserIfNeeded } from '../postgres-app-user-bootstrap.server.js';
+import { bootstrapStudioAppDbUserIfNeeded } from '../postgres-app-user-bootstrap.server.js';
 import { getLastRedisError, isRedisAvailable } from '../redis.server.js';
 import { jsonResponse } from '../shared/db-helpers.js';
 import { resolveEffectiveRequestHost } from '../request-hosts.js';
@@ -180,7 +180,7 @@ export const readyInternal = async (request: Request): Promise<Response> => {
       try {
         client = await pool.connect();
       } catch (error) {
-        const bootstrapped = await bootstrapAcceptanceAppDbUserIfNeeded(error);
+        const bootstrapped = await bootstrapStudioAppDbUserIfNeeded(error);
         if (!bootstrapped) {
           throw error;
         }

--- a/packages/auth/src/postgres-app-user-bootstrap.server.test.ts
+++ b/packages/auth/src/postgres-app-user-bootstrap.server.test.ts
@@ -47,41 +47,41 @@ describe('postgres-app-user bootstrap', () => {
   });
 
   it('returns false when bootstrap conditions are not met', async () => {
-    const { bootstrapAcceptanceAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
+    const { bootstrapStudioAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
 
-    await expect(bootstrapAcceptanceAppDbUserIfNeeded(new Error('password authentication failed'))).resolves.toBe(
+    await expect(bootstrapStudioAppDbUserIfNeeded(new Error('password authentication failed'))).resolves.toBe(
       false
     );
 
-    process.env.SVA_RUNTIME_PROFILE = 'acceptance-hb';
-    await expect(bootstrapAcceptanceAppDbUserIfNeeded(new Error('another error'))).resolves.toBe(false);
+    process.env.SVA_RUNTIME_PROFILE = 'studio';
+    await expect(bootstrapStudioAppDbUserIfNeeded(new Error('another error'))).resolves.toBe(false);
   });
 
   it('returns false when required passwords are unavailable', async () => {
-    process.env.SVA_RUNTIME_PROFILE = 'acceptance-hb';
+    process.env.SVA_RUNTIME_PROFILE = 'studio';
     process.env.POSTGRES_PASSWORD = '';
     delete process.env.POSTGRES_PASSWORD_FILE;
     state.getAppDbPassword.mockReturnValue(undefined);
 
-    const { bootstrapAcceptanceAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
+    const { bootstrapStudioAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
 
     await expect(
-      bootstrapAcceptanceAppDbUserIfNeeded(new Error('password authentication failed for user "sva_app"'))
+      bootstrapStudioAppDbUserIfNeeded(new Error('password authentication failed for user "sva_app"'))
     ).resolves.toBe(false);
   });
 
-  it('bootstraps the acceptance app user with file-based superuser password', async () => {
-    process.env.SVA_RUNTIME_PROFILE = 'acceptance-hb';
+  it('bootstraps the studio app user with file-based superuser password', async () => {
+    process.env.SVA_RUNTIME_PROFILE = 'studio';
     process.env.POSTGRES_PASSWORD_FILE = '/run/secrets/postgres-password';
     delete process.env.POSTGRES_PASSWORD;
     process.env.APP_DB_USER = 'app_user';
     process.env.POSTGRES_USER = 'postgres';
     process.env.POSTGRES_DB = 'studio';
 
-    const { bootstrapAcceptanceAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
+    const { bootstrapStudioAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
 
     await expect(
-      bootstrapAcceptanceAppDbUserIfNeeded(new Error('password authentication failed for user "sva_app"'))
+      bootstrapStudioAppDbUserIfNeeded(new Error('password authentication failed for user "sva_app"'))
     ).resolves.toBe(true);
 
     expect(state.readFileSync).toHaveBeenCalledWith('/run/secrets/postgres-password', 'utf8');
@@ -91,9 +91,9 @@ describe('postgres-app-user bootstrap', () => {
     );
     expect(state.clientQuery).toHaveBeenCalledWith('GRANT iam_app TO "app_user"');
     expect(state.logger.info).toHaveBeenCalledWith(
-      'Bootstrapped acceptance app DB role',
+      'Bootstrapped studio app DB role',
       expect.objectContaining({
-        operation: 'acceptance_db_bootstrap',
+        operation: 'studio_db_bootstrap',
         app_db_user: 'app_user',
         database: 'studio',
       })
@@ -101,20 +101,20 @@ describe('postgres-app-user bootstrap', () => {
   });
 
   it('logs a warning and returns false when bootstrap itself fails', async () => {
-    process.env.SVA_RUNTIME_PROFILE = 'acceptance-hb';
+    process.env.SVA_RUNTIME_PROFILE = 'studio';
     process.env.POSTGRES_PASSWORD = 'super-secret';
     state.clientQuery.mockRejectedValue(new Error('bootstrap failed'));
 
-    const { bootstrapAcceptanceAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
+    const { bootstrapStudioAppDbUserIfNeeded } = await import('./postgres-app-user-bootstrap.server.js');
 
     await expect(
-      bootstrapAcceptanceAppDbUserIfNeeded(new Error('password authentication failed for user "sva_app"'))
+      bootstrapStudioAppDbUserIfNeeded(new Error('password authentication failed for user "sva_app"'))
     ).resolves.toBe(false);
 
     expect(state.logger.warn).toHaveBeenCalledWith(
-      'Acceptance DB bootstrap failed',
+      'Studio DB bootstrap failed',
       expect.objectContaining({
-        operation: 'acceptance_db_bootstrap',
+        operation: 'studio_db_bootstrap',
         error: 'bootstrap failed',
       })
     );

--- a/packages/auth/src/postgres-app-user-bootstrap.server.ts
+++ b/packages/auth/src/postgres-app-user-bootstrap.server.ts
@@ -34,8 +34,8 @@ const readPostgresSuperuserPasswords = (): readonly string[] => {
   return [...new Set(candidates)];
 };
 
-const shouldAttemptAcceptanceBootstrap = (error: unknown): boolean => {
-  if (process.env.SVA_RUNTIME_PROFILE !== 'acceptance-hb') {
+const shouldAttemptStudioBootstrap = (error: unknown): boolean => {
+  if (process.env.SVA_RUNTIME_PROFILE !== 'studio') {
     return false;
   }
 
@@ -93,8 +93,8 @@ $bootstrap$;
         `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA iam TO ${quotedAppDbUser}`
       );
       await client.query(`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA iam TO ${quotedAppDbUser}`);
-      logger.info('Bootstrapped acceptance app DB role', {
-        operation: 'acceptance_db_bootstrap',
+      logger.info('Bootstrapped studio app DB role', {
+        operation: 'studio_db_bootstrap',
         app_db_user: appDbUser,
         database: postgresDb,
       });
@@ -109,16 +109,16 @@ $bootstrap$;
   throw lastError instanceof Error ? lastError : new Error(String(lastError ?? 'DB bootstrap failed'));
 };
 
-export const bootstrapAcceptanceAppDbUserIfNeeded = async (error: unknown): Promise<boolean> => {
-  if (!shouldAttemptAcceptanceBootstrap(error)) {
+export const bootstrapStudioAppDbUserIfNeeded = async (error: unknown): Promise<boolean> => {
+  if (!shouldAttemptStudioBootstrap(error)) {
     return false;
   }
 
   if (!bootstrapPromise) {
     bootstrapPromise = runBootstrap()
       .catch((bootstrapError) => {
-        logger.warn('Acceptance DB bootstrap failed', {
-          operation: 'acceptance_db_bootstrap',
+        logger.warn('Studio DB bootstrap failed', {
+          operation: 'studio_db_bootstrap',
           error: bootstrapError instanceof Error ? bootstrapError.message : String(bootstrapError),
         });
         return false;

--- a/packages/auth/src/redis-session.fallback.test.ts
+++ b/packages/auth/src/redis-session.fallback.test.ts
@@ -54,7 +54,7 @@ describe('redis-session fail-fast behavior', () => {
     state.logger.error.mockReset();
     process.env = {
       ...originalEnv,
-      SVA_RUNTIME_PROFILE: 'acceptance-hb',
+      SVA_RUNTIME_PROFILE: 'studio',
       SVA_AUTH_ALLOW_IN_MEMORY_SESSION_FALLBACK: 'true',
     };
   });

--- a/packages/auth/src/runtime-secrets.server.test.ts
+++ b/packages/auth/src/runtime-secrets.server.test.ts
@@ -92,7 +92,7 @@ describe('runtime-secrets.server', () => {
   it('keeps docker redis hostname for non-local runtime profiles', async () => {
     process.env = {
       ...originalEnv,
-      SVA_RUNTIME_PROFILE: 'acceptance-hb',
+      SVA_RUNTIME_PROFILE: 'studio',
     };
     delete process.env.REDIS_URL;
 

--- a/packages/auth/src/shared/db-helpers.ts
+++ b/packages/auth/src/shared/db-helpers.ts
@@ -1,5 +1,5 @@
 import { Pool, type PoolClient } from 'pg';
-import { bootstrapAcceptanceAppDbUserIfNeeded } from '../postgres-app-user-bootstrap.server.js';
+import { bootstrapStudioAppDbUserIfNeeded } from '../postgres-app-user-bootstrap.server.js';
 
 export type QueryResult<TRow> = {
   rowCount: number;
@@ -70,7 +70,7 @@ export const withInstanceDb = async <T>(
   try {
     client = (await pool.connect()) as PoolClient & QueryClient;
   } catch (error) {
-    const bootstrapped = await bootstrapAcceptanceAppDbUserIfNeeded(error);
+    const bootstrapped = await bootstrapStudioAppDbUserIfNeeded(error);
     if (!bootstrapped) {
       throw error;
     }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -21,8 +21,7 @@
     "lint": {
       "executor": "@nx/eslint:lint",
       "options": {
-        "lintFilePatterns": ["packages/core/src/**/*.{ts,tsx,js,jsx}"],
-        "command": "pnpm --filter @sva/core exec tsc -p tsconfig.lib.json --noEmit"
+        "lintFilePatterns": ["packages/core/src/**/*.{ts,tsx,js,jsx}"]
       }
     },
     "test:unit": {

--- a/packages/data/project.json
+++ b/packages/data/project.json
@@ -22,8 +22,7 @@
     "lint": {
       "executor": "@nx/eslint:lint",
       "options": {
-        "lintFilePatterns": ["packages/data/src/**/*.{ts,tsx,js,jsx}"],
-        "command": "pnpm --filter @sva/data exec tsc -p tsconfig.lib.json --noEmit"
+        "lintFilePatterns": ["packages/data/src/**/*.{ts,tsx,js,jsx}"]
       }
     },
     "test:unit": {

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -46,3 +46,40 @@ test('runtime artifact verification runs workspace node helper via bash', () => 
   assert.match(script, /KEYCLOAK_PORT="\$\{KEYCLOAK_PORT\}" bash "\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
   assert.doesNotMatch(script, /(^|[^[:alnum:]_])"\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
 });
+
+test('runtime artifact checks avoid stale images and dev JSX false positives', () => {
+  const imageVerifyScript = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'scripts/ci/verify-studio-image.sh'),
+    'utf8'
+  );
+  const runtimeVerifyScript = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'scripts/ci/verify-runtime-artifact.sh'),
+    'utf8'
+  );
+  const portainerDockerfile = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'deploy/portainer/Dockerfile'),
+    'utf8'
+  );
+  const patchRuntimeArtifact = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'scripts/ci/patch-runtime-artifact.ts'),
+    'utf8'
+  );
+
+  assert.match(imageVerifyScript, /docker pull "\$\{IMAGE_REF\}"/);
+  assert.doesNotMatch(imageVerifyScript, /skipped-local/);
+  assert.doesNotMatch(imageVerifyScript, /docker image inspect "\$\{IMAGE_REF\}"/);
+
+  assert.match(runtimeVerifyScript, /grep -E -q 'jsxDEV\|jsx-dev-runtime'/);
+  assert.match(runtimeVerifyScript, /"\$\{SERVER_INDEX_PATH\}"/);
+  assert.match(runtimeVerifyScript, /"\$\{PATCHED_SERVER_ENTRY_PATH\}"/);
+  assert.match(runtimeVerifyScript, /"\$\{SERVER_CHUNK_PATH\}"/);
+  assert.doesNotMatch(runtimeVerifyScript, /grep -R -E 'jsxDEV\|jsx-dev-runtime' "\$\{APP_DIR\}\/\.output\/server"/);
+
+  assert.match(portainerDockerfile, /--exclude-dir='node_modules'/);
+  assert.match(portainerDockerfile, /--exclude='\*\.map'/);
+  assert.match(portainerDockerfile, /--include='\*\.mjs'/);
+
+  assert.match(patchRuntimeArtifact, /createRequire/);
+  assert.match(patchRuntimeArtifact, /requireFromApp\.resolve\(`\$\{packageName\}\/package\.json`\)/);
+  assert.doesNotMatch(patchRuntimeArtifact, /node_modules', '\.pnpm', 'node_modules'/);
+});

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -79,7 +79,9 @@ test('runtime artifact checks avoid stale images and dev JSX false positives', (
   assert.match(portainerDockerfile, /--exclude='\*\.map'/);
   assert.match(portainerDockerfile, /--include='\*\.mjs'/);
 
-  assert.match(patchRuntimeArtifact, /createRequire/);
-  assert.match(patchRuntimeArtifact, /requireFromApp\.resolve\(`\$\{packageName\}\/package\.json`\)/);
+  assert.match(patchRuntimeArtifact, /findPnpmPackageDir/);
+  assert.match(patchRuntimeArtifact, /path\.join\(pnpmDir, entry\.name, 'node_modules', \.\.\.packageSegments\)/);
+  assert.match(patchRuntimeArtifact, /path\.join\(currentDir, 'node_modules', \.\.\.packageSegments\)/);
   assert.doesNotMatch(patchRuntimeArtifact, /node_modules', '\.pnpm', 'node_modules'/);
+  assert.doesNotMatch(patchRuntimeArtifact, /requireFromApp\.resolve/);
 });

--- a/packages/plugin-news/project.json
+++ b/packages/plugin-news/project.json
@@ -18,8 +18,7 @@
         "lintFilePatterns": [
           "packages/plugin-news/src/**/*.{ts,tsx,js,jsx}",
           "packages/plugin-news/tests/**/*.{ts,tsx,js,jsx}"
-        ],
-        "command": "pnpm --filter @sva/plugin-news exec tsc -p tsconfig.lib.json --noEmit"
+        ]
       }
     },
     "test:unit": {

--- a/packages/sdk/project.json
+++ b/packages/sdk/project.json
@@ -25,8 +25,7 @@
         "lintFilePatterns": [
           "packages/sdk/src/**/*.{ts,tsx,js,jsx}",
           "packages/sdk/tests/**/*.{ts,tsx,js,jsx}"
-        ],
-        "command": "pnpm --filter @sva/sdk exec tsc -p tsconfig.lib.json --noEmit"
+        ]
       }
     },
     "test:unit": {

--- a/packages/sdk/src/runtime-profile.ts
+++ b/packages/sdk/src/runtime-profile.ts
@@ -1,4 +1,4 @@
-export const RUNTIME_PROFILES = ['local-keycloak', 'local-builder', 'acceptance-hb', 'studio'] as const;
+export const RUNTIME_PROFILES = ['local-keycloak', 'local-builder', 'studio'] as const;
 
 export type RuntimeProfile = (typeof RUNTIME_PROFILES)[number];
 export type RuntimeProfileAuthMode = 'keycloak' | 'mock';
@@ -85,25 +85,6 @@ const PROFILE_DEFINITIONS = {
       'VITE_PUBLIC_BUILDER_KEY',
     ],
     usesBuilder: true,
-  },
-  'acceptance-hb': {
-    authMode: 'keycloak',
-    description: 'Serverbetrieb fuer HB-Abnahme mit produktionsnaher Realm-Anbindung.',
-    isLocal: false,
-    requiredEnvKeys: [
-      ...COMMON_REQUIRED_ENV_KEYS,
-      ...REMOTE_CONNECTION_REQUIRED_ENV_KEYS,
-      'SVA_AUTH_CLIENT_SECRET',
-      'SVA_AUTH_STATE_SECRET',
-      'SVA_AUTH_REDIRECT_URI',
-      'SVA_AUTH_POST_LOGOUT_REDIRECT_URI',
-      'KEYCLOAK_ADMIN_BASE_URL',
-      'KEYCLOAK_ADMIN_REALM',
-      'KEYCLOAK_ADMIN_CLIENT_SECRET',
-      'KEYCLOAK_ADMIN_CLIENT_ID',
-      'SVA_PARENT_DOMAIN',
-    ],
-    usesBuilder: false,
   },
   studio: {
     authMode: 'keycloak',

--- a/packages/sdk/tests/deploy-feedback-loop.test.ts
+++ b/packages/sdk/tests/deploy-feedback-loop.test.ts
@@ -38,7 +38,7 @@ const createReport = (overrides: Partial<AcceptanceDeployReport> = {}): Acceptan
   migrationFiles: [],
   observability: { notes: [] },
   externalProbes: [],
-  profile: 'acceptance-hb',
+  profile: 'studio',
   releaseDecision: {
     summary: 'Alle technischen Gates erfolgreich.',
     technicalGatePassed: true,
@@ -48,7 +48,7 @@ const createReport = (overrides: Partial<AcceptanceDeployReport> = {}): Acceptan
     imageDigest: 'sha256:abc',
     imageRef: 'ghcr.io/example/sva-studio@sha256:abc',
     imageRepository: 'sva-studio',
-    profile: 'acceptance-hb',
+    profile: 'studio',
     releaseMode: 'app-only',
     workflow: 'Acceptance Deploy',
   },

--- a/packages/sdk/tests/runtime-env.shared.test.ts
+++ b/packages/sdk/tests/runtime-env.shared.test.ts
@@ -111,7 +111,7 @@ SET
       {
         jsonOutput: false,
       },
-      'acceptance-hb'
+      'studio'
     );
 
     expect(result).toEqual({
@@ -134,7 +134,7 @@ SET
           GITHUB_ACTIONS: 'true',
           GITHUB_WORKFLOW: 'Acceptance Deploy',
         },
-        'acceptance-hb',
+        'studio',
         'deploy',
       ),
     ).toEqual({ mode: 'ci-runner' });
@@ -162,18 +162,6 @@ SET
         'deploy',
       ),
     ).toEqual({ mode: 'local-operator' });
-  });
-
-  it('rejects explicit local operator context outside the studio profile', () => {
-    expect(() =>
-      assertDeterministicRemoteMutationContext(
-        {
-          SVA_REMOTE_OPERATOR_CONTEXT: 'local-operator',
-        },
-        'acceptance-hb',
-        'deploy',
-      ),
-    ).toThrow(/greift nur, wenn SVA_REMOTE_OPERATOR_CONTEXT nicht auf local-operator steht/);
   });
 
   it('detects documented truthy flag values for local emergency overrides', () => {
@@ -218,7 +206,7 @@ SET
   it('renders a markdown report with the required evidence fields', () => {
     const paths = buildAcceptanceReportPaths('/tmp/artifacts', 'acceptance-deploy', '2026-03-20T12:00:00.000Z');
     const report: AcceptanceDeployReport = {
-      profile: 'acceptance-hb',
+      profile: 'studio',
       status: 'ok',
       generatedAt: '2026-03-20T12:00:00.000Z',
       reportId: paths.reportId,
@@ -278,7 +266,7 @@ SET
         requiredKeys: ['SVA_RUNTIME_PROFILE', 'SVA_PUBLIC_BASE_URL', 'SVA_STACK_NAME'],
         derivedKeys: ['IAM_DATABASE_URL', 'REDIS_URL'],
         effectiveSummary: {
-          runtimeProfile: 'acceptance-hb',
+          runtimeProfile: 'studio',
           stackName: 'sva-studio',
           publicBaseUrl: 'https://example.test',
         },
@@ -306,7 +294,7 @@ SET
         imageRepository: 'sva-studio',
         imageTag: 'ghcr.io/example/sva-studio:1.2.3',
         monitoringConfigImageTag: '1.2.3',
-        profile: 'acceptance-hb',
+        profile: 'studio',
         releaseMode: 'schema-and-app',
         workflow: 'Acceptance Deploy',
       },
@@ -373,7 +361,6 @@ SET
 
   it('uses remote status execution for swarm profiles and local status execution for local profiles', () => {
     expect(getRuntimeStatusExecutionMode('studio')).toBe('remote');
-    expect(getRuntimeStatusExecutionMode('acceptance-hb')).toBe('remote');
     expect(getRuntimeStatusExecutionMode('local-keycloak')).toBe('local');
   });
 });

--- a/packages/sdk/tests/runtime-profile.test.ts
+++ b/packages/sdk/tests/runtime-profile.test.ts
@@ -14,14 +14,13 @@ describe('runtime-profile', () => {
   it('parses supported profiles', () => {
     expect(parseRuntimeProfile('local-keycloak')).toBe('local-keycloak');
     expect(parseRuntimeProfile('local-builder')).toBe('local-builder');
-    expect(parseRuntimeProfile('acceptance-hb')).toBe('acceptance-hb');
     expect(parseRuntimeProfile('studio')).toBe('studio');
     expect(parseRuntimeProfile('unknown')).toBeNull();
   });
 
   it('resolves the runtime profile from env', () => {
     expect(getRuntimeProfileFromEnv({ SVA_RUNTIME_PROFILE: 'local-builder' })).toBe('local-builder');
-    expect(getRuntimeProfileFromEnv({ VITE_SVA_RUNTIME_PROFILE: 'acceptance-hb' })).toBe('acceptance-hb');
+    expect(getRuntimeProfileFromEnv({ VITE_SVA_RUNTIME_PROFILE: 'studio' })).toBe('studio');
     expect(getRuntimeProfileFromEnv({})).toBeNull();
   });
 
@@ -32,9 +31,8 @@ describe('runtime-profile', () => {
 
   it('exposes required env keys per profile', () => {
     expect(getRuntimeProfileRequiredEnvKeys('local-builder')).toContain('VITE_PUBLIC_BUILDER_KEY');
-    expect(getRuntimeProfileRequiredEnvKeys('acceptance-hb')).toContain('SVA_PARENT_DOMAIN');
-    expect(getRuntimeProfileRequiredEnvKeys('acceptance-hb')).toContain('SVA_AUTH_STATE_SECRET');
     expect(getRuntimeProfileRequiredEnvKeys('studio')).toContain('SVA_PARENT_DOMAIN');
+    expect(getRuntimeProfileRequiredEnvKeys('studio')).toContain('SVA_AUTH_STATE_SECRET');
     expect(getRuntimeProfileRequiredEnvKeys('studio')).toContain('KEYCLOAK_ADMIN_CLIENT_SECRET');
     expect(getRuntimeProfileDerivedEnvKeys('local-builder')).toEqual([]);
     expect(getRuntimeProfileDerivedEnvKeys('studio')).toEqual(['IAM_DATABASE_URL', 'REDIS_URL']);
@@ -83,8 +81,8 @@ describe('runtime-profile', () => {
   });
 
   it('reports invalid runtime env values', () => {
-    const result = validateRuntimeProfileEnv('acceptance-hb', {
-      SVA_RUNTIME_PROFILE: 'acceptance-hb',
+    const result = validateRuntimeProfileEnv('studio', {
+      SVA_RUNTIME_PROFILE: 'studio',
       SVA_PUBLIC_BASE_URL: 'https://hb.example.app',
       OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
       SVA_MAINSERVER_GRAPHQL_URL: 'https://mainserver.example/graphql',

--- a/packages/sva-mainserver/project.json
+++ b/packages/sva-mainserver/project.json
@@ -22,8 +22,7 @@
     "lint": {
       "executor": "@nx/eslint:lint",
       "options": {
-        "lintFilePatterns": ["packages/sva-mainserver/src/**/*.{ts,tsx,js,jsx}"],
-        "command": "pnpm --filter @sva/sva-mainserver exec tsc -p tsconfig.lib.json --noEmit"
+        "lintFilePatterns": ["packages/sva-mainserver/src/**/*.{ts,tsx,js,jsx}"]
       }
     },
     "test:unit": {

--- a/scripts/ci/patch-runtime-artifact.ts
+++ b/scripts/ci/patch-runtime-artifact.ts
@@ -1,8 +1,10 @@
 import { cp, mkdir, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
 const appDirArg = process.argv[2] ?? 'apps/sva-studio-react';
 const appDir = path.resolve(appDirArg);
+const requireFromApp = createRequire(path.join(appDir, 'package.json'));
 const outputServerDir = path.join(appDir, '.output', 'server');
 const outputBuildDir = path.join(outputServerDir, 'chunks', 'build');
 const outputSsrDir = path.join(outputServerDir, '_ssr');
@@ -38,24 +40,11 @@ const assertServerEntryContract = (source: string, filePath: string) => {
 };
 
 const findWorkspacePackageDir = async (packageName: string) => {
-  let currentDir = appDir;
-
-  while (true) {
-    const pnpmPackageDir = path.join(currentDir, 'node_modules', '.pnpm', 'node_modules', packageName);
-    if (await pathExists(pnpmPackageDir)) {
-      return realpath(pnpmPackageDir);
-    }
-
-    const packageDir = path.join(currentDir, 'node_modules', packageName);
-    if (await pathExists(packageDir)) {
-      return realpath(packageDir);
-    }
-
-    const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) {
-      return null;
-    }
-    currentDir = parentDir;
+  try {
+    const packageJsonPath = requireFromApp.resolve(`${packageName}/package.json`);
+    return realpath(path.dirname(packageJsonPath));
+  } catch {
+    return null;
   }
 };
 

--- a/scripts/ci/patch-runtime-artifact.ts
+++ b/scripts/ci/patch-runtime-artifact.ts
@@ -1,10 +1,8 @@
 import { cp, mkdir, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
 import path from 'node:path';
 
 const appDirArg = process.argv[2] ?? 'apps/sva-studio-react';
 const appDir = path.resolve(appDirArg);
-const requireFromApp = createRequire(path.join(appDir, 'package.json'));
 const outputServerDir = path.join(appDir, '.output', 'server');
 const outputBuildDir = path.join(outputServerDir, 'chunks', 'build');
 const outputSsrDir = path.join(outputServerDir, '_ssr');
@@ -39,12 +37,48 @@ const assertServerEntryContract = (source: string, filePath: string) => {
   }
 };
 
-const findWorkspacePackageDir = async (packageName: string) => {
-  try {
-    const packageJsonPath = requireFromApp.resolve(`${packageName}/package.json`);
-    return realpath(path.dirname(packageJsonPath));
-  } catch {
+const findPnpmPackageDir = async (currentDir: string, packageName: string) => {
+  const pnpmDir = path.join(currentDir, 'node_modules', '.pnpm');
+  if (!(await pathExists(pnpmDir))) {
     return null;
+  }
+
+  const packageSegments = packageName.split('/');
+  const entries = await readdir(pnpmDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const packageDir = path.join(pnpmDir, entry.name, 'node_modules', ...packageSegments);
+    if (await pathExists(packageDir)) {
+      return realpath(packageDir);
+    }
+  }
+
+  return null;
+};
+
+const findWorkspacePackageDir = async (packageName: string) => {
+  let currentDir = appDir;
+  const packageSegments = packageName.split('/');
+
+  while (true) {
+    const packageDir = path.join(currentDir, 'node_modules', ...packageSegments);
+    if (await pathExists(packageDir)) {
+      return realpath(packageDir);
+    }
+
+    const pnpmPackageDir = await findPnpmPackageDir(currentDir, packageName);
+    if (pnpmPackageDir) {
+      return pnpmPackageDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null;
+    }
+    currentDir = parentDir;
   }
 };
 

--- a/scripts/ci/patch-runtime-artifact.ts
+++ b/scripts/ci/patch-runtime-artifact.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { cp, mkdir, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const appDirArg = process.argv[2] ?? 'apps/sva-studio-react';
@@ -37,11 +37,59 @@ const assertServerEntryContract = (source: string, filePath: string) => {
   }
 };
 
+const findWorkspacePackageDir = async (packageName: string) => {
+  let currentDir = appDir;
+
+  while (true) {
+    const pnpmPackageDir = path.join(currentDir, 'node_modules', '.pnpm', 'node_modules', packageName);
+    if (await pathExists(pnpmPackageDir)) {
+      return realpath(pnpmPackageDir);
+    }
+
+    const packageDir = path.join(currentDir, 'node_modules', packageName);
+    if (await pathExists(packageDir)) {
+      return realpath(packageDir);
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null;
+    }
+    currentDir = parentDir;
+  }
+};
+
+const ensureTslibRuntimeContract = async () => {
+  const sourceTslibDir = await findWorkspacePackageDir('tslib');
+  if (!sourceTslibDir) {
+    throw new Error('tslib konnte im Workspace-node_modules nicht gefunden werden.');
+  }
+
+  const sourceModuleEntryPath = path.join(sourceTslibDir, 'modules', 'index.js');
+  const sourceCjsEntryPath = path.join(sourceTslibDir, 'tslib.js');
+  if (!(await pathExists(sourceModuleEntryPath)) || !(await pathExists(sourceCjsEntryPath))) {
+    throw new Error(`tslib Runtime-Vertrag ist unvollstaendig: ${sourceTslibDir}`);
+  }
+
+  const outputTslibDir = path.join(outputServerDir, 'node_modules', 'tslib');
+  await mkdir(path.dirname(outputTslibDir), { recursive: true });
+  await rm(outputTslibDir, { force: true, recursive: true });
+  await cp(sourceTslibDir, outputTslibDir, { force: true, recursive: true });
+
+  const outputModuleEntryPath = path.join(outputTslibDir, 'modules', 'index.js');
+  const outputCjsEntryPath = path.join(outputTslibDir, 'tslib.js');
+  if (!(await pathExists(outputModuleEntryPath)) || !(await pathExists(outputCjsEntryPath))) {
+    throw new Error(`tslib Runtime-Vertrag wurde nicht vollstaendig nach ${outputTslibDir} kopiert.`);
+  }
+};
+
 const main = async () => {
   const [finalServerEntrySource, nitroSsrEntryExists] = await Promise.all([
     readFile(finalServerEntryPath, 'utf8'),
     pathExists(generatedNitroSsrEntryPath),
   ]);
+
+  await ensureTslibRuntimeContract();
 
   if (nitroSsrEntryExists && finalServerEntrySource.includes('./_ssr/ssr.mjs')) {
     const generatedNitroSsrEntrySource = await readFile(generatedNitroSsrEntryPath, 'utf8');

--- a/scripts/ci/verify-runtime-artifact.sh
+++ b/scripts/ci/verify-runtime-artifact.sh
@@ -205,6 +205,23 @@ assert_artifact_contract() {
     return 1
   fi
 
+  if grep -R -E 'jsxDEV|jsx-dev-runtime' "${APP_DIR}/.output/server"; then
+    echo "Finaler Server-Output enthaelt React Development-JSX und ist nicht production-tauglich." >&2
+    return 1
+  fi
+
+  if grep -R -Fq 'from "tslib"' "${APP_DIR}/.output/server"; then
+    if [ ! -f "${APP_DIR}/.output/server/node_modules/tslib/modules/index.js" ]; then
+      echo "Finaler Server-Output importiert tslib, aber tslib/modules/index.js fehlt." >&2
+      return 1
+    fi
+
+    if [ ! -f "${APP_DIR}/.output/server/node_modules/tslib/tslib.js" ]; then
+      echo "Finaler Server-Output importiert tslib, aber tslib/tslib.js fehlt." >&2
+      return 1
+    fi
+  fi
+
   return 0
 }
 

--- a/scripts/ci/verify-runtime-artifact.sh
+++ b/scripts/ci/verify-runtime-artifact.sh
@@ -205,7 +205,10 @@ assert_artifact_contract() {
     return 1
   fi
 
-  if grep -R -E 'jsxDEV|jsx-dev-runtime' "${APP_DIR}/.output/server"; then
+  if grep -E -q 'jsxDEV|jsx-dev-runtime' \
+    "${SERVER_INDEX_PATH}" \
+    "${PATCHED_SERVER_ENTRY_PATH}" \
+    "${SERVER_CHUNK_PATH}"; then
     echo "Finaler Server-Output enthaelt React Development-JSX und ist nicht production-tauglich." >&2
     return 1
   fi

--- a/scripts/ci/verify-studio-image.sh
+++ b/scripts/ci/verify-studio-image.sh
@@ -255,7 +255,10 @@ if [ "${VERIFY_STATUS}" = "ok" ]; then
 fi
 
 if [ "${VERIFY_STATUS}" = "ok" ]; then
-  if docker pull "${IMAGE_REF}" >/dev/null; then
+  if docker image inspect "${IMAGE_REF}" >/dev/null 2>&1 && [[ "${IMAGE_REF}" != */* ]]; then
+    set_phase_var IMAGE_PULL_STATUS skipped-local
+    mark_phase image-pull skipped-local
+  elif docker pull "${IMAGE_REF}" >/dev/null; then
     set_phase_var IMAGE_PULL_STATUS ok
     mark_phase image-pull ok
   else

--- a/scripts/ci/verify-studio-image.sh
+++ b/scripts/ci/verify-studio-image.sh
@@ -255,10 +255,7 @@ if [ "${VERIFY_STATUS}" = "ok" ]; then
 fi
 
 if [ "${VERIFY_STATUS}" = "ok" ]; then
-  if docker image inspect "${IMAGE_REF}" >/dev/null 2>&1 && [[ "${IMAGE_REF}" != */* ]]; then
-    set_phase_var IMAGE_PULL_STATUS skipped-local
-    mark_phase image-pull skipped-local
-  elif docker pull "${IMAGE_REF}" >/dev/null; then
+  if docker pull "${IMAGE_REF}" >/dev/null; then
     set_phase_var IMAGE_PULL_STATUS ok
     mark_phase image-pull ok
   else

--- a/scripts/ops/runtime-env.remote.test.ts
+++ b/scripts/ops/runtime-env.remote.test.ts
@@ -24,7 +24,7 @@ __SVA_DOCTOR_JSON___END
 noise after
 `);
 
-    const resolution = await resolveTenantRuntimeTargets('acceptance-hb', {
+    const resolution = await resolveTenantRuntimeTargets('studio', {
       IAM_DATABASE_URL: 'postgres://db',
       REDIS_URL: 'redis://cache',
       SVA_AUTH_CLIENT_SECRET: 'secret',


### PR DESCRIPTION
## Zusammenfassung

- härtet den Studio-Runtime-Artefakt-Build und ergänzt die Runtime-Artefakt-Verifikation
- entfernt aktive `acceptance-hb`-Runtime-Referenzen und bereinigt damit alte Happy-Browser-Artefaktpfade
- richtet Nx-Cleanup- und betroffene Package-Konfigurationen auf die Runtime-Artefakt-Checks aus

## Auswirkung

Der PR stabilisiert den Build-/Containerpfad für das Studio-Runtime-Artefakt und reduziert Abhängigkeiten auf nicht mehr aktive Runtime-Varianten. Die Änderungen betreffen Build-/CI-Konfiguration, Runtime-Profile und zugehörige Tests.

## Validierung

- `git diff --check origin/main...HEAD`
- `pnpm test:pr`