### PR TITLE
fix: restore sonar new code gate

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ export default [
             '../../../scripts/ci/complexity-gate.ts',
             '../../../scripts/ci/coverage-gate.ts',
             '../../../scripts/ci/prepare-sonar-lcov.ts',
+            '../../../scripts/ci/sonar-paths.ts',
             '../../../scripts/ops/deploy-feedback-loop.ts',
             '../../../scripts/ops/runtime/bootstrap-job.ts',
             '../../../scripts/ops/runtime/deploy-project.ts',

--- a/openspec/changes/add-bot-comment-handling-gate/design.md
+++ b/openspec/changes/add-bot-comment-handling-gate/design.md
@@ -1,0 +1,48 @@
+## Kontext
+
+Das Repository besitzt bereits spezialisierte Review-Agents, eine dokumentierte Review-Governance und mehrere PR-Qualitygates. Was bisher fehlt, ist ein explizites Gate dafuer, dass maschinell erzeugte PR-Kommentare nicht unbeachtet bleiben. Der gewuenschte Prozess soll nicht die fachliche Entscheidung automatisieren, sondern erzwingen, dass zu jedem relevanten Bot-Kommentar eine dokumentierte Bearbeitung vorliegt.
+
+## Zielbild
+
+Vor dem Merge muss jeder relevante Kommentar von `Copilot` oder `chatgpt-codex-connector[bot]` einen Bearbeitungsnachweis haben. Der Nachweis unterscheidet dabei zwischen:
+
+- umgesetzt
+- bewusst nicht umgesetzt
+- anderweitig erledigt
+
+Die Governance fordert keinen Automatismus zur Uebernahme des Feedbacks. Sie fordert nur einen dokumentierten Abschluss pro Kommentar.
+
+## Kommentararten
+
+Der Change betrachtet zwei Arten von Kommentaren:
+
+- Review-Threads auf Code-Diffs
+- normale PR-Konversationskommentare
+
+Beide Arten muessen vom Gate ausgewertet werden. Review-Threads koennen zusaetzlich den nativen Zustand `resolved` tragen. Normale PR-Kommentare brauchen stattdessen einen standardisierten textuellen Bearbeitungsnachweis durch eine menschliche Antwort.
+
+## Bearbeitungsnachweis
+
+Ein Kommentar gilt als bearbeitet, wenn mindestens eine menschliche Maintainer-Antwort den Kommentar eindeutig abschliesst. Fuer normale PR-Kommentare und fuer die inhaltliche Dokumentation von Review-Threads wird ein standardisierter Marker vorgesehen, zum Beispiel:
+
+- `Handled: accepted`
+- `Handled: rejected`
+- `Handled: done`
+
+Der Marker muss von einer kurzen Begruendung oder einem Verweis auf die Umsetzung begleitet werden. Fuer Review-Threads reicht ein blosses `resolved` ohne dokumentierte Antwort nicht aus; der Thread soll sowohl inhaltlich beantwortet als auch technisch geschlossen sein.
+
+## Gate-Verhalten
+
+Das PR-Gate ist blockierend. Es schlaegt fehl, wenn mindestens ein relevanter Bot-Kommentar keinen gueltigen Bearbeitungsnachweis hat. Das Gate listet die offenen Kommentare in einer maschinen- und menschenlesbaren Zusammenfassung auf.
+
+Nicht im Scope dieses Changes:
+
+- automatische Bewertung, ob eine Ablehnung fachlich korrekt war
+- allgemeine Governance fuer menschliche Review-Kommentare
+- automatische Aufloesung oder Beantwortung von Kommentaren
+
+## Technische Hinweise
+
+Die Identitaeten der betroffenen Bot-Autoren muessen mindestens `Copilot` und `chatgpt-codex-connector[bot]` umfassen. Fuer spaetere Erweiterbarkeit soll die Auswertung intern als explizite Allowlist modellierbar bleiben, auch wenn die Governance in diesem Change nur diese beiden Quellen verbindlich macht.
+
+Die Auswertung muss zwischen Review-Thread-Kommentaren und normalen PR-Kommentaren unterscheiden und darf Kommentare anderer Autoren nicht als blockierend einstufen.

--- a/openspec/changes/add-bot-comment-handling-gate/proposal.md
+++ b/openspec/changes/add-bot-comment-handling-gate/proposal.md
@@ -1,0 +1,31 @@
+# Change: Bearbeitungsnachweis fuer Bot-PR-Kommentare als Qualitygate einfuehren
+
+## Why
+
+PRs enthalten zunehmend Review-Hinweise von `Copilot` und `chatgpt-codex-connector[bot]`. Diese Hinweise sollen nicht stillschweigend liegen bleiben, sondern vor dem Merge nachvollziehbar bearbeitet werden. "Bearbeitet" bedeutet dabei nicht zwingend, dass das Feedback umgesetzt wird, sondern dass fuer jeden relevanten Bot-Kommentar eine bewusste Entscheidung dokumentiert ist.
+
+## What Changes
+
+- Einfuehrung eines verbindlichen Bearbeitungsnachweises fuer Bot-Kommentare in Pull Requests
+- Abdeckung sowohl fuer Review-Threads auf Diffs als auch fuer normale PR-Konversationskommentare
+- Festlegung, welche Nachweise als "bearbeitet" gelten:
+  - umgesetzt und beantwortet
+  - bewusst nicht umgesetzt, aber nachvollziehbar beantwortet
+  - bei Review-Threads zusaetzlich als resolved markiert
+- Einfuehrung eines blockierenden PR-Qualitygates, das unbearbeitete Bot-Kommentare vor Merge sichtbar macht
+- Definition eines minimalen, auditierbaren Statusmodells fuer akzeptierte, abgelehnte oder anderweitig erledigte Bot-Kommentare
+
+## Impact
+
+- Affected specs:
+  - `review-governance`
+- Affected code:
+  - `.github/workflows/`
+  - `scripts/ci/`
+  - potenziell Hilfscode fuer GitHub-API-Auswertung
+- Affected arc42 sections:
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/10-quality-requirements.md`
+- Affected docs:
+  - `docs/development/review-agent-governance.md`
+  - optional `docs/development/testing-strategy.md` fuer das neue PR-Gate

--- a/openspec/changes/add-bot-comment-handling-gate/specs/review-governance/spec.md
+++ b/openspec/changes/add-bot-comment-handling-gate/specs/review-governance/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Bot-Kommentare muessen vor Merge bearbeitet werden
+Das Repository SHALL vor dem Merge fuer jeden relevanten PR-Kommentar von `Copilot` oder `chatgpt-codex-connector[bot]` einen nachvollziehbaren Bearbeitungsnachweis verlangen.
+
+#### Scenario: Review-Thread wurde umgesetzt und abgeschlossen
+- **GIVEN** ein Review-Thread auf einem Diff stammt von `Copilot` oder `chatgpt-codex-connector[bot]`
+- **AND** ein Maintainer antwortet inhaltlich auf den Hinweis
+- **AND** der Thread wird anschliessend als resolved markiert
+- **WHEN** das PR-Gate den Status der Bot-Kommentare auswertet
+- **THEN** gilt dieser Bot-Kommentar als bearbeitet
+
+#### Scenario: Normaler PR-Kommentar wird bewusst nicht umgesetzt
+- **GIVEN** ein normaler PR-Konversationskommentar stammt von `Copilot` oder `chatgpt-codex-connector[bot]`
+- **AND** ein Maintainer antwortet mit einem standardisierten Bearbeitungsmarker
+- **AND** die Antwort enthaelt eine kurze Begruendung, warum das Feedback bewusst nicht umgesetzt wird
+- **WHEN** das PR-Gate den Status der Bot-Kommentare auswertet
+- **THEN** gilt dieser Bot-Kommentar als bearbeitet
+
+#### Scenario: Kommentar ohne Nachweis bleibt offen
+- **GIVEN** ein relevanter Bot-Kommentar in einem Pull Request
+- **AND** es gibt weder eine qualifizierte Antwort noch einen sonstigen gueltigen Bearbeitungsnachweis
+- **WHEN** das PR-Gate den Status der Bot-Kommentare auswertet
+- **THEN** gilt dieser Bot-Kommentar als unbearbeitet
+- **AND** der Pull Request darf das Bot-Kommentar-Gate nicht bestehen
+
+### Requirement: Bearbeitungsnachweise muessen standardisierte Abschlusszustaende tragen
+Das Repository SHALL fuer relevante Bot-Kommentare standardisierte Abschlusszustaende verwenden, damit akzeptierte, abgelehnte und anderweitig erledigte Entscheidungen maschinell und menschlich nachvollziehbar bleiben.
+
+#### Scenario: Akzeptierter Kommentar ist maschinenlesbar markiert
+- **GIVEN** ein relevanter Bot-Kommentar wurde umgesetzt
+- **WHEN** ein Maintainer den Abschluss dokumentiert
+- **THEN** verwendet die Antwort einen standardisierten Marker fuer einen akzeptierten Abschluss
+- **AND** der Marker ist fuer die Gate-Auswertung maschinenlesbar
+
+#### Scenario: Abgelehnter Kommentar ist maschinenlesbar markiert
+- **GIVEN** ein relevanter Bot-Kommentar wird bewusst nicht umgesetzt
+- **WHEN** ein Maintainer den Abschluss dokumentiert
+- **THEN** verwendet die Antwort einen standardisierten Marker fuer einen abgelehnten Abschluss
+- **AND** die Antwort enthaelt eine kurze fachliche oder technische Begruendung
+
+### Requirement: Bot-Kommentar-Gate muss Review-Threads und normale PR-Kommentare getrennt auswerten
+Das Repository SHALL relevante Bot-Review-Threads und relevante normale Bot-PR-Kommentare als getrennte Kommentararten auswerten und pro Art den passenden Abschlussnachweis verlangen.
+
+#### Scenario: Review-Thread braucht Antwort und Resolve
+- **GIVEN** ein relevanter Bot-Kommentar ist Teil eines Review-Threads auf einem Diff
+- **WHEN** der Kommentar als bearbeitet gewertet werden soll
+- **THEN** reicht eine blosse textuelle Antwort ohne Resolve nicht aus
+- **AND** der Thread braucht zusaetzlich einen Abschluss im Thread-Zustand
+
+#### Scenario: Normaler PR-Kommentar braucht Antwort statt Resolve
+- **GIVEN** ein relevanter Bot-Kommentar ist ein normaler PR-Konversationskommentar
+- **WHEN** der Kommentar als bearbeitet gewertet werden soll
+- **THEN** darf das Gate keinen nativen Resolve-Zustand voraussetzen
+- **AND** es verlangt stattdessen eine standardisierte menschliche Antwort als Nachweis
+
+#### Scenario: Kommentare anderer Autoren blockieren dieses Gate nicht
+- **GIVEN** ein Kommentar stammt nicht von `Copilot` und nicht von `chatgpt-codex-connector[bot]`
+- **WHEN** das Bot-Kommentar-Gate den Pull Request auswertet
+- **THEN** zaehlt dieser Kommentar nicht zum Pflichtumfang dieses Gates

--- a/openspec/changes/add-bot-comment-handling-gate/tasks.md
+++ b/openspec/changes/add-bot-comment-handling-gate/tasks.md
@@ -1,0 +1,14 @@
+## 1. Specification
+
+- [ ] 1.1 Bearbeitungsnachweis fuer Bot-Review-Threads und normale Bot-PR-Kommentare in `review-governance` spezifizieren
+- [ ] 1.2 Statusmodell fuer `accepted`, `rejected` und sonstige erledigte Bot-Kommentare als Governance-Anforderung dokumentieren
+- [ ] 1.3 Blockierendes PR-Qualitygate fuer unbearbeitete Bot-Kommentare spezifizieren
+- [ ] 1.4 `openspec validate add-bot-comment-handling-gate --strict` ausfuehren
+
+## 2. Implementation
+
+- [ ] 2.1 GitHub-Workflow fuer das Bot-Kommentar-Gate unter `.github/workflows/` einfuehren
+- [ ] 2.2 GitHub-API-Auswertung fuer Review-Threads und normale PR-Kommentare unter `scripts/ci/` implementieren
+- [ ] 2.3 Standardisierte Bearbeitungsmarker und ihre Validierungsregeln dokumentieren
+- [ ] 2.4 Architektur- und Governance-Dokumentation fuer das neue Gate aktualisieren
+- [ ] 2.5 Tests fuer offene, beantwortete, abgelehnte und aufgeloeste Bot-Kommentare ergaenzen

--- a/packages/auth-runtime/src/auth-route-handlers.test.ts
+++ b/packages/auth-runtime/src/auth-route-handlers.test.ts
@@ -107,6 +107,18 @@ vi.mock('./auth-server/login.js', () => ({
   createLoginUrl: vi.fn(),
 }));
 
+vi.mock('./auth-server/callback.js', () => ({
+  handleCallback: vi.fn(),
+}));
+
+vi.mock('./auth-server/logout.js', () => ({
+  logoutSession: vi.fn(),
+}));
+
+vi.mock('./redis-session.js', () => ({
+  getSession: vi.fn(),
+}));
+
 vi.mock('./login-state-cookie.js', () => ({
   encodeLoginStateCookie: vi.fn(() => 'encoded-login-state-cookie'),
   decodeLoginStateCookie: vi.fn(() => null),
@@ -468,6 +480,41 @@ describe('loginHandler (full auth path)', () => {
     expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toContain('openid-connect/auth');
   });
+
+  it('returns a silent failure page when silent SSO is currently suppressed', async () => {
+    const { loginHandler } = await import('./auth-route-handlers.js');
+
+    mocks.readCookieFromRequest.mockImplementation((_request: Request, cookieName: string) =>
+      cookieName === 'silent_sso' ? String(Date.now() + 60_000) : null
+    );
+
+    const response = await loginHandler(new Request('http://localhost/auth/login?silent=1'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/html');
+    await expect(response.text()).resolves.toContain("status: 'failure'");
+  });
+
+  it('maps tenant auth resolution errors to a dependency response', async () => {
+    const { loginHandler } = await import('./auth-route-handlers.js');
+    const { resolveAuthConfigForRequest } = await import('./config.js');
+    const { TenantAuthResolutionError } = await import('./runtime-errors.js');
+
+    vi.mocked(resolveAuthConfigForRequest).mockRejectedValueOnce(
+      new TenantAuthResolutionError({
+        host: 'studio.example.org',
+        reason: 'tenant_inactive',
+      })
+    );
+
+    const response = await loginHandler(new Request('https://studio.example.org/auth/login'));
+
+    expect(response.status).toBe(503);
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Auth route failed during tenant auth resolution',
+      expect.objectContaining({ reason_code: 'scope_resolution_failed', tenant_host: 'studio.example.org' })
+    );
+  });
 });
 
 describe('logoutHandler', () => {
@@ -529,6 +576,71 @@ describe('logoutHandler', () => {
       expect.objectContaining({ operation: 'logout_cookie_cleanup' })
     );
   });
+
+  it('logs out an active session and emits a logout audit event', async () => {
+    const { logoutHandler } = await import('./auth-route-handlers.js');
+    const { resolveAuthConfigForRequest } = await import('./config.js');
+    const { getSession } = await import('./redis-session.js');
+    const { logoutSession } = await import('./auth-server/logout.js');
+    const { emitAuthAuditEvent } = await import('./audit-events.js');
+
+    vi.mocked(resolveAuthConfigForRequest).mockResolvedValueOnce({
+      ...authConfigBase,
+      kind: 'instance',
+      instanceId: 'de-test',
+    } as never);
+    mocks.readCookieFromRequest.mockImplementation((_request: Request, cookieName: string) =>
+      cookieName === 'sva_session' ? 'session-1' : 'unused-cookie'
+    );
+    vi.mocked(getSession).mockResolvedValueOnce({
+      user: { id: 'kc-user-1', instanceId: 'de-test' },
+    } as never);
+    vi.mocked(logoutSession).mockResolvedValueOnce('http://localhost/signed-out');
+
+    const response = await logoutHandler(
+      new Request('http://localhost/auth/logout', {
+        method: 'POST',
+        headers: { 'x-sva-logout-intent': 'user' },
+      })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('http://localhost/signed-out');
+    expect(emitAuthAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'logout',
+        actorUserId: 'kc-user-1',
+        outcome: 'success',
+        workspaceId: 'de-test',
+      })
+    );
+  });
+
+  it('returns a dependency error when the session store is unavailable during logout', async () => {
+    const { logoutHandler } = await import('./auth-route-handlers.js');
+    const { resolveAuthConfigForRequest } = await import('./config.js');
+    const { getSession } = await import('./redis-session.js');
+    const { SessionStoreUnavailableError } = await import('./runtime-errors.js');
+
+    vi.mocked(resolveAuthConfigForRequest).mockResolvedValueOnce(authConfigBase as never);
+    mocks.readCookieFromRequest.mockImplementation((_request: Request, cookieName: string) =>
+      cookieName === 'sva_session' ? 'session-1' : 'unused-cookie'
+    );
+    vi.mocked(getSession).mockRejectedValueOnce(new SessionStoreUnavailableError('logout'));
+
+    const response = await logoutHandler(
+      new Request('http://localhost/auth/logout', {
+        method: 'POST',
+        headers: { 'x-sva-logout-intent': 'user' },
+      })
+    );
+
+    expect(response.status).toBe(503);
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Auth route failed because session storage is unavailable',
+      expect.objectContaining({ reason_code: 'session_store_unavailable' })
+    );
+  });
 });
 
 describe('callbackHandler', () => {
@@ -567,6 +679,80 @@ describe('callbackHandler', () => {
     expect(mocks.logger.info).toHaveBeenCalledWith(
       'Callback cookie cleanup prepared',
       expect.objectContaining({ had_session_cookie_on_callback: true })
+    );
+  });
+
+  it('redirects back to /auth/login when callback parameters are incomplete', async () => {
+    const { callbackHandler } = await import('./auth-route-handlers.js');
+    const { resolveAuthConfigForRequest } = await import('./config.js');
+
+    vi.mocked(resolveAuthConfigForRequest).mockResolvedValueOnce(authConfigBase as never);
+
+    const response = await callbackHandler(new Request('http://localhost/auth/callback?state=state-abc123def456'));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/auth/login');
+  });
+
+  it('redirects to state-expired when the login state cookie is stale', async () => {
+    const { callbackHandler } = await import('./auth-route-handlers.js');
+    const { resolveAuthConfigForRequest } = await import('./config.js');
+    const { decodeLoginStateCookie } = await import('./login-state-cookie.js');
+
+    vi.mocked(resolveAuthConfigForRequest).mockResolvedValueOnce(authConfigBase as never);
+    vi.mocked(decodeLoginStateCookie).mockReturnValueOnce({
+      state: 'state-abc123def456',
+      codeVerifier: 'verifier',
+      nonce: 'nonce',
+      createdAt: Date.now() - 11 * 60 * 1000,
+      returnTo: '/admin',
+      silent: false,
+      kind: 'platform',
+    } as never);
+
+    const response = await callbackHandler(
+      new Request('http://localhost/auth/callback?code=abc&state=state-abc123def456')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/?auth=state-expired');
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      'Expired callback cookie cleanup prepared',
+      expect.objectContaining({ operation: 'login_callback_cookie_cleanup' })
+    );
+  });
+
+  it('returns an error redirect when token validation fails during callback', async () => {
+    const { callbackHandler } = await import('./auth-route-handlers.js');
+    const { resolveAuthConfigForRequest } = await import('./config.js');
+    const { handleCallback } = await import('./auth-server/callback.js');
+    const { decodeLoginStateCookie } = await import('./login-state-cookie.js');
+
+    vi.mocked(resolveAuthConfigForRequest).mockResolvedValueOnce(authConfigBase as never);
+    vi.mocked(decodeLoginStateCookie).mockReturnValueOnce({
+      state: 'state-abc123def456',
+      codeVerifier: 'verifier',
+      nonce: 'nonce',
+      createdAt: Date.now(),
+      returnTo: '/admin',
+      silent: false,
+      kind: 'platform',
+    } as never);
+    vi.mocked(handleCallback).mockRejectedValueOnce({
+      error: 'invalid_grant',
+      error_description: 'Code verifier mismatch',
+      response: { status: 401 },
+    });
+
+    const response = await callbackHandler(
+      new Request('http://localhost/auth/callback?code=abc&state=state-abc123def456')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/?auth=error');
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      'Token validation failed in callback',
+      expect.objectContaining({ reason_code: 'token_validate_failed', oauth_error: 'invalid_grant' })
     );
   });
 });

--- a/packages/auth-runtime/src/auth-server/callback.test.ts
+++ b/packages/auth-runtime/src/auth-server/callback.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  getAuthConfig: vi.fn(),
+  jitProvisionAccount: vi.fn(),
+  getOidcConfig: vi.fn(),
+  invalidateOidcConfig: vi.fn(),
+  authorizationCodeGrant: vi.fn(),
+  consumeLoginState: vi.fn(),
+  createSession: vi.fn(),
+  getSessionControlState: vi.fn(),
+  isRetryableTokenExchangeError: vi.fn(),
+  getScopeFromAuthConfig: vi.fn(),
+  buildSessionUser: vi.fn(),
+  resolveSessionExpiry: vi.fn(),
+}));
+
+vi.mock('@sva/server-runtime', () => ({
+  createSdkLogger: () => mocks.logger,
+}));
+
+vi.mock('../config.js', () => ({
+  getAuthConfig: mocks.getAuthConfig,
+}));
+
+vi.mock('../jit-provisioning.js', () => ({
+  jitProvisionAccount: mocks.jitProvisionAccount,
+}));
+
+vi.mock('../log-context.js', () => ({
+  buildLogContext: vi.fn(() => ({ trace_id: 'trace-test' })),
+}));
+
+vi.mock('../oidc.js', () => ({
+  client: {
+    authorizationCodeGrant: mocks.authorizationCodeGrant,
+  },
+  getOidcConfig: mocks.getOidcConfig,
+  invalidateOidcConfig: mocks.invalidateOidcConfig,
+}));
+
+vi.mock('../redis-session.js', () => ({
+  consumeLoginState: mocks.consumeLoginState,
+  createSession: mocks.createSession,
+  getSessionControlState: mocks.getSessionControlState,
+}));
+
+vi.mock('../error-guards.js', () => ({
+  isRetryableTokenExchangeError: mocks.isRetryableTokenExchangeError,
+}));
+
+vi.mock('../scope.js', () => ({
+  getScopeFromAuthConfig: mocks.getScopeFromAuthConfig,
+}));
+
+vi.mock('./shared.js', () => ({
+  buildSessionUser: mocks.buildSessionUser,
+  resolveSessionExpiry: mocks.resolveSessionExpiry,
+}));
+
+const authConfig = {
+  kind: 'platform' as const,
+  issuer: 'https://issuer.example/realms/test',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  loginStateSecret: 'login-state-secret',
+  redirectUri: 'https://studio.example/auth/callback',
+  postLogoutRedirectUri: 'https://studio.example',
+  scopes: 'openid profile',
+  sessionCookieName: 'sva_session',
+  loginStateCookieName: 'login_state',
+  silentSsoSuppressCookieName: 'silent_sso',
+  sessionTtlMs: 3_600_000,
+  sessionRedisTtlBufferMs: 60_000,
+  silentSsoSuppressAfterLogoutMs: 30_000,
+  authRealm: 'test',
+};
+
+describe('handleCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getAuthConfig.mockReturnValue(authConfig);
+    mocks.getOidcConfig.mockResolvedValue({ issuer: authConfig.issuer });
+    mocks.getSessionControlState.mockResolvedValue({ minimumSessionVersion: 2 });
+    mocks.isRetryableTokenExchangeError.mockReturnValue(false);
+    mocks.getScopeFromAuthConfig.mockReturnValue({ kind: 'platform' });
+    mocks.resolveSessionExpiry.mockReturnValue(1_717_171_717_000);
+    mocks.buildSessionUser.mockReturnValue({
+      id: 'kc-user-1',
+      instanceId: 'de-test',
+      roles: ['iam_admin'],
+    });
+    mocks.createSession.mockResolvedValue(undefined);
+    mocks.jitProvisionAccount.mockResolvedValue(undefined);
+    mocks.authorizationCodeGrant.mockResolvedValue({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      id_token: 'id-token',
+      expiresIn: () => 300,
+      claims: () => ({ sub: 'kc-user-1', preferred_username: 'admin' }),
+    });
+  });
+
+  it('rejects missing login state from the session store', async () => {
+    const { handleCallback } = await import('./callback.js');
+
+    mocks.consumeLoginState.mockResolvedValueOnce(null);
+
+    await expect(handleCallback({ code: 'code-1', state: 'state-1', authConfig })).rejects.toThrow(
+      'Invalid login state'
+    );
+
+    expect(mocks.authorizationCodeGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects instance login states without an instanceId', async () => {
+    const { handleCallback } = await import('./callback.js');
+
+    await expect(
+      handleCallback({
+        code: 'code-1',
+        state: 'state-1',
+        authConfig: { ...authConfig, kind: 'instance', instanceId: 'de-test' },
+        loginState: {
+          kind: 'instance',
+          codeVerifier: 'verifier',
+          nonce: 'nonce',
+          createdAt: Date.now(),
+        },
+      })
+    ).rejects.toThrow('Invalid login state: missing instanceId for instance scope');
+  });
+
+  it('rejects login states that do not match the configured scope', async () => {
+    const { handleCallback } = await import('./callback.js');
+
+    mocks.getScopeFromAuthConfig.mockReturnValueOnce({ kind: 'instance', instanceId: 'de-test' });
+
+    await expect(
+      handleCallback({
+        code: 'code-1',
+        state: 'state-1',
+        authConfig: { ...authConfig, kind: 'instance', instanceId: 'de-test' },
+        loginState: {
+          kind: 'platform',
+          codeVerifier: 'verifier',
+          nonce: 'nonce',
+          createdAt: Date.now(),
+        },
+      })
+    ).rejects.toThrow('Invalid login state: scope mismatch');
+  });
+
+  it('invalidates cached OIDC config and retries the token exchange once', async () => {
+    const { handleCallback } = await import('./callback.js');
+
+    const retryableError = new Error('jwks rotation');
+    mocks.authorizationCodeGrant
+      .mockRejectedValueOnce(retryableError)
+      .mockResolvedValueOnce({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        id_token: 'id-token',
+        expiresIn: () => 300,
+        claims: () => ({ sub: 'kc-user-1' }),
+      });
+    mocks.isRetryableTokenExchangeError.mockImplementation((error: unknown) => error === retryableError);
+
+    const result = await handleCallback({
+      code: 'code-1',
+      state: 'state-1',
+      iss: 'https://issuer.example/realms/test',
+      authConfig,
+      loginState: {
+        kind: 'platform',
+        codeVerifier: 'verifier',
+        nonce: 'nonce',
+        createdAt: Date.now(),
+        silent: true,
+      },
+    });
+
+    expect(mocks.invalidateOidcConfig).toHaveBeenCalledWith(authConfig);
+    expect(mocks.authorizationCodeGrant).toHaveBeenCalledTimes(2);
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(mocks.jitProvisionAccount).toHaveBeenCalledWith({
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+    });
+    expect(result.retryPerformed).toBe(true);
+    expect(result.sessionId).toBeTypeOf('string');
+    expect(result.loginState).toMatchObject({ kind: 'platform', silent: true });
+  });
+
+  it('logs and swallows jit provisioning failures after session creation', async () => {
+    const { handleCallback } = await import('./callback.js');
+
+    mocks.jitProvisionAccount.mockRejectedValueOnce(new Error('jit unavailable'));
+
+    const result = await handleCallback({
+      code: 'code-1',
+      state: 'state-1',
+      authConfig,
+      loginState: {
+        kind: 'platform',
+        codeVerifier: 'verifier',
+        nonce: 'nonce',
+        createdAt: Date.now(),
+      },
+    });
+
+    expect(result.user.id).toBe('kc-user-1');
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'JIT provisioning failed after callback',
+      expect.objectContaining({
+        operation: 'jit_provision',
+        user_id: 'kc-user-1',
+        instance_id: 'de-test',
+        error: 'jit unavailable',
+      })
+    );
+  });
+});

--- a/packages/auth-runtime/src/iam-account-management/platform-handlers.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/platform-handlers.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type DbClient = {
+  query: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+};
+
+const state = vi.hoisted(() => {
+  const logger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  return {
+    logger,
+    createSdkLogger: vi.fn(() => logger),
+    getInstanceConfig: vi.fn(),
+    getWorkspaceContext: vi.fn(() => ({ requestId: 'req-123' })),
+    isCanonicalAuthHost: vi.fn(() => false),
+    classifyHost: vi.fn(),
+    isTrafficEnabledInstanceStatus: vi.fn(() => true),
+    loadInstanceByHostname: vi.fn(),
+    getPermissionCacheHealth: vi.fn(() => ({ status: 'ready' as const })),
+    bootstrapStudioAppDbUserIfNeeded: vi.fn(),
+    getLastRedisError: vi.fn(),
+    isRedisAvailable: vi.fn(),
+    jsonResponse: vi.fn((status: number, payload: unknown) =>
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ),
+    resolveEffectiveRequestHost: vi.fn(),
+    resolveIdentityProvider: vi.fn(),
+    resolvePool: vi.fn(),
+    isKeycloakIdentityProvider: vi.fn(),
+    trackKeycloakCall: vi.fn(),
+    addActiveSpanEvent: vi.fn(),
+    annotateActiveSpan: vi.fn(),
+    runCriticalIamSchemaGuard: vi.fn(),
+    summarizeSchemaGuardFailures: vi.fn(),
+  };
+});
+
+vi.mock('@sva/server-runtime', () => ({
+  createSdkLogger: state.createSdkLogger,
+  getInstanceConfig: state.getInstanceConfig,
+  getWorkspaceContext: state.getWorkspaceContext,
+  isCanonicalAuthHost: state.isCanonicalAuthHost,
+}));
+
+vi.mock('@sva/core', () => ({
+  classifyHost: state.classifyHost,
+  isTrafficEnabledInstanceStatus: state.isTrafficEnabledInstanceStatus,
+}));
+
+vi.mock('@sva/data-repositories/server', () => ({
+  loadInstanceByHostname: state.loadInstanceByHostname,
+}));
+
+vi.mock('../iam-authorization/shared.js', () => ({
+  getPermissionCacheHealth: state.getPermissionCacheHealth,
+}));
+
+vi.mock('../postgres-app-user-bootstrap.js', () => ({
+  bootstrapStudioAppDbUserIfNeeded: state.bootstrapStudioAppDbUserIfNeeded,
+}));
+
+vi.mock('../redis.js', () => ({
+  getLastRedisError: state.getLastRedisError,
+  isRedisAvailable: state.isRedisAvailable,
+}));
+
+vi.mock('../db.js', () => ({
+  jsonResponse: state.jsonResponse,
+}));
+
+vi.mock('../request-hosts.js', () => ({
+  resolveEffectiveRequestHost: state.resolveEffectiveRequestHost,
+}));
+
+vi.mock('./shared.js', () => ({
+  isKeycloakIdentityProvider: state.isKeycloakIdentityProvider,
+  resolveIdentityProvider: state.resolveIdentityProvider,
+  resolvePool: state.resolvePool,
+  trackKeycloakCall: state.trackKeycloakCall,
+}));
+
+vi.mock('./diagnostics.js', () => ({
+  addActiveSpanEvent: state.addActiveSpanEvent,
+  annotateActiveSpan: state.annotateActiveSpan,
+}));
+
+vi.mock('./schema-guard.js', () => ({
+  runCriticalIamSchemaGuard: state.runCriticalIamSchemaGuard,
+  summarizeSchemaGuardFailures: state.summarizeSchemaGuardFailures,
+}));
+
+const defaultEnv = {
+  KEYCLOAK_ADMIN_REALM: 'platform-realm',
+  KEYCLOAK_ADMIN_CLIENT_ID: 'platform-admin-client',
+  SVA_AUTH_ISSUER: 'https://auth.example.test/realms/platform-fallback',
+};
+
+const createDbClient = (): DbClient => ({
+  query: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+});
+
+const importSubject = async () => import('./platform-handlers.js');
+
+describe('platform handlers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+
+    vi.stubEnv('KEYCLOAK_ADMIN_REALM', defaultEnv.KEYCLOAK_ADMIN_REALM);
+    vi.stubEnv('KEYCLOAK_ADMIN_CLIENT_ID', defaultEnv.KEYCLOAK_ADMIN_CLIENT_ID);
+    vi.stubEnv('SVA_AUTH_ISSUER', defaultEnv.SVA_AUTH_ISSUER);
+
+    state.getWorkspaceContext.mockReturnValue({ requestId: 'req-123' });
+    state.getInstanceConfig.mockReturnValue(undefined);
+    state.isCanonicalAuthHost.mockReturnValue(false);
+    state.classifyHost.mockReturnValue({ kind: 'unknown' });
+    state.isTrafficEnabledInstanceStatus.mockReturnValue(true);
+    state.loadInstanceByHostname.mockResolvedValue(null);
+    state.getPermissionCacheHealth.mockReturnValue({ status: 'ready' });
+    state.bootstrapStudioAppDbUserIfNeeded.mockResolvedValue(false);
+    state.getLastRedisError.mockReturnValue('redis down');
+    state.isRedisAvailable.mockResolvedValue(true);
+    state.resolveEffectiveRequestHost.mockReturnValue('platform.example.test');
+    state.resolveIdentityProvider.mockReturnValue(null);
+    state.resolvePool.mockReturnValue({
+      connect: vi.fn().mockResolvedValue(createDbClient()),
+    });
+    state.isKeycloakIdentityProvider.mockReturnValue(false);
+    state.trackKeycloakCall.mockImplementation(async (_operation: string, handler: () => Promise<unknown>) => handler());
+    state.runCriticalIamSchemaGuard.mockResolvedValue({ ok: true, checks: [] });
+    state.summarizeSchemaGuardFailures.mockReturnValue('schema drift detected');
+  });
+
+  it('returns alive payload with request context in liveInternal', async () => {
+    const { liveInternal } = await importSubject();
+
+    const response = await liveInternal(new Request('https://platform.example.test/internal/live'));
+    const payload = (await response.json()) as {
+      path: string;
+      requestId: string;
+      status: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe('alive');
+    expect(payload.requestId).toBe('req-123');
+    expect(payload.path).toBe('/internal/live');
+  });
+
+  it('maps missing pool, redis failure and missing keycloak admin client to not_ready services', async () => {
+    const { readyInternal } = await importSubject();
+
+    state.resolvePool.mockReturnValue(null);
+    state.isRedisAvailable.mockResolvedValue(false);
+    state.getPermissionCacheHealth.mockReturnValue({ status: 'failed' });
+
+    const response = await readyInternal(new Request('https://platform.example.test/internal/ready'));
+    const payload = (await response.json()) as {
+      status: string;
+      checks: {
+        auth: { scopeKind: string; activeRealm?: string };
+        authorizationCache: { status: string };
+        errors: Record<string, string>;
+        services: Record<string, { reasonCode?: string; status: string }>;
+      };
+      path: string;
+      requestId: string;
+    };
+
+    expect(response.status).toBe(503);
+    expect(payload.status).toBe('not_ready');
+    expect(payload.requestId).toBe('req-123');
+    expect(payload.path).toBe('/internal/ready');
+    expect(payload.checks.auth).toMatchObject({
+      scopeKind: 'platform',
+      activeRealm: 'platform-realm',
+    });
+    expect(payload.checks.errors).toEqual({
+      db: 'IAM database not configured',
+      redis: 'redis down',
+      keycloak: 'Keycloak admin client not configured',
+    });
+    expect(payload.checks.authorizationCache.status).toBe('failed');
+    expect(payload.checks.services).toMatchObject({
+      authorizationCache: { reasonCode: 'authorization_cache_failed', status: 'not_ready' },
+      database: { status: 'not_ready' },
+      redis: { reasonCode: 'redis_ping_failed', status: 'not_ready' },
+      keycloak: { reasonCode: 'keycloak_admin_not_configured', status: 'not_ready' },
+    });
+    expect(state.logger.error).toHaveBeenCalledTimes(3);
+    expect(state.annotateActiveSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'dependency.database.status': 'not_ready',
+        'dependency.redis.status': 'not_ready',
+        'dependency.keycloak.status': 'not_ready',
+      })
+    );
+  });
+
+  it('bootstraps the db user on first connect failure and reports degraded authorization cache', async () => {
+    const { readyInternal } = await importSubject();
+
+    const dbClient = createDbClient();
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('role missing'))
+      .mockResolvedValueOnce(dbClient);
+    const listRoles = vi.fn().mockResolvedValue([{ id: 'role-1' }]);
+
+    state.resolvePool.mockReturnValue({ connect });
+    state.bootstrapStudioAppDbUserIfNeeded.mockResolvedValue(true);
+    state.resolveIdentityProvider.mockReturnValue({
+      provider: { listRoles },
+    });
+    state.isKeycloakIdentityProvider.mockReturnValue(true);
+    state.getPermissionCacheHealth.mockReturnValue({ status: 'degraded' });
+
+    const response = await readyInternal(new Request('https://platform.example.test/internal/ready'));
+    const payload = (await response.json()) as {
+      status: string;
+      checks: {
+        diagnostics: Record<string, unknown>;
+        services: Record<string, { reasonCode?: string; status: string }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe('degraded');
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(dbClient.query).toHaveBeenCalledWith('SELECT 1;');
+    expect(dbClient.release).toHaveBeenCalledTimes(1);
+    expect(state.bootstrapStudioAppDbUserIfNeeded).toHaveBeenCalledTimes(1);
+    expect(state.trackKeycloakCall).toHaveBeenCalledTimes(1);
+    expect(listRoles).toHaveBeenCalledTimes(1);
+    expect(payload.checks.diagnostics).toEqual({});
+    expect(payload.checks.services.authorizationCache).toEqual({
+      reasonCode: 'authorization_cache_degraded',
+      status: 'degraded',
+    });
+    expect(state.logger.warn).toHaveBeenCalledWith(
+      'iam_readiness_degraded',
+      expect.objectContaining({
+        dependency: 'authorization_cache',
+        reason_code: 'authorization_cache_degraded',
+      })
+    );
+  });
+
+  it('returns tenant auth metadata and schema drift diagnostics when the critical schema guard fails', async () => {
+    const { readyInternal } = await importSubject();
+
+    const dbClient = createDbClient();
+
+    state.getInstanceConfig.mockReturnValue({ parentDomain: 'example.test' });
+    state.classifyHost.mockReturnValue({ kind: 'tenant' });
+    state.resolveEffectiveRequestHost.mockReturnValue('tenant.example.test');
+    state.loadInstanceByHostname.mockResolvedValue({
+      status: 'active',
+      authRealm: 'tenant-realm',
+      authClientId: 'tenant-login-client',
+      tenantAdminClient: undefined,
+    });
+    state.resolvePool.mockReturnValue({
+      connect: vi.fn().mockResolvedValue(dbClient),
+    });
+    state.runCriticalIamSchemaGuard.mockResolvedValue({ ok: false, checks: [{ schemaObject: 'iam.groups' }] });
+    state.resolveIdentityProvider.mockReturnValue({
+      provider: { kind: 'mock-non-keycloak' },
+    });
+
+    const response = await readyInternal(new Request('https://platform.example.test/internal/ready'));
+    const payload = (await response.json()) as {
+      status: string;
+      checks: {
+        auth: {
+          activeRealm: string;
+          breakGlass: { configured: boolean };
+          login: { configured: boolean };
+          platformAdmin: { configured: boolean };
+          scopeKind: string;
+          tenantAdmin: { configured: boolean; fallbackToLoginClient: boolean; secretConfigured: boolean };
+        };
+        diagnostics: {
+          db: {
+            reason_code: string;
+            schema_guard: { ok: boolean };
+          };
+        };
+        errors: Record<string, string>;
+        services: Record<string, { reasonCode?: string; status: string }>;
+      };
+    };
+
+    expect(response.status).toBe(503);
+    expect(payload.status).toBe('not_ready');
+    expect(payload.checks.auth).toMatchObject({
+      scopeKind: 'instance',
+      activeRealm: 'tenant-realm',
+      login: { configured: true },
+      tenantAdmin: {
+        configured: false,
+        fallbackToLoginClient: true,
+        secretConfigured: false,
+      },
+      platformAdmin: { configured: true },
+      breakGlass: { configured: true },
+    });
+    expect(payload.checks.errors.db).toBe('schema drift detected');
+    expect(payload.checks.diagnostics.db).toMatchObject({
+      reason_code: 'schema_drift',
+      schema_guard: { ok: false },
+    });
+    expect(payload.checks.services.database).toEqual({
+      reasonCode: 'schema_drift',
+      status: 'not_ready',
+    });
+    expect(state.logger.error).toHaveBeenCalledWith(
+      'iam_readiness_dependency_failed',
+      expect.objectContaining({
+        dependency: 'database',
+        reason_code: 'schema_drift',
+      })
+    );
+    expect(state.trackKeycloakCall).not.toHaveBeenCalled();
+  });
+
+  it('falls back to platform auth metadata and maps keycloak errors when tenant lookup and keycloak checks fail', async () => {
+    const { readyInternal } = await importSubject();
+
+    const keycloakError = new Error('keycloak unavailable');
+
+    state.getInstanceConfig.mockReturnValue({ parentDomain: 'example.test' });
+    state.classifyHost.mockReturnValue({ kind: 'tenant' });
+    state.resolveEffectiveRequestHost.mockReturnValue('tenant.example.test');
+    state.loadInstanceByHostname.mockRejectedValue(new Error('lookup unavailable'));
+    state.resolveIdentityProvider.mockReturnValue({
+      provider: { listRoles: vi.fn().mockRejectedValue(keycloakError) },
+    });
+    state.isKeycloakIdentityProvider.mockReturnValue(true);
+    state.trackKeycloakCall.mockImplementation(async (_operation: string, handler: () => Promise<unknown>) => handler());
+
+    const response = await readyInternal(new Request('https://platform.example.test/internal/ready'));
+    const payload = (await response.json()) as {
+      status: string;
+      checks: {
+        auth: { activeRealm?: string; scopeKind: string };
+        errors: Record<string, string>;
+        services: Record<string, { reasonCode?: string; status: string }>;
+      };
+    };
+
+    expect(response.status).toBe(503);
+    expect(payload.status).toBe('not_ready');
+    expect(payload.checks.auth).toMatchObject({
+      scopeKind: 'platform',
+      activeRealm: 'platform-realm',
+    });
+    expect(payload.checks.errors.keycloak).toBe('keycloak unavailable');
+    expect(payload.checks.services.keycloak).toEqual({
+      reasonCode: 'keycloak_dependency_failed',
+      status: 'not_ready',
+    });
+    expect(state.logger.error).toHaveBeenCalledWith(
+      'iam_readiness_dependency_failed',
+      expect.objectContaining({
+        dependency: 'keycloak',
+        reason_code: 'keycloak_dependency_failed',
+      })
+    );
+  });
+});

--- a/packages/auth-runtime/src/iam-authorization/permission-store.test.ts
+++ b/packages/auth-runtime/src/iam-authorization/permission-store.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getRedisPermissionSnapshot: vi.fn(),
+  setRedisPermissionSnapshot: vi.fn(),
+  loadPermissionsFromDb: vi.fn(),
+  ensureInvalidationListener: vi.fn(),
+  buildRequestContext: vi.fn(() => ({ trace_id: 'trace-test' })),
+  cacheLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  logger: {
+    error: vi.fn(),
+  },
+  iamCacheLookupCounter: {
+    add: vi.fn(),
+  },
+  cacheMetricsState: {
+    lookups: 0,
+    staleLookups: 0,
+  },
+  recordPermissionCacheColdStart: vi.fn(),
+  recordPermissionCacheRecompute: vi.fn(),
+  recordPermissionCacheRedisLatency: vi.fn(),
+  permissionSnapshotCache: {
+    get: vi.fn(),
+    set: vi.fn(),
+    size: vi.fn(),
+  },
+}));
+
+vi.mock('./redis-permission-snapshot.server.js', () => ({
+  getRedisPermissionSnapshot: mocks.getRedisPermissionSnapshot,
+  setRedisPermissionSnapshot: mocks.setRedisPermissionSnapshot,
+}));
+
+vi.mock('./permission-store.queries.js', () => ({
+  loadPermissionsFromDb: mocks.loadPermissionsFromDb,
+}));
+
+vi.mock('./shared.js', () => ({
+  buildRequestContext: mocks.buildRequestContext,
+  cacheLogger: mocks.cacheLogger,
+  cacheMetricsState: mocks.cacheMetricsState,
+  ensureInvalidationListener: mocks.ensureInvalidationListener,
+  iamCacheLookupCounter: mocks.iamCacheLookupCounter,
+  logger: mocks.logger,
+  permissionSnapshotCache: mocks.permissionSnapshotCache,
+  recordPermissionCacheColdStart: mocks.recordPermissionCacheColdStart,
+  recordPermissionCacheRecompute: mocks.recordPermissionCacheRecompute,
+  recordPermissionCacheRedisLatency: mocks.recordPermissionCacheRedisLatency,
+}));
+
+describe('resolveEffectivePermissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cacheMetricsState.lookups = 0;
+    mocks.cacheMetricsState.staleLookups = 0;
+    mocks.ensureInvalidationListener.mockResolvedValue(undefined);
+    mocks.permissionSnapshotCache.size.mockReturnValue(1);
+    mocks.permissionSnapshotCache.get.mockReturnValue({
+      status: 'miss',
+    });
+    mocks.permissionSnapshotCache.set.mockReturnValue({
+      snapshotVersion: 'snap-1',
+    });
+    mocks.getRedisPermissionSnapshot.mockResolvedValue({
+      hit: false,
+      reason: 'miss',
+    });
+    mocks.setRedisPermissionSnapshot.mockResolvedValue({
+      ok: true,
+      version: 'redis-1',
+    });
+    mocks.loadPermissionsFromDb.mockResolvedValue([
+      { action: 'news.read', effect: 'allow' },
+    ]);
+  });
+
+  it('returns a memory-cache hit without touching redis or the database', async () => {
+    const { resolveEffectivePermissions } = await import('./permission-store.js');
+
+    mocks.permissionSnapshotCache.get.mockReturnValueOnce({
+      status: 'hit',
+      snapshot: {
+        permissions: [{ action: 'news.read', effect: 'allow' }],
+        snapshotVersion: 'memory-1',
+      },
+      ttlRemainingSeconds: 42,
+    });
+
+    const result = await resolveEffectivePermissions({
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      permissions: [{ action: 'news.read', effect: 'allow' }],
+      cacheStatus: 'hit',
+      snapshotVersion: 'memory-1',
+    });
+    expect(mocks.getRedisPermissionSnapshot).not.toHaveBeenCalled();
+    expect(mocks.loadPermissionsFromDb).not.toHaveBeenCalled();
+  });
+
+  it('hydrates the in-memory cache from a redis hit', async () => {
+    const { resolveEffectivePermissions } = await import('./permission-store.js');
+
+    mocks.getRedisPermissionSnapshot.mockResolvedValueOnce({
+      hit: true,
+      permissions: [{ action: 'events.read', effect: 'allow' }],
+      version: 'redis-2',
+    });
+    mocks.permissionSnapshotCache.set.mockReturnValueOnce({
+      snapshotVersion: 'memory-2',
+    });
+
+    const result = await resolveEffectivePermissions({
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+      organizationId: 'org-1',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      permissions: [{ action: 'events.read', effect: 'allow' }],
+      cacheStatus: 'hit',
+      snapshotVersion: 'memory-2',
+    });
+    expect(mocks.permissionSnapshotCache.set).toHaveBeenCalledTimes(1);
+    expect(mocks.loadPermissionsFromDb).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when redis is unavailable', async () => {
+    const { resolveEffectivePermissions } = await import('./permission-store.js');
+
+    mocks.getRedisPermissionSnapshot.mockResolvedValueOnce({
+      hit: false,
+      reason: 'redis_unavailable',
+    });
+
+    const result = await resolveEffectivePermissions({
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'database_unavailable' });
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Redis permission snapshot lookup failed',
+      expect.objectContaining({ operation: 'cache_lookup_failed', error: 'redis_unavailable' })
+    );
+  });
+
+  it('recomputes stale snapshots from the database and reports recompute status', async () => {
+    const { resolveEffectivePermissions } = await import('./permission-store.js');
+
+    mocks.permissionSnapshotCache.get.mockReturnValueOnce({
+      status: 'stale',
+      ageSeconds: 600,
+    });
+    mocks.loadPermissionsFromDb.mockResolvedValueOnce([
+      { action: 'locations.manage', effect: 'allow' },
+    ]);
+    mocks.setRedisPermissionSnapshot.mockResolvedValueOnce({
+      ok: true,
+      version: 'redis-3',
+    });
+    mocks.permissionSnapshotCache.set.mockReturnValueOnce({
+      snapshotVersion: 'memory-3',
+    });
+
+    const result = await resolveEffectivePermissions({
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+      geoUnitId: 'geo-1',
+      geoHierarchy: ['geo-1', 'geo-1', 'geo-2'],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      permissions: [{ action: 'locations.manage', effect: 'allow' }],
+      cacheStatus: 'recompute',
+      snapshotVersion: 'memory-3',
+    });
+    expect(mocks.recordPermissionCacheRecompute).toHaveBeenCalledTimes(1);
+    expect(mocks.cacheLogger.info).toHaveBeenCalledWith(
+      'Permission snapshot recomputed after stale detection',
+      expect.objectContaining({ operation: 'cache_invalidate', trigger: 'recompute' })
+    );
+  });
+
+  it('fails closed when redis snapshot writes fail after recompute', async () => {
+    const { resolveEffectivePermissions } = await import('./permission-store.js');
+
+    mocks.setRedisPermissionSnapshot.mockResolvedValueOnce({
+      ok: false,
+      reason: 'redis_unavailable',
+    });
+
+    const result = await resolveEffectivePermissions({
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'database_unavailable' });
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Redis permission snapshot write failed after recompute',
+      expect.objectContaining({ operation: 'cache_store_failed', error: 'redis_unavailable' })
+    );
+  });
+});

--- a/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
+++ b/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
@@ -1,0 +1,494 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SessionUser = {
+  id: string;
+  instanceId?: string;
+  roles: string[];
+};
+
+type AccountRow = {
+  id: string;
+  keycloak_subject: string;
+  email_ciphertext?: string | null;
+  display_name_ciphertext?: string | null;
+  processing_restricted_at?: string | null;
+  non_essential_processing_opt_out_at?: string | null;
+};
+
+const mocks = vi.hoisted(() => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  withRequestContext: vi.fn(async (_input: unknown, handler: () => Promise<Response>) => handler()),
+  withAuthenticatedUser: vi.fn(),
+  validateCsrf: vi.fn(() => null),
+  withResolvedInstanceDb: vi.fn(),
+  createPoolResolver: vi.fn(() => () => null),
+  createDsrExportFlows: vi.fn(),
+  createDsrExportStatusHandlers: vi.fn(),
+  runSelfExport: vi.fn(),
+  runAdminExport: vi.fn(),
+  getSelfExportStatus: vi.fn(),
+  getAdminExportStatus: vi.fn(),
+  runDsrMaintenance: vi.fn(),
+  listAdminDsrCases: vi.fn(),
+  loadDsrSelfServiceOverview: vi.fn(),
+  parseFieldEncryptionConfigFromEnv: vi.fn(() => ({ keyId: 'enc-1' })),
+  encryptFieldValue: vi.fn((value: string) => `enc:${value}`),
+  requireIdempotencyKey: vi.fn(() => ({ key: 'idem-1' })),
+  reserveIdempotency: vi.fn(),
+  completeIdempotency: vi.fn(),
+  toPayloadHash: vi.fn(() => 'hash-1'),
+  asApiItem: vi.fn((item: unknown, requestId?: string) => ({ data: item, requestId })),
+  asApiList: vi.fn((items: unknown, page: unknown, requestId?: string) => ({ data: items, page, requestId })),
+  createApiError: vi.fn((status: number, error: string, message: string, requestId?: string) =>
+    new Response(JSON.stringify({ error, message, requestId }), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  ),
+  readPage: vi.fn(() => ({ page: 1, pageSize: 20 })),
+  getWorkspaceContext: vi.fn(() => ({ requestId: 'req-test', traceId: 'trace-test' })),
+  safeParse: vi.fn((body: unknown) => ({
+    success: typeof body === 'object' && body !== null,
+    data: body,
+  })),
+}));
+
+class MockDsrAccountSnapshotNotFoundError extends Error {}
+
+vi.mock('@sva/server-runtime', () => ({
+  createSdkLogger: () => mocks.logger,
+  getWorkspaceContext: mocks.getWorkspaceContext,
+  withRequestContext: mocks.withRequestContext,
+}));
+
+vi.mock('@sva/core/security', () => ({
+  encryptFieldValue: mocks.encryptFieldValue,
+  parseFieldEncryptionConfigFromEnv: mocks.parseFieldEncryptionConfigFromEnv,
+}));
+
+vi.mock('@sva/iam-governance/dsr-export-flows', () => ({
+  createDsrExportFlows: (...args: unknown[]) => {
+    mocks.createDsrExportFlows(...args);
+    return {
+      runSelfExport: mocks.runSelfExport,
+      runAdminExport: mocks.runAdminExport,
+    };
+  },
+}));
+
+vi.mock('@sva/iam-governance/dsr-export-status', () => ({
+  createDsrExportStatusHandlers: (...args: unknown[]) => {
+    mocks.createDsrExportStatusHandlers(...args);
+    return {
+      getSelfExportStatus: mocks.getSelfExportStatus,
+      getAdminExportStatus: mocks.getAdminExportStatus,
+    };
+  },
+}));
+
+vi.mock('@sva/iam-governance/dsr-maintenance', () => ({
+  runDsrMaintenance: mocks.runDsrMaintenance,
+}));
+
+vi.mock('@sva/iam-governance', () => ({
+  listAdminDsrCases: mocks.listAdminDsrCases,
+  loadDsrSelfServiceOverview: mocks.loadDsrSelfServiceOverview,
+}));
+
+vi.mock('@sva/iam-governance/dsr-read-models-internal', () => ({
+  DsrAccountSnapshotNotFoundError: MockDsrAccountSnapshotNotFoundError,
+}));
+
+vi.mock('../middleware.js', () => ({
+  withAuthenticatedUser: mocks.withAuthenticatedUser,
+}));
+
+vi.mock('../runtime-secrets.js', () => ({
+  getIamDatabaseUrl: vi.fn(() => 'postgres://db.example/sva'),
+}));
+
+vi.mock('../db.js', () => ({
+  createPoolResolver: mocks.createPoolResolver,
+  jsonResponse: (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  textResponse: (status: number, body: string) => new Response(body, { status }),
+  withResolvedInstanceDb: mocks.withResolvedInstanceDb,
+}));
+
+vi.mock('../log-context.js', () => ({
+  buildLogContext: vi.fn(() => ({ trace_id: 'trace-test' })),
+}));
+
+vi.mock('../shared/schemas.js', () => ({
+  dataSubjectRightsRequestSchema: {
+    safeParse: mocks.safeParse,
+  },
+}));
+
+vi.mock('../iam-account-management/api-helpers.js', () => ({
+  asApiItem: mocks.asApiItem,
+  asApiList: mocks.asApiList,
+  createApiError: mocks.createApiError,
+  readPage: mocks.readPage,
+  requireIdempotencyKey: mocks.requireIdempotencyKey,
+  toPayloadHash: mocks.toPayloadHash,
+}));
+
+vi.mock('../iam-account-management/shared.js', () => ({
+  completeIdempotency: mocks.completeIdempotency,
+  reserveIdempotency: mocks.reserveIdempotency,
+}));
+
+vi.mock('../iam-account-management/csrf.js', () => ({
+  validateCsrf: mocks.validateCsrf,
+}));
+
+const baseUser: SessionUser = {
+  id: 'kc-user-1',
+  instanceId: 'de-test',
+  roles: ['editor'],
+};
+
+const buildAccount = (overrides: Partial<AccountRow> = {}): AccountRow => ({
+  id: 'account-1',
+  keycloak_subject: 'kc-user-1',
+  email_ciphertext: 'enc:mail',
+  display_name_ciphertext: 'enc:name',
+  processing_restricted_at: null,
+  non_essential_processing_opt_out_at: null,
+  ...overrides,
+});
+
+const buildDbClient = (options: {
+  account?: AccountRow | null;
+  hasLegalHold?: boolean;
+  legalHoldInsertId?: string;
+  releaseCount?: number;
+  requestIds?: string[];
+} = {}) => {
+  const requestIds = [...(options.requestIds ?? ['request-1', 'request-2'])];
+
+  return {
+    query: vi.fn(async (text: string) => {
+      if (text.includes('FROM iam.accounts a')) {
+        return options.account
+          ? { rowCount: 1, rows: [options.account] }
+          : { rowCount: 0, rows: [] };
+      }
+
+      if (text.includes('FROM iam.legal_holds')) {
+        return options.hasLegalHold ? { rowCount: 1, rows: [{ id: 'hold-1' }] } : { rowCount: 0, rows: [] };
+      }
+
+      if (text.includes('INSERT INTO iam.data_subject_requests')) {
+        return { rowCount: 1, rows: [{ id: requestIds.shift() ?? 'request-x' }] };
+      }
+
+      if (text.includes('INSERT INTO iam.legal_holds')) {
+        return { rowCount: 1, rows: [{ id: options.legalHoldInsertId ?? 'hold-created-1' }] };
+      }
+
+      if (text.includes('UPDATE iam.legal_holds')) {
+        return {
+          rowCount: options.releaseCount ?? 1,
+          rows: Array.from({ length: options.releaseCount ?? 1 }, (_, index) => ({ id: `released-${index + 1}` })),
+        };
+      }
+
+      return { rowCount: 1, rows: [] };
+    }),
+  };
+};
+
+const expectJson = async (response: Response) => response.json();
+
+describe('iam data subject rights handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    mocks.withAuthenticatedUser.mockImplementation(async (_request: Request, handler: (ctx: { user: SessionUser }) => Promise<Response>) =>
+      handler({ user: baseUser })
+    );
+    mocks.withResolvedInstanceDb.mockImplementation(async (_resolver: unknown, instanceId: string, work: (client: ReturnType<typeof buildDbClient>) => Promise<Response>) =>
+      work(buildDbClient({ account: buildAccount({ id: 'account-1', keycloak_subject: 'kc-user-1' }) }))
+    );
+    mocks.runDsrMaintenance.mockResolvedValue({ dryRun: false, affected: 0 });
+    mocks.loadDsrSelfServiceOverview.mockResolvedValue({ totals: { open: 1 } });
+    mocks.listAdminDsrCases.mockResolvedValue({ items: [{ id: 'case-1' }], total: 1 });
+  });
+
+  it('rejects invalid self-export formats before touching the database', async () => {
+    const { dataExportHandler } = await import('./core.js');
+
+    const response = await dataExportHandler(
+      new Request('http://localhost/iam/me/data-export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Idempotency-Key': 'idem-1' },
+        body: JSON.stringify({ format: 'pdf', async: false }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'invalid_export_format' });
+    expect(mocks.withResolvedInstanceDb).not.toHaveBeenCalled();
+  });
+
+  it('rejects admin exports without a target subject', async () => {
+    const { adminDataExportHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['iam_admin'] } })
+    );
+
+    const response = await adminDataExportHandler(
+      new Request('http://localhost/iam/admin/data-export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Idempotency-Key': 'idem-1' },
+        body: JSON.stringify({ format: 'json' }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'missing_target_keycloak_subject' });
+  });
+
+  it('redirects rectification requests to the dedicated profile correction endpoint', async () => {
+    const { dataSubjectRequestHandler } = await import('./core.js');
+
+    const response = await dataSubjectRequestHandler(
+      new Request('http://localhost/iam/me/data-subject-rights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'rectification', payload: {} }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'use_profile_correction_endpoint' });
+  });
+
+  it('returns not_found when the requester account cannot be resolved', async () => {
+    const { dataSubjectRequestHandler } = await import('./core.js');
+
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(buildDbClient({ account: null }))
+    );
+
+    const response = await dataSubjectRequestHandler(
+      new Request('http://localhost/iam/me/data-subject-rights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'deletion', payload: { reason: 'cleanup' } }),
+      })
+    );
+
+    expect(response.status).toBe(404);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'account_not_found' });
+  });
+
+  it('returns blocked_legal_hold when a deletion request hits an active hold', async () => {
+    const { dataSubjectRequestHandler } = await import('./core.js');
+
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(
+        buildDbClient({
+          account: buildAccount({ id: 'account-42' }),
+          hasLegalHold: true,
+          requestIds: ['blocked-request-1'],
+        })
+      )
+    );
+
+    const response = await dataSubjectRequestHandler(
+      new Request('http://localhost/iam/me/data-subject-rights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'deletion', payload: { reason: 'cleanup' } }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({
+      requestId: 'blocked-request-1',
+      status: 'blocked_legal_hold',
+    });
+  });
+
+  it('blocks optional processing when restriction or objection flags are active', async () => {
+    const { optionalProcessingExecuteHandler } = await import('./core.js');
+
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(
+        buildDbClient({
+          account: buildAccount({
+            processing_restricted_at: '2026-05-01T10:00:00.000Z',
+            non_essential_processing_opt_out_at: '2026-05-01T11:00:00.000Z',
+          }),
+        })
+      )
+    );
+
+    const response = await optionalProcessingExecuteHandler(
+      new Request('http://localhost/iam/me/optional-processing?instanceId=de-test')
+    );
+
+    expect(response.status).toBe(423);
+    await expect(expectJson(response)).resolves.toEqual({
+      error: 'processing_restricted',
+      blockedByRestriction: true,
+      blockedByObjection: true,
+    });
+  });
+
+  it('rejects invalid legal hold expiration timestamps before database access', async () => {
+    const { legalHoldApplyHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['system_admin'] } })
+    );
+
+    const response = await legalHoldApplyHandler(
+      new Request('http://localhost/iam/admin/legal-holds/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetKeycloakSubject: 'kc-target-1',
+          holdUntil: 'not-a-date',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'invalid_hold_until' });
+    expect(mocks.withResolvedInstanceDb).not.toHaveBeenCalled();
+  });
+
+  it('returns target_account_not_found when applying a legal hold to an unknown subject', async () => {
+    const { legalHoldApplyHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['system_admin'] } })
+    );
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(buildDbClient({ account: null }))
+    );
+
+    const response = await legalHoldApplyHandler(
+      new Request('http://localhost/iam/admin/legal-holds/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetKeycloakSubject: 'kc-target-1',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(404);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'target_account_not_found' });
+  });
+
+  it('returns target_account_not_found when releasing a legal hold for an unknown subject', async () => {
+    const { legalHoldReleaseHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['system_admin'] } })
+    );
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(buildDbClient({ account: null }))
+    );
+
+    const response = await legalHoldReleaseHandler(
+      new Request('http://localhost/iam/admin/legal-holds/release', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetKeycloakSubject: 'kc-target-1',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(404);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'target_account_not_found' });
+  });
+
+  it('maps missing DSR account snapshots to not_found for self-service overview', async () => {
+    const { getMyDataSubjectRightsHandler } = await import('./core.js');
+
+    mocks.loadDsrSelfServiceOverview.mockRejectedValueOnce(new MockDsrAccountSnapshotNotFoundError('missing'));
+
+    const response = await getMyDataSubjectRightsHandler(
+      new Request('http://localhost/iam/me/data-subject-rights/overview?instanceId=de-test')
+    );
+
+    expect(response.status).toBe(404);
+    await expect(expectJson(response)).resolves.toEqual({
+      error: 'not_found',
+      message: 'Konto nicht gefunden.',
+      requestId: 'req-test',
+    });
+  });
+
+  it('passes dryRun through to the DSR maintenance runner', async () => {
+    const { dataSubjectMaintenanceHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['support_admin'] } })
+    );
+    mocks.runDsrMaintenance.mockResolvedValueOnce({ dryRun: true, affected: 3 });
+
+    const response = await dataSubjectMaintenanceHandler(
+      new Request('http://localhost/iam/admin/data-subject-rights/maintenance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: true }),
+      })
+    );
+
+    expect(mocks.runDsrMaintenance).toHaveBeenCalledWith(expect.anything(), {
+      instanceId: 'de-test',
+      dryRun: true,
+    });
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({ dryRun: true, affected: 3 });
+  });
+
+  it('rejects invalid admin export status job ids before database access', async () => {
+    const { adminDataExportStatusHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['iam_admin'] } })
+    );
+
+    const response = await adminDataExportStatusHandler(
+      new Request('http://localhost/iam/admin/data-export/status?instanceId=de-test&jobId=not-a-uuid')
+    );
+
+    expect(response.status).toBe(400);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'invalid_job_id' });
+    expect(mocks.withResolvedInstanceDb).not.toHaveBeenCalled();
+  });
+
+  it('requires an admin role for the DSR case list', async () => {
+    const { listAdminDataSubjectRightsCasesHandler } = await import('./core.js');
+
+    const response = await listAdminDataSubjectRightsCasesHandler(
+      new Request('http://localhost/iam/admin/data-subject-rights/cases?instanceId=de-test')
+    );
+
+    expect(response.status).toBe(403);
+    await expect(expectJson(response)).resolves.toEqual({
+      error: 'forbidden',
+      message: 'Keine Berechtigung für DSR-Transparenz.',
+      requestId: 'req-test',
+    });
+  });
+});

--- a/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
+++ b/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
@@ -491,4 +491,184 @@ describe('iam data subject rights handlers', () => {
       requestId: 'req-test',
     });
   });
+
+  it('delegates self export status lookups to the status handler', async () => {
+    const { dataExportStatusHandler } = await import('./core.js');
+
+    mocks.getSelfExportStatus.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'ready' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const response = await dataExportStatusHandler(
+      new Request('http://localhost/iam/me/data-export/status?instanceId=de-test&jobId=123e4567-e89b-12d3-a456-426614174000&download=json')
+    );
+
+    expect(mocks.getSelfExportStatus).toHaveBeenCalledWith({
+      client: expect.anything(),
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+      jobId: '123e4567-e89b-12d3-a456-426614174000',
+      downloadFormat: 'json',
+    });
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({ status: 'ready' });
+  });
+
+  it('returns encryption_not_configured when profile correction cannot encrypt fields', async () => {
+    const { profileCorrectionHandler } = await import('./core.js');
+
+    mocks.parseFieldEncryptionConfigFromEnv.mockReturnValueOnce(null);
+
+    const response = await profileCorrectionHandler(
+      new Request('http://localhost/iam/me/profile-correction', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.test' }),
+      })
+    );
+
+    expect(response.status).toBe(503);
+    await expect(expectJson(response)).resolves.toEqual({ error: 'encryption_not_configured' });
+    expect(mocks.withResolvedInstanceDb).not.toHaveBeenCalled();
+  });
+
+  it('persists profile corrections and returns a completed rectification request', async () => {
+    const { profileCorrectionHandler } = await import('./core.js');
+
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(
+        buildDbClient({
+          account: buildAccount({
+            id: 'account-77',
+            keycloak_subject: 'kc-user-1',
+            email_ciphertext: 'old-email',
+            display_name_ciphertext: 'old-display',
+          }),
+          requestIds: ['rectify-1'],
+        })
+      )
+    );
+
+    const response = await profileCorrectionHandler(
+      new Request('http://localhost/iam/me/profile-correction', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'new@example.test',
+          displayName: 'New Display Name',
+          reason: 'fix-typo',
+        }),
+      })
+    );
+
+    expect(mocks.encryptFieldValue).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({
+      status: 'ok',
+      requestId: 'rectify-1',
+    });
+  });
+
+  it('creates a legal hold and emits an audit event on success', async () => {
+    const { legalHoldApplyHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['system_admin'] } })
+    );
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(
+        buildDbClient({
+          account: buildAccount({ id: 'target-1', keycloak_subject: 'kc-target-1' }),
+          legalHoldInsertId: 'hold-99',
+        })
+      )
+    );
+
+    const response = await legalHoldApplyHandler(
+      new Request('http://localhost/iam/admin/legal-holds/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetKeycloakSubject: 'kc-target-1',
+          holdReason: 'investigation',
+          holdUntil: '2026-06-01T12:00:00.000Z',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({
+      legalHoldId: 'hold-99',
+      status: 'active',
+    });
+  });
+
+  it('returns the released hold count when a legal hold is removed', async () => {
+    const { legalHoldReleaseHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['system_admin'] } })
+    );
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, instanceId, work) =>
+      work(
+        buildDbClient({
+          account: buildAccount({ id: 'target-1', keycloak_subject: 'kc-target-1' }),
+          releaseCount: 2,
+        })
+      )
+    );
+
+    const response = await legalHoldReleaseHandler(
+      new Request('http://localhost/iam/admin/legal-holds/release', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetKeycloakSubject: 'kc-target-1',
+          releaseReason: 'resolved',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({
+      releasedCount: 2,
+    });
+  });
+
+  it('lists admin DSR cases with normalized paging and filters', async () => {
+    const { listAdminDataSubjectRightsCasesHandler } = await import('./core.js');
+
+    mocks.withAuthenticatedUser.mockImplementationOnce(async (_request, handler) =>
+      handler({ user: { ...baseUser, roles: ['support_admin'] } })
+    );
+    mocks.readPage.mockReturnValueOnce({ page: 2, pageSize: 10 });
+    mocks.listAdminDsrCases.mockResolvedValueOnce({
+      items: [{ id: 'case-1' }, { id: 'case-2' }],
+      total: 2,
+    });
+
+    const response = await listAdminDataSubjectRightsCasesHandler(
+      new Request(
+        'http://localhost/iam/admin/data-subject-rights/cases?instanceId=de-test&type=deletion&status=accepted&search=alice'
+      )
+    );
+
+    expect(mocks.listAdminDsrCases).toHaveBeenCalledWith(expect.anything(), {
+      instanceId: 'de-test',
+      page: 2,
+      pageSize: 10,
+      search: 'alice',
+      type: 'deletion',
+      status: 'accepted',
+    });
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({
+      data: [{ id: 'case-1' }, { id: 'case-2' }],
+      page: { page: 2, pageSize: 10, total: 2 },
+      requestId: 'req-test',
+    });
+  });
 });

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -357,4 +357,124 @@ describe('KeycloakAdminClient', () => {
     now = 20_000;
     await expect(client.listUsers()).rejects.toBeInstanceOf(KeycloakAdminRequestError);
   });
+
+  it('fails user creation when Keycloak omits the location header', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith('/protocol/openid-connect/token')) {
+        return jsonResponse({ access_token: 'token-a', expires_in: 300 });
+      }
+      if (init?.method === 'POST' && url.pathname === '/admin/realms/tenant/users') {
+        return new Response(null, { status: 201 });
+      }
+      return jsonResponse({ errorMessage: 'Unhandled request' }, { status: 500 });
+    });
+    const client = createClient(fetchImpl);
+
+    await expect(
+      client.createUser({
+        email: 'created@example.test',
+      })
+    ).rejects.toMatchObject({
+      statusCode: 502,
+      code: 'missing_location_header',
+    });
+  });
+
+  it('maps object-shaped role count responses and missing realms correctly', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL): Promise<Response> => {
+      const path = new URL(String(input)).pathname;
+      if (path.endsWith('/protocol/openid-connect/token')) {
+        return jsonResponse({ access_token: 'token-a', expires_in: 300 });
+      }
+      if (path === '/admin/realms/tenant/roles/count') {
+        return jsonResponse({ count: 9 });
+      }
+      if (path === '/admin/realms/tenant') {
+        return jsonResponse({ error: 'not_found' }, { status: 404 });
+      }
+      return jsonResponse({ errorMessage: 'Unhandled request' }, { status: 500 });
+    });
+    const client = createClient(fetchImpl);
+
+    await expect(client.countRoles()).resolves.toBe(9);
+    await expect(client.getRealm()).resolves.toBeNull();
+  });
+
+  it('creates a protocol mapper when none exists yet', async () => {
+    const requests: RecordedRequest[] = [];
+    const fetchImpl = vi.fn(async (input: string | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(String(input));
+      const method = init?.method ?? 'GET';
+      const path = `${url.pathname}${url.search}`;
+      requests.push({
+        method,
+        path,
+        body: typeof init?.body === 'string' ? init.body : undefined,
+      });
+
+      if (path === '/realms/master/protocol/openid-connect/token') {
+        return jsonResponse({ access_token: 'token-a', expires_in: 300 });
+      }
+      if (method === 'GET' && path === '/admin/realms/tenant/clients?clientId=studio') {
+        return jsonResponse([
+          {
+            id: 'client-1',
+            clientId: 'studio',
+          },
+        ]);
+      }
+      if (
+        method === 'GET' &&
+        path === '/admin/realms/tenant/clients/client-1/protocol-mappers/models'
+      ) {
+        return jsonResponse([]);
+      }
+      if (method === 'POST') {
+        return noContentResponse();
+      }
+      return jsonResponse({ errorMessage: `Unhandled ${method} ${path}` }, { status: 500 });
+    });
+    const client = createClient(fetchImpl);
+
+    await expect(
+      client.ensureUserAttributeProtocolMapper({
+        clientId: 'studio',
+        name: 'instanceId',
+        userAttribute: 'instanceId',
+        claimName: 'instanceId',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(
+      requests.some(
+        (request) =>
+          request.method === 'POST' &&
+          request.path === '/admin/realms/tenant/clients/client-1/protocol-mappers/models' &&
+          request.body?.includes('"claim.name":"instanceId"')
+      )
+    ).toBe(true);
+  });
+
+  it('returns null for missing client secrets and ignores realm conflicts', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(String(input));
+      const method = init?.method ?? 'GET';
+      const path = `${url.pathname}${url.search}`;
+      if (path === '/realms/master/protocol/openid-connect/token') {
+        return jsonResponse({ access_token: 'token-a', expires_in: 300 });
+      }
+      if (method === 'POST' && path === '/admin/realms') {
+        return jsonResponse({ errorMessage: 'already exists' }, { status: 409 });
+      }
+      if (method === 'GET' && path === '/admin/realms/tenant/clients?clientId=missing-client') {
+        return jsonResponse([]);
+      }
+      return jsonResponse({ errorMessage: `Unhandled ${method} ${path}` }, { status: 500 });
+    });
+    const client = createClient(fetchImpl);
+
+    await expect(client.ensureRealm({ displayName: 'Tenant' })).resolves.toBeUndefined();
+    await expect(client.getOidcClientSecretValue('missing-client')).resolves.toBeNull();
+  });
 });

--- a/packages/core/src/iam/authorization-engine.test.ts
+++ b/packages/core/src/iam/authorization-engine.test.ts
@@ -151,6 +151,37 @@ describe('evaluateAuthorizeDecision', () => {
     expect(deniedResult.reason).toBe('permission_missing');
   });
 
+  it('allows globally scoped permissions without an organization id', () => {
+    const result = evaluateAuthorizeDecision(baseRequest(), [
+      {
+        ...basePermission(),
+        organizationId: undefined,
+      },
+    ]);
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('allowed_by_rbac');
+  });
+
+  it('denies organization-scoped permissions when the request has no target organization', () => {
+    const request: AuthorizeRequest = {
+      ...baseRequest(),
+      resource: {
+        ...baseRequest().resource,
+        organizationId: undefined,
+      },
+      context: {
+        ...baseRequest().context,
+        organizationId: undefined,
+      },
+    };
+
+    const result = evaluateAuthorizeDecision(request, [basePermission()]);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('permission_missing');
+  });
+
   it('denies with hierarchy restriction when organization is blocked', () => {
     const request: AuthorizeRequest = {
       ...baseRequest(),

--- a/packages/core/src/iam/runtime-diagnostics.ts
+++ b/packages/core/src/iam/runtime-diagnostics.ts
@@ -18,7 +18,78 @@ type RuntimeDiagnosticSafeDetails = Readonly<{
   safeDetails?: IamRuntimeSafeDetails;
 }>;
 
+const PRE_SYNC_REASON_CLASSIFICATIONS = new Map<string, IamRuntimeDiagnosticClassification>([
+  ['auth_resolution_failed', 'auth_resolution'],
+  ['auth_config_missing', 'auth_resolution'],
+  ['tenant_auth_resolution_failed', 'auth_resolution'],
+  ['tenant_auth_client_secret_unreadable', 'auth_resolution'],
+  ['oidc_discovery_failed', 'oidc_discovery_or_exchange'],
+  ['oidc_exchange_failed', 'oidc_discovery_or_exchange'],
+  ['oidc_callback_failed', 'oidc_discovery_or_exchange'],
+  ['token_exchange_failed', 'oidc_discovery_or_exchange'],
+  ['frontend_state_stale', 'frontend_state_or_permission_staleness'],
+  ['permission_snapshot_stale', 'frontend_state_or_permission_staleness'],
+  ['permission_refetch_failed', 'frontend_state_or_permission_staleness'],
+  ['legacy_workaround', 'legacy_workaround_or_regression'],
+  ['legacy_session_payload', 'legacy_workaround_or_regression'],
+  ['legacy_allowlist_fallback', 'legacy_workaround_or_regression'],
+  ['return_encrypted', 'legacy_workaround_or_regression'],
+  ['tenant_host_resolution_primary_hostname_fallback', 'legacy_workaround_or_regression'],
+  ['registry_or_provisioning_drift_blocked', 'registry_or_provisioning_drift'],
+]);
+
+const POST_SYNC_REASON_CLASSIFICATIONS = new Map<string, IamRuntimeDiagnosticClassification>([
+  ['tenant_lookup_failed', 'tenant_host_validation'],
+  ['tenant_host_invalid', 'tenant_host_validation'],
+  ['tenant_not_found', 'registry_or_provisioning_drift'],
+  ['tenant_inactive', 'registry_or_provisioning_drift'],
+]);
+
+const SESSION_REASON_CODES = new Set([
+  'token_refresh_failed',
+  'session_user_diagnostics',
+  'session_store_unavailable',
+  'missing_session_instance_id',
+]);
+
+const KEYCLOAK_REASON_CODES = new Set([
+  'keycloak_dependency_failed',
+  'keycloak_admin_not_configured',
+  'keycloak_unavailable',
+]);
+
+const DATABASE_REASON_CODES = new Set([
+  'schema_drift',
+  'missing_table',
+  'missing_column',
+  'database_not_configured',
+]);
+
+const DATABASE_MAPPING_REASON_CODES = new Set([
+  'jit_provision_failed',
+  'foreign_key_violation',
+  'rls_denied',
+]);
+
+const REGISTRY_DRIFT_INPUT_CODES = new Set([
+  'tenant_auth_client_secret_missing',
+  'tenant_admin_client_not_configured',
+  'tenant_admin_client_secret_missing',
+]);
+
+const SESSION_INPUT_CODES = new Set<ApiErrorCode>(['unauthorized', 'reauth_required']);
+const KEYCLOAK_INPUT_CODES = new Set<ApiErrorCode>(['keycloak_unavailable']);
+const DATABASE_INPUT_CODES = new Set<ApiErrorCode>(['database_unavailable']);
+
 const readString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
+const readReasonClassification = (
+  reasonCode: string | undefined,
+  classifications: ReadonlyMap<string, IamRuntimeDiagnosticClassification>
+): IamRuntimeDiagnosticClassification | undefined => (reasonCode ? classifications.get(reasonCode) : undefined);
+
+const matchesReasonCode = (reasonCode: string | undefined, reasonCodes: ReadonlySet<string>): boolean =>
+  reasonCode !== undefined && reasonCodes.has(reasonCode);
 
 const readSafeDetails = (details?: Readonly<Record<string, unknown>>): IamRuntimeSafeDetails | undefined => {
   if (!details) {
@@ -48,45 +119,10 @@ const readSafeDetails = (details?: Readonly<Record<string, unknown>>): IamRuntim
 const classify = ({ input, safeDetails }: RuntimeDiagnosticSafeDetails): IamRuntimeDiagnosticClassification => {
   const reasonCode = safeDetails?.reason_code;
   const syncErrorCode = safeDetails?.sync_error_code;
+  const preSyncClassification = readReasonClassification(reasonCode, PRE_SYNC_REASON_CLASSIFICATIONS);
 
-  if (
-    reasonCode === 'auth_resolution_failed' ||
-    reasonCode === 'auth_config_missing' ||
-    reasonCode === 'tenant_auth_resolution_failed' ||
-    reasonCode === 'tenant_auth_client_secret_unreadable'
-  ) {
-    return 'auth_resolution';
-  }
-
-  if (
-    reasonCode === 'oidc_discovery_failed' ||
-    reasonCode === 'oidc_exchange_failed' ||
-    reasonCode === 'oidc_callback_failed' ||
-    reasonCode === 'token_exchange_failed'
-  ) {
-    return 'oidc_discovery_or_exchange';
-  }
-
-  if (
-    reasonCode === 'frontend_state_stale' ||
-    reasonCode === 'permission_snapshot_stale' ||
-    reasonCode === 'permission_refetch_failed'
-  ) {
-    return 'frontend_state_or_permission_staleness';
-  }
-
-  if (
-    reasonCode === 'legacy_workaround' ||
-    reasonCode === 'legacy_session_payload' ||
-    reasonCode === 'legacy_allowlist_fallback' ||
-    reasonCode === 'return_encrypted' ||
-    reasonCode === 'tenant_host_resolution_primary_hostname_fallback'
-  ) {
-    return 'legacy_workaround_or_regression';
-  }
-
-  if (reasonCode === 'registry_or_provisioning_drift_blocked') {
-    return 'registry_or_provisioning_drift';
+  if (preSyncClassification) {
+    return preSyncClassification;
   }
 
   if (syncErrorCode === 'DB_WRITE_FAILED') {
@@ -97,25 +133,18 @@ const classify = ({ input, safeDetails }: RuntimeDiagnosticSafeDetails): IamRunt
     return 'keycloak_reconcile';
   }
 
-  if (reasonCode === 'tenant_lookup_failed' || reasonCode?.startsWith('tenant_host_resolution_')) {
+  if (reasonCode?.startsWith('tenant_host_resolution_')) {
     return 'tenant_host_validation';
   }
 
-  if (reasonCode === 'tenant_host_invalid') {
-    return 'tenant_host_validation';
-  }
-
-  if (reasonCode === 'tenant_not_found' || reasonCode === 'tenant_inactive') {
-    return 'registry_or_provisioning_drift';
+  const postSyncClassification = readReasonClassification(reasonCode, POST_SYNC_REASON_CLASSIFICATIONS);
+  if (postSyncClassification) {
+    return postSyncClassification;
   }
 
   if (
-    input.code === 'unauthorized' ||
-    input.code === 'reauth_required' ||
-    reasonCode === 'token_refresh_failed' ||
-    reasonCode === 'session_user_diagnostics' ||
-    reasonCode === 'session_store_unavailable' ||
-    reasonCode === 'missing_session_instance_id'
+    SESSION_INPUT_CODES.has(input.code as ApiErrorCode) ||
+    matchesReasonCode(reasonCode, SESSION_REASON_CODES)
   ) {
     return 'session_store_or_session_hydration';
   }
@@ -129,38 +158,19 @@ const classify = ({ input, safeDetails }: RuntimeDiagnosticSafeDetails): IamRunt
     return 'actor_resolution_or_membership';
   }
 
-  if (
-    input.code === 'keycloak_unavailable' ||
-    reasonCode === 'keycloak_dependency_failed' ||
-    reasonCode === 'keycloak_admin_not_configured' ||
-    reasonCode === 'keycloak_unavailable'
-  ) {
+  if (KEYCLOAK_INPUT_CODES.has(input.code as ApiErrorCode) || matchesReasonCode(reasonCode, KEYCLOAK_REASON_CODES)) {
     return 'keycloak_dependency';
   }
 
-  if (
-    input.code === 'database_unavailable' ||
-    reasonCode === 'schema_drift' ||
-    reasonCode === 'missing_table' ||
-    reasonCode === 'missing_column' ||
-    reasonCode === 'database_not_configured'
-  ) {
+  if (DATABASE_INPUT_CODES.has(input.code as ApiErrorCode) || matchesReasonCode(reasonCode, DATABASE_REASON_CODES)) {
     return 'database_or_schema_drift';
   }
 
-  if (
-    reasonCode === 'jit_provision_failed' ||
-    reasonCode === 'foreign_key_violation' ||
-    reasonCode === 'rls_denied'
-  ) {
+  if (matchesReasonCode(reasonCode, DATABASE_MAPPING_REASON_CODES)) {
     return 'database_mapping_or_membership_inconsistency';
   }
 
-  if (
-    input.code === 'tenant_auth_client_secret_missing' ||
-    input.code === 'tenant_admin_client_not_configured' ||
-    input.code === 'tenant_admin_client_secret_missing'
-  ) {
+  if (REGISTRY_DRIFT_INPUT_CODES.has(input.code)) {
     return 'registry_or_provisioning_drift';
   }
 

--- a/packages/data-repositories/src/instance-registry/index.test.ts
+++ b/packages/data-repositories/src/instance-registry/index.test.ts
@@ -460,6 +460,38 @@ describe('instance registry repository', () => {
     expect(statements[2]?.text).not.toContain('permission_key NOT IN (');
   });
 
+  it('sorts managed permission keys and role names alphabetically before writing IAM rows', async () => {
+    const { executor, statements } = createQueuedExecutor([[], [], [], [], [], [], [], [], []]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.syncAssignedModuleIam({
+        instanceId: 'tenant-a',
+        managedModuleIds: ['news'],
+        contracts: [
+          {
+            moduleId: 'news',
+            permissionIds: ['news.write', 'news.read'],
+            systemRoles: [
+              { roleName: 'news_editor', permissionIds: ['news.write'] },
+              { roleName: 'news_admin', permissionIds: ['news.read'] },
+            ],
+          },
+        ],
+      })
+    ).resolves.toBeUndefined();
+
+    const insertedPermissionKeys = statements
+      .filter((entry) => entry.text.includes('INSERT INTO iam.permissions'))
+      .map((entry) => entry.values[1]);
+    const insertedRoleNames = statements
+      .filter((entry) => entry.text.includes('INSERT INTO iam.roles'))
+      .map((entry) => entry.values[1]);
+
+    expect(insertedPermissionKeys).toEqual(['news.read', 'news.write']);
+    expect(insertedRoleNames).toEqual(['news_admin', 'news_editor']);
+  });
+
   it('resolves hostname variants and returns null when they are missing', async () => {
     const { executor } = createQueuedExecutor([[instanceRow], [], [instanceRow], []]);
     const repository = createInstanceRegistryRepository(executor);

--- a/packages/data-repositories/src/instance-registry/index.test.ts
+++ b/packages/data-repositories/src/instance-registry/index.test.ts
@@ -316,6 +316,29 @@ describe('instance registry repository', () => {
     });
   });
 
+  it('maps failed-only reconcile summaries without checkedAt or request correlation', async () => {
+    const { executor } = createQueuedExecutor([
+      [
+        {
+          sync_state: 'failed',
+          role_count: 2,
+          failed_count: 2,
+          pending_count: 0,
+          last_synced_at: null,
+          last_error_code: 'IDP_TIMEOUT',
+        },
+      ],
+      [{ request_id: null, created_at: '2026-04-29T10:04:00.000Z' }],
+    ]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(repository.getRoleReconcileSummary('tenant-a')).resolves.toEqual({
+      status: 'degraded',
+      summary: '2 Rollen mit Fehler.',
+      errorCode: 'IDP_TIMEOUT',
+    });
+  });
+
   it('creates and updates instances with hostname side effects', async () => {
     const { executor, statements } = createQueuedExecutor([[instanceRow], [], [instanceRow], []]);
     const repository = createInstanceRegistryRepository(executor);
@@ -490,6 +513,56 @@ describe('instance registry repository', () => {
 
     expect(insertedPermissionKeys).toEqual(['news.read', 'news.write']);
     expect(insertedRoleNames).toEqual(['news_admin', 'news_editor']);
+  });
+
+  it('skips managed-prefix permission cleanup when managed module ids are empty but still reconciles roles', async () => {
+    const { executor, statements } = createQueuedExecutor([[], [], [], []]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.syncAssignedModuleIam({
+        instanceId: 'tenant-a',
+        managedModuleIds: [],
+        contracts: [
+          {
+            moduleId: 'news',
+            permissionIds: ['news.write'],
+            systemRoles: [{ roleName: 'news_editor', permissionIds: ['news.write'] }],
+          },
+        ],
+      })
+    ).resolves.toBeUndefined();
+
+    expect(statements).toHaveLength(4);
+    expect(statements.some((statement) => statement.text.includes('DELETE FROM iam.permissions'))).toBe(false);
+    expect(statements[3]?.text).toContain('DELETE FROM iam.role_permissions');
+    expect(statements[3]?.text).toContain("NOT IN (('news_editor', 'news.write'))");
+  });
+
+  it('filters stale permissions only within managed prefixes and preserves desired keys in sorted order', async () => {
+    const { executor, statements } = createQueuedExecutor([[], [], [], [], [], [], []]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.syncAssignedModuleIam({
+        instanceId: 'tenant-a',
+        managedModuleIds: ['events', 'news'],
+        contracts: [
+          {
+            moduleId: 'news',
+            permissionIds: ['news.write', 'news.read'],
+            systemRoles: [{ roleName: 'news_admin', permissionIds: [] }],
+          },
+        ],
+      })
+    ).resolves.toBeUndefined();
+
+    const permissionCleanup = statements.find((statement) => statement.text.includes('DELETE FROM iam.permissions'));
+
+    expect(permissionCleanup?.text).toContain("permission_key NOT IN ('news.read', 'news.write')");
+    expect(permissionCleanup?.text).toContain("permission_key LIKE 'events.%'");
+    expect(permissionCleanup?.text).toContain("permission_key LIKE 'news.%'");
+    expect(permissionCleanup?.text).not.toContain("permission_key LIKE 'poi.%'");
   });
 
   it('resolves hostname variants and returns null when they are missing', async () => {

--- a/packages/data-repositories/src/instance-registry/index.ts
+++ b/packages/data-repositories/src/instance-registry/index.ts
@@ -79,6 +79,8 @@ type KeycloakProvisioningRunRow = {
   updated_at: string;
 };
 
+const compareAlphabetically = (left: string, right: string): number => left.localeCompare(right);
+
 type CreatedKeycloakProvisioningRunRow = KeycloakProvisioningRunRow & {
   created: boolean;
 };
@@ -536,10 +538,12 @@ WHERE instance_id = $1
   },
 
   async syncAssignedModuleIam({ instanceId, managedModuleIds, contracts }) {
-    const permissionKeys = Array.from(new Set(contracts.flatMap((contract) => contract.permissionIds))).sort();
+    const permissionKeys = Array.from(new Set(contracts.flatMap((contract) => contract.permissionIds))).sort(
+      compareAlphabetically
+    );
     const managedRoleNames = Array.from(
       new Set(contracts.flatMap((contract) => contract.systemRoles.map((role) => role.roleName)))
-    ).sort();
+    ).sort(compareAlphabetically);
     const rolePermissionPairs = contracts.flatMap((contract) =>
       contract.systemRoles.flatMap((role) =>
         role.permissionIds.map((permissionId) => ({

--- a/packages/data-repositories/src/instance-registry/index.ts
+++ b/packages/data-repositories/src/instance-registry/index.ts
@@ -361,6 +361,67 @@ const quoteSqlLiteral = (value: string): string => `'${value.split("'").join("''
 
 const createTextList = (values: readonly string[]): string => values.map(quoteSqlLiteral).join(', ');
 
+type RolePermissionPair = {
+  readonly roleName: string;
+  readonly permissionId: string;
+};
+
+const listManagedRoleNames = (contracts: readonly InstanceModuleIamContractRecord[]): readonly string[] =>
+  Array.from(new Set(contracts.flatMap((contract) => contract.systemRoles.map((role) => role.roleName)))).sort(
+    compareAlphabetically
+  );
+
+const listRolePermissionPairs = (contracts: readonly InstanceModuleIamContractRecord[]): readonly RolePermissionPair[] => {
+  const pairs: RolePermissionPair[] = [];
+  for (const contract of contracts) {
+    for (const role of contract.systemRoles) {
+      for (const permissionId of role.permissionIds) {
+        pairs.push({
+          roleName: role.roleName,
+          permissionId,
+        });
+      }
+    }
+  }
+  return pairs;
+};
+
+const createDesiredRolePermissionFilter = (pairs: readonly RolePermissionPair[]): string => {
+  if (pairs.length === 0) {
+    return '';
+  }
+
+  const desiredPairSql = pairs
+    .map((pair) => `(${quoteSqlLiteral(pair.roleName)}, ${quoteSqlLiteral(pair.permissionId)})`)
+    .join(', ');
+
+  return `AND (role.role_key, permission.permission_key) NOT IN (${desiredPairSql})`;
+};
+
+const createManagedModulePermissionFilter = (permissionKeys: readonly string[]): string => {
+  if (permissionKeys.length === 0) {
+    return '';
+  }
+
+  return `AND permission_key NOT IN (${createTextList(permissionKeys)})`;
+};
+
+const mapRoleReconcileStatus = (syncState: NonNullable<'synced' | 'pending' | 'failed' | null>): 'ready' | 'degraded' =>
+  syncState === 'synced' ? 'ready' : 'degraded';
+
+const formatRoleReconcileSummary = (failedCount: number, pendingCount: number): string => {
+  const parts: string[] = [];
+
+  if (failedCount > 0) {
+    parts.push(`${failedCount} Rollen mit Fehler`);
+  }
+  if (pendingCount > 0) {
+    parts.push(`${pendingCount} Rollen im Backlog`);
+  }
+
+  return parts.length > 0 ? `${parts.join(', ')}.` : 'Letzter Rollenabgleich ist synchron.';
+};
+
 const listKeycloakProvisioningStepRows = async (
   executor: SqlExecutor,
   runIds: readonly string[]
@@ -541,17 +602,8 @@ WHERE instance_id = $1
     const permissionKeys = Array.from(new Set(contracts.flatMap((contract) => contract.permissionIds))).sort(
       compareAlphabetically
     );
-    const managedRoleNames = Array.from(
-      new Set(contracts.flatMap((contract) => contract.systemRoles.map((role) => role.roleName)))
-    ).sort(compareAlphabetically);
-    const rolePermissionPairs = contracts.flatMap((contract) =>
-      contract.systemRoles.flatMap((role) =>
-        role.permissionIds.map((permissionId) => ({
-          roleName: role.roleName,
-          permissionId,
-        }))
-      )
-    );
+    const managedRoleNames = listManagedRoleNames(contracts);
+    const rolePermissionPairs = listRolePermissionPairs(contracts);
 
     for (const permissionKey of permissionKeys) {
       await executor.execute(
@@ -665,12 +717,7 @@ ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
     }
 
     if (managedRoleNames.length > 0) {
-      const desiredPairSql =
-        rolePermissionPairs.length > 0
-          ? rolePermissionPairs
-              .map((pair) => `(${quoteSqlLiteral(pair.roleName)}, ${quoteSqlLiteral(pair.permissionId)})`)
-              .join(', ')
-          : null;
+      const desiredRolePermissionFilter = createDesiredRolePermissionFilter(rolePermissionPairs);
 
       await executor.execute(
         statement(
@@ -683,11 +730,7 @@ WHERE role_permission.instance_id = $1
   AND permission.instance_id = role_permission.instance_id
   AND permission.id = role_permission.permission_id
   AND role.role_key IN (${createTextList(managedRoleNames)})
-  ${
-    desiredPairSql
-      ? `AND (role.role_key, permission.permission_key) NOT IN (${desiredPairSql})`
-      : ''
-  };
+  ${desiredRolePermissionFilter};
 `,
           [instanceId]
         )
@@ -698,8 +741,7 @@ WHERE role_permission.instance_id = $1
       const managedPrefixConditions = managedModuleIds
         .map((moduleId) => `permission_key LIKE ${quoteSqlLiteral(`${moduleId}.%`)}`)
         .join(' OR ');
-      const desiredPermissionFilter =
-        permissionKeys.length > 0 ? `AND permission_key NOT IN (${createTextList(permissionKeys)})` : '';
+      const desiredPermissionFilter = createManagedModulePermissionFilter(permissionKeys);
 
       await executor.execute(
         statement(
@@ -1019,16 +1061,8 @@ LIMIT 1;
       )
     );
     const correlation = correlationRows[0];
-    const status =
-      aggregate.sync_state === 'failed' ? 'degraded' : aggregate.sync_state === 'pending' ? 'degraded' : 'ready';
-    const summary =
-      aggregate.failed_count > 0 && aggregate.pending_count > 0
-        ? `${aggregate.failed_count} Rollen mit Fehler, ${aggregate.pending_count} Rollen im Backlog.`
-        : aggregate.failed_count > 0
-          ? `${aggregate.failed_count} Rollen mit Fehler.`
-          : aggregate.pending_count > 0
-            ? `${aggregate.pending_count} Rollen im Backlog.`
-            : 'Letzter Rollenabgleich ist synchron.';
+    const status = mapRoleReconcileStatus(aggregate.sync_state);
+    const summary = formatRoleReconcileSummary(aggregate.failed_count, aggregate.pending_count);
 
     return {
       status,

--- a/packages/data-repositories/src/integrations/instance-integrations.server.test.ts
+++ b/packages/data-repositories/src/integrations/instance-integrations.server.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  poolFactory: vi.fn(),
+}));
+
+vi.mock('@sva/server-runtime', () => ({
+  createSdkLogger: () => mocks.logger,
+}));
+
+vi.mock('pg', () => ({
+  Pool: function MockPool(config: unknown) {
+    return mocks.poolFactory(config);
+  },
+}));
+
+const record = {
+  instanceId: 'tenant-a',
+  providerKey: 'sva_mainserver' as const,
+  graphqlBaseUrl: 'https://main.example.test/graphql',
+  oauthTokenUrl: 'https://main.example.test/oauth/token',
+  enabled: true,
+  lastVerifiedAt: '2026-01-01T00:00:00.000Z',
+  lastVerifiedStatus: 'ok',
+};
+
+describe('instance integrations server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('reuses a custom cached loader until save clears it', async () => {
+    const { loadInstanceIntegrationRecord, saveInstanceIntegrationRecord } = await import('./instance-integrations.server.js');
+
+    const queries: string[] = [];
+    const release = vi.fn();
+    const connect = vi.fn(async () => ({
+      query: vi.fn(async (text: string) => {
+        queries.push(text);
+        return { rowCount: 0, rows: [] };
+      }),
+      release,
+    }));
+    mocks.poolFactory.mockReturnValue({
+      connect,
+    });
+
+    const loadRecord = vi.fn(async () => record);
+    const options = {
+      cacheTtlMs: 100,
+      now: () => 1_000,
+      getDatabaseUrl: () => 'postgres://db.example/sva',
+      loadRecord,
+    };
+
+    await expect(loadInstanceIntegrationRecord('tenant-a', 'sva_mainserver', options)).resolves.toEqual(record);
+    await expect(loadInstanceIntegrationRecord('tenant-a', 'sva_mainserver', options)).resolves.toEqual(record);
+    expect(loadRecord).toHaveBeenCalledTimes(1);
+
+    await saveInstanceIntegrationRecord(record, {
+      getDatabaseUrl: () => 'postgres://db.example/sva',
+    });
+
+    await expect(loadInstanceIntegrationRecord('tenant-a', 'sva_mainserver', options)).resolves.toEqual(record);
+    expect(loadRecord).toHaveBeenCalledTimes(2);
+    expect(queries).toContain('BEGIN');
+    expect(queries).toContain('COMMIT');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails fast when no IAM database url is configured', async () => {
+    const { saveInstanceIntegrationRecord } = await import('./instance-integrations.server.js');
+
+    await expect(
+      saveInstanceIntegrationRecord(record, {
+        getDatabaseUrl: () => undefined,
+      })
+    ).rejects.toThrow('IAM database not configured');
+
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      'database_not_configured',
+      expect.objectContaining({
+        operation: 'instance_integration_db_tx',
+        instance_id: 'tenant-a',
+      })
+    );
+  });
+
+  it('logs pool connection failures before rethrowing them', async () => {
+    const { loadInstanceIntegrationRecord } = await import('./instance-integrations.server.js');
+
+    mocks.poolFactory.mockReturnValue({
+      connect: vi.fn(async () => {
+        throw new Error('connect failed');
+      }),
+    });
+
+    await expect(
+      loadInstanceIntegrationRecord('tenant-a', 'sva_mainserver', {
+        getDatabaseUrl: () => 'postgres://db.example/sva',
+      })
+    ).rejects.toThrow('connect failed');
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'pool_connect_failed',
+      expect.objectContaining({
+        operation: 'instance_integration_db_tx',
+        instance_id: 'tenant-a',
+        error: 'connect failed',
+      })
+    );
+  });
+
+  it('rolls back and releases the client when the repository write fails', async () => {
+    const { saveInstanceIntegrationRecord } = await import('./instance-integrations.server.js');
+
+    const release = vi.fn();
+    const query = vi.fn(async (text: string) => {
+      if (text.includes('INSERT INTO iam.instance_integrations')) {
+        throw new Error('write failed');
+      }
+      return { rowCount: 0, rows: [] };
+    });
+    mocks.poolFactory.mockReturnValue({
+      connect: vi.fn(async () => ({
+        query,
+        release,
+      })),
+    });
+
+    await expect(
+      saveInstanceIntegrationRecord(record, {
+        getDatabaseUrl: () => 'postgres://db.example/sva',
+      })
+    ).rejects.toThrow('write failed');
+
+    expect(query).toHaveBeenCalledWith('ROLLBACK');
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      'instance_integration_db_tx_rolled_back',
+      expect.objectContaining({
+        operation: 'instance_integration_db_tx',
+        instance_id: 'tenant-a',
+        error: 'write failed',
+      })
+    );
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'instance_integration_db_tx_failed',
+      expect.objectContaining({
+        operation: 'instance_integration_db_tx',
+        instance_id: 'tenant-a',
+        error: 'write failed',
+      })
+    );
+  });
+});

--- a/packages/data-repositories/src/media/index.test.ts
+++ b/packages/data-repositories/src/media/index.test.ts
@@ -481,6 +481,25 @@ describe('media repository', () => {
     });
   });
 
+  it('fails closed for missing upload sessions and counts and throws on impossible storage adjustments', async () => {
+    const { executor, statements } = createQueuedExecutor([[], [], []]);
+    const repository = createMediaRepository(executor);
+
+    await expect(repository.countAssets({ instanceId: 'tenant-a' })).resolves.toBe(0);
+    await expect(repository.getUploadSessionById('tenant-a', 'upload-missing')).resolves.toBeNull();
+    await expect(
+      repository.adjustStorageUsage({
+        instanceId: 'tenant-a',
+        totalBytesDelta: 128,
+        assetCountDelta: 1,
+      })
+    ).rejects.toThrowError('media_storage_usage_adjust_failed:tenant-a');
+
+    expect(statements[0]?.values).toEqual(['tenant-a']);
+    expect(statements[1]?.values).toEqual(['tenant-a', 'upload-missing']);
+    expect(statements[2]?.values).toEqual(['tenant-a', 128, 1]);
+  });
+
   it('deletes assets in an instance-scoped way', async () => {
     const { executor, statements } = createQueuedExecutor([[]]);
     const repository = createMediaRepository(executor);

--- a/packages/data/src/instance-registry/index.ts
+++ b/packages/data/src/instance-registry/index.ts
@@ -79,6 +79,8 @@ type KeycloakProvisioningRunRow = {
   updated_at: string;
 };
 
+const compareAlphabetically = (left: string, right: string): number => left.localeCompare(right);
+
 type CreatedKeycloakProvisioningRunRow = KeycloakProvisioningRunRow & {
   created: boolean;
 };
@@ -538,7 +540,9 @@ WHERE instance_id = $1
   },
 
   async syncAssignedModuleIam({ instanceId, managedModuleIds, contracts }) {
-    const permissionKeys = Array.from(new Set(contracts.flatMap((contract) => contract.permissionIds))).sort();
+    const permissionKeys = Array.from(new Set(contracts.flatMap((contract) => contract.permissionIds))).sort(
+      compareAlphabetically
+    );
     const rolePermissionPairs = contracts.flatMap((contract) =>
       contract.systemRoles.flatMap((role) =>
         role.permissionIds.map((permissionId) => ({
@@ -547,7 +551,9 @@ WHERE instance_id = $1
         }))
       )
     );
-    const managedRoleNames = Array.from(new Set(rolePermissionPairs.map((pair) => pair.roleName))).sort();
+    const managedRoleNames = Array.from(new Set(rolePermissionPairs.map((pair) => pair.roleName))).sort(
+      compareAlphabetically
+    );
 
     for (const permissionKey of permissionKeys) {
       await executor.execute(

--- a/packages/data/src/instance-registry/index.vitest.test.ts
+++ b/packages/data/src/instance-registry/index.vitest.test.ts
@@ -389,6 +389,52 @@ describe('instance registry repository (vitest)', () => {
     expect(statements.slice(3).some((statement) => statement.text.includes('DELETE FROM iam.permissions'))).toBe(true);
   });
 
+  it('sorts managed permission keys and role names alphabetically before writing IAM rows', async () => {
+    const statements: SqlStatement[] = [];
+    const execute = createSequencedExecutor(
+      [
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+        { rowCount: 1, rows: [] },
+      ],
+      statements
+    );
+    const repository = createInstanceRegistryRepository({ execute });
+
+    await expect(
+      repository.syncAssignedModuleIam({
+        instanceId: 'demo',
+        managedModuleIds: ['news'],
+        contracts: [
+          {
+            moduleId: 'news',
+            permissionIds: ['news.write', 'news.read'],
+            systemRoles: [
+              { roleName: 'news_editor', permissionIds: ['news.write'] },
+              { roleName: 'news_admin', permissionIds: ['news.read'] },
+            ],
+          },
+        ],
+      })
+    ).resolves.toBeUndefined();
+
+    const insertedPermissionKeys = statements
+      .filter((statement) => statement.text.includes('INSERT INTO iam.permissions'))
+      .map((statement) => statement.values[1]);
+    const insertedRoleNames = statements
+      .filter((statement) => statement.text.includes('INSERT INTO iam.roles'))
+      .map((statement) => statement.values[1]);
+
+    expect(insertedPermissionKeys).toEqual(['news.read', 'news.write']);
+    expect(insertedRoleNames).toEqual(['news_admin', 'news_editor']);
+  });
+
   it('maps provisioning runs and audit events including optional fields', async () => {
     const execute = createSequencedExecutor([
       {

--- a/packages/iam-admin/src/group-mutation-handlers.test.ts
+++ b/packages/iam-admin/src/group-mutation-handlers.test.ts
@@ -116,6 +116,40 @@ describe('createGroupMutationHandlers', () => {
     });
   });
 
+  it('returns the role check response before touching the database', async () => {
+    const deps = createDeps([], {
+      requireRoles: vi.fn(() => createJsonResponse(403, { error: { code: 'forbidden' } })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.createGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups', { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(403);
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('maps duplicate group keys to a conflict response', async () => {
+    const deps = createDeps([], {
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('duplicate key value violates unique constraint "groups_instance_key_uniq"');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.createGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups', { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'conflict', message: 'Eine Gruppe mit diesem Schlüssel existiert bereits.' },
+    });
+  });
+
   it('returns 400 when an update contains no changes', async () => {
     const deps = createDeps([], {
       parseRequestBody: vi.fn(async () => ({ ok: true as const, data: {} })),
@@ -129,6 +163,49 @@ describe('createGroupMutationHandlers', () => {
 
     expect(response.status).toBe(400);
     expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid_request for malformed group ids on update', async () => {
+    const deps = createDeps([], {
+      readPathSegment: vi.fn(() => 'not-a-uuid'),
+      isUuid: vi.fn(() => false),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.updateGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups/not-a-uuid', { method: 'PATCH', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'invalid_request', message: 'Ungültige Gruppen-ID' },
+    });
+  });
+
+  it('returns not found when the target group does not exist during update', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({
+        ok: true as const,
+        data: { displayName: 'Renamed' },
+      })),
+      withInstanceScopedDb: vi.fn(async (_instanceId, work) =>
+        work({
+          query: vi.fn(async () => ({ rowCount: 0, rows: [] })),
+        } as never)
+      ),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.updateGroupInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}`, { method: 'PATCH', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'invalid_request', message: 'Gruppe nicht gefunden' },
+    });
   });
 
   it('deletes groups and publishes affected membership invalidations', async () => {

--- a/packages/iam-admin/src/group-mutation-handlers.test.ts
+++ b/packages/iam-admin/src/group-mutation-handlers.test.ts
@@ -150,6 +150,96 @@ describe('createGroupMutationHandlers', () => {
     });
   });
 
+  it('returns the csrf response before resolving the actor', async () => {
+    const deps = createDeps([], {
+      validateCsrf: vi.fn(() => createJsonResponse(419, { error: { code: 'csrf_failed' } })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.createGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups', { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(419);
+    expect(deps.resolveActorInfo).not.toHaveBeenCalled();
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('returns actor resolution errors before parsing the create payload', async () => {
+    const deps = createDeps([], {
+      resolveActorInfo: vi.fn(async () => ({ error: createJsonResponse(401, { error: { code: 'unauthorized' } }) })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.createGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups', { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(401);
+    expect(deps.parseRequestBody).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid_request for malformed create payloads', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({ ok: false as const })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.createGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups', { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'invalid_request', message: 'Ungültige Eingabe' },
+    });
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid_request when group creation payload parsing fails', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({ ok: false as const })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.createGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups', { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('logs and maps unexpected create failures to database_unavailable', async () => {
+    const deps = createDeps([], {
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('database offline');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.createGroupInternal(
+      new Request('http://localhost/api/v1/iam/inst-g/groups', { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(503);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Group creation failed',
+      expect.objectContaining({
+        operation: 'group_create',
+        workspace_id: 'inst-g',
+        error: 'database offline',
+        request_id: 'req-groups',
+        trace_id: 'trace-groups',
+      })
+    );
+  });
+
   it('returns 400 when an update contains no changes', async () => {
     const deps = createDeps([], {
       parseRequestBody: vi.fn(async () => ({ ok: true as const, data: {} })),
@@ -208,6 +298,84 @@ describe('createGroupMutationHandlers', () => {
     });
   });
 
+  it('updates groups, logs the mutation and returns the canonical id', async () => {
+    const query = vi.fn(async () => ({ rowCount: 1, rows: [{ id: groupId }] }));
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({
+        ok: true as const,
+        data: { displayName: 'Renamed', description: null, isActive: false },
+      })),
+      withInstanceScopedDb: vi.fn(async (_instanceId, work) => work({ query } as never)),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.updateGroupInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}`, { method: 'PATCH', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE iam.groups SET'),
+      ['inst-g', groupId, 'Renamed', null, false]
+    );
+    expect(deps.emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'iam_group_updated',
+        payload: { group_id: groupId, changes: { displayName: 'Renamed', description: null, isActive: false } },
+      })
+    );
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      'Group updated',
+      expect.objectContaining({ operation: 'group_update', workspace_id: 'inst-g', group_id: groupId })
+    );
+  });
+
+  it('logs and maps update database failures', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({
+        ok: true as const,
+        data: { displayName: 'Renamed' },
+      })),
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('update failed');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.updateGroupInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}`, { method: 'PATCH', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(503);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Group update failed',
+      expect.objectContaining({
+        operation: 'group_update',
+        workspace_id: 'inst-g',
+        group_id: groupId,
+        error: 'update failed',
+      })
+    );
+  });
+
+  it('returns invalid_request for malformed update payloads', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({ ok: false as const })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.updateGroupInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}`, { method: 'PATCH', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
   it('deletes groups and publishes affected membership invalidations', async () => {
     const deps = createDeps([
       {
@@ -239,6 +407,182 @@ describe('createGroupMutationHandlers', () => {
     );
   });
 
+  it('returns not found when deleting an unknown group', async () => {
+    const deps = createDeps([
+      { rowCount: 0, rows: [] },
+      { rowCount: 0, rows: [] },
+    ]);
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.deleteGroupInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}`, { method: 'DELETE' }),
+      ctx
+    );
+
+    expect(response.status).toBe(404);
+    expect(deps.publishGroupEvent).not.toHaveBeenCalled();
+  });
+
+  it('logs and maps delete database failures', async () => {
+    const deps = createDeps([], {
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('delete failed');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.deleteGroupInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}`, { method: 'DELETE' }),
+      ctx
+    );
+
+    expect(response.status).toBe(503);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Group deletion failed',
+      expect.objectContaining({
+        operation: 'group_delete',
+        workspace_id: 'inst-g',
+        group_id: groupId,
+        error: 'delete failed',
+      })
+    );
+  });
+
+  it('assigns roles to groups and publishes permission change events', async () => {
+    const deps = createDeps();
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.assignGroupRoleInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/roles`, { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.publishGroupEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        event: 'RolePermissionChanged',
+        instanceId: 'inst-g',
+        roleId: groupId,
+      })
+    );
+    expect(deps.emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'iam_group_role_assigned',
+        payload: { group_id: groupId, role_id: groupId },
+      })
+    );
+  });
+
+  it('rejects malformed role ids before removing group roles', async () => {
+    const deps = createDeps([], {
+      readPathSegment: vi.fn((_request, index) => (index === 6 ? 'not-a-role-id' : groupId)),
+      isUuid: vi.fn((value: string) => value !== 'not-a-role-id'),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.removeGroupRoleInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/roles/not-a-role-id`, { method: 'DELETE' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid_request for malformed group role payloads', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({ ok: false as const })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.assignGroupRoleInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/roles`, { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('logs and maps group role assignment failures', async () => {
+    const deps = createDeps([], {
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('role assign failed');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.assignGroupRoleInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/roles`, { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(503);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Group role assignment failed',
+      expect.objectContaining({
+        operation: 'group_role_assign',
+        workspace_id: 'inst-g',
+        group_id: groupId,
+        error: 'role assign failed',
+      })
+    );
+  });
+
+  it('removes group roles and emits the removal event', async () => {
+    const deps = createDeps();
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.removeGroupRoleInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/roles/${groupId}`, { method: 'DELETE' }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.publishGroupEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        event: 'RolePermissionChanged',
+        instanceId: 'inst-g',
+        roleId: groupId,
+      })
+    );
+    expect(deps.emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'iam_group_role_removed',
+        payload: { group_id: groupId, role_id: groupId },
+      })
+    );
+  });
+
+  it('logs and maps group role removal failures', async () => {
+    const deps = createDeps([], {
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('role removal failed');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.removeGroupRoleInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/roles/${groupId}`, { method: 'DELETE' }),
+      ctx
+    );
+
+    expect(response.status).toBe(503);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Group role removal failed',
+      expect.objectContaining({
+        operation: 'group_role_remove',
+        workspace_id: 'inst-g',
+        group_id: groupId,
+        error: 'role removal failed',
+      })
+    );
+  });
+
   it('returns not found when membership assignment cannot resolve the account', async () => {
     const deps = createDeps([{ rowCount: 0, rows: [] }]);
     const handlers = createGroupMutationHandlers(deps);
@@ -252,5 +596,156 @@ describe('createGroupMutationHandlers', () => {
     await expect(response.json()).resolves.toMatchObject({
       error: { code: 'invalid_request', message: 'Benutzer nicht gefunden' },
     });
+  });
+
+  it('assigns group memberships and publishes member added events', async () => {
+    const deps = createDeps([{ rowCount: 1, rows: [{ id: 'account-1' }] }]);
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.assignGroupMembershipInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/members`, { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.publishGroupEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        event: 'GroupMembershipChanged',
+        groupId,
+        accountId: 'account-1',
+        keycloakSubject: 'kc-user-1',
+        changeType: 'added',
+      })
+    );
+    expect(deps.emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'iam_group_member_added',
+        payload: { group_id: groupId, account_id: 'account-1' },
+      })
+    );
+  });
+
+  it('logs and maps unexpected membership assignment failures', async () => {
+    const deps = createDeps([], {
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('membership write failed');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.assignGroupMembershipInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/members`, { method: 'POST', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(503);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Group membership assignment failed',
+      expect.objectContaining({
+        operation: 'group_membership_add',
+        workspace_id: 'inst-g',
+        group_id: groupId,
+        error: 'membership write failed',
+      })
+    );
+  });
+
+  it('removes memberships and still succeeds when the membership account no longer resolves', async () => {
+    const deps = createDeps([{ rowCount: 0, rows: [] }], {
+      parseRequestBody: vi.fn(async () => ({
+        ok: true as const,
+        data: { keycloakSubject: 'missing-user' },
+      })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.removeGroupMembershipInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/members`, { method: 'DELETE', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.publishGroupEvent).not.toHaveBeenCalled();
+    expect(deps.emitActivityLog).not.toHaveBeenCalled();
+  });
+
+  it('removes memberships and publishes the removed event when the account resolves', async () => {
+    const deps = createDeps([{ rowCount: 1, rows: [{ id: 'account-1' }] }], {
+      parseRequestBody: vi.fn(async () => ({
+        ok: true as const,
+        data: { keycloakSubject: 'kc-user-1' },
+      })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.removeGroupMembershipInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/members`, { method: 'DELETE', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.publishGroupEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        event: 'GroupMembershipChanged',
+        groupId,
+        accountId: 'account-1',
+        keycloakSubject: 'kc-user-1',
+        changeType: 'removed',
+      })
+    );
+    expect(deps.emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'iam_group_member_removed',
+        payload: { group_id: groupId, account_id: 'account-1' },
+      })
+    );
+  });
+
+  it('returns invalid_request for malformed membership removal payloads', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({ ok: false as const })),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.removeGroupMembershipInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/members`, { method: 'DELETE', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('logs and maps membership removal failures', async () => {
+    const deps = createDeps([], {
+      parseRequestBody: vi.fn(async () => ({
+        ok: true as const,
+        data: { keycloakSubject: 'kc-user-1' },
+      })),
+      withInstanceScopedDb: vi.fn(async () => {
+        throw new Error('membership removal failed');
+      }),
+    });
+    const handlers = createGroupMutationHandlers(deps);
+
+    const response = await handlers.removeGroupMembershipInternal(
+      new Request(`http://localhost/api/v1/iam/inst-g/groups/${groupId}/members`, { method: 'DELETE', body: '{}' }),
+      ctx
+    );
+
+    expect(response.status).toBe(503);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Group membership removal failed',
+      expect.objectContaining({
+        operation: 'group_membership_remove',
+        workspace_id: 'inst-g',
+        group_id: groupId,
+        error: 'membership removal failed',
+      })
+    );
   });
 });

--- a/packages/iam-admin/src/organization-mutation-handlers.test.ts
+++ b/packages/iam-admin/src/organization-mutation-handlers.test.ts
@@ -237,6 +237,58 @@ describe('organization mutation handlers', () => {
     });
   });
 
+  it('returns the feature-gate response before resolving the actor', async () => {
+    const deps = buildDeps();
+    deps.ensureFeature = vi.fn(() => new Response('disabled', { status: 451 }));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.createOrganizationInternal(
+      new Request('http://localhost/api/v1/iam/organizations', { method: 'POST' }),
+      ctx
+    );
+
+    expect(response.status).toBe(451);
+    expect(deps.resolveActorInfo).not.toHaveBeenCalled();
+  });
+
+  it('replays an existing idempotent organization create result', async () => {
+    const deps = buildDeps();
+    deps.reserveIdempotency = vi.fn(async () => ({
+      status: 'replay',
+      responseStatus: 202,
+      responseBody: { data: { organizationKey: 'alpha' }, replayed: true },
+    }));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.createOrganizationInternal(
+      new Request('http://localhost/api/v1/iam/organizations', { method: 'POST' }),
+      ctx
+    );
+
+    expect(response.status).toBe(202);
+    await expect(json(response)).resolves.toMatchObject({ replayed: true });
+    expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
+  });
+
+  it('returns a conflict for reused idempotency keys with a different payload', async () => {
+    const deps = buildDeps();
+    deps.reserveIdempotency = vi.fn(async () => ({
+      status: 'conflict',
+      message: 'payload mismatch',
+    }));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.createOrganizationInternal(
+      new Request('http://localhost/api/v1/iam/organizations', { method: 'POST' }),
+      ctx
+    );
+
+    expect(response.status).toBe(409);
+    await expect(json(response)).resolves.toMatchObject({
+      error: { code: 'idempotency_key_reuse', message: 'payload mismatch' },
+    });
+  });
+
   it('switches the active organization context and invalidates permissions', async () => {
     const handlers = createOrganizationMutationHandlers(buildDeps());
 
@@ -253,5 +305,25 @@ describe('organization mutation handlers', () => {
       expect.anything(),
       expect.objectContaining({ trigger: 'organization_context_switched' })
     );
+  });
+
+  it('returns invalid_organization_id when the requested organization is outside the actor context', async () => {
+    const deps = buildDeps();
+    state.parseResult = {
+      ok: true,
+      data: { organizationId: '22222222-2222-2222-8222-222222222222' },
+      rawBody: '{}',
+    };
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.updateMyOrganizationContextInternal(
+      new Request('http://localhost/api/v1/iam/me/organization-context', { method: 'PATCH' }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    await expect(json(response)).resolves.toMatchObject({
+      error: { code: 'invalid_organization_id' },
+    });
   });
 });

--- a/packages/iam-admin/src/organization-mutation-handlers.test.ts
+++ b/packages/iam-admin/src/organization-mutation-handlers.test.ts
@@ -151,6 +151,17 @@ describe('organization mutation handlers', () => {
       },
       rawBody: '{}',
     };
+    state.contextOptions = [
+      {
+        organizationId: '11111111-1111-1111-8111-111111111111',
+        organizationKey: 'alpha',
+        isActive: true,
+      },
+    ];
+    state.detail = {
+      id: '11111111-1111-1111-8111-111111111111',
+      organizationKey: 'alpha',
+    };
   });
 
   it('creates organizations and completes idempotency', async () => {
@@ -289,6 +300,257 @@ describe('organization mutation handlers', () => {
     });
   });
 
+  it('updates organizations, rebuilds the subtree and returns the refreshed detail', async () => {
+    const deps = buildDeps();
+    const query = vi.fn(async () => ({ rowCount: 1, rows: [] }));
+    deps.parseRequestBody = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        displayName: 'Alpha 2',
+        parentOrganizationId: null,
+        metadata: { stage: 'beta' },
+      },
+      rawBody: '{}',
+    }));
+    deps.withInstanceScopedDb = vi.fn(async (_instanceId, work) => work({ query } as never));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.updateOrganizationInternal(
+      new Request('http://localhost/api/v1/iam/organizations/11111111-1111-1111-8111-111111111111', {
+        method: 'PATCH',
+        body: '{}',
+      }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE iam.organizations'),
+      [
+        'de-musterhausen',
+        '11111111-1111-1111-8111-111111111111',
+        null,
+        'Alpha 2',
+        null,
+        null,
+        null,
+        JSON.stringify({ stage: 'beta' }),
+        [],
+        0,
+      ]
+    );
+    expect(deps.rebuildOrganizationSubtree).toHaveBeenCalledWith(expect.anything(), {
+      instanceId: 'de-musterhausen',
+      organizationId: '11111111-1111-1111-8111-111111111111',
+    });
+    expect(emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'organization.updated',
+        payload: {
+          organizationId: '11111111-1111-1111-8111-111111111111',
+          parentOrganizationId: null,
+        },
+      })
+    );
+  });
+
+  it('returns conflict when updating an organization reuses an existing key', async () => {
+    const deps = buildDeps();
+    deps.parseRequestBody = vi.fn(async () => ({
+      ok: true as const,
+      data: { organizationKey: 'alpha-2' },
+      rawBody: '{}',
+    }));
+    deps.withInstanceScopedDb = vi.fn(async () => {
+      throw new Error('duplicate key value violates unique constraint "organizations_instance_key_uniq"');
+    });
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.updateOrganizationInternal(
+      new Request('http://localhost/api/v1/iam/organizations/11111111-1111-1111-8111-111111111111', {
+        method: 'PATCH',
+        body: '{}',
+      }),
+      ctx
+    );
+
+    expect(response.status).toBe(409);
+    await expect(json(response)).resolves.toMatchObject({
+      error: { code: 'conflict', message: 'Organisation mit diesem Schlüssel existiert bereits.' },
+    });
+  });
+
+  it('deactivates organizations without children or memberships', async () => {
+    const deps = buildDeps();
+    const query = vi.fn(async () => ({ rowCount: 1, rows: [] }));
+    deps.withInstanceScopedDb = vi.fn(async (_instanceId, work) => work({ query } as never));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.deactivateOrganizationInternal(
+      new Request('http://localhost/api/v1/iam/organizations/11111111-1111-1111-8111-111111111111', {
+        method: 'DELETE',
+      }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE iam.organizations'),
+      ['de-musterhausen', '11111111-1111-1111-8111-111111111111']
+    );
+    expect(emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'organization.deactivated',
+        payload: { organizationId: '11111111-1111-1111-8111-111111111111' },
+      })
+    );
+  });
+
+  it('rejects deactivation when the organization still has memberships', async () => {
+    const deps = buildDeps();
+    deps.loadOrganizationById = vi.fn(async () => ({
+      id: '11111111-1111-1111-8111-111111111111',
+      organization_key: 'alpha',
+      is_active: true,
+      parent_organization_id: null,
+      hierarchy_path: [],
+      depth: 0,
+      child_count: 0,
+      membership_count: 1,
+    }));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.deactivateOrganizationInternal(
+      new Request('http://localhost/api/v1/iam/organizations/11111111-1111-1111-8111-111111111111', {
+        method: 'DELETE',
+      }),
+      ctx
+    );
+
+    expect(response.status).toBe(409);
+    await expect(json(response)).resolves.toMatchObject({
+      error: { code: 'conflict', message: 'Organisation mit Children oder Memberships kann nicht deaktiviert werden.' },
+    });
+  });
+
+  it('assigns organization memberships, invalidates permissions and completes idempotency', async () => {
+    const deps = buildDeps();
+    const query = vi.fn(async (text: string) => {
+      if (text.includes('SELECT id')) {
+        return { rowCount: 1, rows: [{ id: 'account-2' }] };
+      }
+      if (text.includes('SELECT organization_id')) {
+        return { rowCount: 0, rows: [] };
+      }
+      return { rowCount: 1, rows: [] };
+    });
+    deps.parseRequestBody = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        accountId: '22222222-2222-2222-8222-222222222222',
+        visibility: 'internal',
+      },
+      rawBody: '{"accountId":"22222222-2222-2222-8222-222222222222"}',
+    }));
+    deps.withInstanceScopedDb = vi.fn(async (_instanceId, work) => work({ query } as never));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.assignOrganizationMembershipInternal(
+      new Request('http://localhost/api/v1/iam/organizations/11111111-1111-1111-8111-111111111111/memberships', {
+        method: 'POST',
+        body: '{}',
+      }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(notifyPermissionInvalidation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ instanceId: 'de-musterhausen', trigger: 'organization_membership_assigned' })
+    );
+    expect(emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'organization.membership_assigned',
+        payload: {
+          organizationId: '11111111-1111-1111-8111-111111111111',
+          accountId: '22222222-2222-2222-8222-222222222222',
+          isDefaultContext: true,
+        },
+      })
+    );
+    expect(completeIdempotency).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: 'POST:/api/v1/iam/organizations/$organizationId/memberships', status: 'COMPLETED' })
+    );
+  });
+
+  it('returns invalid_request when assigning membership to an account outside the instance', async () => {
+    const deps = buildDeps();
+    deps.parseRequestBody = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        accountId: '22222222-2222-2222-8222-222222222222',
+      },
+      rawBody: '{"accountId":"22222222-2222-2222-8222-222222222222"}',
+    }));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.assignOrganizationMembershipInternal(
+      new Request('http://localhost/api/v1/iam/organizations/11111111-1111-1111-8111-111111111111/memberships', {
+        method: 'POST',
+        body: '{}',
+      }),
+      ctx
+    );
+
+    expect(response.status).toBe(400);
+    await expect(json(response)).resolves.toMatchObject({
+      error: { code: 'invalid_request', message: 'Account gehört nicht zur aktiven Instanz.' },
+    });
+  });
+
+  it('removes organization memberships and promotes a fallback default context when needed', async () => {
+    const deps = buildDeps();
+    const query = vi.fn(async (text: string) => {
+      if (text.includes('SELECT is_default_context')) {
+        return { rowCount: 1, rows: [{ is_default_context: true }] };
+      }
+      return { rowCount: 1, rows: [] };
+    });
+    deps.withInstanceScopedDb = vi.fn(async (_instanceId, work) => work({ query } as never));
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.removeOrganizationMembershipInternal(
+      new Request(
+        'http://localhost/api/v1/iam/organizations/11111111-1111-1111-8111-111111111111/memberships/22222222-2222-2222-8222-222222222222',
+        { method: 'DELETE' }
+      ),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('WITH fallback_membership AS'),
+      ['de-musterhausen', '22222222-2222-2222-8222-222222222222']
+    );
+    expect(notifyPermissionInvalidation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ trigger: 'organization_membership_removed' })
+    );
+    expect(emitActivityLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'organization.membership_removed',
+        payload: {
+          organizationId: '11111111-1111-1111-8111-111111111111',
+          accountId: '22222222-2222-2222-8222-222222222222',
+        },
+      })
+    );
+  });
+
   it('switches the active organization context and invalidates permissions', async () => {
     const handlers = createOrganizationMutationHandlers(buildDeps());
 
@@ -305,6 +567,28 @@ describe('organization mutation handlers', () => {
       expect.anything(),
       expect.objectContaining({ trigger: 'organization_context_switched' })
     );
+  });
+
+  it('rejects inactive organizations as new active context', async () => {
+    const deps = buildDeps();
+    state.contextOptions = [
+      {
+        organizationId: '11111111-1111-1111-8111-111111111111',
+        organizationKey: 'alpha',
+        isActive: false,
+      },
+    ];
+    const handlers = createOrganizationMutationHandlers(deps);
+
+    const response = await handlers.updateMyOrganizationContextInternal(
+      new Request('http://localhost/api/v1/iam/me/organization-context', { method: 'PATCH' }),
+      ctx
+    );
+
+    expect(response.status).toBe(409);
+    await expect(json(response)).resolves.toMatchObject({
+      error: { code: 'organization_inactive', message: 'Inaktive Organisation kann kein aktiver Kontext sein.' },
+    });
   });
 
   it('returns invalid_organization_id when the requested organization is outside the actor context', async () => {

--- a/packages/instance-registry/src/service-helpers.ts
+++ b/packages/instance-registry/src/service-helpers.ts
@@ -41,63 +41,77 @@ const isConfigurationReady = (
 
 const tenantIamPrecedence: ReadonlyArray<IamTenantIamAxis['status']> = ['blocked', 'degraded', 'unknown', 'ready'];
 
+const createUnknownTenantIamAxis = (
+  source: IamTenantIamAxis['source'],
+  summary: string
+): IamTenantIamAxis =>
+  createTenantIamAxis({
+    status: 'unknown',
+    summary,
+    source,
+  });
+
+const buildConfigurationTenantIamAxis = (
+  keycloakStatus?: IamInstanceDetail['keycloakStatus']
+): IamTenantIamAxis => {
+  if (!keycloakStatus) {
+    return createUnknownTenantIamAxis('registry', 'Noch kein Strukturstatus für Tenant-IAM vorhanden.');
+  }
+
+  const configurationReady = isConfigurationReady(keycloakStatus);
+  return createTenantIamAxis({
+    status: configurationReady ? 'ready' : 'degraded',
+    summary: configurationReady
+      ? 'Tenant-IAM-Struktur ist vollständig vorhanden.'
+      : 'Tenant-IAM-Struktur ist unvollständig oder driftet.',
+    source: 'keycloak_status_snapshot',
+  });
+};
+
+const buildEvidenceTenantIamAxis = (
+  evidence: TenantIamEvidence | undefined,
+  fallback: { readonly source: IamTenantIamAxis['source']; readonly summary: string }
+): IamTenantIamAxis => (evidence ? createTenantIamAxis(evidence) : createUnknownTenantIamAxis(fallback.source, fallback.summary));
+
+const resolveTenantIamOverallStatus = (axes: readonly IamTenantIamAxis[]): IamTenantIamAxis['status'] =>
+  tenantIamPrecedence.find((candidate) => axes.some((axis) => axis.status === candidate)) ?? 'unknown';
+
+const resolveDominantTenantIamAxis = (
+  overallStatus: IamTenantIamAxis['status'],
+  axes: readonly IamTenantIamAxis[]
+): IamTenantIamAxis => axes.find((axis) => axis.status === overallStatus) ?? axes[0];
+
+const resolveTenantIamOverallSummary = (overallStatus: IamTenantIamAxis['status']): string => {
+  if (overallStatus === 'ready') {
+    return 'Tenant-IAM ist betriebsbereit.';
+  }
+  if (overallStatus === 'blocked') {
+    return 'Tenant-IAM ist blockiert.';
+  }
+  if (overallStatus === 'degraded') {
+    return 'Tenant-IAM ist eingeschränkt.';
+  }
+  return 'Tenant-IAM-Befund ist unvollständig.';
+};
+
 export const buildTenantIamStatus = (input: {
   keycloakStatus?: IamInstanceDetail['keycloakStatus'];
   accessEvidence?: TenantIamEvidence;
   reconcileEvidence?: TenantIamEvidence;
 }): IamTenantIamStatus => {
-  const configuration = input.keycloakStatus
-    ? createTenantIamAxis({
-        status: isConfigurationReady(input.keycloakStatus) ? 'ready' : 'degraded',
-        summary: isConfigurationReady(input.keycloakStatus)
-          ? 'Tenant-IAM-Struktur ist vollständig vorhanden.'
-          : 'Tenant-IAM-Struktur ist unvollständig oder driftet.',
-        source: 'keycloak_status_snapshot',
-      })
-    : createTenantIamAxis({
-        status: 'unknown',
-        summary: 'Noch kein Strukturstatus für Tenant-IAM vorhanden.',
-        source: 'registry',
-      });
-
-  const access = input.accessEvidence
-    ? createTenantIamAxis(input.accessEvidence)
-    : createTenantIamAxis({
-        status: 'unknown',
-        summary: 'Noch keine tenantlokale Rechteprobe vorhanden.',
-        source: 'access_probe',
-      });
-
-  const reconcile = input.reconcileEvidence
-    ? createTenantIamAxis(input.reconcileEvidence)
-    : createTenantIamAxis({
-        status: 'unknown',
-        summary: 'Noch kein Rollenabgleich ausgeführt.',
-        source: 'role_reconcile',
-      });
-
-  const overallStatus =
-    tenantIamPrecedence.find((candidate) =>
-      [configuration.status, access.status, reconcile.status].includes(candidate)
-    ) ?? 'unknown';
-
-  const dominantAxis =
-    overallStatus === configuration.status
-      ? configuration
-      : overallStatus === access.status
-        ? access
-        : overallStatus === reconcile.status
-          ? reconcile
-          : configuration;
-
-  const overallSummary =
-    overallStatus === 'ready'
-      ? 'Tenant-IAM ist betriebsbereit.'
-      : overallStatus === 'blocked'
-        ? 'Tenant-IAM ist blockiert.'
-        : overallStatus === 'degraded'
-          ? 'Tenant-IAM ist eingeschränkt.'
-          : 'Tenant-IAM-Befund ist unvollständig.';
+  const configuration = buildConfigurationTenantIamAxis(input.keycloakStatus);
+  const access = buildEvidenceTenantIamAxis(input.accessEvidence, {
+    source: 'access_probe',
+    summary: 'Noch keine tenantlokale Rechteprobe vorhanden.',
+  });
+  const reconcile = buildEvidenceTenantIamAxis(input.reconcileEvidence, {
+    source: 'role_reconcile',
+    summary: 'Noch kein Rollenabgleich ausgeführt.',
+  });
+  const axes = [configuration, access, reconcile] as const;
+  const overallStatus = resolveTenantIamOverallStatus(axes);
+  const dominantAxis = resolveDominantTenantIamAxis(overallStatus, axes);
+  const overallSummary = resolveTenantIamOverallSummary(overallStatus);
 
   return {
     configuration,

--- a/packages/monitoring-client/src/otel.server.ts
+++ b/packages/monitoring-client/src/otel.server.ts
@@ -237,7 +237,7 @@ export const createOtelSdk = (config: OtelConfig): NodeSDK => {
 
 export const startOtelSdk = async (config: OtelConfig): Promise<NodeSDK> => {
   const sdk = createOtelSdk(config);
-  await sdk.start();
+  await Promise.resolve(sdk.start());
 
   // Get global logger provider from OTEL API after SDK started
   // Note: Type casting needed as API logs and SDK logs use different LoggerProvider types at runtime

--- a/packages/plugin-sdk/src/plugins.ts
+++ b/packages/plugin-sdk/src/plugins.ts
@@ -524,206 +524,285 @@ export const definePluginModuleIamContract = <const TContract extends PluginModu
   return normalizedContract;
 };
 
+type PluginRegistryValidationContext = {
+  readonly plugin: PluginDefinition;
+  readonly pluginNamespace: string;
+  readonly displayName: string;
+};
+
+const createPluginRegistryValidationContext = (
+  plugin: PluginDefinition,
+  registry: ReadonlyMap<string, PluginDefinition>
+): PluginRegistryValidationContext => {
+  const contributionId = normalizePluginIdentifier(plugin.id);
+  assertPluginContributionAllowedKeys(
+    plugin as unknown as Record<string, unknown>,
+    pluginDefinitionAllowedKeys,
+    contributionId,
+    contributionId
+  );
+
+  const trimmedId = plugin.id.trim();
+  if (trimmedId.length === 0) {
+    throw new Error('invalid_plugin_definition');
+  }
+
+  const pluginNamespace = normalizePluginNamespace(trimmedId);
+  const displayName = plugin.displayName.trim();
+
+  if (pluginNamespace.length === 0 || displayName.length === 0) {
+    throw new Error('invalid_plugin_definition');
+  }
+  if (isReservedPluginNamespace(pluginNamespace)) {
+    throw new Error(`reserved_plugin_namespace:${pluginNamespace}`);
+  }
+  if (registry.has(pluginNamespace)) {
+    throw new Error(`duplicate_plugin:${pluginNamespace}`);
+  }
+
+  return {
+    plugin,
+    pluginNamespace,
+    displayName,
+  };
+};
+
+const assertPluginRegistryActions = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  for (const action of plugin.actions ?? []) {
+    assertPluginContributionAllowedKeys(
+      action as unknown as Record<string, unknown>,
+      actionDefinitionAllowedKeys,
+      pluginNamespace,
+      normalizePluginIdentifier(action.id)
+    );
+    assertPluginPermissionReference(plugin, pluginNamespace, action.id, action.requiredAction);
+  }
+};
+
+const assertOwnedPluginActionReference = (
+  plugin: PluginDefinition,
+  pluginNamespace: string,
+  actionId: string,
+  invalidError: string,
+  ownerMismatchError: string,
+  missingError: string
+): PluginActionDefinition => {
+  const parsed = parseNamespacedPluginIdentifier(actionId);
+  if (parsed === undefined) {
+    throw new Error(invalidError);
+  }
+  if (parsed.namespace !== pluginNamespace) {
+    throw new Error(ownerMismatchError);
+  }
+
+  const action = resolvePluginActionDefinition(plugin, actionId);
+  if (!action) {
+    throw new Error(missingError);
+  }
+
+  return action;
+};
+
+const assertPluginRegistryRoutes = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  for (const route of plugin.routes) {
+    assertPluginContributionAllowedKeys(
+      route as unknown as Record<string, unknown>,
+      routeDefinitionAllowedKeys,
+      pluginNamespace,
+      normalizePluginIdentifier(route.id)
+    );
+    assertPluginRoutePathAllowed(pluginNamespace, normalizePluginIdentifier(route.id), route.path);
+    assertPluginPermissionReference(plugin, pluginNamespace, route.id, route.guard);
+
+    const routeActionId = normalizePluginIdentifier(route.actionId ?? '');
+    if (!routeActionId) {
+      continue;
+    }
+
+    const action = assertOwnedPluginActionReference(
+      plugin,
+      pluginNamespace,
+      routeActionId,
+      `invalid_plugin_route_action_id:${pluginNamespace}:${route.id}:${routeActionId}`,
+      `plugin_route_action_owner_mismatch:${pluginNamespace}:${route.id}:${routeActionId}`,
+      `plugin_route_action_missing:${pluginNamespace}:${route.id}:${routeActionId}`
+    );
+    if (route.guard !== action.requiredAction) {
+      throw new Error(`plugin_route_action_guard_mismatch:${pluginNamespace}:${route.id}:${routeActionId}`);
+    }
+  }
+};
+
+const assertPluginRegistryStandardContentRouteGuardrails = ({
+  plugin,
+  pluginNamespace,
+}: PluginRegistryValidationContext): void => {
+  if (pluginUsesStandardContentAdminResource(plugin) === false) {
+    return;
+  }
+
+  for (const route of plugin.routes) {
+    if (isStandardCrudPluginRoute(pluginNamespace, route.path)) {
+      throw createPluginGuardrailError({
+        code: 'plugin_guardrail_route_bypass',
+        pluginNamespace,
+        contributionId: normalizePluginIdentifier(route.id),
+        fieldOrReason: 'path',
+      });
+    }
+  }
+};
+
+const assertPluginRegistryNavigation = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  for (const navigationItem of plugin.navigation ?? []) {
+    assertPluginContributionAllowedKeys(
+      navigationItem as unknown as Record<string, unknown>,
+      navigationItemAllowedKeys,
+      pluginNamespace,
+      normalizePluginIdentifier(navigationItem.id)
+    );
+    assertPluginPermissionReference(plugin, pluginNamespace, navigationItem.id, navigationItem.requiredAction);
+
+    const navigationActionId = normalizePluginIdentifier(navigationItem.actionId ?? '');
+    if (!navigationActionId) {
+      continue;
+    }
+
+    const action = assertOwnedPluginActionReference(
+      plugin,
+      pluginNamespace,
+      navigationActionId,
+      `invalid_plugin_navigation_action_id:${pluginNamespace}:${navigationItem.id}:${navigationActionId}`,
+      `plugin_navigation_action_owner_mismatch:${pluginNamespace}:${navigationItem.id}:${navigationActionId}`,
+      `plugin_navigation_action_missing:${pluginNamespace}:${navigationItem.id}:${navigationActionId}`
+    );
+    if (
+      navigationItem.requiredAction &&
+      action.requiredAction &&
+      navigationItem.requiredAction !== action.requiredAction
+    ) {
+      throw new Error(
+        `plugin_navigation_action_guard_mismatch:${pluginNamespace}:${navigationItem.id}:${navigationActionId}`
+      );
+    }
+  }
+};
+
+const assertPluginRegistryPermissions = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  for (const permission of plugin.permissions ?? []) {
+    assertPluginContributionAllowedKeys(
+      permission as unknown as Record<string, unknown>,
+      permissionDefinitionAllowedKeys,
+      pluginNamespace,
+      normalizePluginIdentifier(permission.id)
+    );
+    const normalizedPermission = normalizePluginPermissionDefinition(permission);
+    const parsed = parseNamespacedPluginIdentifier(normalizedPermission.id);
+    if (parsed === undefined) {
+      throw new Error(`invalid_plugin_permission_id:${normalizedPermission.id}`);
+    }
+    if (parsed.namespace !== pluginNamespace) {
+      throw new Error(
+        `plugin_permission_namespace_mismatch:${pluginNamespace}:${parsed.namespace}:${normalizedPermission.id}`
+      );
+    }
+  }
+};
+
+const assertPluginRegistryContentTypes = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  for (const contentTypeDefinition of plugin.contentTypes ?? []) {
+    const contributionId = normalizePluginIdentifier(contentTypeDefinition.contentType);
+    assertPluginContributionAllowedKeys(
+      contentTypeDefinition as unknown as Record<string, unknown>,
+      contentTypeDefinitionAllowedKeys,
+      pluginNamespace,
+      contributionId
+    );
+    const normalizedContentType = normalizePluginIdentifier(contentTypeDefinition.contentType);
+    const parsed = parseNamespacedPluginIdentifier(normalizedContentType);
+    if (parsed === undefined) {
+      throw new Error(`invalid_plugin_content_type:${normalizedContentType}`);
+    }
+    if (parsed.namespace !== pluginNamespace) {
+      throw new Error(
+        `plugin_content_type_namespace_mismatch:${pluginNamespace}:${parsed.namespace}:${normalizedContentType}`
+      );
+    }
+  }
+};
+
+const assertPluginRegistryAdminResources = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  for (const adminResource of plugin.adminResources ?? []) {
+    const contributionId = normalizePluginIdentifier(adminResource.resourceId);
+    assertPluginContributionAllowedKeys(
+      adminResource as unknown as Record<string, unknown>,
+      adminResourceDefinitionAllowedKeys,
+      pluginNamespace,
+      contributionId
+    );
+    const normalizedResourceId = normalizePluginIdentifier(adminResource.resourceId);
+    const parsed = parseNamespacedPluginIdentifier(normalizedResourceId);
+    if (parsed === undefined) {
+      throw new Error(`invalid_plugin_admin_resource:${normalizedResourceId}`);
+    }
+    if (parsed.namespace !== pluginNamespace) {
+      throw new Error(
+        `plugin_admin_resource_namespace_mismatch:${pluginNamespace}:${parsed.namespace}:${normalizedResourceId}`
+      );
+    }
+  }
+};
+
+const assertPluginRegistryAuditEvents = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  for (const eventDefinition of plugin.auditEvents ?? []) {
+    const contributionId = normalizePluginIdentifier(eventDefinition.eventType);
+    assertPluginContributionAllowedKeys(
+      eventDefinition as unknown as Record<string, unknown>,
+      auditEventDefinitionAllowedKeys,
+      pluginNamespace,
+      contributionId
+    );
+    const normalizedEventType = normalizePluginIdentifier(eventDefinition.eventType);
+    const parsed = parseNamespacedPluginIdentifier(normalizedEventType);
+    if (parsed === undefined) {
+      throw new Error(`invalid_plugin_audit_event_type:${normalizedEventType}`);
+    }
+    if (parsed.namespace !== pluginNamespace) {
+      throw new Error(
+        `plugin_audit_event_namespace_mismatch:${pluginNamespace}:${parsed.namespace}:${normalizedEventType}`
+      );
+    }
+  }
+};
+
+const assertPluginRegistryModuleIam = ({ plugin, pluginNamespace }: PluginRegistryValidationContext): void => {
+  if (plugin.moduleIam) {
+    definePluginModuleIamContract(pluginNamespace, plugin.moduleIam);
+  }
+};
+
 export const createPluginRegistry = (
   plugins: readonly PluginDefinition[]
 ): ReadonlyMap<string, PluginDefinition> => {
   const registry = new Map<string, PluginDefinition>();
 
   for (const plugin of plugins) {
-    assertPluginContributionAllowedKeys(
-      plugin as unknown as Record<string, unknown>,
-      pluginDefinitionAllowedKeys,
-      normalizePluginIdentifier(plugin.id),
-      normalizePluginIdentifier(plugin.id)
-    );
+    const context = createPluginRegistryValidationContext(plugin, registry);
 
-    const trimmedId = plugin.id.trim();
-    if (trimmedId.length === 0) {
-      throw new Error('invalid_plugin_definition');
-    }
+    assertPluginRegistryActions(context);
+    assertPluginRegistryRoutes(context);
+    assertPluginRegistryStandardContentRouteGuardrails(context);
+    assertPluginRegistryNavigation(context);
+    assertPluginRegistryPermissions(context);
+    assertPluginRegistryContentTypes(context);
+    assertPluginRegistryAdminResources(context);
+    assertPluginRegistryAuditEvents(context);
+    assertPluginRegistryModuleIam(context);
 
-    const id = normalizePluginNamespace(trimmedId);
-    const displayName = plugin.displayName.trim();
-
-    if (id.length === 0 || displayName.length === 0) {
-      throw new Error('invalid_plugin_definition');
-    }
-    if (isReservedPluginNamespace(id)) {
-      throw new Error(`reserved_plugin_namespace:${id}`);
-    }
-    if (registry.has(id)) {
-      throw new Error(`duplicate_plugin:${id}`);
-    }
-
-    for (const action of plugin.actions ?? []) {
-      assertPluginContributionAllowedKeys(
-        action as unknown as Record<string, unknown>,
-        actionDefinitionAllowedKeys,
-        id,
-        normalizePluginIdentifier(action.id)
-      );
-      assertPluginPermissionReference(plugin, id, action.id, action.requiredAction);
-    }
-
-    for (const route of plugin.routes) {
-      assertPluginContributionAllowedKeys(
-        route as unknown as Record<string, unknown>,
-        routeDefinitionAllowedKeys,
-        id,
-        normalizePluginIdentifier(route.id)
-      );
-      assertPluginRoutePathAllowed(id, normalizePluginIdentifier(route.id), route.path);
-      assertPluginPermissionReference(plugin, id, route.id, route.guard);
-
-      const routeActionId = normalizePluginIdentifier(route.actionId ?? '');
-      if (!routeActionId) {
-        continue;
-      }
-
-      const parsed = parseNamespacedPluginIdentifier(routeActionId);
-      if (parsed === undefined) {
-        throw new Error(`invalid_plugin_route_action_id:${id}:${route.id}:${routeActionId}`);
-      }
-      if (parsed.namespace !== id) {
-        throw new Error(`plugin_route_action_owner_mismatch:${id}:${route.id}:${routeActionId}`);
-      }
-
-      const action = resolvePluginActionDefinition(plugin, routeActionId);
-      if (!action) {
-        throw new Error(`plugin_route_action_missing:${id}:${route.id}:${routeActionId}`);
-      }
-      if (route.guard !== action.requiredAction) {
-        throw new Error(`plugin_route_action_guard_mismatch:${id}:${route.id}:${routeActionId}`);
-      }
-    }
-
-    if (pluginUsesStandardContentAdminResource(plugin)) {
-      for (const route of plugin.routes) {
-        if (isStandardCrudPluginRoute(id, route.path)) {
-          throw createPluginGuardrailError({
-            code: 'plugin_guardrail_route_bypass',
-            pluginNamespace: id,
-            contributionId: normalizePluginIdentifier(route.id),
-            fieldOrReason: 'path',
-          });
-        }
-      }
-    }
-
-    for (const navigationItem of plugin.navigation ?? []) {
-      assertPluginContributionAllowedKeys(
-        navigationItem as unknown as Record<string, unknown>,
-        navigationItemAllowedKeys,
-        id,
-        normalizePluginIdentifier(navigationItem.id)
-      );
-      assertPluginPermissionReference(plugin, id, navigationItem.id, navigationItem.requiredAction);
-
-      const navigationActionId = normalizePluginIdentifier(navigationItem.actionId ?? '');
-      if (!navigationActionId) {
-        continue;
-      }
-
-      const parsed = parseNamespacedPluginIdentifier(navigationActionId);
-      if (parsed === undefined) {
-        throw new Error(`invalid_plugin_navigation_action_id:${id}:${navigationItem.id}:${navigationActionId}`);
-      }
-      if (parsed.namespace !== id) {
-        throw new Error(`plugin_navigation_action_owner_mismatch:${id}:${navigationItem.id}:${navigationActionId}`);
-      }
-
-      const action = resolvePluginActionDefinition(plugin, navigationActionId);
-      if (!action) {
-        throw new Error(`plugin_navigation_action_missing:${id}:${navigationItem.id}:${navigationActionId}`);
-      }
-      if (
-        navigationItem.requiredAction &&
-        action.requiredAction &&
-        navigationItem.requiredAction !== action.requiredAction
-      ) {
-        throw new Error(`plugin_navigation_action_guard_mismatch:${id}:${navigationItem.id}:${navigationActionId}`);
-      }
-    }
-
-    for (const permission of plugin.permissions ?? []) {
-      assertPluginContributionAllowedKeys(
-        permission as unknown as Record<string, unknown>,
-        permissionDefinitionAllowedKeys,
-        id,
-        normalizePluginIdentifier(permission.id)
-      );
-      const normalizedPermission = normalizePluginPermissionDefinition(permission);
-      const parsed = parseNamespacedPluginIdentifier(normalizedPermission.id);
-      if (parsed === undefined) {
-        throw new Error(`invalid_plugin_permission_id:${normalizedPermission.id}`);
-      }
-      if (parsed.namespace !== id) {
-        throw new Error(`plugin_permission_namespace_mismatch:${id}:${parsed.namespace}:${normalizedPermission.id}`);
-      }
-    }
-
-    for (const contentTypeDefinition of plugin.contentTypes ?? []) {
-      const contributionId = normalizePluginIdentifier(contentTypeDefinition.contentType);
-      assertPluginContributionAllowedKeys(
-        contentTypeDefinition as unknown as Record<string, unknown>,
-        contentTypeDefinitionAllowedKeys,
-        id,
-        contributionId
-      );
-      const normalizedContentType = normalizePluginIdentifier(contentTypeDefinition.contentType);
-      const parsed = parseNamespacedPluginIdentifier(normalizedContentType);
-      if (parsed === undefined) {
-        throw new Error(`invalid_plugin_content_type:${normalizedContentType}`);
-      }
-      if (parsed.namespace !== id) {
-        throw new Error(`plugin_content_type_namespace_mismatch:${id}:${parsed.namespace}:${normalizedContentType}`);
-      }
-    }
-
-    for (const adminResource of plugin.adminResources ?? []) {
-      const contributionId = normalizePluginIdentifier(adminResource.resourceId);
-      assertPluginContributionAllowedKeys(
-        adminResource as unknown as Record<string, unknown>,
-        adminResourceDefinitionAllowedKeys,
-        id,
-        contributionId
-      );
-      const normalizedResourceId = normalizePluginIdentifier(adminResource.resourceId);
-      const parsed = parseNamespacedPluginIdentifier(normalizedResourceId);
-      if (parsed === undefined) {
-        throw new Error(`invalid_plugin_admin_resource:${normalizedResourceId}`);
-      }
-      if (parsed.namespace !== id) {
-        throw new Error(`plugin_admin_resource_namespace_mismatch:${id}:${parsed.namespace}:${normalizedResourceId}`);
-      }
-    }
-
-    for (const eventDefinition of plugin.auditEvents ?? []) {
-      const contributionId = normalizePluginIdentifier(eventDefinition.eventType);
-      assertPluginContributionAllowedKeys(
-        eventDefinition as unknown as Record<string, unknown>,
-        auditEventDefinitionAllowedKeys,
-        id,
-        contributionId
-      );
-      const normalizedEventType = normalizePluginIdentifier(eventDefinition.eventType);
-      const parsed = parseNamespacedPluginIdentifier(normalizedEventType);
-      if (parsed === undefined) {
-        throw new Error(`invalid_plugin_audit_event_type:${normalizedEventType}`);
-      }
-      if (parsed.namespace !== id) {
-        throw new Error(`plugin_audit_event_namespace_mismatch:${id}:${parsed.namespace}:${normalizedEventType}`);
-      }
-    }
-
-    if (plugin.moduleIam) {
-      definePluginModuleIamContract(id, plugin.moduleIam);
-    }
-
-    registry.set(id, {
+    registry.set(context.pluginNamespace, {
       ...plugin,
-      id,
-      displayName,
+      id: context.pluginNamespace,
+      displayName: context.displayName,
     });
   }
 

--- a/scripts/ci/patch-coverage-gate.ts
+++ b/scripts/ci/patch-coverage-gate.ts
@@ -6,6 +6,7 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 import { assertCoveragePolicy, findCoverageArtifacts, readJson, type CoveragePolicy } from './coverage-gate.ts';
+import { isSonarCoverageExcludedPath, readSonarCoverageExclusions } from './sonar-paths.ts';
 
 interface RunPatchCoverageGateOptions {
   rootDir?: string;
@@ -394,8 +395,11 @@ export function runPatchCoverageGate(options: RunPatchCoverageGateOptions = {}):
   const headRef = options.headRef ?? 'HEAD';
   const targetPct = options.targetPct ?? defaultTargetPct;
   const policy = loadPolicy(rootDir);
+  const sonarCoverageExclusions = readSonarCoverageExclusions(rootDir);
   const projectRoots = resolveProjectRoots(rootDir, policy);
-  const changedFiles = listChangedFiles(rootDir, baseRef, headRef, projectRoots);
+  const changedFiles = listChangedFiles(rootDir, baseRef, headRef, projectRoots).filter(
+    (changedFile) => !isSonarCoverageExcludedPath(changedFile.path, sonarCoverageExclusions)
+  );
   const coverageByFile = parseLcovLineCoverage(rootDir);
 
   let coveredLines = 0;

--- a/scripts/ci/sonar-new-code-gate.ts
+++ b/scripts/ci/sonar-new-code-gate.ts
@@ -6,6 +6,7 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 import { assertCoveragePolicy, findCoverageArtifacts, readJson, type CoveragePolicy } from './coverage-gate.ts';
+import { isSonarCoverageExcludedPath, readSonarCoverageExclusions } from './sonar-paths.ts';
 
 interface RunSonarNewCodeGateOptions {
   rootDir?: string;
@@ -420,8 +421,11 @@ export function runSonarNewCodeGate(options: RunSonarNewCodeGateOptions = {}): R
   const headRef = options.headRef ?? 'HEAD';
   const targetPct = options.targetPct ?? defaultTargetPct;
   const policy = loadPolicy(rootDir);
+  const sonarCoverageExclusions = readSonarCoverageExclusions(rootDir);
   const projectRoots = resolveProjectRoots(rootDir, policy);
-  const changedFiles = listChangedFiles(rootDir, baseRef, headRef, projectRoots);
+  const changedFiles = listChangedFiles(rootDir, baseRef, headRef, projectRoots).filter(
+    (changedFile) => !isSonarCoverageExcludedPath(changedFile.path, sonarCoverageExclusions)
+  );
   const coverageByFile = parseLcovCoverage(rootDir);
 
   let coveredLines = 0;

--- a/scripts/ci/sonar-paths.ts
+++ b/scripts/ci/sonar-paths.ts
@@ -15,6 +15,12 @@ const toGlobRegExp = (pattern: string): RegExp => {
     const char = pattern[index];
     if (char === '*') {
       if (pattern[index + 1] === '*') {
+        if (pattern[index + 2] === '/') {
+          source += '(?:.*/)?';
+          index += 3;
+          continue;
+        }
+
         source += '.*';
         index += 2;
         continue;

--- a/scripts/ci/sonar-paths.ts
+++ b/scripts/ci/sonar-paths.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 const SONAR_PROJECT_PROPERTIES = 'sonar-project.properties';
 const COVERAGE_EXCLUSIONS_KEY = 'sonar.coverage.exclusions';
 
-const normalizePath = (value: string): string => value.split(path.sep).join('/');
+const normalizePath = (value: string): string => value.replaceAll('\\', '/').split(path.sep).join('/');
 
 const escapeRegExp = (value: string): string => value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
 

--- a/scripts/ci/sonar-paths.ts
+++ b/scripts/ci/sonar-paths.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SONAR_PROJECT_PROPERTIES = 'sonar-project.properties';
+const COVERAGE_EXCLUSIONS_KEY = 'sonar.coverage.exclusions';
+
+const normalizePath = (value: string): string => value.split(path.sep).join('/');
+
+const escapeRegExp = (value: string): string => value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+
+const toGlobRegExp = (pattern: string): RegExp => {
+  let source = '';
+
+  for (let index = 0; index < pattern.length; ) {
+    const char = pattern[index];
+    if (char === '*') {
+      if (pattern[index + 1] === '*') {
+        source += '.*';
+        index += 2;
+        continue;
+      }
+
+      source += '[^/]*';
+      index += 1;
+      continue;
+    }
+
+    source += escapeRegExp(char);
+    index += 1;
+  }
+
+  return new RegExp(`^${source}$`);
+};
+
+const parseProperties = (contents: string): Map<string, string> => {
+  const entries = new Map<string, string>();
+
+  for (const line of contents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex < 0) {
+      continue;
+    }
+
+    entries.set(trimmed.slice(0, separatorIndex).trim(), trimmed.slice(separatorIndex + 1).trim());
+  }
+
+  return entries;
+};
+
+export const readSonarCoverageExclusions = (rootDir: string): string[] => {
+  const propertiesPath = path.join(rootDir, SONAR_PROJECT_PROPERTIES);
+  if (!fs.existsSync(propertiesPath)) {
+    return [];
+  }
+
+  const rawValue = parseProperties(fs.readFileSync(propertiesPath, 'utf8')).get(COVERAGE_EXCLUSIONS_KEY);
+  if (!rawValue) {
+    return [];
+  }
+
+  return rawValue
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+};
+
+export const isSonarCoverageExcludedPath = (filePath: string, exclusions: readonly string[]): boolean => {
+  const normalizedPath = normalizePath(filePath);
+  return exclusions.some((pattern) => toGlobRegExp(normalizePath(pattern)).test(normalizedPath));
+};

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,8 +18,8 @@ sonar.javascript.lcov.reportPaths=artifacts/sonar/lcov.info
 # TypeScript
 sonar.typescript.tsconfigPaths=tsconfig.base.json
 
-# Coverage-Ausschlüsse (nur generierte Artefakte)
-sonar.coverage.exclusions=apps/sva-studio-react/src/routeTree.gen.ts
+# Coverage-Ausschlüsse (nur generierte oder lokale Debug-Artefakte)
+sonar.coverage.exclusions=apps/sva-studio-react/src/routeTree.gen.ts,apps/sva-studio-react/src/routes/__debug/phase1-test/**
 
 # Copy-Paste-Detection-Ausschlüsse:
 # - Übersetzungsressourcen und generierte Artefakte

--- a/tooling/testing/coverage-policy.json
+++ b/tooling/testing/coverage-policy.json
@@ -16,16 +16,6 @@
   "exemptProjects": [
     "tooling-testing"
   ],
-  "newCodeExemptProjects": [
-    "auth-runtime",
-    "data-client",
-    "data-repositories",
-    "iam-admin",
-    "iam-governance",
-    "instance-registry",
-    "plugin-sdk",
-    "server-runtime"
-  ],
   "perProjectFloors": {
     "core": {
       "lines": 94,

--- a/tooling/testing/tests/patch-coverage-gate.test.ts
+++ b/tooling/testing/tests/patch-coverage-gate.test.ts
@@ -102,6 +102,12 @@ function writePolicy(rootDir: string, overrides: Record<string, unknown> = {}): 
   );
 }
 
+function writeSonarProjectProperties(rootDir: string, coverageExclusions: readonly string[] = []): void {
+  const contents =
+    coverageExclusions.length > 0 ? `sonar.coverage.exclusions=${coverageExclusions.join(',')}\n` : '\n';
+  fs.writeFileSync(path.join(rootDir, 'sonar-project.properties'), contents);
+}
+
 function writeSourceFile(rootDir: string, relativePath: string, contents: string): void {
   const absolutePath = path.join(rootDir, relativePath);
   fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
@@ -130,6 +136,48 @@ afterEach(() => {
 });
 
 describe('patch coverage gate', () => {
+  it('ignores files excluded from sonar coverage', async () => {
+    const runPatchCoverageGate = await loadRunPatchCoverageGate();
+    const rootDir = createTempWorkspace();
+    initGitRepo(rootDir);
+    writePolicy(rootDir, {
+      perProjectFloors: {
+        'sva-studio-react': {
+          lines: 0,
+          statements: 0,
+          functions: 0,
+          branches: 0,
+        },
+      },
+    });
+    writeSonarProjectProperties(rootDir, ['apps/sva-studio-react/src/routes/__debug/phase1-test/**']);
+    writeSourceFile(
+      rootDir,
+      'apps/sva-studio-react/src/routes/__debug/phase1-test/-index.ts',
+      'export const route = () => new Response("debug");\n'
+    );
+    commitAll(rootDir, 'base');
+    runGit(rootDir, ['checkout', '-b', 'feature/test']);
+
+    writeSourceFile(
+      rootDir,
+      'apps/sva-studio-react/src/routes/__debug/phase1-test/-index.ts',
+      'export const route = () => new Response("debug-2");\n'
+    );
+    commitAll(rootDir, 'change');
+
+    const result = runPatchCoverageGate({
+      rootDir,
+      baseRef: 'main',
+      headRef: 'HEAD',
+      targetPct: 85,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.consideredFiles).toBe(0);
+    expect(result.ignoredFiles).toBe(0);
+  });
+
   it('ignores coverage-exempt projects when computing patch coverage', async () => {
     const runPatchCoverageGate = await loadRunPatchCoverageGate();
     const rootDir = createTempWorkspace();

--- a/tooling/testing/tests/sonar-new-code-gate.test.ts
+++ b/tooling/testing/tests/sonar-new-code-gate.test.ts
@@ -108,6 +108,12 @@ function writePolicy(rootDir: string, overrides: Record<string, unknown> = {}): 
   );
 }
 
+function writeSonarProjectProperties(rootDir: string, coverageExclusions: readonly string[] = []): void {
+  const contents =
+    coverageExclusions.length > 0 ? `sonar.coverage.exclusions=${coverageExclusions.join(',')}\n` : '\n';
+  fs.writeFileSync(path.join(rootDir, 'sonar-project.properties'), contents);
+}
+
 function writeSourceFile(rootDir: string, relativePath: string, contents: string): void {
   const absolutePath = path.join(rootDir, relativePath);
   fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
@@ -175,6 +181,48 @@ describe('sonar new code gate', () => {
     expect(result.missedBranches).toBe(1);
     expect(result.coveragePct).toBe(66.67);
   }, 20_000);
+
+  it('ignores files excluded from sonar coverage', async () => {
+    const runSonarNewCodeGate = await loadRunSonarNewCodeGate();
+    const rootDir = createTempWorkspace();
+    initGitRepo(rootDir);
+    writePolicy(rootDir, {
+      perProjectFloors: {
+        'sva-studio-react': {
+          lines: 0,
+          statements: 0,
+          functions: 0,
+          branches: 0,
+        },
+      },
+    });
+    writeSonarProjectProperties(rootDir, ['apps/sva-studio-react/src/routes/__debug/phase1-test/**']);
+    writeSourceFile(
+      rootDir,
+      'apps/sva-studio-react/src/routes/__debug/phase1-test/-index.ts',
+      'export const route = () => new Response("debug");\n'
+    );
+    commitAll(rootDir, 'base');
+    runGit(rootDir, ['checkout', '-b', 'feature/test']);
+
+    writeSourceFile(
+      rootDir,
+      'apps/sva-studio-react/src/routes/__debug/phase1-test/-index.ts',
+      'export const route = () => new Response("debug-2");\n'
+    );
+    commitAll(rootDir, 'change');
+
+    const result = runSonarNewCodeGate({
+      rootDir,
+      baseRef: 'main',
+      headRef: 'HEAD',
+      targetPct: 85,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.consideredFiles).toBe(0);
+    expect(result.ignoredFiles).toBe(0);
+  });
 
   it('passes when changed lines and branches are fully covered', async () => {
     const runSonarNewCodeGate = await loadRunSonarNewCodeGate();

--- a/tooling/testing/tests/sonar-paths.test.ts
+++ b/tooling/testing/tests/sonar-paths.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isSonarCoverageExcludedPath, readSonarCoverageExclusions } from '../../../scripts/ci/sonar-paths.ts';
+
+const tempDirs: string[] = [];
+
+const createTempRoot = (): string => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sonar-paths-'));
+  tempDirs.push(tempRoot);
+  return tempRoot;
+};
+
+describe('sonar-paths', () => {
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads comma-separated sonar coverage exclusions from sonar-project.properties', () => {
+    const rootDir = createTempRoot();
+    fs.writeFileSync(
+      path.join(rootDir, 'sonar-project.properties'),
+      [
+        '# comment should be ignored',
+        'sonar.projectKey=smart-village-app_sva-studio',
+        'sonar.coverage.exclusions=apps/sva-studio-react/src/routeTree.gen.ts, apps/sva-studio-react/src/routes/__debug/phase1-test/**',
+      ].join('\n')
+    );
+
+    expect(readSonarCoverageExclusions(rootDir)).toEqual([
+      'apps/sva-studio-react/src/routeTree.gen.ts',
+      'apps/sva-studio-react/src/routes/__debug/phase1-test/**',
+    ]);
+  });
+
+  it('matches exact files, recursive globs and normalizes platform separators', () => {
+    const exclusions = [
+      'apps/sva-studio-react/src/routeTree.gen.ts',
+      'apps/sva-studio-react/src/routes/__debug/phase1-test/**',
+    ];
+
+    expect(isSonarCoverageExcludedPath('apps/sva-studio-react/src/routeTree.gen.ts', exclusions)).toBe(true);
+    expect(
+      isSonarCoverageExcludedPath(
+        'apps\\sva-studio-react\\src\\routes\\__debug\\phase1-test\\-index.ts',
+        exclusions
+      )
+    ).toBe(true);
+    expect(isSonarCoverageExcludedPath('apps/sva-studio-react/src/routes/home.tsx', exclusions)).toBe(false);
+  });
+});

--- a/tooling/testing/tests/sonar-paths.test.ts
+++ b/tooling/testing/tests/sonar-paths.test.ts
@@ -53,4 +53,14 @@ describe('sonar-paths', () => {
     ).toBe(true);
     expect(isSonarCoverageExcludedPath('apps/sva-studio-react/src/routes/home.tsx', exclusions)).toBe(false);
   });
+
+  it('matches sonar-style double-star globs with zero directory segments', () => {
+    const exclusions = ['**/routeTree.gen.ts', 'apps/**/home.tsx'];
+
+    expect(isSonarCoverageExcludedPath('routeTree.gen.ts', exclusions)).toBe(true);
+    expect(isSonarCoverageExcludedPath('apps/home.tsx', exclusions)).toBe(true);
+    expect(isSonarCoverageExcludedPath('apps/sva-studio-react/home.tsx', exclusions)).toBe(true);
+    expect(isSonarCoverageExcludedPath('apps/sva-studio-react/src/home.tsx', exclusions)).toBe(true);
+    expect(isSonarCoverageExcludedPath('routeTree.generated.ts', exclusions)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- align the local Sonar-like coverage gate with Sonar exclusions and remove local new-code exemptions
- fix Sonar reliability findings in instance registry string sorting
- raise coverage in auth runtime, IAM admin, and integration server hotspots

## Verification
- pnpm nx run data:test:unit
- pnpm nx run data-repositories:test:unit
- pnpm check:server-runtime
- pnpm nx run tooling-testing:test:unit
- pnpm nx run auth-runtime:test:coverage
- pnpm nx run iam-admin:test:coverage
- pnpm nx run data-repositories:test:coverage
- pnpm nx run data:test:coverage
- pnpm sonar-new-code-gate --base=origin/main
- pnpm nx affected --target=test:unit --base=origin/main

## Notes
- GitHub workflows in this repo only run on pull requests or pushes to main.
- SonarCloud scanning currently runs outside pull requests, so the external Sonar status will only update on the next main-branch analysis unless workflow configuration changes.
