### PR TITLE
[codex] Refine package boundaries task breakdown

### DIFF
--- a/openspec/changes/refactor-sva-studio-react-package-boundaries/tasks.md
+++ b/openspec/changes/refactor-sva-studio-react-package-boundaries/tasks.md
@@ -1,38 +1,26 @@
-## 1. Boundary-Scope und Zielverträge
+## 1. Schritt 1: Legal-Text-Sanitizer und Boundary-Fundament
 
-- [ ] 1.1 OpenSpec-Deltas für `monorepo-structure`, `ui-layout-shell` und `sva-mainserver-integration` finalisieren
-- [ ] 1.2 die Ziel-Ownership je Kandidat festschreiben: Studio-UI nach `@sva/studio-ui-react`, Legal-Text-Sanitizing nach `@sva/iam-governance`, Mainserver-Host-Parsing nach `@sva/sva-mainserver/server`
-- [ ] 1.3 explizit dokumentieren, welche App-Bereiche bewusst im App-Layer bleiben, insbesondere Shell-Komposition, Routing-Bindings und host-spezifische Route-Assemblierung
+- [ ] 1.1 OpenSpec-Deltas für `monorepo-structure`, `ui-layout-shell` und `sva-mainserver-integration` auf die tatsächliche Drei-Schritt-Migration zuschneiden und dokumentieren, welche App-Bereiche bewusst im App-Layer bleiben
+- [ ] 1.2 die Ziel-Ownership für die aktuell klar belegten Kandidaten festschreiben: `sanitizeLegalTextHtml` nach `@sva/iam-governance`, wiederverwendbare Tabellen-/Listen-UI nach `@sva/studio-ui-react`, Mainserver-Host-Parsing nach `@sva/sva-mainserver/server`
+- [ ] 1.3 `apps/sva-studio-react/src/lib/legal-text-html.ts` gegen den kanonischen Helper aus `packages/iam-governance/src/legal-text-html.ts` zurückführen und nur dann einen Kompatibilitäts-Wrapper stehen lassen, wenn die Umstellung nicht atomar möglich ist
+- [ ] 1.4 die direkten App-Consumer des Sanitizers auf die kanonische Ownership umstellen, aktuell mindestens `src/components/RichTextEditor.tsx` und `src/components/LegalTextAcceptanceDialog.tsx`
+- [ ] 1.5 App- und Package-Tests für Legal-Text-Sanitizing so anpassen, dass die kanonische Implementierung abgesichert ist und das app-lokale Duplikat danach entfernt werden kann
 
-## 2. Studio-UI-Konsolidierung
+## 2. Schritt 2: Studio-UI aus der App in `@sva/studio-ui-react` zurückführen
 
-- [ ] 2.1 die duplizierten Tabellen-, Listen- und Basis-UI-Bausteine in `apps/sva-studio-react` inventarisieren und einem Ziel-Export in `packages/studio-ui-react` zuordnen
-- [ ] 2.2 fehlende Package-Exports oder API-Anpassungen in `@sva/studio-ui-react` ergänzen, damit App und Plugins dieselben Bausteine konsumieren können
-- [ ] 2.3 App-Routen und Komponenten schrittweise von lokalen UI-Duplikaten auf Package-Imports umstellen
-- [ ] 2.4 betroffene Unit-Tests für App und Package anpassen oder ergänzen, damit die gemeinsame UI-API abgesichert ist
+- [ ] 2.1 das aktuelle Delta zwischen `apps/sva-studio-react/src/components/StudioDataTable.tsx` und `packages/studio-ui-react/src/studio-data-table.tsx` inventarisieren und die fehlenden Package-API-Teile benennen, insbesondere Labels/i18n, Bulk-Action-Typen und eventuelle App-spezifische Komfortprops
+- [ ] 2.2 `@sva/studio-ui-react` so erweitern oder anpassen, dass die App ihren lokalen `StudioDataTable` ohne Funktionsverlust ersetzen kann, statt einen zweiten kanonischen Tabellenbaustein zu pflegen
+- [ ] 2.3 die bekannten App-Consumer schrittweise auf Package-Imports umstellen, aktuell mindestens `src/routes/content/-content-list-page.tsx`, `src/routes/admin/roles/-roles-page.tsx`, `src/routes/admin/media/-media-page.tsx`, `src/routes/admin/instances/-instances-page.tsx` und `src/routes/admin/users/-user-list-page.tsx`
+- [ ] 2.4 den app-lokalen `StudioDataTable` und zugehörige Duplikat-Tests erst entfernen, wenn die Package-Variante alle benötigten App-Fälle abdeckt und die Route-Tests grün sind
+- [ ] 2.5 betroffene Unit-Tests in App und Package so ergänzen, dass die gemeinsame Tabellen-API als Boundary-Vertrag nachvollziehbar abgesichert ist
 
-## 3. Domain-Helper-Konsolidierung
+## 3. Schritt 3: Mainserver-Host-Adapter aus der App herauslösen und Rest-Audits abschließen
 
-- [ ] 3.1 `sanitizeLegalTextHtml` und zugehörige Tests auf den kanonischen Helper aus `@sva/iam-governance` zurückführen
-- [ ] 3.2 app-lokale Sanitizer-Duplikate entfernen oder auf reine Kompatibilitäts-Wrapper reduzieren, falls eine Zwischenmigration nötig ist
-- [ ] 3.3 prüfen, ob weitere app-lokale Helper mit derselben Ownership-Dynamik existieren, und nur reale Duplikate in denselben Refactoring-Strang aufnehmen
-- [ ] 3.4 direkte App-Consumer wie Rich-Text-Editoren und Legal-Text-Dialoge auf die kanonische `@sva/iam-governance`-API umstellen und die Ownership in Tests nachvollziehbar machen
-
-## 4. Mainserver-Host-Adapter aus der App herauslösen
-
-- [ ] 4.1 News-, Events- und POI-spezifische Request-Parser, Validierung und Host-Mutationslogik in paketseitige Server-Verträge überführen
-- [ ] 4.2 `apps/sva-studio-react` auf dünne Server-Einstiege reduzieren, die Requests entgegennehmen und an die Package-Handler delegieren
-- [ ] 4.3 die Package-Tests so ergänzen, dass die ausgelagerte Parsing- und Fehlerlogik außerhalb der App abgesichert bleibt
-- [ ] 4.4 app-seitige Server- und Routen-Tests auf das neue Delegationsmodell anpassen
-- [ ] 4.5 sicherstellen, dass reine App-interne Helper-Extraktionen nicht als Abschluss gelten; News-, Events- und POI-Parsing muss tatsächlich über paketseitige Verträge nachweisbar sein
-
-## 5. App-lokale Regelduplikate abbauen
-
-- [ ] 5.1 `interfaces-api` auf gemeinsame Regeln für Instanzkontext und Berechtigungsentscheidungen zurückführen, statt dieselbe Fachentscheidung an mehreren Stellen inline zu pflegen
-- [ ] 5.2 Tests für `interfaces-api` so ergänzen, dass die zentralisierte Regelbasis und ihre Fehlerfälle direkt abgesichert sind
-
-## 6. Architektur, Doku und Qualitätssicherung
-
-- [ ] 6.1 betroffene arc42-Abschnitte und Entwicklerdokumentation auf die Ziel-Boundaries aktualisieren
-- [ ] 6.2 relevante Nx-Targets für Unit-, Types- und Boundary-Checks grün ausführen, einschließlich `pnpm check:server-runtime` falls serverseitige Packages betroffen sind
-- [ ] 6.3 `openspec validate refactor-sva-studio-react-package-boundaries --strict` ausführen
+- [ ] 3.1 News-, Events- und POI-spezifische Request-Parser, Validierung und Host-Mutationslogik aus `apps/sva-studio-react/src/lib/mainserver-news-api.server.ts` sowie `apps/sva-studio-react/src/lib/mainserver-events-poi-api.server.ts` in paketseitige Server-Verträge überführen
+- [ ] 3.2 `apps/sva-studio-react/src/server.ts` und verbleibende App-Einstiege auf dünne Delegation reduzieren, sodass die App Requests annimmt und an Package-Handler weiterreicht, aber keine kanonische Inhalts-Parsing-Logik mehr besitzt
+- [ ] 3.3 die Package-Tests so ergänzen, dass Parsing-, Validierungs- und Fehler-Mapping außerhalb der App direkt abgesichert bleiben; app-seitige Tests werden auf das Delegationsmodell umgestellt
+- [ ] 3.4 explizit verifizieren, dass keine bloße app-interne Helper-Extraktion als Abschluss gewertet wird: News-, Events- und POI-Parsing muss danach nachweisbar über paketseitige Verträge laufen
+- [ ] 3.5 `interfaces-api` gezielt auditieren und nur dann in denselben Refactoring-Block aufnehmen, wenn sich beim aktuellen Code ein klarer owning Package-Vertrag für Instanzkontext- oder Berechtigungsregeln nachweisen lässt; andernfalls den Punkt mit Folgeticket aus diesem Change herauslösen
+- [ ] 3.6 betroffene arc42-Abschnitte und Entwicklerdokumentation auf die finalen Boundaries aktualisieren
+- [ ] 3.7 relevante Nx-Targets für Unit-, Types- und Boundary-Checks grün ausführen, einschließlich `pnpm check:server-runtime` für die betroffenen Server-Packages
+- [ ] 3.8 `openspec validate refactor-sva-studio-react-package-boundaries --strict` ausführen


### PR DESCRIPTION
## Was sich aendert

Dieser PR schaerft die `tasks.md` des OpenSpec-Changes `refactor-sva-studio-react-package-boundaries`.

Konkret wird die bisher breite Aufgabenliste in drei realistische Migrationsschritte geschnitten:
- Legal-Text-Sanitizer und Boundary-Fundament
- Rueckfuehrung wiederverwendbarer Studio-UI nach `@sva/studio-ui-react`
- Herausloesen der Mainserver-Host-Adapter aus der App

## Warum sich das aendert

Die bisherige Task-Liste war zu grob und vermischte mehrere Ownership- und Migrationspfade. Der neue Zuschnitt macht die Reihenfolge, Ziel-Ownership und Abschlusskriterien deutlich klarer.

## Auswirkungen

- der Change wird besser in umsetzbare Abschnitte zerlegt
- die Ziel-Packages und konkreten Kandidaten werden klarer benannt
- App-interne Extraktionen ohne echte Package-Uebernahme werden explizit nicht als ausreichend beschrieben

## Validierung

- `openspec validate refactor-sva-studio-react-package-boundaries --strict`
