### PR TITLE
[codex] bundle sonar cleanups into planned change work

### DIFF
--- a/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.test.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.test.ts
@@ -14,7 +14,9 @@ const state = vi.hoisted(() => ({
   listSvaMainserverPoi: vi.fn(),
   getSvaMainserverPoi: vi.fn(),
   deleteSvaMainserverPoi: vi.fn(),
-  createSdkLogger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn() })),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  createSdkLogger: vi.fn(() => ({ info: state.loggerInfo, warn: state.loggerWarn })),
   getWorkspaceContext: vi.fn(() => ({ requestId: 'req-1', traceId: 'trace-1' })),
 }));
 
@@ -469,6 +471,40 @@ describe('dispatchMainserverEventsPoiRequest', () => {
     await expect(response?.json()).resolves.toMatchObject({ error: 'invalid_request' });
     expect(state.createSvaMainserverEvent).not.toHaveBeenCalled();
     expect(state.createSvaMainserverPoi).not.toHaveBeenCalled();
+  });
+
+  it('does not log create success when event payload validation fails', async () => {
+    mockAuthorizedMutation();
+
+    const response = await dispatchMainserverEventsPoiRequest(
+      createRequest('https://studio.test/api/v1/mainserver/events', {
+        method: 'POST',
+        body: JSON.stringify({ description: 'ohne Titel' }),
+      })
+    );
+
+    expect(response?.status).toBe(400);
+    expect(state.loggerInfo).not.toHaveBeenCalledWith(
+      'Mainserver content route succeeded',
+      expect.objectContaining({ operation: 'mainserver_events_create' })
+    );
+  });
+
+  it('does not log update success when poi payload validation fails', async () => {
+    mockAuthorizedMutation();
+
+    const response = await dispatchMainserverEventsPoiRequest(
+      createRequest('https://studio.test/api/v1/mainserver/poi/poi-1', {
+        method: 'PATCH',
+        body: JSON.stringify({ description: 'ohne Name' }),
+      })
+    );
+
+    expect(response?.status).toBe(400);
+    expect(state.loggerInfo).not.toHaveBeenCalledWith(
+      'Mainserver content route succeeded',
+      expect.objectContaining({ operation: 'mainserver_poi_update' })
+    );
   });
 
   it('returns method-not-allowed for unsupported route methods', async () => {

--- a/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts
@@ -291,28 +291,30 @@ const buildEventInput = (input: {
   contact: ReturnType<typeof parseContact> extends Response | infer T | undefined ? T | undefined : never;
   urls: SvaMainserverEventInput['urls'] | undefined;
   tags: readonly string[] | undefined;
-}): SvaMainserverEventInput => ({
-  title: readString(input.body.title) as string,
-  ...(readString(input.body.description) ? { description: readString(input.body.description) } : {}),
-  ...(readString(input.body.externalId) ? { externalId: readString(input.body.externalId) } : {}),
-  ...(readString(input.body.keywords) ? { keywords: readString(input.body.keywords) } : {}),
-  ...(input.dates ? { dates: input.dates } : {}),
-  ...(readBoolean(input.body.repeat) !== undefined ? { repeat: readBoolean(input.body.repeat) } : {}),
-  ...(readString(input.body.categoryName) ? { categoryName: readString(input.body.categoryName) } : {}),
-  ...(input.categories ? { categories: input.categories } : {}),
-  ...(input.addresses ? { addresses: input.addresses } : {}),
-  ...(input.contact ? { contacts: [input.contact] } : {}),
-  ...(input.urls ? { urls: input.urls } : {}),
-  ...(input.tags ? { tags: input.tags } : {}),
-  ...(readString(input.body.recurring) ? { recurring: readString(input.body.recurring) } : {}),
-  ...(readString(input.body.recurringType) ? { recurringType: readString(input.body.recurringType) } : {}),
-  ...(readString(input.body.recurringInterval) ? { recurringInterval: readString(input.body.recurringInterval) } : {}),
-  ...(parseRecurringWeekdays(input.body.recurringWeekdays)
-    ? { recurringWeekdays: parseRecurringWeekdays(input.body.recurringWeekdays) }
-    : {}),
-  ...(readString(input.body.pointOfInterestId) ? { pointOfInterestId: readString(input.body.pointOfInterestId) } : {}),
-  ...(readBoolean(input.body.pushNotification) !== undefined ? { pushNotification: readBoolean(input.body.pushNotification) } : {}),
-});
+}): SvaMainserverEventInput => {
+  const recurringWeekdays = parseRecurringWeekdays(input.body.recurringWeekdays);
+
+  return {
+    title: readString(input.body.title) as string,
+    ...(readString(input.body.description) ? { description: readString(input.body.description) } : {}),
+    ...(readString(input.body.externalId) ? { externalId: readString(input.body.externalId) } : {}),
+    ...(readString(input.body.keywords) ? { keywords: readString(input.body.keywords) } : {}),
+    ...(input.dates ? { dates: input.dates } : {}),
+    ...(readBoolean(input.body.repeat) !== undefined ? { repeat: readBoolean(input.body.repeat) } : {}),
+    ...(readString(input.body.categoryName) ? { categoryName: readString(input.body.categoryName) } : {}),
+    ...(input.categories ? { categories: input.categories } : {}),
+    ...(input.addresses ? { addresses: input.addresses } : {}),
+    ...(input.contact ? { contacts: [input.contact] } : {}),
+    ...(input.urls ? { urls: input.urls } : {}),
+    ...(input.tags ? { tags: input.tags } : {}),
+    ...(readString(input.body.recurring) ? { recurring: readString(input.body.recurring) } : {}),
+    ...(readString(input.body.recurringType) ? { recurringType: readString(input.body.recurringType) } : {}),
+    ...(readString(input.body.recurringInterval) ? { recurringInterval: readString(input.body.recurringInterval) } : {}),
+    ...(recurringWeekdays ? { recurringWeekdays } : {}),
+    ...(readString(input.body.pointOfInterestId) ? { pointOfInterestId: readString(input.body.pointOfInterestId) } : {}),
+    ...(readBoolean(input.body.pushNotification) !== undefined ? { pushNotification: readBoolean(input.body.pushNotification) } : {}),
+  };
+};
 
 const buildPoiInput = (input: {
   body: Record<string, unknown>;
@@ -595,7 +597,9 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       }
       const response = await createContentForRoute(route, actor, request);
       const responseBody = (await response.clone().json().catch(() => null)) as { data?: { id?: string } } | null;
-      logSuccess(`mainserver_${route.contentKind}_create`, responseBody?.data?.id);
+      if (response.ok) {
+        logSuccess(`mainserver_${route.contentKind}_create`, responseBody?.data?.id);
+      }
       return response;
     }
 
@@ -614,7 +618,9 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
         return updateActor;
       }
       const response = await updateContentForRoute(route, updateActor, request);
-      logSuccess(`mainserver_${route.contentKind}_update`, route.itemId);
+      if (response.ok) {
+        logSuccess(`mainserver_${route.contentKind}_update`, route.itemId);
+      }
       return response;
     }
 

--- a/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts
@@ -263,17 +263,9 @@ const parseTags = (value: unknown): readonly string[] | Response | undefined => 
   return value.map(readString).filter((tag): tag is string => Boolean(tag));
 };
 
-const parseEventInput = async (request: Request): Promise<SvaMainserverEventInput | Response> => {
-  const body = (await request.json().catch(() => null)) as unknown;
-  if (!isRecord(body)) {
-    return errorJson(400, 'invalid_request', 'Event-Daten müssen als Objekt gesendet werden.');
-  }
-  const title = readString(body.title);
-  if (!title) {
-    return errorJson(400, 'invalid_request', 'Der Event-Titel ist erforderlich.');
-  }
-  const dates = Array.isArray(body.dates)
-    ? body.dates
+const parseEventDates = (value: unknown): readonly SvaMainserverDateInput[] | undefined =>
+  Array.isArray(value)
+    ? value
         .filter(isRecord)
         .map((date): SvaMainserverDateInput => ({
           ...(readString(date.weekday) ? { weekday: readString(date.weekday) } : {}),
@@ -287,6 +279,74 @@ const parseEventInput = async (request: Request): Promise<SvaMainserverEventInpu
             : {}),
         }))
     : undefined;
+
+const parseRecurringWeekdays = (value: unknown): readonly string[] | undefined =>
+  Array.isArray(value) ? value.map(readString).filter((entry): entry is string => Boolean(entry)) : undefined;
+
+const buildEventInput = (input: {
+  body: Record<string, unknown>;
+  dates: readonly SvaMainserverDateInput[] | undefined;
+  categories: SvaMainserverEventInput['categories'] | undefined;
+  addresses: SvaMainserverEventInput['addresses'] | undefined;
+  contact: ReturnType<typeof parseContact> extends Response | infer T | undefined ? T | undefined : never;
+  urls: SvaMainserverEventInput['urls'] | undefined;
+  tags: readonly string[] | undefined;
+}): SvaMainserverEventInput => ({
+  title: readString(input.body.title) as string,
+  ...(readString(input.body.description) ? { description: readString(input.body.description) } : {}),
+  ...(readString(input.body.externalId) ? { externalId: readString(input.body.externalId) } : {}),
+  ...(readString(input.body.keywords) ? { keywords: readString(input.body.keywords) } : {}),
+  ...(input.dates ? { dates: input.dates } : {}),
+  ...(readBoolean(input.body.repeat) !== undefined ? { repeat: readBoolean(input.body.repeat) } : {}),
+  ...(readString(input.body.categoryName) ? { categoryName: readString(input.body.categoryName) } : {}),
+  ...(input.categories ? { categories: input.categories } : {}),
+  ...(input.addresses ? { addresses: input.addresses } : {}),
+  ...(input.contact ? { contacts: [input.contact] } : {}),
+  ...(input.urls ? { urls: input.urls } : {}),
+  ...(input.tags ? { tags: input.tags } : {}),
+  ...(readString(input.body.recurring) ? { recurring: readString(input.body.recurring) } : {}),
+  ...(readString(input.body.recurringType) ? { recurringType: readString(input.body.recurringType) } : {}),
+  ...(readString(input.body.recurringInterval) ? { recurringInterval: readString(input.body.recurringInterval) } : {}),
+  ...(parseRecurringWeekdays(input.body.recurringWeekdays)
+    ? { recurringWeekdays: parseRecurringWeekdays(input.body.recurringWeekdays) }
+    : {}),
+  ...(readString(input.body.pointOfInterestId) ? { pointOfInterestId: readString(input.body.pointOfInterestId) } : {}),
+  ...(readBoolean(input.body.pushNotification) !== undefined ? { pushNotification: readBoolean(input.body.pushNotification) } : {}),
+});
+
+const buildPoiInput = (input: {
+  body: Record<string, unknown>;
+  categories: SvaMainserverPoiInput['categories'] | undefined;
+  addresses: SvaMainserverPoiInput['addresses'] | undefined;
+  contact: ReturnType<typeof parseContact> extends Response | infer T | undefined ? T | undefined : never;
+  webUrls: SvaMainserverPoiInput['webUrls'] | undefined;
+  tags: readonly string[] | undefined;
+}): SvaMainserverPoiInput => ({
+  name: readString(input.body.name) as string,
+  ...(readString(input.body.description) ? { description: readString(input.body.description) } : {}),
+  ...(readString(input.body.mobileDescription) ? { mobileDescription: readString(input.body.mobileDescription) } : {}),
+  ...(readString(input.body.externalId) ? { externalId: readString(input.body.externalId) } : {}),
+  ...(readString(input.body.keywords) ? { keywords: readString(input.body.keywords) } : {}),
+  ...(readBoolean(input.body.active) !== undefined ? { active: readBoolean(input.body.active) } : {}),
+  ...(readString(input.body.categoryName) ? { categoryName: readString(input.body.categoryName) } : {}),
+  ...(input.body.payload !== undefined ? { payload: input.body.payload } : {}),
+  ...(input.categories ? { categories: input.categories } : {}),
+  ...(input.addresses ? { addresses: input.addresses } : {}),
+  ...(input.contact ? { contact: input.contact } : {}),
+  ...(input.webUrls ? { webUrls: input.webUrls } : {}),
+  ...(input.tags ? { tags: input.tags } : {}),
+});
+
+const parseEventInput = async (request: Request): Promise<SvaMainserverEventInput | Response> => {
+  const body = (await request.json().catch(() => null)) as unknown;
+  if (!isRecord(body)) {
+    return errorJson(400, 'invalid_request', 'Event-Daten müssen als Objekt gesendet werden.');
+  }
+  const title = readString(body.title);
+  if (!title) {
+    return errorJson(400, 'invalid_request', 'Der Event-Titel ist erforderlich.');
+  }
+  const dates = parseEventDates(body.dates);
   const categories = parseCategories(body.categories);
   const addresses = parseAddressList(body.addresses);
   const contact = parseContact(body.contact);
@@ -307,28 +367,7 @@ const parseEventInput = async (request: Request): Promise<SvaMainserverEventInpu
   if (tags instanceof Response) {
     return tags;
   }
-  return {
-    title,
-    ...(readString(body.description) ? { description: readString(body.description) } : {}),
-    ...(readString(body.externalId) ? { externalId: readString(body.externalId) } : {}),
-    ...(readString(body.keywords) ? { keywords: readString(body.keywords) } : {}),
-    ...(dates ? { dates } : {}),
-    ...(readBoolean(body.repeat) !== undefined ? { repeat: readBoolean(body.repeat) } : {}),
-    ...(readString(body.categoryName) ? { categoryName: readString(body.categoryName) } : {}),
-    ...(categories ? { categories } : {}),
-    ...(addresses ? { addresses } : {}),
-    ...(contact ? { contacts: [contact] } : {}),
-    ...(urls ? { urls } : {}),
-    ...(tags ? { tags } : {}),
-    ...(readString(body.recurring) ? { recurring: readString(body.recurring) } : {}),
-    ...(readString(body.recurringType) ? { recurringType: readString(body.recurringType) } : {}),
-    ...(readString(body.recurringInterval) ? { recurringInterval: readString(body.recurringInterval) } : {}),
-    ...(Array.isArray(body.recurringWeekdays)
-      ? { recurringWeekdays: body.recurringWeekdays.map(readString).filter((value): value is string => Boolean(value)) }
-      : {}),
-    ...(readString(body.pointOfInterestId) ? { pointOfInterestId: readString(body.pointOfInterestId) } : {}),
-    ...(readBoolean(body.pushNotification) !== undefined ? { pushNotification: readBoolean(body.pushNotification) } : {}),
-  };
+  return buildEventInput({ body, dates, categories, addresses, contact, urls, tags });
 };
 
 const parsePoiInput = async (request: Request): Promise<SvaMainserverPoiInput | Response> => {
@@ -360,21 +399,7 @@ const parsePoiInput = async (request: Request): Promise<SvaMainserverPoiInput | 
   if (tags instanceof Response) {
     return tags;
   }
-  return {
-    name,
-    ...(readString(body.description) ? { description: readString(body.description) } : {}),
-    ...(readString(body.mobileDescription) ? { mobileDescription: readString(body.mobileDescription) } : {}),
-    ...(readString(body.externalId) ? { externalId: readString(body.externalId) } : {}),
-    ...(readString(body.keywords) ? { keywords: readString(body.keywords) } : {}),
-    ...(readBoolean(body.active) !== undefined ? { active: readBoolean(body.active) } : {}),
-    ...(readString(body.categoryName) ? { categoryName: readString(body.categoryName) } : {}),
-    ...(body.payload !== undefined ? { payload: body.payload } : {}),
-    ...(categories ? { categories } : {}),
-    ...(addresses ? { addresses } : {}),
-    ...(contact ? { contact } : {}),
-    ...(webUrls ? { webUrls } : {}),
-    ...(tags ? { tags } : {}),
-  };
+  return buildPoiInput({ body, categories, addresses, contact, webUrls, tags });
 };
 
 const toMainserverErrorResponse = (error: unknown): Response => {
@@ -449,6 +474,80 @@ const authorizeOrResponse = async (
   };
 };
 
+const listContentForRoute = async (
+  route: Extract<RouteMatch, { kind: 'collection' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string },
+  request: Request
+) => {
+  const listQuery = parseMainserverListQuery(request);
+  return route.contentKind === 'events'
+    ? listSvaMainserverEvents({ ...actor, ...listQuery })
+    : listSvaMainserverPoi({ ...actor, ...listQuery });
+};
+
+const getContentForRoute = async (
+  route: Extract<RouteMatch, { kind: 'item' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string }
+) =>
+  route.contentKind === 'events'
+    ? getSvaMainserverEvent({ ...actor, eventId: route.itemId })
+    : getSvaMainserverPoi({ ...actor, poiId: route.itemId });
+
+const createContentForRoute = async (
+  route: Extract<RouteMatch, { kind: 'collection' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string },
+  request: Request
+) => {
+  if (route.contentKind === 'events') {
+    const parsed = await parseEventInput(request);
+    if (parsed instanceof Response) {
+      return parsed;
+    }
+    const data = await createSvaMainserverEvent({ ...actor, event: parsed });
+    return json({ data }, 201);
+  }
+
+  const parsed = await parsePoiInput(request);
+  if (parsed instanceof Response) {
+    return parsed;
+  }
+  const data = await createSvaMainserverPoi({ ...actor, poi: parsed });
+  return json({ data }, 201);
+};
+
+const updateContentForRoute = async (
+  route: Extract<RouteMatch, { kind: 'item' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string },
+  request: Request
+) => {
+  if (route.contentKind === 'events') {
+    const parsed = await parseEventInput(request);
+    if (parsed instanceof Response) {
+      return parsed;
+    }
+    const data = await updateSvaMainserverEvent({ ...actor, eventId: route.itemId, event: parsed });
+    return json({ data });
+  }
+
+  const parsed = await parsePoiInput(request);
+  if (parsed instanceof Response) {
+    return parsed;
+  }
+  const data = await updateSvaMainserverPoi({ ...actor, poiId: route.itemId, poi: parsed });
+  return json({ data });
+};
+
+const deleteContentForRoute = async (
+  route: Extract<RouteMatch, { kind: 'item' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string }
+) => {
+  const data =
+    route.contentKind === 'events'
+      ? await deleteSvaMainserverEvent({ ...actor, eventId: route.itemId })
+      : await deleteSvaMainserverPoi({ ...actor, poiId: route.itemId });
+  return json({ data });
+};
+
 const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: AuthenticatedRequestContext) => {
   const workspaceContext = getWorkspaceContext();
   const logSuccess = (operation: string, contentId?: string) => {
@@ -470,11 +569,7 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const listQuery = parseMainserverListQuery(request);
-      const data =
-        route.contentKind === 'events'
-          ? await listSvaMainserverEvents({ ...actor, ...listQuery })
-          : await listSvaMainserverPoi({ ...actor, ...listQuery });
+      const data = await listContentForRoute(route, actor, request);
       logSuccess(`mainserver_${route.contentKind}_list`);
       return json(data);
     }
@@ -484,10 +579,7 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const data =
-        route.contentKind === 'events'
-          ? await getSvaMainserverEvent({ ...actor, eventId: route.itemId })
-          : await getSvaMainserverPoi({ ...actor, poiId: route.itemId });
+      const data = await getContentForRoute(route, actor);
       logSuccess(`mainserver_${route.contentKind}_detail`, route.itemId);
       return json({ data });
     }
@@ -501,22 +593,10 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      if (route.contentKind === 'events') {
-        const parsed = await parseEventInput(request);
-        if (parsed instanceof Response) {
-          return parsed;
-        }
-        const data = await createSvaMainserverEvent({ ...actor, event: parsed });
-        logSuccess('mainserver_events_create', data.id);
-        return json({ data }, 201);
-      }
-      const parsed = await parsePoiInput(request);
-      if (parsed instanceof Response) {
-        return parsed;
-      }
-      const data = await createSvaMainserverPoi({ ...actor, poi: parsed });
-      logSuccess('mainserver_poi_create', data.id);
-      return json({ data }, 201);
+      const response = await createContentForRoute(route, actor, request);
+      const responseBody = (await response.clone().json().catch(() => null)) as { data?: { id?: string } } | null;
+      logSuccess(`mainserver_${route.contentKind}_create`, responseBody?.data?.id);
+      return response;
     }
 
     if (route.kind === 'item' && request.method === 'PATCH') {
@@ -533,22 +613,9 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (updateActor instanceof Response) {
         return updateActor;
       }
-      if (route.contentKind === 'events') {
-        const parsed = await parseEventInput(request);
-        if (parsed instanceof Response) {
-          return parsed;
-        }
-        const data = await updateSvaMainserverEvent({ ...updateActor, eventId: route.itemId, event: parsed });
-        logSuccess('mainserver_events_update', route.itemId);
-        return json({ data });
-      }
-      const parsed = await parsePoiInput(request);
-      if (parsed instanceof Response) {
-        return parsed;
-      }
-      const data = await updateSvaMainserverPoi({ ...updateActor, poiId: route.itemId, poi: parsed });
-      logSuccess('mainserver_poi_update', route.itemId);
-      return json({ data });
+      const response = await updateContentForRoute(route, updateActor, request);
+      logSuccess(`mainserver_${route.contentKind}_update`, route.itemId);
+      return response;
     }
 
     if (route.kind === 'item' && request.method === 'DELETE') {
@@ -560,12 +627,9 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const data =
-        route.contentKind === 'events'
-          ? await deleteSvaMainserverEvent({ ...actor, eventId: route.itemId })
-          : await deleteSvaMainserverPoi({ ...actor, poiId: route.itemId });
+      const response = await deleteContentForRoute(route, actor);
       logSuccess(`mainserver_${route.contentKind}_delete`, route.itemId);
-      return json({ data });
+      return response;
     }
 
     return errorJson(405, 'method_not_allowed', 'Methode wird für diesen Mainserver-Inhalt nicht unterstützt.');

--- a/apps/sva-studio-react/src/lib/mainserver-news-api.server.ts
+++ b/apps/sva-studio-react/src/lib/mainserver-news-api.server.ts
@@ -241,6 +241,78 @@ const parseAddress = (value: unknown): SvaMainserverNewsInput['address'] | undef
   };
 };
 
+const parseContentBlockMediaContents = (
+  value: unknown
+): Array<NonNullable<NonNullable<SvaMainserverNewsInput['contentBlocks']>[number]['mediaContents']>[number]> | Response => {
+  const mediaContents: Array<
+    NonNullable<NonNullable<SvaMainserverNewsInput['contentBlocks']>[number]['mediaContents']>[number]
+  > = [];
+
+  if (value === undefined || value === null) {
+    return mediaContents;
+  }
+  if (!Array.isArray(value)) {
+    return errorJson(400, 'invalid_request', 'MediaContent muss als Liste gesendet werden.');
+  }
+
+  for (const media of value) {
+    if (!isRecord(media)) {
+      return errorJson(400, 'invalid_request', 'MediaContent-Einträge müssen Objekte sein.');
+    }
+    const sourceUrl = parseWebUrl(media.sourceUrl);
+    if (sourceUrl instanceof Response) {
+      return sourceUrl;
+    }
+    mediaContents.push({
+      ...(readString(media.captionText) ? { captionText: readString(media.captionText) } : {}),
+      ...(readString(media.copyright) ? { copyright: readString(media.copyright) } : {}),
+      ...(readString(media.contentType) ? { contentType: readString(media.contentType) } : {}),
+      ...(readNumber(media.height) !== undefined ? { height: readNumber(media.height) } : {}),
+      ...(readNumber(media.width) !== undefined ? { width: readNumber(media.width) } : {}),
+      ...(sourceUrl ? { sourceUrl } : {}),
+    });
+  }
+
+  return mediaContents;
+};
+
+const hasValidContentBlocks = (blocks: readonly NonNullable<SvaMainserverNewsInput['contentBlocks']>[number][]) =>
+  blocks.length > 0 &&
+  blocks.some((block) => block.body && getVisibleTextLength(block.body) > 0) &&
+  blocks.every((block) => (block.body?.length ?? 0) <= 50_000);
+
+const buildNewsInput = (input: {
+  body: Record<string, unknown>;
+  publishedAt: string;
+  publicationDate?: string;
+  charactersToBeShown?: number;
+  categories: SvaMainserverNewsInput['categories'] | undefined;
+  sourceUrl: SvaMainserverNewsInput['sourceUrl'] | undefined;
+  address: SvaMainserverNewsInput['address'] | undefined;
+  contentBlocks: SvaMainserverNewsInput['contentBlocks'] | undefined;
+  allowPushNotification: boolean;
+}): SvaMainserverNewsInput => ({
+  title: readString(input.body.title) as string,
+  publishedAt: input.publishedAt,
+  ...(readString(input.body.author) ? { author: readString(input.body.author) } : {}),
+  ...(readString(input.body.keywords) ? { keywords: readString(input.body.keywords) } : {}),
+  ...(readString(input.body.externalId) ? { externalId: readString(input.body.externalId) } : {}),
+  ...(readBoolean(input.body.fullVersion) !== undefined ? { fullVersion: readBoolean(input.body.fullVersion) } : {}),
+  ...(input.charactersToBeShown !== undefined ? { charactersToBeShown: input.charactersToBeShown } : {}),
+  ...(readString(input.body.newsType) ? { newsType: readString(input.body.newsType) } : {}),
+  ...(input.publicationDate ? { publicationDate: input.publicationDate } : {}),
+  ...(readBoolean(input.body.showPublishDate) !== undefined ? { showPublishDate: readBoolean(input.body.showPublishDate) } : {}),
+  ...(readString(input.body.categoryName) ? { categoryName: readString(input.body.categoryName) } : {}),
+  ...(input.categories ? { categories: input.categories } : {}),
+  ...(input.sourceUrl ? { sourceUrl: input.sourceUrl } : {}),
+  ...(input.address ? { address: input.address } : {}),
+  ...(input.contentBlocks ? { contentBlocks: input.contentBlocks } : {}),
+  ...(readString(input.body.pointOfInterestId) ? { pointOfInterestId: readString(input.body.pointOfInterestId) } : {}),
+  ...(input.allowPushNotification && readBoolean(input.body.pushNotification) !== undefined
+    ? { pushNotification: readBoolean(input.body.pushNotification) }
+    : {}),
+});
+
 const parseContentBlocks = (value: unknown): SvaMainserverNewsInput['contentBlocks'] | undefined | Response => {
   if (value === undefined || value === null) {
     return errorJson(400, 'invalid_request', 'Mindestens ein Inhaltsblock benötigt Inhalt und darf maximal 50.000 Zeichen haben.');
@@ -254,30 +326,9 @@ const parseContentBlocks = (value: unknown): SvaMainserverNewsInput['contentBloc
     if (!isRecord(block)) {
       return errorJson(400, 'invalid_request', 'ContentBlocks müssen Objekte sein.');
     }
-    const mediaContents: Array<
-      NonNullable<NonNullable<SvaMainserverNewsInput['contentBlocks']>[number]['mediaContents']>[number]
-    > = [];
-    if (block.mediaContents !== undefined && block.mediaContents !== null) {
-      if (!Array.isArray(block.mediaContents)) {
-        return errorJson(400, 'invalid_request', 'MediaContent muss als Liste gesendet werden.');
-      }
-      for (const media of block.mediaContents) {
-        if (!isRecord(media)) {
-          return errorJson(400, 'invalid_request', 'MediaContent-Einträge müssen Objekte sein.');
-        }
-        const sourceUrl = parseWebUrl(media.sourceUrl);
-        if (sourceUrl instanceof Response) {
-          return sourceUrl;
-        }
-        mediaContents.push({
-          ...(readString(media.captionText) ? { captionText: readString(media.captionText) } : {}),
-          ...(readString(media.copyright) ? { copyright: readString(media.copyright) } : {}),
-          ...(readString(media.contentType) ? { contentType: readString(media.contentType) } : {}),
-          ...(readNumber(media.height) !== undefined ? { height: readNumber(media.height) } : {}),
-          ...(readNumber(media.width) !== undefined ? { width: readNumber(media.width) } : {}),
-          ...(sourceUrl ? { sourceUrl } : {}),
-        });
-      }
+    const mediaContents = parseContentBlockMediaContents(block.mediaContents);
+    if (mediaContents instanceof Response) {
+      return mediaContents;
     }
     blocks.push({
       ...(readString(block.title) ? { title: readString(block.title) } : {}),
@@ -286,11 +337,7 @@ const parseContentBlocks = (value: unknown): SvaMainserverNewsInput['contentBloc
       ...(mediaContents.length > 0 ? { mediaContents } : {}),
     });
   }
-  if (
-    blocks.length === 0 ||
-    blocks.some((block) => (block.body?.length ?? 0) > 50_000) ||
-    blocks.some((block) => block.body && getVisibleTextLength(block.body) > 0) === false
-  ) {
+  if (!hasValidContentBlocks(blocks)) {
     return errorJson(400, 'invalid_request', 'Mindestens ein Inhaltsblock benötigt Inhalt und darf maximal 50.000 Zeichen haben.');
   }
   return blocks;
@@ -356,27 +403,17 @@ const parseNewsInput = async (request: Request, options: ParseOptions): Promise<
 
   return {
     rawBody,
-    news: {
-      title,
+    news: buildNewsInput({
+      body,
       publishedAt,
-      ...(readString(body.author) ? { author: readString(body.author) } : {}),
-      ...(readString(body.keywords) ? { keywords: readString(body.keywords) } : {}),
-      ...(readString(body.externalId) ? { externalId: readString(body.externalId) } : {}),
-      ...(readBoolean(body.fullVersion) !== undefined ? { fullVersion: readBoolean(body.fullVersion) } : {}),
-      ...(charactersToBeShown !== undefined ? { charactersToBeShown } : {}),
-      ...(readString(body.newsType) ? { newsType: readString(body.newsType) } : {}),
-      ...(publicationDate ? { publicationDate } : {}),
-      ...(readBoolean(body.showPublishDate) !== undefined ? { showPublishDate: readBoolean(body.showPublishDate) } : {}),
-      ...(readString(body.categoryName) ? { categoryName: readString(body.categoryName) } : {}),
-      ...(categories ? { categories } : {}),
-      ...(sourceUrl ? { sourceUrl } : {}),
-      ...(address ? { address } : {}),
-      ...(contentBlocks ? { contentBlocks } : {}),
-      ...(readString(body.pointOfInterestId) ? { pointOfInterestId: readString(body.pointOfInterestId) } : {}),
-      ...(options.allowPushNotification && readBoolean(body.pushNotification) !== undefined
-        ? { pushNotification: readBoolean(body.pushNotification) }
-        : {}),
-    },
+      publicationDate,
+      charactersToBeShown,
+      categories,
+      sourceUrl,
+      address,
+      contentBlocks,
+      allowPushNotification: options.allowPushNotification,
+    }),
   };
 };
 
@@ -485,6 +522,33 @@ const authorizeOrResponse = async (
   };
 };
 
+const listNewsForRequest = async (
+  request: Request,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string }
+) => listSvaMainserverNews({ ...actor, ...parseMainserverListQuery(request) });
+
+const getNewsForRoute = async (
+  route: Extract<RouteMatch, { kind: 'item' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string }
+) => getSvaMainserverNews({ ...actor, newsId: route.newsId });
+
+const updateNewsForRoute = async (
+  route: Extract<RouteMatch, { kind: 'item' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string },
+  news: SvaMainserverNewsInput
+) => {
+  const data = await updateSvaMainserverNews({ ...actor, newsId: route.newsId, news });
+  return json({ data });
+};
+
+const deleteNewsForRoute = async (
+  route: Extract<RouteMatch, { kind: 'item' }>,
+  actor: { readonly instanceId: string; readonly keycloakSubject: string }
+) => {
+  const data = await deleteSvaMainserverNews({ ...actor, newsId: route.newsId });
+  return json({ data });
+};
+
 const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: AuthenticatedRequestContext) => {
   const workspaceContext = getWorkspaceContext();
   const logSuccess = (operation: string, newsId?: string) => {
@@ -506,7 +570,7 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const data = await listSvaMainserverNews({ ...actor, ...parseMainserverListQuery(request) });
+      const data = await listNewsForRequest(request, actor);
       logSuccess('mainserver_news_list');
       return json(data);
     }
@@ -516,7 +580,7 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const data = await getSvaMainserverNews({ ...actor, newsId: route.newsId });
+      const data = await getNewsForRoute(route, actor);
       logSuccess('mainserver_news_detail', route.newsId);
       return json({ data });
     }
@@ -606,15 +670,14 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (parsed instanceof Response) {
         return parsed;
       }
-
       const updateActor = await authorizeOrResponse(ctx, 'news.update', route.newsId);
       if (updateActor instanceof Response) {
         return updateActor;
       }
 
-      const data = await updateSvaMainserverNews({ ...updateActor, newsId: route.newsId, news: parsed.news });
+      const response = await updateNewsForRoute(route, updateActor, parsed.news);
       logSuccess('mainserver_news_update', route.newsId);
-      return json({ data });
+      return response;
     }
 
     if (route.kind === 'item' && request.method === 'DELETE') {
@@ -626,9 +689,9 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       if (actor instanceof Response) {
         return actor;
       }
-      const data = await deleteSvaMainserverNews({ ...actor, newsId: route.newsId });
+      const response = await deleteNewsForRoute(route, actor);
       logSuccess('mainserver_news_delete', route.newsId);
-      return json({ data });
+      return response;
     }
 
     return errorJson(405, 'method_not_allowed', 'Methode wird für Mainserver-News nicht unterstützt.');

--- a/docs/reports/sonar-change-bundling-2026-05-02.md
+++ b/docs/reports/sonar-change-bundling-2026-05-02.md
@@ -1,0 +1,161 @@
+# SonarCloud-Buendelung fuer anstehende Changes am 2026-05-02
+
+## Ausgangslage
+
+- Maßgeblicher SonarCloud-Stand: Analyse vom 2026-05-02 17:43 UTC
+- Projekt: `smart-village-app_sva-studio`
+- Quality Gate: `ERROR`
+- Aktueller Gate-Befund: `new_coverage` liegt bei `74.8` und damit unter dem Schwellwert `80`
+- In der oeffentlichen Hotspot-Abfrage waren keine offenen Security Hotspots sichtbar
+
+## Ziel
+
+Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change zu, wenn die betroffenen Stellen durch den jeweiligen Change ohnehin fachlich umgebaut werden. Alles andere bleibt bewusst ausserhalb des Scopes, damit kein generischer Cleanup in fachliche Aenderungen hineinwuchert.
+
+## add-mainserver-plugin-list-pagination
+
+### Take now
+
+- `packages/sva-mainserver/src/server/service.ts`
+  - Regeln: `typescript:S3776`, `typescript:S7735`
+  - Grund: Der Change fuehrt serverseitige Pagination, `hasNextPage`-Ermittlung und Query-Normalisierung ein. Die betroffenen Funktionen enthalten genau den Listen- und Sichtbarkeitsfluss, der im Pagination-Umbau ohnehin zerlegt werden muss.
+- `apps/sva-studio-react/src/lib/mainserver-news-api.server.ts`
+  - Regeln: `typescript:S3776`, `typescript:S7735`
+  - Grund: Die News-Adapter validieren Query- und Request-Flows fuer Listen und Mutationen. Fuer typisierte Search-Params und paginierte Host-Routen ist eine Entzerrung des Kontrollflusses fachlich deckungsgleich.
+- `apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts`
+  - Regeln: `typescript:S3776`, `typescript:S7735`
+  - Grund: Gleicher Grund wie bei News; die Event-/POI-Adapter werden fuer denselben Pagination-Vertrag umgebaut.
+- `packages/plugin-news/src/news.pages.tsx`
+  - Regeln: `typescript:S3776`, `typescript:S2004`, `typescript:S3358`, `typescript:S3735`, `typescript:S6478`, `typescript:S6479`
+  - Grund: Die News-Liste ist explizit im Scope des Changes. Der Wechsel auf `StudioDataTable`, URL-getriebene Paging-States und eine neue Paging-Bedienung rechtfertigt die Mitnahme der Listen- und Render-Smells an genau diesen Stellen.
+
+### Optional if touched
+
+- `packages/plugin-events/src/events.pages.tsx`
+  - Regeln: aktuell keine sichtbaren offenen Befunde in der oeffentlichen Trefferliste
+  - Grund: Wenn die Migration auf `StudioDataTable` neue gemeinsame Hilfsbausteine erzwingt, koennen kleine Strukturverbesserungen direkt mitgenommen werden. Ohne konkrete Sonar-Befunde kein eigener Cleanup-Auftrag.
+- `packages/plugin-poi/src/poi.pages.tsx`
+  - Regeln: aktuell keine sichtbaren offenen Befunde in der oeffentlichen Trefferliste
+  - Grund: Gleiche Einordnung wie bei Events.
+
+### Defer
+
+- `packages/studio-ui-react/src/*`
+  - Regeln: z. B. `typescript:S6819`, `typescript:S1874`, `typescript:S6759`
+  - Grund: Das sind generische UI-Bibliotheksbefunde und keine paginationsspezifischen Aenderungen. Nur anfassen, wenn der Change tatsaechlich neue `StudioDataTable`-APIs benoetigt und die Sonar-Stelle direkt beruehrt.
+- `packages/sva-mainserver/src/server/service.ts` an Stellen ausserhalb der Listenpfade
+  - Regeln: einzelne `S3776`-/`S7735`-Befunde ausserhalb des Pagination-Pfads
+  - Grund: Nicht jeder Mainserver-Smell gehoert automatisch zu diesem Change. Nur die Listen- und Sichtbarkeitslogik ist Pflichtteil.
+
+### Coverage- und Testhinweise
+
+- Dieser Change kann das Quality Gate nur dann nachhaltig verbessern, wenn neben Refactors auch die neuen Listenpfade getestet werden.
+- Mindest-Gates:
+  - `pnpm nx run plugin-news:test:unit`
+  - `pnpm nx run plugin-events:test:unit`
+  - `pnpm nx run plugin-poi:test:unit`
+  - `pnpm nx run sva-studio-react:test:unit`
+  - `pnpm nx run sva-mainserver:test:unit`
+  - `pnpm nx affected --target=test:types --base=origin/main`
+
+## refactor-runtime-module-iam-contract-source
+
+### Take now
+
+- `packages/plugin-sdk/src/plugins.ts`
+  - Regeln: `typescript:S3776`, `typescript:S6564`, `typescript:S7765`, `typescript:S7758`, `typescript:S4325`
+  - Grund: Der Change fuehrt eine gemeinsame Runtime-Quelle fuer Modul-IAM-Vertraege ein. Registry-Merge-, Contract-Normalisierungs- und Guardrail-Logik in `plugins.ts` ist direkt auf dieser Contract-Kante und sollte im selben Umbau gestrafft werden.
+- `packages/auth-runtime/src/iam-instance-registry/provisioning-auth.ts`
+  - Regeln: `typescript:S7763`
+  - Grund: Die Datei ist ein reiner Re-Export-/Wiring-Pfad fuer den gemeinsamen Contract-Edge. Die Sonar-Empfehlung passt unmittelbar zum Refactor-Ziel.
+- `packages/auth-runtime/src/iam-instance-registry/core-runtime.ts`
+  - Regeln: `typescript:S7763`
+  - Grund: Gleiche Einordnung wie oben; Runtime-Wiring wird fuer die neue Contract-Quelle ohnehin angefasst.
+- `packages/auth-runtime/src/iam-instance-registry/service-keycloak.ts`
+  - Regeln: `typescript:S7763`
+  - Grund: Re-Export- und Adapter-Wiring liegt direkt auf dem Pfad, der vom gemeinsamen Contract-Edge profitieren soll.
+
+### Optional if touched
+
+- `packages/instance-registry/src/service-keycloak.ts`
+  - Regeln: `typescript:S3358`, `typescript:S7763`
+  - Grund: Falls der gemeinsame Contract-Edge die Handler-Zusammensetzung in dieser Datei veraendert, koennen die Re-Export- und kleine Struktur-Smells mitgenommen werden.
+- `packages/instance-registry/src/http-contracts.ts`
+  - Regeln: `typescript:S1874`, `typescript:S7753`
+  - Grund: Nur mitnehmen, wenn der Refactor die Runtime-Vertragsform oder HTTP-Contract-Typen direkt beruehrt.
+
+### Defer
+
+- `packages/instance-registry/src/provisioning-auth-plan.ts`
+  - Regeln: `typescript:S3358`, `typescript:S7735`
+  - Grund: Die Datei modelliert Provisioning-Planung und UI-nahe Driftbeschreibungen. Diese Ternary- und Lesbarkeits-Smells sind kein direkter Effekt der gemeinsamen Contract-Quelle und wuerden den Scope unnötig verbreitern.
+- `packages/instance-registry/src/provisioning-auth-evaluation.ts`
+  - Regeln: `typescript:S3358`
+  - Grund: Gleiche Einordnung wie `provisioning-auth-plan.ts`; nur mitnehmen, wenn der Contract-Edge die Evaluationsregeln fachlich aendert.
+- `packages/instance-registry/src/mutation-input-builders.ts`
+  - Regeln: `typescript:S4144`
+  - Grund: Kein klarer Bezug zum Modul-IAM-Contract-Refactor.
+- `packages/instance-registry/src/service-helpers.ts`
+  - Regeln: `typescript:S107`
+  - Grund: Hilfsfunktionszuschnitt ist eher generische Aufraeumarbeit als notwendiger Contract-Umbau.
+- `packages/instance-registry/src/service-keycloak-execution.ts`
+  - Regeln: `typescript:S3358`
+  - Grund: Nur tangentiale Ausfuehrungslogik; kein Pflichtteil fuer die Vertragsquelle.
+
+### Coverage- und Testhinweise
+
+- Dieser Change ist primär Refactor- und Drift-Schutz-Arbeit; der Gate-Hebel liegt eher in Paritaets- und Regressionstests als in Coverage-Masse.
+- Mindest-Gates:
+  - betroffene Unit-Tests in `plugin-sdk`, `auth-runtime` und `instance-registry`
+  - `pnpm check:server-runtime`
+  - `pnpm nx affected --target=test:types --base=origin/main`
+  - zusaetzlich die Runtime-/Provisioning-Checks, die in den Change-Tasks fuer den neuen Contract-Edge vorgesehen sind
+
+## add-p2-admin-resource-host-standards
+
+### Take now
+
+- `packages/plugin-sdk/src/admin-resources.ts`
+  - Regeln: `typescript:S4144`
+  - Grund: Der Change erweitert den Admin-Ressourcenvertrag um deklarative Host-Capabilities. Die doppelten Normalisierungsfunktionen liegen direkt in diesem Vertragsmodul und koennen beim Capability-Zuschnitt sauber zusammengelegt werden.
+- `packages/routing/src/admin-resource-routes.ts`
+  - Regeln: `typescript:S2004`, `typescript:S6653`
+  - Grund: Der Change fuehrt hostseitige Routing- und Search-Param-Standards ein. Die verschachtelte Legacy-Alias-/Redirect-Logik gehoert genau in diesen Umbau und sollte dabei vereinfacht werden.
+
+### Optional if touched
+
+- `apps/sva-studio-react/src/routes/admin/-iam-page.tsx`
+  - Regeln: `typescript:S3735`, `typescript:S2004`, `typescript:S3776`, `typescript:S3358`
+  - Grund: Nur dann mitnehmen, wenn diese Seite fuer die Pilotressource oder hostgefuehrte Capability-UI direkt angepasst wird. Ohne konkrete Host-Capability-Migration waere das ein separater IAM-Page-Refactor.
+- `apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx`
+  - Regeln: `typescript:S6478`, `typescript:S3776`, `typescript:S3358`
+  - Grund: Nur relevant, wenn `adminUsers` als fruehe Pilotressource auf den neuen Host-Standard gehoben wird.
+- `apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx`
+  - Regeln: `typescript:S3776`, `typescript:S6478`
+  - Grund: Gleiche Einordnung wie bei `users`.
+
+### Defer
+
+- `apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx`
+  - Regeln: zahlreiche `typescript:S3776`, `typescript:S3358`, `typescript:S7735`, `typescript:S7776`
+  - Grund: Das ist ein grosser Admin-/Instance-Flow-Refactor mit eigener Komplexitaet. Er passt nicht automatisch zu den Host-Standards fuer Search, Filter, Pagination und Bulk-Actions, solange `instances` nicht explizit Pilotressource des Changes ist.
+- `apps/sva-studio-react/src/routes/admin/media/-media-page.tsx`
+  - Regeln: `typescript:S6478`, `typescript:S1874`
+  - Grund: Der aktuelle Change zielt auf den Admin-Resource-Vertrag, nicht auf einen generischen Media-Page-Cleanup.
+- sonstige `routes/admin/**`-Seitenbefunde
+  - Grund: Nur aufnehmen, wenn die konkrete Seite durch die Capability-Migration zwingend beruehrt wird. Kein breitflaechiger Admin-Refactor im Schatten dieses Changes.
+
+### Coverage- und Testhinweise
+
+- Hier ist die Refactor-Arbeit klein, aber Search-Param-, Deep-Link- und Capability-Validierung braucht gezielte Tests.
+- Mindest-Gates:
+  - betroffene Routing-/UI-Unit-Tests fuer deklarierte Capabilities
+  - `pnpm nx affected --target=test:types --base=origin/main`
+  - die Search-Param- und Route-Validierungschecks, die bereits in den Change-Tasks fuer `packages/routing` und die Host-UI genannt sind
+
+## Uebergreifende Empfehlungen
+
+- `add-mainserver-plugin-list-pagination` ist der staerkste Kandidat fuer echte Sonar-Mitnahme, weil der Change viele stark belastete Listenpfade ohnehin neu strukturiert.
+- `refactor-runtime-module-iam-contract-source` sollte Sonar nur auf der Contract-Kante mitnehmen, nicht tief in Provisioning-Planungslogik.
+- `add-p2-admin-resource-host-standards` bleibt bewusst schmal: Vertrags- und Routing-Code ja, grosse Admin-Seiten nur bei direkter Pilotmigration.
+- Das aktuelle Quality-Gate-Problem ist primaer Coverage-getrieben. Refactors allein werden das Gate nicht schliessen, wenn die neuen Pfade nicht zusaetzlich mit Tests abgesichert werden.

--- a/docs/reports/sonar-change-bundling-2026-05-02.md
+++ b/docs/reports/sonar-change-bundling-2026-05-02.md
@@ -1,4 +1,4 @@
-# SonarCloud-Buendelung fuer anstehende Changes am 2026-05-02
+# SonarCloud-Bündelung für anstehende Changes am 2026-05-02
 
 ## Ausgangslage
 
@@ -6,11 +6,11 @@
 - Projekt: `smart-village-app_sva-studio`
 - Quality Gate: `ERROR`
 - Aktueller Gate-Befund: `new_coverage` liegt bei `74.8` und damit unter dem Schwellwert `80`
-- In der oeffentlichen Hotspot-Abfrage waren keine offenen Security Hotspots sichtbar
+- In der öffentlichen Hotspot-Abfrage waren keine offenen Security Hotspots sichtbar
 
 ## Ziel
 
-Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change zu, wenn die betroffenen Stellen durch den jeweiligen Change ohnehin fachlich umgebaut werden. Alles andere bleibt bewusst ausserhalb des Scopes, damit kein generischer Cleanup in fachliche Aenderungen hineinwuchert.
+Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change zu, wenn die betroffenen Stellen durch den jeweiligen Change ohnehin fachlich umgebaut werden. Alles andere bleibt bewusst außerhalb des Scopes, damit kein generischer Cleanup in fachliche Änderungen hineinwuchert.
 
 ## add-mainserver-plugin-list-pagination
 
@@ -18,13 +18,13 @@ Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change
 
 - `packages/sva-mainserver/src/server/service.ts`
   - Regeln: `typescript:S3776`, `typescript:S7735`
-  - Grund: Der Change fuehrt serverseitige Pagination, `hasNextPage`-Ermittlung und Query-Normalisierung ein. Die betroffenen Funktionen enthalten genau den Listen- und Sichtbarkeitsfluss, der im Pagination-Umbau ohnehin zerlegt werden muss.
+  - Grund: Der Change führt serverseitige Pagination, `hasNextPage`-Ermittlung und Query-Normalisierung ein. Die betroffenen Funktionen enthalten genau den Listen- und Sichtbarkeitsfluss, der im Pagination-Umbau ohnehin zerlegt werden muss.
 - `apps/sva-studio-react/src/lib/mainserver-news-api.server.ts`
   - Regeln: `typescript:S3776`, `typescript:S7735`
-  - Grund: Die News-Adapter validieren Query- und Request-Flows fuer Listen und Mutationen. Fuer typisierte Search-Params und paginierte Host-Routen ist eine Entzerrung des Kontrollflusses fachlich deckungsgleich.
+  - Grund: Die News-Adapter validieren Query- und Request-Flows für Listen und Mutationen. Für typisierte Search-Params und paginierte Host-Routen ist eine Entzerrung des Kontrollflusses fachlich deckungsgleich.
 - `apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts`
   - Regeln: `typescript:S3776`, `typescript:S7735`
-  - Grund: Gleicher Grund wie bei News; die Event-/POI-Adapter werden fuer denselben Pagination-Vertrag umgebaut.
+  - Grund: Gleicher Grund wie bei News; die Event-/POI-Adapter werden für denselben Pagination-Vertrag umgebaut.
 - `packages/plugin-news/src/news.pages.tsx`
   - Regeln: `typescript:S3776`, `typescript:S2004`, `typescript:S3358`, `typescript:S3735`, `typescript:S6478`, `typescript:S6479`
   - Grund: Die News-Liste ist explizit im Scope des Changes. Der Wechsel auf `StudioDataTable`, URL-getriebene Paging-States und eine neue Paging-Bedienung rechtfertigt die Mitnahme der Listen- und Render-Smells an genau diesen Stellen.
@@ -32,20 +32,20 @@ Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change
 ### Optional if touched
 
 - `packages/plugin-events/src/events.pages.tsx`
-  - Regeln: aktuell keine sichtbaren offenen Befunde in der oeffentlichen Trefferliste
-  - Grund: Wenn die Migration auf `StudioDataTable` neue gemeinsame Hilfsbausteine erzwingt, koennen kleine Strukturverbesserungen direkt mitgenommen werden. Ohne konkrete Sonar-Befunde kein eigener Cleanup-Auftrag.
+  - Regeln: aktuell keine sichtbaren offenen Befunde in der öffentlichen Trefferliste
+  - Grund: Wenn die Migration auf `StudioDataTable` neue gemeinsame Hilfsbausteine erzwingt, können kleine Strukturverbesserungen direkt mitgenommen werden. Ohne konkrete Sonar-Befunde kein eigener Cleanup-Auftrag.
 - `packages/plugin-poi/src/poi.pages.tsx`
-  - Regeln: aktuell keine sichtbaren offenen Befunde in der oeffentlichen Trefferliste
+  - Regeln: aktuell keine sichtbaren offenen Befunde in der öffentlichen Trefferliste
   - Grund: Gleiche Einordnung wie bei Events.
 
 ### Defer
 
 - `packages/studio-ui-react/src/*`
   - Regeln: z. B. `typescript:S6819`, `typescript:S1874`, `typescript:S6759`
-  - Grund: Das sind generische UI-Bibliotheksbefunde und keine paginationsspezifischen Aenderungen. Nur anfassen, wenn der Change tatsaechlich neue `StudioDataTable`-APIs benoetigt und die Sonar-Stelle direkt beruehrt.
-- `packages/sva-mainserver/src/server/service.ts` an Stellen ausserhalb der Listenpfade
-  - Regeln: einzelne `S3776`-/`S7735`-Befunde ausserhalb des Pagination-Pfads
-  - Grund: Nicht jeder Mainserver-Smell gehoert automatisch zu diesem Change. Nur die Listen- und Sichtbarkeitslogik ist Pflichtteil.
+  - Grund: Das sind generische UI-Bibliotheksbefunde und keine paginationsspezifischen Änderungen. Nur anfassen, wenn der Change tatsächlich neue `StudioDataTable`-APIs benötigt und die Sonar-Stelle direkt berührt.
+- `packages/sva-mainserver/src/server/service.ts` an Stellen außerhalb der Listenpfade
+  - Regeln: einzelne `S3776`-/`S7735`-Befunde außerhalb des Pagination-Pfads
+  - Grund: Nicht jeder Mainserver-Smell gehört automatisch zu diesem Change. Nur die Listen- und Sichtbarkeitslogik ist Pflichtteil.
 
 ### Coverage- und Testhinweise
 
@@ -64,13 +64,13 @@ Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change
 
 - `packages/plugin-sdk/src/plugins.ts`
   - Regeln: `typescript:S3776`, `typescript:S6564`, `typescript:S7765`, `typescript:S7758`, `typescript:S4325`
-  - Grund: Der Change fuehrt eine gemeinsame Runtime-Quelle fuer Modul-IAM-Vertraege ein. Registry-Merge-, Contract-Normalisierungs- und Guardrail-Logik in `plugins.ts` ist direkt auf dieser Contract-Kante und sollte im selben Umbau gestrafft werden.
+  - Grund: Der Change führt eine gemeinsame Runtime-Quelle für Modul-IAM-Verträge ein. Registry-Merge-, Contract-Normalisierungs- und Guardrail-Logik in `plugins.ts` ist direkt auf dieser Contract-Kante und sollte im selben Umbau gestrafft werden.
 - `packages/auth-runtime/src/iam-instance-registry/provisioning-auth.ts`
   - Regeln: `typescript:S7763`
-  - Grund: Die Datei ist ein reiner Re-Export-/Wiring-Pfad fuer den gemeinsamen Contract-Edge. Die Sonar-Empfehlung passt unmittelbar zum Refactor-Ziel.
+  - Grund: Die Datei ist ein reiner Re-Export-/Wiring-Pfad für den gemeinsamen Contract-Edge. Die Sonar-Empfehlung passt unmittelbar zum Refactor-Ziel.
 - `packages/auth-runtime/src/iam-instance-registry/core-runtime.ts`
   - Regeln: `typescript:S7763`
-  - Grund: Gleiche Einordnung wie oben; Runtime-Wiring wird fuer die neue Contract-Quelle ohnehin angefasst.
+  - Grund: Gleiche Einordnung wie oben; Runtime-Wiring wird für die neue Contract-Quelle ohnehin angefasst.
 - `packages/auth-runtime/src/iam-instance-registry/service-keycloak.ts`
   - Regeln: `typescript:S7763`
   - Grund: Re-Export- und Adapter-Wiring liegt direkt auf dem Pfad, der vom gemeinsamen Contract-Edge profitieren soll.
@@ -79,10 +79,10 @@ Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change
 
 - `packages/instance-registry/src/service-keycloak.ts`
   - Regeln: `typescript:S3358`, `typescript:S7763`
-  - Grund: Falls der gemeinsame Contract-Edge die Handler-Zusammensetzung in dieser Datei veraendert, koennen die Re-Export- und kleine Struktur-Smells mitgenommen werden.
+  - Grund: Falls der gemeinsame Contract-Edge die Handler-Zusammensetzung in dieser Datei verändert, können die Re-Export- und kleine Struktur-Smells mitgenommen werden.
 - `packages/instance-registry/src/http-contracts.ts`
   - Regeln: `typescript:S1874`, `typescript:S7753`
-  - Grund: Nur mitnehmen, wenn der Refactor die Runtime-Vertragsform oder HTTP-Contract-Typen direkt beruehrt.
+  - Grund: Nur mitnehmen, wenn der Refactor die Runtime-Vertragsform oder HTTP-Contract-Typen direkt berührt.
 
 ### Defer
 
@@ -91,25 +91,25 @@ Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change
   - Grund: Die Datei modelliert Provisioning-Planung und UI-nahe Driftbeschreibungen. Diese Ternary- und Lesbarkeits-Smells sind kein direkter Effekt der gemeinsamen Contract-Quelle und wuerden den Scope unnötig verbreitern.
 - `packages/instance-registry/src/provisioning-auth-evaluation.ts`
   - Regeln: `typescript:S3358`
-  - Grund: Gleiche Einordnung wie `provisioning-auth-plan.ts`; nur mitnehmen, wenn der Contract-Edge die Evaluationsregeln fachlich aendert.
+  - Grund: Gleiche Einordnung wie `provisioning-auth-plan.ts`; nur mitnehmen, wenn der Contract-Edge die Evaluationsregeln fachlich ändert.
 - `packages/instance-registry/src/mutation-input-builders.ts`
   - Regeln: `typescript:S4144`
   - Grund: Kein klarer Bezug zum Modul-IAM-Contract-Refactor.
 - `packages/instance-registry/src/service-helpers.ts`
   - Regeln: `typescript:S107`
-  - Grund: Hilfsfunktionszuschnitt ist eher generische Aufraeumarbeit als notwendiger Contract-Umbau.
+  - Grund: Hilfsfunktionszuschnitt ist eher generische Aufräumarbeit als notwendiger Contract-Umbau.
 - `packages/instance-registry/src/service-keycloak-execution.ts`
   - Regeln: `typescript:S3358`
-  - Grund: Nur tangentiale Ausfuehrungslogik; kein Pflichtteil fuer die Vertragsquelle.
+  - Grund: Nur tangentiale Ausführungslogik; kein Pflichtteil für die Vertragsquelle.
 
 ### Coverage- und Testhinweise
 
-- Dieser Change ist primär Refactor- und Drift-Schutz-Arbeit; der Gate-Hebel liegt eher in Paritaets- und Regressionstests als in Coverage-Masse.
+- Dieser Change ist primär Refactor- und Drift-Schutz-Arbeit; der Gate-Hebel liegt eher in Paritäts- und Regressionstests als in Coverage-Masse.
 - Mindest-Gates:
   - betroffene Unit-Tests in `plugin-sdk`, `auth-runtime` und `instance-registry`
   - `pnpm check:server-runtime`
   - `pnpm nx affected --target=test:types --base=origin/main`
-  - zusaetzlich die Runtime-/Provisioning-Checks, die in den Change-Tasks fuer den neuen Contract-Edge vorgesehen sind
+  - zusätzlich die Runtime-/Provisioning-Checks, die in den Change-Tasks für den neuen Contract-Edge vorgesehen sind
 
 ## add-p2-admin-resource-host-standards
 
@@ -117,19 +117,19 @@ Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change
 
 - `packages/plugin-sdk/src/admin-resources.ts`
   - Regeln: `typescript:S4144`
-  - Grund: Der Change erweitert den Admin-Ressourcenvertrag um deklarative Host-Capabilities. Die doppelten Normalisierungsfunktionen liegen direkt in diesem Vertragsmodul und koennen beim Capability-Zuschnitt sauber zusammengelegt werden.
+  - Grund: Der Change erweitert den Admin-Ressourcenvertrag um deklarative Host-Capabilities. Die doppelten Normalisierungsfunktionen liegen direkt in diesem Vertragsmodul und können beim Capability-Zuschnitt sauber zusammengelegt werden.
 - `packages/routing/src/admin-resource-routes.ts`
   - Regeln: `typescript:S2004`, `typescript:S6653`
-  - Grund: Der Change fuehrt hostseitige Routing- und Search-Param-Standards ein. Die verschachtelte Legacy-Alias-/Redirect-Logik gehoert genau in diesen Umbau und sollte dabei vereinfacht werden.
+  - Grund: Der Change führt hostseitige Routing- und Search-Param-Standards ein. Die verschachtelte Legacy-Alias-/Redirect-Logik gehört genau in diesen Umbau und sollte dabei vereinfacht werden.
 
 ### Optional if touched
 
 - `apps/sva-studio-react/src/routes/admin/-iam-page.tsx`
   - Regeln: `typescript:S3735`, `typescript:S2004`, `typescript:S3776`, `typescript:S3358`
-  - Grund: Nur dann mitnehmen, wenn diese Seite fuer die Pilotressource oder hostgefuehrte Capability-UI direkt angepasst wird. Ohne konkrete Host-Capability-Migration waere das ein separater IAM-Page-Refactor.
+  - Grund: Nur dann mitnehmen, wenn diese Seite für die Pilotressource oder hostgeführte Capability-UI direkt angepasst wird. Ohne konkrete Host-Capability-Migration wäre das ein separater IAM-Page-Refactor.
 - `apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx`
   - Regeln: `typescript:S6478`, `typescript:S3776`, `typescript:S3358`
-  - Grund: Nur relevant, wenn `adminUsers` als fruehe Pilotressource auf den neuen Host-Standard gehoben wird.
+  - Grund: Nur relevant, wenn `adminUsers` als frühe Pilotressource auf den neuen Host-Standard gehoben wird.
 - `apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx`
   - Regeln: `typescript:S3776`, `typescript:S6478`
   - Grund: Gleiche Einordnung wie bei `users`.
@@ -138,24 +138,24 @@ Diese Arbeitsliste ordnet offene SonarCloud-Issues nur dann einem aktiven Change
 
 - `apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx`
   - Regeln: zahlreiche `typescript:S3776`, `typescript:S3358`, `typescript:S7735`, `typescript:S7776`
-  - Grund: Das ist ein grosser Admin-/Instance-Flow-Refactor mit eigener Komplexitaet. Er passt nicht automatisch zu den Host-Standards fuer Search, Filter, Pagination und Bulk-Actions, solange `instances` nicht explizit Pilotressource des Changes ist.
+  - Grund: Das ist ein großer Admin-/Instance-Flow-Refactor mit eigener Komplexität. Er passt nicht automatisch zu den Host-Standards für Search, Filter, Pagination und Bulk-Actions, solange `instances` nicht explizit Pilotressource des Changes ist.
 - `apps/sva-studio-react/src/routes/admin/media/-media-page.tsx`
   - Regeln: `typescript:S6478`, `typescript:S1874`
   - Grund: Der aktuelle Change zielt auf den Admin-Resource-Vertrag, nicht auf einen generischen Media-Page-Cleanup.
 - sonstige `routes/admin/**`-Seitenbefunde
-  - Grund: Nur aufnehmen, wenn die konkrete Seite durch die Capability-Migration zwingend beruehrt wird. Kein breitflaechiger Admin-Refactor im Schatten dieses Changes.
+  - Grund: Nur aufnehmen, wenn die konkrete Seite durch die Capability-Migration zwingend berührt wird. Kein breitflächiger Admin-Refactor im Schatten dieses Changes.
 
 ### Coverage- und Testhinweise
 
 - Hier ist die Refactor-Arbeit klein, aber Search-Param-, Deep-Link- und Capability-Validierung braucht gezielte Tests.
 - Mindest-Gates:
-  - betroffene Routing-/UI-Unit-Tests fuer deklarierte Capabilities
+  - betroffene Routing-/UI-Unit-Tests für deklarierte Capabilities
   - `pnpm nx affected --target=test:types --base=origin/main`
-  - die Search-Param- und Route-Validierungschecks, die bereits in den Change-Tasks fuer `packages/routing` und die Host-UI genannt sind
+  - die Search-Param- und Route-Validierungschecks, die bereits in den Change-Tasks für `packages/routing` und die Host-UI genannt sind
 
-## Uebergreifende Empfehlungen
+## Übergreifende Empfehlungen
 
-- `add-mainserver-plugin-list-pagination` ist der staerkste Kandidat fuer echte Sonar-Mitnahme, weil der Change viele stark belastete Listenpfade ohnehin neu strukturiert.
+- `add-mainserver-plugin-list-pagination` ist der stärkste Kandidat für echte Sonar-Mitnahme, weil der Change viele stark belastete Listenpfade ohnehin neu strukturiert.
 - `refactor-runtime-module-iam-contract-source` sollte Sonar nur auf der Contract-Kante mitnehmen, nicht tief in Provisioning-Planungslogik.
-- `add-p2-admin-resource-host-standards` bleibt bewusst schmal: Vertrags- und Routing-Code ja, grosse Admin-Seiten nur bei direkter Pilotmigration.
-- Das aktuelle Quality-Gate-Problem ist primaer Coverage-getrieben. Refactors allein werden das Gate nicht schliessen, wenn die neuen Pfade nicht zusaetzlich mit Tests abgesichert werden.
+- `add-p2-admin-resource-host-standards` bleibt bewusst schmal: Vertrags- und Routing-Code ja, große Admin-Seiten nur bei direkter Pilotmigration.
+- Das aktuelle Quality-Gate-Problem ist primär Coverage-getrieben. Refactors allein werden das Gate nicht schließen, wenn die neuen Pfade nicht zusätzlich mit Tests abgesichert werden.

--- a/packages/auth-runtime/src/iam-instance-registry/provisioning-auth.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/provisioning-auth.ts
@@ -14,26 +14,28 @@ import {
 
 export { provisionInstanceAuthArtifacts, provisionInstanceAuthArtifactsViaProvisioner };
 
-export const getInstanceKeycloakPreflight = createInstanceKeycloakPreflightReader(
-  readKeycloakState,
-  readKeycloakAccessError
-);
+const createInstanceKeycloakReaders = (
+  readState: typeof readKeycloakState
+): Readonly<{
+  getInstanceKeycloakPreflight: ReturnType<typeof createInstanceKeycloakPreflightReader>;
+  getInstanceKeycloakPlan: ReturnType<typeof createInstanceKeycloakPlanReader>;
+  getInstanceKeycloakStatus: ReturnType<typeof createInstanceKeycloakStatusReader>;
+}> => {
+  const getInstanceKeycloakPreflight = createInstanceKeycloakPreflightReader(readState, readKeycloakAccessError);
 
-export const getInstanceKeycloakPreflightViaProvisioner = createInstanceKeycloakPreflightReader(
-  readKeycloakStateViaProvisioner,
-  readKeycloakAccessError
-);
+  return {
+    getInstanceKeycloakPreflight,
+    getInstanceKeycloakPlan: createInstanceKeycloakPlanReader(readState, getInstanceKeycloakPreflight),
+    getInstanceKeycloakStatus: createInstanceKeycloakStatusReader(readState),
+  };
+};
 
-export const getInstanceKeycloakPlan = createInstanceKeycloakPlanReader(
-  readKeycloakState,
-  getInstanceKeycloakPreflight
-);
+const defaultReaders = createInstanceKeycloakReaders(readKeycloakState);
+const provisionerReaders = createInstanceKeycloakReaders(readKeycloakStateViaProvisioner);
 
-export const getInstanceKeycloakPlanViaProvisioner = createInstanceKeycloakPlanReader(
-  readKeycloakStateViaProvisioner,
-  getInstanceKeycloakPreflightViaProvisioner
-);
-
-export const getInstanceKeycloakStatus = createInstanceKeycloakStatusReader(readKeycloakState);
-
-export const getInstanceKeycloakStatusViaProvisioner = createInstanceKeycloakStatusReader(readKeycloakStateViaProvisioner);
+export const getInstanceKeycloakPreflight = defaultReaders.getInstanceKeycloakPreflight;
+export const getInstanceKeycloakPreflightViaProvisioner = provisionerReaders.getInstanceKeycloakPreflight;
+export const getInstanceKeycloakPlan = defaultReaders.getInstanceKeycloakPlan;
+export const getInstanceKeycloakPlanViaProvisioner = provisionerReaders.getInstanceKeycloakPlan;
+export const getInstanceKeycloakStatus = defaultReaders.getInstanceKeycloakStatus;
+export const getInstanceKeycloakStatusViaProvisioner = provisionerReaders.getInstanceKeycloakStatus;

--- a/packages/auth-runtime/src/iam-instance-registry/service-keycloak.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/service-keycloak.ts
@@ -20,43 +20,49 @@ import { withAuthInstanceRegistryDeps } from './instance-registry-deps.js';
 export { createGetKeycloakProvisioningRunHandler, createRuntimeResolver };
 
 const authSecretDeps = () => withAuthInstanceRegistryDeps({});
+const bindRegistryServiceDeps = <T>(factory: (deps: InstanceRegistryServiceDeps) => T) => (deps: InstanceRegistryServiceDeps): T =>
+  factory(withAuthInstanceRegistryDeps(deps));
+
+const decryptSecret = (
+  decryptor: typeof decryptTargetAuthClientSecret,
+  instanceId: string,
+  ciphertext: string | null | undefined
+): string | undefined => decryptor(authSecretDeps(), instanceId, ciphertext);
+
+const loadRepositorySecret = async (
+  loader: typeof loadTargetRepositoryAuthClientSecret,
+  repository: InstanceRegistryRepository,
+  instanceId: string
+): Promise<string | undefined> => loader(authSecretDeps(), repository, instanceId);
 
 export const decryptAuthClientSecret = (
   instanceId: string,
   ciphertext: string | null | undefined
-): string | undefined => decryptTargetAuthClientSecret(authSecretDeps(), instanceId, ciphertext);
+): string | undefined => decryptSecret(decryptTargetAuthClientSecret, instanceId, ciphertext);
 
 export const decryptTenantAdminClientSecret = (
   instanceId: string,
   ciphertext: string | null | undefined
-): string | undefined => decryptTargetTenantAdminClientSecret(authSecretDeps(), instanceId, ciphertext);
+): string | undefined => decryptSecret(decryptTargetTenantAdminClientSecret, instanceId, ciphertext);
 
 export const loadRepositoryAuthClientSecret = async (
   repository: InstanceRegistryRepository,
   instanceId: string
-): Promise<string | undefined> =>
-  loadTargetRepositoryAuthClientSecret(authSecretDeps(), repository, instanceId);
+): Promise<string | undefined> => loadRepositorySecret(loadTargetRepositoryAuthClientSecret, repository, instanceId);
 
 export const loadRepositoryTenantAdminClientSecret = async (
   repository: InstanceRegistryRepository,
   instanceId: string
 ): Promise<string | undefined> =>
-  loadTargetRepositoryTenantAdminClientSecret(authSecretDeps(), repository, instanceId);
+  loadRepositorySecret(loadTargetRepositoryTenantAdminClientSecret, repository, instanceId);
 
 export const loadInstanceWithSecret = (deps: InstanceRegistryServiceDeps, instanceId: string) =>
   loadTargetInstanceWithSecret(withAuthInstanceRegistryDeps(deps), instanceId);
 
-export const createGetKeycloakStatusHandler = (deps: InstanceRegistryServiceDeps) =>
-  createTargetGetKeycloakStatusHandler(withAuthInstanceRegistryDeps(deps));
-
-export const createGetKeycloakPreflightHandler = (deps: InstanceRegistryServiceDeps) =>
-  createTargetGetKeycloakPreflightHandler(withAuthInstanceRegistryDeps(deps));
-
-export const createPlanKeycloakProvisioningHandler = (deps: InstanceRegistryServiceDeps) =>
-  createTargetPlanKeycloakProvisioningHandler(withAuthInstanceRegistryDeps(deps));
-
-export const createExecuteKeycloakProvisioningHandler = (deps: InstanceRegistryServiceDeps) =>
-  createTargetExecuteKeycloakProvisioningHandler(withAuthInstanceRegistryDeps(deps));
-
-export const createReconcileKeycloakHandler = (deps: InstanceRegistryServiceDeps) =>
-  createTargetReconcileKeycloakHandler(withAuthInstanceRegistryDeps(deps));
+export const createGetKeycloakStatusHandler = bindRegistryServiceDeps(createTargetGetKeycloakStatusHandler);
+export const createGetKeycloakPreflightHandler = bindRegistryServiceDeps(createTargetGetKeycloakPreflightHandler);
+export const createPlanKeycloakProvisioningHandler = bindRegistryServiceDeps(createTargetPlanKeycloakProvisioningHandler);
+export const createExecuteKeycloakProvisioningHandler = bindRegistryServiceDeps(
+  createTargetExecuteKeycloakProvisioningHandler
+);
+export const createReconcileKeycloakHandler = bindRegistryServiceDeps(createTargetReconcileKeycloakHandler);

--- a/packages/plugin-events/src/events.pages.tsx
+++ b/packages/plugin-events/src/events.pages.tsx
@@ -132,11 +132,93 @@ const compactForm = (form: EventFormInput): EventFormInput => ({
 const errorMessage = (pt: ReturnType<typeof usePluginTranslation>, error: unknown, fallbackKey: string) =>
   error instanceof EventsApiError ? error.message : pt(fallbackKey);
 
+type ListSearchState = Record<string, unknown>;
+
+type ListPaginationState = Readonly<{
+  page: number;
+  pageSize: number;
+  hasNextPage: boolean;
+}>;
+
+type ListPaginationNavProps = Readonly<{
+  ariaLabel: string;
+  pageLabel: string;
+  previousLabel: string;
+  nextLabel: string;
+  pagination: ListPaginationState;
+  onPageChange: (page: number) => void;
+}>;
+
+const updateListSearchPage = (
+  current: ListSearchState,
+  page: number,
+  pageSize: number
+): ListSearchState => ({
+  ...current,
+  page,
+  pageSize,
+});
+
+const EventListEditAction = ({ id, label }: Readonly<{ id: string; label: string }>) => (
+  <Button asChild variant="outline" size="sm">
+    <Link to="/admin/events/$id" params={{ id }}>
+      {label}
+    </Link>
+  </Button>
+);
+
+const EventsPaginationNav = ({
+  ariaLabel,
+  pageLabel,
+  previousLabel,
+  nextLabel,
+  pagination,
+  onPageChange,
+}: ListPaginationNavProps) => (
+  <nav aria-label={ariaLabel} className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+    <p key={pagination.page} aria-live="polite" className="animate-pagination-active">
+      {pageLabel}
+    </p>
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={pagination.page <= 1}
+        onClick={() => onPageChange(Math.max(1, pagination.page - 1))}
+      >
+        {previousLabel}
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={!pagination.hasNextPage}
+        onClick={() => onPageChange(pagination.page + 1)}
+      >
+        {nextLabel}
+      </Button>
+    </div>
+  </nav>
+);
+
+const createEventsListColumns = (pt: ReturnType<typeof usePluginTranslation>) => [
+  { id: 'title', header: pt('fields.title'), cell: (item: EventContentItem) => item.title },
+  { id: 'categoryName', header: pt('fields.categoryName'), cell: (item: EventContentItem) => item.categoryName ?? '—' },
+  {
+    id: 'dateStart',
+    header: pt('fields.dateStart'),
+    cell: (item: EventContentItem) =>
+      item.dates?.[0]?.dateStart ? new Date(item.dates[0].dateStart).toLocaleString() : '—',
+  },
+];
+
 export function EventsListPage() {
   const pt = usePluginTranslation('events');
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
   const { page, pageSize } = normalizeListSearch(search);
+  const editLabel = pt('actions.edit');
   const [result, setResult] = React.useState<EventListResult>({
     data: [],
     pagination: { page, pageSize, hasNextPage: false },
@@ -144,20 +226,30 @@ export function EventsListPage() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
+  const handlePageChange = React.useCallback(
+    (nextPage: number) => {
+      Promise.resolve(
+        navigate({
+          to: '/admin/events',
+          search: (current: ListSearchState) => updateListSearchPage(current, nextPage, result.pagination.pageSize),
+        })
+      ).catch(() => undefined);
+    },
+    [navigate, result.pagination.pageSize]
+  );
+
   React.useEffect(() => {
     if (search.page === page && search.pageSize === pageSize) {
       return;
     }
 
-    void navigate({
-      to: '/admin/events',
-      replace: true,
-      search: (current: Record<string, unknown>) => ({
-        ...current,
-        page,
-        pageSize,
-      }),
-    });
+    Promise.resolve(
+      navigate({
+        to: '/admin/events',
+        replace: true,
+        search: (current: ListSearchState) => updateListSearchPage(current, page, pageSize),
+      })
+    ).catch(() => undefined);
   }, [navigate, page, pageSize, search.page, search.pageSize]);
 
   React.useEffect(() => {
@@ -211,70 +303,20 @@ export function EventsListPage() {
               selectRow: ({ label }) => label,
             }}
             data={result.data}
-            columns={[
-              { id: 'title', header: pt('fields.title'), cell: (item: EventContentItem) => item.title },
-              { id: 'categoryName', header: pt('fields.categoryName'), cell: (item: EventContentItem) => item.categoryName ?? '—' },
-              {
-                id: 'dateStart',
-                header: pt('fields.dateStart'),
-                cell: (item: EventContentItem) =>
-                  item.dates?.[0]?.dateStart ? new Date(item.dates[0].dateStart).toLocaleString() : '—',
-              },
-            ]}
-            rowActions={(item) => (
-              <Button asChild variant="outline" size="sm">
-                <Link to="/admin/events/$id" params={{ id: item.id }}>
-                  {pt('actions.edit')}
-                </Link>
-              </Button>
-            )}
+            columns={createEventsListColumns(pt)}
+            rowActions={(item) => <EventListEditAction id={item.id} label={editLabel} />}
             emptyState={null}
             getRowId={(item) => item.id}
             selectionMode="none"
           />
-          <nav aria-label={pt('pagination.ariaLabel')} className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
-            <p key={result.pagination.page} aria-live="polite" className="animate-pagination-active">
-              {pt('pagination.pageLabel', { page: result.pagination.page })}
-            </p>
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={result.pagination.page <= 1}
-                onClick={() =>
-                  void navigate({
-                    to: '/admin/events',
-                    search: (current: Record<string, unknown>) => ({
-                      ...current,
-                      page: Math.max(1, result.pagination.page - 1),
-                      pageSize: result.pagination.pageSize,
-                    }),
-                  })
-                }
-              >
-                {pt('pagination.previous')}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={!result.pagination.hasNextPage}
-                onClick={() =>
-                  void navigate({
-                    to: '/admin/events',
-                    search: (current: Record<string, unknown>) => ({
-                      ...current,
-                      page: result.pagination.page + 1,
-                      pageSize: result.pagination.pageSize,
-                    }),
-                  })
-                }
-              >
-                {pt('pagination.next')}
-              </Button>
-            </div>
-          </nav>
+          <EventsPaginationNav
+            ariaLabel={pt('pagination.ariaLabel')}
+            pageLabel={pt('pagination.pageLabel', { page: result.pagination.page })}
+            previousLabel={pt('pagination.previous')}
+            nextLabel={pt('pagination.next')}
+            pagination={result.pagination}
+            onPageChange={handlePageChange}
+          />
         </div>
       ) : null}
     </StudioOverviewPageTemplate>

--- a/packages/plugin-events/tests/events.pages.test.tsx
+++ b/packages/plugin-events/tests/events.pages.test.tsx
@@ -45,18 +45,21 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
   useNavigate: () => navigateMock,
   useParams: () => paramsMock(),
-  useSearch: () => ({ page: 1, pageSize: 25 }),
+  useSearch: () => searchMock(),
 }));
 
 const navigateMock = vi.fn();
 const paramsMock = vi.fn(() => ({ id: 'event-1' }));
+const searchMock = vi.fn(() => ({ page: 1, pageSize: 25 }));
 
 describe('EventsListPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     navigateMock.mockReset();
     paramsMock.mockReset();
+    searchMock.mockReset();
     paramsMock.mockReturnValue({ id: 'event-1' });
+    searchMock.mockReturnValue({ page: 1, pageSize: 25 });
     registerPluginTranslationResolver((key) => {
       const labels: Record<string, string> = {
         'events.list.title': 'Events',
@@ -129,6 +132,72 @@ describe('EventsListPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Events konnten nicht geladen werden.')).toBeTruthy();
+    });
+  });
+
+  it('navigates through paginated list results', async () => {
+    vi.mocked(listEvents).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'event-1',
+          title: 'Stadtfest',
+          categoryName: 'Kultur',
+          dates: [{ dateStart: '2026-04-14T09:30:00.000Z' }],
+        },
+      ],
+      pagination: { page: 2, pageSize: 25, hasNextPage: true },
+    });
+
+    render(<EventsListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Seite {{page}}')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zurück' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+
+    expect(navigateMock).toHaveBeenCalledTimes(2);
+
+    const previousTarget = navigateMock.mock.calls[0]?.[0] as {
+      search: (current: Record<string, unknown>) => Record<string, unknown>;
+    };
+    const nextTarget = navigateMock.mock.calls[1]?.[0] as {
+      search: (current: Record<string, unknown>) => Record<string, unknown>;
+    };
+
+    expect(previousTarget.search({ filter: 'open' })).toEqual({
+      filter: 'open',
+      page: 1,
+      pageSize: 25,
+    });
+    expect(nextTarget.search({ filter: 'open' })).toEqual({
+      filter: 'open',
+      page: 3,
+      pageSize: 25,
+    });
+  });
+
+  it('reads pagination values from search params and falls back for invalid values', async () => {
+    searchMock.mockReturnValueOnce({ page: 3, pageSize: 50 });
+
+    render(<EventsListPage />);
+
+    await waitFor(() => {
+      expect(listEvents).toHaveBeenCalledWith({ page: 3, pageSize: 50 });
+    });
+
+    cleanup();
+    searchMock.mockReturnValueOnce({ page: undefined, pageSize: 0 });
+    vi.mocked(listEvents).mockResolvedValueOnce({
+      data: [],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+
+    render(<EventsListPage />);
+
+    await waitFor(() => {
+      expect(listEvents).toHaveBeenCalledWith({ page: 1, pageSize: 25 });
     });
   });
 

--- a/packages/plugin-news/src/news.pages.tsx
+++ b/packages/plugin-news/src/news.pages.tsx
@@ -119,6 +119,33 @@ const resolveNewsErrorMessage = (pt: ReturnType<typeof usePluginTranslation>, er
   return pt(fallbackKey);
 };
 
+type ListSearchState = Record<string, unknown>;
+
+type ListPaginationState = Readonly<{
+  page: number;
+  pageSize: number;
+  hasNextPage: boolean;
+}>;
+
+type ListPaginationNavProps = Readonly<{
+  ariaLabel: string;
+  pageLabel: string;
+  previousLabel: string;
+  nextLabel: string;
+  pagination: ListPaginationState;
+  onPageChange: (page: number) => void;
+}>;
+
+const updateListSearchPage = (
+  current: ListSearchState,
+  page: number,
+  pageSize: number
+): ListSearchState => ({
+  ...current,
+  page,
+  pageSize,
+});
+
 const persistFlashMessage = (code: FlashMessageCode) => {
   if (typeof globalThis.window === 'undefined') {
     return;
@@ -275,6 +302,72 @@ const firstBlockSummary = (item: NewsContentItem) => {
 
 const categorySummary = (item: NewsContentItem) =>
   item.categoryName ?? item.categories?.map((category) => category.name).join(', ') ?? item.payload.category ?? '—';
+
+const NewsListEditAction = ({ id, label }: Readonly<{ id: string; label: string }>) => (
+  <Button asChild variant="outline" size="sm">
+    <Link to="/admin/news/$id" params={{ id }}>
+      {label}
+    </Link>
+  </Button>
+);
+
+const NewsPaginationNav = ({
+  ariaLabel,
+  pageLabel,
+  previousLabel,
+  nextLabel,
+  pagination,
+  onPageChange,
+}: ListPaginationNavProps) => (
+  <nav aria-label={ariaLabel} className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+    <p key={pagination.page} aria-live="polite" className="animate-pagination-active">
+      {pageLabel}
+    </p>
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={pagination.page <= 1}
+        onClick={() => onPageChange(Math.max(1, pagination.page - 1))}
+      >
+        {previousLabel}
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={!pagination.hasNextPage}
+        onClick={() => onPageChange(pagination.page + 1)}
+      >
+        {nextLabel}
+      </Button>
+    </div>
+  </nav>
+);
+
+const createNewsListColumns = (pt: ReturnType<typeof usePluginTranslation>) => [
+  {
+    id: 'title',
+    header: pt('fields.title'),
+    cell: (item: NewsContentItem) => (
+      <div>
+        <div className="font-medium">{item.title}</div>
+        <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{firstBlockSummary(item)}</div>
+      </div>
+    ),
+  },
+  {
+    id: 'categoryName',
+    header: pt('fields.categoryName'),
+    cell: categorySummary,
+  },
+  {
+    id: 'updatedAt',
+    header: pt('fields.updatedAt'),
+    cell: (item: NewsContentItem) => formatDate(item.updatedAt),
+  },
+];
 
 const NewsForm = ({
   mode,
@@ -932,6 +1025,7 @@ export const NewsListPage = () => {
   const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
   const createLabel = resolvePluginActionLabel(pt, pluginNewsActionIds.create);
   const editLabel = resolvePluginActionLabel(pt, pluginNewsActionIds.edit);
+  const columns = createNewsListColumns(pt);
   const { page, pageSize } = normalizeListSearch(search);
   const [result, setResult] = React.useState<NewsListResult>({
     data: [],
@@ -941,20 +1035,30 @@ export const NewsListPage = () => {
   const [error, setError] = React.useState<string | null>(null);
   const [flashMessage, setFlashMessage] = React.useState<FlashMessageCode | null>(null);
 
+  const handlePageChange = React.useCallback(
+    (nextPage: number) => {
+      Promise.resolve(
+        navigate({
+          to: '/admin/news',
+          search: (current: ListSearchState) => updateListSearchPage(current, nextPage, result.pagination.pageSize),
+        })
+      ).catch(() => undefined);
+    },
+    [navigate, result.pagination.pageSize]
+  );
+
   React.useEffect(() => {
     if (search.page === page && search.pageSize === pageSize) {
       return;
     }
 
-    void navigate({
-      to: '/admin/news',
-      replace: true,
-      search: (current: Record<string, unknown>) => ({
-        ...current,
-        page,
-        pageSize,
-      }),
-    });
+    Promise.resolve(
+      navigate({
+        to: '/admin/news',
+        replace: true,
+        search: (current: ListSearchState) => updateListSearchPage(current, page, pageSize),
+      })
+    ).catch(() => undefined);
   }, [navigate, page, pageSize, search.page, search.pageSize]);
 
   React.useEffect(() => {
@@ -1028,86 +1132,21 @@ export const NewsListPage = () => {
               selectRow: ({ label }) => label,
             }}
             data={result.data}
-            columns={[
-              {
-                id: 'title',
-                header: pt('fields.title'),
-                cell: (item: NewsContentItem) => (
-                  <div>
-                    <div className="font-medium">{item.title}</div>
-                    <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{firstBlockSummary(item)}</div>
-                  </div>
-                ),
-              },
-              {
-                id: 'categoryName',
-                header: pt('fields.categoryName'),
-                cell: categorySummary,
-              },
-              {
-                id: 'updatedAt',
-                header: pt('fields.updatedAt'),
-                cell: (item: NewsContentItem) => formatDate(item.updatedAt),
-              },
-            ]}
-            rowActions={(item) => (
-              <Button asChild variant="outline" size="sm">
-                <Link to="/admin/news/$id" params={{ id: item.id }}>
-                  {editLabel}
-                </Link>
-              </Button>
-            )}
+            columns={columns}
+            rowActions={(item) => <NewsListEditAction id={item.id} label={editLabel} />}
             emptyState={null}
             getRowId={(item) => item.id}
             selectionMode="none"
           />
 
-          <nav
-            aria-label={pt('pagination.ariaLabel')}
-            className="flex items-center justify-between gap-3 text-sm text-muted-foreground"
-          >
-            <p key={result.pagination.page} aria-live="polite" className="animate-pagination-active">
-              {pt('pagination.pageLabel', { page: result.pagination.page })}
-            </p>
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={result.pagination.page <= 1}
-                onClick={() =>
-                  void navigate({
-                    to: '/admin/news',
-                    search: (current: Record<string, unknown>) => ({
-                      ...current,
-                      page: Math.max(1, result.pagination.page - 1),
-                      pageSize: result.pagination.pageSize,
-                    }),
-                  })
-                }
-              >
-                {pt('pagination.previous')}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={!result.pagination.hasNextPage}
-                onClick={() =>
-                  void navigate({
-                    to: '/admin/news',
-                    search: (current: Record<string, unknown>) => ({
-                      ...current,
-                      page: result.pagination.page + 1,
-                      pageSize: result.pagination.pageSize,
-                    }),
-                  })
-                }
-              >
-                {pt('pagination.next')}
-              </Button>
-            </div>
-          </nav>
+          <NewsPaginationNav
+            ariaLabel={pt('pagination.ariaLabel')}
+            pageLabel={pt('pagination.pageLabel', { page: result.pagination.page })}
+            previousLabel={pt('pagination.previous')}
+            nextLabel={pt('pagination.next')}
+            pagination={result.pagination}
+            onPageChange={handlePageChange}
+          />
         </div>
       )}
     </StudioOverviewPageTemplate>

--- a/packages/plugin-poi/src/poi.pages.tsx
+++ b/packages/plugin-poi/src/poi.pages.tsx
@@ -112,11 +112,88 @@ const compactForm = (form: PoiFormInput): PoiFormInput => ({
 const errorMessage = (pt: ReturnType<typeof usePluginTranslation>, error: unknown, fallbackKey: string) =>
   error instanceof PoiApiError ? error.message : pt(fallbackKey);
 
+type ListSearchState = Record<string, unknown>;
+
+type ListPaginationState = Readonly<{
+  page: number;
+  pageSize: number;
+  hasNextPage: boolean;
+}>;
+
+type ListPaginationNavProps = Readonly<{
+  ariaLabel: string;
+  pageLabel: string;
+  previousLabel: string;
+  nextLabel: string;
+  pagination: ListPaginationState;
+  onPageChange: (page: number) => void;
+}>;
+
+const updateListSearchPage = (
+  current: ListSearchState,
+  page: number,
+  pageSize: number
+): ListSearchState => ({
+  ...current,
+  page,
+  pageSize,
+});
+
+const PoiListEditAction = ({ id, label }: Readonly<{ id: string; label: string }>) => (
+  <Button asChild variant="outline" size="sm">
+    <Link to="/admin/poi/$id" params={{ id }}>
+      {label}
+    </Link>
+  </Button>
+);
+
+const PoiPaginationNav = ({
+  ariaLabel,
+  pageLabel,
+  previousLabel,
+  nextLabel,
+  pagination,
+  onPageChange,
+}: ListPaginationNavProps) => (
+  <nav aria-label={ariaLabel} className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+    <p key={pagination.page} aria-live="polite" className="animate-pagination-active">
+      {pageLabel}
+    </p>
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={pagination.page <= 1}
+        onClick={() => onPageChange(Math.max(1, pagination.page - 1))}
+      >
+        {previousLabel}
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={!pagination.hasNextPage}
+        onClick={() => onPageChange(pagination.page + 1)}
+      >
+        {nextLabel}
+      </Button>
+    </div>
+  </nav>
+);
+
+const createPoiListColumns = (pt: ReturnType<typeof usePluginTranslation>) => [
+  { id: 'name', header: pt('fields.name'), cell: (item: PoiContentItem) => item.name },
+  { id: 'categoryName', header: pt('fields.categoryName'), cell: (item: PoiContentItem) => item.categoryName ?? '—' },
+  { id: 'active', header: pt('fields.active'), cell: (item: PoiContentItem) => (item.active === false ? '—' : '✓') },
+];
+
 export function PoiListPage() {
   const pt = usePluginTranslation('poi');
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as { readonly page?: number; readonly pageSize?: number };
   const { page, pageSize } = normalizeListSearch(search);
+  const editLabel = pt('actions.edit');
   const [result, setResult] = React.useState<PoiListResult>({
     data: [],
     pagination: { page, pageSize, hasNextPage: false },
@@ -124,20 +201,30 @@ export function PoiListPage() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
+  const handlePageChange = React.useCallback(
+    (nextPage: number) => {
+      Promise.resolve(
+        navigate({
+          to: '/admin/poi',
+          search: (current: ListSearchState) => updateListSearchPage(current, nextPage, result.pagination.pageSize),
+        })
+      ).catch(() => undefined);
+    },
+    [navigate, result.pagination.pageSize]
+  );
+
   React.useEffect(() => {
     if (search.page === page && search.pageSize === pageSize) {
       return;
     }
 
-    void navigate({
-      to: '/admin/poi',
-      replace: true,
-      search: (current: Record<string, unknown>) => ({
-        ...current,
-        page,
-        pageSize,
-      }),
-    });
+    Promise.resolve(
+      navigate({
+        to: '/admin/poi',
+        replace: true,
+        search: (current: ListSearchState) => updateListSearchPage(current, page, pageSize),
+      })
+    ).catch(() => undefined);
   }, [navigate, page, pageSize, search.page, search.pageSize]);
 
   React.useEffect(() => {
@@ -191,65 +278,20 @@ export function PoiListPage() {
               selectRow: ({ label }) => label,
             }}
             data={result.data}
-            columns={[
-              { id: 'name', header: pt('fields.name'), cell: (item: PoiContentItem) => item.name },
-              { id: 'categoryName', header: pt('fields.categoryName'), cell: (item: PoiContentItem) => item.categoryName ?? '—' },
-              { id: 'active', header: pt('fields.active'), cell: (item: PoiContentItem) => (item.active === false ? '—' : '✓') },
-            ]}
-            rowActions={(item) => (
-              <Button asChild variant="outline" size="sm">
-                <Link to="/admin/poi/$id" params={{ id: item.id }}>
-                  {pt('actions.edit')}
-                </Link>
-              </Button>
-            )}
+            columns={createPoiListColumns(pt)}
+            rowActions={(item) => <PoiListEditAction id={item.id} label={editLabel} />}
             emptyState={null}
             getRowId={(item) => item.id}
             selectionMode="none"
           />
-          <nav aria-label={pt('pagination.ariaLabel')} className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
-            <p key={result.pagination.page} aria-live="polite" className="animate-pagination-active">
-              {pt('pagination.pageLabel', { page: result.pagination.page })}
-            </p>
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={result.pagination.page <= 1}
-                onClick={() =>
-                  void navigate({
-                    to: '/admin/poi',
-                    search: (current: Record<string, unknown>) => ({
-                      ...current,
-                      page: Math.max(1, result.pagination.page - 1),
-                      pageSize: result.pagination.pageSize,
-                    }),
-                  })
-                }
-              >
-                {pt('pagination.previous')}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={!result.pagination.hasNextPage}
-                onClick={() =>
-                  void navigate({
-                    to: '/admin/poi',
-                    search: (current: Record<string, unknown>) => ({
-                      ...current,
-                      page: result.pagination.page + 1,
-                      pageSize: result.pagination.pageSize,
-                    }),
-                  })
-                }
-              >
-                {pt('pagination.next')}
-              </Button>
-            </div>
-          </nav>
+          <PoiPaginationNav
+            ariaLabel={pt('pagination.ariaLabel')}
+            pageLabel={pt('pagination.pageLabel', { page: result.pagination.page })}
+            previousLabel={pt('pagination.previous')}
+            nextLabel={pt('pagination.next')}
+            pagination={result.pagination}
+            onPageChange={handlePageChange}
+          />
         </div>
       ) : null}
     </StudioOverviewPageTemplate>

--- a/packages/plugin-poi/tests/poi.pages.test.tsx
+++ b/packages/plugin-poi/tests/poi.pages.test.tsx
@@ -47,18 +47,21 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
   useNavigate: () => navigateMock,
   useParams: () => paramsMock(),
-  useSearch: () => ({ page: 1, pageSize: 25 }),
+  useSearch: () => searchMock(),
 }));
 
 const navigateMock = vi.fn();
 const paramsMock = vi.fn(() => ({ id: 'poi-1' }));
+const searchMock = vi.fn(() => ({ page: 1, pageSize: 25 }));
 
 describe('PoiListPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     navigateMock.mockReset();
     paramsMock.mockReset();
+    searchMock.mockReset();
     paramsMock.mockReturnValue({ id: 'poi-1' });
+    searchMock.mockReturnValue({ page: 1, pageSize: 25 });
     registerPluginTranslationResolver((key) => {
       const labels: Record<string, string> = {
         'poi.list.title': 'POI',
@@ -132,6 +135,72 @@ describe('PoiListPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('POI konnten nicht geladen werden.')).toBeTruthy();
+    });
+  });
+
+  it('navigates through paginated list results', async () => {
+    vi.mocked(listPoi).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'poi-1',
+          name: 'Rathaus',
+          categoryName: 'Verwaltung',
+          active: true,
+        },
+      ],
+      pagination: { page: 2, pageSize: 25, hasNextPage: true },
+    });
+
+    render(<PoiListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Seite {{page}}')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zurück' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+
+    expect(navigateMock).toHaveBeenCalledTimes(2);
+
+    const previousTarget = navigateMock.mock.calls[0]?.[0] as {
+      search: (current: Record<string, unknown>) => Record<string, unknown>;
+    };
+    const nextTarget = navigateMock.mock.calls[1]?.[0] as {
+      search: (current: Record<string, unknown>) => Record<string, unknown>;
+    };
+
+    expect(previousTarget.search({ filter: 'open' })).toEqual({
+      filter: 'open',
+      page: 1,
+      pageSize: 25,
+    });
+    expect(nextTarget.search({ filter: 'open' })).toEqual({
+      filter: 'open',
+      page: 3,
+      pageSize: 25,
+    });
+  });
+
+  it('reads pagination values from search params and falls back for invalid values', async () => {
+    searchMock.mockReturnValueOnce({ page: 3, pageSize: 50 });
+
+    render(<PoiListPage />);
+
+    await waitFor(() => {
+      expect(listPoi).toHaveBeenCalledWith({ page: 3, pageSize: 50 });
+    });
+
+    cleanup();
+    searchMock.mockReturnValueOnce({ page: undefined, pageSize: 0 });
+    vi.mocked(listPoi).mockResolvedValueOnce({
+      data: [],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+
+    render(<PoiListPage />);
+
+    await waitFor(() => {
+      expect(listPoi).toHaveBeenCalledWith({ page: 1, pageSize: 25 });
     });
   });
 

--- a/packages/plugin-sdk/src/admin-resources.ts
+++ b/packages/plugin-sdk/src/admin-resources.ts
@@ -311,6 +311,188 @@ const normalizeActionId = (resourceId: string, fieldName: string, value: string)
   return normalized;
 };
 
+const normalizeSearchCapability = (
+  resourceId: string,
+  search: AdminResourceListSearchCapability
+): AdminResourceListSearchCapability => {
+  assertAllowedCapabilityKeys(
+    resourceId,
+    `${resourceId}.capabilities.list.search`,
+    search as unknown as Record<string, unknown>,
+    adminResourceSearchCapabilityAllowedKeys
+  );
+
+  const fields = search.fields.map((field) => normalizeCapabilityId(resourceId, 'capabilities.list.search.fields', field));
+  if (fields.length === 0) {
+    throw new Error(`invalid_admin_resource_capability:${resourceId}:capabilities.list.search.fields`);
+  }
+
+  assertUniqueValues(resourceId, 'duplicate_admin_resource_search_field', fields);
+
+  return {
+    param: normalizeSearchParamName(resourceId, 'capabilities.list.search.param', search.param ?? 'q'),
+    placeholderKey: normalizeLabelKey(resourceId, 'capabilities.list.search.placeholderKey', search.placeholderKey),
+    fields,
+  };
+};
+
+const normalizeFilterCapability = (
+  resourceId: string,
+  filter: AdminResourceListFilterCapability
+): AdminResourceListFilterCapability => {
+  assertAllowedCapabilityKeys(
+    resourceId,
+    `${resourceId}.capabilities.list.filters`,
+    filter as unknown as Record<string, unknown>,
+    adminResourceFilterCapabilityAllowedKeys
+  );
+
+  const id = normalizeCapabilityId(resourceId, 'capabilities.list.filters.id', filter.id);
+  const options = filter.options.map((option) => {
+    assertAllowedCapabilityKeys(
+      resourceId,
+      `${resourceId}.capabilities.list.filters.${id}.options`,
+      option as unknown as Record<string, unknown>,
+      adminResourceFilterOptionAllowedKeys
+    );
+    return {
+      value: normalizeCapabilityId(resourceId, `capabilities.list.filters.${id}.options.value`, option.value),
+      labelKey: normalizeLabelKey(resourceId, `capabilities.list.filters.${id}.options.labelKey`, option.labelKey),
+    };
+  });
+
+  if (options.length === 0) {
+    throw new Error(`invalid_admin_resource_capability:${resourceId}:capabilities.list.filters.${id}.options`);
+  }
+
+  assertUniqueValues(resourceId, 'duplicate_admin_resource_filter_option', options.map((option) => option.value));
+
+  const defaultValue = filter.defaultValue
+    ? normalizeCapabilityId(resourceId, `capabilities.list.filters.${id}.defaultValue`, filter.defaultValue)
+    : undefined;
+  if (defaultValue && options.some((option) => option.value === defaultValue) === false) {
+    throw new Error(`invalid_admin_resource_filter_default:${resourceId}:${id}:${defaultValue}`);
+  }
+
+  return {
+    id,
+    param: normalizeSearchParamName(resourceId, `capabilities.list.filters.${id}.param`, filter.param ?? id),
+    labelKey: normalizeLabelKey(resourceId, `capabilities.list.filters.${id}.labelKey`, filter.labelKey),
+    bindingKey: normalizeBindingKey(resourceId, `capabilities.list.filters.${id}.bindingKey`, filter.bindingKey),
+    options,
+    defaultValue,
+  };
+};
+
+const normalizeSortingCapability = (
+  resourceId: string,
+  sorting: AdminResourceListSortingCapability
+): AdminResourceListSortingCapability => {
+  assertAllowedCapabilityKeys(
+    resourceId,
+    `${resourceId}.capabilities.list.sorting`,
+    sorting as unknown as Record<string, unknown>,
+    adminResourceSortingCapabilityAllowedKeys
+  );
+
+  const fields = sorting.fields.map((field) => {
+    assertAllowedCapabilityKeys(
+      resourceId,
+      `${resourceId}.capabilities.list.sorting.fields`,
+      field as unknown as Record<string, unknown>,
+      adminResourceSortingFieldAllowedKeys
+    );
+    return {
+      id: normalizeCapabilityId(resourceId, 'capabilities.list.sorting.fields.id', field.id),
+      labelKey: normalizeLabelKey(resourceId, 'capabilities.list.sorting.fields.labelKey', field.labelKey),
+      bindingKey: normalizeBindingKey(resourceId, 'capabilities.list.sorting.fields.bindingKey', field.bindingKey),
+    };
+  });
+
+  if (fields.length === 0) {
+    throw new Error(`invalid_admin_resource_capability:${resourceId}:capabilities.list.sorting.fields`);
+  }
+
+  assertUniqueValues(resourceId, 'duplicate_admin_resource_sort_field', fields.map((field) => field.id));
+
+  const defaultField = normalizeCapabilityId(resourceId, 'capabilities.list.sorting.defaultField', sorting.defaultField);
+  if (fields.some((field) => field.id === defaultField) === false) {
+    throw new Error(`invalid_admin_resource_sort_default:${resourceId}:${defaultField}`);
+  }
+  if (sorting.defaultDirection !== 'asc' && sorting.defaultDirection !== 'desc') {
+    throw new Error(`invalid_admin_resource_sort_direction:${resourceId}:${sorting.defaultDirection}`);
+  }
+
+  return {
+    param: normalizeSearchParamName(resourceId, 'capabilities.list.sorting.param', sorting.param ?? 'sort'),
+    defaultField,
+    defaultDirection: sorting.defaultDirection,
+    fields,
+  };
+};
+
+const normalizePaginationCapability = (
+  resourceId: string,
+  pagination: AdminResourceListPaginationCapability
+): AdminResourceListPaginationCapability => {
+  assertAllowedCapabilityKeys(
+    resourceId,
+    `${resourceId}.capabilities.list.pagination`,
+    pagination as unknown as Record<string, unknown>,
+    adminResourcePaginationCapabilityAllowedKeys
+  );
+
+  const pageSizeOptions = [...pagination.pageSizeOptions];
+  if (
+    pagination.defaultPageSize < 1 ||
+    pageSizeOptions.length === 0 ||
+    pageSizeOptions.some((option) => option < 1 || Number.isInteger(option) === false)
+  ) {
+    throw new Error(`invalid_admin_resource_pagination:${resourceId}`);
+  }
+
+  assertUniqueValues(resourceId, 'duplicate_admin_resource_page_size', pageSizeOptions.map(String));
+  if (!pageSizeOptions.includes(pagination.defaultPageSize)) {
+    throw new Error(`invalid_admin_resource_pagination_default:${resourceId}:${pagination.defaultPageSize}`);
+  }
+
+  return {
+    pageParam: normalizeSearchParamName(resourceId, 'capabilities.list.pagination.pageParam', pagination.pageParam ?? 'page'),
+    pageSizeParam: normalizeSearchParamName(
+      resourceId,
+      'capabilities.list.pagination.pageSizeParam',
+      pagination.pageSizeParam ?? 'pageSize'
+    ),
+    defaultPageSize: pagination.defaultPageSize,
+    pageSizeOptions,
+  };
+};
+
+const normalizeBulkActionCapability = (
+  resourceId: string,
+  action: AdminResourceListBulkActionCapability
+): AdminResourceListBulkActionCapability => {
+  assertAllowedCapabilityKeys(
+    resourceId,
+    `${resourceId}.capabilities.list.bulkActions`,
+    action as unknown as Record<string, unknown>,
+    adminResourceBulkActionCapabilityAllowedKeys
+  );
+
+  const id = normalizeCapabilityId(resourceId, 'capabilities.list.bulkActions.id', action.id);
+  if (action.selectionModes.length === 0 || action.selectionModes.some((mode) => !ADMIN_RESOURCE_BULK_SELECTION_MODES.has(mode))) {
+    throw new Error(`invalid_admin_resource_bulk_action_selection:${resourceId}:${id}`);
+  }
+
+  return {
+    id,
+    labelKey: normalizeLabelKey(resourceId, `capabilities.list.bulkActions.${id}.labelKey`, action.labelKey),
+    actionId: normalizeActionId(resourceId, `capabilities.list.bulkActions.${id}.actionId`, action.actionId),
+    bindingKey: normalizeBindingKey(resourceId, `capabilities.list.bulkActions.${id}.bindingKey`, action.bindingKey),
+    selectionModes: [...action.selectionModes],
+  };
+};
+
 const normalizeListCapabilities = (
   resourceId: string,
   capabilities: AdminResourceListCapabilities | undefined
@@ -326,167 +508,16 @@ const normalizeListCapabilities = (
     adminResourceListCapabilitiesAllowedKeys
   );
 
-  const search = capabilities.search
-    ? (() => {
-        assertAllowedCapabilityKeys(
-          resourceId,
-          `${resourceId}.capabilities.list.search`,
-          capabilities.search as unknown as Record<string, unknown>,
-          adminResourceSearchCapabilityAllowedKeys
-        );
-        const fields = capabilities.search.fields.map((field) =>
-          normalizeCapabilityId(resourceId, 'capabilities.list.search.fields', field)
-        );
-        if (fields.length === 0) {
-          throw new Error(`invalid_admin_resource_capability:${resourceId}:capabilities.list.search.fields`);
-        }
-        assertUniqueValues(resourceId, 'duplicate_admin_resource_search_field', fields);
-        return {
-          param: normalizeSearchParamName(resourceId, 'capabilities.list.search.param', capabilities.search.param ?? 'q'),
-          placeholderKey: normalizeLabelKey(resourceId, 'capabilities.list.search.placeholderKey', capabilities.search.placeholderKey),
-          fields,
-        };
-      })()
-    : undefined;
-
-  const filters = capabilities.filters?.map((filter) => {
-    assertAllowedCapabilityKeys(
-      resourceId,
-      `${resourceId}.capabilities.list.filters`,
-      filter as unknown as Record<string, unknown>,
-      adminResourceFilterCapabilityAllowedKeys
-    );
-    const id = normalizeCapabilityId(resourceId, 'capabilities.list.filters.id', filter.id);
-    const options = filter.options.map((option) => {
-      assertAllowedCapabilityKeys(
-        resourceId,
-        `${resourceId}.capabilities.list.filters.${id}.options`,
-        option as unknown as Record<string, unknown>,
-        adminResourceFilterOptionAllowedKeys
-      );
-      return {
-        value: normalizeCapabilityId(resourceId, `capabilities.list.filters.${id}.options.value`, option.value),
-        labelKey: normalizeLabelKey(resourceId, `capabilities.list.filters.${id}.options.labelKey`, option.labelKey),
-      };
-    });
-    if (options.length === 0) {
-      throw new Error(`invalid_admin_resource_capability:${resourceId}:capabilities.list.filters.${id}.options`);
-    }
-    assertUniqueValues(resourceId, 'duplicate_admin_resource_filter_option', options.map((option) => option.value));
-    const defaultValue = filter.defaultValue
-      ? normalizeCapabilityId(resourceId, `capabilities.list.filters.${id}.defaultValue`, filter.defaultValue)
-      : undefined;
-    if (defaultValue && options.some((option) => option.value === defaultValue) === false) {
-      throw new Error(`invalid_admin_resource_filter_default:${resourceId}:${id}:${defaultValue}`);
-    }
-    return {
-      id,
-      param: normalizeSearchParamName(resourceId, `capabilities.list.filters.${id}.param`, filter.param ?? id),
-      labelKey: normalizeLabelKey(resourceId, `capabilities.list.filters.${id}.labelKey`, filter.labelKey),
-      bindingKey: normalizeBindingKey(resourceId, `capabilities.list.filters.${id}.bindingKey`, filter.bindingKey),
-      options,
-      defaultValue,
-    };
-  });
+  const search = capabilities.search ? normalizeSearchCapability(resourceId, capabilities.search) : undefined;
+  const filters = capabilities.filters?.map((filter) => normalizeFilterCapability(resourceId, filter));
 
   if (filters) {
     assertUniqueValues(resourceId, 'duplicate_admin_resource_filter', filters.map((filter) => filter.id));
   }
 
-  const sorting = capabilities.sorting
-    ? (() => {
-        assertAllowedCapabilityKeys(
-          resourceId,
-          `${resourceId}.capabilities.list.sorting`,
-          capabilities.sorting as unknown as Record<string, unknown>,
-          adminResourceSortingCapabilityAllowedKeys
-        );
-        const fields = capabilities.sorting.fields.map((field) => {
-          assertAllowedCapabilityKeys(
-            resourceId,
-            `${resourceId}.capabilities.list.sorting.fields`,
-            field as unknown as Record<string, unknown>,
-            adminResourceSortingFieldAllowedKeys
-          );
-          return {
-            id: normalizeCapabilityId(resourceId, 'capabilities.list.sorting.fields.id', field.id),
-            labelKey: normalizeLabelKey(resourceId, 'capabilities.list.sorting.fields.labelKey', field.labelKey),
-            bindingKey: normalizeBindingKey(resourceId, 'capabilities.list.sorting.fields.bindingKey', field.bindingKey),
-          };
-        });
-        if (fields.length === 0) {
-          throw new Error(`invalid_admin_resource_capability:${resourceId}:capabilities.list.sorting.fields`);
-        }
-        assertUniqueValues(resourceId, 'duplicate_admin_resource_sort_field', fields.map((field) => field.id));
-        const defaultField = normalizeCapabilityId(resourceId, 'capabilities.list.sorting.defaultField', capabilities.sorting.defaultField);
-        if (fields.some((field) => field.id === defaultField) === false) {
-          throw new Error(`invalid_admin_resource_sort_default:${resourceId}:${defaultField}`);
-        }
-        return {
-          param: normalizeSearchParamName(resourceId, 'capabilities.list.sorting.param', capabilities.sorting.param ?? 'sort'),
-          defaultField,
-          defaultDirection: capabilities.sorting.defaultDirection,
-          fields,
-        };
-      })()
-    : undefined;
-
-  if (sorting && sorting.defaultDirection !== 'asc' && sorting.defaultDirection !== 'desc') {
-    throw new Error(`invalid_admin_resource_sort_direction:${resourceId}:${sorting.defaultDirection}`);
-  }
-
-  const pagination = capabilities.pagination
-    ? (() => {
-        assertAllowedCapabilityKeys(
-          resourceId,
-          `${resourceId}.capabilities.list.pagination`,
-          capabilities.pagination as unknown as Record<string, unknown>,
-          adminResourcePaginationCapabilityAllowedKeys
-        );
-        const pageSizeOptions = [...capabilities.pagination.pageSizeOptions];
-        if (
-          capabilities.pagination.defaultPageSize < 1 ||
-          pageSizeOptions.length === 0 ||
-          pageSizeOptions.some((option) => option < 1 || Number.isInteger(option) === false)
-        ) {
-          throw new Error(`invalid_admin_resource_pagination:${resourceId}`);
-        }
-        assertUniqueValues(resourceId, 'duplicate_admin_resource_page_size', pageSizeOptions.map(String));
-        if (!pageSizeOptions.includes(capabilities.pagination.defaultPageSize)) {
-          throw new Error(`invalid_admin_resource_pagination_default:${resourceId}:${capabilities.pagination.defaultPageSize}`);
-        }
-        return {
-          pageParam: normalizeSearchParamName(resourceId, 'capabilities.list.pagination.pageParam', capabilities.pagination.pageParam ?? 'page'),
-          pageSizeParam: normalizeSearchParamName(
-            resourceId,
-            'capabilities.list.pagination.pageSizeParam',
-            capabilities.pagination.pageSizeParam ?? 'pageSize'
-          ),
-          defaultPageSize: capabilities.pagination.defaultPageSize,
-          pageSizeOptions,
-        };
-      })()
-    : undefined;
-
-  const bulkActions = capabilities.bulkActions?.map((action) => {
-    assertAllowedCapabilityKeys(
-      resourceId,
-      `${resourceId}.capabilities.list.bulkActions`,
-      action as unknown as Record<string, unknown>,
-      adminResourceBulkActionCapabilityAllowedKeys
-    );
-    const id = normalizeCapabilityId(resourceId, 'capabilities.list.bulkActions.id', action.id);
-    if (action.selectionModes.length === 0 || action.selectionModes.some((mode) => !ADMIN_RESOURCE_BULK_SELECTION_MODES.has(mode))) {
-      throw new Error(`invalid_admin_resource_bulk_action_selection:${resourceId}:${id}`);
-    }
-    return {
-      id,
-      labelKey: normalizeLabelKey(resourceId, `capabilities.list.bulkActions.${id}.labelKey`, action.labelKey),
-      actionId: normalizeActionId(resourceId, `capabilities.list.bulkActions.${id}.actionId`, action.actionId),
-      bindingKey: normalizeBindingKey(resourceId, `capabilities.list.bulkActions.${id}.bindingKey`, action.bindingKey),
-      selectionModes: [...action.selectionModes],
-    };
-  });
+  const sorting = capabilities.sorting ? normalizeSortingCapability(resourceId, capabilities.sorting) : undefined;
+  const pagination = capabilities.pagination ? normalizePaginationCapability(resourceId, capabilities.pagination) : undefined;
+  const bulkActions = capabilities.bulkActions?.map((action) => normalizeBulkActionCapability(resourceId, action));
 
   if (bulkActions) {
     assertUniqueValues(resourceId, 'duplicate_admin_resource_bulk_action', bulkActions.map((action) => action.id));
@@ -497,7 +528,7 @@ const normalizeListCapabilities = (
     ...(filters?.map((filter) => filter.param) ?? []),
     ...(sorting ? [sorting.param] : []),
     ...(pagination ? [pagination.pageParam, pagination.pageSizeParam] : []),
-  ];
+  ].filter((value): value is string => typeof value === 'string');
   assertUniqueValues(resourceId, 'duplicate_admin_resource_search_param', searchParams);
 
   return {
@@ -698,6 +729,9 @@ const normalizeAdminResourceDefinition = (resource: AdminResourceDefinition): Ad
     }
   }
 
+  const normalizedPermissions = normalizeAdminResourcePermissions(resourceId, resource.permissions);
+  const normalizedCapabilities = normalizeAdminResourceCapabilities(resourceId, resource.capabilities);
+
   return {
     ...resource,
     resourceId,
@@ -712,10 +746,8 @@ const normalizeAdminResourceDefinition = (resource: AdminResourceDefinition): Ad
         ? validateViewDefinition(resourceId, 'history', resource.views.history)
         : undefined,
     },
-    ...(normalizeAdminResourcePermissions(resourceId, resource.permissions)
-      ? { permissions: normalizeAdminResourcePermissions(resourceId, resource.permissions) }
-      : {}),
-    capabilities: normalizeAdminResourceCapabilities(resourceId, resource.capabilities),
+    ...(normalizedPermissions ? { permissions: normalizedPermissions } : {}),
+    capabilities: normalizedCapabilities,
     contentUi: normalizeAdminResourceContentUi(resourceId, resource.guard, resource.contentUi),
   };
 };

--- a/packages/plugin-sdk/tests/admin-resources.test.ts
+++ b/packages/plugin-sdk/tests/admin-resources.test.ts
@@ -186,4 +186,40 @@ describe('admin resources', () => {
       ])
     ).toThrow('invalid_admin_resource_view:news.articles:detail');
   });
+
+  it('rejects duplicate normalized search params across list capabilities', () => {
+    expect(() =>
+      createAdminResourceRegistry([
+        {
+          resourceId: 'news.articles',
+          basePath: 'news',
+          titleKey: 'news.articles.title',
+          guard: 'content',
+          views: {
+            list: { bindingKey: 'content' },
+            create: { bindingKey: 'contentCreate' },
+            detail: { bindingKey: 'contentDetail' },
+          },
+          capabilities: {
+            list: {
+              search: {
+                param: 'q',
+                placeholderKey: 'news.search.placeholder',
+                fields: ['title'],
+              },
+              filters: [
+                {
+                  id: 'status',
+                  param: 'q',
+                  labelKey: 'news.filters.status',
+                  bindingKey: 'news.filters.status',
+                  options: [{ value: 'draft', labelKey: 'news.filters.status.draft' }],
+                },
+              ],
+            },
+          },
+        },
+      ])
+    ).toThrow('duplicate_admin_resource_search_param:news.articles:q');
+  });
 });

--- a/packages/routing/src/admin-resource-routes.test.ts
+++ b/packages/routing/src/admin-resource-routes.test.ts
@@ -464,6 +464,29 @@ describe('admin resource routes', () => {
     });
   });
 
+  it('does not attach list search normalization when no list capabilities are declared', () => {
+    const routeFactories = createAdminResourceRouteFactories(bindings, [
+      {
+        resourceId: 'news.content',
+        basePath: 'news',
+        titleKey: 'news.navigation.title',
+        guard: 'content',
+        views: {
+          list: { bindingKey: 'content' },
+          create: { bindingKey: 'contentCreate' },
+          detail: { bindingKey: 'contentDetail' },
+        },
+      } as never,
+    ]);
+    const rootRoute = { id: 'root' };
+    const listRoute = routeFactories
+      .map((factory) => factory(rootRoute as never))
+      .map((route) => readRouteOptions(route))
+      .find((route) => route.path === '/admin/news');
+
+    expect(listRoute?.validateSearch).toBeUndefined();
+  });
+
   it('redirects legacy content aliases using href and location.href fallbacks', () => {
     const routeFactories = createLegacyContentAliasFactories();
     const rootRoute = { id: 'root' };

--- a/packages/routing/src/admin-resource-routes.ts
+++ b/packages/routing/src/admin-resource-routes.ts
@@ -62,7 +62,6 @@ const resolveOptionalContentUiBindingKey = (
   }
   return bindingKey;
 };
-
 const getAdminResourceBindings = (bindings: AppRouteBindings, resource: AdminResourceDefinition): AdminResourceBindingResolver => {
   const defaultList = resolveBindingKey(bindings, resource, 'list', resource.views.list.bindingKey);
   const defaultCreate = resolveBindingKey(bindings, resource, 'create', resource.views.create.bindingKey);
@@ -85,7 +84,6 @@ const assertSupportedAdminDetailBinding = (bindingKey: BindingKey): void => {
     throw new Error(`unsupported_admin_resource_detail_binding:${bindingKey}`);
   }
 };
-
 const adminResourceGuardMap = {
   content: { list: 'content', create: 'contentCreate', detail: 'contentDetail', history: 'content' },
   media: { list: 'media', create: 'media', detail: 'media', history: 'media' },
@@ -96,7 +94,6 @@ const adminResourceGuardMap = {
   adminGroups: { list: 'adminGroups', create: 'adminGroupCreate', detail: 'adminGroupDetail', history: 'adminGroups' },
   adminLegalTexts: { list: 'adminLegalTexts', create: 'adminLegalTextCreate', detail: 'adminLegalTextDetail', history: 'adminLegalTexts' },
 } as const satisfies Record<AdminResourceDefinition['guard'], Record<AdminResourceRouteKind, AccountUiRouteGuardKey>>;
-
 const resolveAdminResourceGuard = (resource: AdminResourceDefinition, routeKind: AdminResourceRouteKind): AccountUiRouteGuardKey =>
   adminResourceGuardMap[resource.guard][routeKind];
 
@@ -141,6 +138,37 @@ const ensureRequiredPermissions = async (
     throw redirect({ href: '/?error=auth.insufficientRole' });
   }
 };
+const createListRouteDefinition = (resource: AdminResourceDefinition, binding: BindingKey, basePath: string): UiRouteDefinition => ({
+  binding,
+  resource,
+  guard: resolveAdminResourceGuard(resource, 'list'),
+  path: basePath,
+  routeKind: 'list',
+  validateSearch: resource.capabilities?.list
+    ? (search: Record<string, unknown>) => normalizeAdminResourceListSearch(resource, search)
+    : undefined,
+});
+
+const createStaticRouteDefinition = (
+  resource: AdminResourceDefinition,
+  routeKind: Exclude<AdminResourceRouteKind, 'list'>,
+  binding: BindingKey,
+  path: string
+): UiRouteDefinition => ({
+  binding,
+  resource,
+  guard: resolveAdminResourceGuard(resource, routeKind),
+  path,
+  routeKind,
+});
+const createHistoryRouteDefinition = (
+  resource: AdminResourceDefinition,
+  binding: BindingKey | undefined,
+  detailPath: string
+): readonly UiRouteDefinition[] =>
+  binding
+    ? [createStaticRouteDefinition(resource, 'history', binding, toAdminHistoryRoutePath(detailPath))]
+    : [];
 
 const createAdminResourceRouteDefinitions = (
   bindings: AppRouteBindings,
@@ -152,43 +180,11 @@ const createAdminResourceRouteDefinitions = (
     const detailBindingKey = resolveBindingKey(bindings, resource, 'detail', resource.views.detail.bindingKey);
     assertSupportedAdminDetailBinding(detailBindingKey);
     const detailPath = getAdminDetailRoutePath(basePath, detailBindingKey);
-
     return [
-      {
-        binding: resolvedBindings.list,
-        resource,
-        guard: resolveAdminResourceGuard(resource, 'list'),
-        path: basePath,
-        routeKind: 'list',
-        validateSearch: resource.capabilities?.list
-          ? (search: Record<string, unknown>) => normalizeAdminResourceListSearch(resource, search)
-          : undefined,
-      },
-      {
-        binding: resolvedBindings.create,
-        resource,
-        guard: resolveAdminResourceGuard(resource, 'create'),
-        path: toAdminCreateRoutePath(basePath),
-        routeKind: 'create',
-      },
-      {
-        binding: resolvedBindings.detail,
-        resource,
-        guard: resolveAdminResourceGuard(resource, 'detail'),
-        path: detailPath,
-        routeKind: 'detail',
-      },
-      ...(resolvedBindings.history
-        ? [
-            {
-              binding: resolvedBindings.history,
-              resource,
-              guard: resolveAdminResourceGuard(resource, 'history'),
-              path: toAdminHistoryRoutePath(detailPath),
-              routeKind: 'history',
-            } satisfies UiRouteDefinition,
-          ]
-        : []),
+      createListRouteDefinition(resource, resolvedBindings.list, basePath),
+      createStaticRouteDefinition(resource, 'create', resolvedBindings.create, toAdminCreateRoutePath(basePath)),
+      createStaticRouteDefinition(resource, 'detail', resolvedBindings.detail, detailPath),
+      ...createHistoryRouteDefinition(resource, resolvedBindings.history, detailPath),
     ] as const;
   });
 
@@ -201,7 +197,6 @@ export const createAdminResourceRouteFactories = (
     (definition) =>
       (rootRoute: RootRoute) => {
         const guard = createAccountUiRouteGuard(definition.guard, diagnostics, definition.path);
-
         return createRoute({
           getParentRoute: () => rootRoute,
           path: definition.path,
@@ -221,10 +216,7 @@ export const createLegacyContentAliasFactories = (
 ): readonly AppRouteFactory[] => {
   const canonicalContentPath = resolveCanonicalContentAdminRoutePath(resources);
   const legacyAliases = [
-    {
-      aliasPrefix: LEGACY_CONTENT_ALIAS_PREFIX,
-      canonicalPath: canonicalContentPath,
-    },
+    { aliasPrefix: LEGACY_CONTENT_ALIAS_PREFIX, canonicalPath: canonicalContentPath },
     ...resources
       .filter((resource) => resource.guard === 'content' && resource.basePath !== 'content')
       .map((resource) => ({
@@ -232,28 +224,24 @@ export const createLegacyContentAliasFactories = (
         canonicalPath: toAdminRoutePath(resource.basePath),
       })),
   ];
-
+  const createLegacyAliasRouteFactory = (aliasPrefix: string, canonicalPath: string, path: string): AppRouteFactory => (rootRoute: RootRoute) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path,
+      beforeLoad: (options) => {
+        const href = readBeforeLoadHref(options);
+        throw redirect({
+          href:
+            aliasPrefix === LEGACY_CONTENT_ALIAS_PREFIX
+              ? normalizeLegacyContentHref(href, canonicalPath)
+              : normalizeLegacyAdminResourceHref({ href, aliasPrefix, canonicalPath }),
+        });
+      },
+      component: () => null,
+    });
   return legacyAliases.flatMap(({ aliasPrefix, canonicalPath }) =>
-    [aliasPrefix, toAdminCreateRoutePath(aliasPrefix), `${aliasPrefix}/$contentId`].map(
-      (path) => (rootRoute: RootRoute) =>
-        createRoute({
-          getParentRoute: () => rootRoute,
-          path,
-          beforeLoad: (options) => {
-            const href = readBeforeLoadHref(options);
-            throw redirect({
-              href:
-                aliasPrefix === LEGACY_CONTENT_ALIAS_PREFIX
-                  ? normalizeLegacyContentHref(href, canonicalPath)
-                  : normalizeLegacyAdminResourceHref({
-                      href,
-                      aliasPrefix,
-                      canonicalPath,
-                    }),
-            });
-          },
-          component: () => null,
-        })
+    [aliasPrefix, toAdminCreateRoutePath(aliasPrefix), `${aliasPrefix}/$contentId`].map((path) =>
+      createLegacyAliasRouteFactory(aliasPrefix, canonicalPath, path)
     )
   );
 };

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -538,11 +538,15 @@ const toListResult = <TItem>(
   },
 });
 
-const normalizeListInput = (input: SvaMainserverListInput): SvaMainserverListInput => {
-  const requestedPageSize = Math.trunc(input.pageSize) || 0;
-  const pageSize = ALLOWED_MAINSERVER_PAGE_SIZES.includes(requestedPageSize as (typeof ALLOWED_MAINSERVER_PAGE_SIZES)[number])
-    ? requestedPageSize
+const normalizeAllowedPageSize = (pageSize: number): (typeof ALLOWED_MAINSERVER_PAGE_SIZES)[number] => {
+  const requestedPageSize = Math.trunc(pageSize) || 0;
+  return ALLOWED_MAINSERVER_PAGE_SIZES.includes(requestedPageSize as (typeof ALLOWED_MAINSERVER_PAGE_SIZES)[number])
+    ? (requestedPageSize as (typeof ALLOWED_MAINSERVER_PAGE_SIZES)[number])
     : 25;
+};
+
+const normalizeListInput = (input: SvaMainserverListInput): SvaMainserverListInput => {
+  const pageSize = normalizeAllowedPageSize(input.pageSize);
   const maxPage = Math.floor(MAX_MAINSERVER_VISIBLE_OFFSET / pageSize) + 1;
   const page = Math.min(Math.max(1, Math.trunc(input.page) || 1), maxPage);
 
@@ -611,6 +615,63 @@ const resolveGraphqlStatusErrorCode = (status: number): SvaMainserverErrorCode =
     return 'forbidden';
   }
   return 'network_error';
+};
+
+type VisibleListCollectionState<TItem> = {
+  readonly collectedVisibleItems: TItem[];
+  visibleIndex: number;
+  skip: number;
+  exhausted: boolean;
+  hasNextPage: boolean;
+};
+
+const createVisibleListCollectionState = <TItem>(): VisibleListCollectionState<TItem> => ({
+  collectedVisibleItems: [],
+  visibleIndex: 0,
+  skip: 0,
+  exhausted: false,
+  hasNextPage: false,
+});
+
+const assertUpstreamScanLimit = (skip: number) => {
+  if (skip > MAX_MAINSERVER_UPSTREAM_SCAN_RECORDS) {
+    throw toSvaMainserverError({
+      code: 'invalid_response',
+      message: 'Mainserver-Pagination erfordert zu viele Upstream-Datensätze für sichtbare Ergebnisse.',
+      statusCode: 502,
+    });
+  }
+};
+
+const updateVisibleListCollectionState = <TUpstreamItem, TItem>(
+  state: VisibleListCollectionState<TItem>,
+  input: {
+    readonly upstreamItems: readonly TUpstreamItem[];
+    readonly startIndex: number;
+    readonly targetVisibleCount: number;
+    readonly isVisible: (item: TUpstreamItem) => boolean;
+    readonly mapItem: (item: TUpstreamItem) => TItem;
+  }
+) => {
+  for (const item of input.upstreamItems) {
+    if (input.isVisible(item) === false) {
+      continue;
+    }
+
+    if (state.visibleIndex >= input.startIndex) {
+      state.collectedVisibleItems.push(input.mapItem(item));
+      if (state.collectedVisibleItems.length >= input.targetVisibleCount) {
+        state.hasNextPage = true;
+        break;
+      }
+    }
+
+    state.visibleIndex += 1;
+    if (state.visibleIndex >= input.startIndex + input.targetVisibleCount) {
+      state.hasNextPage = true;
+      break;
+    }
+  }
 };
 
 const parseGraphqlPayload = <TResult>(payload: unknown): TResult => {
@@ -1706,65 +1767,43 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     const startIndex = (normalizedInput.page - 1) * normalizedInput.pageSize;
     const targetVisibleCount = normalizedInput.pageSize + 1;
     const batchSize = Math.min(MAX_MAINSERVER_PAGE_SIZE, normalizedInput.pageSize + 1);
-    const collectedVisibleItems: TItem[] = [];
-    let visibleIndex = 0;
-    let skip = 0;
-    let exhausted = false;
-    let hasNextPage = false;
+    const state = createVisibleListCollectionState<TItem>();
 
-    while (collectedVisibleItems.length < targetVisibleCount && exhausted === false && hasNextPage === false) {
-      if (skip > MAX_MAINSERVER_UPSTREAM_SCAN_RECORDS) {
-        throw toSvaMainserverError({
-          code: 'invalid_response',
-          message: 'Mainserver-Pagination erfordert zu viele Upstream-Datensätze für sichtbare Ergebnisse.',
-          statusCode: 502,
-        });
-      }
+    while (
+      state.collectedVisibleItems.length < targetVisibleCount &&
+      state.exhausted === false &&
+      state.hasNextPage === false
+    ) {
+      assertUpstreamScanLimit(state.skip);
 
       const response = await executeGraphqlWithConfig<TQueryResult>(
         {
           ...normalizedInput,
           document: options.document,
           operationName: options.operationName,
-          variables: { limit: batchSize, skip, order: options.order },
+          variables: { limit: batchSize, skip: state.skip, order: options.order },
         },
         config
       );
 
       const upstreamItems = options.readItems(response);
-      exhausted = upstreamItems.length < batchSize;
-      skip += upstreamItems.length;
+      state.exhausted = upstreamItems.length < batchSize;
+      state.skip += upstreamItems.length;
 
-      for (const item of upstreamItems) {
-        if (options.isVisible(item) === false) {
-          continue;
-        }
-
-        if (visibleIndex >= startIndex) {
-          collectedVisibleItems.push(options.mapItem(item));
-          if (collectedVisibleItems.length >= targetVisibleCount) {
-            hasNextPage = true;
-            break;
-          }
-        }
-
-        visibleIndex += 1;
-        if (visibleIndex >= startIndex + targetVisibleCount) {
-          hasNextPage = true;
-          break;
-        }
-      }
+      updateVisibleListCollectionState(state, {
+        upstreamItems,
+        startIndex,
+        targetVisibleCount,
+        isVisible: options.isVisible,
+        mapItem: options.mapItem,
+      });
 
       if (upstreamItems.length === 0) {
         break;
       }
     }
 
-    return toListResult(
-      normalizedInput,
-      collectedVisibleItems.slice(0, normalizedInput.pageSize),
-      hasNextPage
-    );
+    return toListResult(normalizedInput, state.collectedVisibleItems.slice(0, normalizedInput.pageSize), state.hasNextPage);
   };
 
   const listNewsWithConfig = async (


### PR DESCRIPTION
## Was hat sich geändert?

- SonarCloud-Befunde aus drei anstehenden Changes gezielt mit der laufenden Arbeit gebündelt und als Report dokumentiert.
- Pagination- und Listenpfade für Mainserver-News, Events und POI in Host-Adaptern, Plugin-Pages und `sva-mainserver` entkoppelt.
- IAM-/Contract-nahe Wrapper in `auth-runtime` auf kleinere gemeinsame Binder reduziert.
- Host-Standards für Admin-Ressourcen in `plugin-sdk` und `routing` strukturell gestrafft und mit zusätzlichen Guardrail-/Routing-Tests abgesichert.

## Warum?

Die offenen Sonar-Befunde lagen genau an Pfaden, die in den geplanten Changes ohnehin fachlich berührt werden. Ziel dieses PR ist, diese Refactors direkt dort mitzunehmen, statt später breite, schlecht zuordenbare Cleanup-PRs nachzuschieben.

## Auswirkungen

- Klarere Pagination- und Listenflüsse in Mainserver-, Events-, POI- und News-Pfaden.
- Weniger Verdrahtungsduplikate in IAM-/Contract-Wrappers.
- Lesbarer und enger abgegrenzter Host-Backbone für Admin-Ressourcen.
- Eine gebündelte Sonar-Arbeitsgrundlage unter `docs/reports/sonar-change-bundling-2026-05-02.md`.

## Validierung

Erfolgreich gelaufen:

- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main`
- `pnpm nx run auth-runtime:check:runtime`
- `pnpm check:file-placement`
- `pnpm complexity-gate`
- betroffene Paket-Tests für `plugin-news`, `plugin-events`, `plugin-poi`, `plugin-sdk`, `routing`, `auth-runtime`, `sva-mainserver`

Teilweise blockiert lokal:

- `pnpm test:pr` lief bis in `test:integration`, scheitert aber lokal an `monitoring-client:test:integration`, weil `127.0.0.1:3001` bereits belegt ist und der Monitoring-Compose-Stack deshalb Grafana nicht binden kann.

## Bekannte Hinweise

- `plugin-news`-Tests erzeugen weiterhin bekannte Happy-DOM-/Media-Fetch-Teardown-Meldungen, ohne rot zu werden.
- Der offene `test:pr`-Blocker ist ein lokaler Portkonflikt, kein fachlicher Testfehler im geänderten Code.
