### PR TITLE
fix(mainserver): pass likeType for news likes

### DIFF
--- a/packages/sva-mainserver/src/generated/news.ts
+++ b/packages/sva-mainserver/src/generated/news.ts
@@ -241,11 +241,11 @@ const newsItemFields = `
     dateEnd
     timeStart
     timeEnd
-    likeCount
-    likedByMe
+    likeCount(likeType: "Shout")
+    likedByMe(likeType: "Shout")
   }
-  likeCount
-  likedByMe
+  likeCount(likeType: "NewsItem")
+  likedByMe(likeType: "NewsItem")
   pushNotificationsSentAt
   createdAt
   updatedAt


### PR DESCRIPTION
## Kontext

Der bb-guben Mainserver verlangt fuer likedByMe inzwischen das Pflichtargument likeType. Die Studio-News-Query wurde deshalb bei der News-Liste mit graphql_error abgelehnt.

## Änderung

- likeCount/likedByMe fuer NewsItem mit likeType: NewsItem
- likeCount/likedByMe fuer Announcements/Shouts mit likeType: Shout

## Verifikation

- pnpm nx run sva-mainserver:test:unit
- pnpm check:server-runtime
- Studio Image Verify fuer Digest sha256:789cccb79b203fe933e5a828274fccc097bdba600c841058ae2b49f2e78a2c7d
- pnpm env:smoke:studio -- --json
- pnpm env:doctor:studio -- --json (warn nur Observability-Probe)
