### PR TITLE
[codex] Add waste management plugin proposal

### DIFF
--- a/openspec/changes/add-waste-management-plugin/design.md
+++ b/openspec/changes/add-waste-management-plugin/design.md
@@ -1,0 +1,483 @@
+## Context
+
+Im `Newcms` existiert ein fachlicher Abfallkalender-MVP mit React-Oberflaechen, einer API-Schicht gegen Supabase-Functions und einem relationalen `waste_*`-Schema. Das Studio besitzt dagegen bereits klare Zielgrenzen:
+
+- Fachoberflaechen leben in Workspace-Plugins ueber `@sva/plugin-sdk`.
+- Wiederverwendbare UI kommt aus `@sva/studio-ui-react`.
+- Routing, Guards und Search-Param-Validierung bleiben hostgefuehrt.
+- Datenzugriff auf externe oder fachspezifische Systeme wird ueber schmale Host-Fassaden gekapselt.
+- Instanzisolation und Auditierung sind verbindliche Querschnittsanforderungen.
+
+Der Waste-Management-Change muss diese Welten zusammenbringen, ohne `Newcms` als Architektur in das Studio zu kopieren.
+
+## Goals
+
+- Vollstaendige Admin-Capability fuer Waste-Management im Studio schaffen
+- Freies Plugin `waste-management` mit eigener Fachnavigation unter `/plugins/waste-management`
+- Hostgefuehrte Studio-API fuer Waste-CRUD, Zuordnungen, CSV-Import, Seed und Reset
+- Genau eine Waste-Fachdatenbank pro Studio-Instanz mit klarer technischer Konfiguration im Studio-Postgres
+- Fokus auf den Betrieb als fuehrendes Waste-System; sekundaere Fuehrung bleibt als spaetere Erweiterungsrichtung architektonisch offen
+- Feingranulares Modul-IAM und revisionsfaehige Auditspur fuer alle Mutationen
+- Fachlich belastbares Adress-, Feiertags- und Abweichungsmodell fuer spaetere App-/Push-Ausspielung vorbereiten
+- `Newcms` nur als fachliche und UX-Referenz nutzen
+
+## Non-Goals
+
+- Keine Buergerkanal- oder Mobile-Read-API
+- Keine Export-/Feed-Schnittstellen
+- Keine Uebernahme der `Newcms`-Edge-Functions als produktive Backend-Strategie
+- Keine Host-owned `adminResource`-Materialisierung als Hauptoberflaeche
+
+## Decisions
+
+### 1. Plugin- und Routing-Modell
+
+Das Modul wird als freies Fachplugin `waste-management` modelliert. Die Hauptoberflaeche wird unter `/plugins/waste-management` materialisiert und besitzt typisierte Search-Params fuer:
+
+- aktiven Haupttab
+- Such- und Filterzustaende
+- Paging/Sortierung fuer Listen
+- fokussierte Detail- oder Bearbeitungskontexte
+- adressbezogene Auswahl- oder Zuordnungskontexte, wenn sie fuer Deep-Links oder Wiedereinstieg relevant sind
+
+Warum:
+- Die Oberflaeche ist kein standardisiertes Content-CRUD, sondern ein komplexer Workflow aus Tabellen, Hierarchien, Bulk-Operationen und Spezialtools.
+- Das bestehende host-owned `adminResource`-Muster fuer Content waere hier kuenstlich und wuerde die Fachnavigation eher verbergen als vereinheitlichen.
+
+### 2. Server-Fassade und Datenzugriff
+
+Das Plugin importiert keinen Supabase-Client und spricht ausschliesslich die Studio-Fassade unter `/api/v1/waste-management/*` an. Die Fassade kapselt:
+
+- Autorisierung und Instanzkontext
+- Validierung und Fehlerabbildung
+- Mapping zwischen HTTP-Vertrag und Datenmodell
+- Audit-Ausloesung
+- serverseitige Aufloesung der fuer die aktive Instanz hinterlegten Waste-Datenquelle
+- Datenzugriff auf das `waste_*`-Schema der aufgeloesten Waste-Fachdatenbank
+- Vorbereitung spaeterer Upstream-Importe oder Synchronisationslaeufe aus fuehrenden Fremdsystemen
+
+Warum:
+- Das folgt dem bestehenden Studio-Muster fuer hostgefuehrte Persistenzgrenzen.
+- Browserseitiger Direktsupabasezugriff wuerde Instanzisolation, Logging und Sicherheitskontrollen unterlaufen.
+- Die `Newcms`-Edge-Functions wuerden eine zweite Runtime-Grenze mit eigener Fehler- und Auth-Logik einfuehren.
+- Die Auswahl der richtigen Waste-Datenbank pro Instanz darf nicht im Plugin liegen, sondern muss serverseitig aus dem Instanzkontext und der hinterlegten Modulkonfiguration erfolgen.
+
+### 3. Datenmodell und Migration
+
+Die bestehende `waste_*`-Tabellenfamilie ist die Migrationsbasis, aber kein unveraenderlicher Vertrag. Das Zielbild trennt zentrale Studio-Governance von Waste-Fachdaten:
+
+- das zentrale Studio-Postgres bleibt System of Record fuer Instanzen, Rollen, Rechte, Audits und technische Modulkonfiguration
+- jede Studio-Instanz erhaelt genau eine eigene Waste-Fachdatenbank beziehungsweise genau ein eigenes Supabase-Projekt fuer fachliche Waste-Daten
+- die fuer eine Instanz gueltige Waste-Datenquelle wird als serverseitig geschuetzte Modulkonfiguration verwaltet und ueber die Host-Fassade aufgeloest
+- Waste-Fachdaten werden nicht als regulaeres Persistenzmodell in der zentralen Studio-Postgres mitgefuehrt
+- IAM-, Rollen-, Rechte- und Audit-Primärdaten des Studios werden nicht in der externen Waste-Fachdatenbank gespeichert
+- Waste-spezifische Migrations-, Job- und sonstige plugininterne Hilfsdaten duerfen in der externen Waste-Fachdatenbank gespeichert werden, solange sie keine zentrale Studio-Governance duplizieren
+- zusaetzliche Status-, Monitoring- und fortlaufende Historienmetadaten zur Erreichbarkeit, Pruefung und Entwicklung der externen Waste-Datenquelle duerfen zentral im Studio-Postgres gehalten werden
+
+Die Waste-Fachdatenbank selbst ist die Mandantengrenze. Das Zielbild fuehrt Waste-Daten daher ohne zusaetzlichen fachlichen `instance_id`-Mandantenschnitt in den Waste-Tabellen:
+
+- bestehende globale Annahmen aus `Newcms` werden bereinigt
+- inkompatible Korrekturen sind erlaubt, sofern ein expliziter Migrationspfad dokumentiert wird
+- Seed und Reset muessen die aktive Waste-Datenbank der Instanz beachten
+
+Warum:
+- Studio-IAM, Routing und Verwaltungslogik arbeiten instanzzentriert.
+- Bei genau einer Waste-Datenbank pro Instanz waere ein zusaetzlicher Mandantenschnitt innerhalb derselben Fachdatenbank redundant und fehleranfaellig.
+- Die Trennung vermeidet, dass fachliche Massendaten, Betriebsrechte und revisionsrelevante Governance-Daten in derselben Persistenzgrenze vermischt werden.
+
+### 3a. Primaer- und Sekundaersystem-Modell
+
+Der aktuelle Change fokussiert den Betrieb von SVA Studio als fuehrendes Waste-System.
+
+- Waste-Daten werden originär ueber das Studio gepflegt.
+- Import, Seed und Reset arbeiten auf dieser fuehrenden Datenhaltung.
+- Die Host-Fassade bleibt die einzige Plugin-Schnittstelle.
+- Die technische Datenquellenkonfiguration pro Instanz bleibt ueber Studio-Einstellungen pflegbar, ohne dass das Plugin direkte Datenbank-Credentials kennen oder speichern darf.
+
+Sekundaere Fuehrung durch ein externes Fachsystem bleibt fuer spaetere Changes architektonisch zulaessig, ist hier aber ausdruecklich nicht fachlich ausdefiniert:
+
+- keine konkrete Fremdsystem-Schnittstelle
+- keine Schreibsperren oder Override-Regeln fuer Sync-Modi
+- keine Konfliktlogik zwischen Synchronisation und manueller Pflege
+
+### 3e. Datenquellen-Lebenszyklus und Ausfallverhalten
+
+Die Waste-Datenquelle einer Instanz wird vollstaendig ueber die zentrale Studio-Governance konfiguriert.
+
+- Verbindungsdaten liegen im Studio-Postgres.
+- Status-, Monitoring- und fortlaufende Historienmetadaten zur externen Waste-Datenquelle duerfen ebenfalls im Studio-Postgres gehalten werden.
+- Die Host-Runtime loest daraus die aktive Waste-Datenquelle serverseitig auf.
+- Die Konfiguration bleibt ueber `waste-management.settings.manage` pflegbar.
+
+Die erste verpflichtende Ereignishistorie im Studio-Postgres umfasst mindestens:
+
+- erfolgreiche und fehlgeschlagene Connection-Checks
+- Rekonfigurationen der Waste-Datenquelle
+- Start, Erfolg und Fehler von Waste-Migrationen
+- Start, Erfolg und Fehler von CSV-Importen
+- Start, Erfolg und Fehler von Seed-Operationen
+- Start, Erfolg und Fehler von Reset-Operationen
+
+Diese erste Historie bleibt bewusst technisch:
+
+- sie dient zunaechst der Betriebs- und Monitoring-Sicht auf die externe Datenquelle
+- fachliche Einordnungen oder tiefergehende Business-Historien sind in diesem Change kein Pflichtbestandteil
+
+Fehlgeschlagene Connection-Checks wirken nicht nur historisierend:
+
+- sie muessen zusaetzlich einen sofort sichtbaren aktuellen Status an der zentralen Instanz-/Plugin-Konfiguration hinterlassen
+- Administratoren sollen damit ohne Auswertung der Verlaufshistorie erkennen koennen, dass die externe Waste-Datenquelle aktuell gestoert ist
+- erfolgreiche Connection-Checks heben diesen sichtbaren Stoerungsstatus sofort wieder auf
+- die fortlaufende Historie bleibt davon unberuehrt und bildet den Verlauf weiter ab
+
+Fuer den aktuellen Change gilt ausserdem:
+
+- beim Laden der Settings-Seite darf automatisch ein expliziter Connection-Check ausgefuehrt werden
+- auf anderen Waste-Seiten duerfen erfolgreiche oder fehlgeschlagene echte DB-Zugriffe den sichtbaren technischen Status implizit mitbeeinflussen
+- fachliche Fehler ohne Connectivity-Bezug duerfen dabei keinen Stoerungsstatus setzen
+- periodische Hintergrund-Checks oder eigenstaendige Monitoring-Scheduler sind nicht Teil dieses Changes
+- fuer die erste, billigste Statuslogik darf jeder technisch erfolgreiche echte DB-Zugriff den sichtbaren Status unmittelbar wieder auf `ok` setzen
+
+Wenn die aktuell konfigurierte Waste-Datenquelle nicht erreichbar ist, darf das Modul nicht einfach vollstaendig unbenutzbar werden:
+
+- die Einstellungen zur Waste-Datenquelle muessen weiterhin erreichbar bleiben
+- Verbindungsdaten muessen aktualisiert werden koennen, etwa wenn eine Supabase-Datenbank umgezogen wurde
+- Connection-Tests und Statuspruefungen muessen serverseitig ausfuehrbar bleiben
+- fachliche CRUD-Operationen gegen Waste-Daten duerfen fehlschlagen, aber die Rekonfiguration der Datenquelle darf dadurch nicht blockiert werden
+
+### 3f. Migrationsmodell pro Instanz
+
+Schema-Migrationen fuer die Waste-Fachdatenbank werden instanzbezogen und plugingefuehrt angeboten.
+
+- Beim ersten Start des Plugins fuer eine Instanz muss erkennbar sein, ob die zugeordnete Waste-Datenbank initialisiert werden muss.
+- Nach einem Plugin-Update muss erkennbar sein, ob fuer die Instanz ausstehende Waste-Migrationen vorliegen.
+- Die Migrationen werden nicht blind im Hintergrund erzwungen, sondern im Plugin beziehungsweise ueber die Host-Fassade als ausfuehrbare Admin-Operation angeboten.
+- Auch Migrationen sind hochrelevante technische Operationen und muessen nachvollziehbar protokolliert werden.
+
+### 3b. Terminlogik fuer Einzelverschiebungen
+
+Wiederkehrende Touren werden nicht nur durch starre Rhythmen beschrieben. Das Zielbild muss manuelle Einzelverschiebungen fachlich verarbeiten koennen.
+
+- Eine Verschiebung einzelner Termine darf nicht nur als isolierte Notiz behandelt werden.
+- Die Fachlogik muss ausdruecklich modellieren koennen, ob eine Einzelkorrektur nur den Einzeltermin betrifft oder die nachfolgende Serienlogik beeinflusst.
+- Das konkrete Regelwerk wird implementierungsseitig praezisiert, der Change fixiert aber bereits, dass Folgeeffekte fachlich unterstuetzt werden muessen.
+
+### 3c. Feiertags- und Adressmodell
+
+Das Waste-Management-Zielbild muss die im Konzept genannten fachlichen Basismodelle ausdruecklich tragen:
+
+- Feiertage und andere globale Abweichungsgruende sind eigenstaendige Ausloeser fuer Terminverschiebungen und nicht nur freie Kommentarfelder.
+- Die Adresslogik folgt der Hierarchie `Ort -> Strasse -> Hausnummer`, wobei nachgelagerte Auswahlmengen von der vorangehenden Ebene abhaengen.
+- Das Datenmodell muss diese Hierarchie sowohl fuer redaktionelle Pflege als auch fuer spaetere kanalbezogene Auswahl- und Personalisierungsfluesse abbilden koennen.
+
+### 3d. Mehrsprachige und farbcodierte Fachstammdaten
+
+Abfallarten und fachnahe Darstellungen muessen nicht nur technisch verwaltbar, sondern auch fuer verschiedene Kanaele ausspielbar bleiben.
+
+- Fachstammdaten muessen mehrsprachige Bezeichnungen tragen koennen.
+- Farbcodes fuer Abfallarten oder Tourdarstellungen sind Teil des fachlichen Vertrags und nicht nur reine UI-Dekoration.
+- Das Zielbild bleibt damit kompatibel zu spaeteren Kalender-, Push- oder App-Darstellungen, ohne diese in diesem Change schon umzusetzen.
+
+### 4. IAM und Hochrisiko-Operationen
+
+Das Modul erhaelt einen feingranularen Namespace `waste-management.*`. Das Zielbild trennt mindestens:
+
+- `waste-management.read`
+- `waste-management.master-data.manage`
+- `waste-management.tours.manage`
+- `waste-management.scheduling.manage`
+- `waste-management.import.execute`
+- `waste-management.seed.execute`
+- `waste-management.reset.execute`
+- `waste-management.settings.manage`
+
+Reset bleibt auch fuer Produktivumgebungen zulaessig, aber nur mit:
+
+- separatem Hochrisiko-Recht
+- expliziter mehrstufiger Bestaetigung
+- klarer Scope-Anzeige
+- Audit-Event mit Instanz-, Actor- und Ergebniskontext
+
+Das gilt nicht nur serverseitig. Die UI muss schreibende und gefaehrliche Aktionen konsequent aus Rechten ableiten:
+
+- rein lesende Nutzer sehen keine impliziten Schreibpfade
+- gefaehrliche Tools wie Seed und Reset erscheinen nur mit den dafuer vorgesehenen Rechten
+- die UI darf keine zweite, lockerere Rechteinterpretation neben dem Host etablieren
+
+### 5. Audit und Historie
+
+Verlauf/Historie wird fuer das Modul nicht ueber eigene Primairtabellen geloest, sondern ueber die Studio-Audit-Basis modelliert:
+
+- alle Mutationen erzeugen Audit-Events
+- Seed, Reset und CSV-Import tragen erweiterte sichere Metadaten
+- fachliche Verlaufsansichten lesen in diesem Change aus der einfachsten tragfaehigen Loesung auf Basis derselben Auditspur; dedizierte Read-Modelle bleiben optional
+
+Warum:
+- Das vermeidet parallele Revisions- und Verlaufssysteme.
+- Sicherheitskritische Operationen muessen ohnehin revisionsfaehig im zentralen Auditvertrag sichtbar sein.
+
+### 5a. Asynchrone Data-Tools
+
+CSV-Import, Seed, Reset und Waste-Schema-Migrationen werden als asynchrone Operationen modelliert.
+
+- Ausloesen und Statusabfrage sind getrennte Schritte.
+- Langlaufende Operationen blockieren nicht die normale Request-Laufzeit.
+- Ergebnisse, Fehler und Fortschrittsstatus muessen fuer Administratoren nachvollziehbar rueckgemeldet werden.
+- Reset bezieht sich nur auf Waste-Fachdaten der aktiven Instanz und nicht auf die technische Datenquellenkonfiguration im Studio-Postgres.
+
+Die zugrunde liegende Job-Orchestrierung soll nicht waste-spezifisch bleiben, sondern als generische Studio-Faehigkeit gedacht werden:
+
+- das Studio stellt ein allgemeines, pluginuebergreifendes Jobmodell bereit
+- das Waste-Plugin nutzt dieses Jobmodell fuer Import, Seed, Reset und Migrationen mit eigenen Jobtypen oder plugin-spezifischem Payload
+- restart-sichere Persistenz, Status und Lifecycle gehoeren zur allgemeinen Studio-Faehigkeit und nicht als einmalige Sonderlogik in das Waste-Plugin
+- die zentrale Persistenz dieser allgemeinen Job-Faehigkeit liegt im Studio-Postgres
+- die erste feste Statusmenge dieser allgemeinen Job-Faehigkeit umfasst mindestens `queued`, `running`, `succeeded`, `failed`, `cancelled`
+- automatische Retry-Logik ist in dieser ersten Ausbaustufe bewusst nicht enthalten
+- fehlgeschlagene oder abgebrochene Jobs werden in dieser ersten Ausbaustufe nicht in-place neu gestartet; stattdessen wird bei Bedarf ein neuer Job angelegt
+- `cancelled` wird in dieser ersten Ausbaustufe bereits als Status reserviert, ohne dass damit schon fuer alle Jobtypen ein echter Abbruchpfad garantiert werden muss
+- die allgemeine Job-Faehigkeit soll nicht nur technisch wiederverwendbar, sondern auch im UI als pluginuebergreifendes Studio-Konzept sichtbar sein
+- die erste zentrale UI-Verankerung dieser allgemeinen Job-Faehigkeit erfolgt unter dem bestehenden Sidebar-Punkt `Monitoring`
+- ein spaeteres Desktop-Widget fuer Monitoring oder Jobs bleibt moeglich, ist aber nicht Teil dieses Changes
+- die erste konkrete `Monitoring`-Sicht bleibt eine technische und zunaechst temporaere Admin-Sicht
+- sie darf Jobs, aktuellen technischen Datenquellenstatus und technische Ereignishistorie kombinieren
+- eine breitere fachliche Betriebsoberflaeche wird in diesem Change noch nicht festgelegt
+- plugininterne technische Hilfsdaten koennen weiterhin in der externen Waste-Datenbank liegen, die uebergreifende Job-Orchestrierung soll aber auf Wiederverwendung fuer weitere Plugins ausgelegt werden
+
+Diese Plattformfaehigkeit wird in diesem Change bewusst nicht nur als schmale Vorstufe angelegt. Sie soll bereits im ersten Wurf tragfaehig genug fuer weitere reale Plugin-Nutzer sein, solange Waste der erste konkrete Treiber bleibt.
+
+Die Andockstelle dafuer soll explizit ueber das Plugin-Modell des Studios laufen:
+
+- Plugins registrieren ueber `@sva/plugin-sdk` ihre fachlichen Jobtypen
+- Plugins registrieren ueber `@sva/plugin-sdk` ihre fachlichen Importprofile
+- das Studio liefert dazu die allgemeine Runtime, Persistenz, UI und Orchestrierung
+- Plugins beschreiben also Fachvertraege, das Studio uebernimmt die generische Ausfuehrung
+
+### 5b. Generische Import-Faehigkeit und Mapping
+
+Auch strukturierte Datenimporte sollen nicht als Waste-Sonderloesung enden. Das Studio bekommt dafuer eine generische Import-Faehigkeit, die bereits in diesem Change als substanzielle Plattformbasis fuer weitere Plugins angelegt wird.
+
+- das Studio stellt einen allgemeinen Import-Rahmen fuer CSV, Excel sowie schema-nahe JSON- und XML-Quellen bereit
+- dieser Rahmen deckt Upload, Vorpruefung, Quellformat-Erkennung, Spalten- oder Feldmapping, Validierung, asynchronen Importjob und Ergebnisdarstellung ab
+- Plugins definieren fachliche Importprofile, das Studio stellt die generische Laufzeit- und Bedienlogik bereit
+- diese pluginseitigen Importprofile werden ueber einen expliziten Plugin-Vertrag registriert statt nur lose neben der Runtime zu existieren
+- Waste ist nur der erste Nutzer dieser allgemeinen Import-Faehigkeit
+
+Die erste allgemeine Import-Oberflaeche wird als mehrstufiger Wizard gedacht:
+
+- Quelle waehlen
+- Importprofil waehlen
+- Mapping pruefen oder korrigieren
+- Validierungsvorschau ansehen
+- Import als Job starten
+- Ergebnis, Fehler und Importprotokoll einsehen
+
+Ein Importprofil beschreibt mindestens:
+
+- fachlichen Importtyp und technische Kennung
+- Zielfelder und Pflichtfelder
+- erlaubte Quellformate
+- kanonische Vorlage mit Beispielspalten und bei Bedarf Beispieldateien
+- Mapping-Regeln und Normalisierungshinweise
+- fachliche und technische Validierungen
+
+Fuer Waste werden in diesem Change mindestens drei solche Importprofile verpflichtend vorgesehen:
+
+- `geografie-abholorte`
+- `touren`
+- `ausweichtermine`
+
+Jeder dieser Importtypen behaelt:
+
+- ein eigenes explizites Spaltenschema
+- eine eigene Vorlage
+- eine eigene Validierung
+
+Warum:
+
+- Ein einziger "Universalimport" fuehrt schnell zu unscharfen Fehlervertraegen und schwer wartbaren Sonderregeln.
+- Getrennte Profile bleiben fuer Nutzer, Tests und spaetere Weiterentwicklung deutlich klarer.
+- Das Studio lernt damit eine allgemeine Importfaehigkeit, ohne Waste-spezifische Feldlogik in die Plattform zu ziehen.
+
+Fuer das Mapping selbst gilt:
+
+- das Studio darf automatische Mapping-Vorschlaege fuer Quellspalten oder Quellfelder erzeugen
+- diese Vorschlaege bleiben immer pruef- und manuell korrigierbar
+- die erste Ausbaustufe darf einfache heuristische Vorschlaege wie Schreibvarianten, Umlaute oder naheliegende Aliasnamen beruecksichtigen
+- das Studio darf zusaetzlich einfache gespeicherte Mapping-Vorlagen pro Instanz und Importprofil vorhalten
+- diese gespeicherten Mappings dienen der Wiederverwendung haeufiger Importlaeufe, ohne bereits eine komplexe Versionierungs- oder Freigabelogik einzufuehren
+- die Schnittstelle fuer Mapping-Vorschlaege wird bewusst so geschnitten, dass spaeter eine externe KI-basierte Vorschlagslogik angeschlossen werden kann
+- diese spaetere KI-Anbindung ist in diesem Change ausdruecklich noch nicht Teil der produktiven Architektur, die Integrationsstelle soll aber leicht wiederauffindbar und austauschbar bleiben
+
+### 5c. UI-Grenze zwischen Plugin und allgemeiner Studio-UI
+
+Die Waste-Oberflaeche enthaelt mehrere starke Interaktionsmuster, aber nicht jedes sichtbare Element ist deshalb ein allgemeiner Plattformbaustein. Die Schnittgrenze muss bewusst zwischen wiederverwendbarer Bedienlogik und Waste-spezifischer Fachoberflaeche gezogen werden.
+
+Als allgemeine Studio-UI-Bausteine kommen in diesem Change insbesondere in Betracht:
+
+- generischer Import-Dialog-Flow mit Upload, Mapping, Validierung, Job-Start und Ergebnisansicht
+- generische Job- und Monitoring-Darstellung
+- generische Tabellen- und Bulk-Action-Muster
+- generische Hochrisiko-Confirm-Dialoge
+- generische technische Statusanzeigen fuer Datenquellen und langlaufende Operationen
+
+Diese Bausteine gehoeren nach `packages/studio-ui-react`, sofern sie nicht bereits in passender Form vorhanden sind.
+
+Bewusst fachlich im Waste-Plugin verbleiben:
+
+- die Waste-Hauptseite und ihre fachliche Orchestrierung
+- der Jahreskalender fuer Tourtermine
+- Dialoge fuer Touren, Ausweichtermine, Abholorte, Fraktionen und Zuordnungen
+- Waste-spezifische Filter-, Formular- und Terminlogik
+
+Warum:
+
+- Wiederverwendbare Interaktionsmuster helfen auch spaeteren Plugins und staerken die Plattform.
+- Fachdialoge und Jahreskalender tragen bereits zu viel Waste-spezifische Semantik, um als allgemeine UI-Komponenten glaubwuerdig neutral zu bleiben.
+- Eine zu fruehe Zentralisierung solcher Fachkomponenten wuerde die UI-Library mit versteckter Pluginlogik aufladen.
+
+### 6. Portierungsstrategie gegen `Newcms`
+
+`Newcms` darf fuer Waste-Management als starke UX- und Fachreferenz dienen. Das Ziel ist ausdruecklich nicht, die Oberflaeche kuenstlich neu zu erfinden. Gleichzeitig darf ein optisch aehnlicher Port nicht zu einer verdeckten Architekturuebernahme fuehren.
+
+Zulaessig zur Uebernahme oder engen Anlehnung sind:
+
+- Seitenzuschnitt, Informationsarchitektur und Tab-Struktur
+- Tabellenaufbau, Spaltenlogik, Filterfuehrung und Dialogabfolgen
+- Formulare, Feldgruppen und fachliche Benennungen
+- rein praesentationale Komponenten oder View-Model-Logik, sofern sie auf Studio-Contracts umgestellt werden
+- UX-Muster fuer Bulk-Flows, Konflikthinweise, Fehlerdarstellung und gefaehrliche Bestaetigungen
+
+Nicht zulaessig zur produktiven Uebernahme sind:
+
+- `Newcms`-Hooks fuer Datenladen, Mutation, Auth oder Kontextauflosung
+- `Newcms`-API-Clients, Edge-Functions oder direkte Supabase-Aufrufe
+- `Newcms`-spezifische Zustandscontainer, globale Stores oder implizite Datenlebenszyklen
+- `Newcms`-Berechtigungslogik, die nicht auf `waste-management.*` und Host-Guards gemappt wurde
+- `Newcms`-Datenmodelle oder DTOs als stillschweigender Studio-Vertrag
+- `Newcms`-Annahmen ueber Singleton-Datenhaltung, globale Datensaetze oder fehlende Instanzgrenzen
+
+Jedes aus `Newcms` uebernommene Artefakt muss vor produktiver Nutzung einer der folgenden Studio-Grenzen eindeutig zugeordnet werden:
+
+- `packages/plugin-waste-management`: praesentationale UI, lokale View-Model-Logik, Plugin-spezifische Bedienablaeufe
+- `packages/routing`: Route-Materialisierung, Search-Params, Guards
+- `packages/auth-runtime` und `packages/server-runtime`: Host-API, Actor-Kontext, Datenquellenauflosung, Fehlervertrag
+- `packages/data` und `packages/data-repositories`: Studio-Governance-Persistenz, technische Settings und hostseitige Waste-Repositories
+- `packages/iam-admin` und `packages/iam-governance`: Rollen, Rechte, Audit, Governance-Sichten
+
+Der Port ist daher als Anti-Corruption-Strategie zu verstehen:
+
+- `Newcms` liefert fachliche Referenz und moegliches Quellmaterial
+- Studio definiert die produktiven Laufzeitvertraege
+- jeder Portierungsschritt mappt UI und Fachkonzepte explizit auf Studio-Packages und Studio-Contracts
+- kein uebernommenes Artefakt darf eine zweite, implizite Architekturgrenze neben dem Studio etablieren
+
+Vor jeder groesseren Uebernahme aus `Newcms` muss das Team fuer das betroffene Artefakt dokumentieren:
+
+- was konkret uebernommen wird
+- ob es rein praesentational ist oder fachliche Logik enthaelt
+- in welches Studio-Package die Verantwortung faellt
+- welche `Newcms`-Abhaengigkeiten entfernt oder ersetzt werden muessen
+- wie Routing, Datenzugriff, Rechte und Audit auf Studio-Vertraege gemappt werden
+
+Ein optisch fast `1:1` uebernommenes UI ist damit zulaessig. Ein technisch fast `1:1` uebernommener Laufzeit- oder Datenvertrag ist ausdruecklich nicht zulaessig.
+
+## API Surface
+
+Die Host-Fassade kapselt mindestens folgende Ressourcengruppen:
+
+- `fractions`
+- `regions`
+- `cities`
+- `streets`
+- `house-numbers`
+- `collection-locations`
+- `tours`
+- `tour-date-shifts`
+- `global-date-shifts`
+- `location-tour-links`
+- `imports/csv`
+- `tools/seed`
+- `tools/reset`
+- `tools/migrations`
+- `settings`
+
+Der genaue HTTP-Zuschnitt bleibt implementierungsseitig frei, solange Namespace, Instanzscoping, Rechtezuordnung, asynchrones Jobmodell und Fehlervertrag konsistent bleiben.
+
+Unter `settings` muss der Change mindestens die instanzbezogene Pflege der Waste-Datenquelle ermoeglichen:
+
+- Pflegen der Verbindungsdaten fuer genau eine Waste-Datenquelle der Instanz
+- Validieren und nachvollziehbares Rueckmelden, ob die konfigurierte Waste-Datenquelle fuer die Instanz erreichbar ist
+- Weiterarbeiten an der Rekonfiguration auch dann, wenn die bisherige Waste-Datenquelle nicht mehr erreichbar ist
+
+Zusaetzlich muss der API-/Service-Zuschnitt den aktuellen Primaermodus sauber tragen und spaetere Erweiterungen nicht verbauen:
+
+- originäre Studio-Pflege
+- spaetere Uebernahme oder Synchronisation aus einem extern fuehrenden System darf architektonisch moeglich bleiben, ist aber nicht Teil dieses Changes
+
+Die Fassade muss ausserdem ausreichend fachliche Filter- und Listenabfragen fuer den Admin-Betrieb unterstuetzen, insbesondere fuer:
+
+- Abfallarten
+- Adresshierarchien
+- Touren und deren Status
+- Abweichungs- und Feiertagskontexte
+
+## Risks / Trade-offs
+
+- Instanzisierung des vorhandenen Schemas ist der groesste Migrationshebel und kann historische `Newcms`-Daten aufraeumen muessen.
+- Der Betrieb einer eigenen Waste-Datenbank pro Instanz erhoeht den Aufwand fuer Datenquellenpflege, Erreichbarkeitspruefung und Migrationsmanagement.
+- Eine freie Plugin-Route bietet fachlich mehr Freiheit, verlangt aber mehr Sorgfalt bei Search-Param-, Empty-/Error-State- und Accessibility-Standards.
+- Reset in Produktion ist fachlich gewollt, erhoeht aber die Anforderungen an Rechtemodell, Audit und explizite Bestaetigung im UI.
+
+## Migration Plan
+
+1. Capability und Zielvertraege in OpenSpec festziehen.
+2. Schema-Zielbild und Migrationspfad fuer Instanzbezug spezifizieren.
+3. Plugin-, Routing-, IAM- und Auditvertraege implementieren.
+4. Datenzugriff und Fassade hostseitig aufbauen.
+5. `Newcms`-MVP fachlich in Studio-UI ueberfuehren, ohne Code direkt zu portieren.
+
+## Package Impact and Execution Slices
+
+Die Umsetzung soll nicht als ein einzelner Block erfolgen, sondern in getrennten Package-Slices, damit die Bearbeitung und Review-Grenzen klar bleiben.
+
+### Slice A: Neues Fachplugin und Admin-UI
+
+- `packages/plugin-waste-management`: fachliche Seiten, Dialoge, Tabellen, Formulare, Search-Params, Host-API-Client, Modul-IAM- und Audit-Definitionen
+- `packages/plugin-sdk`: falls fuer freie Fachplugins neue Hilfen fuer Audit, Settings oder Host-Fetching benoetigt werden
+- `packages/studio-ui-react`: wiederverwendbare Tabellen-, Dialog-, Confirm- oder Statusbausteine, sofern bestehende UI-Bausteine fuer Waste-Management nicht ausreichen
+- `apps/sva-studio-react`: statische Plugin-Registrierung, Shell-Integration und eventuelle Admin-Einstellungsseiten fuer instanzbezogene Waste-Konfiguration
+
+### Slice B: Routing und Runtime-Anbindung
+
+- `packages/routing`: freie Plugin-Route `/plugins/waste-management`, Search-Param-Vertrag, Host-Route-Registrierung fuer `/api/v1/waste-management/*`, Guards und Sichtbarkeitslogik
+- `packages/auth-runtime`: Einhaengen der Waste-HTTP-Endpunkte in die bestehende Runtime, Auth-, Actor- und Request-Context-Aufloesung fuer Waste-Requests
+- `packages/server-runtime`: gemeinsame Runtime-Helfer fuer Logging, Fehlerabbildung, Request-Kontext, Secret- und Datenquellenauflosung
+
+### Slice C: Zentrale Governance- und Instanzkonfiguration
+
+- `packages/instance-registry`: instanzbezogene technische Modulkonfiguration fuer die Waste-Datenquelle im zentralen Studio-Postgres, inklusive Read-/Write-Modelle fuer Admin-Ansichten
+- `packages/data-repositories`: primaere Heimat fuer Persistenz der Waste-Datenquellen-Konfiguration, zentrale Governance-Queries, technische Settings-Validierung und Datenzugriff auf Studio-Postgres sowie fuer spaetere Waste-Fachdatenbank-Repositories
+- `packages/data`: nur falls noetig eine duenne Orchestrierungs- oder Kompositionsschicht, aber keine neue primaere Heimat fuer Waste-SQL
+- `packages/core`: gemeinsame Contracts fuer Waste-Settings, Datenquellenstatus und instanzbezogene Verwaltungsmodelle, falls diese package-uebergreifend gebraucht werden
+
+### Slice D: Waste-Host-Fassade, IAM und Audit
+
+- `packages/auth-runtime` oder ein gleichwertiger Host-Runtime-Einstiegspunkt: HTTP-Handler fuer `/api/v1/waste-management/*`
+- `packages/server-runtime`: serverseitige Aufloesung der aktiven Waste-Datenquelle, Secret-Nutzung und technische Fehlervertraege
+- `packages/data-repositories`: hostseitige Repositories fuer Waste-Fachdatenbankzugriffe gegen die `waste_*`-Tabellenfamilie
+- `packages/iam-admin`: Integration der neuen `waste-management.*` Rechte in Rollen- und Permission-Verwaltung, soweit die bestehenden IAM-Admin-Flows diese zentral pflegen
+- `packages/iam-governance`: zentrale Audit-Auswertung, Audit-Read-Modelle oder Governance-Sichten fuer Waste-Mutationen, sofern diese im Studio sichtbar gemacht werden
+
+### Slice E: Tests, Dokumentation und Architektur
+
+- `apps/sva-studio-react`: E2E- und Integrationspfade fuer Plugin, Rechte und Einstellungen
+- `packages/plugin-waste-management`, `packages/routing`, `packages/auth-runtime`, `packages/data`, `packages/data-repositories`, `packages/instance-registry`: Unit- und Type-Tests entlang der jeweiligen Slice-Verantwortung
+- `docs/architecture/*`: Arc42-Fortschreibung fuer Persistenzgrenzen, Instanzkonfiguration und Runtime-Boundaries
+
+Jeder dieser Slices soll im Change als eigener Task-Abschnitt gefuehrt werden, damit Umsetzung, Review und Tests getrennt geplant und abgenommen werden koennen.
+
+## Open Questions
+
+- Die konkrete Ausgestaltung eines spaeteren sekundaeren Fremdsystem-Modus bleibt offen.
+- Konfliktregeln zwischen Synchronisation und manueller Pflege bleiben offen.
+- Die genaue Menge URL-stabiler Detail- oder Editorzustaende wird implementierungsnah innerhalb des hier gesetzten Routing-Rahmens finalisiert.

--- a/openspec/changes/add-waste-management-plugin/proposal.md
+++ b/openspec/changes/add-waste-management-plugin/proposal.md
@@ -1,0 +1,96 @@
+# Change: Waste-Management-Plugin fuer SVA Studio integrieren
+
+## Why
+
+Das Studio hat heute kein Fachmodul fuer den vollstaendigen kommunalen Abfallkalender. Im bestehenden `Newcms` existiert bereits ein fachlich brauchbarer MVP fuer Stammdaten, Touren, Terminverschiebungen und Data-Tools, aber dessen Architektur passt nicht zu den Plugin-, Routing-, IAM- und Host-Grenzen des Studios.
+
+Das Studio benoetigt deshalb einen eigenstaendigen Change, der das Waste-Management entlang der bestehenden Zielarchitektur neu aufsetzt: als freies Fachplugin mit hostgefuehrter Server-Fassade, instanzgebundenem Datenmodell, feingranularem Modul-IAM und auditierbaren Hochrisiko-Operationen. Ohne diesen Change wuerde ein direkter Port aus `Newcms` die Plugin-Boundary, die Studio-Serververantwortung und die Instanzisolation unterlaufen.
+
+## What Changes
+
+- Neues Fachplugin `@sva/plugin-waste-management` mit freier Route `/plugins/waste-management`
+- Neue Capability `waste-management` fuer die vollstaendige Admin-Oberflaeche des Abfallkalenders
+- Hostgefuehrte Server-Fassade unter `/api/v1/waste-management/*` fuer CRUD- und Spezialoperationen
+- Genau eine instanzbezogene Waste-Fachdatenbank pro Studio-Instanz mit serverseitig aufgeloester Verbindung und im Studio-Postgres hinterlegter Datenquellenkonfiguration
+- Direkter serverseitiger Zugriff auf die bestehende `waste_*`-Tabellenfamilie als Migrationsbasis innerhalb der jeweiligen Waste-Fachdatenbank, ohne Abhaengigkeit auf `Newcms`-Edge-Functions
+- Detaillierte Portierungsregeln, die `Newcms` als UX- und Fachreferenz zulaessig machen, aber einen verdeckten Architekturport in Plugin, Runtime, IAM und Persistenz ausschliessen
+- Gezielte Schema-Weiterentwicklung innerhalb der Waste-Fachdatenbank inklusive dokumentiertem Migrationspfad und pluginangebotenen Update-Migrationen
+- Fokus auf Betrieb als fuehrendes Fachsystem; sekundaere Fremdsystem-Synchronisation bleibt nur architektonisch offen
+- Erweiterte Terminlogik fuer manuelle Einzelverschiebungen und konsistente Folgeeffekte auf wiederkehrende Tourtermine
+- Feiertags- und Abweichungslogik als ausdruecklicher Fachbestandteil des Terminmodells
+- Adresshierarchie fuer Ort, Strasse und Hausnummer als fachlicher Kernvertrag fuer Zuordnung und spaetere Ausspielkanaele
+- Mehrsprachige, farbcodierte Fachstammdaten fuer Abfallarten und Tourdarstellungen
+- Feingranulares Modul-IAM fuer Lesen, Stammdaten, Touren/Zuordnungen, Scheduling, Import, Seed, Reset und Einstellungen
+- Audit-Integration fuer alle Mutationen, insbesondere CSV-Import, Seed und Reset
+- Klare Trennung zwischen zentralem Studio-Postgres fuer Rollen, Rechte, Audits und Modulkonfigurationen einerseits und instanzbezogenen Waste-Fachdaten andererseits
+- Keine IAM-, Rollen-, Rechte- oder Audit-Primärdaten des Studios in der externen Waste-/Supabase-Datenbank
+- Waste-spezifische Migrations-, Job- und sonstige plugininterne Hilfsdaten duerfen in der externen Waste-/Supabase-Datenbank liegen
+- Das Studio-Postgres darf zusaetzlich zentrale Status-, Monitoring- und fortlaufende Historienmetadaten zur externen Waste-Datenquelle fuehren
+- Die generische Studio-Job-Faehigkeit ist zentral persistent im Studio-Postgres und verwendet initial mindestens die Stati `queued`, `running`, `succeeded`, `failed`, `cancelled`
+- Das Studio stellt zusaetzlich eine generische Import-Faehigkeit fuer CSV, Excel sowie schema-nahe JSON- und XML-Quellen bereit, die ueber pluginseitig definierte Importprofile genutzt wird
+- Die generischen Studio-Faehigkeiten fuer Jobs und strukturierte Importe werden in diesem Change bereits als tragfaehige Plattformbasis fuer weitere Plugins aufgebaut und nicht nur als schmale Waste-Vorbereitung
+- Der `plugin-sdk` wird dabei so erweitert, dass Plugins explizit Jobtypen und Importprofile registrieren koennen, waehrend das Studio Runtime, UI und Orchestrierung zentral bereitstellt
+- Importprofile beschreiben je Plugin und Importtyp mindestens Zielfelder, Pflichtfelder, erlaubte Quellformate, Mapping-Regeln, Validierungen sowie eine kanonische Vorlage mit Beispieldatei oder Beispielspalten
+- Die erste Studio-Import-Oberflaeche wird als mehrstufiger Wizard mit Quellwahl, Profilwahl, Mapping-Pruefung, Validierungsvorschau, Job-Start und Ergebnisansicht modelliert
+- Das Studio darf fuer solche Importprofile automatische Mapping-Vorschlaege fuer Quellspalten erzeugen; Benutzer muessen diese Vorschlaege pruefen und manuell korrigieren koennen
+- Das Studio darf einfache gespeicherte Mapping-Vorlagen pro Instanz und Importprofil vorhalten, damit wiederkehrende Importe nicht jedes Mal neu gemappt werden muessen
+- Die automatische Mapping-Strecke wird so geschnitten, dass spaeter eine externe KI-basierte Vorschlagslogik als austauschbare Integrationsstelle ergaenzt werden kann, ohne den generischen Importvertrag neu zu zerlegen
+- Automatische Retry-Logik ist nicht Teil der ersten generischen Studio-Job-Faehigkeit
+- Fehlgeschlagene oder abgebrochene Jobs werden in der ersten Ausbaustufe nicht neu gestartet, sondern bei Bedarf als neue Jobs erneut angestossen
+- `cancelled` ist in der ersten Ausbaustufe Teil des Statusmodells, ohne dass fuer alle Jobtypen bereits eine aktive Cancel-Mechanik verpflichtend sein muss
+- Die generische Studio-Job-Faehigkeit soll in der ersten Ausbaustufe auch UI-seitig als pluginuebergreifendes Studio-Konzept sichtbar werden
+- Die erste pluginuebergreifende Job-Sicht wird unter dem bestehenden Sidebar-Punkt `Monitoring` verankert; ein spaeteres Desktop-Widget ist nicht Teil dieses Changes
+- Die erste `Monitoring`-Sicht bleibt eine technische und zunaechst temporaere Admin-Sicht fuer Jobs, Datenquellenstatus und technische Ereignishistorie; eine breitere Betriebsoberflaeche ist nicht Teil dieses Changes
+- Wiederverwendbare Interaktionsmuster wie Import-Dialog-Flow, Job-/Monitoring-Darstellung, Bulk-Actions, Hochrisiko-Confirm und technische Statusanzeigen werden als allgemeine Studio-UI-Bausteine geschnitten
+- Waste-spezifische Screens, Jahreskalender, Touren-, Ausweichtermin-, Abholort- und Fraktionsdialoge bleiben hingegen fachliche Bestandteile des Plugins und wandern nicht in die allgemeine Plugin-UI-Library
+- Die erste Pflichtmenge dieser zentralen Historie umfasst mindestens Connection-Checks, Datenquellen-Rekonfigurationen sowie Start/Erfolg/Fehler von Migration, Import, Seed und Reset
+- Diese erste zentrale Historie bleibt zunaechst auf technische Ereignisse beschraenkt
+- Fehlgeschlagene Connection-Checks muessen zusaetzlich sofort einen sichtbaren aktuellen Status an der zentralen Instanz-/Plugin-Konfiguration setzen
+- Erfolgreiche Connection-Checks heben diesen sichtbaren Stoerungsstatus sofort wieder auf; der Verlauf bleibt ueber die Historie nachvollziehbar
+- Beim Laden der Settings-Seite darf automatisch ein expliziter Connection-Check laufen; ausserhalb davon duerfen echte erfolgreiche oder fehlgeschlagene DB-Zugriffe den sichtbaren Status implizit mitaktualisieren
+- Periodische Hintergrund-Checks sind nicht Teil dieses Changes
+- Fuer den aktuellen sichtbaren Status gilt die einfachste Regel: jeder technisch erfolgreiche echte DB-Zugriff darf den Status sofort auf `ok` setzen
+- Asynchrone Data-Tools fuer CSV-Import, Seed, Reset und Waste-Schema-Migrationen auf Basis einer generischen Studio-Job-Faehigkeit mit nachvollziehbarem Statusmodell
+- Waste nutzt fuer `geografie-abholorte`, `touren` und `ausweichtermine` die generische Studio-Import-Faehigkeit mit jeweils eigenem Importprofil und eigener Validierung
+- Search-Param- und Routing-Vertrag fuer tab-lastige Fachnavigation, Filter und Deep-Links
+- Rechtegesteuerte UI-Sichtbarkeit fuer schreibende und gefaehrliche Aktionen
+- Architektur- und Arc42-Fortschreibung fuer Plugin-Boundary, Server-Fassade, Instanzisolierung und Auditverhalten
+
+## Non-Goals
+
+- Keine oeffentlichen Buerger-Read-APIs fuer Abfalltermine in diesem Change
+- Keine Export- oder Feed-Schnittstellen wie iCal, JSON-Feeds oder PDF-Exporte in diesem Change
+- Keine produktive Push-Benachrichtigungs-Ausspielung in diesem Change
+- Keine konkrete Fremdsystem-Synchronisation oder Konfliktlogik fuer sekundaere Fuehrung in diesem Change
+- Kein direkter Wiedergebrauch von `Newcms`-UI, `Newcms`-Hooks oder `Newcms`-Supabase-Functions als produktiver Studio-Vertrag
+- Kein produktiver Import oder Laufzeitvertrag gegen `Newcms`-spezifische Hooks, API-Clients, Auth-Logik, Zustandscontainer oder Persistenzannahmen
+
+## Impact
+
+- Affected specs:
+  - `waste-management`
+  - `routing`
+  - `iam-access-control`
+  - `iam-auditing`
+  - `architecture-documentation`
+- Affected code:
+  - `packages/plugin-waste-management`
+  - `apps/sva-studio-react`
+  - `packages/routing`
+  - `packages/plugin-sdk`
+  - `packages/auth-runtime`
+  - `packages/instance-registry`
+  - `packages/server-runtime`
+  - `packages/data`
+  - `packages/data-repositories`
+  - `packages/iam-admin`
+  - `packages/iam-governance`
+  - `packages/core`
+  - `packages/studio-ui-react`
+- Affected arc42 sections:
+  - `docs/architecture/04-solution-strategy.md`
+  - `docs/architecture/05-building-block-view.md`
+  - `docs/architecture/06-runtime-view.md`
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/10-quality-requirements.md`
+  - `docs/architecture/11-risks-and-technical-debt.md`

--- a/openspec/changes/add-waste-management-plugin/specs/architecture-documentation/spec.md
+++ b/openspec/changes/add-waste-management-plugin/specs/architecture-documentation/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+### Requirement: Arc42 dokumentiert Waste-Management als Plugin- und Server-Capability
+
+Das System SHALL die Waste-Management-Integration in den betroffenen Arc42-Abschnitten nachvollziehbar dokumentieren.
+
+#### Scenario: Plugin-, Runtime- und Sicherheitsgrenzen werden fortgeschrieben
+
+- **WHEN** der Change `add-waste-management-plugin` umgesetzt wird
+- **THEN** dokumentieren die betroffenen Arc42-Abschnitte die Plugin-Boundary, die freie Route `/plugins/waste-management`, die hostgefuehrte Studio-Fassade und die Datenzugriffsgrenzen gegen Supabase/Postgres
+- **AND** die Doku beschreibt, dass `Newcms` nur fachliche Referenz bleibt
+- **AND** die Doku beschreibt die Portierungsgrenze zwischen zulaessiger UX-Anlehnung und unzulaessiger Architekturuebernahme explizit
+
+### Requirement: Arc42 dokumentiert Instanzisierung und Hochrisiko-Operationen
+
+Das System SHALL die instanzbezogene Waste-Datenhaltung sowie Seed- und Reset-Schutzmechanismen architektonisch verankern.
+
+#### Scenario: Architektur beschreibt Instanzisolierung und Reset-Risiko
+
+- **WHEN** ein Teammitglied die Arc42-Dokumentation fuer Waste-Management nachschlaegt
+- **THEN** sind Instanzscoping, Migrationsrichtung des `waste_*`-Schemas, Auditverhalten und Hochrisiko-Schutz fuer Reset nachvollziehbar beschrieben
+- **AND** die Dokumentation benennt die betroffenen Qualitäts- und Risikoaspekte explizit

--- a/openspec/changes/add-waste-management-plugin/specs/iam-access-control/spec.md
+++ b/openspec/changes/add-waste-management-plugin/specs/iam-access-control/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+### Requirement: Waste-Management verwendet feingranulares Modul-IAM
+
+Das System SHALL fuer Waste-Management einen feingranularen, voll qualifizierten Modul-IAM-Vertrag im Namespace `waste-management.*` bereitstellen.
+
+#### Scenario: Fachrechte sind getrennt modelliert
+
+- **WHEN** das Waste-Management-Plugin Actions, Guards oder UI-Zustaende deklariert
+- **THEN** referenziert es ausschliesslich fully-qualified Rechte im Namespace `waste-management.*`
+- **AND** mindestens Lesen, Stammdatenpflege, Touren/Zuordnungen, Scheduling, CSV-Import, Seed, Reset und Einstellungen sind getrennt adressierbar
+
+### Requirement: Waste-Management-Rechte sind instanzgebunden
+
+Das System SHALL Waste-Management-Autorisierung strikt auf die aktive Instanz begrenzen.
+
+#### Scenario: Benutzer darf Waste-Daten nur der aktiven Instanz pflegen
+
+- **WHEN** eine Waste-Management-Operation gegen eine Ressource einer anderen Instanz gerichtet ist
+- **THEN** wird die Operation verweigert
+- **AND** ein passender Denial- oder Fehlergrund wird geliefert
+- **AND** ein Rechtebesitz ohne passenden Instanzkontext ist nicht ausreichend
+
+### Requirement: Hochrisiko-Rechte fuer Seed und Reset bleiben getrennt
+
+Das System SHALL Seed- und Reset-Operationen als gesondert autorisierbare Hochrisiko-Aktionen behandeln.
+
+#### Scenario: Import-Recht ist nicht gleich Reset-Recht
+
+- **WHEN** ein Benutzer CSV-Import ausfuehren darf, aber kein Reset-Recht besitzt
+- **THEN** bleibt der Reset-Pfad fuer ihn unzulaessig
+- **AND** die Import-Berechtigung ermoeglicht keine implizite Eskalation auf Seed oder Reset
+
+#### Scenario: Reset erfordert separates Hochrisiko-Recht
+
+- **WHEN** ein Benutzer einen Waste-Reset in einer beliebigen Umgebung ausloesen moechte
+- **THEN** wird die Operation nur mit einem expliziten Reset-Recht zugelassen
+- **AND** die Berechtigung bleibt von allgemeinen Schreib- oder Verwaltungsrechten getrennt

--- a/openspec/changes/add-waste-management-plugin/specs/iam-auditing/spec.md
+++ b/openspec/changes/add-waste-management-plugin/specs/iam-auditing/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+### Requirement: Waste-Management-Mutationen sind revisionsfaehig auditierbar
+
+Das System SHALL fuer alle Mutationen des Waste-Management-Moduls revisionsfaehige Audit-Events erzeugen.
+
+#### Scenario: CRUD- und Zuordnungsoperationen erzeugen Auditspur
+
+- **WHEN** Waste-Masterdaten, Abholorte, Touren, Datumsverschiebungen oder Zuordnungen erstellt, geaendert oder geloescht werden
+- **THEN** entsteht jeweils ein Audit-Event mit Zeitpunkt, pseudonymisierter Actor-Referenz, Instanzkontext, fachlicher Operation und Ergebnis
+- **AND** Klartext-PII oder rohe Request-Payloads werden nicht unveraendert in die Auditspur geschrieben
+
+### Requirement: CSV-Import, Seed und Reset erzeugen erweiterte Auditmetadaten
+
+Das System SHALL fuer Waste-Management-Data-Tools erweiterte, aber sichere Auditmetadaten protokollieren.
+
+#### Scenario: CSV-Import bleibt nachvollziehbar
+
+- **WHEN** ein Benutzer einen Waste-CSV-Import ausfuehrt
+- **THEN** enthaelt das Audit-Event mindestens Instanzkontext, Action-Namespace, Ergebnis sowie Counts fuer verarbeitete, uebersprungene und fehlgeschlagene Datensaetze
+- **AND** importierte Freitextinhalte oder PII werden nicht ungefiltert in die Auditdaten geschrieben
+
+#### Scenario: Seed und Reset sind als Hochrisiko-Ereignisse erkennbar
+
+- **WHEN** ein Seed oder Reset fuer Waste-Daten ausgefuehrt wird
+- **THEN** ist das Audit-Ereignis als Hochrisiko-Operation unterscheidbar
+- **AND** es enthaelt Scope, Ergebnis, best-effort `request_id` und `trace_id`
+- **AND** Reviewer koennen Actor, Instanz und betroffenes Werkzeug revisionssicher nachvollziehen
+
+### Requirement: Historie fuer Waste-Management basiert auf der Studio-Auditspur
+
+Das System SHALL Verlauf und Historie fuer Waste-Management auf die zentrale Studio-Auditspur stuetzen statt ein paralleles Primaersystem einzufuehren.
+
+#### Scenario: Verlaufsansicht referenziert zentrale Auditbasis
+
+- **WHEN** Waste-Management eine Historie oder Aktivitaetsansicht bereitstellt
+- **THEN** basiert sie auf der bestehenden Studio-Audit-Infrastruktur oder daraus abgeleiteten Read-Modellen
+- **AND** es wird kein davon fachlich unabhaengiges Verlaufssystem als primaerer Vertrag eingefuehrt

--- a/openspec/changes/add-waste-management-plugin/specs/routing/spec.md
+++ b/openspec/changes/add-waste-management-plugin/specs/routing/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+### Requirement: Freie Waste-Management-Plugin-Route bleibt hostvalidiert
+
+Das System SHALL eine freie Plugin-Route fuer Waste-Management unter `/plugins/waste-management` materialisieren und dabei weiterhin hostgefuehrte Guard- und Search-Param-Validierung erzwingen.
+
+#### Scenario: Plugin-Route wird hostseitig validiert
+
+- **GIVEN** das Plugin `waste-management` deklariert seine freie Fachroute
+- **WHEN** der Host den Route-Tree aufbaut
+- **THEN** wird die Route nur ueber die zentrale Routing-Registry materialisiert
+- **AND** Guard- und Search-Param-Vertrag bleiben hostgefuehrt
+- **AND** das Plugin bringt keine eigene parallele Routing-Registrierung ausserhalb des Host-Vertrags ein
+
+### Requirement: Waste-Management-Search-Params sind canonical und teilbar
+
+Das System SHALL fuer die Waste-Management-Route kanonische, typisierte Search-Params fuer Tabs, Filter, Suche und Paging bereitstellen.
+
+#### Scenario: Deep-Link in fachlichen Teilzustand
+
+- **WHEN** ein Benutzer einen Deep-Link auf einen bestimmten Waste-Management-Tab mit Filter- oder Suchzustand oeffnet
+- **THEN** stellt das Routing denselben fachlichen Zustand reproduzierbar wieder her
+- **AND** ungueltige oder unbekannte Search-Params werden deterministisch normalisiert
+
+#### Scenario: Search-Params bleiben innerhalb des Plugin-Namespace
+
+- **WHEN** die Waste-Management-Route ihren fachlichen Zustand serialisiert
+- **THEN** bleiben die Parameter auf den Plugin-Pfadkontext begrenzt
+- **AND** sie kollidieren nicht mit unverbundenen Host- oder Fremdplugin-Zustaenden

--- a/openspec/changes/add-waste-management-plugin/specs/waste-management/spec.md
+++ b/openspec/changes/add-waste-management-plugin/specs/waste-management/spec.md
@@ -1,0 +1,543 @@
+## ADDED Requirements
+### Requirement: Waste-Management ist eine vollstaendige Studio-Capability
+
+Das System SHALL eine eigenstaendige Capability `waste-management` fuer die vollstaendige administrative Pflege des kommunalen Abfallkalenders bereitstellen.
+
+#### Scenario: Waste-Management deckt den vollen Admin-Scope ab
+
+- **WHEN** das Waste-Management-Modul im Studio verwendet wird
+- **THEN** koennen Muellarten, Regionen, Orte, Strassen, Hausnummern, Abholorte, Touren, Standort-Zuordnungen, globale Datumsverschiebungen und tourbezogene Datumsverschiebungen verwaltet werden
+- **AND** das Modul umfasst CSV-Import, Seed, Reset und modulbezogene Einstellungen
+- **AND** Feiertags- und sonstige Abweichungslogik ist Teil des fachlichen Scopes
+- **AND** oeffentliche Buerger-Read-APIs oder Export-Feeds sind nicht Teil dieser Capability
+
+### Requirement: Waste-Management verwendet eine freie Plugin-Route
+
+Das System SHALL Waste-Management als freies Plugin unter `/plugins/waste-management` materialisieren.
+
+#### Scenario: Studio navigiert auf die Waste-Management-Hauptoberflaeche
+
+- **WHEN** ein berechtigter Benutzer `/plugins/waste-management` aufruft
+- **THEN** rendert das Studio die modulare Waste-Management-Oberflaeche innerhalb der normalen App-Shell
+- **AND** die fachliche Hauptnavigation bleibt innerhalb des Plugin-Pfads
+- **AND** der Hauptpfad wird nicht als host-owned `adminResource` materialisiert
+
+### Requirement: Waste-Management verwendet typisierte Search-Params
+
+Das System SHALL den fachlichen UI-Zustand des Waste-Management-Plugins ueber typisierte Search-Params abbilden, soweit er teilbar oder reload-stabil sein muss.
+
+#### Scenario: Tab- und Filterzustand ist reload-stabil
+
+- **WHEN** ein Benutzer im Waste-Management zwischen Tabs wechselt oder Filter und Suche nutzt
+- **THEN** werden die relevanten Zustaende ueber typisierte Search-Params serialisiert
+- **AND** ein Reload oder Deep-Link stellt denselben fachlichen Kontext wieder her
+- **AND** ungueltige Werte werden auf einen kanonischen Defaultzustand normalisiert
+
+#### Scenario: Fachliche Filter sind ausdruecklicher Teil des Admin-Vertrags
+
+- **WHEN** Benutzer in Waste-Management-Listen nach Abfallarten, Orten, Touren, Status oder Abweichungskontexten filtern
+- **THEN** bleiben diese Filter reproduzierbar, teilbar und reload-stabil
+- **AND** der Listenvertrag haengt nicht ausschliesslich an lokalem Komponenten-State
+
+### Requirement: Waste-Management nutzt eine hostgefuehrte Server-Fassade
+
+Das System SHALL alle Waste-Management-Datenzugriffe ueber eine hostgefuehrte Studio-Fassade unter `/api/v1/waste-management/*` kapseln.
+
+#### Scenario: Plugin spricht keine Supabase-Schnittstelle direkt
+
+- **WHEN** die Plugin-Oberflaeche Waste-Management-Daten liest oder mutiert
+- **THEN** spricht sie ausschliesslich die Studio-Fassade unter `/api/v1/waste-management/*` an
+- **AND** das Plugin importiert keinen direkten Supabase-Client
+- **AND** das Plugin haengt nicht von `Newcms`-Edge-Functions als produktivem Vertrag ab
+
+#### Scenario: Host-Fassade loest die Waste-Datenquelle pro Instanz serverseitig auf
+
+- **WHEN** ein Request des Plugins Waste-Daten lesen oder mutieren will
+- **THEN** bestimmt die Host-Fassade anhand des aktiven Instanzkontexts die hinterlegte Waste-Datenquelle
+- **AND** die Datenbankverbindung wird serverseitig hergestellt
+- **AND** das Plugin erhaelt keinen direkten Zugriff auf Datenbank-Credentials oder rohe Verbindungsdetails
+
+### Requirement: Waste-Management verwendet die `waste_*`-Tabellenfamilie als Migrationsbasis
+
+Das System SHALL die bestehende `waste_*`-Tabellenfamilie als Migrationsbasis fuer das Waste-Management nutzen, ohne sie als unveraenderlichen Vertrag zu behandeln.
+
+#### Scenario: Schema darf kontrolliert bereinigt werden
+
+- **WHEN** das Studio das Waste-Management-Zielbild implementiert
+- **THEN** bleibt die vorhandene `waste_*`-Tabellenfamilie die fachliche Grundlage
+- **AND** inkompatible Bereinigungen oder Erweiterungen sind zulaessig, wenn ein klarer Migrationspfad dokumentiert ist
+- **AND** das Zielbild wird nicht durch die bestehende `Newcms`-Struktur technisch blockiert
+
+### Requirement: Waste-Management trennt Studio-Governance von Waste-Fachdatenbanken
+
+Das System SHALL zentrale Studio-Governance-Daten von instanzbezogenen Waste-Fachdatenbanken trennen.
+
+#### Scenario: Studio-Postgres bleibt die zentrale Governance-Persistenz
+
+- **WHEN** das Studio Rollen, Rechte, Audits oder technische Modulkonfigurationen fuer Waste-Management verwaltet
+- **THEN** werden diese Daten in der zentralen Studio-Persistenz gehalten
+- **AND** fachliche Waste-Massendaten werden dort nicht als regulaeres Betriebsmodell mitgefuehrt
+
+#### Scenario: Externe Waste-Datenbank speichert keine Studio-Governance-Primärdaten
+
+- **WHEN** die externe Waste- oder Supabase-Datenbank einer Instanz fuer das Waste-Management verwendet wird
+- **THEN** werden dort keine IAM-, Rollen-, Rechte- oder Audit-Primärdaten des Studios als fuehrender Vertrag gespeichert
+- **AND** diese Governance-Daten bleiben im zentralen Studio-Postgres verankert
+
+#### Scenario: Studio darf zentrale Monitoring- und Historienmetadaten zur externen Datenquelle fuehren
+
+- **WHEN** das Studio den Zustand, die Erreichbarkeit oder die Entwicklung der externen Waste-Datenquelle einer Instanz nachhalten will
+- **THEN** duerfen zu dieser Datenquelle zentrale Status-, Monitoring- oder Historienmetadaten im Studio-Postgres gespeichert werden
+- **AND** diese Metadaten ersetzen nicht die fachliche Waste-Datenhaltung in der externen Waste-Datenbank
+
+#### Scenario: Studio fuehrt eine fortlaufende Ereignishistorie zur externen Datenquelle
+
+- **WHEN** Pruefungen, Verbindungsfehler, Rekonfigurationen, Migrationen oder vergleichbare technische Ereignisse rund um die externe Waste-Datenquelle auftreten
+- **THEN** kann das Studio diese Ereignisse als fortlaufende Historie im Studio-Postgres protokollieren
+- **AND** die Historie dient Monitoring, Betrieb und Nachvollziehbarkeit ueber die Zeit
+- **AND** sie ersetzt nicht die plugininterne Job- oder Migrationspersistenz in der externen Waste-Datenbank
+
+#### Scenario: Erste Pflichtmenge der zentralen Ereignishistorie ist definiert
+
+- **WHEN** das Studio die externe Waste-Datenquelle einer Instanz zentral beobachtet
+- **THEN** umfasst die erste verpflichtende Ereignishistorie mindestens erfolgreiche und fehlgeschlagene Connection-Checks
+- **AND** sie umfasst Rekonfigurationen der Datenquelle
+- **AND** sie umfasst jeweils Start, Erfolg und Fehler von Migration, CSV-Import, Seed und Reset
+
+#### Scenario: Erste zentrale Historie bleibt technisch
+
+- **WHEN** das Studio die erste verpflichtende Historie zur externen Waste-Datenquelle fuehrt
+- **THEN** beschraenkt sich diese Historie zunaechst auf technische Ereignisse
+- **AND** fachliche Einordnungen oder weitergehende Business-Historien sind in diesem Change nicht verpflichtend
+
+#### Scenario: Fehlgeschlagener Connection-Check setzt sofort einen sichtbaren aktuellen Status
+
+- **WHEN** ein Connection-Check fuer die externe Waste-Datenquelle einer Instanz fehlschlaegt
+- **THEN** wird dieses Ereignis nicht nur zentral historisiert
+- **AND** zusaetzlich wird an der zentralen Instanz- oder Plugin-Konfiguration sofort ein sichtbarer aktueller Fehler- oder Stoerungsstatus gesetzt
+
+#### Scenario: Erfolgreicher Connection-Check hebt den aktuellen Stoerungsstatus sofort auf
+
+- **WHEN** ein nachfolgender Connection-Check fuer die externe Waste-Datenquelle erfolgreich ist
+- **THEN** wird ein zuvor gesetzter sichtbarer aktueller Stoerungsstatus an der zentralen Instanz- oder Plugin-Konfiguration sofort aufgehoben
+- **AND** die zentrale Historie behaelt den zeitlichen Verlauf der Stoerung dennoch bei
+
+#### Scenario: Settings-Seite darf automatisch einen expliziten Connection-Check ausloesen
+
+- **WHEN** ein berechtigter Benutzer die Settings-Seite fuer die Waste-Datenquelle einer Instanz oeffnet
+- **THEN** darf das System automatisch einen expliziten Connection-Check fuer diese Datenquelle ausfuehren
+- **AND** das Ergebnis darf den sichtbaren aktuellen Status unmittelbar aktualisieren
+
+#### Scenario: Echte DB-Zugriffe duerfen den sichtbaren Status implizit aktualisieren
+
+- **WHEN** regulaere Waste-Lese- oder Schreibzugriffe gegen die externe Datenquelle technisch erfolgreich oder wegen eines Connectivity-Problems fehlgeschlagen sind
+- **THEN** darf das System daraus den sichtbaren aktuellen technischen Status der Datenquelle aktualisieren
+- **AND** rein fachliche Fehler ohne Connectivity-Bezug setzen keinen Stoerungsstatus
+- **AND** jeder technisch erfolgreiche echte DB-Zugriff darf den sichtbaren aktuellen Status unmittelbar wieder auf `ok` setzen
+
+#### Scenario: Periodische Hintergrund-Checks sind nicht Teil dieses Changes
+
+- **WHEN** das Studio die externe Waste-Datenquelle im Rahmen dieses Changes beobachtet
+- **THEN** werden keine periodischen Hintergrund-Checks oder eigenstaendigen Monitoring-Scheduler als verpflichtender Bestandteil eingefuehrt
+
+#### Scenario: Plugininterne Waste-Betriebsdaten duerfen in der externen Waste-Datenbank liegen
+
+- **WHEN** das Waste-Management technische Hilfsdaten fuer Migrationen, asynchrone Jobs oder vergleichbare plugininterne Betriebsablaeufe benoetigt
+- **THEN** duerfen diese Daten in der externen Waste- oder Supabase-Datenbank der Instanz gespeichert werden
+- **AND** dadurch werden keine zentralen IAM-, Rollen-, Rechte-, Audit- oder Instanz-Governance-Daten des Studios aus dem Studio-Postgres verdraengt
+
+#### Scenario: Jede Studio-Instanz besitzt ihre eigene Waste-Fachdatenbank
+
+- **WHEN** Waste-Management fuer eine Studio-Instanz aktiviert wird
+- **THEN** ist dieser Instanz genau eine eigene Waste-Fachdatenquelle zugeordnet
+- **AND** fachliche Waste-Daten werden in dieser instanzbezogenen Datenbank gehalten
+- **AND** andere Studio-Instanzen verwenden davon getrennte Waste-Fachdatenquellen
+
+#### Scenario: Die Waste-Datenbank selbst bildet die Mandantengrenze
+
+- **WHEN** fachliche Waste-Daten innerhalb der einer Instanz zugeordneten Waste-Fachdatenbank gespeichert oder gelesen werden
+- **THEN** dient die Datenbank selbst als Mandantengrenze
+- **AND** das Zielbild fuehrt keinen zusaetzlichen fachlichen `instance_id`-Mandantenschnitt als primaeren Vertrag in den Waste-Fachtabellen ein
+
+### Requirement: Waste-Management erlaubt die instanzbezogene Konfiguration der Waste-Datenquelle
+
+Das System SHALL fuer jede Studio-Instanz eine ueber Studio-Einstellungen pflegbare Waste-Datenquelle bereitstellen.
+
+#### Scenario: Berechtigter Benutzer pflegt die Waste-Datenquelle ueber Studio-Einstellungen
+
+- **WHEN** ein Benutzer mit `waste-management.settings.manage` die Modul-Einstellungen der aktiven Instanz bearbeitet
+- **THEN** kann er die fuer diese Instanz vorgesehene genau eine Waste-Datenquelle konfigurieren oder aktualisieren
+- **AND** die Aenderung wird ueber die Host-Fassade verarbeitet
+- **AND** die Verbindungsdaten werden im zentralen Studio-Postgres gehalten
+- **AND** Secrets oder Zugangsdaten werden nicht im Browser offengelegt
+
+#### Scenario: Studio validiert die konfigurierte Waste-Datenquelle nachvollziehbar
+
+- **WHEN** fuer eine Instanz eine Waste-Datenquelle gespeichert oder aktualisiert wird
+- **THEN** validiert das System die Konfiguration serverseitig
+- **AND** Erfolg oder Fehler werden fuer den Benutzer nachvollziehbar rueckgemeldet
+- **AND** ungueltige oder unvollstaendige Konfigurationen duerfen nicht stillschweigend aktiv werden
+
+#### Scenario: Rekonfiguration bleibt bei nicht erreichbarer Datenquelle moeglich
+
+- **WHEN** die aktuell hinterlegte Waste-Datenquelle einer Instanz nicht mehr erreichbar ist, etwa nach einem Umzug der Supabase-Datenbank
+- **THEN** bleibt mindestens der Settings-Pfad zur Datenquellenkonfiguration verfuegbar
+- **AND** ein berechtigter Benutzer kann die Verbindungsdaten serverseitig aktualisieren und erneut pruefen
+- **AND** die Unerreichbarkeit der alten Datenquelle blockiert die Rekonfiguration nicht
+
+### Requirement: `Newcms` darf nur als UX- und Fachreferenz portiert werden
+
+Das System SHALL `Newcms` fuer Waste-Management nur als UX- und Fachreferenz oder als Quelle praesentationaler Artefakte nutzen, nicht als produktiven Laufzeitvertrag.
+
+#### Scenario: Studio uebernimmt die Informationsarchitektur, aber nicht die Runtime-Kopplung
+
+- **WHEN** ein Team Teile der `Newcms`-Oberflaeche fuer Waste-Management uebernimmt oder eng nachbaut
+- **THEN** duerfen Seitenzuschnitt, Tab-Struktur, Tabellenlayout, Filterfuehrung, Dialogabfolgen und Feldgruppierungen fachlich oder visuell angelehnt sein
+- **AND** produktive Routing-, Datenzugriffs-, Auth-, Audit- und Persistenzvertraege werden ausschliesslich ueber Studio-Packages hergestellt
+
+#### Scenario: Portierte UI bleibt an Studio-Contracts gebunden
+
+- **WHEN** praesentationale Komponenten oder lokale View-Model-Logik aus `Newcms` als Ausgangsmaterial dienen
+- **THEN** werden sie auf Studio-Contracts fuer Routing, Host-API, Rechte, Audit und Instanzkontext umgestellt
+- **AND** es verbleibt kein produktiver Laufzeitvertrag gegen `Newcms`
+
+### Requirement: Waste-Management verbietet produktive `Newcms`-Runtime-Abhaengigkeiten
+
+Das System SHALL keine produktiven Runtime-, Hook-, Client- oder Datenmodell-Abhaengigkeiten auf `Newcms` in die Studio-Umsetzung uebernehmen.
+
+#### Scenario: Direkte `Newcms`-Abhaengigkeiten sind ausgeschlossen
+
+- **WHEN** das Waste-Management-Plugin oder zugehoerige Host-Packages gebaut oder ausgefuehrt werden
+- **THEN** importieren sie keine `Newcms`-Hooks, keine `Newcms`-API-Clients und keine `Newcms`-Edge-Functions als produktiven Vertrag
+- **AND** sie nutzen keine direkte Supabase-Anbindung aus `Newcms`
+
+#### Scenario: Implizite Architekturannahmen aus `Newcms` werden nicht uebernommen
+
+- **WHEN** fachliche Logik oder Datenmodelle aus `Newcms` als Vorlage dienen
+- **THEN** werden globale Datenannahmen, Singleton-Modelle, fehlende Instanzgrenzen oder `Newcms`-spezifische Zustandscontainer nicht stillschweigend mit uebernommen
+- **AND** die resultierende Studio-Umsetzung bleibt mit Instanzscoping, Host-Fassade und zentralem IAM/Audit konsistent
+
+### Requirement: Jede Portierung aus `Newcms` wird auf Studio-Packages und Studio-Vertraege gemappt
+
+Das System SHALL fuer jedes wesentlich aus `Newcms` uebernommene Artefakt eine explizite Zuordnung zu Studio-Packages und Studio-Vertraegen herstellen.
+
+#### Scenario: Portiertes Artefakt wird vor Umsetzung klassifiziert
+
+- **WHEN** ein groesseres UI-Element, ein Workflow oder fachliche Logik aus `Newcms` uebernommen werden soll
+- **THEN** wird dokumentiert, ob das Artefakt praesentational, fachlogisch oder infrastrukturell ist
+- **AND** es wird einem Studio-Package mit klarer Verantwortung zugeordnet
+- **AND** benoetigte Ersetzungen fuer Routing, Datenzugriff, Rechte, Audit und Settings werden explizit benannt
+
+#### Scenario: Ein Artefakt mit verdeckter Architekturkopplung wird nicht direkt portiert
+
+- **WHEN** ein `Newcms`-Artefakt gleichzeitig UI und produktive Daten-, Rechte- oder Runtime-Annahmen enthaelt
+- **THEN** wird es vor der Uebernahme in praesentationale und architekturrelevante Teile zerlegt
+- **AND** nur die zur Studio-Architektur passenden Teile duerfen direkt uebernommen oder eng angelehnt werden
+- **AND** die verbleibenden Teile werden gegen Studio-spezifische Implementierungen ersetzt
+
+### Requirement: Waste-Management fokussiert in diesem Change den Primaermodus
+
+Das System SHALL in diesem Change den Betrieb von SVA Studio als fuehrendes Waste-System spezifizieren.
+
+#### Scenario: Studio ist fuehrendes Waste-System
+
+- **WHEN** eine Instanz Waste-Daten originär im Studio pflegt
+- **THEN** kann das Modul alle fachlichen Daten und Werkzeuge ohne externes fuehrendes System bereitstellen
+- **AND** Studio bleibt die operative Quelle fuer Waste-Management innerhalb dieser Instanz
+
+#### Scenario: Sekundaerer Fremdsystem-Modus bleibt vertagt
+
+- **WHEN** spaeter ein externer Primaersystem-Modus ergaenzt werden soll
+- **THEN** verbaut dieser Change die dafuer noetigen Host-Boundaries nicht
+- **AND** konkrete Schreib-, Konflikt- oder Synchronisationsregeln sind nicht Teil dieses Changes
+
+### Requirement: Waste-Management bildet die Adresshierarchie fachlich explizit ab
+
+Das System SHALL die fuer den Abfallkalender relevante Adresshierarchie aus Ort, Strasse und Hausnummer ausdruecklich modellieren.
+
+#### Scenario: Nachgelagerte Auswahl folgt der vorangehenden Adressstufe
+
+- **WHEN** eine Adresse ueber Ort, Strasse und Hausnummer aufgebaut oder zugeordnet wird
+- **THEN** richtet sich die Auswahlmenge der naechsten Stufe nach der vorherigen Auswahl
+- **AND** die Hierarchie bleibt fuer redaktionelle Pflege und spaetere kanalbezogene Nutzung konsistent
+
+#### Scenario: Hausnummer bleibt optional, wenn der fachliche Kontext es erlaubt
+
+- **WHEN** eine Zuordnung oder Pflegeoperation nicht zwingend bis auf Hausnummerebene gehen muss
+- **THEN** kann das Modell auf einer hoeheren Adressstufe verbleiben
+- **AND** das System behandelt diese Teiladressierung als fachlich gueltigen Zustand
+
+### Requirement: Waste-Management unterstuetzt wiederkehrende Terminlogik mit Folgeeffekten
+
+Das System SHALL wiederkehrende Tourtermine so modellieren, dass manuelle Einzelverschiebungen fachlich korrekt verarbeitet werden koennen.
+
+#### Scenario: Einzelverschiebung betrifft nur den Einzeltermin
+
+- **WHEN** ein wiederkehrender Tourtermin einmalig manuell verschoben wird
+- **THEN** kann das System diese Korrektur als isolierte Ausnahme modellieren
+- **AND** nachfolgende Termine bleiben unveraendert, sofern die Fachregel dies vorsieht
+
+#### Scenario: Einzelverschiebung beeinflusst Folgetermine
+
+- **WHEN** eine manuelle Terminverschiebung laut Fachregel Auswirkungen auf die nachfolgende Terminserie haben soll
+- **THEN** kann das System diesen Folgeeffekt ausdruecklich modellieren
+- **AND** nachgelagerte Termine werden konsistent auf Basis der geaenderten Serienlogik berechnet oder markiert
+
+### Requirement: Waste-Management behandelt Feiertage und Abweichungen als erstklassige Fachlogik
+
+Das System SHALL Feiertage und andere globale Abweichungsgruende als eigenstaendige Fachlogik fuer Terminverschiebungen behandeln.
+
+#### Scenario: Feiertag loest globale Terminverschiebung aus
+
+- **WHEN** ein Feiertag oder ein anderer globaler Abweichungsgrund einen regulaeren Tourtermin betrifft
+- **THEN** kann das System diese Verschiebung explizit modellieren
+- **AND** die daraus resultierende Terminlogik bleibt fuer betroffene Touren nachvollziehbar
+- **AND** Feiertagsmanagement ist nicht nur als freier Text oder manueller Nebeneffekt abgebildet
+
+### Requirement: Waste-Daten sind instanzbezogen isoliert
+
+Das System SHALL Waste-Management-Daten im Zielbild instanzbezogen scopen.
+
+#### Scenario: Instanzgrenze wird bei Lesezugriffen erzwungen
+
+- **WHEN** ein Benutzer im Kontext einer aktiven Instanz Waste-Daten aufruft
+- **THEN** werden nur Waste-Daten der aktiven Instanz gelesen
+- **AND** Daten anderer Instanzen bleiben unsichtbar
+
+#### Scenario: Instanzgrenze wird bei Mutationen erzwungen
+
+- **WHEN** ein Benutzer Waste-Daten erstellt, aendert, importiert, seeded oder zuruecksetzt
+- **THEN** wirkt die Operation ausschliesslich innerhalb der aktiven Instanz
+- **AND** instanzfremde Datensaetze duerfen dadurch nicht veraendert werden
+
+### Requirement: Waste-Management-Datenquellen und Migrationen bleiben administrierbar
+
+Das System SHALL die instanzbezogene Waste-Datenquelle und deren Schema-Migrationsstand administrierbar halten.
+
+#### Scenario: Plugin bietet Initialisierung oder Update-Migrationen an
+
+- **WHEN** das Waste-Management-Plugin fuer eine Instanz erstmals gestartet wird oder nach einem Update feststellt, dass ausstehende Waste-Migrationen vorliegen
+- **THEN** bietet das System die erforderliche Initialisierung oder Migration als explizite Admin-Operation an
+- **AND** die Migration wird nicht als verdeckter Browser-Direktzugriff an Supabase ausgefuehrt
+
+#### Scenario: Migrationen sind nachvollziehbare technische Operationen
+
+- **WHEN** eine Waste-Migration fuer die aktive Instanz ausgefuehrt wird
+- **THEN** ist deren Ergebnis fuer Administratoren nachvollziehbar
+- **AND** Erfolg, Fehler oder ausstehender Status koennen ueber Studio-Vertraege eingesehen werden
+
+### Requirement: Waste-Management bildet Sicherheits- und Betriebszustaende sichtbar ab
+
+Das System SHALL fuer Waste-Management konsistente Lade-, Leer-, Fehler-, Berechtigungs- und Bestaetigungszustaende bereitstellen.
+
+#### Scenario: Benutzer ohne Schreibrechte sieht nur lesenden Zustand
+
+- **WHEN** ein Benutzer nur ueber `waste-management.read` verfuegt
+- **THEN** kann er fachliche Daten lesen
+- **AND** schreibende Aktionen wie Erstellen, Bearbeiten, Import, Seed oder Reset sind verborgen oder deaktiviert
+
+#### Scenario: Gefaehrliche Werkzeuge folgen separaten UI-Rechten
+
+- **WHEN** ein Benutzer kein Spezialrecht fuer Seed oder Reset besitzt
+- **THEN** erscheinen diese Werkzeuge nicht als regulaere verfuegbare Aktionen
+- **AND** die UI fuehrt keinen alternativen Pfad an der serverseitigen Autorisierung vorbei ein
+
+#### Scenario: Fehler aus der Host-Fassade werden benutzerfuehrend dargestellt
+
+- **WHEN** die Studio-Fassade eine fachliche oder technische Fehlerantwort fuer Waste-Management liefert
+- **THEN** zeigt das Plugin einen Studio-konformen Fehlerzustand mit handlungsleitender Rueckmeldung
+- **AND** keine rohen Backend-Interna oder Stacktraces werden im UI offengelegt
+
+#### Scenario: Nicht erreichbare Waste-Datenquelle fuehrt in einen konfigurierbaren Fehlerzustand
+
+- **WHEN** die Waste-Datenquelle der aktiven Instanz nicht erreichbar ist
+- **THEN** zeigt das Plugin einen klaren technischen Fehlerzustand fuer fachliche Datenoperationen
+- **AND** ein Benutzer mit `waste-management.settings.manage` wird zu einem Rekonfigurations- oder Pruefpfad gefuehrt
+- **AND** die Unerreichbarkeit fuehrt nicht dazu, dass die technische Rekonfiguration der Datenquelle verborgen wird
+
+### Requirement: Waste-Fachstammdaten unterstuetzen mehrsprachige und farbcodierte Darstellungen
+
+Das System SHALL fachnahe Waste-Stammdaten fuer spaetere mehrsprachige und visuelle Ausspielung vorbereiten.
+
+#### Scenario: Abfallarten tragen mehrsprachige Bezeichnungen
+
+- **WHEN** eine Abfallart oder vergleichbare fachliche Stammdaten gepflegt werden
+- **THEN** koennen die fachlichen Bezeichnungen mehrsprachig verwaltet werden
+- **AND** die Daten bleiben fuer unterschiedliche Kanaele konsistent nutzbar
+
+#### Scenario: Farbcodes sind Teil des fachlichen Vertrags
+
+- **WHEN** Abfallarten oder fachnahe Tourdarstellungen im System gepflegt werden
+- **THEN** koennen ihnen definierte Farbcodes zugeordnet werden
+- **AND** diese Farbcodes gelten als fachlich relevante Darstellungsinformation und nicht nur als lokale UI-Zierde
+
+### Requirement: Waste-Management umfasst kontrollierte Data-Tools
+
+Das System SHALL CSV-Import, Seed und Reset als kontrollierte Data-Tools im Waste-Management-Modul bereitstellen.
+
+#### Scenario: Waste-Importe nutzen generische Studio-Importprofile
+
+- **WHEN** das Waste-Management strukturierte Quelldaten importiert
+- **THEN** nutzt es dafuer eine allgemeine Studio-Import-Faehigkeit statt einer nur fuer Waste gebauten Sonderloesung
+- **AND** Waste definiert dafuer pluginseitige Importprofile statt eine eigene parallele Importplattform aufzubauen
+
+#### Scenario: Generische Import-Faehigkeit wird als Plattformbasis aufgebaut
+
+- **WHEN** das Studio die erste allgemeine Import-Faehigkeit in diesem Change bereitstellt
+- **THEN** wird sie bereits als tragfaehige Plattformbasis fuer weitere Plugins aufgebaut
+- **AND** sie bleibt nicht nur eine schmale vorbereitende Sonderloesung fuer Waste allein
+
+#### Scenario: Importprofile werden ueber einen expliziten Plugin-Vertrag registriert
+
+- **WHEN** ein Plugin strukturierte Datenimporte ueber die allgemeine Studio-Import-Faehigkeit anbieten will
+- **THEN** registriert es seine Importprofile ueber einen expliziten Plugin-Vertrag
+- **AND** das Studio uebernimmt darauf aufbauend die generische Runtime, UI und Orchestrierung
+
+#### Scenario: Erste Waste-Importtypen sind getrennt spezifiziert
+
+- **WHEN** der erste verbindliche Importumfang fuer Waste beschrieben wird
+- **THEN** werden mindestens die getrennten Importprofile `geografie-abholorte`, `touren` und `ausweichtermine` vorgesehen
+- **AND** weitere spaetere Importprofile bleiben zulaessig, sind in diesem Change aber noch nicht verpflichtend
+
+#### Scenario: Jeder Waste-Importtyp besitzt eigenes Schema, Vorlage und Validierung
+
+- **WHEN** ein Waste-Importprofil definiert wird
+- **THEN** besitzt es ein eigenes explizites Spalten- oder Feldschema
+- **AND** es bringt eine kanonische Vorlage mit Beispielspalten und bei Bedarf einer Beispieldatei mit
+- **AND** es enthaelt eigene fachliche und technische Validierungsregeln
+
+#### Scenario: Generische Import-Faehigkeit unterstuetzt mehrere Quellformate
+
+- **WHEN** das Studio die erste allgemeine Import-Faehigkeit fuer Waste bereitstellt
+- **THEN** unterstuetzt sie mindestens CSV, Excel sowie schema-nahe JSON- und XML-Quellen
+- **AND** JSON und XML muessen dabei ohne komplexe ETL-Sonderlogik auf das jeweilige Importprofil abbildbar bleiben
+
+#### Scenario: Erste Import-Oberflaeche folgt einem mehrstufigen Wizard
+
+- **WHEN** das Studio die erste allgemeine Import-Oberflaeche fuer Waste bereitstellt
+- **THEN** fuehrt sie Benutzer mindestens durch Quellwahl, Profilwahl, Mapping-Pruefung, Validierungsvorschau, Job-Start und Ergebnisansicht
+- **AND** diese Bedienlogik wird als allgemeines Studio-Muster und nicht als einmaliger Waste-Sonderdialog aufgebaut
+
+#### Scenario: Import-Mapping darf automatische Vorschlaege erzeugen
+
+- **WHEN** ein Benutzer Quelldaten auf ein Waste-Importprofil abbildet
+- **THEN** darf das Studio automatische Mapping-Vorschlaege fuer Quellspalten oder Quellfelder erzeugen
+- **AND** der Benutzer kann diese Vorschlaege vor dem Import pruefen und manuell korrigieren
+
+#### Scenario: Mapping-Vorlagen duerfen pro Instanz und Importprofil gespeichert werden
+
+- **WHEN** Benutzer fuer wiederkehrende Importe ein manuell angepasstes Mapping erfolgreich verwenden
+- **THEN** darf das Studio dieses Mapping als einfache Vorlage pro Instanz und Importprofil speichern
+- **AND** spaetere Importe duerfen diese Vorlage erneut verwenden, ohne dass in diesem Change bereits eine komplexe Versions- oder Freigabelogik verpflichtend wird
+
+#### Scenario: KI-basierte Mapping-Vorschlaege bleiben spaeter integrierbar
+
+- **WHEN** das Studio die erste automatische Mapping-Strecke fuer Importprofile bereitstellt
+- **THEN** wird die Vorschlagslogik so gekapselt, dass spaeter auch eine externe KI-basierte Mapping-Hilfe angeschlossen werden kann
+- **AND** diese moegliche KI-Integration ist in diesem Change noch nicht als produktiver Bestandteil verpflichtend
+
+#### Scenario: CSV-Import validiert Daten und meldet Fehler nachvollziehbar
+
+- **WHEN** ein Benutzer einen CSV-Import fuer Waste-Daten ausfuehrt
+- **THEN** startet das System eine asynchrone Import-Operation
+- **AND** der Import validiert die Daten fachlich und technisch
+- **AND** importierte, uebersprungene und fehlgeschlagene Datensaetze koennen ueber einen nachvollziehbaren Status rueckgemeldet werden
+
+#### Scenario: Seed-Werkzeug ist gesondert geschuetzt
+
+- **WHEN** ein Benutzer Seed-Daten laden moechte
+- **THEN** ist das Werkzeug nur mit dem dafuer vorgesehenen Spezialrecht verfuegbar
+- **AND** die Seed-Operation wirkt ausschliesslich im aktiven Instanzkontext
+- **AND** die Ausfuehrung erfolgt als asynchrone Operation mit nachvollziehbarem Ergebnisstatus
+
+#### Scenario: Reset verlangt explizite Hochrisiko-Bestaetigung
+
+- **WHEN** ein Benutzer einen Reset fuer Waste-Daten ausloesen moechte
+- **THEN** verlangt das System eine explizite Hochrisiko-Bestaetigung mit sichtbarem Scope
+- **AND** die Operation ist nur mit einem separaten Reset-Recht verfuegbar
+- **AND** auch in Produktionsumgebungen bleibt diese Schutzstrecke verbindlich
+- **AND** der Reset bezieht sich nur auf Waste-Fachdaten der aktiven Instanz und nicht auf die technische Datenquellenkonfiguration im Studio-Postgres
+
+#### Scenario: Migrationen werden als asynchrone Data-Tools behandelt
+
+- **WHEN** ein Benutzer eine ausstehende Waste-Schema-Migration fuer die aktive Instanz anstoesst
+- **THEN** wird die Operation asynchron ausgefuehrt
+- **AND** Start, Fortschritt, Erfolg oder Fehler koennen nachvollziehbar eingesehen werden
+
+#### Scenario: Waste nutzt eine generische Studio-Job-Faehigkeit
+
+- **WHEN** das Waste-Management langlaufende Operationen wie Migration, CSV-Import, Seed oder Reset ausfuehrt
+- **THEN** verwendet es dafuer ein allgemeines Studio-Jobmodell statt einer nur fuer Waste gebauten Sonderloesung
+- **AND** Waste liefert dabei nur plugin-spezifische Jobtypen oder Payloads auf dieser allgemeinen Studio-Faehigkeit
+
+#### Scenario: Generische Job-Faehigkeit wird als Plattformbasis aufgebaut
+
+- **WHEN** das Studio die erste allgemeine Job-Faehigkeit in diesem Change bereitstellt
+- **THEN** wird sie bereits als tragfaehige Plattformbasis fuer weitere Plugins aufgebaut
+- **AND** sie bleibt nicht nur eine schmale vorbereitende Sonderloesung fuer Waste allein
+
+#### Scenario: Jobtypen werden ueber einen expliziten Plugin-Vertrag registriert
+
+- **WHEN** ein Plugin langlaufende Operationen ueber die allgemeine Studio-Job-Faehigkeit anbieten will
+- **THEN** registriert es seine fachlichen Jobtypen ueber einen expliziten Plugin-Vertrag
+- **AND** das Studio uebernimmt darauf aufbauend die generische Runtime, Persistenz, UI und Orchestrierung
+
+#### Scenario: Generische Studio-Jobs sind zentral im Studio-Postgres persistent
+
+- **WHEN** das Studio pluginuebergreifende langlaufende Jobs verwaltet
+- **THEN** liegt deren zentrale Persistenz im Studio-Postgres
+- **AND** diese allgemeine Job-Persistenz wird nicht als primaerer Vertrag in externe Plugin-Datenbanken verlagert
+
+#### Scenario: Erste feste Statusmenge der generischen Studio-Job-Faehigkeit ist definiert
+
+- **WHEN** das Studio langlaufende Jobs fuer Waste oder spaetere Plugins fuehrt
+- **THEN** umfasst die erste feste Statusmenge mindestens `queued`, `running`, `succeeded`, `failed`, `cancelled`
+
+#### Scenario: Erste generische Studio-Jobs enthalten keine automatische Retry-Logik
+
+- **WHEN** die erste Ausbaustufe der generischen Studio-Job-Faehigkeit langlaufende Operationen ausfuehrt
+- **THEN** enthaelt sie keine automatische Retry-Logik als Pflichtbestandteil
+- **AND** moegliche Wiederholungsmechanismen bleiben spaeteren Erweiterungen vorbehalten
+
+#### Scenario: Wiederholung erfolgt durch neuen Job statt Neustart eines bestehenden Jobs
+
+- **WHEN** ein Job in der ersten Ausbaustufe fehlschlaegt oder abgebrochen wurde
+- **THEN** wird er nicht als derselbe Job erneut gestartet
+- **AND** eine erneute Ausfuehrung erfolgt bei Bedarf durch das Anlegen eines neuen Jobs
+
+#### Scenario: `cancelled` ist zunaechst nur als Status vorgesehen
+
+- **WHEN** die erste Ausbaustufe der generischen Studio-Job-Faehigkeit das Statusmodell definiert
+- **THEN** ist `cancelled` als Status bereits vorgesehen
+- **AND** daraus folgt noch keine Pflicht, fuer alle Jobtypen bereits einen echten aktiven Abbruchpfad bereitzustellen
+
+#### Scenario: Generische Studio-Jobs sind pluginuebergreifend im UI sichtbar
+
+- **WHEN** das Studio die erste Ausbaustufe seiner generischen Job-Faehigkeit bereitstellt
+- **THEN** ist diese nicht nur technisch, sondern auch UI-seitig als pluginuebergreifendes Studio-Konzept sichtbar
+- **AND** Waste-Jobs erscheinen damit nicht ausschliesslich als isolierte plugininterne Sonderdarstellung
+
+#### Scenario: Erste zentrale Job-Sicht haengt unter `Monitoring`
+
+- **WHEN** das Studio die erste pluginuebergreifende UI-Sicht fuer generische Jobs bereitstellt
+- **THEN** wird diese unter dem bestehenden Sidebar-Punkt `Monitoring` verankert
+- **AND** ein spaeteres Desktop-Widget ist fuer diesen Change nicht verpflichtend
+
+#### Scenario: Erste Monitoring-Sicht bleibt in ihrer Informationsarchitektur flexibel
+
+- **WHEN** das Studio die erste zentrale `Monitoring`-Sicht fuer Jobs und externe Datenquellen aufbaut
+- **THEN** bleibt diese zunaechst eine technische und temporaere Admin-Sicht
+- **AND** sie darf initial Jobs, aktuellen technischen Datenquellenstatus und technische Ereignishistorie zeigen
+- **AND** eine breitere fachliche Betriebsoberflaeche wird in diesem Change nicht verpflichtend eingefuehrt
+
+#### Scenario: Wiederverwendbare UI-Muster werden als allgemeine Studio-Bausteine geschnitten
+
+- **WHEN** das Waste-Management neue UI fuer Import, Jobs, Bulk-Actions, Hochrisiko-Bestaetigungen oder technische Statusanzeigen benoetigt
+- **THEN** werden diese Muster als allgemeine Studio-UI-Bausteine umgesetzt oder aus bestehenden allgemeinen Bausteinen abgeleitet
+- **AND** sie verbleiben nicht als einmalige isolierte Sonderloesung im Waste-Plugin, sofern ihre Semantik fachneutral genug fuer weitere Plugins ist
+
+#### Scenario: Fachliche Waste-Dialoge und Jahreskalender bleiben im Plugin
+
+- **WHEN** die Waste-Oberflaeche Jahreskalender, Touren-, Ausweichtermin-, Abholort-, Fraktions- oder Zuordnungsdialoge bereitstellt
+- **THEN** bleiben diese Komponenten fachliche Bestandteile von `packages/plugin-waste-management`
+- **AND** sie werden in diesem Change nicht als allgemeine Plugin-UI-Komponenten in die zentrale UI-Library verschoben

--- a/openspec/changes/add-waste-management-plugin/tasks.md
+++ b/openspec/changes/add-waste-management-plugin/tasks.md
@@ -1,0 +1,72 @@
+## 1. Specification
+
+- [x] 1.1 Neue Capability `waste-management` mit Scope, UI-Vertrag und Ressourcenmodell spezifizieren
+- [x] 1.2 Freie Plugin-Route `/plugins/waste-management` samt Search-Param-Erwartungen spezifizieren
+- [x] 1.3 Host-Fassade `/api/v1/waste-management/*` und deren Boundary gegen Plugin und Datenzugriff spezifizieren
+- [x] 1.4 Instanzbezogene Weiterentwicklung des `waste_*`-Schemas und Migrationsrichtung spezifizieren
+- [x] 1.5 Feingranulares Modul-IAM fuer Lesen, Pflege, Import, Seed, Reset und Einstellungen spezifizieren
+- [x] 1.6 Audit- und Historienerwartungen fuer Mutationen, CSV-Import, Seed und Reset spezifizieren
+- [x] 1.7 Relevante Arc42-Auswirkungen fuer Plugin-, Runtime-, Sicherheits- und Risiko-Sicht dokumentieren
+- [x] 1.8 Betrieb als fuehrendes oder sekundaeres Waste-System und daraus folgende Integrationsoffenheit spezifizieren
+- [x] 1.9 Erweiterte Terminlogik fuer Einzelverschiebungen und Folgeeffekte spezifizieren
+- [x] 1.10 Detaillierte Portierungsregeln fuer zulaessige `Newcms`-Uebernahmen und verbotene Architekturkopplungen spezifizieren
+- [x] 1.11 Datenquellen-, Primaermodus- und asynchrone Tool-Entscheidungen spezifizieren
+- [x] 1.12 `openspec validate add-waste-management-plugin --strict` ausfuehren
+
+## 2. Slice A: Contracts und Portierungsinventar
+
+- [ ] 2.1 Vor dem Portieren aus `Newcms` eine Artefaktliste fuer die geplante UI-Uebernahme erstellen und je Artefakt festhalten, ob es praesentational, fachlogisch oder infrastrukturell ist
+- [ ] 2.2 In `packages/core` gemeinsame Contracts fuer Waste-Settings, Datenquellenstatus, generische Job-Status und instanzbezogene Verwaltungsmodelle ergaenzen
+- [ ] 2.3 Fuer alle aus `Newcms` angelehnten Artefakte dokumentieren und pruefen, dass keine produktiven `Newcms`-Hooks, API-Clients, Stores oder Rechteannahmen verbleiben
+
+## 2a. Slice A2: Generische Job-Faehigkeit
+
+- [ ] 2a.1 Eine allgemeine Studio-Job-Faehigkeit fuer langlaufende Plugin-Operationen als tragfaehige Plattformbasis definieren, die fuer Waste und weitere reale Plugins direkt wiederverwendbar ist
+- [ ] 2a.2 Die minimale Persistenz-, Status- und Lifecycle-Schnittstelle dieser generischen Job-Faehigkeit festlegen und in die betroffenen Plattform-Packages einhaengen
+- [ ] 2a.3 Im `packages/plugin-sdk` einen expliziten Plugin-Vertrag fuer die Registrierung fachlicher Jobtypen vorsehen
+
+## 2b. Slice A3: Generische Import-Faehigkeit
+
+- [ ] 2b.1 Eine allgemeine Studio-Import-Faehigkeit fuer CSV, Excel sowie schema-nahe JSON- und XML-Quellen als tragfaehige Plattformbasis definieren, die fuer Waste und weitere reale Plugins direkt wiederverwendbar ist
+- [ ] 2b.2 Pluginseitige Importprofile mit kanonischer Vorlage, Mapping-Regeln und Validierungsvertrag als allgemeines Plattformmuster festlegen
+- [ ] 2b.3 Die erste automatische Mapping-Strecke mit manueller Korrekturfunktion so schneiden, dass spaeter eine externe KI-basierte Vorschlagslogik als austauschbare Integrationsstelle angeschlossen werden kann
+- [ ] 2b.4 Den allgemeinen Import-Dialog als mehrstufigen Wizard mit Quellwahl, Profilwahl, Mapping, Validierungsvorschau, Job-Start und Ergebnisansicht festlegen
+- [ ] 2b.5 Einfache gespeicherte Mapping-Vorlagen pro Instanz und Importprofil als wiederverwendbares Plattformmuster vorsehen, ohne bereits komplexe Versionierungslogik einzufuehren
+- [ ] 2b.6 Im `packages/plugin-sdk` einen expliziten Plugin-Vertrag fuer die Registrierung fachlicher Importprofile vorsehen
+
+## 3. Slice B: Zentrale Governance- und Instanzkonfiguration
+
+- [ ] 3.1 In `packages/instance-registry` die instanzbezogene technische Waste-Modulkonfiguration als Teil der Studio-Governance modellieren
+- [ ] 3.2 In `packages/data-repositories` die primaere Persistenz fuer Waste-Datenquellen-Konfiguration, Connection-Checks und Governance-Queries im zentralen Studio-Postgres implementieren
+- [ ] 3.3 In `packages/data` nur bei Bedarf eine duenne Orchestrierungs- oder Kompositionsschicht ergaenzen, ohne dort neue primaere Waste-SQL-Heimat aufzubauen
+
+## 4. Slice C: Runtime, Datenquellenauflosung und Waste-Repositories
+
+- [ ] 4.1 In `packages/server-runtime` die serverseitige Aufloesung der aktiven Waste-Datenquelle, Secret-Nutzung, Connection-Tests und technische Fehlervertraege kapseln
+- [ ] 4.2 In `packages/data-repositories` die hostseitigen Repositories fuer die `waste_*`-Tabellenfamilie der instanzbezogenen Waste-Fachdatenbank implementieren
+- [ ] 4.3 Die Waste-spezifische Einbindung in die generische Studio-Job-Faehigkeit fuer Initialisierung, Update-Migrationen, Import, Seed und Reset vorbereiten
+
+## 5. Slice D: Host-Fassade, Routing, IAM und Audit
+
+- [ ] 5.1 In `packages/auth-runtime` die HTTP-Handler fuer `/api/v1/waste-management/*` mit Validierung, Rechtepruefung, Fehlervertrag und Endpunkten fuer die generische Job-Faehigkeit implementieren
+- [ ] 5.2 In `packages/routing` die freie Plugin-Route, Search-Param-Validierung, Guards und Sichtbarkeitsregeln fuer Waste-Management integrieren
+- [ ] 5.3 In `packages/routing` und `packages/auth-runtime` die Host-Routen fuer `/api/v1/waste-management/*` einschliesslich asynchroner Tool- und Migrationspfade in die bestehende Runtime- und Route-Registrierung aufnehmen
+- [ ] 5.4 In `packages/iam-admin` die neuen `waste-management.*` Rechte in Rollen- und Permission-Verwaltung integrieren, soweit diese zentral vom Studio gepflegt werden
+- [ ] 5.5 In `packages/iam-governance` die zentrale Audit-Integration und gegebenenfalls einfache Audit-basierte Verlaufsansichten fuer Waste-Mutationen anbinden
+- [ ] 5.6 Audit-Events, Modul-IAM und Berechtigungsauflosung fuer `waste-management.*` im Zusammenspiel von `packages/plugin-sdk`, `packages/iam-admin` und `packages/iam-governance` verdrahten
+
+## 6. Slice E: Fachplugin und Admin-UI
+
+- [ ] 6.1 `packages/plugin-waste-management` anlegen und die fachliche Hauptoberflaeche unter `/plugins/waste-management` mit typisierten Search-Params materialisieren
+- [ ] 6.2 In `packages/plugin-waste-management` die Waste-Admin-UI fuer Tabs, Tabellen, Dialoge, Bulk-Flows sowie Lade-, Leer-, Fehler-, Job- und Berechtigungszustaende umsetzen
+- [ ] 6.3 In `packages/plugin-waste-management` die Host-API-Clients fuer CRUD, Settings, asynchrone Import-, Seed-, Reset- und Migrationsoperationen anbinden
+- [ ] 6.4 In `packages/studio-ui-react` einen wiederverwendbaren Import-Dialog-Flow sowie allgemeine Job-, Monitoring-, Bulk-Action-, Hochrisiko-Confirm- und Statusbausteine ergaenzen, soweit diese noch nicht vorhanden sind
+- [ ] 6.5 In `packages/plugin-waste-management` Jahreskalender, Touren-, Ausweichtermin-, Abholort-, Fraktions- und Zuordnungsdialoge bewusst als fachliche Plugin-Komponenten halten und nur gegen die allgemeinen UI-Bausteine andocken
+- [ ] 6.6 In `apps/sva-studio-react` die statische Plugin-Registrierung und die Einbettung der instanzbezogenen Waste-Einstellungen in die Studio-Shell ergaenzen
+
+## 7. Slice F: Tests, Dokumentation und Architektur
+
+- [ ] 7.1 Unit- und Type-Tests in `packages/plugin-waste-management`, `packages/routing`, `packages/auth-runtime`, `packages/server-runtime`, `packages/data-repositories` und `packages/instance-registry` entlang der jeweiligen Slice-Verantwortung ergaenzen
+- [ ] 7.2 Integrations- und E2E-Tests in `apps/sva-studio-react` fuer Plugin-Navigation, Rechte, Settings, Rekonfiguration, CRUD, Import, Seed, Reset, Migrationen und Instanzisolation ergaenzen
+- [ ] 7.3 Relevante Arc42- und Entwicklerdokumentation fuer Persistenzgrenzen, Instanzkonfiguration, Runtime-Boundaries, asynchrone Data-Tools und Primaermodus aktualisieren
+- [ ] 7.4 In der Architektur- und Entwicklerdokumentation die Portierungsstrategie gegen `Newcms` inklusive zulaessiger UX-Anlehnung und verbotener Architekturkopplungen festhalten


### PR DESCRIPTION
## Was sich aendert

Dieser PR fuegt den OpenSpec-Change `add-waste-management-plugin` hinzu.

Der Proposal schaerft insbesondere:
- die Trennung zwischen zentralem `Studio-Postgres` und externer instanzbezogener Waste-/Supabase-Datenbank
- die Waste-spezifische Fach- und Betriebsdatenhaltung gegenueber zentraler Governance, IAM und Audit
- die generische Studio-Plattformfaehigkeit fuer Jobs und strukturierte Importe
- den expliziten `plugin-sdk`-Vertrag zur Registrierung von Jobtypen und Importprofilen
- die UI-Grenze zwischen allgemeinen Studio-UI-Bausteinen und fachlichen Waste-Komponenten
- die Portierungsgrenze gegen `Newcms`

## Warum sich das aendert

Der urspruengliche Change hatte noch mehrere Unschärfen bei Datenquellen, Plattformgrenzen, UI-Wiederverwendung und langfristiger Plugin-SDK-Ausrichtung. Dieser Proposal bringt die Architektur in einen konsistenteren Zustand, bevor Implementierung beginnt.

## Auswirkungen

- `Waste-Management` wird als freies Fachplugin mit hostgefuehrter Server-Fassade und klarer Instanztrennung beschrieben
- Jobs und strukturierte Importe werden nicht nur als Waste-Sonderfall, sondern als tragfaehige Plattformbasis fuer weitere Plugins angelegt
- `Monitoring` bleibt zunaechst bewusst eine technische Admin-Sicht
- `packages/studio-ui-react` und `packages/plugin-sdk` bekommen klarere kuenftige Verantwortung im Zielbild

## Validierung

- `openspec validate add-waste-management-plugin --strict`
