### PR TITLE
release(studio): deploy main with news likeType fix

### DIFF
--- a/packages/sva-mainserver/src/generated/news.ts
+++ b/packages/sva-mainserver/src/generated/news.ts
@@ -241,11 +241,11 @@ const newsItemFields = `
     dateEnd
     timeStart
     timeEnd
-    likeCount
-    likedByMe
+    likeCount(likeType: "Shout")
+    likedByMe(likeType: "Shout")
   }
-  likeCount
-  likedByMe
+  likeCount(likeType: "NewsItem")
+  likedByMe(likeType: "NewsItem")
   pushNotificationsSentAt
   createdAt
   updatedAt


### PR DESCRIPTION
## Kontext

Der neue Studio-Stand basiert auf main Commit 684765b8, darf aber den gestern ausgerollten Mainserver-News-Fix nicht verlieren. origin/main enthielt den likeType-Fix noch nicht, daher wurde ein Release-Branch aus origin/main plus erneuter likeType-Korrektur erstellt.

## Migration

Keine schema-and-app Migration nötig: Im Diff gegen den zuletzt ausgerollten Hotfix wurden keine packages/data/migrations/*.sql / Goose-Migrationsdateien geändert. Rollout erfolgte als app-only.

## Verifikation

- pnpm nx run sva-mainserver:test:unit
- pnpm check:server-runtime
- Studio Image Build grün
- Studio Image Verify grün für sha256:a5cfda43625c789f8c60f69278c4dd2565e670dda6874212621c10d1e5c95adb
- pnpm env:smoke:studio -- --json grün
- pnpm env:doctor:studio -- --json warn nur observability_probe_empty
