### PR TITLE
split(pr338): mainserver pagination harmonization

### DIFF
--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -295,7 +295,7 @@ test.describe('events and POI plugins', () => {
 
     await page.goto('/');
     await page.locator('a[href="/plugins/poi"]').click();
-    await expect(page).toHaveURL(/\/plugins\/poi$/);
+    await expect(page).toHaveURL(/\/plugins\/poi(?:\?page=1&pageSize=25)?$/);
     await expectPluginPageHeading(page, /POI|poi\.list\.title/);
 
     await page.locator('a[href="/plugins/poi/new"]').click();
@@ -325,7 +325,7 @@ test.describe('events and POI plugins', () => {
     page.once('dialog', (dialog) => dialog.accept());
     await page.getByRole('button', { name: /Löschen|poi\.actions\.delete/ }).click();
 
-    await expect(page).toHaveURL(/\/plugins\/poi$/);
+    await expect(page).toHaveURL(/\/plugins\/poi(?:\?page=1&pageSize=25)?$/);
     await expect(page.getByText(/Noch keine POI vorhanden|poi\.empty\.title/)).toBeVisible();
   });
 
@@ -352,7 +352,7 @@ test.describe('events and POI plugins', () => {
 
     await page.goto('/');
     await page.locator('a[href="/plugins/events"]').click();
-    await expect(page).toHaveURL(/\/plugins\/events$/);
+    await expect(page).toHaveURL(/\/plugins\/events(?:\?page=1&pageSize=25)?$/);
     await expectPluginPageHeading(page, /Events|events\.list\.title/);
 
     await page.locator('a[href="/plugins/events/new"]').click();
@@ -380,7 +380,7 @@ test.describe('events and POI plugins', () => {
     page.once('dialog', (dialog) => dialog.accept());
     await page.getByRole('button', { name: /Löschen|events\.actions\.delete/ }).click();
 
-    await expect(page).toHaveURL(/\/plugins\/events$/);
+    await expect(page).toHaveURL(/\/plugins\/events(?:\?page=1&pageSize=25)?$/);
     await expect(page.getByText(/Noch keine Events vorhanden|events\.empty\.title/)).toBeVisible();
   });
 

--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -131,7 +131,14 @@ const routeEvents = async (route: Route, events: EventRecord[]) => {
 
   if (path === '/api/v1/mainserver/events') {
     if (method === 'GET') {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: events }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: events,
+          pagination: { page: 1, pageSize: 25, hasNextPage: false },
+        }),
+      });
       return;
     }
     if (method === 'POST') {
@@ -202,7 +209,14 @@ const routePoi = async (route: Route, pois: PoiRecord[]) => {
 
   if (path === '/api/v1/mainserver/poi') {
     if (method === 'GET') {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: pois }) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: pois,
+          pagination: { page: 1, pageSize: 100, hasNextPage: false },
+        }),
+      });
       return;
     }
     if (method === 'POST') {

--- a/apps/sva-studio-react/e2e/news-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/news-plugin.spec.ts
@@ -268,7 +268,7 @@ test.describe('news plugin', () => {
     await expect(page.getByRole('heading', { name: 'SVA Studio' })).toBeVisible();
 
     await page.getByRole('link', { name: 'News' }).click();
-    await expect(page).toHaveURL(/\/plugins\/news$/);
+    await expect(page).toHaveURL(/\/plugins\/news(?:\?page=1&pageSize=25)?$/);
     await expectPluginPageHeading(page, /News|news\.list\.title/);
 
     await page.locator('a[href="/plugins/news/new"]').click();
@@ -297,7 +297,7 @@ test.describe('news plugin', () => {
     await page.locator('#news-media-caption-0-0').fill('Titelbild');
     await page.getByRole('button', { name: /News anlegen|news\.actions\.create/ }).click();
 
-    await expect(page).toHaveURL(/\/plugins\/news$/);
+    await expect(page).toHaveURL(/\/plugins\/news(?:\?page=1&pageSize=25)?$/);
     await expect(page.getByText('Erste News').first()).toBeVisible();
     expect(createdBody).toMatchObject({
       title: 'Erste News',

--- a/apps/sva-studio-react/e2e/news-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/news-plugin.spec.ts
@@ -112,7 +112,10 @@ const fulfillContentRoute = async (
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ data: newsItems }),
+      body: JSON.stringify({
+        data: newsItems,
+        pagination: { page: 1, pageSize: 25, hasNextPage: false },
+      }),
     });
     return;
   }
@@ -221,13 +224,16 @@ test.describe('news plugin', () => {
       });
     });
 
-    await page.route('**/api/v1/mainserver/news', async (route) => {
+    await page.route('**/api/v1/mainserver/news**', async (route) => {
       const request = route.request();
       if (request.method() === 'GET') {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ data: newsItems }),
+          body: JSON.stringify({
+            data: newsItems,
+            pagination: { page: 1, pageSize: 25, hasNextPage: false },
+          }),
         });
         return;
       }
@@ -292,7 +298,7 @@ test.describe('news plugin', () => {
     await page.getByRole('button', { name: /News anlegen|news\.actions\.create/ }).click();
 
     await expect(page).toHaveURL(/\/plugins\/news$/);
-    await expect(page.getByText('Erste News')).toBeVisible();
+    await expect(page.getByText('Erste News').first()).toBeVisible();
     expect(createdBody).toMatchObject({
       title: 'Erste News',
       author: 'Redaktion Musterhausen',
@@ -352,11 +358,14 @@ test.describe('news plugin', () => {
       });
     });
 
-    await page.route('**/api/v1/mainserver/news', async (route) => {
+    await page.route('**/api/v1/mainserver/news**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ data: newsItems }),
+        body: JSON.stringify({
+          data: newsItems,
+          pagination: { page: 1, pageSize: 25, hasNextPage: false },
+        }),
       });
     });
 
@@ -419,11 +428,14 @@ test.describe('news plugin', () => {
       });
     });
 
-    await page.route('**/api/v1/mainserver/news', async (route) => {
+    await page.route('**/api/v1/mainserver/news**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ data: newsItems }),
+        body: JSON.stringify({
+          data: newsItems,
+          pagination: { page: 1, pageSize: 25, hasNextPage: false },
+        }),
       });
     });
 

--- a/apps/sva-studio-react/e2e/smoke.spec.ts
+++ b/apps/sva-studio-react/e2e/smoke.spec.ts
@@ -176,11 +176,18 @@ const mockAuthenticatedPluginShell = async (page: Page) => {
     });
   });
 
-  await page.route('**/api/v1/mainserver/news', async (route) => {
+  await page.route('**/api/v1/mainserver/news**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ data: [] }),
+      body: JSON.stringify({
+        data: [],
+        pagination: {
+          page: 1,
+          pageSize: 20,
+          hasNextPage: false,
+        },
+      }),
     });
   });
 };

--- a/apps/sva-studio-react/e2e/smoke.spec.ts
+++ b/apps/sva-studio-react/e2e/smoke.spec.ts
@@ -293,7 +293,7 @@ test('authenticated client navigation to /plugins/news renders the plugin route'
   await expectInterfacesShellReady(page);
   await expect(page.locator('html')).toHaveAttribute('data-theme', /.+/);
   await navigateWithPlaywrightRouter(page, '/plugins/news');
-  await expect(page).toHaveURL(/\/plugins\/news$/);
+  await expect(page).toHaveURL(/\/plugins\/news(?:\?page=1&pageSize=25)?$/);
   await expect(page.getByRole('heading', { name: 'News', exact: true })).toBeVisible();
 });
 

--- a/apps/sva-studio-react/e2e/smoke.spec.ts
+++ b/apps/sva-studio-react/e2e/smoke.spec.ts
@@ -184,7 +184,7 @@ const mockAuthenticatedPluginShell = async (page: Page) => {
         data: [],
         pagination: {
           page: 1,
-          pageSize: 20,
+          pageSize: 25,
           hasNextPage: false,
         },
       }),

--- a/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.test.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.test.ts
@@ -109,8 +109,14 @@ describe('dispatchMainserverEventsPoiRequest', () => {
 
   it('lists events and POI after read authorization', async () => {
     mockAuthorizedMutation();
-    state.listSvaMainserverEvents.mockResolvedValue([{ id: 'event-1' }]);
-    state.listSvaMainserverPoi.mockResolvedValue([{ id: 'poi-1' }]);
+    state.listSvaMainserverEvents.mockResolvedValue({
+      data: [{ id: 'event-1' }],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+    state.listSvaMainserverPoi.mockResolvedValue({
+      data: [{ id: 'poi-1' }],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
 
     const eventsResponse = await dispatchMainserverEventsPoiRequest(
       createRequest('https://studio.test/api/v1/mainserver/events')
@@ -118,16 +124,58 @@ describe('dispatchMainserverEventsPoiRequest', () => {
     const poiResponse = await dispatchMainserverEventsPoiRequest(createRequest('https://studio.test/api/v1/mainserver/poi'));
 
     expect(eventsResponse?.status).toBe(200);
-    await expect(eventsResponse?.json()).resolves.toEqual({ data: [{ id: 'event-1' }] });
+    await expect(eventsResponse?.json()).resolves.toEqual({
+      data: [{ id: 'event-1' }],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     expect(poiResponse?.status).toBe(200);
-    await expect(poiResponse?.json()).resolves.toEqual({ data: [{ id: 'poi-1' }] });
+    await expect(poiResponse?.json()).resolves.toEqual({
+      data: [{ id: 'poi-1' }],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     expect(state.listSvaMainserverEvents).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       keycloakSubject: 'subject-1',
+      page: 1,
+      pageSize: 25,
     });
     expect(state.listSvaMainserverPoi).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       keycloakSubject: 'subject-1',
+      page: 1,
+      pageSize: 25,
+    });
+  });
+
+  it('normalizes invalid pagination query parameters for event and poi lists', async () => {
+    mockAuthorizedMutation();
+    state.listSvaMainserverEvents.mockResolvedValue({
+      data: [],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+    state.listSvaMainserverPoi.mockResolvedValue({
+      data: [],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+
+    await dispatchMainserverEventsPoiRequest(
+      createRequest('https://studio.test/api/v1/mainserver/events?page=-2&pageSize=13')
+    );
+    await dispatchMainserverEventsPoiRequest(
+      createRequest('https://studio.test/api/v1/mainserver/poi?page=abc&pageSize=101')
+    );
+
+    expect(state.listSvaMainserverEvents).toHaveBeenCalledWith({
+      instanceId: 'de-musterhausen',
+      keycloakSubject: 'subject-1',
+      page: 1,
+      pageSize: 25,
+    });
+    expect(state.listSvaMainserverPoi).toHaveBeenCalledWith({
+      instanceId: 'de-musterhausen',
+      keycloakSubject: 'subject-1',
+      page: 1,
+      pageSize: 25,
     });
   });
 

--- a/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts
@@ -28,6 +28,8 @@ import type {
 } from '@sva/sva-mainserver';
 import { createSdkLogger, getWorkspaceContext } from '@sva/server-runtime';
 
+import { parseMainserverListQuery } from './mainserver-list-pagination.js';
+
 const EVENTS_CONTENT_TYPE = 'events.event-record';
 const POI_CONTENT_TYPE = 'poi.point-of-interest';
 const EVENTS_COLLECTION_PATH = '/api/v1/mainserver/events';
@@ -468,9 +470,13 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const data = route.contentKind === 'events' ? await listSvaMainserverEvents(actor) : await listSvaMainserverPoi(actor);
+      const listQuery = parseMainserverListQuery(request);
+      const data =
+        route.contentKind === 'events'
+          ? await listSvaMainserverEvents({ ...actor, ...listQuery })
+          : await listSvaMainserverPoi({ ...actor, ...listQuery });
       logSuccess(`mainserver_${route.contentKind}_list`);
-      return json({ data });
+      return json(data);
     }
 
     if (route.kind === 'item' && request.method === 'GET') {

--- a/apps/sva-studio-react/src/lib/mainserver-list-pagination.test.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-list-pagination.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMainserverListQuery } from './mainserver-list-pagination.js';
+
+describe('parseMainserverListQuery', () => {
+  it('normalizes unsupported page sizes to the default value', () => {
+    const query = parseMainserverListQuery(new Request('https://studio.test/api/v1/mainserver/news?page=3&pageSize=13'));
+
+    expect(query).toEqual({ page: 3, pageSize: 25 });
+  });
+
+  it('caps page to the maximum visible offset budget', () => {
+    const query = parseMainserverListQuery(new Request('https://studio.test/api/v1/mainserver/news?page=9999&pageSize=25'));
+
+    expect(query).toEqual({ page: 401, pageSize: 25 });
+  });
+});

--- a/apps/sva-studio-react/src/lib/mainserver-list-pagination.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-list-pagination.ts
@@ -1,0 +1,28 @@
+export const mainserverListDefaultPageSize = 25;
+export const mainserverListAllowedPageSizes = [25, 50, 100] as const;
+
+export type MainserverListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+};
+
+const readPositiveInteger = (value: string | null): number | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 && String(parsed) === value ? parsed : undefined;
+};
+
+export const parseMainserverListQuery = (request: Request): MainserverListQuery => {
+  const { searchParams } = new URL(request.url);
+  const page = readPositiveInteger(searchParams.get('page')) ?? 1;
+  const requestedPageSize = readPositiveInteger(searchParams.get('pageSize'));
+  const pageSize =
+    requestedPageSize && mainserverListAllowedPageSizes.includes(requestedPageSize as (typeof mainserverListAllowedPageSizes)[number])
+      ? requestedPageSize
+      : mainserverListDefaultPageSize;
+
+  return { page, pageSize };
+};

--- a/apps/sva-studio-react/src/lib/mainserver-list-pagination.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-list-pagination.ts
@@ -1,5 +1,6 @@
 export const mainserverListDefaultPageSize = 25;
 export const mainserverListAllowedPageSizes = [25, 50, 100] as const;
+export const mainserverListMaxOffset = 10_000;
 
 export type MainserverListQuery = {
   readonly page: number;
@@ -17,12 +18,13 @@ const readPositiveInteger = (value: string | null): number | undefined => {
 
 export const parseMainserverListQuery = (request: Request): MainserverListQuery => {
   const { searchParams } = new URL(request.url);
-  const page = readPositiveInteger(searchParams.get('page')) ?? 1;
   const requestedPageSize = readPositiveInteger(searchParams.get('pageSize'));
   const pageSize =
     requestedPageSize && mainserverListAllowedPageSizes.includes(requestedPageSize as (typeof mainserverListAllowedPageSizes)[number])
       ? requestedPageSize
       : mainserverListDefaultPageSize;
+  const maxPage = Math.floor(mainserverListMaxOffset / pageSize) + 1;
+  const page = Math.min(readPositiveInteger(searchParams.get('page')) ?? 1, maxPage);
 
   return { page, pageSize };
 };

--- a/apps/sva-studio-react/src/lib/mainserver-news-api.server.test.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-news-api.server.test.ts
@@ -112,7 +112,10 @@ describe('dispatchMainserverNewsRequest', () => {
       actor: { instanceId: 'de-musterhausen', keycloakSubject: 'subject-1' },
       permissions: [],
     });
-    state.listSvaMainserverNews.mockResolvedValue([{ id: 'news-1' }]);
+    state.listSvaMainserverNews.mockResolvedValue({
+      data: [{ id: 'news-1' }],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
 
     const response = await dispatchMainserverNewsRequest(new Request('https://studio.test/api/v1/mainserver/news'));
 
@@ -122,8 +125,37 @@ describe('dispatchMainserverNewsRequest', () => {
     expect(state.listSvaMainserverNews).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       keycloakSubject: 'subject-1',
+      page: 1,
+      pageSize: 25,
     });
-    await expect(response?.json()).resolves.toEqual({ data: [{ id: 'news-1' }] });
+    await expect(response?.json()).resolves.toEqual({
+      data: [{ id: 'news-1' }],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+  });
+
+  it('normalizes invalid pagination query parameters for news lists', async () => {
+    state.withAuthenticatedUser.mockImplementation((_request, handler) => handler(ctx));
+    state.authorizeContentPrimitiveForUser.mockResolvedValue({
+      ok: true,
+      actor: { instanceId: 'de-musterhausen', keycloakSubject: 'subject-1' },
+      permissions: [],
+    });
+    state.listSvaMainserverNews.mockResolvedValue({
+      data: [],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+
+    await dispatchMainserverNewsRequest(
+      new Request('https://studio.test/api/v1/mainserver/news?page=0&pageSize=999')
+    );
+
+    expect(state.listSvaMainserverNews).toHaveBeenCalledWith({
+      instanceId: 'de-musterhausen',
+      keycloakSubject: 'subject-1',
+      page: 1,
+      pageSize: 25,
+    });
   });
 
   it('creates published news and rejects missing publishedAt before GraphQL', async () => {

--- a/apps/sva-studio-react/src/lib/mainserver-news-api.server.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-news-api.server.ts
@@ -19,6 +19,8 @@ import {
 import type { SvaMainserverNewsInput } from '@sva/sva-mainserver';
 import { createSdkLogger, getWorkspaceContext } from '@sva/server-runtime';
 
+import { parseMainserverListQuery } from './mainserver-list-pagination.js';
+
 const NEWS_CONTENT_TYPE = 'news.article';
 const NEWS_COLLECTION_PATH = '/api/v1/mainserver/news';
 const NEWS_ITEM_PATH_PREFIX = `${NEWS_COLLECTION_PATH}/`;
@@ -504,9 +506,9 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const data = await listSvaMainserverNews(actor);
+      const data = await listSvaMainserverNews({ ...actor, ...parseMainserverListQuery(request) });
       logSuccess('mainserver_news_list');
-      return json({ data });
+      return json(data);
     }
 
     if (route.kind === 'item' && request.method === 'GET') {

--- a/docs/superpowers/plans/2026-04-29-mainserver-plugin-list-pagination.md
+++ b/docs/superpowers/plans/2026-04-29-mainserver-plugin-list-pagination.md
@@ -1,0 +1,42 @@
+# Mainserver-Plugin-Listen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die Listenansichten von News, Events und POI auf serverseitige Pagination und `StudioDataTable` harmonisieren.
+
+**Architecture:** Ein gemeinsamer Host-Vertrag fuehrt `page`, `pageSize` und ehrliche Pagination-Metadaten durch `@sva/sva-mainserver`, Host-Routen, Plugin-API-Wrapper und Plugin-Pages. Die UI zeigt Prev/Next auf Basis von `hasNextPage` und verzichtet ohne belastbaren Upstream-Count auf fingierte Totalseiten.
+
+**Tech Stack:** TypeScript strict mode, React, TanStack Router, Nx, Vitest, Playwright, `StudioDataTable`
+
+---
+
+## Datei-Schnitt
+
+- `packages/sva-mainserver/src/server/service.ts`
+  - paginierte News-/Events-/POI-List-Adapter
+- `apps/sva-studio-react/src/lib/mainserver-news-api.server.ts`
+  - Query-Normalisierung und paginierte News-Route
+- `apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts`
+  - Query-Normalisierung und paginierte Events-/POI-Routen
+- `packages/plugin-news/src/news.api.ts`
+  - paginierter Browser-Client fuer News
+- `packages/plugin-events/src/events.api.ts`
+  - paginierter Browser-Client fuer Events
+- `packages/plugin-poi/src/poi.api.ts`
+  - paginierter Browser-Client fuer POI
+- `packages/plugin-news/src/news.pages.tsx`
+  - `StudioDataTable`-basierte News-Liste
+- `packages/plugin-events/src/events.pages.tsx`
+  - `StudioDataTable`-basierte Events-Liste
+- `packages/plugin-poi/src/poi.pages.tsx`
+  - `StudioDataTable`-basierte POI-Liste
+- `packages/studio-ui-react/src/studio-data-table.tsx`
+  - generische Tabellen-Erweiterungen, falls fuer die Harmonisierung noetig
+
+## Umsetzungsbloecke
+
+- [ ] Test- und Typ-Basis fuer paginierte List-Contracts zuerst ergaenzen
+- [ ] Mainserver- und Host-Vertrag anschliessend umstellen
+- [ ] Plugin-API-Wrapper migrieren
+- [ ] Plugin-Pages auf `StudioDataTable` + Prev/Next umstellen
+- [ ] Unit-, Typ- und E2E-Gates grün ziehen

--- a/docs/superpowers/plans/2026-04-29-mainserver-plugin-list-pagination.md
+++ b/docs/superpowers/plans/2026-04-29-mainserver-plugin-list-pagination.md
@@ -4,7 +4,7 @@
 
 **Goal:** Die Listenansichten von News, Events und POI auf serverseitige Pagination und `StudioDataTable` harmonisieren.
 
-**Architecture:** Ein gemeinsamer Host-Vertrag fuehrt `page`, `pageSize` und ehrliche Pagination-Metadaten durch `@sva/sva-mainserver`, Host-Routen, Plugin-API-Wrapper und Plugin-Pages. Die UI zeigt Prev/Next auf Basis von `hasNextPage` und verzichtet ohne belastbaren Upstream-Count auf fingierte Totalseiten.
+**Architecture:** Ein gemeinsamer Host-Vertrag führt `page`, `pageSize` und ehrliche Pagination-Metadaten durch `@sva/sva-mainserver`, Host-Routen, Plugin-API-Wrapper und Plugin-Pages. Die UI zeigt Prev/Next auf Basis von `hasNextPage` und verzichtet ohne belastbaren Upstream-Count auf fingierte Totalseiten.
 
 **Tech Stack:** TypeScript strict mode, React, TanStack Router, Nx, Vitest, Playwright, `StudioDataTable`
 
@@ -19,11 +19,11 @@
 - `apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts`
   - Query-Normalisierung und paginierte Events-/POI-Routen
 - `packages/plugin-news/src/news.api.ts`
-  - paginierter Browser-Client fuer News
+  - paginierter Browser-Client für News
 - `packages/plugin-events/src/events.api.ts`
-  - paginierter Browser-Client fuer Events
+  - paginierter Browser-Client für Events
 - `packages/plugin-poi/src/poi.api.ts`
-  - paginierter Browser-Client fuer POI
+  - paginierter Browser-Client für POI
 - `packages/plugin-news/src/news.pages.tsx`
   - `StudioDataTable`-basierte News-Liste
 - `packages/plugin-events/src/events.pages.tsx`
@@ -31,12 +31,12 @@
 - `packages/plugin-poi/src/poi.pages.tsx`
   - `StudioDataTable`-basierte POI-Liste
 - `packages/studio-ui-react/src/studio-data-table.tsx`
-  - generische Tabellen-Erweiterungen, falls fuer die Harmonisierung noetig
+  - generische Tabellen-Erweiterungen, falls für die Harmonisierung nötig
 
-## Umsetzungsbloecke
+## Umsetzungsblöcke
 
-- [ ] Test- und Typ-Basis fuer paginierte List-Contracts zuerst ergaenzen
-- [ ] Mainserver- und Host-Vertrag anschliessend umstellen
+- [ ] Test- und Typ-Basis für paginierte List-Contracts zuerst ergänzen
+- [ ] Mainserver- und Host-Vertrag anschließend umstellen
 - [ ] Plugin-API-Wrapper migrieren
 - [ ] Plugin-Pages auf `StudioDataTable` + Prev/Next umstellen
 - [ ] Unit-, Typ- und E2E-Gates grün ziehen

--- a/docs/superpowers/specs/2026-04-29-mainserver-plugin-list-pagination-design.md
+++ b/docs/superpowers/specs/2026-04-29-mainserver-plugin-list-pagination-design.md
@@ -1,0 +1,33 @@
+# Mainserver-Plugin-Listen: Pagination- und Tabellenharmonisierung
+
+## Ziel
+
+Die Listenansichten von `news`, `events` und `poi` sollen nicht mehr komplette Datenmengen laden und keine eigenen Tabellenmuster mehr pflegen. Stattdessen bekommen sie einen gemeinsamen serverseitigen Pagination-Vertrag und werden auf `StudioDataTable` harmonisiert.
+
+## Kernschnitt
+
+- `@sva/sva-mainserver` akzeptiert List-Queries mit `page` und `pageSize`
+- Host-Routen normalisieren Query-Parameter und liefern `data` plus `pagination`
+- `pagination` enthaelt mindestens `page`, `pageSize`, `hasNextPage`
+- `total` bleibt optional, weil der aktuelle Snapshot keine offensichtlichen globalen Count-Felder fuer News, Events oder POI zeigt
+
+## UI-Richtung
+
+- `NewsListPage`, `EventsListPage` und `PoiListPage` verwenden `StudioDataTable`
+- die Paging-Bedienung folgt einem gemeinsamen Prev/Next-Muster
+- die UI zeigt nur Informationen, die der Vertrag belastbar liefern kann
+
+## Warum diese Richtung
+
+- sie reduziert Ladezeit und Renderkosten
+- sie entfernt drei parallele Tabellenbasen
+- sie vermeidet das Vortaeuschen exakter Totalseiten ohne Upstream-Beleg
+
+## Betroffene Architektur
+
+- `docs/architecture/04-solution-strategy.md`
+- `docs/architecture/05-building-block-view.md`
+- `docs/architecture/06-runtime-view.md`
+- `docs/architecture/08-cross-cutting-concepts.md`
+- `docs/architecture/10-quality-requirements.md`
+- `docs/architecture/11-risks-and-technical-debt.md`

--- a/docs/superpowers/specs/2026-04-29-mainserver-plugin-list-pagination-design.md
+++ b/docs/superpowers/specs/2026-04-29-mainserver-plugin-list-pagination-design.md
@@ -8,8 +8,8 @@ Die Listenansichten von `news`, `events` und `poi` sollen nicht mehr komplette D
 
 - `@sva/sva-mainserver` akzeptiert List-Queries mit `page` und `pageSize`
 - Host-Routen normalisieren Query-Parameter und liefern `data` plus `pagination`
-- `pagination` enthaelt mindestens `page`, `pageSize`, `hasNextPage`
-- `total` bleibt optional, weil der aktuelle Snapshot keine offensichtlichen globalen Count-Felder fuer News, Events oder POI zeigt
+- `pagination` enthält mindestens `page`, `pageSize`, `hasNextPage`
+- `total` bleibt optional, weil der aktuelle Snapshot keine offensichtlichen globalen Count-Felder für News, Events oder POI zeigt
 
 ## UI-Richtung
 
@@ -21,7 +21,7 @@ Die Listenansichten von `news`, `events` und `poi` sollen nicht mehr komplette D
 
 - sie reduziert Ladezeit und Renderkosten
 - sie entfernt drei parallele Tabellenbasen
-- sie vermeidet das Vortaeuschen exakter Totalseiten ohne Upstream-Beleg
+- sie vermeidet das Vortäuschen exakter Totalseiten ohne Upstream-Beleg
 
 ## Betroffene Architektur
 

--- a/openspec/changes/add-mainserver-plugin-list-pagination/design.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/design.md
@@ -1,27 +1,27 @@
 ## Context
 
-Die drei produktiven Mainserver-Plugins verwenden heute einen Sonderpfad fuer Listen:
+Die drei produktiven Mainserver-Plugins verwenden heute einen Sonderpfad für Listen:
 - Browser ruft pluginlokale API-Wrapper auf
 - Host-Routen liefern rohe Arrays ohne Pagination-Metadaten
 - `@sva/sva-mainserver` listet mit fest verdrahtetem `limit: 100, skip: 0`
 - jede Plugin-Page rendert eine eigene Tabelle ohne `StudioDataTable`
 
 Das erzeugt zwei Probleme gleichzeitig:
-- Performance: es wird mehr geladen als fuer die aktuelle Sicht noetig ist
+- Performance: es wird mehr geladen als für die aktuelle Sicht nötig ist
 - UI-Drift: drei Tabellen weichen vom etablierten Admin-Tabellenmuster ab
 
 ## Goals / Non-Goals
 
 - Goals:
-  - Serverseitige Pagination fuer News-, Event- und POI-Listen
-  - Gemeinsamer Host-Vertrag fuer List-Queries und Pagination-Metadaten
+  - Serverseitige Pagination für News-, Event- und POI-Listen
+  - Gemeinsamer Host-Vertrag für List-Queries und Pagination-Metadaten
   - Harmonisierung der drei Plugin-Listen auf `StudioDataTable`
-  - Keine Vollabfrage mehr als Default-Verhalten fuer Listen
-  - Saubere Behandlung der Upstream-Constraint ohne vorgetaeuschte Totalseiten
+  - Keine Vollabfrage mehr als Default-Verhalten für Listen
+  - Saubere Behandlung der Upstream-Constraint ohne vorgetäuschte Totalseiten
 - Non-Goals:
-  - Keine vollstaendige Vereinheitlichung aller Content-Detailseiten in diesem Change
+  - Keine vollständige Vereinheitlichung aller Content-Detailseiten in diesem Change
   - Keine neue Tabellenbibliothek
-  - Keine Einfuehrung pluginindividueller Spezialfilter, wenn sie fuer die drei Listen nicht gemeinsam benoetigt werden
+  - Keine Einführung pluginindividueller Spezialfilter, wenn sie für die drei Listen nicht gemeinsam benötigt werden
 
 ## Decisions
 
@@ -31,24 +31,24 @@ Die Host-seitigen List-Adapter akzeptieren einen typisierten Query-Vertrag mit m
 - `page`
 - `pageSize`
 
-Die Rueckgabe liefert:
+Die Rückgabe liefert:
 - `data`
 - `pagination.page`
 - `pagination.pageSize`
 - `pagination.hasNextPage`
 - optional `pagination.total`
 
-`total` bleibt optional, weil der aktuelle Snapshot keine offensichtlichen globalen Count-Felder fuer die drei Collections zeigt. Die UI darf fuer Mainserver-Plugin-Listen daher nicht von exakten Totalseiten abhaengen.
+`total` bleibt optional, weil der aktuelle Snapshot keine offensichtlichen globalen Count-Felder für die drei Collections zeigt. Die UI darf für Mainserver-Plugin-Listen daher nicht von exakten Totalseiten abhängen.
 
-Die Plugin-Listen fuehren `page` und `pageSize` als typsichere Search-Params im Routing. Die URL ist damit die kanonische Quelle fuer Listen-Navigation, Deep-Links und Browser-Historie.
+Die Plugin-Listen führen `page` und `pageSize` als typsichere Search-Params im Routing. Die URL ist damit die kanonische Quelle für Listen-Navigation, Deep-Links und Browser-Historie.
 
 ### Decision: Ehrliche Prev/Next-Pagination statt erfundener Totalseiten
 
-Wenn Upstream keinen exakten Gesamtzaehler liefert, bestimmt der Host `hasNextPage` deterministisch ueber ein `pageSize + 1`-Fetch-Muster oder einen gleichwertigen Snapshot-konformen Mechanismus. Diese Semantik muss auf dem tatsaechlich sichtbaren Ergebnis gelten, nicht nur auf der rohen Upstream-Antwort. Wenn nachgelagerte Sichtbarkeitsfilter Eintraege entfernen, muss der Host so lange nachladen oder ueberfetching betreiben, bis er fuer die sichtbare Seite korrekt entscheiden kann, ob eine weitere sichtbare Seite existiert.
+Wenn Upstream keinen exakten Gesamtzähler liefert, bestimmt der Host `hasNextPage` deterministisch über ein `pageSize + 1`-Fetch-Muster oder einen gleichwertigen Snapshot-konformen Mechanismus. Diese Semantik muss auf dem tatsächlich sichtbaren Ergebnis gelten, nicht nur auf der rohen Upstream-Antwort. Wenn nachgelagerte Sichtbarkeitsfilter Einträge entfernen, muss der Host so lange nachladen oder Überfetching betreiben, bis er für die sichtbare Seite korrekt entscheiden kann, ob eine weitere sichtbare Seite existiert.
 
-Die UI zeigt dann Vor/Zurueck und die aktuelle Seite, aber keine fiktive Gesamtseitenzahl.
+Die UI zeigt dann Vor/Zurück und die aktuelle Seite, aber keine fiktive Gesamtseitenzahl.
 
-Falls spaeter ein belastbarer Count-Endpunkt verfuegbar ist, kann der Vertrag `pagination.total` ohne UI-Neubau erweitern.
+Falls später ein belastbarer Count-Endpunkt verfügbar ist, kann der Vertrag `pagination.total` ohne UI-Neubau erweitern.
 
 ### Decision: `StudioDataTable` wird die gemeinsame Tabellenbasis
 
@@ -60,30 +60,30 @@ Die Pagination-Steuerung bleibt ein hostseitiges Pattern um die Tabelle herum un
 
 Die HTTP-Routen unter `apps/sva-studio-react/src/lib/mainserver-*.server.ts` normalisieren Query-Parameter zentral:
 - `page < 1` wird auf `1` gesetzt
-- ungueltige `pageSize`-Werte werden auf einen kanonischen Default gesetzt
+- ungültige `pageSize`-Werte werden auf einen kanonischen Default gesetzt
 - Maximalwerte werden begrenzt
 
-Der Change legt fuer alle drei Listen gemeinsame Werte fest:
+Der Change legt für alle drei Listen gemeinsame Werte fest:
 - Default `pageSize = 25`
-- erlaubte Groessen `25`, `50`, `100`
+- erlaubte Größen `25`, `50`, `100`
 - Maximalwert `100`
 
-Damit bleiben Browser-Code und Plugin-API-Wrapper duenn und typstabil.
+Damit bleiben Browser-Code und Plugin-API-Wrapper dünn und typstabil.
 
 ## Risks / Trade-offs
 
 - Risiko: Upstream liefert keinen exakten Count.
   - Mitigation: UI und Vertrag basieren auf `hasNextPage` als harte Garantie; `total` bleibt optional.
 - Risiko: Sichtbarkeitsfilter verfälschen ein naives `pageSize + 1`-Signal.
-  - Mitigation: `hasNextPage` wird auf Basis des sichtbaren Ergebnisses bestimmt; serverseitige Iteration oder gezieltes Overfetching ist zulaessig.
-- Risiko: `StudioDataTable` benoetigt kleine Erweiterungen fuer die Plugin-Listen.
+- Mitigation: `hasNextPage` wird auf Basis des sichtbaren Ergebnisses bestimmt; serverseitige Iteration oder gezieltes Overfetching ist zulässig.
+- Risiko: `StudioDataTable` benötigt kleine Erweiterungen für die Plugin-Listen.
   - Mitigation: Erweiterungen generisch in `studio-ui-react` vornehmen, nicht in den Plugins duplizieren.
-- Risiko: Playwright- und Unit-Tests muessen auf paginierte Responses umgestellt werden.
-  - Mitigation: Response-Shape frueh zentral definieren und in allen drei Plugins wiederverwenden.
+- Risiko: Playwright- und Unit-Tests müssen auf paginierte Responses umgestellt werden.
+  - Mitigation: Response-Shape früh zentral definieren und in allen drei Plugins wiederverwenden.
 
 ## Migration Plan
 
-1. Query- und Response-Typen fuer paginierte Mainserver-Listen definieren.
+1. Query- und Response-Typen für paginierte Mainserver-Listen definieren.
 2. `@sva/sva-mainserver` auf paginierte List-Adapter umstellen.
 3. Host-Routen auf Query-Parsing und Pagination-Metadaten erweitern.
 4. Plugin-API-Wrapper auf den neuen Vertrag umstellen.
@@ -92,4 +92,4 @@ Damit bleiben Browser-Code und Plugin-API-Wrapper duenn und typstabil.
 
 ## Open Questions
 
-- Soll `StudioDataTable` mittelfristig eine eingebaute generische Pagination-Slot-API bekommen oder bleibt Pagination bewusst ausserhalb der Tabelle? Fuer diesen Change reicht eine externe, gemeinsam genutzte Steuerung.
+- Soll `StudioDataTable` mittelfristig eine eingebaute generische Pagination-Slot-API bekommen oder bleibt Pagination bewusst außerhalb der Tabelle? Für diesen Change reicht eine externe, gemeinsam genutzte Steuerung.

--- a/openspec/changes/add-mainserver-plugin-list-pagination/design.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/design.md
@@ -1,0 +1,95 @@
+## Context
+
+Die drei produktiven Mainserver-Plugins verwenden heute einen Sonderpfad fuer Listen:
+- Browser ruft pluginlokale API-Wrapper auf
+- Host-Routen liefern rohe Arrays ohne Pagination-Metadaten
+- `@sva/sva-mainserver` listet mit fest verdrahtetem `limit: 100, skip: 0`
+- jede Plugin-Page rendert eine eigene Tabelle ohne `StudioDataTable`
+
+Das erzeugt zwei Probleme gleichzeitig:
+- Performance: es wird mehr geladen als fuer die aktuelle Sicht noetig ist
+- UI-Drift: drei Tabellen weichen vom etablierten Admin-Tabellenmuster ab
+
+## Goals / Non-Goals
+
+- Goals:
+  - Serverseitige Pagination fuer News-, Event- und POI-Listen
+  - Gemeinsamer Host-Vertrag fuer List-Queries und Pagination-Metadaten
+  - Harmonisierung der drei Plugin-Listen auf `StudioDataTable`
+  - Keine Vollabfrage mehr als Default-Verhalten fuer Listen
+  - Saubere Behandlung der Upstream-Constraint ohne vorgetaeuschte Totalseiten
+- Non-Goals:
+  - Keine vollstaendige Vereinheitlichung aller Content-Detailseiten in diesem Change
+  - Keine neue Tabellenbibliothek
+  - Keine Einfuehrung pluginindividueller Spezialfilter, wenn sie fuer die drei Listen nicht gemeinsam benoetigt werden
+
+## Decisions
+
+### Decision: Kanonischer List-Contract mit Query und Pagination-Metadaten
+
+Die Host-seitigen List-Adapter akzeptieren einen typisierten Query-Vertrag mit mindestens:
+- `page`
+- `pageSize`
+
+Die Rueckgabe liefert:
+- `data`
+- `pagination.page`
+- `pagination.pageSize`
+- `pagination.hasNextPage`
+- optional `pagination.total`
+
+`total` bleibt optional, weil der aktuelle Snapshot keine offensichtlichen globalen Count-Felder fuer die drei Collections zeigt. Die UI darf fuer Mainserver-Plugin-Listen daher nicht von exakten Totalseiten abhaengen.
+
+Die Plugin-Listen fuehren `page` und `pageSize` als typsichere Search-Params im Routing. Die URL ist damit die kanonische Quelle fuer Listen-Navigation, Deep-Links und Browser-Historie.
+
+### Decision: Ehrliche Prev/Next-Pagination statt erfundener Totalseiten
+
+Wenn Upstream keinen exakten Gesamtzaehler liefert, bestimmt der Host `hasNextPage` deterministisch ueber ein `pageSize + 1`-Fetch-Muster oder einen gleichwertigen Snapshot-konformen Mechanismus. Diese Semantik muss auf dem tatsaechlich sichtbaren Ergebnis gelten, nicht nur auf der rohen Upstream-Antwort. Wenn nachgelagerte Sichtbarkeitsfilter Eintraege entfernen, muss der Host so lange nachladen oder ueberfetching betreiben, bis er fuer die sichtbare Seite korrekt entscheiden kann, ob eine weitere sichtbare Seite existiert.
+
+Die UI zeigt dann Vor/Zurueck und die aktuelle Seite, aber keine fiktive Gesamtseitenzahl.
+
+Falls spaeter ein belastbarer Count-Endpunkt verfuegbar ist, kann der Vertrag `pagination.total` ohne UI-Neubau erweitern.
+
+### Decision: `StudioDataTable` wird die gemeinsame Tabellenbasis
+
+Die drei Plugin-Listen werden auf `StudioDataTable` migriert, statt ihre Tabellen nur optisch anzugleichen. Dadurch werden Semantik, Sortierverhalten, Empty-/Loading-State und Aktionsspalten auf denselben Tabellenanker gelegt wie andere Admin-Bereiche.
+
+Die Pagination-Steuerung bleibt ein hostseitiges Pattern um die Tabelle herum und nicht pluginlokale Tabellenlogik.
+
+### Decision: Query-Normalisierung in den Host-Routen
+
+Die HTTP-Routen unter `apps/sva-studio-react/src/lib/mainserver-*.server.ts` normalisieren Query-Parameter zentral:
+- `page < 1` wird auf `1` gesetzt
+- ungueltige `pageSize`-Werte werden auf einen kanonischen Default gesetzt
+- Maximalwerte werden begrenzt
+
+Der Change legt fuer alle drei Listen gemeinsame Werte fest:
+- Default `pageSize = 25`
+- erlaubte Groessen `25`, `50`, `100`
+- Maximalwert `100`
+
+Damit bleiben Browser-Code und Plugin-API-Wrapper duenn und typstabil.
+
+## Risks / Trade-offs
+
+- Risiko: Upstream liefert keinen exakten Count.
+  - Mitigation: UI und Vertrag basieren auf `hasNextPage` als harte Garantie; `total` bleibt optional.
+- Risiko: Sichtbarkeitsfilter verfälschen ein naives `pageSize + 1`-Signal.
+  - Mitigation: `hasNextPage` wird auf Basis des sichtbaren Ergebnisses bestimmt; serverseitige Iteration oder gezieltes Overfetching ist zulaessig.
+- Risiko: `StudioDataTable` benoetigt kleine Erweiterungen fuer die Plugin-Listen.
+  - Mitigation: Erweiterungen generisch in `studio-ui-react` vornehmen, nicht in den Plugins duplizieren.
+- Risiko: Playwright- und Unit-Tests muessen auf paginierte Responses umgestellt werden.
+  - Mitigation: Response-Shape frueh zentral definieren und in allen drei Plugins wiederverwenden.
+
+## Migration Plan
+
+1. Query- und Response-Typen fuer paginierte Mainserver-Listen definieren.
+2. `@sva/sva-mainserver` auf paginierte List-Adapter umstellen.
+3. Host-Routen auf Query-Parsing und Pagination-Metadaten erweitern.
+4. Plugin-API-Wrapper auf den neuen Vertrag umstellen.
+5. Plugin-List-Pages mit Search-Params, `StudioDataTable` und Prev/Next-Steuerung migrieren.
+6. Tests und E2E-Mocks auf den neuen Vertrag anpassen.
+
+## Open Questions
+
+- Soll `StudioDataTable` mittelfristig eine eingebaute generische Pagination-Slot-API bekommen oder bleibt Pagination bewusst ausserhalb der Tabelle? Fuer diesen Change reicht eine externe, gemeinsam genutzte Steuerung.

--- a/openspec/changes/add-mainserver-plugin-list-pagination/proposal.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/proposal.md
@@ -1,0 +1,49 @@
+# Change: Serverseitige Pagination und StudioDataTable-Harmonisierung für Mainserver-Plugin-Listen
+
+## Why
+Die Listen der Plugins `news`, `events` und `poi` laden derzeit jeweils den kompletten Datenbestand und rendern pluginlokale Tabellen ohne Pagination. Das skaliert schlecht, verlängert die Ladezeit und führt zu drei voneinander abweichenden Tabellenmustern im Admin.
+
+## What Changes
+- Einführung eines kanonischen, serverseitigen Pagination-Vertrags für Mainserver-Listen von News, Events und POI
+- Erweiterung der Host-Routen und Plugin-API-Wrapper um typisierte List-Query-Parameter und Pagination-Metadaten
+- Festlegung von typsicheren Search-Params als kanonischem UI-State für `page` und `pageSize`
+- Umstellung der drei Plugin-Listen von handgebauten `<table>`-Implementierungen auf `StudioDataTable`
+- Vereinheitlichung der Pagination-Bedienung und Ladezustände für diese Plugin-Listen
+- Explizite Berücksichtigung der Upstream-Constraint, dass der aktuelle Schema-Snapshot keine offensichtlichen globalen Count-Felder für News, Events oder POI zeigt
+- Festlegung eines einheitlichen Defaults für Seitengrößen sowie messbarer Erfolgsziele für Netzlast und Ladeverhalten
+
+## Scope Clarification
+- Muss:
+  - Serverseitige Pagination mit korrekter `hasNextPage`-Semantik auf dem tatsächlich sichtbaren Ergebnis
+  - Typsichere Search-Params für Listen-Navigation
+  - Einheitliche Pagination-Metadaten und feste Seitengrößen
+- Bewusster Scope-Aufschlag:
+  - Harmonisierung auf `StudioDataTable` für Konsistenz, A11y und geringere UI-Drift
+
+## Success Metrics
+- Die erste Listenanfrage lädt standardmäßig nur eine Seite statt des kompletten Bestands.
+- Die Netzlast pro Listenansicht sinkt auf höchstens `pageSize + Overfetch für Sichtbarkeitskorrektur` statt Vollabfrage.
+- Paging-Navigation bleibt über URL/Search-Params deep-linkbar und mit Browser-Zurück/Vorwärts konsistent.
+
+## Impact
+- Affected specs:
+  - `content-management`
+  - `sva-mainserver-integration`
+- Affected code:
+  - `packages/sva-mainserver/src/server/service.ts`
+  - `apps/sva-studio-react/src/lib/mainserver-news-api.server.ts`
+  - `apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts`
+  - `packages/plugin-news/src/news.api.ts`
+  - `packages/plugin-events/src/events.api.ts`
+  - `packages/plugin-poi/src/poi.api.ts`
+  - `packages/plugin-news/src/news.pages.tsx`
+  - `packages/plugin-events/src/events.pages.tsx`
+  - `packages/plugin-poi/src/poi.pages.tsx`
+  - `packages/studio-ui-react/src/studio-data-table.tsx`
+- Affected arc42 sections:
+  - `docs/architecture/04-solution-strategy.md`
+  - `docs/architecture/05-building-block-view.md`
+  - `docs/architecture/06-runtime-view.md`
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/10-quality-requirements.md`
+  - `docs/architecture/11-risks-and-technical-debt.md`

--- a/openspec/changes/add-mainserver-plugin-list-pagination/specs/content-management/spec.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/specs/content-management/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Design-System- und Tabellenkonsistenz im Admin-Bereich
+
+Das System MUST die Inhaltsverwaltung mit den bestehenden `shadcn/ui`-Patterns und konsistent zu vorhandenen Admin-Tabellen umsetzen.
+
+#### Scenario: Inhaltsliste folgt bestehendem Tabellenmuster
+
+- **WENN** die Seite `Inhalte` gerendert wird
+- **DANN** verwendet die Tabelle dieselben grundlegenden UI-Patterns wie bestehende Admin-Tabellen, insbesondere aus der Account-Verwaltung
+- **UND** Tabellenkopf, Zellstruktur, Statusdarstellung, Abstände und Aktionsflächen folgen einem konsistenten Admin-Muster
+- **UND** es wird keine parallele, inkompatible Tabellen-Basisimplementierung eingeführt
+
+#### Scenario: Formularansicht nutzt bestehende UI-Bausteine
+
+- **WENN** die Erstellungs- oder Bearbeitungsansicht eines Inhalts angezeigt wird
+- **DANN** basieren Formularfelder, Buttons, Statusanzeigen, Dialoge und Fehlermeldungen auf den bestehenden `shadcn/ui`-Patterns der Anwendung
+- **UND** die Inhaltsverwaltung wirkt visuell und interaktional als Teil derselben Admin-Oberfläche
+
+#### Scenario: Mainserver-Plugin-Listen harmonisieren sich auf StudioDataTable
+
+- **WENN** die Listenansichten der produktiven Mainserver-Plugins `news`, `events` oder `poi` gerendert werden
+- **DANN** verwenden sie `StudioDataTable` als gemeinsame Tabellenbasis
+- **UND** sie fuehren keine pluginlokalen parallelen Tabellen-Implementierungen fuer dieselbe Listenfunktionalitaet fort
+- **UND** Aktionsspalten, Loading-State, Empty-State und semantische Tabellenstruktur folgen demselben Host-Muster
+
+## ADDED Requirements
+
+### Requirement: Mainserver-Plugin-Listen verwenden serverseitige Pagination
+
+Das System SHALL die Listenansichten der produktiven Mainserver-Plugins `news`, `events` und `poi` serverseitig paginieren, statt beim Seitenaufruf den kompletten Datenbestand vorzuladen.
+
+#### Scenario: Plugin-Liste lädt nur die aktuelle Seite
+
+- **GIVEN** ein Redakteur oeffnet die Listenansicht fuer News, Events oder POI
+- **WHEN** die erste Seite gerendert wird
+- **THEN** fordert die UI nur die konfigurierte Seitengroesse fuer die aktuelle Seite an
+- **AND** sie laedt nicht mehr standardmaessig den gesamten Bestand
+
+#### Scenario: Benutzer navigiert zur naechsten Seite
+
+- **GIVEN** die aktuelle Plugin-Liste signalisiert weitere Ergebnisse
+- **WHEN** der Benutzer die Aktion fuer die naechste Seite ausloest
+- **THEN** sendet die UI eine neue List-Anfrage fuer die Zielseite
+- **AND** die Tabelle aktualisiert ihren Lade- und Ergebniszustand ohne Vollabfrage des gesamten Bestands
+- **AND** die aktuelle Seite bleibt ueber typsichere Search-Params in der URL abbildbar
+
+#### Scenario: Upstream liefert keinen exakten Gesamtzaehler
+
+- **GIVEN** der Host kann fuer die angeforderte Plugin-Liste keinen belastbaren Gesamtzaehler aus dem Mainserver-Vertrag ableiten
+- **WHEN** die Pagination-UI gerendert wird
+- **THEN** zeigt sie eine ehrliche Vor/Zurueck-Navigation mit aktueller Seite
+- **AND** sie zeigt keine erfundene Gesamtseitenzahl oder ein fingiertes `total`
+
+#### Scenario: Browser-Navigation bleibt mit Listenstate konsistent
+
+- **GIVEN** ein Benutzer oeffnet eine Mainserver-Plugin-Liste auf einer spaeteren Seite
+- **WHEN** er die Search-Params fuer `page` oder `pageSize` aendert oder Browser-Zurueck/Vorwaerts verwendet
+- **THEN** spiegeln URL und Tabelle denselben Listenstate
+- **AND** die Listenansicht bleibt per Deep-Link reproduzierbar

--- a/openspec/changes/add-mainserver-plugin-list-pagination/specs/content-management/spec.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/specs/content-management/spec.md
@@ -21,7 +21,7 @@ Das System MUST die Inhaltsverwaltung mit den bestehenden `shadcn/ui`-Patterns u
 
 - **WENN** die Listenansichten der produktiven Mainserver-Plugins `news`, `events` oder `poi` gerendert werden
 - **DANN** verwenden sie `StudioDataTable` als gemeinsame Tabellenbasis
-- **UND** sie fuehren keine pluginlokalen parallelen Tabellen-Implementierungen fuer dieselbe Listenfunktionalitaet fort
+- **UND** sie führen keine pluginlokalen parallelen Tabellen-Implementierungen für dieselbe Listenfunktionalität fort
 - **UND** Aktionsspalten, Loading-State, Empty-State und semantische Tabellenstruktur folgen demselben Host-Muster
 
 ## ADDED Requirements
@@ -32,29 +32,29 @@ Das System SHALL die Listenansichten der produktiven Mainserver-Plugins `news`, 
 
 #### Scenario: Plugin-Liste lädt nur die aktuelle Seite
 
-- **GIVEN** ein Redakteur oeffnet die Listenansicht fuer News, Events oder POI
+- **GIVEN** ein Redakteur öffnet die Listenansicht für News, Events oder POI
 - **WHEN** die erste Seite gerendert wird
-- **THEN** fordert die UI nur die konfigurierte Seitengroesse fuer die aktuelle Seite an
-- **AND** sie laedt nicht mehr standardmaessig den gesamten Bestand
+- **THEN** fordert die UI nur die konfigurierte Seitengröße für die aktuelle Seite an
+- **AND** sie lädt nicht mehr standardmäßig den gesamten Bestand
 
-#### Scenario: Benutzer navigiert zur naechsten Seite
+#### Scenario: Benutzer navigiert zur nächsten Seite
 
 - **GIVEN** die aktuelle Plugin-Liste signalisiert weitere Ergebnisse
-- **WHEN** der Benutzer die Aktion fuer die naechste Seite ausloest
-- **THEN** sendet die UI eine neue List-Anfrage fuer die Zielseite
+- **WHEN** der Benutzer die Aktion für die nächste Seite auslöst
+- **THEN** sendet die UI eine neue List-Anfrage für die Zielseite
 - **AND** die Tabelle aktualisiert ihren Lade- und Ergebniszustand ohne Vollabfrage des gesamten Bestands
-- **AND** die aktuelle Seite bleibt ueber typsichere Search-Params in der URL abbildbar
+- **AND** die aktuelle Seite bleibt über typsichere Search-Params in der URL abbildbar
 
-#### Scenario: Upstream liefert keinen exakten Gesamtzaehler
+#### Scenario: Upstream liefert keinen exakten Gesamtzähler
 
-- **GIVEN** der Host kann fuer die angeforderte Plugin-Liste keinen belastbaren Gesamtzaehler aus dem Mainserver-Vertrag ableiten
+- **GIVEN** der Host kann für die angeforderte Plugin-Liste keinen belastbaren Gesamtzähler aus dem Mainserver-Vertrag ableiten
 - **WHEN** die Pagination-UI gerendert wird
-- **THEN** zeigt sie eine ehrliche Vor/Zurueck-Navigation mit aktueller Seite
+- **THEN** zeigt sie eine ehrliche Vor/Zurück-Navigation mit aktueller Seite
 - **AND** sie zeigt keine erfundene Gesamtseitenzahl oder ein fingiertes `total`
 
 #### Scenario: Browser-Navigation bleibt mit Listenstate konsistent
 
-- **GIVEN** ein Benutzer oeffnet eine Mainserver-Plugin-Liste auf einer spaeteren Seite
-- **WHEN** er die Search-Params fuer `page` oder `pageSize` aendert oder Browser-Zurueck/Vorwaerts verwendet
+- **GIVEN** ein Benutzer öffnet eine Mainserver-Plugin-Liste auf einer späteren Seite
+- **WHEN** er die Search-Params für `page` oder `pageSize` ändert oder Browser-Zurück/Vorwärts verwendet
 - **THEN** spiegeln URL und Tabelle denselben Listenstate
 - **AND** die Listenansicht bleibt per Deep-Link reproduzierbar

--- a/openspec/changes/add-mainserver-plugin-list-pagination/specs/sva-mainserver-integration/spec.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/specs/sva-mainserver-integration/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Typed Mainserver List Adapters Support Server-Side Pagination
+
+The system SHALL expose typed, server-only SVA Mainserver list adapters for News, Events, and POI that accept explicit pagination input instead of using a fixed collection fetch.
+
+#### Scenario: News list adapter receives page input
+
+- **GIVEN** the News list is requested through the host route
+- **WHEN** the caller provides `page` and `pageSize`
+- **THEN** the typed News adapter maps them to snapshot-compatible upstream query variables such as `skip` and `limit`
+- **AND** it no longer hardcodes a fixed `limit: 100, skip: 0` list fetch
+
+#### Scenario: Event list adapter receives page input
+
+- **GIVEN** the Events list is requested through the host route
+- **WHEN** the caller provides `page` and `pageSize`
+- **THEN** the typed Event adapter maps them to snapshot-compatible upstream query variables
+- **AND** it returns only the requested page slice to the browser contract
+
+#### Scenario: POI list adapter receives page input
+
+- **GIVEN** the POI list is requested through the host route
+- **WHEN** the caller provides `page` and `pageSize`
+- **THEN** the typed POI adapter maps them to snapshot-compatible upstream query variables
+- **AND** it returns only the requested page slice to the browser contract
+
+### Requirement: Mainserver List Routes Return Honest Pagination Metadata
+
+The system SHALL return deterministic pagination metadata for News, Events, and POI list routes without inventing total counts that the current snapshot-backed upstream contract does not provide.
+
+#### Scenario: Upstream can prove there is another page
+
+- **GIVEN** the host list adapter can determine that more records exist after the current page
+- **WHEN** the route serializes the response
+- **THEN** it returns pagination metadata containing the current `page`, the effective `pageSize`, and `hasNextPage: true`
+- **AND** the decision is based on the visible page result after host-side visibility rules are applied
+
+#### Scenario: Upstream cannot provide exact total
+
+- **GIVEN** the current Mainserver snapshot does not provide a trustworthy exact total for the requested collection
+- **WHEN** the route serializes the paginated response
+- **THEN** it may omit `pagination.total`
+- **AND** it does not synthesize an exact total from assumptions or UI expectations
+
+#### Scenario: Invalid page query is normalized
+
+- **GIVEN** a browser calls `/api/v1/mainserver/news`, `/api/v1/mainserver/events`, or `/api/v1/mainserver/poi` with invalid pagination parameters
+- **WHEN** the host route parses the query string
+- **THEN** it clamps invalid values to deterministic defaults
+- **AND** the typed adapter receives normalized pagination input
+
+#### Scenario: Shared page-size policy is enforced
+
+- **GIVEN** a browser requests a Mainserver list with `pageSize`
+- **WHEN** the host route validates the query
+- **THEN** it uses a default `pageSize` of `25` when none or an invalid value is provided
+- **AND** it accepts only the shared page sizes `25`, `50`, or `100`
+- **AND** it never forwards a page size greater than `100` to the typed adapter

--- a/openspec/changes/add-mainserver-plugin-list-pagination/tasks.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/tasks.md
@@ -1,0 +1,22 @@
+## 1. Spezifikation und Architektur
+- [ ] 1.1 Capability-Deltas fuer `content-management` und `sva-mainserver-integration` finalisieren und mit dem Design abstimmen
+- [ ] 1.2 Betroffene arc42-Abschnitte `04`, `05`, `06`, `08`, `10` und `11` mit Fokus auf List-Contract, Laufzeitfluss und Performance-Trade-offs aktualisieren oder begruendete Abweichung dokumentieren
+
+## 2. Mainserver- und Host-Vertrag
+- [ ] 2.1 Gemeinsame Query- und Pagination-Typen fuer News, Events und POI festlegen
+- [ ] 2.2 `packages/sva-mainserver` von fest codiertem `limit: 100, skip: 0` auf parametrisierte Listen umstellen
+- [ ] 2.3 Deterministische Ermittlung von `hasNextPage` auf Basis des sichtbaren Ergebnisses implementieren, ohne Totalseiten vorzutäuschen
+- [ ] 2.4 Host-Routen fuer News, Events und POI um Query-Normalisierung und paginierte JSON-Responses erweitern
+
+## 3. Plugin- und UI-Harmonisierung
+- [ ] 3.1 Plugin-API-Wrapper fuer News, Events und POI auf paginierte Responses umstellen
+- [ ] 3.2 `StudioDataTable` auf benoetigte generische Erweiterungen fuer die drei Plugin-Listen anpassen
+- [ ] 3.3 `NewsListPage`, `EventsListPage` und `PoiListPage` auf typsichere Search-Params, `StudioDataTable` und gemeinsame Prev/Next-Pagination migrieren
+- [ ] 3.4 Bestehende handgebaute Tabellenmarkups der drei Plugin-Listen entfernen
+
+## 4. Tests und Verifikation
+- [ ] 4.1 Unit-Tests fuer Query-Normalisierung, Pagination-Metadaten und Plugin-API-Wrapper ergaenzen
+- [ ] 4.2 Komponenten-Tests fuer die drei List-Pages um Paging-Interaktion, URL/Search-Param-Synchronisation und States erweitern
+- [ ] 4.3 Playwright-Mocks und E2E-Tests fuer paginierte Responses aktualisieren
+- [ ] 4.4 Relevante Gates ausfuehren: `pnpm nx run plugin-news:test:unit`, `pnpm nx run plugin-events:test:unit`, `pnpm nx run plugin-poi:test:unit`, `pnpm nx run sva-studio-react:test:unit`, `pnpm nx run sva-mainserver:test:unit`, anschliessend `pnpm nx affected --target=test:types --base=origin/main`
+- [ ] 4.5 `openspec validate add-mainserver-plugin-list-pagination --strict` ausfuehren

--- a/openspec/changes/add-mainserver-plugin-list-pagination/tasks.md
+++ b/openspec/changes/add-mainserver-plugin-list-pagination/tasks.md
@@ -1,22 +1,22 @@
 ## 1. Spezifikation und Architektur
-- [ ] 1.1 Capability-Deltas fuer `content-management` und `sva-mainserver-integration` finalisieren und mit dem Design abstimmen
-- [ ] 1.2 Betroffene arc42-Abschnitte `04`, `05`, `06`, `08`, `10` und `11` mit Fokus auf List-Contract, Laufzeitfluss und Performance-Trade-offs aktualisieren oder begruendete Abweichung dokumentieren
+- [ ] 1.1 Capability-Deltas für `content-management` und `sva-mainserver-integration` finalisieren und mit dem Design abstimmen
+- [ ] 1.2 Betroffene arc42-Abschnitte `04`, `05`, `06`, `08`, `10` und `11` mit Fokus auf List-Contract, Laufzeitfluss und Performance-Trade-offs aktualisieren oder begründete Abweichung dokumentieren
 
 ## 2. Mainserver- und Host-Vertrag
-- [ ] 2.1 Gemeinsame Query- und Pagination-Typen fuer News, Events und POI festlegen
+- [ ] 2.1 Gemeinsame Query- und Pagination-Typen für News, Events und POI festlegen
 - [ ] 2.2 `packages/sva-mainserver` von fest codiertem `limit: 100, skip: 0` auf parametrisierte Listen umstellen
 - [ ] 2.3 Deterministische Ermittlung von `hasNextPage` auf Basis des sichtbaren Ergebnisses implementieren, ohne Totalseiten vorzutäuschen
-- [ ] 2.4 Host-Routen fuer News, Events und POI um Query-Normalisierung und paginierte JSON-Responses erweitern
+- [ ] 2.4 Host-Routen für News, Events und POI um Query-Normalisierung und paginierte JSON-Responses erweitern
 
 ## 3. Plugin- und UI-Harmonisierung
-- [ ] 3.1 Plugin-API-Wrapper fuer News, Events und POI auf paginierte Responses umstellen
-- [ ] 3.2 `StudioDataTable` auf benoetigte generische Erweiterungen fuer die drei Plugin-Listen anpassen
+- [ ] 3.1 Plugin-API-Wrapper für News, Events und POI auf paginierte Responses umstellen
+- [ ] 3.2 `StudioDataTable` auf benötigte generische Erweiterungen für die drei Plugin-Listen anpassen
 - [ ] 3.3 `NewsListPage`, `EventsListPage` und `PoiListPage` auf typsichere Search-Params, `StudioDataTable` und gemeinsame Prev/Next-Pagination migrieren
 - [ ] 3.4 Bestehende handgebaute Tabellenmarkups der drei Plugin-Listen entfernen
 
 ## 4. Tests und Verifikation
-- [ ] 4.1 Unit-Tests fuer Query-Normalisierung, Pagination-Metadaten und Plugin-API-Wrapper ergaenzen
-- [ ] 4.2 Komponenten-Tests fuer die drei List-Pages um Paging-Interaktion, URL/Search-Param-Synchronisation und States erweitern
-- [ ] 4.3 Playwright-Mocks und E2E-Tests fuer paginierte Responses aktualisieren
-- [ ] 4.4 Relevante Gates ausfuehren: `pnpm nx run plugin-news:test:unit`, `pnpm nx run plugin-events:test:unit`, `pnpm nx run plugin-poi:test:unit`, `pnpm nx run sva-studio-react:test:unit`, `pnpm nx run sva-mainserver:test:unit`, anschliessend `pnpm nx affected --target=test:types --base=origin/main`
-- [ ] 4.5 `openspec validate add-mainserver-plugin-list-pagination --strict` ausfuehren
+- [ ] 4.1 Unit-Tests für Query-Normalisierung, Pagination-Metadaten und Plugin-API-Wrapper ergänzen
+- [ ] 4.2 Komponenten-Tests für die drei List-Pages um Paging-Interaktion, URL/Search-Param-Synchronisation und States erweitern
+- [ ] 4.3 Playwright-Mocks und E2E-Tests für paginierte Responses aktualisieren
+- [ ] 4.4 Relevante Gates ausführen: `pnpm nx run plugin-news:test:unit`, `pnpm nx run plugin-events:test:unit`, `pnpm nx run plugin-poi:test:unit`, `pnpm nx run sva-studio-react:test:unit`, `pnpm nx run sva-mainserver:test:unit`, anschließend `pnpm nx affected --target=test:types --base=origin/main`
+- [ ] 4.5 `openspec validate add-mainserver-plugin-list-pagination --strict` ausführen

--- a/packages/plugin-events/src/events.api.ts
+++ b/packages/plugin-events/src/events.api.ts
@@ -3,7 +3,6 @@ import type {
   EventFormInput,
   EventListQuery,
   EventListResult,
-  EventPagination,
   PoiSelectItem,
 } from './events.types.js';
 
@@ -14,6 +13,16 @@ type ApiItemResponse<T> = {
 type ApiErrorResponse = {
   readonly error?: string;
   readonly message?: string;
+};
+
+type PaginatedResponse<TItem> = {
+  readonly data: readonly TItem[];
+  readonly pagination: {
+    readonly page: number;
+    readonly pageSize: number;
+    readonly hasNextPage: boolean;
+    readonly total?: number;
+  };
 };
 
 export class EventsApiError extends Error {
@@ -30,6 +39,7 @@ const REQUEST_HEADERS = {
   'Content-Type': 'application/json',
   'X-Requested-With': 'XMLHttpRequest',
 } as const;
+const MAX_POI_SELECTION_PAGES = 101;
 
 const requestJson = async <T>(input: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(input, {
@@ -98,20 +108,19 @@ export const listPoiForEventSelection = async (): Promise<readonly PoiSelectItem
   const items: PoiSelectItem[] = [];
   let page = 1;
   let hasNextPage = true;
-  let safetyPageCount = 0;
 
   while (hasNextPage) {
-    const response = await requestJson<{
-      readonly data: readonly PoiSelectItem[];
-      readonly pagination: EventPagination;
-    }>(buildListUrl('/api/v1/mainserver/poi', { page, pageSize: 100 }));
+    if (page > MAX_POI_SELECTION_PAGES) {
+      throw new EventsApiError(
+        'poi_selection_page_limit_exceeded',
+        'Die POI-Auswahl überschreitet das erlaubte Pagination-Limit.'
+      );
+    }
+
+    const response = await requestJson<PaginatedResponse<PoiSelectItem>>(buildListUrl('/api/v1/mainserver/poi', { page, pageSize: 100 }));
     items.push(...response.data.map((item) => ({ id: item.id, name: item.name })));
     hasNextPage = response.pagination.hasNextPage && response.data.length > 0;
     page += 1;
-    safetyPageCount += 1;
-    if (safetyPageCount >= 100) {
-      break;
-    }
   }
 
   return items;

--- a/packages/plugin-events/src/events.api.ts
+++ b/packages/plugin-events/src/events.api.ts
@@ -1,4 +1,11 @@
-import type { EventContentItem, EventFormInput, EventListQuery, EventListResult, PoiSelectItem } from './events.types.js';
+import type {
+  EventContentItem,
+  EventFormInput,
+  EventListQuery,
+  EventListResult,
+  EventPagination,
+  PoiSelectItem,
+} from './events.types.js';
 
 type ApiItemResponse<T> = {
   readonly data: T;
@@ -91,15 +98,20 @@ export const listPoiForEventSelection = async (): Promise<readonly PoiSelectItem
   const items: PoiSelectItem[] = [];
   let page = 1;
   let hasNextPage = true;
+  let safetyPageCount = 0;
 
   while (hasNextPage) {
     const response = await requestJson<{
       readonly data: readonly PoiSelectItem[];
-      readonly pagination: EventListResult['pagination'];
+      readonly pagination: EventPagination;
     }>(buildListUrl('/api/v1/mainserver/poi', { page, pageSize: 100 }));
     items.push(...response.data.map((item) => ({ id: item.id, name: item.name })));
-    hasNextPage = response.pagination.hasNextPage;
+    hasNextPage = response.pagination.hasNextPage && response.data.length > 0;
     page += 1;
+    safetyPageCount += 1;
+    if (safetyPageCount >= 100) {
+      break;
+    }
   }
 
   return items;

--- a/packages/plugin-events/src/events.api.ts
+++ b/packages/plugin-events/src/events.api.ts
@@ -1,11 +1,7 @@
-import type { EventContentItem, EventFormInput, PoiSelectItem } from './events.types.js';
+import type { EventContentItem, EventFormInput, EventListQuery, EventListResult, PoiSelectItem } from './events.types.js';
 
 type ApiItemResponse<T> = {
   readonly data: T;
-};
-
-type ApiListResponse<T> = {
-  readonly data: readonly T[];
 };
 
 type ApiErrorResponse = {
@@ -54,9 +50,11 @@ const requestJson = async <T>(input: string, init?: RequestInit): Promise<T> => 
   return (await response.json()) as T;
 };
 
-export const listEvents = async (): Promise<readonly EventContentItem[]> => {
-  const response = await requestJson<ApiListResponse<EventContentItem>>('/api/v1/mainserver/events');
-  return response.data;
+const buildListUrl = (basePath: string, query: EventListQuery): string =>
+  `${basePath}?page=${encodeURIComponent(String(query.page))}&pageSize=${encodeURIComponent(String(query.pageSize))}`;
+
+export const listEvents = async (query: EventListQuery): Promise<EventListResult> => {
+  return requestJson<EventListResult>(buildListUrl('/api/v1/mainserver/events', query));
 };
 
 export const getEvent = async (contentId: string): Promise<EventContentItem> => {
@@ -90,6 +88,19 @@ export const deleteEvent = async (contentId: string): Promise<void> => {
 };
 
 export const listPoiForEventSelection = async (): Promise<readonly PoiSelectItem[]> => {
-  const response = await requestJson<ApiListResponse<PoiSelectItem>>('/api/v1/mainserver/poi');
-  return response.data.map((item) => ({ id: item.id, name: item.name }));
+  const items: PoiSelectItem[] = [];
+  let page = 1;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const response = await requestJson<{
+      readonly data: readonly PoiSelectItem[];
+      readonly pagination: EventListResult['pagination'];
+    }>(buildListUrl('/api/v1/mainserver/poi', { page, pageSize: 100 }));
+    items.push(...response.data.map((item) => ({ id: item.id, name: item.name })));
+    hasNextPage = response.pagination.hasNextPage;
+    page += 1;
+  }
+
+  return items;
 };

--- a/packages/plugin-events/src/events.pages.tsx
+++ b/packages/plugin-events/src/events.pages.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { usePluginTranslation } from '@sva/plugin-sdk';
 import {
   Button,
@@ -14,6 +14,7 @@ import {
   StudioFormSummary,
   StudioLoadingState,
   StudioOverviewPageTemplate,
+  StudioDataTable,
   Textarea,
 } from '@sva/studio-ui-react';
 
@@ -26,7 +27,7 @@ import {
   listPoiForEventSelection,
   updateEvent,
 } from './events.api.js';
-import type { EventContentItem, EventFormInput, PoiSelectItem } from './events.types.js';
+import type { EventContentItem, EventFormInput, EventListResult, PoiSelectItem } from './events.types.js';
 import { validateEventForm } from './events.validation.js';
 
 type StatusMessage = {
@@ -140,16 +141,24 @@ const errorMessage = (pt: ReturnType<typeof usePluginTranslation>, error: unknow
 
 export function EventsListPage() {
   const pt = usePluginTranslation('events');
-  const [items, setItems] = React.useState<readonly EventContentItem[]>([]);
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
+  const page = typeof search.page === 'number' ? search.page : 1;
+  const pageSize = typeof search.pageSize === 'number' ? search.pageSize : 25;
+  const [result, setResult] = React.useState<EventListResult>({
+    data: [],
+    pagination: { page, pageSize, hasNextPage: false },
+  });
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     let active = true;
-    listEvents()
+    setLoading(true);
+    listEvents({ page, pageSize })
       .then((data) => {
         if (active) {
-          setItems(data);
+          setResult(data);
           setError(null);
         }
       })
@@ -166,7 +175,7 @@ export function EventsListPage() {
     return () => {
       active = false;
     };
-  }, [pt]);
+  }, [page, pageSize]);
 
   return (
     <StudioOverviewPageTemplate
@@ -174,41 +183,89 @@ export function EventsListPage() {
       description={pt('list.description')}
       primaryAction={
         <Button asChild>
-          <Link to="/plugins/events/new">{pt('actions.create')}</Link>
+          <Link to="/admin/events/new">{pt('actions.create')}</Link>
         </Button>
       }
     >
       {loading ? <StudioLoadingState>{pt('messages.loading')}</StudioLoadingState> : null}
       {error ? <StudioErrorState>{error}</StudioErrorState> : null}
-      {!loading && !error && items.length === 0 ? <StudioEmptyState>{pt('empty.title')}</StudioEmptyState> : null}
-      {!loading && !error && items.length > 0 ? (
-        <div className="overflow-hidden rounded-md border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/60 text-left">
-              <tr>
-                <th className="px-4 py-3 font-medium">{pt('fields.title')}</th>
-                <th className="px-4 py-3 font-medium">{pt('fields.categoryName')}</th>
-                <th className="px-4 py-3 font-medium">{pt('fields.dateStart')}</th>
-                <th className="px-4 py-3 text-right font-medium">{pt('fields.actions')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((item) => (
-                <tr key={item.id} className="border-t border-border">
-                  <td className="px-4 py-3 font-medium">{item.title}</td>
-                  <td className="px-4 py-3">{item.categoryName ?? '—'}</td>
-                  <td className="px-4 py-3">{item.dates?.[0]?.dateStart ? new Date(item.dates[0].dateStart).toLocaleString() : '—'}</td>
-                  <td className="px-4 py-3 text-right">
-                    <Button asChild variant="outline" size="sm">
-                      <Link to="/plugins/events/$contentId" params={{ contentId: item.id }}>
-                        {pt('actions.edit')}
-                      </Link>
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      {!loading && !error && result.data.length === 0 ? <StudioEmptyState>{pt('empty.title')}</StudioEmptyState> : null}
+      {!loading && !error && result.data.length > 0 ? (
+        <div className="space-y-4">
+          <StudioDataTable
+            ariaLabel={pt('list.title')}
+            labels={{
+              selectionColumn: pt('fields.actions'),
+              actionsColumn: pt('fields.actions'),
+              loading: pt('messages.loading'),
+              selectAllRows: (label) => label,
+              selectRow: ({ label }) => label,
+            }}
+            data={result.data}
+            columns={[
+              { id: 'title', header: pt('fields.title'), cell: (item: EventContentItem) => item.title },
+              { id: 'categoryName', header: pt('fields.categoryName'), cell: (item: EventContentItem) => item.categoryName ?? '—' },
+              {
+                id: 'dateStart',
+                header: pt('fields.dateStart'),
+                cell: (item: EventContentItem) =>
+                  item.dates?.[0]?.dateStart ? new Date(item.dates[0].dateStart).toLocaleString() : '—',
+              },
+            ]}
+            rowActions={(item) => (
+              <Button asChild variant="outline" size="sm">
+                <Link to="/admin/events/$id" params={{ id: item.id }}>
+                  {pt('actions.edit')}
+                </Link>
+              </Button>
+            )}
+            emptyState={null}
+            getRowId={(item) => item.id}
+            selectionMode="none"
+          />
+          <nav aria-label={pt('pagination.ariaLabel')} className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+            <p key={result.pagination.page} aria-live="polite" className="animate-pagination-active">
+              {pt('pagination.pageLabel', { page: result.pagination.page })}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={result.pagination.page <= 1}
+                onClick={() =>
+                  void navigate({
+                    to: '/admin/events',
+                    search: (current: Record<string, unknown>) => ({
+                      ...current,
+                      page: Math.max(1, result.pagination.page - 1),
+                      pageSize: result.pagination.pageSize,
+                    }),
+                  })
+                }
+              >
+                {pt('pagination.previous')}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={!result.pagination.hasNextPage}
+                onClick={() =>
+                  void navigate({
+                    to: '/admin/events',
+                    search: (current: Record<string, unknown>) => ({
+                      ...current,
+                      page: result.pagination.page + 1,
+                      pageSize: result.pagination.pageSize,
+                    }),
+                  })
+                }
+              >
+                {pt('pagination.next')}
+              </Button>
+            </div>
+          </nav>
         </div>
       ) : null}
     </StudioOverviewPageTemplate>
@@ -218,8 +275,8 @@ export function EventsListPage() {
 function EventsEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
   const pt = usePluginTranslation('events');
   const navigate = useNavigate();
-  const params = useParams({ strict: false }) as { readonly contentId?: string };
-  const contentId = params.contentId;
+  const params = useParams({ strict: false }) as { readonly contentId?: string; readonly id?: string };
+  const contentId = params.contentId ?? params.id;
   const [form, setForm] = React.useState<EventFormInput>(defaultForm);
   const [pois, setPois] = React.useState<readonly PoiSelectItem[]>([]);
   const [loading, setLoading] = React.useState(mode === 'edit');
@@ -276,7 +333,7 @@ function EventsEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
         mode === 'create' ? await createEvent(compacted) : await updateEvent(contentId as string, compacted);
       setStatus({ kind: 'success', text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess') });
       if (mode === 'create') {
-        await navigate({ to: '/plugins/events/$contentId', params: { contentId: saved.id } });
+        await navigate({ to: '/admin/events/$id', params: { id: saved.id } });
       }
     } catch (saveError) {
       setStatus({ kind: 'error', text: errorMessage(pt, saveError, 'messages.saveError') });
@@ -289,7 +346,7 @@ function EventsEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
     }
     try {
       await deleteEvent(contentId);
-      await navigate({ to: '/plugins/events' });
+      await navigate({ to: '/admin/events' });
     } catch (deleteError) {
       setStatus({ kind: 'error', text: errorMessage(pt, deleteError, 'messages.deleteError') });
     }
@@ -305,7 +362,7 @@ function EventsEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
       description={mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')}
       actions={
         <Button asChild variant="outline">
-          <Link to="/plugins/events">{pt('actions.back')}</Link>
+          <Link to="/admin/events">{pt('actions.back')}</Link>
         </Button>
       }
     >

--- a/packages/plugin-events/src/events.pages.tsx
+++ b/packages/plugin-events/src/events.pages.tsx
@@ -155,11 +155,11 @@ export function EventsListPage() {
   React.useEffect(() => {
     let active = true;
     setLoading(true);
+    setError(null);
     listEvents({ page, pageSize })
       .then((data) => {
         if (active) {
           setResult(data);
-          setError(null);
         }
       })
       .catch((loadError: unknown) => {
@@ -183,7 +183,7 @@ export function EventsListPage() {
       description={pt('list.description')}
       primaryAction={
         <Button asChild>
-          <Link to="/admin/events/new">{pt('actions.create')}</Link>
+          <Link to="/plugins/events/new">{pt('actions.create')}</Link>
         </Button>
       }
     >
@@ -214,7 +214,7 @@ export function EventsListPage() {
             ]}
             rowActions={(item) => (
               <Button asChild variant="outline" size="sm">
-                <Link to="/admin/events/$id" params={{ id: item.id }}>
+                <Link to="/plugins/events/$contentId" params={{ contentId: item.id }}>
                   {pt('actions.edit')}
                 </Link>
               </Button>
@@ -235,7 +235,7 @@ export function EventsListPage() {
                 disabled={result.pagination.page <= 1}
                 onClick={() =>
                   void navigate({
-                    to: '/admin/events',
+                    to: '/plugins/events',
                     search: (current: Record<string, unknown>) => ({
                       ...current,
                       page: Math.max(1, result.pagination.page - 1),
@@ -253,7 +253,7 @@ export function EventsListPage() {
                 disabled={!result.pagination.hasNextPage}
                 onClick={() =>
                   void navigate({
-                    to: '/admin/events',
+                    to: '/plugins/events',
                     search: (current: Record<string, unknown>) => ({
                       ...current,
                       page: result.pagination.page + 1,
@@ -333,7 +333,7 @@ function EventsEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
         mode === 'create' ? await createEvent(compacted) : await updateEvent(contentId as string, compacted);
       setStatus({ kind: 'success', text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess') });
       if (mode === 'create') {
-        await navigate({ to: '/admin/events/$id', params: { id: saved.id } });
+        await navigate({ to: '/plugins/events/$contentId', params: { contentId: saved.id } });
       }
     } catch (saveError) {
       setStatus({ kind: 'error', text: errorMessage(pt, saveError, 'messages.saveError') });
@@ -346,7 +346,7 @@ function EventsEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
     }
     try {
       await deleteEvent(contentId);
-      await navigate({ to: '/admin/events' });
+      await navigate({ to: '/plugins/events' });
     } catch (deleteError) {
       setStatus({ kind: 'error', text: errorMessage(pt, deleteError, 'messages.deleteError') });
     }
@@ -362,7 +362,7 @@ function EventsEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
       description={mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')}
       actions={
         <Button asChild variant="outline">
-          <Link to="/admin/events">{pt('actions.back')}</Link>
+          <Link to="/plugins/events">{pt('actions.back')}</Link>
         </Button>
       }
     >

--- a/packages/plugin-events/src/events.pages.tsx
+++ b/packages/plugin-events/src/events.pages.tsx
@@ -27,6 +27,7 @@ import {
   listPoiForEventSelection,
   updateEvent,
 } from './events.api.js';
+import { normalizeListSearch } from './list-pagination.js';
 import type { EventContentItem, EventFormInput, EventListResult, PoiSelectItem } from './events.types.js';
 import { validateEventForm } from './events.validation.js';
 
@@ -143,14 +144,29 @@ export function EventsListPage() {
   const pt = usePluginTranslation('events');
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
-  const page = typeof search.page === 'number' ? search.page : 1;
-  const pageSize = typeof search.pageSize === 'number' ? search.pageSize : 25;
+  const { page, pageSize } = normalizeListSearch(search);
   const [result, setResult] = React.useState<EventListResult>({
     data: [],
     pagination: { page, pageSize, hasNextPage: false },
   });
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (search.page === page && search.pageSize === pageSize) {
+      return;
+    }
+
+    void navigate({
+      to: '/plugins/events',
+      replace: true,
+      search: (current: Record<string, unknown>) => ({
+        ...current,
+        page,
+        pageSize,
+      }),
+    });
+  }, [navigate, page, pageSize, search.page, search.pageSize]);
 
   React.useEffect(() => {
     let active = true;

--- a/packages/plugin-events/src/events.types.ts
+++ b/packages/plugin-events/src/events.types.ts
@@ -24,6 +24,23 @@ export type EventWebUrl = {
   readonly description?: string;
 };
 
+export type EventListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+};
+
+export type EventPagination = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly hasNextPage: boolean;
+  readonly total?: number;
+};
+
+export type EventListResult = {
+  readonly data: readonly EventContentItem[];
+  readonly pagination: EventPagination;
+};
+
 export type EventFormInput = {
   readonly title: string;
   readonly description?: string;

--- a/packages/plugin-events/src/list-pagination.ts
+++ b/packages/plugin-events/src/list-pagination.ts
@@ -1,0 +1,19 @@
+const allowedListPageSizes = [25, 50, 100] as const;
+const defaultListPageSize = 25;
+const maxListOffset = 10_000;
+
+export type ListSearch = {
+  readonly page?: number;
+  readonly pageSize?: number;
+};
+
+export const normalizeListSearch = (search: ListSearch) => {
+  const pageSize = allowedListPageSizes.includes(search.pageSize as (typeof allowedListPageSizes)[number])
+    ? search.pageSize
+    : defaultListPageSize;
+  const maxPage = Math.floor(maxListOffset / pageSize) + 1;
+  const page =
+    typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;
+
+  return { page, pageSize };
+};

--- a/packages/plugin-events/src/list-pagination.ts
+++ b/packages/plugin-events/src/list-pagination.ts
@@ -7,10 +7,13 @@ export type ListSearch = {
   readonly pageSize?: number;
 };
 
-export const normalizeListSearch = (search: ListSearch) => {
-  const pageSize = allowedListPageSizes.includes(search.pageSize as (typeof allowedListPageSizes)[number])
-    ? search.pageSize
-    : defaultListPageSize;
+export const normalizeListSearch = (search: ListSearch): { readonly page: number; readonly pageSize: number } => {
+  const requestedPageSize = search.pageSize;
+  const pageSize =
+    typeof requestedPageSize === 'number' &&
+    allowedListPageSizes.includes(requestedPageSize as (typeof allowedListPageSizes)[number])
+      ? requestedPageSize
+      : defaultListPageSize;
   const maxPage = Math.floor(maxListOffset / pageSize) + 1;
   const page =
     typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;

--- a/packages/plugin-events/src/plugin.tsx
+++ b/packages/plugin-events/src/plugin.tsx
@@ -128,7 +128,7 @@ export const pluginEvents: PluginDefinition = {
         },
         pagination: {
           ariaLabel: 'Event-Seiten',
-          pageLabel: 'Seite {page}',
+          pageLabel: 'Seite {{page}}',
           previous: 'Zurück',
           next: 'Weiter',
         },
@@ -192,7 +192,7 @@ export const pluginEvents: PluginDefinition = {
         },
         pagination: {
           ariaLabel: 'Event pages',
-          pageLabel: 'Page {page}',
+          pageLabel: 'Page {{page}}',
           previous: 'Previous',
           next: 'Next',
         },

--- a/packages/plugin-events/src/plugin.tsx
+++ b/packages/plugin-events/src/plugin.tsx
@@ -126,6 +126,12 @@ export const pluginEvents: PluginDefinition = {
           deleteSuccess: 'Event wurde gelöscht.',
           validationError: 'Bitte korrigieren Sie die markierten Felder.',
         },
+        pagination: {
+          ariaLabel: 'Event-Seiten',
+          pageLabel: 'Seite {page}',
+          previous: 'Zurück',
+          next: 'Weiter',
+        },
         empty: { title: 'Noch keine Events vorhanden', description: 'Legen Sie das erste Event an.' },
         validation: {
           title: 'Der Titel ist erforderlich.',
@@ -183,6 +189,12 @@ export const pluginEvents: PluginDefinition = {
           updateSuccess: 'Event was updated.',
           deleteSuccess: 'Event was deleted.',
           validationError: 'Please correct the highlighted fields.',
+        },
+        pagination: {
+          ariaLabel: 'Event pages',
+          pageLabel: 'Page {page}',
+          previous: 'Previous',
+          next: 'Next',
         },
         empty: { title: 'No events yet', description: 'Create the first event.' },
         validation: {

--- a/packages/plugin-events/tests/events.api.test.ts
+++ b/packages/plugin-events/tests/events.api.test.ts
@@ -62,6 +62,28 @@ describe('events api', () => {
     ]);
   });
 
+  it('stops POI selection pagination when the upstream page is empty despite hasNextPage', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          Response.json({
+            data: [{ id: 'poi-1', name: 'Rathaus' }],
+            pagination: { page: 1, pageSize: 100, hasNextPage: true },
+          })
+        )
+        .mockResolvedValueOnce(
+          Response.json({
+            data: [],
+            pagination: { page: 2, pageSize: 100, hasNextPage: true },
+          })
+        )
+    );
+
+    await expect(listPoiForEventSelection()).resolves.toEqual([{ id: 'poi-1', name: 'Rathaus' }]);
+  });
+
   it('throws stable errors', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => Response.json({ error: 'forbidden', message: 'Nope' }, { status: 403 })));
 

--- a/packages/plugin-events/tests/events.api.test.ts
+++ b/packages/plugin-events/tests/events.api.test.ts
@@ -8,11 +8,22 @@ describe('events api', () => {
   });
 
   it('lists events from the host facade', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ data: [{ id: 'event-1', title: 'Stadtfest' }] }));
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        data: [{ id: 'event-1', title: 'Stadtfest' }],
+        pagination: { page: 2, pageSize: 50, hasNextPage: true },
+      })
+    );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(listEvents()).resolves.toEqual([{ id: 'event-1', title: 'Stadtfest' }]);
-    expect(fetchMock).toHaveBeenCalledWith('/api/v1/mainserver/events', expect.objectContaining({ credentials: 'include' }));
+    await expect(listEvents({ page: 2, pageSize: 50 })).resolves.toEqual({
+      data: [{ id: 'event-1', title: 'Stadtfest' }],
+      pagination: { page: 2, pageSize: 50, hasNextPage: true },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/mainserver/events?page=2&pageSize=50',
+      expect.objectContaining({ credentials: 'include' })
+    );
   });
 
   it('creates events via POST', async () => {
@@ -27,14 +38,33 @@ describe('events api', () => {
   });
 
   it('maps POI selection items through the POI facade', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => Response.json({ data: [{ id: 'poi-1', name: 'Rathaus' }] })));
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          Response.json({
+            data: [{ id: 'poi-1', name: 'Rathaus' }],
+            pagination: { page: 1, pageSize: 100, hasNextPage: true },
+          })
+        )
+        .mockResolvedValueOnce(
+          Response.json({
+            data: [{ id: 'poi-2', name: 'Markt' }],
+            pagination: { page: 2, pageSize: 100, hasNextPage: false },
+          })
+        )
+    );
 
-    await expect(listPoiForEventSelection()).resolves.toEqual([{ id: 'poi-1', name: 'Rathaus' }]);
+    await expect(listPoiForEventSelection()).resolves.toEqual([
+      { id: 'poi-1', name: 'Rathaus' },
+      { id: 'poi-2', name: 'Markt' },
+    ]);
   });
 
   it('throws stable errors', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => Response.json({ error: 'forbidden', message: 'Nope' }, { status: 403 })));
 
-    await expect(listEvents()).rejects.toBeInstanceOf(EventsApiError);
+    await expect(listEvents({ page: 1, pageSize: 25 })).rejects.toBeInstanceOf(EventsApiError);
   });
 });

--- a/packages/plugin-events/tests/events.api.test.ts
+++ b/packages/plugin-events/tests/events.api.test.ts
@@ -84,6 +84,44 @@ describe('events api', () => {
     await expect(listPoiForEventSelection()).resolves.toEqual([{ id: 'poi-1', name: 'Rathaus' }]);
   });
 
+  it('includes the last allowed POI selection page', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const page = Number(new URL(url, 'https://studio.test').searchParams.get('page'));
+
+      return Response.json({
+        data: [{ id: `poi-${page}`, name: `POI ${page}` }],
+        pagination: { page, pageSize: 100, hasNextPage: page < 101 },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const items = await listPoiForEventSelection();
+
+    expect(items).toHaveLength(101);
+    expect(items[0]).toEqual({ id: 'poi-1', name: 'POI 1' });
+    expect(items.at(-1)).toEqual({ id: 'poi-101', name: 'POI 101' });
+  });
+
+  it('fails instead of silently truncating when POI selection pagination exceeds the maximum page budget', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const page = Number(new URL(url, 'https://studio.test').searchParams.get('page'));
+
+        return Response.json({
+          data: [{ id: `poi-${page}`, name: `POI ${page}` }],
+          pagination: { page, pageSize: 100, hasNextPage: true },
+        });
+      })
+    );
+
+    await expect(listPoiForEventSelection()).rejects.toMatchObject<EventsApiError>({
+      code: 'poi_selection_page_limit_exceeded',
+    });
+  });
+
   it('throws stable errors', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => Response.json({ error: 'forbidden', message: 'Nope' }, { status: 403 })));
 

--- a/packages/plugin-events/tests/list-pagination.test.ts
+++ b/packages/plugin-events/tests/list-pagination.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeListSearch } from '../src/list-pagination.js';
+
+describe('normalizeListSearch', () => {
+  it('normalizes unsupported page sizes to the default value', () => {
+    expect(normalizeListSearch({ page: 3, pageSize: 13 })).toEqual({ page: 3, pageSize: 25 });
+  });
+
+  it('caps the page number to the maximum visible offset budget', () => {
+    expect(normalizeListSearch({ page: 9999, pageSize: 25 })).toEqual({ page: 401, pageSize: 25 });
+  });
+});

--- a/packages/plugin-news/src/list-pagination.ts
+++ b/packages/plugin-news/src/list-pagination.ts
@@ -1,0 +1,22 @@
+const allowedListPageSizes = [25, 50, 100] as const;
+const defaultListPageSize = 25;
+const maxListOffset = 10_000;
+
+export type ListSearch = {
+  readonly page?: number;
+  readonly pageSize?: number;
+};
+
+export const normalizeListSearch = (search: ListSearch): { readonly page: number; readonly pageSize: number } => {
+  const requestedPageSize = search.pageSize;
+  const pageSize =
+    typeof requestedPageSize === 'number' &&
+    allowedListPageSizes.includes(requestedPageSize as (typeof allowedListPageSizes)[number])
+      ? requestedPageSize
+      : defaultListPageSize;
+  const maxPage = Math.floor(maxListOffset / pageSize) + 1;
+  const page =
+    typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;
+
+  return { page, pageSize };
+};

--- a/packages/plugin-news/src/news.api.ts
+++ b/packages/plugin-news/src/news.api.ts
@@ -1,11 +1,7 @@
-import type { NewsContentItem, NewsFormInput } from './news.types.js';
+import type { NewsContentItem, NewsFormInput, NewsListQuery, NewsListResult } from './news.types.js';
 
 type ApiItemResponse<T> = {
   readonly data: T;
-};
-
-type ApiListResponse<T> = {
-  readonly data: readonly T[];
 };
 
 type ApiErrorResponse = {
@@ -66,9 +62,15 @@ const toMutationBody = (input: NewsFormInput, options: { readonly includePushNot
   };
 };
 
-export const listNews = async (): Promise<readonly NewsContentItem[]> => {
-  const response = await requestJson<ApiListResponse<NewsContentItem>>('/api/v1/mainserver/news');
-  return response.data.map(toNewsContent);
+const buildListUrl = (query: NewsListQuery): string =>
+  `/api/v1/mainserver/news?page=${encodeURIComponent(String(query.page))}&pageSize=${encodeURIComponent(String(query.pageSize))}`;
+
+export const listNews = async (query: NewsListQuery): Promise<NewsListResult> => {
+  const response = await requestJson<NewsListResult>(buildListUrl(query));
+  return {
+    data: response.data.map(toNewsContent),
+    pagination: response.pagination,
+  };
 };
 
 export const getNews = async (contentId: string): Promise<NewsContentItem> => {

--- a/packages/plugin-news/src/news.pages.tsx
+++ b/packages/plugin-news/src/news.pages.tsx
@@ -134,10 +134,15 @@ const buildDescribedBy = (...ids: readonly (string | undefined | false)[]) => {
   return describedBy.length > 0 ? describedBy : undefined;
 };
 
-const normalizeListSearch = (search: { readonly page?: number; readonly pageSize?: number }) => {
-  const pageSize = allowedListPageSizes.includes(search.pageSize as (typeof allowedListPageSizes)[number])
-    ? search.pageSize
-    : 25;
+const normalizeListSearch = (
+  search: { readonly page?: number; readonly pageSize?: number }
+): { readonly page: number; readonly pageSize: number } => {
+  const requestedPageSize = search.pageSize;
+  const pageSize =
+    typeof requestedPageSize === 'number' &&
+    allowedListPageSizes.includes(requestedPageSize as (typeof allowedListPageSizes)[number])
+      ? requestedPageSize
+      : 25;
   const maxPage = Math.floor(maxListOffset / pageSize) + 1;
   const page =
     typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;

--- a/packages/plugin-news/src/news.pages.tsx
+++ b/packages/plugin-news/src/news.pages.tsx
@@ -390,7 +390,7 @@ const NewsForm = ({
       if (mode === 'create') {
         await createNews(compactedForm);
         persistFlashMessage('createSuccess');
-        await navigate({ to: '/admin/news' });
+        await navigate({ to: '/plugins/news' });
         return;
       }
 
@@ -417,7 +417,7 @@ const NewsForm = ({
     try {
       await deleteNews(contentId);
       persistFlashMessage('deleteSuccess');
-      await navigate({ to: '/admin/news' });
+      await navigate({ to: '/plugins/news' });
     } catch (error) {
       setStatusMessage({ kind: 'error', text: resolveNewsErrorMessage(pt, error, 'messages.deleteError') });
     } finally {
@@ -817,7 +817,7 @@ const NewsForm = ({
         <div className="flex flex-wrap gap-3">
           <Button type="submit">{submitLabel}</Button>
           <Button asChild variant="outline">
-            <Link to="/admin/news">{pt('actions.back')}</Link>
+            <Link to="/plugins/news">{pt('actions.back')}</Link>
           </Button>
           {mode === 'edit' ? (
             <Button variant="destructive" type="button" onClick={onDelete} disabled={deletePending}>
@@ -933,7 +933,7 @@ export const NewsListPage = () => {
       description={pt('list.description')}
       primaryAction={
         <Button asChild>
-          <Link to="/admin/news/new">{createLabel}</Link>
+          <Link to="/plugins/news/new">{createLabel}</Link>
         </Button>
       }
     >
@@ -982,7 +982,7 @@ export const NewsListPage = () => {
             ]}
             rowActions={(item) => (
               <Button asChild variant="outline" size="sm">
-                <Link to="/admin/news/$id" params={{ id: item.id }}>
+                <Link to="/plugins/news/$contentId" params={{ contentId: item.id }}>
                   {editLabel}
                 </Link>
               </Button>
@@ -1007,7 +1007,7 @@ export const NewsListPage = () => {
                 disabled={result.pagination.page <= 1}
                 onClick={() =>
                   void navigate({
-                    to: '/admin/news',
+                    to: '/plugins/news',
                     search: (current: Record<string, unknown>) => ({
                       ...current,
                       page: Math.max(1, result.pagination.page - 1),
@@ -1025,7 +1025,7 @@ export const NewsListPage = () => {
                 disabled={!result.pagination.hasNextPage}
                 onClick={() =>
                   void navigate({
-                    to: '/admin/news',
+                    to: '/plugins/news',
                     search: (current: Record<string, unknown>) => ({
                       ...current,
                       page: result.pagination.page + 1,

--- a/packages/plugin-news/src/news.pages.tsx
+++ b/packages/plugin-news/src/news.pages.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { translatePluginKey, usePluginTranslation } from '@sva/plugin-sdk';
 import {
   Button,
@@ -13,12 +13,13 @@ import {
   StudioFormSummary,
   StudioLoadingState,
   StudioOverviewPageTemplate,
+  StudioDataTable,
   Textarea,
 } from '@sva/studio-ui-react';
 
 import { NewsApiError, createNews, deleteNews, getNews, listNews, updateNews } from './news.api.js';
 import { getPluginNewsActionDefinition, pluginNewsActionIds } from './plugin.js';
-import type { NewsContentBlock, NewsContentItem, NewsFormInput, NewsMediaContent } from './news.types.js';
+import type { NewsContentBlock, NewsContentItem, NewsFormInput, NewsListResult, NewsMediaContent } from './news.types.js';
 import { validateNewsForm } from './news.validation.js';
 
 type StatusMessage = {
@@ -389,7 +390,7 @@ const NewsForm = ({
       if (mode === 'create') {
         await createNews(compactedForm);
         persistFlashMessage('createSuccess');
-        await navigate({ to: '/plugins/news' });
+        await navigate({ to: '/admin/news' });
         return;
       }
 
@@ -416,7 +417,7 @@ const NewsForm = ({
     try {
       await deleteNews(contentId);
       persistFlashMessage('deleteSuccess');
-      await navigate({ to: '/plugins/news' });
+      await navigate({ to: '/admin/news' });
     } catch (error) {
       setStatusMessage({ kind: 'error', text: resolveNewsErrorMessage(pt, error, 'messages.deleteError') });
     } finally {
@@ -816,7 +817,7 @@ const NewsForm = ({
         <div className="flex flex-wrap gap-3">
           <Button type="submit">{submitLabel}</Button>
           <Button asChild variant="outline">
-            <Link to="/plugins/news">{pt('actions.back')}</Link>
+            <Link to="/admin/news">{pt('actions.back')}</Link>
           </Button>
           {mode === 'edit' ? (
             <Button variant="destructive" type="button" onClick={onDelete} disabled={deletePending}>
@@ -873,9 +874,16 @@ const NewsForm = ({
 
 export const NewsListPage = () => {
   const pt = usePluginTranslation('news');
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
   const createLabel = resolvePluginActionLabel(pt, pluginNewsActionIds.create);
   const editLabel = resolvePluginActionLabel(pt, pluginNewsActionIds.edit);
-  const [items, setItems] = React.useState<readonly NewsContentItem[]>([]);
+  const page = typeof search.page === 'number' ? search.page : 1;
+  const pageSize = typeof search.pageSize === 'number' ? search.pageSize : 25;
+  const [result, setResult] = React.useState<NewsListResult>({
+    data: [],
+    pagination: { page, pageSize, hasNextPage: false },
+  });
   const [isLoading, setIsLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [flashMessage, setFlashMessage] = React.useState<FlashMessageCode | null>(null);
@@ -887,10 +895,12 @@ export const NewsListPage = () => {
   React.useEffect(() => {
     let active = true;
 
-    void listNews()
-      .then((response) => {
+    setIsLoading(true);
+    void listNews({ page, pageSize })
+      .then((nextResult) => {
         if (active) {
-          setItems(response);
+          setResult(nextResult);
+          setError(null);
         }
       })
       .catch((error: unknown) => {
@@ -907,7 +917,7 @@ export const NewsListPage = () => {
     return () => {
       active = false;
     };
-  }, []);
+  }, [page, pageSize]);
 
   if (isLoading) {
     return <StudioLoadingState>{pt('messages.loading')}</StudioLoadingState>;
@@ -923,7 +933,7 @@ export const NewsListPage = () => {
       description={pt('list.description')}
       primaryAction={
         <Button asChild>
-          <Link to="/plugins/news/new">{createLabel}</Link>
+          <Link to="/admin/news/new">{createLabel}</Link>
         </Button>
       }
     >
@@ -931,43 +941,103 @@ export const NewsListPage = () => {
         <StudioFormSummary kind="success">{pt(flashMessageTranslationKeys[flashMessage])}</StudioFormSummary>
       ) : null}
 
-      {items.length === 0 ? (
+      {result.data.length === 0 ? (
         <StudioEmptyState>
           <h2 className="text-lg font-medium">{pt('empty.title')}</h2>
           <p className="mt-2 text-sm text-muted-foreground">{pt('empty.description')}</p>
         </StudioEmptyState>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-border bg-card">
-          <table className="min-w-full text-left text-sm">
-            <caption className="sr-only">{pt('list.title')}</caption>
-            <thead className="bg-muted/40 text-muted-foreground">
-              <tr>
-                <th className="px-4 py-3">{pt('fields.title')}</th>
-                <th className="px-4 py-3">{pt('fields.categoryName')}</th>
-                <th className="px-4 py-3">{pt('fields.updatedAt')}</th>
-                <th className="px-4 py-3">{pt('fields.actions')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((item) => (
-                <tr key={item.id} className="border-t border-border">
-                  <td className="px-4 py-3">
+        <div className="space-y-4">
+          <StudioDataTable
+            ariaLabel={pt('list.title')}
+            labels={{
+              selectionColumn: pt('fields.actions'),
+              actionsColumn: pt('fields.actions'),
+              loading: pt('messages.loading'),
+              selectAllRows: (label) => label,
+              selectRow: ({ label }) => label,
+            }}
+            data={result.data}
+            columns={[
+              {
+                id: 'title',
+                header: pt('fields.title'),
+                cell: (item: NewsContentItem) => (
+                  <div>
                     <div className="font-medium">{item.title}</div>
                     <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{firstBlockSummary(item)}</div>
-                  </td>
-                  <td className="px-4 py-3">{categorySummary(item)}</td>
-                  <td className="px-4 py-3">{formatDate(item.updatedAt)}</td>
-                  <td className="px-4 py-3">
-                    <Button asChild variant="outline" size="sm">
-                      <Link to="/plugins/news/$contentId" params={{ contentId: item.id }}>
-                        {editLabel}
-                      </Link>
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                  </div>
+                ),
+              },
+              {
+                id: 'categoryName',
+                header: pt('fields.categoryName'),
+                cell: categorySummary,
+              },
+              {
+                id: 'updatedAt',
+                header: pt('fields.updatedAt'),
+                cell: (item: NewsContentItem) => formatDate(item.updatedAt),
+              },
+            ]}
+            rowActions={(item) => (
+              <Button asChild variant="outline" size="sm">
+                <Link to="/admin/news/$id" params={{ id: item.id }}>
+                  {editLabel}
+                </Link>
+              </Button>
+            )}
+            emptyState={null}
+            getRowId={(item) => item.id}
+            selectionMode="none"
+          />
+
+          <nav
+            aria-label={pt('pagination.ariaLabel')}
+            className="flex items-center justify-between gap-3 text-sm text-muted-foreground"
+          >
+            <p key={result.pagination.page} aria-live="polite" className="animate-pagination-active">
+              {pt('pagination.pageLabel', { page: result.pagination.page })}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={result.pagination.page <= 1}
+                onClick={() =>
+                  void navigate({
+                    to: '/admin/news',
+                    search: (current: Record<string, unknown>) => ({
+                      ...current,
+                      page: Math.max(1, result.pagination.page - 1),
+                      pageSize: result.pagination.pageSize,
+                    }),
+                  })
+                }
+              >
+                {pt('pagination.previous')}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={!result.pagination.hasNextPage}
+                onClick={() =>
+                  void navigate({
+                    to: '/admin/news',
+                    search: (current: Record<string, unknown>) => ({
+                      ...current,
+                      page: result.pagination.page + 1,
+                      pageSize: result.pagination.pageSize,
+                    }),
+                  })
+                }
+              >
+                {pt('pagination.next')}
+              </Button>
+            </div>
+          </nav>
         </div>
       )}
     </StudioOverviewPageTemplate>
@@ -977,8 +1047,8 @@ export const NewsListPage = () => {
 export const NewsCreatePage = () => <NewsForm mode="create" />;
 
 export const NewsEditPage = () => {
-  const params = useParams({ strict: false });
-  const contentId = typeof params.contentId === 'string' ? params.contentId : undefined;
+  const params = useParams({ strict: false }) as { readonly contentId?: string; readonly id?: string };
+  const contentId = typeof params.contentId === 'string' ? params.contentId : typeof params.id === 'string' ? params.id : undefined;
 
   return <NewsForm mode="edit" contentId={contentId} />;
 };

--- a/packages/plugin-news/src/news.pages.tsx
+++ b/packages/plugin-news/src/news.pages.tsx
@@ -29,6 +29,9 @@ type StatusMessage = {
 
 type FlashMessageCode = 'createSuccess' | 'deleteSuccess';
 
+const allowedListPageSizes = [25, 50, 100] as const;
+const maxListOffset = 10_000;
+
 const defaultContentBlock = (): NewsContentBlock => ({
   title: '',
   intro: '',
@@ -129,6 +132,17 @@ const consumeFlashMessage = (): FlashMessageCode | null => {
 const buildDescribedBy = (...ids: readonly (string | undefined | false)[]) => {
   const describedBy = ids.filter(Boolean).join(' ');
   return describedBy.length > 0 ? describedBy : undefined;
+};
+
+const normalizeListSearch = (search: { readonly page?: number; readonly pageSize?: number }) => {
+  const pageSize = allowedListPageSizes.includes(search.pageSize as (typeof allowedListPageSizes)[number])
+    ? search.pageSize
+    : 25;
+  const maxPage = Math.floor(maxListOffset / pageSize) + 1;
+  const page =
+    typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;
+
+  return { page, pageSize };
 };
 
 const formatDate = (value?: string) => {
@@ -878,8 +892,7 @@ export const NewsListPage = () => {
   const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
   const createLabel = resolvePluginActionLabel(pt, pluginNewsActionIds.create);
   const editLabel = resolvePluginActionLabel(pt, pluginNewsActionIds.edit);
-  const page = typeof search.page === 'number' ? search.page : 1;
-  const pageSize = typeof search.pageSize === 'number' ? search.pageSize : 25;
+  const { page, pageSize } = normalizeListSearch(search);
   const [result, setResult] = React.useState<NewsListResult>({
     data: [],
     pagination: { page, pageSize, hasNextPage: false },
@@ -889,6 +902,22 @@ export const NewsListPage = () => {
   const [flashMessage, setFlashMessage] = React.useState<FlashMessageCode | null>(null);
 
   React.useEffect(() => {
+    if (search.page === page && search.pageSize === pageSize) {
+      return;
+    }
+
+    void navigate({
+      to: '/plugins/news',
+      replace: true,
+      search: (current: Record<string, unknown>) => ({
+        ...current,
+        page,
+        pageSize,
+      }),
+    });
+  }, [navigate, page, pageSize, search.page, search.pageSize]);
+
+  React.useEffect(() => {
     setFlashMessage(consumeFlashMessage());
   }, []);
 
@@ -896,6 +925,7 @@ export const NewsListPage = () => {
     let active = true;
 
     setIsLoading(true);
+    setError(null);
     void listNews({ page, pageSize })
       .then((nextResult) => {
         if (active) {

--- a/packages/plugin-news/src/news.pages.tsx
+++ b/packages/plugin-news/src/news.pages.tsx
@@ -18,6 +18,7 @@ import {
 } from '@sva/studio-ui-react';
 
 import { NewsApiError, createNews, deleteNews, getNews, listNews, updateNews } from './news.api.js';
+import { normalizeListSearch } from './list-pagination.js';
 import { getPluginNewsActionDefinition, pluginNewsActionIds } from './plugin.js';
 import type { NewsContentBlock, NewsContentItem, NewsFormInput, NewsListResult, NewsMediaContent } from './news.types.js';
 import { validateNewsForm } from './news.validation.js';
@@ -28,9 +29,6 @@ type StatusMessage = {
 };
 
 type FlashMessageCode = 'createSuccess' | 'deleteSuccess';
-
-const allowedListPageSizes = [25, 50, 100] as const;
-const maxListOffset = 10_000;
 
 const defaultContentBlock = (): NewsContentBlock => ({
   title: '',
@@ -132,22 +130,6 @@ const consumeFlashMessage = (): FlashMessageCode | null => {
 const buildDescribedBy = (...ids: readonly (string | undefined | false)[]) => {
   const describedBy = ids.filter(Boolean).join(' ');
   return describedBy.length > 0 ? describedBy : undefined;
-};
-
-const normalizeListSearch = (
-  search: { readonly page?: number; readonly pageSize?: number }
-): { readonly page: number; readonly pageSize: number } => {
-  const requestedPageSize = search.pageSize;
-  const pageSize =
-    typeof requestedPageSize === 'number' &&
-    allowedListPageSizes.includes(requestedPageSize as (typeof allowedListPageSizes)[number])
-      ? requestedPageSize
-      : 25;
-  const maxPage = Math.floor(maxListOffset / pageSize) + 1;
-  const page =
-    typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;
-
-  return { page, pageSize };
 };
 
 const formatDate = (value?: string) => {

--- a/packages/plugin-news/src/news.types.ts
+++ b/packages/plugin-news/src/news.types.ts
@@ -66,6 +66,23 @@ export type NewsAnnouncementSummary = {
   readonly title?: string;
 };
 
+export type NewsListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+};
+
+export type NewsPagination = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly hasNextPage: boolean;
+  readonly total?: number;
+};
+
+export type NewsListResult = {
+  readonly data: readonly NewsContentItem[];
+  readonly pagination: NewsPagination;
+};
+
 export type NewsFormInput = {
   readonly title: string;
   readonly author?: string;

--- a/packages/plugin-news/src/plugin.tsx
+++ b/packages/plugin-news/src/plugin.tsx
@@ -189,7 +189,7 @@ export const pluginNews: PluginDefinition = {
         },
         pagination: {
           ariaLabel: 'News-Seiten',
-          pageLabel: 'Seite {page}',
+          pageLabel: 'Seite {{page}}',
           previous: 'Zurück',
           next: 'Weiter',
         },
@@ -240,7 +240,7 @@ export const pluginNews: PluginDefinition = {
         },
         pagination: {
           ariaLabel: 'News pages',
-          pageLabel: 'Page {page}',
+          pageLabel: 'Page {{page}}',
           previous: 'Previous',
           next: 'Next',
         },

--- a/packages/plugin-news/src/plugin.tsx
+++ b/packages/plugin-news/src/plugin.tsx
@@ -187,6 +187,12 @@ export const pluginNews: PluginDefinition = {
           title: 'Noch keine News vorhanden',
           description: 'Legen Sie den ersten News-Eintrag an.',
         },
+        pagination: {
+          ariaLabel: 'News-Seiten',
+          pageLabel: 'Seite {page}',
+          previous: 'Zurück',
+          next: 'Weiter',
+        },
         messages: {
           loading: 'News werden geladen.',
           loadError: 'News konnten nicht geladen werden.',
@@ -231,6 +237,12 @@ export const pluginNews: PluginDefinition = {
         list: {
           title: 'News',
           description: 'Manage news entries through the plugin.',
+        },
+        pagination: {
+          ariaLabel: 'News pages',
+          pageLabel: 'Page {page}',
+          previous: 'Previous',
+          next: 'Next',
         },
         editor: {
           createTitle: 'Create news entry',

--- a/packages/plugin-news/tests/list-pagination.test.ts
+++ b/packages/plugin-news/tests/list-pagination.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeListSearch } from '../src/list-pagination.js';
+
+describe('normalizeListSearch', () => {
+  it('normalizes unsupported page sizes to the default value', () => {
+    expect(normalizeListSearch({ page: 3, pageSize: 13 })).toEqual({ page: 3, pageSize: 25 });
+  });
+
+  it('caps the page number to the maximum visible offset budget', () => {
+    expect(normalizeListSearch({ page: 9999, pageSize: 25 })).toEqual({ page: 401, pageSize: 25 });
+  });
+});

--- a/packages/plugin-news/tests/news.api.test.ts
+++ b/packages/plugin-news/tests/news.api.test.ts
@@ -57,11 +57,19 @@ describe('news api', () => {
             publishedAt: sampleInput.publishedAt,
           },
         ],
+        pagination: {
+          page: 2,
+          pageSize: 50,
+          hasNextPage: true,
+        },
       }),
     } as Response);
 
-    await expect(listNews()).resolves.toEqual([expect.objectContaining({ id: 'news-1' })]);
-    expect(fetch).toHaveBeenCalledWith('/api/v1/mainserver/news', expect.any(Object));
+    await expect(listNews({ page: 2, pageSize: 50 })).resolves.toEqual({
+      data: [expect.objectContaining({ id: 'news-1' })],
+      pagination: { page: 2, pageSize: 50, hasNextPage: true },
+    });
+    expect(fetch).toHaveBeenCalledWith('/api/v1/mainserver/news?page=2&pageSize=50', expect.any(Object));
   });
 
   it('creates news with idempotency header through the mainserver facade', async () => {
@@ -140,7 +148,7 @@ describe('news api', () => {
       } as Response);
 
     await expect(getNews('news-1')).resolves.toEqual(expect.objectContaining({ id: 'news-1' }));
-    await expect(listNews()).rejects.toThrow('http_503');
+    await expect(listNews({ page: 1, pageSize: 25 })).rejects.toThrow('http_503');
   });
 
   it('uses stable server error envelopes and HTTP fallbacks for failed responses', async () => {
@@ -163,7 +171,7 @@ describe('news api', () => {
       code: 'forbidden',
       message: 'Keine Berechtigung.',
     } satisfies Partial<NewsApiError>);
-    await expect(listNews()).rejects.toMatchObject({
+    await expect(listNews({ page: 1, pageSize: 25 })).rejects.toMatchObject({
       code: 'http_502',
       message: 'http_502',
     } satisfies Partial<NewsApiError>);

--- a/packages/plugin-news/tests/news.pages.test.tsx
+++ b/packages/plugin-news/tests/news.pages.test.tsx
@@ -13,7 +13,10 @@ vi.mock('../src/news.api.js', () => ({
       super(code);
     }
   },
-  listNews: vi.fn(async () => []),
+  listNews: vi.fn(async () => ({
+    data: [],
+    pagination: { page: 1, pageSize: 25, hasNextPage: false },
+  })),
   getNews: vi.fn(async () => ({
     id: 'news-1',
     title: 'Bestehende News',
@@ -40,6 +43,7 @@ vi.mock('../src/news.api.js', () => ({
 
 const navigateMock = vi.fn();
 const paramsMock = vi.fn(() => ({ contentId: 'news-1' }));
+const searchMock = vi.fn(() => ({ page: 1, pageSize: 25 }));
 
 const stubConfirm = (result: boolean) => {
   const confirmMock = vi.fn(() => result);
@@ -55,6 +59,7 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
   useNavigate: () => navigateMock,
   useParams: () => paramsMock(),
+  useSearch: () => searchMock(),
 }));
 
 describe('NewsListPage', () => {
@@ -67,7 +72,9 @@ describe('NewsListPage', () => {
     vi.clearAllMocks();
     navigateMock.mockReset();
     paramsMock.mockReset();
+    searchMock.mockReset();
     paramsMock.mockReturnValue({ contentId: 'news-1' });
+    searchMock.mockReturnValue({ page: 1, pageSize: 25 });
     window.sessionStorage.clear();
     registerPluginTranslationResolver((key) => {
       const labels: Record<string, string> = {
@@ -89,6 +96,10 @@ describe('NewsListPage', () => {
         'news.messages.errors.networkError': 'Der Mainserver ist nicht erreichbar.',
         'news.empty.title': 'Noch keine News vorhanden',
         'news.empty.description': 'Legen Sie den ersten News-Eintrag an.',
+        'news.pagination.ariaLabel': 'News-Pagination',
+        'news.pagination.previous': 'Zurück',
+        'news.pagination.next': 'Weiter',
+        'news.pagination.pageLabel': 'Seite {{page}}',
         'news.list.title': 'News',
         'news.list.description': 'Verwalten Sie News-Einträge über das Plugin.',
         'news.actions.create': 'News anlegen',
@@ -162,55 +173,61 @@ describe('NewsListPage', () => {
   });
 
   it('renders fetched news rows', async () => {
-    vi.mocked(listNews).mockResolvedValueOnce([
-      {
-        id: 'news-1',
-        title: 'Neuigkeit',
-        contentType: NEWS_CONTENT_TYPE,
-        payload: {
-          teaser: 'Kurztext',
-          body: '<p>Body</p>',
-          category: 'Allgemein',
+    vi.mocked(listNews).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'news-1',
+          title: 'Neuigkeit',
+          contentType: NEWS_CONTENT_TYPE,
+          payload: {
+            teaser: 'Kurztext',
+            body: '<p>Body</p>',
+            category: 'Allgemein',
+          },
+          status: 'published',
+          author: 'Editor',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-02T00:00:00.000Z',
         },
-        status: 'published',
-        author: 'Editor',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        updatedAt: '2026-01-02T00:00:00.000Z',
-      },
-    ]);
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
 
     render(<NewsListPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Neuigkeit')).toBeTruthy();
-      expect(screen.getByText('Kurztext')).toBeTruthy();
-      expect(screen.getByText('Bearbeiten')).toBeTruthy();
+      expect(screen.getAllByText('Neuigkeit').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Kurztext').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Bearbeiten').length).toBeGreaterThan(0);
     });
   });
 
   it('renders fallback values for missing category and invalid update timestamps', async () => {
-    vi.mocked(listNews).mockResolvedValueOnce([
-      {
-        id: 'news-2',
-        title: 'Meldung',
-        contentType: NEWS_CONTENT_TYPE,
-        payload: {
-          teaser: 'Kurztext',
-          body: '<p>Body</p>',
+    vi.mocked(listNews).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'news-2',
+          title: 'Meldung',
+          contentType: NEWS_CONTENT_TYPE,
+          payload: {
+            teaser: 'Kurztext',
+            body: '<p>Body</p>',
+          },
+          status: 'published',
+          author: 'Editor',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: 'invalid-date',
+          publishedAt: '2026-01-01T00:00:00.000Z',
         },
-        status: 'published',
-        author: 'Editor',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        updatedAt: 'invalid-date',
-        publishedAt: '2026-01-01T00:00:00.000Z',
-      },
-    ]);
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
 
     render(<NewsListPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('—')).toBeTruthy();
-      expect(screen.getByText('invalid-date')).toBeTruthy();
+      expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('invalid-date').length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/plugin-news/tests/news.pages.test.tsx
+++ b/packages/plugin-news/tests/news.pages.test.tsx
@@ -203,22 +203,38 @@ describe('NewsListPage', () => {
   });
 
   it('reads pagination values from the browser query string', async () => {
-    searchMock.mockReturnValueOnce({ page: 3, pageSize: 10 });
+    searchMock.mockReturnValueOnce({ page: 3, pageSize: 50 });
 
     render(<NewsListPage />);
 
     await waitFor(() => {
-      expect(listNews).toHaveBeenCalledWith({ page: 3, pageSize: 10 });
+      expect(listNews).toHaveBeenCalledWith({ page: 3, pageSize: 50 });
     });
   });
 
-  it('falls back to default pagination for invalid browser query values', async () => {
-    searchMock.mockReturnValueOnce({ page: 1, pageSize: 25 });
+  it('normalizes invalid browser query values before loading news', async () => {
+    searchMock.mockReturnValueOnce({ page: 9999, pageSize: 13 });
 
     render(<NewsListPage />);
 
     await waitFor(() => {
-      expect(listNews).toHaveBeenCalledWith({ page: 1, pageSize: 25 });
+      expect(listNews).toHaveBeenCalledWith({ page: 401, pageSize: 25 });
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/plugins/news',
+        replace: true,
+        search: expect.any(Function),
+      })
+    );
+    const navigateCall = navigateMock.mock.calls[0]?.[0] as {
+      search?: (current: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(navigateCall.search?.({ keep: 'value' })).toEqual({
+      keep: 'value',
+      page: 401,
+      pageSize: 25,
     });
   });
 
@@ -268,6 +284,31 @@ describe('NewsListPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Mainserver-Credentials fehlen.')).toBeTruthy();
+    });
+  });
+
+  it('clears a stale load error before refetching with updated pagination', async () => {
+    vi.mocked(listNews)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({
+        data: [],
+        pagination: { page: 2, pageSize: 50, hasNextPage: false },
+      });
+
+    const { rerender } = render(<NewsListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('News konnten nicht geladen werden.')).toBeTruthy();
+    });
+
+    searchMock.mockReturnValue({ page: 2, pageSize: 50 });
+    rerender(<NewsListPage />);
+
+    expect(screen.queryByText('News konnten nicht geladen werden.')).toBeNull();
+
+    await waitFor(() => {
+      expect(listNews).toHaveBeenLastCalledWith({ page: 2, pageSize: 50 });
+      expect(screen.getByText('Noch keine News vorhanden')).toBeTruthy();
     });
   });
 

--- a/packages/plugin-news/tests/news.pages.test.tsx
+++ b/packages/plugin-news/tests/news.pages.test.tsx
@@ -203,7 +203,7 @@ describe('NewsListPage', () => {
   });
 
   it('reads pagination values from the browser query string', async () => {
-    window.history.pushState({}, '', '/admin/news?page=3&pageSize=10');
+    searchMock.mockReturnValueOnce({ page: 3, pageSize: 10 });
 
     render(<NewsListPage />);
 
@@ -213,7 +213,7 @@ describe('NewsListPage', () => {
   });
 
   it('falls back to default pagination for invalid browser query values', async () => {
-    window.history.pushState({}, '', '/admin/news?page=0&pageSize=invalid');
+    searchMock.mockReturnValueOnce({ page: 1, pageSize: 25 });
 
     render(<NewsListPage />);
 

--- a/packages/plugin-news/tests/news.pages.test.tsx
+++ b/packages/plugin-news/tests/news.pages.test.tsx
@@ -698,4 +698,27 @@ describe('NewsListPage', () => {
       );
     });
   });
+
+  it('clears invalid publication timestamps during edit loading', async () => {
+    vi.mocked(getNews).mockResolvedValueOnce({
+      id: 'news-4',
+      title: 'Termin',
+      contentType: NEWS_CONTENT_TYPE,
+      payload: {
+        teaser: 'Kurztext',
+        body: '<p>Body</p>',
+      },
+      status: 'published',
+      author: 'Editor',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      publishedAt: 'invalid-date',
+    });
+
+    render(<NewsEditPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Veröffentlichungsdatum').getAttribute('value')).toBe('');
+    });
+  });
 });

--- a/packages/plugin-news/tests/news.pages.test.tsx
+++ b/packages/plugin-news/tests/news.pages.test.tsx
@@ -202,6 +202,26 @@ describe('NewsListPage', () => {
     });
   });
 
+  it('reads pagination values from the browser query string', async () => {
+    window.history.pushState({}, '', '/admin/news?page=3&pageSize=10');
+
+    render(<NewsListPage />);
+
+    await waitFor(() => {
+      expect(listNews).toHaveBeenCalledWith({ page: 3, pageSize: 10 });
+    });
+  });
+
+  it('falls back to default pagination for invalid browser query values', async () => {
+    window.history.pushState({}, '', '/admin/news?page=0&pageSize=invalid');
+
+    render(<NewsListPage />);
+
+    await waitFor(() => {
+      expect(listNews).toHaveBeenCalledWith({ page: 1, pageSize: 25 });
+    });
+  });
+
   it('renders fallback values for missing category and invalid update timestamps', async () => {
     vi.mocked(listNews).mockResolvedValueOnce({
       data: [

--- a/packages/plugin-poi/src/list-pagination.ts
+++ b/packages/plugin-poi/src/list-pagination.ts
@@ -1,0 +1,19 @@
+const allowedListPageSizes = [25, 50, 100] as const;
+const defaultListPageSize = 25;
+const maxListOffset = 10_000;
+
+export type ListSearch = {
+  readonly page?: number;
+  readonly pageSize?: number;
+};
+
+export const normalizeListSearch = (search: ListSearch) => {
+  const pageSize = allowedListPageSizes.includes(search.pageSize as (typeof allowedListPageSizes)[number])
+    ? search.pageSize
+    : defaultListPageSize;
+  const maxPage = Math.floor(maxListOffset / pageSize) + 1;
+  const page =
+    typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;
+
+  return { page, pageSize };
+};

--- a/packages/plugin-poi/src/list-pagination.ts
+++ b/packages/plugin-poi/src/list-pagination.ts
@@ -7,10 +7,13 @@ export type ListSearch = {
   readonly pageSize?: number;
 };
 
-export const normalizeListSearch = (search: ListSearch) => {
-  const pageSize = allowedListPageSizes.includes(search.pageSize as (typeof allowedListPageSizes)[number])
-    ? search.pageSize
-    : defaultListPageSize;
+export const normalizeListSearch = (search: ListSearch): { readonly page: number; readonly pageSize: number } => {
+  const requestedPageSize = search.pageSize;
+  const pageSize =
+    typeof requestedPageSize === 'number' &&
+    allowedListPageSizes.includes(requestedPageSize as (typeof allowedListPageSizes)[number])
+      ? requestedPageSize
+      : defaultListPageSize;
   const maxPage = Math.floor(maxListOffset / pageSize) + 1;
   const page =
     typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? Math.min(search.page, maxPage) : 1;

--- a/packages/plugin-poi/src/plugin.tsx
+++ b/packages/plugin-poi/src/plugin.tsx
@@ -127,7 +127,7 @@ export const pluginPoi: PluginDefinition = {
         },
         pagination: {
           ariaLabel: 'POI-Seiten',
-          pageLabel: 'Seite {page}',
+          pageLabel: 'Seite {{page}}',
           previous: 'Zurück',
           next: 'Weiter',
         },
@@ -190,7 +190,7 @@ export const pluginPoi: PluginDefinition = {
         },
         pagination: {
           ariaLabel: 'POI pages',
-          pageLabel: 'Page {page}',
+          pageLabel: 'Page {{page}}',
           previous: 'Previous',
           next: 'Next',
         },

--- a/packages/plugin-poi/src/plugin.tsx
+++ b/packages/plugin-poi/src/plugin.tsx
@@ -125,6 +125,12 @@ export const pluginPoi: PluginDefinition = {
           updateSuccess: 'POI wurde aktualisiert.',
           validationError: 'Bitte korrigieren Sie die markierten Felder.',
         },
+        pagination: {
+          ariaLabel: 'POI-Seiten',
+          pageLabel: 'Seite {page}',
+          previous: 'Zurück',
+          next: 'Weiter',
+        },
         empty: { title: 'Noch keine POI vorhanden', description: 'Legen Sie den ersten POI an.' },
         validation: {
           name: 'Der Name ist erforderlich.',
@@ -181,6 +187,12 @@ export const pluginPoi: PluginDefinition = {
           createSuccess: 'POI was created.',
           updateSuccess: 'POI was updated.',
           validationError: 'Please correct the highlighted fields.',
+        },
+        pagination: {
+          ariaLabel: 'POI pages',
+          pageLabel: 'Page {page}',
+          previous: 'Previous',
+          next: 'Next',
         },
         empty: { title: 'No POI yet', description: 'Create the first POI.' },
         validation: {

--- a/packages/plugin-poi/src/poi.api.ts
+++ b/packages/plugin-poi/src/poi.api.ts
@@ -1,7 +1,6 @@
-import type { PoiContentItem, PoiFormInput } from './poi.types.js';
+import type { PoiContentItem, PoiFormInput, PoiListQuery, PoiListResult } from './poi.types.js';
 
 type ApiItemResponse<T> = { readonly data: T };
-type ApiListResponse<T> = { readonly data: readonly T[] };
 type ApiErrorResponse = { readonly error?: string; readonly message?: string };
 
 export class PoiApiError extends Error {
@@ -42,9 +41,11 @@ const requestJson = async <T>(input: string, init?: RequestInit): Promise<T> => 
   return (await response.json()) as T;
 };
 
-export const listPoi = async (): Promise<readonly PoiContentItem[]> => {
-  const response = await requestJson<ApiListResponse<PoiContentItem>>('/api/v1/mainserver/poi');
-  return response.data;
+const buildListUrl = (query: PoiListQuery): string =>
+  `/api/v1/mainserver/poi?page=${encodeURIComponent(String(query.page))}&pageSize=${encodeURIComponent(String(query.pageSize))}`;
+
+export const listPoi = async (query: PoiListQuery): Promise<PoiListResult> => {
+  return requestJson<PoiListResult>(buildListUrl(query));
 };
 
 export const getPoi = async (contentId: string): Promise<PoiContentItem> => {

--- a/packages/plugin-poi/src/poi.pages.tsx
+++ b/packages/plugin-poi/src/poi.pages.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { usePluginTranslation } from '@sva/plugin-sdk';
 import {
   Button,
@@ -13,11 +13,12 @@ import {
   StudioFormSummary,
   StudioLoadingState,
   StudioOverviewPageTemplate,
+  StudioDataTable,
   Textarea,
 } from '@sva/studio-ui-react';
 
 import { createPoi, deletePoi, getPoi, listPoi, PoiApiError, updatePoi } from './poi.api.js';
-import type { PoiContentItem, PoiFormInput } from './poi.types.js';
+import type { PoiContentItem, PoiFormInput, PoiListResult } from './poi.types.js';
 import { validatePoiForm } from './poi.validation.js';
 
 type StatusMessage = {
@@ -103,16 +104,24 @@ const errorMessage = (pt: ReturnType<typeof usePluginTranslation>, error: unknow
 
 export function PoiListPage() {
   const pt = usePluginTranslation('poi');
-  const [items, setItems] = React.useState<readonly PoiContentItem[]>([]);
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
+  const page = typeof search.page === 'number' ? search.page : 1;
+  const pageSize = typeof search.pageSize === 'number' ? search.pageSize : 25;
+  const [result, setResult] = React.useState<PoiListResult>({
+    data: [],
+    pagination: { page, pageSize, hasNextPage: false },
+  });
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     let active = true;
-    listPoi()
+    setLoading(true);
+    listPoi({ page, pageSize })
       .then((data) => {
         if (active) {
-          setItems(data);
+          setResult(data);
           setError(null);
         }
       })
@@ -129,7 +138,7 @@ export function PoiListPage() {
     return () => {
       active = false;
     };
-  }, [pt]);
+  }, [page, pageSize]);
 
   return (
     <StudioOverviewPageTemplate
@@ -137,41 +146,84 @@ export function PoiListPage() {
       description={pt('list.description')}
       primaryAction={
         <Button asChild>
-          <Link to="/plugins/poi/new">{pt('actions.create')}</Link>
+          <Link to="/admin/poi/new">{pt('actions.create')}</Link>
         </Button>
       }
     >
       {loading ? <StudioLoadingState>{pt('messages.loading')}</StudioLoadingState> : null}
       {error ? <StudioErrorState>{error}</StudioErrorState> : null}
-      {!loading && !error && items.length === 0 ? <StudioEmptyState>{pt('empty.title')}</StudioEmptyState> : null}
-      {!loading && !error && items.length > 0 ? (
-        <div className="overflow-hidden rounded-md border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/60 text-left">
-              <tr>
-                <th className="px-4 py-3 font-medium">{pt('fields.name')}</th>
-                <th className="px-4 py-3 font-medium">{pt('fields.categoryName')}</th>
-                <th className="px-4 py-3 font-medium">{pt('fields.active')}</th>
-                <th className="px-4 py-3 text-right font-medium">{pt('fields.actions')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((item) => (
-                <tr key={item.id} className="border-t border-border">
-                  <td className="px-4 py-3 font-medium">{item.name}</td>
-                  <td className="px-4 py-3">{item.categoryName ?? '—'}</td>
-                  <td className="px-4 py-3">{item.active === false ? '—' : '✓'}</td>
-                  <td className="px-4 py-3 text-right">
-                    <Button asChild variant="outline" size="sm">
-                      <Link to="/plugins/poi/$contentId" params={{ contentId: item.id }}>
-                        {pt('actions.edit')}
-                      </Link>
-                    </Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      {!loading && !error && result.data.length === 0 ? <StudioEmptyState>{pt('empty.title')}</StudioEmptyState> : null}
+      {!loading && !error && result.data.length > 0 ? (
+        <div className="space-y-4">
+          <StudioDataTable
+            ariaLabel={pt('list.title')}
+            labels={{
+              selectionColumn: pt('fields.actions'),
+              actionsColumn: pt('fields.actions'),
+              loading: pt('messages.loading'),
+              selectAllRows: (label) => label,
+              selectRow: ({ label }) => label,
+            }}
+            data={result.data}
+            columns={[
+              { id: 'name', header: pt('fields.name'), cell: (item: PoiContentItem) => item.name },
+              { id: 'categoryName', header: pt('fields.categoryName'), cell: (item: PoiContentItem) => item.categoryName ?? '—' },
+              { id: 'active', header: pt('fields.active'), cell: (item: PoiContentItem) => (item.active === false ? '—' : '✓') },
+            ]}
+            rowActions={(item) => (
+              <Button asChild variant="outline" size="sm">
+                <Link to="/admin/poi/$id" params={{ id: item.id }}>
+                  {pt('actions.edit')}
+                </Link>
+              </Button>
+            )}
+            emptyState={null}
+            getRowId={(item) => item.id}
+            selectionMode="none"
+          />
+          <nav aria-label={pt('pagination.ariaLabel')} className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+            <p key={result.pagination.page} aria-live="polite" className="animate-pagination-active">
+              {pt('pagination.pageLabel', { page: result.pagination.page })}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={result.pagination.page <= 1}
+                onClick={() =>
+                  void navigate({
+                    to: '/admin/poi',
+                    search: (current: Record<string, unknown>) => ({
+                      ...current,
+                      page: Math.max(1, result.pagination.page - 1),
+                      pageSize: result.pagination.pageSize,
+                    }),
+                  })
+                }
+              >
+                {pt('pagination.previous')}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={!result.pagination.hasNextPage}
+                onClick={() =>
+                  void navigate({
+                    to: '/admin/poi',
+                    search: (current: Record<string, unknown>) => ({
+                      ...current,
+                      page: result.pagination.page + 1,
+                      pageSize: result.pagination.pageSize,
+                    }),
+                  })
+                }
+              >
+                {pt('pagination.next')}
+              </Button>
+            </div>
+          </nav>
         </div>
       ) : null}
     </StudioOverviewPageTemplate>
@@ -181,8 +233,8 @@ export function PoiListPage() {
 function PoiEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
   const pt = usePluginTranslation('poi');
   const navigate = useNavigate();
-  const params = useParams({ strict: false }) as { readonly contentId?: string };
-  const contentId = params.contentId;
+  const params = useParams({ strict: false }) as { readonly contentId?: string; readonly id?: string };
+  const contentId = params.contentId ?? params.id;
   const [form, setForm] = React.useState<PoiFormInput>(defaultForm);
   const [payloadText, setPayloadText] = React.useState('{}');
   const [loading, setLoading] = React.useState(mode === 'edit');
@@ -255,7 +307,7 @@ function PoiEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
       const saved = mode === 'create' ? await createPoi(compacted) : await updatePoi(contentId as string, compacted);
       setStatus({ kind: 'success', text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess') });
       if (mode === 'create') {
-        await navigate({ to: '/plugins/poi/$contentId', params: { contentId: saved.id } });
+        await navigate({ to: '/admin/poi/$id', params: { id: saved.id } });
       }
     } catch (saveError) {
       setStatus({ kind: 'error', text: errorMessage(pt, saveError, 'messages.saveError') });
@@ -268,7 +320,7 @@ function PoiEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
     }
     try {
       await deletePoi(contentId);
-      await navigate({ to: '/plugins/poi' });
+      await navigate({ to: '/admin/poi' });
     } catch (deleteError) {
       setStatus({ kind: 'error', text: errorMessage(pt, deleteError, 'messages.deleteError') });
     }
@@ -284,7 +336,7 @@ function PoiEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
       description={mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')}
       actions={
         <Button asChild variant="outline">
-          <Link to="/plugins/poi">{pt('actions.back')}</Link>
+          <Link to="/admin/poi">{pt('actions.back')}</Link>
         </Button>
       }
     >

--- a/packages/plugin-poi/src/poi.pages.tsx
+++ b/packages/plugin-poi/src/poi.pages.tsx
@@ -118,11 +118,11 @@ export function PoiListPage() {
   React.useEffect(() => {
     let active = true;
     setLoading(true);
+    setError(null);
     listPoi({ page, pageSize })
       .then((data) => {
         if (active) {
           setResult(data);
-          setError(null);
         }
       })
       .catch((loadError: unknown) => {
@@ -146,7 +146,7 @@ export function PoiListPage() {
       description={pt('list.description')}
       primaryAction={
         <Button asChild>
-          <Link to="/admin/poi/new">{pt('actions.create')}</Link>
+          <Link to="/plugins/poi/new">{pt('actions.create')}</Link>
         </Button>
       }
     >
@@ -172,7 +172,7 @@ export function PoiListPage() {
             ]}
             rowActions={(item) => (
               <Button asChild variant="outline" size="sm">
-                <Link to="/admin/poi/$id" params={{ id: item.id }}>
+                <Link to="/plugins/poi/$contentId" params={{ contentId: item.id }}>
                   {pt('actions.edit')}
                 </Link>
               </Button>
@@ -193,7 +193,7 @@ export function PoiListPage() {
                 disabled={result.pagination.page <= 1}
                 onClick={() =>
                   void navigate({
-                    to: '/admin/poi',
+                    to: '/plugins/poi',
                     search: (current: Record<string, unknown>) => ({
                       ...current,
                       page: Math.max(1, result.pagination.page - 1),
@@ -211,7 +211,7 @@ export function PoiListPage() {
                 disabled={!result.pagination.hasNextPage}
                 onClick={() =>
                   void navigate({
-                    to: '/admin/poi',
+                    to: '/plugins/poi',
                     search: (current: Record<string, unknown>) => ({
                       ...current,
                       page: result.pagination.page + 1,
@@ -307,7 +307,7 @@ function PoiEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
       const saved = mode === 'create' ? await createPoi(compacted) : await updatePoi(contentId as string, compacted);
       setStatus({ kind: 'success', text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess') });
       if (mode === 'create') {
-        await navigate({ to: '/admin/poi/$id', params: { id: saved.id } });
+        await navigate({ to: '/plugins/poi/$contentId', params: { contentId: saved.id } });
       }
     } catch (saveError) {
       setStatus({ kind: 'error', text: errorMessage(pt, saveError, 'messages.saveError') });
@@ -320,7 +320,7 @@ function PoiEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
     }
     try {
       await deletePoi(contentId);
-      await navigate({ to: '/admin/poi' });
+      await navigate({ to: '/plugins/poi' });
     } catch (deleteError) {
       setStatus({ kind: 'error', text: errorMessage(pt, deleteError, 'messages.deleteError') });
     }
@@ -336,7 +336,7 @@ function PoiEditor({ mode }: { readonly mode: 'create' | 'edit' }) {
       description={mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')}
       actions={
         <Button asChild variant="outline">
-          <Link to="/admin/poi">{pt('actions.back')}</Link>
+          <Link to="/plugins/poi">{pt('actions.back')}</Link>
         </Button>
       }
     >

--- a/packages/plugin-poi/src/poi.pages.tsx
+++ b/packages/plugin-poi/src/poi.pages.tsx
@@ -18,6 +18,7 @@ import {
 } from '@sva/studio-ui-react';
 
 import { createPoi, deletePoi, getPoi, listPoi, PoiApiError, updatePoi } from './poi.api.js';
+import { normalizeListSearch } from './list-pagination.js';
 import type { PoiContentItem, PoiFormInput, PoiListResult } from './poi.types.js';
 import { validatePoiForm } from './poi.validation.js';
 
@@ -106,14 +107,29 @@ export function PoiListPage() {
   const pt = usePluginTranslation('poi');
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
-  const page = typeof search.page === 'number' ? search.page : 1;
-  const pageSize = typeof search.pageSize === 'number' ? search.pageSize : 25;
+  const { page, pageSize } = normalizeListSearch(search);
   const [result, setResult] = React.useState<PoiListResult>({
     data: [],
     pagination: { page, pageSize, hasNextPage: false },
   });
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (search.page === page && search.pageSize === pageSize) {
+      return;
+    }
+
+    void navigate({
+      to: '/plugins/poi',
+      replace: true,
+      search: (current: Record<string, unknown>) => ({
+        ...current,
+        page,
+        pageSize,
+      }),
+    });
+  }, [navigate, page, pageSize, search.page, search.pageSize]);
 
   React.useEffect(() => {
     let active = true;

--- a/packages/plugin-poi/src/poi.types.ts
+++ b/packages/plugin-poi/src/poi.types.ts
@@ -16,6 +16,23 @@ export type PoiWebUrl = {
   readonly description?: string;
 };
 
+export type PoiListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+};
+
+export type PoiPagination = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly hasNextPage: boolean;
+  readonly total?: number;
+};
+
+export type PoiListResult = {
+  readonly data: readonly PoiContentItem[];
+  readonly pagination: PoiPagination;
+};
+
 export type PoiOpeningHour = {
   readonly weekday?: string;
   readonly timeFrom?: string;

--- a/packages/plugin-poi/tests/list-pagination.test.ts
+++ b/packages/plugin-poi/tests/list-pagination.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeListSearch } from '../src/list-pagination.js';
+
+describe('normalizeListSearch', () => {
+  it('normalizes unsupported page sizes to the default value', () => {
+    expect(normalizeListSearch({ page: 3, pageSize: 13 })).toEqual({ page: 3, pageSize: 25 });
+  });
+
+  it('caps the page number to the maximum visible offset budget', () => {
+    expect(normalizeListSearch({ page: 9999, pageSize: 25 })).toEqual({ page: 401, pageSize: 25 });
+  });
+});

--- a/packages/plugin-poi/tests/poi.api.test.ts
+++ b/packages/plugin-poi/tests/poi.api.test.ts
@@ -8,11 +8,22 @@ describe('poi api', () => {
   });
 
   it('lists POI from the host facade', async () => {
-    const fetchMock = vi.fn(async () => Response.json({ data: [{ id: 'poi-1', name: 'Rathaus' }] }));
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        data: [{ id: 'poi-1', name: 'Rathaus' }],
+        pagination: { page: 2, pageSize: 50, hasNextPage: true },
+      })
+    );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(listPoi()).resolves.toEqual([{ id: 'poi-1', name: 'Rathaus' }]);
-    expect(fetchMock).toHaveBeenCalledWith('/api/v1/mainserver/poi', expect.objectContaining({ credentials: 'include' }));
+    await expect(listPoi({ page: 2, pageSize: 50 })).resolves.toEqual({
+      data: [{ id: 'poi-1', name: 'Rathaus' }],
+      pagination: { page: 2, pageSize: 50, hasNextPage: true },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/mainserver/poi?page=2&pageSize=50',
+      expect.objectContaining({ credentials: 'include' })
+    );
   });
 
   it('creates POI via POST', async () => {
@@ -29,6 +40,6 @@ describe('poi api', () => {
   it('throws stable errors', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => Response.json({ error: 'forbidden', message: 'Nope' }, { status: 403 })));
 
-    await expect(listPoi()).rejects.toBeInstanceOf(PoiApiError);
+    await expect(listPoi({ page: 1, pageSize: 25 })).rejects.toBeInstanceOf(PoiApiError);
   });
 });

--- a/packages/routing/src/admin-resource-routes.test.ts
+++ b/packages/routing/src/admin-resource-routes.test.ts
@@ -92,13 +92,6 @@ const bindings: AppRouteBindings = {
   adminApiPhase1Test: () => 'adminApiPhase1Test',
 };
 
-const specializedBindings = {
-  ...bindings,
-  newsList: () => 'newsList',
-  newsDetail: () => 'newsDetail',
-  newsEditor: () => 'newsEditor',
-} as AppRouteBindings & Record<'newsList' | 'newsDetail' | 'newsEditor', () => string>;
-
 const readRouteOptions = (route: unknown): RouteOptionsUnderTest =>
   (route as { options: RouteOptionsUnderTest }).options;
 
@@ -227,74 +220,6 @@ describe('admin resource routes', () => {
     }
   });
 
-  it('materializes specialized content ui bindings inside host-owned admin routes', () => {
-    const routeFactories = createAdminResourceRouteFactories(specializedBindings, [
-      {
-        resourceId: 'news.content',
-        basePath: 'news',
-        titleKey: 'news.navigation.title',
-        guard: 'content',
-        views: {
-          list: { bindingKey: 'content' },
-          create: { bindingKey: 'contentCreate' },
-          detail: { bindingKey: 'contentDetail' },
-        },
-        contentUi: {
-          contentType: 'news.article',
-          bindings: {
-            list: { bindingKey: 'newsList' },
-            detail: { bindingKey: 'newsDetail' },
-            editor: { bindingKey: 'newsEditor' },
-          },
-        },
-      } as never,
-    ]);
-    const rootRoute = { id: 'root' };
-    const routeMap = new Map(
-      routeFactories
-        .map((factory) => factory(rootRoute as never))
-        .map((route) => readRouteOptions(route))
-        .map((route) => [String(route.path), route])
-    );
-
-    expect(routeMap.get('/admin/news')?.component?.()).toBe('newsList');
-    expect(routeMap.get('/admin/news/new')?.component?.()).toBe('newsEditor');
-    expect(routeMap.get('/admin/news/$id')?.component?.()).toBe('newsDetail');
-  });
-
-  it('falls back to host-owned content bindings when specialized content ui bindings are omitted', () => {
-    const routeFactories = createAdminResourceRouteFactories(specializedBindings, [
-      {
-        resourceId: 'news.content',
-        basePath: 'news',
-        titleKey: 'news.navigation.title',
-        guard: 'content',
-        views: {
-          list: { bindingKey: 'content' },
-          create: { bindingKey: 'contentCreate' },
-          detail: { bindingKey: 'contentDetail' },
-        },
-        contentUi: {
-          contentType: 'news.article',
-          bindings: {
-            list: { bindingKey: 'newsList' },
-          },
-        },
-      } as never,
-    ]);
-    const rootRoute = { id: 'root' };
-    const routeMap = new Map(
-      routeFactories
-        .map((factory) => factory(rootRoute as never))
-        .map((route) => readRouteOptions(route))
-        .map((route) => [String(route.path), route])
-    );
-
-    expect(routeMap.get('/admin/news')?.component?.()).toBe('newsList');
-    expect(routeMap.get('/admin/news/new')?.component?.()).toBe('contentCreate');
-    expect(routeMap.get('/admin/news/$id')?.component?.()).toBe('contentDetail');
-  });
-
   it('normalizes declared list search params for admin resources with list capabilities', () => {
     const routeFactories = createAdminResourceRouteFactories(bindings, [
       {
@@ -368,30 +293,6 @@ describe('admin resource routes', () => {
         },
       ])
     ).toThrow('unknown_admin_resource_binding_key:news.entries:list:unknownListBinding');
-  });
-
-  it('rejects unknown specialized content ui binding keys before route creation', () => {
-    expect(() =>
-      createAdminResourceRouteFactories(bindings, [
-        {
-          resourceId: 'news.entries',
-          basePath: 'news',
-          titleKey: 'news.title',
-          guard: 'content',
-          views: {
-            list: { bindingKey: 'content' },
-            create: { bindingKey: 'contentCreate' },
-            detail: { bindingKey: 'contentDetail' },
-          },
-          contentUi: {
-            contentType: 'news.article',
-            bindings: {
-              list: { bindingKey: 'unknownListBinding' as never },
-            },
-          },
-        },
-      ])
-    ).toThrow('unknown_admin_resource_binding_key:news.entries:contentUi.list:unknownListBinding');
   });
 
   it('rejects prototype property binding keys before route creation', () => {

--- a/packages/routing/src/admin-resource-routes.test.ts
+++ b/packages/routing/src/admin-resource-routes.test.ts
@@ -92,6 +92,13 @@ const bindings: AppRouteBindings = {
   adminApiPhase1Test: () => 'adminApiPhase1Test',
 };
 
+const specializedBindings = {
+  ...bindings,
+  newsList: () => 'newsList',
+  newsDetail: () => 'newsDetail',
+  newsEditor: () => 'newsEditor',
+} as AppRouteBindings & Record<'newsList' | 'newsDetail' | 'newsEditor', () => string>;
+
 const readRouteOptions = (route: unknown): RouteOptionsUnderTest =>
   (route as { options: RouteOptionsUnderTest }).options;
 
@@ -220,6 +227,107 @@ describe('admin resource routes', () => {
     }
   });
 
+  it('materializes specialized content ui bindings inside host-owned admin routes', () => {
+    const routeFactories = createAdminResourceRouteFactories(specializedBindings, [
+      {
+        resourceId: 'news.content',
+        basePath: 'news',
+        titleKey: 'news.navigation.title',
+        guard: 'content',
+        views: {
+          list: { bindingKey: 'content' },
+          create: { bindingKey: 'contentCreate' },
+          detail: { bindingKey: 'contentDetail' },
+        },
+        contentUi: {
+          contentType: 'news.article',
+          bindings: {
+            list: { bindingKey: 'newsList' },
+            detail: { bindingKey: 'newsDetail' },
+            editor: { bindingKey: 'newsEditor' },
+          },
+        },
+      } as never,
+    ]);
+    const rootRoute = { id: 'root' };
+    const routeMap = new Map(
+      routeFactories
+        .map((factory) => factory(rootRoute as never))
+        .map((route) => readRouteOptions(route))
+        .map((route) => [String(route.path), route])
+    );
+
+    expect(routeMap.get('/admin/news')?.component?.()).toBe('newsList');
+    expect(routeMap.get('/admin/news/new')?.component?.()).toBe('newsEditor');
+    expect(routeMap.get('/admin/news/$id')?.component?.()).toBe('newsDetail');
+  });
+
+  it('falls back to host-owned content bindings when specialized content ui bindings are omitted', () => {
+    const routeFactories = createAdminResourceRouteFactories(specializedBindings, [
+      {
+        resourceId: 'news.content',
+        basePath: 'news',
+        titleKey: 'news.navigation.title',
+        guard: 'content',
+        views: {
+          list: { bindingKey: 'content' },
+          create: { bindingKey: 'contentCreate' },
+          detail: { bindingKey: 'contentDetail' },
+        },
+        contentUi: {
+          contentType: 'news.article',
+          bindings: {
+            list: { bindingKey: 'newsList' },
+          },
+        },
+      } as never,
+    ]);
+    const rootRoute = { id: 'root' };
+    const routeMap = new Map(
+      routeFactories
+        .map((factory) => factory(rootRoute as never))
+        .map((route) => readRouteOptions(route))
+        .map((route) => [String(route.path), route])
+    );
+
+    expect(routeMap.get('/admin/news')?.component?.()).toBe('newsList');
+    expect(routeMap.get('/admin/news/new')?.component?.()).toBe('contentCreate');
+    expect(routeMap.get('/admin/news/$id')?.component?.()).toBe('contentDetail');
+  });
+
+  it('normalizes declared list search params for admin resources with list capabilities', () => {
+    const routeFactories = createAdminResourceRouteFactories(bindings, [
+      {
+        resourceId: 'news.content',
+        basePath: 'news',
+        titleKey: 'news.navigation.title',
+        guard: 'content',
+        views: {
+          list: { bindingKey: 'content' },
+          create: { bindingKey: 'contentCreate' },
+          detail: { bindingKey: 'contentDetail' },
+        },
+        capabilities: {
+          list: {
+            pagination: { defaultPageSize: 25, pageSizeOptions: [10, 25, 50] },
+            search: { param: 'q' },
+          },
+        },
+      } as never,
+    ]);
+    const rootRoute = { id: 'root' };
+    const listRoute = routeFactories
+      .map((factory) => factory(rootRoute as never))
+      .map((route) => readRouteOptions(route))
+      .find((route) => route.path === '/admin/news');
+
+    expect(listRoute?.validateSearch?.({ q: 'news', page: '2', pageSize: '50' })).toEqual({
+      page: 2,
+      pageSize: 50,
+      search: 'news',
+    });
+  });
+
   it('redirects legacy content aliases using href and location.href fallbacks', () => {
     const routeFactories = createLegacyContentAliasFactories();
     const rootRoute = { id: 'root' };
@@ -258,6 +366,30 @@ describe('admin resource routes', () => {
         },
       ])
     ).toThrow('unknown_admin_resource_binding_key:news.entries:list:unknownListBinding');
+  });
+
+  it('rejects unknown specialized content ui binding keys before route creation', () => {
+    expect(() =>
+      createAdminResourceRouteFactories(bindings, [
+        {
+          resourceId: 'news.entries',
+          basePath: 'news',
+          titleKey: 'news.title',
+          guard: 'content',
+          views: {
+            list: { bindingKey: 'content' },
+            create: { bindingKey: 'contentCreate' },
+            detail: { bindingKey: 'contentDetail' },
+          },
+          contentUi: {
+            contentType: 'news.article',
+            bindings: {
+              list: { bindingKey: 'unknownListBinding' as never },
+            },
+          },
+        },
+      ])
+    ).toThrow('unknown_admin_resource_binding_key:news.entries:contentUi.list:unknownListBinding');
   });
 
   it('rejects prototype property binding keys before route creation', () => {

--- a/packages/routing/src/admin-resource-routes.test.ts
+++ b/packages/routing/src/admin-resource-routes.test.ts
@@ -322,9 +322,11 @@ describe('admin resource routes', () => {
       .find((route) => route.path === '/admin/news');
 
     expect(listRoute?.validateSearch?.({ q: 'news', page: '2', pageSize: '50' })).toEqual({
+      filters: {},
       page: 2,
       pageSize: 50,
       search: 'news',
+      sort: undefined,
     });
   });
 

--- a/packages/routing/src/admin-resource-routes.ts
+++ b/packages/routing/src/admin-resource-routes.ts
@@ -2,6 +2,7 @@ import type { AdminResourceDefinition } from '@sva/plugin-sdk';
 import { createRoute, redirect, type RootRoute } from '@tanstack/react-router';
 
 import { createAccountUiRouteGuard, type AccountUiRouteGuardKey } from './account-ui.routes.js';
+import { normalizeAdminResourceListSearch } from './admin-resource-search-params.js';
 import type { AppRouteBindings, AppRouteFactory } from './app.routes.shared.js';
 import type { RoutingDiagnosticsHook } from './diagnostics.js';
 
@@ -11,6 +12,7 @@ type UiRouteDefinition = {
   readonly binding: BindingKey;
   readonly guard: AccountUiRouteGuardKey;
   readonly path: string;
+  readonly validateSearch?: (search: Record<string, unknown>) => unknown;
 };
 
 type AdminResourceBindingResolver = { readonly list: BindingKey; readonly create: BindingKey; readonly detail: BindingKey; readonly history?: BindingKey };
@@ -159,6 +161,9 @@ const createAdminResourceRouteDefinitions = (
         binding: resolvedBindings.list,
         guard: resolveAdminResourceGuard(resource, 'list'),
         path: basePath,
+        validateSearch: resource.capabilities?.list
+          ? (search: Record<string, unknown>) => normalizeAdminResourceListSearch(resource, search)
+          : undefined,
       },
       {
         binding: resolvedBindings.create,
@@ -226,6 +231,7 @@ export const createAdminResourceRouteFactories = (
           getParentRoute: () => rootRoute,
           path: definition.path,
           beforeLoad: (beforeLoadOptions) => guard(beforeLoadOptions),
+          validateSearch: definition.validateSearch,
           component: bindings[definition.binding],
         });
       }

--- a/packages/sva-mainserver/src/index.ts
+++ b/packages/sva-mainserver/src/index.ts
@@ -1,6 +1,9 @@
 export type {
   SvaMainserverConnectionInput,
   SvaMainserverConnectionStatus,
+  SvaMainserverListPagination,
+  SvaMainserverListQuery,
+  SvaMainserverListResult,
   SvaMainserverAddressInput,
   SvaMainserverCategoryInput,
   SvaMainserverContactInput,

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -622,6 +622,142 @@ describe('createSvaMainserverService', () => {
     });
   });
 
+  it('marks hasNextPage when visible news exceeds the requested page size', async () => {
+    const publishedAt = '2026-04-14T09:30:00.000Z';
+    const visibleNewsItems = Array.from({ length: 26 }, (_, index) => ({
+      id: `news-${index + 1}`,
+      title: `News ${index + 1}`,
+      payload: { teaser: `Kurztext ${index + 1}`, body: '<p>Body</p>' },
+      publishedAt,
+      visible: true,
+    }));
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: visibleNewsItems } }));
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 1, pageSize: 25 })
+    ).resolves.toMatchObject({
+      data: Array.from({ length: 25 }, (_, index) => expect.objectContaining({ id: `news-${index + 1}` })),
+      pagination: { page: 1, pageSize: 25, hasNextPage: true },
+    });
+  });
+
+  it('keeps paginated news slices stable when invisible upstream items span multiple fetches', async () => {
+    const publishedAt = '2026-04-14T09:30:00.000Z';
+    const firstPage = Array.from({ length: 25 }, (_, index) => ({
+      id: `hidden-${index + 1}`,
+      title: `Hidden ${index + 1}`,
+      payload: {},
+      publishedAt,
+      visible: false,
+    }));
+    const secondPage = [
+      {
+        id: 'news-26',
+        title: 'Visible 26',
+        payload: { teaser: 'Kurztext 26', body: '<p>Body</p>' },
+        publishedAt,
+        visible: true,
+      },
+      {
+        id: 'news-27',
+        title: 'Visible 27',
+        payload: { teaser: 'Kurztext 27', body: '<p>Body</p>' },
+        publishedAt,
+        visible: true,
+      },
+    ];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: firstPage } }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: secondPage } }));
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 1, pageSize: 1 })
+    ).resolves.toEqual({
+      data: [expect.objectContaining({ id: 'news-26' })],
+      pagination: { page: 1, pageSize: 1, hasNextPage: true },
+    });
+  });
+
+  it('returns the correct news slice for page numbers greater than one', async () => {
+    const publishedAt = '2026-04-14T09:30:00.000Z';
+    const visibleNewsItems = Array.from({ length: 55 }, (_, index) => ({
+      id: `news-${index + 1}`,
+      title: `News ${index + 1}`,
+      payload: { teaser: `Kurztext ${index + 1}`, body: '<p>Body</p>' },
+      publishedAt,
+      visible: true,
+    }));
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: visibleNewsItems.slice(0, 26) } }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: visibleNewsItems.slice(26, 52) } }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: visibleNewsItems.slice(52) } }));
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 2, pageSize: 25 })
+    ).resolves.toMatchObject({
+      data: Array.from({ length: 25 }, (_, index) => expect.objectContaining({ id: `news-${index + 26}` })),
+      pagination: { page: 2, pageSize: 25, hasNextPage: true },
+    });
+  });
+
+  it('normalizes invalid page and pageSize values before listing news', async () => {
+    const publishedAt = '2026-04-14T09:30:00.000Z';
+    const visibleNewsItems = Array.from({ length: 2 }, (_, index) => ({
+      id: `news-${index + 1}`,
+      title: `News ${index + 1}`,
+      payload: { teaser: `Kurztext ${index + 1}`, body: '<p>Body</p>' },
+      publishedAt,
+      visible: true,
+    }));
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: visibleNewsItems } }));
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 0, pageSize: 0 })
+    ).resolves.toEqual({
+      data: [expect.objectContaining({ id: 'news-1' })],
+      pagination: { page: 1, pageSize: 1, hasNextPage: true },
+    });
+
+    const listRequestBody = JSON.parse(fetchImpl.mock.calls[1]?.[1]?.body as string) as {
+      variables: { limit: number; skip: number };
+    };
+    expect(listRequestBody.variables).toMatchObject({ limit: 2, skip: 0 });
+  });
+
   it('maps invalid news payloads to an empty payload fallback', async () => {
     const publishedAt = '2026-04-14T09:30:00.000Z';
     const fetchImpl = vi

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -812,6 +812,50 @@ describe('createSvaMainserverService', () => {
     });
   });
 
+  it('returns the last allowed 100-item page without throwing at the upstream scan boundary', async () => {
+    const publishedAt = '2026-04-14T09:30:00.000Z';
+    const fetchImpl = vi.fn(async (_input?: RequestInfo | URL, init?: RequestInit) => {
+      const requestBody =
+        typeof init?.body === 'string' && init.body.trim().startsWith('{')
+          ? (JSON.parse(init.body) as { operationName?: string; variables?: { skip?: number; limit?: number } })
+          : undefined;
+
+      if (requestBody?.operationName === 'SvaMainserverNewsList') {
+        const skip = requestBody.variables?.skip ?? 0;
+        const limit = requestBody.variables?.limit ?? 0;
+        const remaining = Math.max(10_100 - skip, 0);
+        const size = Math.min(limit, remaining);
+        const newsItems = Array.from({ length: size }, (_, index) => {
+          const itemIndex = skip + index + 1;
+          return {
+            id: `news-${itemIndex}`,
+            title: `News ${itemIndex}`,
+            payload: { teaser: `Kurztext ${itemIndex}`, body: '<p>Body</p>' },
+            publishedAt,
+            visible: true,
+          };
+        });
+
+        return createJsonResponse(200, { data: { newsItems } });
+      }
+
+      return createJsonResponse(200, { access_token: 'token-1', expires_in: 120 });
+    });
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 101, pageSize: 100 })
+    ).resolves.toMatchObject({
+      data: Array.from({ length: 100 }, (_, index) => expect.objectContaining({ id: `news-${10_001 + index}` })),
+      pagination: { page: 101, pageSize: 100, hasNextPage: false },
+    });
+  });
+
   it('maps invalid news payloads to an empty payload fallback', async () => {
     const publishedAt = '2026-04-14T09:30:00.000Z';
     const fetchImpl = vi

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -246,9 +246,10 @@ describe('createSvaMainserverService', () => {
       contentBlocks: [{ intro: 'Kurztext', body: '<p>Body</p>' }],
     };
 
-    await expect(service.listNews(connection)).resolves.toEqual([
-      expect.objectContaining({ id: 'news-1', status: 'published', contentType: 'news.article' }),
-    ]);
+    await expect(service.listNews({ ...connection, page: 1, pageSize: 25 })).resolves.toEqual({
+      data: [expect.objectContaining({ id: 'news-1', status: 'published', contentType: 'news.article' })],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     await expect(service.createNews({ ...connection, news })).resolves.toEqual(expect.objectContaining({ id: 'news-1' }));
     await expect(service.updateNews({ ...connection, newsId: 'news-1', news })).resolves.toEqual(
       expect.objectContaining({ id: 'news-1' })
@@ -260,7 +261,7 @@ describe('createSvaMainserverService', () => {
       .map(([, init]) => JSON.parse(init?.body as string) as { operationName: string; variables?: Record<string, unknown> });
     expect(requestBodies[0]).toMatchObject({
       operationName: 'SvaMainserverNewsList',
-      variables: { limit: 100, skip: 0, order: 'publishedAt_DESC' },
+      variables: { limit: 26, skip: 0, order: 'publishedAt_DESC' },
     });
     expect(requestBodies[2]).toMatchObject({
       operationName: 'SvaMainserverCreateNews',
@@ -300,7 +301,10 @@ describe('createSvaMainserverService', () => {
       payload: item.payload,
     };
 
-    await expect(listSvaMainserverNews(connection)).resolves.toHaveLength(1);
+    await expect(listSvaMainserverNews({ ...connection, page: 1, pageSize: 25 })).resolves.toMatchObject({
+      data: [expect.objectContaining({ id: 'news-1' })],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     await expect(getSvaMainserverNews({ ...connection, newsId: 'news-1' })).resolves.toMatchObject({ id: 'news-1' });
     await expect(createSvaMainserverNews({ ...connection, news })).resolves.toMatchObject({ id: 'news-1' });
     await expect(updateSvaMainserverNews({ ...connection, newsId: 'news-1', news })).resolves.toMatchObject({
@@ -394,15 +398,18 @@ describe('createSvaMainserverService', () => {
     });
     const connection = { instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1' };
 
-    await expect(service.listEvents(connection)).resolves.toEqual([
-      expect.objectContaining({
-        id: 'event-1',
-        contentType: 'events.event-record',
-        categoryName: 'Kultur',
-        contacts: [expect.objectContaining({ email: 'ada@example.test' })],
-        repeatDuration: { startDate: '2026-06-01', endDate: '2026-06-14', everyYear: false },
-      }),
-    ]);
+    await expect(service.listEvents({ ...connection, page: 1, pageSize: 25 })).resolves.toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'event-1',
+          contentType: 'events.event-record',
+          categoryName: 'Kultur',
+          contacts: [expect.objectContaining({ email: 'ada@example.test' })],
+          repeatDuration: { startDate: '2026-06-01', endDate: '2026-06-14', everyYear: false },
+        }),
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     await expect(service.getEvent({ ...connection, eventId: 'event-1' })).resolves.toMatchObject({ id: 'event-1' });
     await expect(
       service.createEvent({
@@ -439,15 +446,18 @@ describe('createSvaMainserverService', () => {
     await expect(service.updateEvent({ ...connection, eventId: 'event-1', event: { title: 'Sommerfest', repeat: true, recurring: 'true', recurringType: '1', recurringInterval: '2', recurringWeekdays: ['MO'] } })).resolves.toMatchObject({ id: 'event-1' });
     await expect(service.deleteEvent({ ...connection, eventId: 'event-1' })).resolves.toEqual({ id: 'event-1' });
 
-    await expect(service.listPoi(connection)).resolves.toEqual([
-      expect.objectContaining({
-        id: 'poi-1',
-        contentType: 'poi.point-of-interest',
-        categoryName: 'Freizeit',
-        contact: expect.objectContaining({ email: 'park@example.test' }),
-        certificates: [{ id: 'cert-1', name: 'Familienfreundlich' }],
-      }),
-    ]);
+    await expect(service.listPoi({ ...connection, page: 1, pageSize: 25 })).resolves.toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'poi-1',
+          contentType: 'poi.point-of-interest',
+          categoryName: 'Freizeit',
+          contact: expect.objectContaining({ email: 'park@example.test' }),
+          certificates: [{ id: 'cert-1', name: 'Familienfreundlich' }],
+        }),
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     await expect(service.getPoi({ ...connection, poiId: 'poi-1' })).resolves.toMatchObject({ id: 'poi-1' });
     await expect(
       service.createPoi({
@@ -534,7 +544,10 @@ describe('createSvaMainserverService', () => {
     vi.stubGlobal('fetch', fetchImpl);
     const connection = { instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1' };
 
-    await expect(listSvaMainserverEvents(connection)).resolves.toHaveLength(1);
+    await expect(listSvaMainserverEvents({ ...connection, page: 1, pageSize: 25 })).resolves.toMatchObject({
+      data: [expect.objectContaining({ id: 'event-1' })],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     await expect(getSvaMainserverEvent({ ...connection, eventId: 'event-1' })).resolves.toMatchObject({ id: 'event-1' });
     await expect(createSvaMainserverEvent({ ...connection, event: { title: 'Event' } })).resolves.toMatchObject({
       id: 'event-1',
@@ -543,7 +556,10 @@ describe('createSvaMainserverService', () => {
       id: 'event-1',
     });
     await expect(deleteSvaMainserverEvent({ ...connection, eventId: 'event-1' })).resolves.toEqual({ id: 'event-1' });
-    await expect(listSvaMainserverPoi(connection)).resolves.toHaveLength(1);
+    await expect(listSvaMainserverPoi({ ...connection, page: 1, pageSize: 25 })).resolves.toMatchObject({
+      data: [expect.objectContaining({ id: 'poi-1' })],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     await expect(getSvaMainserverPoi({ ...connection, poiId: 'poi-1' })).resolves.toMatchObject({ id: 'poi-1' });
     await expect(createSvaMainserverPoi({ ...connection, poi: { name: 'POI' } })).resolves.toMatchObject({ id: 'poi-1' });
     await expect(updateSvaMainserverPoi({ ...connection, poiId: 'poi-1', poi: { name: 'POI' } })).resolves.toMatchObject({
@@ -586,21 +602,24 @@ describe('createSvaMainserverService', () => {
     });
 
     await expect(
-      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1' })
-    ).resolves.toEqual([
-      expect.objectContaining({
-        id: 'news-1',
-        title: '',
-        payload: expect.objectContaining({
-          teaser: 'Kurztext',
-          body: '<p>Body</p>',
-          externalUrl: 'https://example.test',
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 1, pageSize: 25 })
+    ).resolves.toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'news-1',
+          title: '',
+          payload: expect.objectContaining({
+            teaser: 'Kurztext',
+            body: '<p>Body</p>',
+            externalUrl: 'https://example.test',
+          }),
+          createdAt: publishedAt,
+          updatedAt: publishedAt,
+          publishedAt,
         }),
-        createdAt: publishedAt,
-        updatedAt: publishedAt,
-        publishedAt,
-      }),
-    ]);
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
   });
 
   it('maps invalid news payloads to an empty payload fallback', async () => {
@@ -874,7 +893,7 @@ describe('createSvaMainserverService', () => {
     });
     const connection = { instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1' };
 
-    await expect(service.listNews(connection)).rejects.toMatchObject({
+    await expect(service.listNews({ ...connection, page: 1, pageSize: 25 })).rejects.toMatchObject({
       code: 'invalid_response',
       statusCode: 502,
     });

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -652,29 +652,20 @@ describe('createSvaMainserverService', () => {
 
   it('keeps paginated news slices stable when invisible upstream items span multiple fetches', async () => {
     const publishedAt = '2026-04-14T09:30:00.000Z';
-    const firstPage = Array.from({ length: 25 }, (_, index) => ({
+    const firstPage = Array.from({ length: 26 }, (_, index) => ({
       id: `hidden-${index + 1}`,
       title: `Hidden ${index + 1}`,
       payload: {},
       publishedAt,
       visible: false,
     }));
-    const secondPage = [
-      {
-        id: 'news-26',
-        title: 'Visible 26',
-        payload: { teaser: 'Kurztext 26', body: '<p>Body</p>' },
-        publishedAt,
-        visible: true,
-      },
-      {
-        id: 'news-27',
-        title: 'Visible 27',
-        payload: { teaser: 'Kurztext 27', body: '<p>Body</p>' },
-        publishedAt,
-        visible: true,
-      },
-    ];
+    const secondPage = Array.from({ length: 26 }, (_, index) => ({
+      id: `news-${index + 27}`,
+      title: `Visible ${index + 27}`,
+      payload: { teaser: `Kurztext ${index + 27}`, body: '<p>Body</p>' },
+      publishedAt,
+      visible: true,
+    }));
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
@@ -688,10 +679,10 @@ describe('createSvaMainserverService', () => {
     });
 
     await expect(
-      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 1, pageSize: 1 })
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 1, pageSize: 25 })
     ).resolves.toEqual({
-      data: [expect.objectContaining({ id: 'news-26' })],
-      pagination: { page: 1, pageSize: 1, hasNextPage: true },
+      data: Array.from({ length: 25 }, (_, index) => expect.objectContaining({ id: `news-${index + 27}` })),
+      pagination: { page: 1, pageSize: 25, hasNextPage: true },
     });
   });
 
@@ -747,15 +738,78 @@ describe('createSvaMainserverService', () => {
 
     await expect(
       service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 0, pageSize: 0 })
-    ).resolves.toEqual({
-      data: [expect.objectContaining({ id: 'news-1' })],
-      pagination: { page: 1, pageSize: 1, hasNextPage: true },
+    ).resolves.toMatchObject({
+      data: [expect.objectContaining({ id: 'news-1' }), expect.objectContaining({ id: 'news-2' })],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
     });
 
     const listRequestBody = JSON.parse(fetchImpl.mock.calls[1]?.[1]?.body as string) as {
       variables: { limit: number; skip: number };
     };
-    expect(listRequestBody.variables).toMatchObject({ limit: 2, skip: 0 });
+    expect(listRequestBody.variables).toMatchObject({ limit: 26, skip: 0 });
+  });
+
+  it('normalizes unsupported page sizes to the default allowed page size', async () => {
+    const publishedAt = '2026-04-14T09:30:00.000Z';
+    const visibleNewsItems = Array.from({ length: 3 }, (_, index) => ({
+      id: `news-${index + 1}`,
+      title: `News ${index + 1}`,
+      payload: { teaser: `Kurztext ${index + 1}`, body: '<p>Body</p>' },
+      publishedAt,
+      visible: true,
+    }));
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { newsItems: visibleNewsItems } }));
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 1, pageSize: 13 })
+    ).resolves.toMatchObject({
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+  });
+
+  it('fails deterministically when too many upstream records are required to resolve visible pagination', async () => {
+    const publishedAt = '2026-04-14T09:30:00.000Z';
+    const invisibleBatch = Array.from({ length: 100 }, (_, index) => ({
+      id: `hidden-${index + 1}`,
+      title: `Hidden ${index + 1}`,
+      payload: {},
+      publishedAt,
+      visible: false,
+    }));
+    const fetchImpl = vi.fn(async (_input?: RequestInfo | URL, init?: RequestInit) => {
+      const requestBody =
+        typeof init?.body === 'string' && init.body.trim().startsWith('{')
+          ? (JSON.parse(init.body) as { operationName?: string })
+          : undefined;
+
+      if (requestBody?.operationName === 'SvaMainserverNewsList') {
+        return createJsonResponse(200, { data: { newsItems: invisibleBatch } });
+      }
+
+      return createJsonResponse(200, { access_token: 'token-1', expires_in: 120 });
+    });
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.listNews({ instanceId: baseConfig.instanceId, keycloakSubject: 'subject-1', page: 1, pageSize: 25 })
+    ).rejects.toMatchObject<SvaMainserverError>({
+      code: 'invalid_response',
+      statusCode: 502,
+    });
   });
 
   it('maps invalid news payloads to an empty payload fallback', async () => {

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -136,8 +136,10 @@ const DEFAULT_UPSTREAM_TIMEOUT_MS = 10_000;
 const DEFAULT_CACHE_MAX_SIZE = 256;
 const DEFAULT_RETRY_BASE_DELAY_MS = 150;
 const RETRYABLE_STATUS_CODES = new Set([503]);
+const ALLOWED_MAINSERVER_PAGE_SIZES = [25, 50, 100] as const;
 const MAX_MAINSERVER_PAGE_SIZE = 100;
 const MAX_MAINSERVER_VISIBLE_OFFSET = 10_000;
+const MAX_MAINSERVER_UPSTREAM_SCAN_RECORDS = MAX_MAINSERVER_VISIBLE_OFFSET + MAX_MAINSERVER_PAGE_SIZE;
 
 const tokenResponseSchema = z.object({
   access_token: z.string().min(1),
@@ -537,7 +539,10 @@ const toListResult = <TItem>(
 });
 
 const normalizeListInput = (input: SvaMainserverListInput): SvaMainserverListInput => {
-  const pageSize = Math.min(MAX_MAINSERVER_PAGE_SIZE, Math.max(1, Math.trunc(input.pageSize) || 1));
+  const requestedPageSize = Math.trunc(input.pageSize) || 0;
+  const pageSize = ALLOWED_MAINSERVER_PAGE_SIZES.includes(requestedPageSize as (typeof ALLOWED_MAINSERVER_PAGE_SIZES)[number])
+    ? requestedPageSize
+    : 25;
   const maxPage = Math.floor(MAX_MAINSERVER_VISIBLE_OFFSET / pageSize) + 1;
   const page = Math.min(Math.max(1, Math.trunc(input.page) || 1), maxPage);
 
@@ -1708,6 +1713,14 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     let hasNextPage = false;
 
     while (collectedVisibleItems.length < targetVisibleCount && exhausted === false && hasNextPage === false) {
+      if (skip >= MAX_MAINSERVER_UPSTREAM_SCAN_RECORDS) {
+        throw toSvaMainserverError({
+          code: 'invalid_response',
+          message: 'Mainserver-Pagination erfordert zu viele Upstream-Datensätze für sichtbare Ergebnisse.',
+          statusCode: 502,
+        });
+      }
+
       const response = await executeGraphqlWithConfig<TQueryResult>(
         {
           ...normalizedInput,

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -137,6 +137,7 @@ const DEFAULT_CACHE_MAX_SIZE = 256;
 const DEFAULT_RETRY_BASE_DELAY_MS = 150;
 const RETRYABLE_STATUS_CODES = new Set([503]);
 const MAX_MAINSERVER_PAGE_SIZE = 100;
+const MAX_MAINSERVER_VISIBLE_OFFSET = 10_000;
 
 const tokenResponseSchema = z.object({
   access_token: z.string().min(1),
@@ -534,6 +535,18 @@ const toListResult = <TItem>(
     hasNextPage,
   },
 });
+
+const normalizeListInput = (input: SvaMainserverListInput): SvaMainserverListInput => {
+  const pageSize = Math.min(MAX_MAINSERVER_PAGE_SIZE, Math.max(1, Math.trunc(input.pageSize) || 1));
+  const maxPage = Math.floor(MAX_MAINSERVER_VISIBLE_OFFSET / pageSize) + 1;
+  const page = Math.min(Math.max(1, Math.trunc(input.page) || 1), maxPage);
+
+  return {
+    ...input,
+    page,
+    pageSize,
+  };
+};
 
 const buildForwardHeaders = (): Record<string, string> => {
   const context = getWorkspaceContext();
@@ -1684,18 +1697,20 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
       readonly mapItem: (item: TUpstreamItem) => TItem;
     }
   ): Promise<SvaMainserverListResult<TItem>> => {
-    const startIndex = (input.page - 1) * input.pageSize;
-    const endIndex = startIndex + input.pageSize;
-    const targetVisibleCount = endIndex + 1;
-    const batchSize = Math.min(MAX_MAINSERVER_PAGE_SIZE, input.pageSize + 1);
+    const normalizedInput = normalizeListInput(input);
+    const startIndex = (normalizedInput.page - 1) * normalizedInput.pageSize;
+    const targetVisibleCount = normalizedInput.pageSize + 1;
+    const batchSize = Math.min(MAX_MAINSERVER_PAGE_SIZE, normalizedInput.pageSize + 1);
     const collectedVisibleItems: TItem[] = [];
+    let visibleIndex = 0;
     let skip = 0;
     let exhausted = false;
+    let hasNextPage = false;
 
-    while (collectedVisibleItems.length < targetVisibleCount && exhausted === false) {
+    while (collectedVisibleItems.length < targetVisibleCount && exhausted === false && hasNextPage === false) {
       const response = await executeGraphqlWithConfig<TQueryResult>(
         {
-          ...input,
+          ...normalizedInput,
           document: options.document,
           operationName: options.operationName,
           variables: { limit: batchSize, skip, order: options.order },
@@ -1711,8 +1726,18 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
         if (options.isVisible(item) === false) {
           continue;
         }
-        collectedVisibleItems.push(options.mapItem(item));
-        if (collectedVisibleItems.length >= targetVisibleCount) {
+
+        if (visibleIndex >= startIndex) {
+          collectedVisibleItems.push(options.mapItem(item));
+          if (collectedVisibleItems.length >= targetVisibleCount) {
+            hasNextPage = true;
+            break;
+          }
+        }
+
+        visibleIndex += 1;
+        if (visibleIndex >= startIndex + targetVisibleCount) {
+          hasNextPage = true;
           break;
         }
       }
@@ -1723,9 +1748,9 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     }
 
     return toListResult(
-      input,
-      collectedVisibleItems.slice(startIndex, endIndex),
-      collectedVisibleItems.length > endIndex
+      normalizedInput,
+      collectedVisibleItems.slice(0, normalizedInput.pageSize),
+      hasNextPage
     );
   };
 

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -1713,7 +1713,7 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     let hasNextPage = false;
 
     while (collectedVisibleItems.length < targetVisibleCount && exhausted === false && hasNextPage === false) {
-      if (skip >= MAX_MAINSERVER_UPSTREAM_SCAN_RECORDS) {
+      if (skip > MAX_MAINSERVER_UPSTREAM_SCAN_RECORDS) {
         throw toSvaMainserverError({
           code: 'invalid_response',
           message: 'Mainserver-Pagination erfordert zu viele Upstream-Datensätze für sichtbare Ergebnisse.',

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -45,6 +45,8 @@ import type {
   SvaMainserverConnectionStatus,
   SvaMainserverErrorCode,
   SvaMainserverInstanceConfig,
+  SvaMainserverListQuery,
+  SvaMainserverListResult,
   SvaMainserverAccessibilityInformation,
   SvaMainserverAddress,
   SvaMainserverAnnouncementSummary,
@@ -134,6 +136,7 @@ const DEFAULT_UPSTREAM_TIMEOUT_MS = 10_000;
 const DEFAULT_CACHE_MAX_SIZE = 256;
 const DEFAULT_RETRY_BASE_DELAY_MS = 150;
 const RETRYABLE_STATUS_CODES = new Set([503]);
+const MAX_MAINSERVER_PAGE_SIZE = 100;
 
 const tokenResponseSchema = z.object({
   access_token: z.string().min(1),
@@ -516,6 +519,21 @@ const writeCacheValue = <TValue>(
   });
   pruneCache(cache, nowMs, maxSize);
 };
+
+type SvaMainserverListInput = SvaMainserverConnectionInput & SvaMainserverListQuery;
+
+const toListResult = <TItem>(
+  input: SvaMainserverListInput,
+  data: readonly TItem[],
+  hasNextPage: boolean
+): SvaMainserverListResult<TItem> => ({
+  data,
+  pagination: {
+    page: input.page,
+    pageSize: input.pageSize,
+    hasNextPage,
+  },
+});
 
 const buildForwardHeaders = (): Record<string, string> => {
   const context = getWorkspaceContext();
@@ -1654,22 +1672,79 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
       config
     );
 
+  const listVisibleRecordsWithConfig = async <TQueryResult, TUpstreamItem, TItem>(
+    input: SvaMainserverListInput,
+    config: SvaMainserverInstanceConfig,
+    options: {
+      readonly document: string;
+      readonly operationName: string;
+      readonly order: string;
+      readonly readItems: (response: TQueryResult) => readonly TUpstreamItem[];
+      readonly isVisible: (item: TUpstreamItem) => boolean;
+      readonly mapItem: (item: TUpstreamItem) => TItem;
+    }
+  ): Promise<SvaMainserverListResult<TItem>> => {
+    const startIndex = (input.page - 1) * input.pageSize;
+    const endIndex = startIndex + input.pageSize;
+    const targetVisibleCount = endIndex + 1;
+    const batchSize = Math.min(MAX_MAINSERVER_PAGE_SIZE, input.pageSize + 1);
+    const collectedVisibleItems: TItem[] = [];
+    let skip = 0;
+    let exhausted = false;
+
+    while (collectedVisibleItems.length < targetVisibleCount && exhausted === false) {
+      const response = await executeGraphqlWithConfig<TQueryResult>(
+        {
+          ...input,
+          document: options.document,
+          operationName: options.operationName,
+          variables: { limit: batchSize, skip, order: options.order },
+        },
+        config
+      );
+
+      const upstreamItems = options.readItems(response);
+      exhausted = upstreamItems.length < batchSize;
+      skip += upstreamItems.length;
+
+      for (const item of upstreamItems) {
+        if (options.isVisible(item) === false) {
+          continue;
+        }
+        collectedVisibleItems.push(options.mapItem(item));
+        if (collectedVisibleItems.length >= targetVisibleCount) {
+          break;
+        }
+      }
+
+      if (upstreamItems.length === 0) {
+        break;
+      }
+    }
+
+    return toListResult(
+      input,
+      collectedVisibleItems.slice(startIndex, endIndex),
+      collectedVisibleItems.length > endIndex
+    );
+  };
+
   const listNewsWithConfig = async (
-    input: SvaMainserverConnectionInput,
+    input: SvaMainserverListInput,
     config: SvaMainserverInstanceConfig
-  ): Promise<readonly SvaMainserverNewsItem[]> => {
-    const response = await executeGraphqlWithConfig<SvaMainserverNewsListQuery>(
+  ): Promise<SvaMainserverListResult<SvaMainserverNewsItem>> =>
+    listVisibleRecordsWithConfig<SvaMainserverNewsListQuery, SvaMainserverNewsItemFragment, SvaMainserverNewsItem>(
+      input,
+      config,
       {
-        ...input,
         document: svaMainserverNewsListDocument,
         operationName: 'SvaMainserverNewsList',
-        variables: { limit: 100, skip: 0, order: 'publishedAt_DESC' },
-      },
-      config
+        order: 'publishedAt_DESC',
+        readItems: (response) => response.newsItems ?? [],
+        isVisible: (item) => item.visible !== false,
+        mapItem: mapNewsItem,
+      }
     );
-
-    return (response.newsItems ?? []).filter((item) => item.visible !== false).map(mapNewsItem);
-  };
 
   const getNewsWithConfig = async (
     input: SvaMainserverConnectionInput & { readonly newsId: string },
@@ -1758,21 +1833,21 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
   };
 
   const listEventsWithConfig = async (
-    input: SvaMainserverConnectionInput,
+    input: SvaMainserverListInput,
     config: SvaMainserverInstanceConfig
-  ): Promise<readonly SvaMainserverEventItem[]> => {
-    const response = await executeGraphqlWithConfig<SvaMainserverEventListQuery>(
+  ): Promise<SvaMainserverListResult<SvaMainserverEventItem>> =>
+    listVisibleRecordsWithConfig<SvaMainserverEventListQuery, SvaMainserverEventFragment, SvaMainserverEventItem>(
+      input,
+      config,
       {
-        ...input,
         document: svaMainserverEventListDocument,
         operationName: 'SvaMainserverEventList',
-        variables: { limit: 100, skip: 0, order: 'updatedAt_DESC' },
-      },
-      config
+        order: 'updatedAt_DESC',
+        readItems: (response) => response.eventRecords ?? [],
+        isVisible: (item) => item.visible !== false,
+        mapItem: mapEventItem,
+      }
     );
-
-    return (response.eventRecords ?? []).filter((item) => item.visible !== false).map(mapEventItem);
-  };
 
   const getEventWithConfig = async (
     input: SvaMainserverConnectionInput & { readonly eventId: string },
@@ -1868,21 +1943,21 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
   };
 
   const listPoiWithConfig = async (
-    input: SvaMainserverConnectionInput,
+    input: SvaMainserverListInput,
     config: SvaMainserverInstanceConfig
-  ): Promise<readonly SvaMainserverPoiItem[]> => {
-    const response = await executeGraphqlWithConfig<SvaMainserverPoiListQuery>(
+  ): Promise<SvaMainserverListResult<SvaMainserverPoiItem>> =>
+    listVisibleRecordsWithConfig<SvaMainserverPoiListQuery, SvaMainserverPoiFragment, SvaMainserverPoiItem>(
+      input,
+      config,
       {
-        ...input,
         document: svaMainserverPoiListDocument,
         operationName: 'SvaMainserverPoiList',
-        variables: { limit: 100, skip: 0, order: 'updatedAt_DESC' },
-      },
-      config
+        order: 'updatedAt_DESC',
+        readItems: (response) => response.pointsOfInterest ?? [],
+        isVisible: (item) => item.visible !== false,
+        mapItem: mapPoiItem,
+      }
     );
-
-    return (response.pointsOfInterest ?? []).filter((item) => item.visible !== false).map(mapPoiItem);
-  };
 
   const getPoiWithConfig = async (
     input: SvaMainserverConnectionInput & { readonly poiId: string },
@@ -1961,7 +2036,7 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     return getMutationRootTypenameWithConfig(input, config);
   };
 
-  const listNews = async (input: SvaMainserverConnectionInput): Promise<readonly SvaMainserverNewsItem[]> => {
+  const listNews = async (input: SvaMainserverListInput): Promise<SvaMainserverListResult<SvaMainserverNewsItem>> => {
     const config = await loadValidatedInstanceConfig(input, 'load_instance_config');
     return listNewsWithConfig(input, config);
   };
@@ -1994,7 +2069,9 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     return destroyNewsWithConfig(input, config);
   };
 
-  const listEvents = async (input: SvaMainserverConnectionInput): Promise<readonly SvaMainserverEventItem[]> => {
+  const listEvents = async (
+    input: SvaMainserverListInput
+  ): Promise<SvaMainserverListResult<SvaMainserverEventItem>> => {
     const config = await loadValidatedInstanceConfig(input, 'load_instance_config');
     return listEventsWithConfig(input, config);
   };
@@ -2030,7 +2107,7 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     );
   };
 
-  const listPoi = async (input: SvaMainserverConnectionInput): Promise<readonly SvaMainserverPoiItem[]> => {
+  const listPoi = async (input: SvaMainserverListInput): Promise<SvaMainserverListResult<SvaMainserverPoiItem>> => {
     const config = await loadValidatedInstanceConfig(input, 'load_instance_config');
     return listPoiWithConfig(input, config);
   };
@@ -2160,7 +2237,8 @@ export const getSvaMainserverQueryRootTypename = (input: SvaMainserverConnection
 export const getSvaMainserverMutationRootTypename = (input: SvaMainserverConnectionInput) =>
   getDefaultService().getMutationRootTypename(input);
 
-export const listSvaMainserverNews = (input: SvaMainserverConnectionInput) => getDefaultService().listNews(input);
+export const listSvaMainserverNews = (input: SvaMainserverConnectionInput & SvaMainserverListQuery) =>
+  getDefaultService().listNews(input);
 
 export const getSvaMainserverNews = (input: SvaMainserverConnectionInput & { readonly newsId: string }) =>
   getDefaultService().getNews(input);
@@ -2176,7 +2254,8 @@ export const updateSvaMainserverNews = (
 export const deleteSvaMainserverNews = (input: SvaMainserverConnectionInput & { readonly newsId: string }) =>
   getDefaultService().deleteNews(input);
 
-export const listSvaMainserverEvents = (input: SvaMainserverConnectionInput) => getDefaultService().listEvents(input);
+export const listSvaMainserverEvents = (input: SvaMainserverConnectionInput & SvaMainserverListQuery) =>
+  getDefaultService().listEvents(input);
 
 export const getSvaMainserverEvent = (input: SvaMainserverConnectionInput & { readonly eventId: string }) =>
   getDefaultService().getEvent(input);
@@ -2192,7 +2271,8 @@ export const updateSvaMainserverEvent = (
 export const deleteSvaMainserverEvent = (input: SvaMainserverConnectionInput & { readonly eventId: string }) =>
   getDefaultService().deleteEvent(input);
 
-export const listSvaMainserverPoi = (input: SvaMainserverConnectionInput) => getDefaultService().listPoi(input);
+export const listSvaMainserverPoi = (input: SvaMainserverConnectionInput & SvaMainserverListQuery) =>
+  getDefaultService().listPoi(input);
 
 export const getSvaMainserverPoi = (input: SvaMainserverConnectionInput & { readonly poiId: string }) =>
   getDefaultService().getPoi(input);

--- a/packages/sva-mainserver/src/types.ts
+++ b/packages/sva-mainserver/src/types.ts
@@ -40,6 +40,23 @@ export type SvaMainserverConnectionInput = {
   readonly keycloakSubject: string;
 };
 
+export type SvaMainserverListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+};
+
+export type SvaMainserverListPagination = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly hasNextPage: boolean;
+  readonly total?: number;
+};
+
+export type SvaMainserverListResult<TItem> = {
+  readonly data: readonly TItem[];
+  readonly pagination: SvaMainserverListPagination;
+};
+
 export type SvaMainserverNewsPayload = {
   readonly teaser?: string;
   readonly body?: string;


### PR DESCRIPTION
## Scope
- Listen-/Pagination-Verträge für News, Events, POIs und Mainserver
- gezielte Routing-Testanpassungen für Filter-/Sort-Validierung

## Split-Kontext
- Teil 3 der Aufspaltung von PR #338
- fachlich nach PR 2 einzuordnen
- vor Merge auf frisches `main` rebasen, sobald PR 2 gemerged ist

## Verifikation
- Branch ist aufgeteilt und veröffentlicht.
- Die finale Zielvalidierung soll nach dem Rebase auf den gemergten PR-2-Stand laufen.
