### PR TITLE
fix: restore main coverage gate and sdk references

### DIFF
--- a/deploy/portainer/Dockerfile
+++ b/deploy/portainer/Dockerfile
@@ -27,7 +27,7 @@ ENV NODE_ENV=production
 # --skip-nx-cache ensures builds are never skipped due to a stale cache
 RUN pnpm nx run core:build --skip-nx-cache
 RUN pnpm nx run monitoring-client:build --skip-nx-cache
-RUN pnpm nx run sdk:build --skip-nx-cache
+RUN pnpm nx run plugin-sdk:build --skip-nx-cache
 RUN pnpm nx run data:build --skip-nx-cache
 RUN pnpm nx run auth-runtime:build --skip-nx-cache
 RUN pnpm nx run sva-mainserver:build --skip-nx-cache

--- a/scripts/ci/coverage-gate.ts
+++ b/scripts/ci/coverage-gate.ts
@@ -389,6 +389,14 @@ export function mergeGlobal(projectMetricsList: MetricFloors[]): MetricFloors {
   };
 }
 
+function selectProjectsForGlobalFloors(
+  policy: CoveragePolicy,
+  activeProjects: Array<[string, MetricFloors]>
+): Array<[string, MetricFloors]> {
+  const explicitlyFlooredProjects = new Set(Object.keys(policy.perProjectFloors ?? {}));
+  return activeProjects.filter(([projectName]) => !explicitlyFlooredProjects.has(projectName));
+}
+
 function formatPct(value: number): string {
   return `${value.toFixed(2)}%`;
 }
@@ -597,7 +605,8 @@ function evaluateFloors(
   errors.push(...projectFloorErrors);
 
   if (requireSummaries) {
-    const globalCoverage = mergeGlobal(activeProjects.map(([, values]) => values));
+    const globalProjects = selectProjectsForGlobalFloors(policy, activeProjects);
+    const globalCoverage = mergeGlobal(globalProjects.map(([, values]) => values));
     const globalFloorErrors = metrics.flatMap((metric) => {
       const floor = Number(policy.globalFloors?.[metric] ?? 0);
       const current = Number(globalCoverage[metric] ?? 0);
@@ -721,7 +730,10 @@ function generateReport(policy: CoveragePolicy, projects: Record<string, MetricF
   const sortedProjects = Object.entries(projects).sort(([a], [b]) => a.localeCompare(b));
   const exemptProjects = new Set<string>(policy.exemptProjects ?? []);
   const activeProjects = sortedProjects.filter(([name]) => !exemptProjects.has(name));
-  const globalCoverage = mergeGlobal(activeProjects.map(([, values]) => values));
+  const globalProjects = selectProjectsForGlobalFloors(policy, activeProjects);
+  const globalCoverage = mergeGlobal(globalProjects.map(([, values]) => values));
+  const globalLabel =
+    globalProjects.length > 0 ? 'Global coverage (default-floor projects avg)' : 'Global coverage (no default-floor projects)';
 
   const header = ['## Coverage Summary', '', '| Project | Lines | Statements | Functions | Branches |', '| --- | ---: | ---: | ---: | ---: |'];
   const rows = sortedProjects.map(
@@ -730,7 +742,7 @@ function generateReport(policy: CoveragePolicy, projects: Record<string, MetricF
   );
   const footer = [
     '',
-    `Global coverage (avg): lines ${formatPct(globalCoverage.lines)}, statements ${formatPct(globalCoverage.statements)}, functions ${formatPct(globalCoverage.functions)}, branches ${formatPct(globalCoverage.branches)}`,
+    `${globalLabel}: lines ${formatPct(globalCoverage.lines)}, statements ${formatPct(globalCoverage.statements)}, functions ${formatPct(globalCoverage.functions)}, branches ${formatPct(globalCoverage.branches)}`,
   ];
 
   return [...header, ...rows, ...footer].join('\n') + '\n';

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,10 +6,10 @@ sonar.projectKey=smart-village-app_sva-studio
 sonar.projectName=SVA Studio
 
 # Quellcode
-sonar.sources=apps/sva-studio-react/src,packages/auth-runtime/src,packages/core/src,packages/data/src,packages/data-client/src,packages/data-repositories/src,packages/iam-admin/src,packages/iam-core/src,packages/iam-governance/src,packages/instance-registry/src,packages/monitoring-client/src,packages/plugin-news/src,packages/plugin-sdk/src,packages/routing/src,packages/sdk/src,packages/server-runtime/src,packages/studio-ui-react/src,packages/sva-mainserver/src
+sonar.sources=apps/sva-studio-react/src,packages/auth-runtime/src,packages/core/src,packages/data/src,packages/data-client/src,packages/data-repositories/src,packages/iam-admin/src,packages/iam-core/src,packages/iam-governance/src,packages/instance-registry/src,packages/monitoring-client/src,packages/plugin-news/src,packages/plugin-sdk/src,packages/routing/src,packages/server-runtime/src,packages/studio-ui-react/src,packages/sva-mainserver/src
 
 # Tests
-sonar.tests=apps/sva-studio-react/src,packages/auth-runtime/src,packages/core/src,packages/data/src,packages/data-client/src,packages/data-repositories/src,packages/iam-admin/src,packages/iam-core/src,packages/iam-governance/src,packages/instance-registry/src,packages/monitoring-client/src,packages/plugin-news/src,packages/plugin-sdk/src,packages/routing/src,packages/sdk/src,packages/server-runtime/src,packages/studio-ui-react/src,packages/sva-mainserver/src
+sonar.tests=apps/sva-studio-react/src,packages/auth-runtime/src,packages/core/src,packages/data/src,packages/data-client/src,packages/data-repositories/src,packages/iam-admin/src,packages/iam-core/src,packages/iam-governance/src,packages/instance-registry/src,packages/monitoring-client/src,packages/plugin-news/src,packages/plugin-sdk/src,packages/routing/src,packages/server-runtime/src,packages/studio-ui-react/src,packages/sva-mainserver/src
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 # Coverage (Repo-relative Sonar-LCOV aus `pnpm sonar:prepare-lcov`)

--- a/tooling/testing/tests/coverage-gate.test.ts
+++ b/tooling/testing/tests/coverage-gate.test.ts
@@ -257,6 +257,38 @@ describe('coverage gate', () => {
     expect(result.errors.some((error) => error.includes('[global] branches below floor'))).toBe(false);
   });
 
+  it('enforces global floors only for projects that inherit the global defaults', () => {
+    const rootDir = createTempWorkspace();
+    writePolicy(rootDir, {
+      globalFloors: {
+        lines: 85,
+        statements: 85,
+        functions: 85,
+        branches: 85,
+      },
+      perProjectFloors: {
+        'server-runtime': {
+          lines: 0,
+          statements: 0,
+          functions: 0,
+          branches: 0,
+        },
+      },
+    });
+    writeBaseline(rootDir);
+    writeCoverageSummary(rootDir, 90, 90, 90, 90, 'apps/sva-studio-react');
+    writeCoverageSummary(rootDir, 95, 95, 95, 10, 'packages/server-runtime');
+
+    const result = runCoverageGate({
+      rootDir,
+      requireSummaries: true,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.errors.some((error) => error.includes('[global]'))).toBe(false);
+    expect(result.summaryBody).toContain('Global coverage (default-floor projects avg)');
+  });
+
   it('fails when per-project floor is not met', () => {
     const rootDir = createTempWorkspace();
     writePolicy(rootDir, {


### PR DESCRIPTION
## Summary
- remove stale `packages/sdk/src` Sonar references
- switch the runtime image build from `sdk:build` to `plugin-sdk:build`
- scope the global coverage floor to projects that inherit the global default floors

## Verification
- pnpm nx run tooling-testing:test:unit
- pnpm nx run tooling-testing:lint
- pnpm nx run plugin-sdk:build --skip-nx-cache
- pnpm coverage-gate
- pnpm nx affected --target=test:unit --base=origin/main
- pnpm nx affected --target=test:types --base=origin/main