### PR TITLE
[codex] Fix studio image verify tag sanitizing

### DIFF
--- a/.github/workflows/studio-artifact-verify.yml
+++ b/.github/workflows/studio-artifact-verify.yml
@@ -72,7 +72,7 @@ jobs:
           digest_short="$(printf '%s' "${IMAGE_DIGEST}" | cut -d: -f2 | cut -c1-12)"
           artifact_suffix="${digest_short}"
           if [ -n "${IMAGE_TAG}" ]; then
-            safe_tag="$(printf '%s' "${IMAGE_TAG}" | tr -cs '[:alnum:]._- ' '-' | tr ' ' '-' | sed 's/^-*//; s/-*$//')"
+            safe_tag="$(printf '%s' "${IMAGE_TAG}" | sed -E 's/[^[:alnum:]. _-]+/-/g; s/[[:space:]]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')"
             if [ -n "${safe_tag}" ]; then
               artifact_suffix="${safe_tag}"
             fi

--- a/packages/sdk/tests/package-scripts.test.ts
+++ b/packages/sdk/tests/package-scripts.test.ts
@@ -29,6 +29,11 @@ function loadCoveragePolicy(): CoveragePolicy {
   ) as CoveragePolicy;
 }
 
+function loadStudioArtifactVerifyWorkflow(): string {
+  const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+  return fs.readFileSync(path.join(rootDir, '.github/workflows/studio-artifact-verify.yml'), 'utf8');
+}
+
 describe('workspace package scripts', () => {
   it('keeps patch coverage enforcement in the standard PR gate', () => {
     const packageJson = loadRootPackageJson();
@@ -84,5 +89,14 @@ describe('workspace package scripts', () => {
     const packageJson = loadRootPackageJson();
 
     expect(packageJson.scripts?.['env:release:studio:local']).toBe('tsx scripts/ops/studio-release-local.ts');
+  });
+
+  it('keeps studio image verify tag sanitizing portable on GitHub runners', () => {
+    const workflow = loadStudioArtifactVerifyWorkflow();
+
+    expect(workflow).toContain(
+      "safe_tag=\"$(printf '%s' \"${IMAGE_TAG}\" | sed -E 's/[^[:alnum:]. _-]+/-/g; s/[[:space:]]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')\""
+    );
+    expect(workflow).not.toContain("tr -cs '[:alnum:]._- ' '-'");
   });
 });


### PR DESCRIPTION
## Was wurde geändert?
- die Tag-Sanitisierung im Workflow `Studio Image Verify` auf eine portable `sed`-Variante umgestellt
- einen Regressionstest ergänzt, der die kaputte `tr`-Form künftig verbietet

## Warum?
Der Verify-Workflow auf `main` brach bereits im Step `Validate immutable image input` ab, bevor `docker pull` oder die eigentliche Image-Verifikation liefen.

Root Cause:
`tr -cs '[:alnum:]._- ' '-'` ist auf den GitHub-Ubuntu-Runnern nicht portabel und schlägt mit `range-endpoints of '_- ' are in reverse collating sequence order` fehl.

## Auswirkung
- `Studio Build and Verify` kann die Verify-Stufe wieder vollständig durchlaufen
- der Fix ist von laufender Feature-Arbeit getrennt und isoliert gegen `main`

## Verifikation
- `pnpm nx run sdk:test:unit -- packages/sdk/tests/package-scripts.test.ts`
