### PR TITLE
docs(openspec): carry forward pr338 react boundary follow-up

### DIFF
--- a/openspec/changes/refactor-sva-studio-react-package-boundaries/design.md
+++ b/openspec/changes/refactor-sva-studio-react-package-boundaries/design.md
@@ -1,0 +1,68 @@
+## Kontext
+
+`apps/sva-studio-react` ist die Host-App des Studios und darf App-spezifische Zusammensetzung enthalten. Gleichzeitig existieren im Workspace bereits Zielpackages mit klarer Ownership fuer wiederverwendbare UI, fachliche Sanitizer und Mainserver-Serververtraege. Ein Teil dieser Verantwortungen wurde trotzdem app-lokal implementiert oder dupliziert.
+
+Die Folge ist kein einzelner Laufzeitfehler, sondern Boundary-Drift:
+
+- dieselben Studio-UI-Bausteine existieren sowohl in der App als auch in `@sva/studio-ui-react`
+- Legal-Text-Sanitizing existiert sowohl in der App als auch in `@sva/iam-governance`
+- Mainserver-Inhaltsrouten fuer News, Events und POI enthalten in der App umfangreiche Parse-, Validierungs- und Mutationslogik statt duenne Host-Einstiege
+
+## Ziele
+
+- `apps/sva-studio-react` auf App-Komposition und framework-nahe Entry-Points begrenzen
+- wiederverwendbare Studio-UI zentral aus `@sva/studio-ui-react` bereitstellen
+- kanonische Domain-Helper nur im owning Package pflegen
+- Mainserver-Host-Logik in serverseitigen Packages statt in App-Libs verankern
+- Doku, Tests und Imports auf denselben Boundary-Vertrag ausrichten
+
+## Nicht-Ziele
+
+- keine Verlagerung host-spezifischer Route-Bindings in generische Packages
+- keine Herausloesung plugin-spezifischer Feld- oder Editorlogik aus den Fachplugins
+- kein grossflaechiges Re-Themeing oder funktionales UI-Redesign
+- keine neue Sammelfassade, die bestehende Zielpackages erneut verdeckt
+
+## Entscheidungen
+
+- `@sva/studio-ui-react` ist der kanonische Ort fuer wiederverwendbare Studio-Primitives, Listen-Templates, Tabellen und vergleichbare Verwaltungs-UI.
+- `apps/sva-studio-react/src/components/ui/**` darf nur noch App-spezifische Spezialbausteine enthalten, fuer die kein geteilter Vertrag benoetigt wird.
+- `@sva/iam-governance` ist die kanonische Ownership fuer Legal-Text-HTML-Sanitizing. Die App konsumiert diese Funktion, statt eine zweite Implementierung zu pflegen.
+- `@sva/sva-mainserver/server` oder eng dazugehoerige serverseitige Zielmodule tragen die Ownership fuer host-owned News-, Events- und POI-Request-Parsing, Validierung und Mutations-Delegation.
+- `apps/sva-studio-react` behaelt framework-spezifische Server-Einstiege, Request-Matching und Route-Assemblierung, delegiert aber fachliche Serverlogik an Packages.
+- `appRouteBindings`, `appAdminResources` und vergleichbare Host-Assemblierung bleiben im App-Layer, solange sie keine generische Wiederverwendung ueber mehrere Consumer beanspruchen.
+
+## Architektur-Schnitt
+
+### 1. Studio-UI
+
+Die App darf Seiten zusammensetzen, aber keine zweite kanonische Verwaltungs-UI aufbauen. Lokale Duplikate von `StudioDataTable`, Listen-Templates und geteilten Basis-Primitives werden entweder entfernt oder in Package-Exporte ueberfuehrt. Dadurch konsumieren App und Plugins dieselbe UI-Oberflaeche.
+
+### 2. Domain-Helper
+
+Sanitizer und vergleichbare fachlich sensible Helper duerfen nicht parallel in App und Package weiterentwickelt werden. Wenn ein owning Package bereits existiert, wird die App auf dessen API zurueckgefuehrt. Das vermeidet Drift bei Security- und Governance-Regeln.
+
+### 3. Mainserver-Host-Adapter
+
+Die App soll Requests empfangen und an Zielpackages delegieren, nicht selbst den fachlichen Serververtrag definieren. News-, Events- und POI-Handler werden deshalb so geschnitten, dass Parsing, Fehlerabbildung und Upstream-Mutationslogik ausserhalb der App testbar und wiederverwendbar liegen. Die App behaelt nur den TanStack-Start- oder Nitro-spezifischen Einstieg.
+
+## Risiken / Trade-offs
+
+- Das Refactoring kann kurzfristig mehr Package-API-Arbeit in `@sva/studio-ui-react` und `@sva/sva-mainserver` erzeugen.
+  - Minderung: nur reale Duplikate und nachweisbare Boundary-Verstosse in den Scope aufnehmen.
+- Beim Zusammenziehen von UI kann eine bestehende App-Variante leicht andere Props oder i18n-Annahmen haben.
+  - Minderung: Ziel-API zuerst inventarisieren und dann kontrolliert auf gemeinsame Exporte heben.
+- Das Verlagern von Serverlogik kann Package-Grenzen oder Runtime-Abhaengigkeiten beruehren.
+  - Minderung: `pnpm check:server-runtime` frueh und gezielt laufen lassen und keine browsernahen Abhaengigkeiten in Server-Packages ziehen.
+
+## Migrationsplan
+
+1. Kandidaten inventarisieren und den owning Packages zuordnen.
+2. Fehlende Package-APIs schaffen, bevor App-Imports umgestellt werden.
+3. App-Komponenten und App-Servereinstiege auf Package-Vertraege umstellen.
+4. Verbleibende App-spezifische Spezialfaelle explizit dokumentieren.
+5. Architektur- und Entwicklerdokumentation auf die neuen Ziel-Boundaries synchronisieren.
+
+## Offene Fragen
+
+- Ob die Mainserver-Host-Handler direkt in `@sva/sva-mainserver/server` aufgehen oder ein eng gekoppeltes serverseitiges Teilmodul benoetigen, wird waehrend der Implementierung anhand der vorhandenen Runtime-Abhaengigkeiten entschieden.

--- a/openspec/changes/refactor-sva-studio-react-package-boundaries/proposal.md
+++ b/openspec/changes/refactor-sva-studio-react-package-boundaries/proposal.md
@@ -1,0 +1,64 @@
+# Change: App-Grenzen von `sva-studio-react` auf Zielpackages zurückführen
+
+## Why
+
+`apps/sva-studio-react` enthält derzeit mehrere Verantwortungen, die bereits fachlich passenden Workspace-Packages gehören oder dort in abgeschwächter Form schon existieren. Dazu zählen insbesondere duplizierte Studio-UI-Bausteine, ein eigener Legal-Text-HTML-Sanitizer sowie umfangreiche Mainserver-Request-Parser und Host-Handler für News, Events und POI.
+
+Diese Drift verwischt Ownership, erschwert Reviews, erhöht die Gefahr funktionaler Abweichungen zwischen App und Package und unterläuft die bestehende Zielarchitektur aus `@sva/studio-ui-react`, `@sva/iam-governance` und `@sva/sva-mainserver/server`.
+
+Die Review des laufenden Changes hat zusätzlich gezeigt, dass ein reiner Zuschnitt innerhalb von `apps/sva-studio-react` die Boundary-Ziele nicht erfüllt. App-interne Helper-Extraktionen ohne echte Package-Verlagerung würden dieselbe Ownership weiter im App-Layer belassen und die in Proposal und Specs versprochene Zielarchitektur nur scheinbar erreichen.
+
+## What Changes
+
+- führt die wiederverwendbare Studio-Listen- und Tabellen-UI aus `apps/sva-studio-react` in `@sva/studio-ui-react` zusammen
+- reduziert app-lokale Basis-UI-Primitives auf echte App-Spezialfälle und ersetzt Duplikate durch Package-Imports
+- deklariert `@sva/iam-governance` als kanonische Ownership für Legal-Text-HTML-Sanitizing auch für die React-App
+- verlagert host-owned Mainserver-Request-Parsing und inhaltsbezogene Server-Handler aus der App in paketseitige Server-Verträge
+- begrenzt `apps/sva-studio-react` auf App-Komposition, Routing-Bindings, Shell-Zusammensetzung und framework-spezifische Server-Einstiege
+- konsolidiert app-lokale Zugriffs- und Kontextregeln in Schnittstellen-Serverfunktionen, damit dieselben Fachentscheidungen nicht mehrfach im App-Layer gepflegt werden
+- aktualisiert Architektur- und Entwicklerdokumentation an den betroffenen Boundary-Stellen
+
+## Out of Scope
+
+- keine funktionale Neugestaltung der Studio-Shell oder der Content-Workflows
+- keine Neuverteilung plugin-spezifischer Fachlogik aus `@sva/plugin-news`, `@sva/plugin-events` oder `@sva/plugin-poi`
+- keine erzwungene Verschiebung host-spezifischer Routing-Konfiguration wie `appRouteBindings` oder `appAdminResources`, solange diese App-Komposition bleiben
+- kein Breaking Redesign der öffentlichen Package-APIs über das für die Boundary-Konsolidierung notwendige Maß hinaus
+- kein bloßes app-internes Umorganisieren von Parse- oder Validierungslogik als Ersatz für die geforderte Package-Ownership
+
+## Impact
+
+- Affected specs:
+  - `monorepo-structure`
+  - `ui-layout-shell`
+  - `sva-mainserver-integration`
+- Affected code:
+  - `apps/sva-studio-react/src/components/**`
+  - `apps/sva-studio-react/src/components/ui/**`
+  - `apps/sva-studio-react/src/components/RichTextEditor.tsx`
+  - `apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.tsx`
+  - `apps/sva-studio-react/src/lib/interfaces-api.ts`
+  - `apps/sva-studio-react/src/lib/legal-text-html.ts`
+  - `apps/sva-studio-react/src/lib/mainserver-news-api.server.ts`
+  - `apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts`
+  - `apps/sva-studio-react/src/routes/**`
+  - `packages/studio-ui-react/src/**`
+  - `packages/iam-governance/src/**`
+  - `packages/sva-mainserver/src/**`
+  - `docs/architecture/**`
+  - relevante Entwicklerdokumentation unter `docs/development/**` und `docs/guides/**`
+- Affected arc42 sections:
+  - `docs/architecture/04-solution-strategy.md`
+  - `docs/architecture/05-building-block-view.md`
+  - `docs/architecture/06-runtime-view.md`
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/11-risks-and-technical-debt.md`
+
+## Success Criteria
+
+- wiederverwendbare Studio-Listen- und Tabellenbausteine werden nur noch aus `@sva/studio-ui-react` konsumiert
+- die React-App verwendet keinen eigenen kanonischen Legal-Text-Sanitizer mehr neben `@sva/iam-governance`
+- host-owned Mainserver-Inhaltsrouten für News, Events und POI enthalten in der App nur noch dünne Entry-Point-Logik
+- app-seitige Schnittstellenfunktionen pflegen keine doppelten Regeln für Instanzkontext und Zugriffsentscheidungen, wenn dieselbe Fachentscheidung lokal bereits zentralisiert werden kann
+- Mainserver-spezifische Parse-, Validierungs- und Fehler-Mappings sind in Package-Tests absicherbar und nicht nur über App-Tests indirekt nachweisbar
+- neue oder bestehende Package-Boundaries sind durch Tests, Imports und Doku konsistent nachvollziehbar

--- a/openspec/changes/refactor-sva-studio-react-package-boundaries/specs/monorepo-structure/spec.md
+++ b/openspec/changes/refactor-sva-studio-react-package-boundaries/specs/monorepo-structure/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+### Requirement: App-Layer bleibt auf Komposition begrenzt
+
+Das System SHALL `apps/sva-studio-react` als Host-App fuer Shell-, Routing- und Framework-Komposition nutzen, aber wiederverwendbare Studio-UI, owning Domain-Helper und fachliche Serververtraege in passende Workspace-Packages verlagern.
+
+#### Scenario: Wiederverwendbare Studio-UI wird im Package gehalten
+
+- **WHEN** eine Tabelle, ein Listen-Template, ein Formular-Primitive oder ein vergleichbarer Studio-Baustein von mehreren Routen, Plugins oder Hosts genutzt werden kann
+- **THEN** liegt seine kanonische Implementierung in einem Zielpackage wie `@sva/studio-ui-react`
+- **AND** `apps/sva-studio-react` fuehrt dafuer keine zweite kanonische Implementierung
+
+#### Scenario: Domain-Helper mit bestehender Ownership bleiben im owning Package
+
+- **WHEN** ein fachlicher Helper wie ein Legal-Text-Sanitizer bereits ein owning Package besitzt
+- **THEN** konsumiert die App diesen Helper aus dem owning Package
+- **AND** die App pflegt keine parallele Fachimplementierung mit eigener Regelbasis
+
+#### Scenario: App-seitige Kompatibilitaetsschichten bleiben nicht selbst Owner
+
+- **WHEN** die App aus Migrationsgruenden noch einen lokalen Wrapper oder eine lokale Serverfunktion fuer einen bereits zentralisierten Fachvertrag behaelt
+- **THEN** delegiert diese Schicht an die kanonische Ownership oder eine lokal gemeinsam genutzte Regelbasis
+- **AND** sie fuehrt keine zweite, inline duplizierte Fachentscheidung als konkurrierende Owner-Logik weiter
+
+#### Scenario: Host-spezifische Komposition bleibt in der App
+
+- **WHEN** Routing-Bindings, Shell-Zusammensetzung oder host-spezifische Resource-Assemblierung konfiguriert werden
+- **THEN** duerfen diese in `apps/sva-studio-react` verbleiben
+- **AND** sie werden nicht nur aus Abstraktionsgruenden in ein generisches Package verschoben

--- a/openspec/changes/refactor-sva-studio-react-package-boundaries/specs/sva-mainserver-integration/spec.md
+++ b/openspec/changes/refactor-sva-studio-react-package-boundaries/specs/sva-mainserver-integration/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+### Requirement: App-Host-Einstiege fuer Mainserver-Inhalte bleiben duenn
+
+Das System SHALL host-owned Mainserver-Inhaltsrouten fuer News, Events und POI so schneiden, dass `apps/sva-studio-react` nur framework-spezifische Einstiege und Request-Dispatching enthaelt, waehrend Request-Parsing, fachliche Validierung, Fehlerabbildung und Mutationsdelegation in serverseitigen Zielpackages liegen.
+
+#### Scenario: News-Request wird ueber duennen App-Einstieg delegiert
+
+- **GIVEN** die Host-App empfaengt einen Request fuer News
+- **WHEN** der Request verarbeitet wird
+- **THEN** uebernimmt die App nur Request-Matching und framework-spezifischen Einstiegscode
+- **AND** Parsing, Validierung und fachliche Mutationslogik werden von einem serverseitigen Package-Handler ausgefuehrt
+
+#### Scenario: Events- oder POI-Request wird ueber duennen App-Einstieg delegiert
+
+- **GIVEN** die Host-App empfaengt einen Request fuer Events oder POI
+- **WHEN** der Request verarbeitet wird
+- **THEN** uebernimmt die App nur Request-Matching und framework-spezifischen Einstiegscode
+- **AND** Parsing, Validierung und fachliche Mutationslogik werden von einem serverseitigen Package-Handler ausgefuehrt
+
+#### Scenario: Mainserver-spezifische Validierungsregeln sind paketseitig testbar
+
+- **WHEN** Mainserver-Eingaben, Fehlerfaelle oder Feldmappings getestet werden
+- **THEN** koennen diese Tests gegen package-seitige Servermodule laufen
+- **AND** die App muss fuer diese fachlichen Tests keine kanonische Owner-Schicht bleiben
+
+#### Scenario: App-interne Umsortierung ersetzt keine Package-Delegation
+
+- **WHEN** News-, Events- oder POI-Parsing in kleinere Helper innerhalb von `apps/sva-studio-react` zerlegt wird
+- **THEN** gilt dies allein nicht als Erfuellung des Boundary-Vertrags
+- **AND** der fachliche Parse-, Validierungs- und Fehlervertrag muss weiterhin ueber ein serverseitiges Zielpackage konsumierbar und testbar sein

--- a/openspec/changes/refactor-sva-studio-react-package-boundaries/specs/ui-layout-shell/spec.md
+++ b/openspec/changes/refactor-sva-studio-react-package-boundaries/specs/ui-layout-shell/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+### Requirement: Standardisiertes Listen-Seiten-Template
+
+Das Studio SHALL fuer Verwaltungs- und Listenansichten ein gemeinsames Seiten-Template bereitstellen, das Breadcrumbs aus der Shell ergaenzt und darunter Titel, Beschreibung, optionale Primaeraktion sowie den Listeninhalt in konsistenter Struktur rendert. Die kanonische Implementierung dieses Templates SHALL ueber `@sva/studio-ui-react` bereitgestellt werden, damit App und Plugins denselben Vertrag nutzen.
+
+#### Scenario: Listen-Seite nutzt das Standard-Template
+
+- **WHEN** eine Verwaltungsseite des Studios gerendert wird
+- **THEN** zeigt die Seite unterhalb der bestehenden Breadcrumbs einen Titel und optionalen Beschreibungstext
+- **AND** eine optionale Primaeraktion wie `Neu erstellen` steht auf Titelhoehe rechts
+- **AND** der Listeninhalt folgt einem gemeinsamen Layoutgeruest statt einer route-spezifischen Eigenstruktur
+
+#### Scenario: App und Plugins konsumieren denselben Template-Vertrag
+
+- **WHEN** eine App-Route oder ein Plugin ein Listen-Seiten-Template benoetigt
+- **THEN** importiert sie dieses aus `@sva/studio-ui-react`
+- **AND** `apps/sva-studio-react` pflegt dafuer keine zweite kanonische Template-Komponente
+
+### Requirement: Standardisierte Datentabelle fuer Verwaltungslisten
+
+Das Studio SHALL eine wiederverwendbare Datentabelle fuer Verwaltungslisten bereitstellen, die Auswahl, Sortierung, Toolbar-Aktionen und mobile Darstellung konsistent abbildet. Die kanonische Implementierung dieser Tabelle SHALL ueber `@sva/studio-ui-react` bereitgestellt werden.
+
+#### Scenario: Tabelle mit Bulk-Aktionen und Sortierung
+
+- **WHEN** eine Studio-Verwaltungsseite tabellarische Daten anzeigt
+- **THEN** enthaelt die Tabelle optional eine Auswahlspalte als erste Spalte
+- **AND** sortierbare Spaltenkoepfe zeigen ihren Sortierzustand zugaenglich an
+- **AND** eine Aktionsspalte wird als letzte Spalte gerendert
+- **AND** eine Toolbar oberhalb der Tabelle kann Bulk-Aktionen, Filter und sekundaere Aktionen aufnehmen
+
+#### Scenario: Mobile Darstellung einer Verwaltungs-Tabelle
+
+- **WHEN** eine Studio-Verwaltungsseite auf kleinem Viewport geoeffnet wird
+- **THEN** wird die Tabelle als mobile Kartenansicht mit denselben Kerndaten und Aktionen nutzbar dargestellt
+- **AND** Auswahl- und Aktionsmuster bleiben funktionsgleich erreichbar
+
+#### Scenario: App und Plugins konsumieren denselben Tabellen-Vertrag
+
+- **WHEN** eine App-Route oder ein Plugin eine Verwaltungs-Tabelle benoetigt
+- **THEN** importiert sie diese aus `@sva/studio-ui-react`
+- **AND** app-lokale Tabellenkopien werden nicht als zweite kanonische Implementierung weitergefuehrt

--- a/openspec/changes/refactor-sva-studio-react-package-boundaries/tasks.md
+++ b/openspec/changes/refactor-sva-studio-react-package-boundaries/tasks.md
@@ -1,0 +1,38 @@
+## 1. Boundary-Scope und Zielverträge
+
+- [ ] 1.1 OpenSpec-Deltas für `monorepo-structure`, `ui-layout-shell` und `sva-mainserver-integration` finalisieren
+- [ ] 1.2 die Ziel-Ownership je Kandidat festschreiben: Studio-UI nach `@sva/studio-ui-react`, Legal-Text-Sanitizing nach `@sva/iam-governance`, Mainserver-Host-Parsing nach `@sva/sva-mainserver/server`
+- [ ] 1.3 explizit dokumentieren, welche App-Bereiche bewusst im App-Layer bleiben, insbesondere Shell-Komposition, Routing-Bindings und host-spezifische Route-Assemblierung
+
+## 2. Studio-UI-Konsolidierung
+
+- [ ] 2.1 die duplizierten Tabellen-, Listen- und Basis-UI-Bausteine in `apps/sva-studio-react` inventarisieren und einem Ziel-Export in `packages/studio-ui-react` zuordnen
+- [ ] 2.2 fehlende Package-Exports oder API-Anpassungen in `@sva/studio-ui-react` ergänzen, damit App und Plugins dieselben Bausteine konsumieren können
+- [ ] 2.3 App-Routen und Komponenten schrittweise von lokalen UI-Duplikaten auf Package-Imports umstellen
+- [ ] 2.4 betroffene Unit-Tests für App und Package anpassen oder ergänzen, damit die gemeinsame UI-API abgesichert ist
+
+## 3. Domain-Helper-Konsolidierung
+
+- [ ] 3.1 `sanitizeLegalTextHtml` und zugehörige Tests auf den kanonischen Helper aus `@sva/iam-governance` zurückführen
+- [ ] 3.2 app-lokale Sanitizer-Duplikate entfernen oder auf reine Kompatibilitäts-Wrapper reduzieren, falls eine Zwischenmigration nötig ist
+- [ ] 3.3 prüfen, ob weitere app-lokale Helper mit derselben Ownership-Dynamik existieren, und nur reale Duplikate in denselben Refactoring-Strang aufnehmen
+- [ ] 3.4 direkte App-Consumer wie Rich-Text-Editoren und Legal-Text-Dialoge auf die kanonische `@sva/iam-governance`-API umstellen und die Ownership in Tests nachvollziehbar machen
+
+## 4. Mainserver-Host-Adapter aus der App herauslösen
+
+- [ ] 4.1 News-, Events- und POI-spezifische Request-Parser, Validierung und Host-Mutationslogik in paketseitige Server-Verträge überführen
+- [ ] 4.2 `apps/sva-studio-react` auf dünne Server-Einstiege reduzieren, die Requests entgegennehmen und an die Package-Handler delegieren
+- [ ] 4.3 die Package-Tests so ergänzen, dass die ausgelagerte Parsing- und Fehlerlogik außerhalb der App abgesichert bleibt
+- [ ] 4.4 app-seitige Server- und Routen-Tests auf das neue Delegationsmodell anpassen
+- [ ] 4.5 sicherstellen, dass reine App-interne Helper-Extraktionen nicht als Abschluss gelten; News-, Events- und POI-Parsing muss tatsächlich über paketseitige Verträge nachweisbar sein
+
+## 5. App-lokale Regelduplikate abbauen
+
+- [ ] 5.1 `interfaces-api` auf gemeinsame Regeln für Instanzkontext und Berechtigungsentscheidungen zurückführen, statt dieselbe Fachentscheidung an mehreren Stellen inline zu pflegen
+- [ ] 5.2 Tests für `interfaces-api` so ergänzen, dass die zentralisierte Regelbasis und ihre Fehlerfälle direkt abgesichert sind
+
+## 6. Architektur, Doku und Qualitätssicherung
+
+- [ ] 6.1 betroffene arc42-Abschnitte und Entwicklerdokumentation auf die Ziel-Boundaries aktualisieren
+- [ ] 6.2 relevante Nx-Targets für Unit-, Types- und Boundary-Checks grün ausführen, einschließlich `pnpm check:server-runtime` falls serverseitige Packages betroffen sind
+- [ ] 6.3 `openspec validate refactor-sva-studio-react-package-boundaries --strict` ausführen


### PR DESCRIPTION
## Summary
- carry forward the remaining OpenSpec follow-up from PR 338 onto a fresh branch from current main
- include only the  change set
- avoid reintroducing stale code drift from the original aggregate branch

## Validation
- openspec validate refactor-sva-studio-react-package-boundaries --strict
