### PR TITLE
ci: schedule app e2e on main only

### DIFF
--- a/.github/workflows/app-e2e.yml
+++ b/.github/workflows/app-e2e.yml
@@ -5,21 +5,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
-  pull_request:
-    paths:
-      - 'apps/sva-studio-react/**'
-      - 'packages/auth-runtime/**'
-      - 'packages/iam-admin/**'
-      - 'packages/iam-core/**'
-      - 'packages/iam-governance/**'
-      - 'packages/instance-registry/**'
-      - 'packages/routing/**'
-      - 'packages/plugin-example/**'
-      - 'docker-compose.yml'
-      - '.github/workflows/app-e2e.yml'
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- remove PR and push triggers from the app E2E workflow
- keep manual dispatch available
- run the workflow once per day on main via GitHub Actions schedule

## Notes
- the schedule uses UTC (0 3 * * *), which is currently 05:00 in Europe/Berlin during DST
- no product code changes are included in this PR
