### PR TITLE
docs(openspec): add runtime module iam contract follow-up

### DIFF
--- a/openspec/changes/refactor-runtime-module-iam-contract-source/design.md
+++ b/openspec/changes/refactor-runtime-module-iam-contract-source/design.md
@@ -1,0 +1,67 @@
+## Context
+
+Mit `plugin.moduleIam` existiert bereits ein deklarativer Vertrag fuer modulbezogene Permissions und Systemrollen. Der aktuelle Runtime-Pfad in `auth-runtime` repliziert diese Information jedoch noch einmal in einer lokalen `Map`. Dadurch entsteht eine fachliche Driftquelle zwischen:
+
+- Plugin-Definitionen
+- Build-Time-Host-Registry
+- Runtime-Seeding und Instanzdiagnostik
+
+Die Runtime darf fuer diese Vertraege nicht von React-Komponenten oder UI-spezifischen Paketkanten abhaengen. Deshalb reicht ein direkter Import produktiver Plugin-Pakete in `auth-runtime` nicht als saubere Loesung.
+
+## Goals / Non-Goals
+
+- Goals:
+  - eine einzige kanonische Runtime-Quelle fuer Modul-IAM-Vertraege schaffen
+  - serverseitige Nutzung ohne UI-/React-Abhaengigkeit ermoeglichen
+  - Drift zwischen Routing, Modulverwaltung, IAM-Seeding und Runtime-Access-Control verhindern
+  - kuenftige Plugin-Aenderungen mit minimaler Verdrahtung in Runtime und Provisioning wirksam machen
+- Non-Goals:
+  - kein vollstaendiger Umbau des gesamten Plugin-Systems
+  - keine neue dynamische Plugin-Ladeinfrastruktur zur Laufzeit
+  - keine fachliche Aenderung an Modulzuweisungs-, Entzugs- oder Fail-Closed-Semantik
+
+## Decisions
+
+- Decision: Die Runtime konsumiert keine manuell gepflegte Modul-Registry mehr.
+  - Why: Dieselbe fachliche Information darf nicht parallel in Plugin-Paketen und in `auth-runtime` modelliert werden.
+
+- Decision: Es wird ein framework-agnostischer Contract-Edge eingefuehrt, der nur die fuer Runtime und Provisioning benoetigten Modul-IAM-Daten bereitstellt.
+  - Why: `auth-runtime` braucht serverseitig sichere, ESM-kompatible Imports ohne React- oder UI-Kopplung.
+
+- Decision: Build-Time-Host-Registry und Runtime-Registry muessen aus derselben Vertragsfamilie erzeugt werden.
+  - Why: Nur so bleiben UI, Routing, IAM-Seeding und Diagnose deterministisch konsistent.
+
+## Alternatives considered
+
+- Direkter Import der Plugin-Pakete in `auth-runtime`
+  - Verworfen, weil die Plugin-Pakete heute React- und Host-Naehe mitbringen und damit unnoetige Runtime-Kopplung erzeugen.
+
+- Manuelle Map in `auth-runtime` beibehalten und nur durch Tests absichern
+  - Verworfen, weil Tests die Doppelquelle nur beobachten, aber nicht beseitigen.
+
+- Build-Time-Registry serialisieren und serverseitig wieder einlesen
+  - Moeglich, aber nur sinnvoll, wenn der erzeugte Artefaktpfad stabil, build-unabhaengig und fuer Node-ESM sauber konsumierbar ist. Das ist eine moegliche technische Auspraegung, aber nicht die fachliche Kernentscheidung.
+
+## Risks / Trade-offs
+
+- Neue Paketkante oder neues gemeinsames Contract-Modul kann Folge-PRs im PR-338-Split betreffen.
+  - Mitigation: Den Umbau als separaten Folge-PR nach der akuten Stabilisierung umsetzen.
+
+- Ein zu UI-naher Contract-Edge wuerde die aktuelle Architekturgrenze verschlechtern.
+  - Mitigation: Nur reine Vertragsdaten und Helper in den gemeinsamen Edge aufnehmen, keine React-Komponenten oder Host-Bindings.
+
+- Bestehende Tests koennen implizit auf die manuelle Runtime-Registry zugeschnitten sein.
+  - Mitigation: Paritaets-Tests auf Contract-Ebene und gezielte Runtime-Regressionstests ergaenzen.
+
+## Migration Plan
+
+1. Gemeinsamen Runtime-Contract-Edge definieren
+2. `auth-runtime` und `instance-registry` auf diesen Edge umstellen
+3. Manuelle Runtime-Registry entfernen
+4. Paritaets- und Drift-Tests ergaenzen
+5. Architektur- und Betriebsdoku aktualisieren
+
+## Open Questions
+
+- Liegt der gemeinsame Contract-Edge sinnvoller in `plugin-sdk` oder in einem neuen dedizierten Workspace-Package?
+- Soll die Runtime den Vertrag direkt aus Quellmodulen beziehen oder aus einem erzeugten build-/artifact-stabilen Export?

--- a/openspec/changes/refactor-runtime-module-iam-contract-source/proposal.md
+++ b/openspec/changes/refactor-runtime-module-iam-contract-source/proposal.md
@@ -1,0 +1,32 @@
+# Change: Gemeinsame Runtime-Quelle fuer Modul-IAM-Vertraege einfuehren
+
+## Why
+
+Die aktuelle Runtime-Pfadverdrahtung fuer Instanz-Modul-IAM verwendet in `packages/auth-runtime/src/iam-instance-registry/repository.ts` eine manuell gepflegte Registry. Seit `plugin.moduleIam` die kanonischen Modulvertraege beschreibt, existieren damit zwei Quellen fuer dieselbe fachliche Wahrheit.
+
+Diese Doppelquelle ist fehleranfaellig: Runtime-Seeding, Modulverwaltung, Routing-Gating und kuenftige Plugin-Aenderungen koennen auseinanderlaufen, obwohl sie denselben Modulsatz beschreiben sollten. Der Umbau soll diese Driftquelle beseitigen, ohne `auth-runtime` direkt an React-lastige Plugin-Pakete zu koppeln.
+
+## What Changes
+
+- Eine gemeinsame, framework-agnostische Runtime-Quelle fuer Modul-IAM-Vertraege wird eingefuehrt
+- Runtime- und Provisioning-Pfade lesen modulbezogene IAM-Vertraege ausschliesslich aus dieser gemeinsamen Quelle
+- Manuelle Modul-IAM-Registry-Maps in `auth-runtime` werden entfernt
+- Plugin- und Host-Integration bleiben deklarativ ueber `plugin.moduleIam`, aber die Runtime konsumiert einen stabilen, serverseitig sicheren Vertrag
+- Paritaets- und Drift-Tests sichern ab, dass Routing, UI, Runtime-Seeding und Access-Control denselben Modulkatalog verwenden
+
+## Impact
+
+- Affected specs:
+  - `instance-provisioning`
+  - `iam-access-control`
+- Affected code:
+  - `packages/auth-runtime`
+  - `packages/instance-registry`
+  - `packages/plugin-sdk`
+  - gegebenenfalls neues gemeinsames Workspace-Package oder neuer serverseitiger Contract-Edge
+- Affected arc42 sections:
+  - `docs/architecture/05-building-block-view.md`
+  - `docs/architecture/06-runtime-view.md`
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/09-architecture-decisions.md`
+  - `docs/architecture/11-risks-and-technical-debt.md`

--- a/openspec/changes/refactor-runtime-module-iam-contract-source/specs/iam-access-control/spec.md
+++ b/openspec/changes/refactor-runtime-module-iam-contract-source/specs/iam-access-control/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+### Requirement: Modulbezogene Access-Control verwendet dieselbe Vertragsfamilie wie Runtime und Host
+
+Das System SHALL modulbezogene Permission- und Rollenentscheidungen auf einer gemeinsamen Vertragsfamilie aufbauen, die fuer Host, Runtime und IAM-Seeding konsistent ist.
+
+#### Scenario: Modulbezogene Autorisierung driftet nicht von Runtime-Seeding weg
+
+- **WHEN** ein Modul fuer eine Instanz zugewiesen ist und modulbezogene Permissions ausgewertet werden
+- **THEN** basieren Runtime-Seeding, Snapshot-Basis und Autorisierungsentscheidung auf derselben Vertragsfamilie
+- **AND** existiert keine separate manuelle Runtime-Definition mit abweichenden Rollen- oder Permission-Listen
+
+#### Scenario: Vertragsaenderungen sind in allen Ebenen konsistent sichtbar
+
+- **WHEN** sich ein kanonischer Modul-IAM-Vertrag aendert
+- **THEN** werden Build-Time-Host-Verhalten, Runtime-Seeding und modulbezogene Access-Control konsistent aus derselben Quelle oder derselben daraus erzeugten Vertragsfamilie abgeleitet
+- **AND** koennen Aenderungen nicht nur in einer Ebene wirksam werden, waehrend andere Ebenen alte Vertragsdaten behalten

--- a/openspec/changes/refactor-runtime-module-iam-contract-source/specs/instance-provisioning/spec.md
+++ b/openspec/changes/refactor-runtime-module-iam-contract-source/specs/instance-provisioning/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+### Requirement: Runtime und Provisioning nutzen eine gemeinsame Modul-IAM-Vertragsquelle
+
+Das System SHALL fuer modulbezogene IAM-Ableitungen in Runtime, Provisioning und Instanzdiagnostik eine gemeinsame, framework-agnostische Vertragsquelle verwenden.
+
+#### Scenario: Runtime-Seeding liest keine manuelle Parallel-Registry mehr
+
+- **WHEN** die Runtime den Sollzustand fuer modulbezogene Permissions und Systemrollen ableitet
+- **THEN** liest sie die benoetigten Modul-IAM-Vertraege aus einer gemeinsamen kanonischen Vertragsquelle
+- **AND** verwendet keine separat in `auth-runtime` gepflegte manuelle Modul-Registry
+
+#### Scenario: Serverseitiger Vertragskonsum bleibt UI-unabhaengig
+
+- **WHEN** ein serverseitiger Pfad Modul-IAM-Vertraege konsumiert
+- **THEN** haengt dieser Pfad nicht von React-Komponenten, Host-Bindings oder UI-spezifischen Plugin-Importen ab
+- **AND** bleibt der Vertrag fuer Node-ESM und Workspace-Runtime sauber konsumierbar
+
+## MODIFIED Requirements
+### Requirement: Idempotenter Provisioning-Workflow
+
+Das System SHALL neue Instanzen ueber einen idempotenten Provisioning-Workflow anlegen, der technische Teilaufgaben und Teilfehler kontrolliert behandelt. Soweit der Workflow modulbezogene IAM-Basisartefakte oder deren Reparatur ableitet, verwendet er dafuer dieselbe gemeinsame Modul-IAM-Vertragsquelle wie Runtime und Diagnose.
+
+#### Scenario: Erfolgreiche Neuanlage einer Instanz
+
+- **WHEN** eine berechtigte Person eine neue Instanz mit gueltiger `instanceId` und gueltigem Ziel-Hostname anfordert
+- **THEN** legt das System einen Provisioning-Lauf an
+- **AND** erstellt oder reserviert die benoetigten Registry- und Basis-Konfigurationsartefakte
+- **AND** erzeugt oder validiert getrennt den Login-Client `authClientId` und den Tenant-Admin-Client `tenantAdminClient.clientId`
+- **AND** dokumentiert den Uebergang bis zum Status `active`
+
+#### Scenario: Modulbezogene IAM-Basis wird aus derselben Vertragsquelle repariert
+
+- **WHEN** ein Provisioning-, Repair- oder Reseed-Pfad modulbezogene IAM-Artefakte einer Instanz auf Sollstand bringt
+- **THEN** verwendet dieser Pfad dieselbe gemeinsame Modul-IAM-Vertragsquelle wie Runtime und Access-Control
+- **AND** koennen Plugin-Vertragsaenderungen nicht stillschweigend nur im UI- oder nur im Runtime-Pfad wirksam werden

--- a/openspec/changes/refactor-runtime-module-iam-contract-source/tasks.md
+++ b/openspec/changes/refactor-runtime-module-iam-contract-source/tasks.md
@@ -1,0 +1,28 @@
+## 1. Specification and Design Alignment
+
+- [ ] 1.1 Betroffene Capability-Deltas fuer gemeinsame Runtime-Vertragsquelle und Access-Control-Paritaet vervollstaendigen
+- [ ] 1.2 Technischen Zielzuschnitt fuer den framework-agnostischen Contract-Edge festlegen (`plugin-sdk`-Edge oder neues Package)
+- [ ] 1.3 `openspec validate refactor-runtime-module-iam-contract-source --strict` ausfuehren
+
+## 2. Shared Contract Source
+
+- [ ] 2.1 Gemeinsamen, serverseitig sicheren Modul-IAM-Contract-Edge einfuehren
+- [ ] 2.2 Sicherstellen, dass der Edge keine React-/UI-Abhaengigkeiten und keine ungeeigneten Runtime-Imports mitzieht
+- [ ] 2.3 Node-ESM- und Workspace-Dependencies fuer den neuen Contract-Pfad sauber ausweisen
+
+## 3. Runtime and Provisioning Refactor
+
+- [ ] 3.1 `auth-runtime` auf die gemeinsame Contract-Quelle umstellen
+- [ ] 3.2 Manuelle Modul-IAM-Registry-Maps aus Runtime- und Wiring-Pfaden entfernen
+- [ ] 3.3 Instanz-Registry-, Provisioning- und IAM-Seeding-Pfade auf denselben Contract-Edge ausrichten
+
+## 4. Verification and Drift Protection
+
+- [ ] 4.1 Paritaets-Tests zwischen Plugin-Vertraegen, Build-Time-Registry und Runtime-Contract einfuehren
+- [ ] 4.2 Regressionstests fuer Modulzuweisung, IAM-Seeding und fail-closed Access-Control gegen den neuen Edge ergaenzen
+- [ ] 4.3 Betroffene Unit-, Type- und Runtime-Checks gruenziehen
+
+## 5. Documentation
+
+- [ ] 5.1 Relevante arc42-Abschnitte fuer die neue Contract-Quelle aktualisieren
+- [ ] 5.2 Risiken und Migrationshinweise fuer Folge-PRs dokumentieren


### PR DESCRIPTION
## Summary
- capture the follow-up refactor for a shared runtime module IAM contract source
- separate the runtime/provisioning contract-edge work from the already merged PR 338 split chain
- keep the change as a dedicated OpenSpec follow-up without reintroducing stale aggregate-branch code

## Validation
- openspec validate refactor-runtime-module-iam-contract-source --strict
