### PR TITLE
[codex] Fix IAM instance admin provisioning flow

### DIFF
--- a/apps/sva-studio-react/package.json
+++ b/apps/sva-studio-react/package.json
@@ -44,6 +44,7 @@
     "jiti": "^2.6.1",
     "lucide-react": "^1.11.0",
     "nitro": "3.0.260415-beta",
+    "postcss": "^8.5.11",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.5.0",

--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -869,6 +869,17 @@ export const i18nResources = {
           rotateClientSecret: 'Client-Secret rotieren',
           loadRun: 'Run laden',
         },
+        feedback: {
+          preflightUpdated: 'Vorbedingungen wurden aktualisiert.',
+          keycloakStatusUpdated: 'Keycloak-Status wurde aktualisiert.',
+          provisioningPreviewUpdated: 'Provisioning-Vorschau wurde aktualisiert.',
+          provisioningQueued: 'Provisioning-Auftrag wurde gespeichert und zur Abarbeitung vorgemerkt.',
+          tenantIamProbeUpdated: 'Tenant-IAM-Rechteprobe wurde aktualisiert.',
+          workerEnvMissing:
+            'Der Provisioning-Worker kann Keycloak derzeit nicht technisch prüfen. Im laufenden Prozess fehlt {{envName}}.',
+          workerProjectionHint:
+            'Die angezeigten Vorbedingungen und der Keycloak-Status sind derzeit nur eine Registry-basierte Vorabschätzung. Ein echter Live-Abgleich erfolgt erst im Provisioning-Worker.',
+        },
         keycloakPanel: {
           title: 'Keycloak-Status und Bootstrap',
           subtitle: 'Abgleich von Realm, Client, Mapper und Tenant-Admin für die ausgewählte Instanz.',
@@ -3085,6 +3096,17 @@ export const i18nResources = {
           resetTenantAdmin: 'Reset tenant admin',
           rotateClientSecret: 'Rotate client secret',
           loadRun: 'Load run',
+        },
+        feedback: {
+          preflightUpdated: 'Preflight data was refreshed.',
+          keycloakStatusUpdated: 'Keycloak status was refreshed.',
+          provisioningPreviewUpdated: 'Provisioning preview was refreshed.',
+          provisioningQueued: 'The provisioning job was queued for execution.',
+          tenantIamProbeUpdated: 'The tenant IAM access probe was refreshed.',
+          workerEnvMissing:
+            'The provisioning worker cannot technically inspect Keycloak right now. The running process is missing {{envName}}.',
+          workerProjectionHint:
+            'The displayed preflight and Keycloak status are currently only a registry-based projection. A real live reconciliation only happens inside the provisioning worker.',
         },
         keycloakPanel: {
           title: 'Keycloak status and bootstrap',

--- a/apps/sva-studio-react/src/routes/admin/instances/-field-help.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-field-help.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FieldHelp } from './-field-help';
+
+describe('FieldHelp', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the help panel in a fixed top-layer overlay aligned to the trigger', () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1024,
+    });
+
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function mockRect(this: HTMLElement) {
+        if (this instanceof HTMLButtonElement) {
+          return {
+            x: 24,
+            y: 140,
+            width: 20,
+            height: 20,
+            top: 140,
+            right: 44,
+            bottom: 160,
+            left: 24,
+            toJSON: () => '',
+          } as DOMRect;
+        }
+
+        return {
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          toJSON: () => '',
+        } as DOMRect;
+      });
+
+    render(
+      <FieldHelp
+        title="Auth-Issuer-URL"
+        what="Was"
+        value="Wert"
+        source="Quelle"
+        impact="Auswirkung"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Auth-Issuer-URL' }));
+
+    const tooltip = screen.getByRole('tooltip', { name: 'Auth-Issuer-URL' });
+    expect(tooltip.parentElement).toBe(document.body);
+    expect(tooltip.className).toContain('fixed');
+    expect(tooltip.className).toContain('z-[120]');
+    expect(tooltip.getAttribute('style')).toContain('left: 24px;');
+    expect(tooltip.getAttribute('style')).toContain('top: 168px;');
+
+    getBoundingClientRectSpy.mockRestore();
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+});

--- a/apps/sva-studio-react/src/routes/admin/instances/-field-help.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-field-help.test.tsx
@@ -71,4 +71,114 @@ describe('FieldHelp', () => {
       value: originalInnerWidth,
     });
   });
+
+  it('renders the optional default hint and opens above the trigger when there is no space below', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 240,
+    });
+
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function mockRect(this: HTMLElement) {
+        if (this instanceof HTMLButtonElement) {
+          return {
+            x: 64,
+            y: 210,
+            width: 20,
+            height: 20,
+            top: 210,
+            right: 84,
+            bottom: 230,
+            left: 64,
+            toJSON: () => '',
+          } as DOMRect;
+        }
+
+        return {
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          toJSON: () => '',
+        } as DOMRect;
+      });
+
+    const offsetWidthSpy = vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(320);
+    const offsetHeightSpy = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(140);
+
+    render(
+      <FieldHelp
+        title="Auth-Issuer-URL"
+        what="Was"
+        value="Wert"
+        source="Quelle"
+        impact="Auswirkung"
+        defaultHint="Standardwert bleibt leer."
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Auth-Issuer-URL' }));
+
+    const tooltip = screen.getByRole('tooltip', { name: 'Auth-Issuer-URL' });
+    expect(screen.getByText('Standardwert bleibt leer.')).toBeTruthy();
+    expect(tooltip.getAttribute('style')).toContain('left: 64px;');
+    expect(tooltip.getAttribute('style')).toContain('top: 62px;');
+
+    offsetWidthSpy.mockRestore();
+    offsetHeightSpy.mockRestore();
+    getBoundingClientRectSpy.mockRestore();
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+  });
+
+  it('closes the help panel on outside click, escape, and repeated toggle', () => {
+    render(
+      <div>
+        <button type="button">Außen</button>
+        <FieldHelp
+          title="Auth-Issuer-URL"
+          what="Was"
+          value="Wert"
+          source="Quelle"
+          impact="Auswirkung"
+        />
+      </div>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Auth-Issuer-URL' });
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip', { name: 'Auth-Issuer-URL' })).toBeTruthy();
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Außen' }));
+    expect(screen.queryByRole('tooltip', { name: 'Auth-Issuer-URL' })).toBeNull();
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip', { name: 'Auth-Issuer-URL' })).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip', { name: 'Auth-Issuer-URL' })).toBeNull();
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip', { name: 'Auth-Issuer-URL' })).toBeTruthy();
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('tooltip', { name: 'Auth-Issuer-URL' })).toBeNull();
+  });
 });

--- a/apps/sva-studio-react/src/routes/admin/instances/-field-help.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-field-help.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createPortal } from 'react-dom';
 import { CircleHelp } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
@@ -13,10 +14,40 @@ type FieldHelpProps = {
   readonly defaultHint?: string;
 };
 
+const POPOVER_WIDTH_PX = 320;
+const VIEWPORT_PADDING_PX = 12;
+const TRIGGER_OFFSET_PX = 8;
+
 export const FieldHelp = ({ title, what, value, source, impact, defaultHint }: FieldHelpProps) => {
   const [open, setOpen] = React.useState(false);
+  const [popoverPosition, setPopoverPosition] = React.useState<{ left: number; top: number } | null>(null);
   const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+  const popoverRef = React.useRef<HTMLDivElement | null>(null);
   const popoverId = React.useId();
+
+  const updatePopoverPosition = React.useCallback(() => {
+    if (!buttonRef.current || !popoverRef.current) {
+      return;
+    }
+
+    const triggerRect = buttonRef.current.getBoundingClientRect();
+    const popoverWidth = popoverRef.current.offsetWidth || POPOVER_WIDTH_PX;
+    const popoverHeight = popoverRef.current.offsetHeight || 0;
+
+    const maxLeft = Math.max(VIEWPORT_PADDING_PX, window.innerWidth - popoverWidth - VIEWPORT_PADDING_PX);
+    const left = Math.min(Math.max(triggerRect.left, VIEWPORT_PADDING_PX), maxLeft);
+
+    const maxTop = Math.max(VIEWPORT_PADDING_PX, window.innerHeight - popoverHeight - VIEWPORT_PADDING_PX);
+    const preferredTop = triggerRect.bottom + TRIGGER_OFFSET_PX;
+    const canOpenAbove = triggerRect.top - TRIGGER_OFFSET_PX - popoverHeight >= VIEWPORT_PADDING_PX;
+    const top =
+      preferredTop > maxTop && canOpenAbove
+        ? triggerRect.top - popoverHeight - TRIGGER_OFFSET_PX
+        : Math.min(Math.max(preferredTop, VIEWPORT_PADDING_PX), maxTop);
+
+    setPopoverPosition({ left, top });
+  }, []);
 
   React.useEffect(() => {
     if (!open) {
@@ -24,7 +55,8 @@ export const FieldHelp = ({ title, what, value, source, impact, defaultHint }: F
     }
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
+      const targetNode = event.target as Node;
+      if (!containerRef.current?.contains(targetNode) && !popoverRef.current?.contains(targetNode)) {
         setOpen(false);
       }
     };
@@ -43,9 +75,31 @@ export const FieldHelp = ({ title, what, value, source, impact, defaultHint }: F
     };
   }, [open]);
 
+  React.useLayoutEffect(() => {
+    if (!open) {
+      setPopoverPosition(null);
+      return;
+    }
+
+    updatePopoverPosition();
+
+    const handleViewportChange = () => {
+      updatePopoverPosition();
+    };
+
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
+
+    return () => {
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
+    };
+  }, [open, updatePopoverPosition]);
+
   return (
     <div ref={containerRef} className="relative inline-flex items-center">
       <button
+        ref={buttonRef}
         type="button"
         className={cn(
           'inline-flex h-5 w-5 items-center justify-center rounded-full border border-border text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
@@ -58,49 +112,54 @@ export const FieldHelp = ({ title, what, value, source, impact, defaultHint }: F
       >
         <CircleHelp className="h-3.5 w-3.5" />
       </button>
-      {open ? (
-        <div
-          id={popoverId}
-          role="tooltip"
-          aria-label={title}
-          className="absolute right-0 top-7 z-20 w-80 rounded-xl border border-border bg-card p-4 shadow-2xl"
-        >
-          <div className="space-y-3 text-sm">
-            <div>
-              <div className="font-medium text-foreground">{title}</div>
-            </div>
-            <div>
-              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t('admin.instances.help.sections.what')}
+      {open && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              ref={popoverRef}
+              id={popoverId}
+              role="tooltip"
+              aria-label={title}
+              className="fixed z-[120] w-80 rounded-xl border border-border bg-card p-4 shadow-2xl"
+              style={popoverPosition ? { left: `${popoverPosition.left}px`, top: `${popoverPosition.top}px` } : undefined}
+            >
+              <div className="space-y-3 text-sm">
+                <div>
+                  <div className="font-medium text-foreground">{title}</div>
+                </div>
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {t('admin.instances.help.sections.what')}
+                  </div>
+                  <p className="mt-1 text-muted-foreground">{what}</p>
+                </div>
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {t('admin.instances.help.sections.value')}
+                  </div>
+                  <p className="mt-1 text-muted-foreground">{value}</p>
+                </div>
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {t('admin.instances.help.sections.source')}
+                  </div>
+                  <p className="mt-1 text-muted-foreground">{source}</p>
+                </div>
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {t('admin.instances.help.sections.impact')}
+                  </div>
+                  <p className="mt-1 text-muted-foreground">{impact}</p>
+                </div>
+                {defaultHint ? (
+                  <div className="rounded-lg border border-border/80 bg-muted/40 p-3 text-xs text-muted-foreground">
+                    {defaultHint}
+                  </div>
+                ) : null}
               </div>
-              <p className="mt-1 text-muted-foreground">{what}</p>
-            </div>
-            <div>
-              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t('admin.instances.help.sections.value')}
-              </div>
-              <p className="mt-1 text-muted-foreground">{value}</p>
-            </div>
-            <div>
-              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t('admin.instances.help.sections.source')}
-              </div>
-              <p className="mt-1 text-muted-foreground">{source}</p>
-            </div>
-            <div>
-              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t('admin.instances.help.sections.impact')}
-              </div>
-              <p className="mt-1 text-muted-foreground">{impact}</p>
-            </div>
-            {defaultHint ? (
-              <div className="rounded-lg border border-border/80 bg-muted/40 p-3 text-xs text-muted-foreground">
-                {defaultHint}
-              </div>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
+            </div>,
+            document.body
+          )
+        : null}
     </div>
   );
 };

--- a/apps/sva-studio-react/src/routes/admin/instances/-field-help.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-field-help.tsx
@@ -17,6 +17,7 @@ type FieldHelpProps = {
 const POPOVER_WIDTH_PX = 320;
 const VIEWPORT_PADDING_PX = 12;
 const TRIGGER_OFFSET_PX = 8;
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
 
 export const FieldHelp = ({ title, what, value, source, impact, defaultHint }: FieldHelpProps) => {
   const [open, setOpen] = React.useState(false);
@@ -75,7 +76,7 @@ export const FieldHelp = ({ title, what, value, source, impact, defaultHint }: F
     };
   }, [open]);
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!open) {
       setPopoverPosition(null);
       return;

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -395,6 +395,140 @@ describe('InstanceDetailPage', () => {
     });
   });
 
+  it('shows visible feedback after workflow checks are triggered', async () => {
+    const refreshKeycloakPreflight = vi.fn().mockResolvedValue({
+      overallStatus: 'ready',
+      checks: [],
+    });
+    const refreshKeycloakStatus = vi.fn().mockResolvedValue({
+      realmExists: true,
+    });
+    const planKeycloakProvisioning = vi.fn().mockResolvedValue({
+      overallStatus: 'ready',
+      steps: [],
+    });
+
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        refreshKeycloakPreflight,
+        refreshKeycloakStatus,
+        planKeycloakProvisioning,
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Betrieb' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Vorbedingungen prüfen' })[0]);
+
+    await waitFor(() => {
+      expect(refreshKeycloakPreflight).toHaveBeenCalledWith('demo');
+    });
+    expect(screen.getByText('Vorbedingungen wurden aktualisiert.')).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Keycloak-Status prüfen' })[0]);
+    await waitFor(() => {
+      expect(refreshKeycloakStatus).toHaveBeenCalledWith('demo');
+    });
+    expect(screen.getByText('Keycloak-Status wurde aktualisiert.')).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Provisioning-Vorschau laden' })[0]);
+    await waitFor(() => {
+      expect(planKeycloakProvisioning).toHaveBeenCalledWith('demo');
+    });
+    expect(screen.getByText('Provisioning-Vorschau wurde aktualisiert.')).toBeTruthy();
+  });
+
+  it('surfaces a missing worker env blocker from the latest provisioning run', () => {
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        selectedInstance: createSelectedInstance({
+          latestKeycloakProvisioningRun: {
+            id: 'run-failed',
+            intent: 'provision',
+            mode: 'existing',
+            overallStatus: 'failed',
+            driftSummary: 'Provisioning wurde mit einem Fehler abgebrochen.',
+            requestId: 'req-worker',
+            steps: [
+              {
+                stepKey: 'worker_preflight_snapshot',
+                title: 'Vorbedingungen prüfen',
+                status: 'failed',
+                summary: 'Die Vorbedingungen blockieren die Ausführung.',
+                details: {
+                  preflight: {
+                    checks: [
+                      {
+                        checkKey: 'keycloak_admin_access',
+                        status: 'blocked',
+                        title: 'Technischer Keycloak-Zugriff',
+                        summary: 'Der technische Keycloak-Admin-Client konnte den Ziel-Realm nicht lesen.',
+                        details: {
+                          error: 'Missing required env: KEYCLOAK_ADMIN_BASE_URL',
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          keycloakProvisioningRuns: [],
+        }),
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    expect(
+      screen.getByText(
+        'Der Provisioning-Worker kann Keycloak derzeit nicht technisch prüfen. Im laufenden Prozess fehlt KEYCLOAK_ADMIN_BASE_URL.'
+      )
+    ).toBeTruthy();
+  });
+
+  it('marks worker-pending projections as non-live keycloak evidence', () => {
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        selectedInstance: createSelectedInstance({
+          keycloakPreflight: {
+            overallStatus: 'warning',
+            checkedAt: '2026-01-01T00:00:00.000Z',
+            checks: [
+              {
+                checkKey: 'keycloak_admin_access',
+                status: 'warning',
+                title: 'Technischer Keycloak-Zugriff',
+                summary: 'Die technische Prüfung wird durch den Provisioning-Worker durchgeführt und ist noch nicht gelaufen.',
+                details: {
+                  source: 'worker_pending',
+                },
+              },
+            ],
+          },
+          keycloakPlan: {
+            mode: 'existing',
+            overallStatus: 'ready',
+            generatedAt: '2026-01-01T00:00:00.000Z',
+            driftSummary: 'Keycloak und Registry weisen Drift auf und werden beim nächsten Lauf abgeglichen.',
+            steps: [],
+          },
+          latestKeycloakProvisioningRun: undefined,
+          keycloakProvisioningRuns: [],
+        }),
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    expect(
+      screen.getByText(
+        'Die angezeigten Vorbedingungen und der Keycloak-Status sind derzeit nur eine Registry-basierte Vorabschätzung. Ein echter Live-Abgleich erfolgt erst im Provisioning-Worker.'
+      )
+    ).toBeTruthy();
+  });
+
   it('renders a separate tenant IAM operations block', async () => {
     useInstancesMock.mockReturnValue(
       createInstancesApiState({

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -439,6 +439,41 @@ describe('InstanceDetailPage', () => {
     expect(screen.getByText('Provisioning-Vorschau wurde aktualisiert.')).toBeTruthy();
   });
 
+  it('clears stale success feedback before a later workflow action fails', async () => {
+    const apiState = createInstancesApiState();
+    apiState.refreshKeycloakPreflight = vi.fn().mockResolvedValue({
+      overallStatus: 'ready',
+      checks: [],
+    });
+    apiState.refreshKeycloakStatus = vi.fn().mockResolvedValue(false);
+    apiState.mutationError = null;
+
+    useInstancesMock.mockImplementation(() => apiState);
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Betrieb' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Vorbedingungen prüfen' })[0]);
+
+    await waitFor(() => {
+      expect(apiState.refreshKeycloakPreflight).toHaveBeenCalledWith('demo');
+    });
+    expect(screen.getByText('Vorbedingungen wurden aktualisiert.')).toBeTruthy();
+
+    apiState.mutationError = {
+      status: 500,
+      code: 'keycloak_unavailable',
+      message: 'Status konnte nicht gelesen werden.',
+    };
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Keycloak-Status prüfen' })[0]);
+
+    await waitFor(() => {
+      expect(apiState.refreshKeycloakStatus).toHaveBeenCalledWith('demo');
+    });
+    expect(screen.queryByText('Vorbedingungen wurden aktualisiert.')).toBeNull();
+  });
+
   it('surfaces a missing worker env blocker from the latest provisioning run', () => {
     useInstancesMock.mockReturnValue(
       createInstancesApiState({

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -780,4 +780,83 @@ describe('InstanceDetailPage', () => {
       expect(loadKeycloakProvisioningRun).toHaveBeenCalledWith('demo', 'run-history-1');
     });
   });
+
+  it('renders a loading shell when no matching instance detail is selected', () => {
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        selectedInstance: createSelectedInstance({
+          instanceId: 'other-instance',
+        }),
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    expect(screen.getByText('Inhalte werden geladen ...')).toBeTruthy();
+    expect(screen.queryByText('Operativer Überblick')).toBeNull();
+  });
+
+  it('shows generated-secret and empty artifact states for a new realm setup', () => {
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        selectedInstance: createSelectedInstance({
+          realmMode: 'new',
+          authClientSecretConfigured: false,
+          tenantAdminClient: {
+            clientId: 'sva-studio-admin',
+            secretConfigured: false,
+          },
+          keycloakStatus: undefined,
+          keycloakPreflight: {
+            overallStatus: 'warning',
+            checkedAt: '2026-01-01T00:00:00.000Z',
+            checks: [],
+          },
+          keycloakPlan: {
+            mode: 'new',
+            overallStatus: 'warning',
+            generatedAt: '2026-01-01T00:00:00.000Z',
+            driftSummary: 'Noch keine Vorschau vorhanden.',
+            steps: [],
+          },
+          latestKeycloakProvisioningRun: undefined,
+          keycloakProvisioningRuns: [],
+          provisioningRuns: [],
+          moduleIamStatus: {
+            overall: {
+              status: 'unknown',
+              summary: 'Noch keine Module zugewiesen.',
+              source: 'registry',
+            },
+            modules: [],
+          },
+        }),
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    const tenantClientSecret = screen.getByLabelText('Tenant-Client-Secret', {
+      selector: '#detail-auth-client-secret',
+    }) as HTMLInputElement;
+    expect(tenantClientSecret.disabled).toBe(true);
+    expect(tenantClientSecret.placeholder).toContain('automatisch');
+    expect(
+      screen.getByText('Für neue Realms wird das Tenant-Client-Secret erst beim Provisioning erzeugt und danach gespeichert.')
+    ).toBeTruthy();
+
+    const tenantAdminClientSecret = screen.getByLabelText('Tenant-Admin-Client-Secret', {
+      selector: '#detail-tenant-admin-client-secret',
+    }) as HTMLInputElement;
+    expect(tenantAdminClientSecret.placeholder).toContain('Secret fehlt noch');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Betrieb' }));
+    expect(screen.getByText(/der instanz sind aktuell keine module zugewiesen/i)).toBeTruthy();
+    expect(screen.getByText(/für diese instanz wurde noch keine provisioning-vorschau erzeugt/i)).toBeTruthy();
+    expect(screen.getByText(/es liegen noch keine keycloak-statusdaten für diese instanz vor/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Historie' }));
+    expect(screen.getByText(/für diese instanz wurden noch keine keycloak-provisioning-läufe aufgezeichnet/i)).toBeTruthy();
+    expect(screen.getByText(/für diese instanz liegen noch keine läufe vor/i)).toBeTruthy();
+  });
 });

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -113,7 +113,16 @@ const createInstancesApiState = (overrides: Record<string, unknown> = {}) => ({
   detailLoading: false,
   statusLoading: false,
   error: null,
-  mutationError: null,
+  mutationError: null as
+    | {
+        status: number;
+        code: string;
+        message: string;
+        classification?: string;
+        recommendedAction?: string;
+        requestId?: string;
+      }
+    | null,
   filters: {
     search: '',
     status: 'all',
@@ -446,7 +455,9 @@ describe('InstanceDetailPage', () => {
   });
 
   it('clears stale success feedback before a later workflow action fails', async () => {
-    const apiState = createInstancesApiState();
+    const apiState = createInstancesApiState() as ReturnType<typeof createInstancesApiState> & {
+      mutationError: { status: number; code: string; message: string } | null;
+    };
     apiState.refreshKeycloakPreflight = vi.fn().mockResolvedValue({
       overallStatus: 'ready',
       checks: [],
@@ -486,37 +497,6 @@ describe('InstanceDetailPage', () => {
     useInstancesMock.mockReturnValue(
       createInstancesApiState({
         selectedInstance: createSelectedInstance({
-          latestKeycloakProvisioningRun: {
-            id: 'run-history',
-            intent: 'provision',
-            mode: 'existing',
-            overallStatus: 'failed',
-            driftSummary: 'Historischer Lauf mit altem Fehler.',
-            requestId: 'req-history',
-            steps: [
-              {
-                stepKey: 'worker_preflight_snapshot',
-                title: 'Vorbedingungen prüfen',
-                status: 'failed',
-                summary: 'Historischer Lauf hatte einen anderen Fehler.',
-                details: {
-                  preflight: {
-                    checks: [
-                      {
-                        checkKey: 'keycloak_admin_access',
-                        status: 'blocked',
-                        title: 'Technischer Keycloak-Zugriff',
-                        summary: 'Historischer Fehler.',
-                        details: {
-                          error: 'Missing required env: KEYCLOAK_REALM',
-                        },
-                      },
-                    ],
-                  },
-                },
-              },
-            ],
-          },
           latestKeycloakProvisioningRun: {
             id: 'run-failed',
             intent: 'provision',
@@ -572,6 +552,37 @@ describe('InstanceDetailPage', () => {
                           summary: 'Der technische Keycloak-Admin-Client konnte den Ziel-Realm nicht lesen.',
                           details: {
                             error: 'Missing required env: KEYCLOAK_ADMIN_BASE_URL',
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              id: 'run-history',
+              intent: 'provision',
+              mode: 'existing',
+              overallStatus: 'failed',
+              driftSummary: 'Historischer Lauf mit altem Fehler.',
+              requestId: 'req-history',
+              steps: [
+                {
+                  stepKey: 'worker_preflight_snapshot',
+                  title: 'Vorbedingungen prüfen',
+                  status: 'failed',
+                  summary: 'Historischer Lauf hatte einen anderen Fehler.',
+                  details: {
+                    preflight: {
+                      checks: [
+                        {
+                          checkKey: 'keycloak_admin_access',
+                          status: 'blocked',
+                          title: 'Technischer Keycloak-Zugriff',
+                          summary: 'Historischer Fehler.',
+                          details: {
+                            error: 'Missing required env: KEYCLOAK_REALM',
                           },
                         },
                       ],

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -424,19 +424,25 @@ describe('InstanceDetailPage', () => {
     await waitFor(() => {
       expect(refreshKeycloakPreflight).toHaveBeenCalledWith('demo');
     });
-    expect(screen.getByText('Vorbedingungen wurden aktualisiert.')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Vorbedingungen wurden aktualisiert.')).toBeTruthy();
+    });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Keycloak-Status prüfen' })[0]);
     await waitFor(() => {
       expect(refreshKeycloakStatus).toHaveBeenCalledWith('demo');
     });
-    expect(screen.getByText('Keycloak-Status wurde aktualisiert.')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Keycloak-Status wurde aktualisiert.')).toBeTruthy();
+    });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Provisioning-Vorschau laden' })[0]);
     await waitFor(() => {
       expect(planKeycloakProvisioning).toHaveBeenCalledWith('demo');
     });
-    expect(screen.getByText('Provisioning-Vorschau wurde aktualisiert.')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Provisioning-Vorschau wurde aktualisiert.')).toBeTruthy();
+    });
   });
 
   it('clears stale success feedback before a later workflow action fails', async () => {
@@ -458,7 +464,9 @@ describe('InstanceDetailPage', () => {
     await waitFor(() => {
       expect(apiState.refreshKeycloakPreflight).toHaveBeenCalledWith('demo');
     });
-    expect(screen.getByText('Vorbedingungen wurden aktualisiert.')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Vorbedingungen wurden aktualisiert.')).toBeTruthy();
+    });
 
     apiState.mutationError = {
       status: 500,
@@ -478,6 +486,37 @@ describe('InstanceDetailPage', () => {
     useInstancesMock.mockReturnValue(
       createInstancesApiState({
         selectedInstance: createSelectedInstance({
+          latestKeycloakProvisioningRun: {
+            id: 'run-history',
+            intent: 'provision',
+            mode: 'existing',
+            overallStatus: 'failed',
+            driftSummary: 'Historischer Lauf mit altem Fehler.',
+            requestId: 'req-history',
+            steps: [
+              {
+                stepKey: 'worker_preflight_snapshot',
+                title: 'Vorbedingungen prüfen',
+                status: 'failed',
+                summary: 'Historischer Lauf hatte einen anderen Fehler.',
+                details: {
+                  preflight: {
+                    checks: [
+                      {
+                        checkKey: 'keycloak_admin_access',
+                        status: 'blocked',
+                        title: 'Technischer Keycloak-Zugriff',
+                        summary: 'Historischer Fehler.',
+                        details: {
+                          error: 'Missing required env: KEYCLOAK_REALM',
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
           latestKeycloakProvisioningRun: {
             id: 'run-failed',
             intent: 'provision',
@@ -509,7 +548,39 @@ describe('InstanceDetailPage', () => {
               },
             ],
           },
-          keycloakProvisioningRuns: [],
+          keycloakProvisioningRuns: [
+            {
+              id: 'run-failed',
+              intent: 'provision',
+              mode: 'existing',
+              overallStatus: 'failed',
+              driftSummary: 'Provisioning wurde mit einem Fehler abgebrochen.',
+              requestId: 'req-worker',
+              steps: [
+                {
+                  stepKey: 'worker_preflight_snapshot',
+                  title: 'Vorbedingungen prüfen',
+                  status: 'failed',
+                  summary: 'Die Vorbedingungen blockieren die Ausführung.',
+                  details: {
+                    preflight: {
+                      checks: [
+                        {
+                          checkKey: 'keycloak_admin_access',
+                          status: 'blocked',
+                          title: 'Technischer Keycloak-Zugriff',
+                          summary: 'Der technische Keycloak-Admin-Client konnte den Ziel-Realm nicht lesen.',
+                          details: {
+                            error: 'Missing required env: KEYCLOAK_ADMIN_BASE_URL',
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
         }),
       })
     );
@@ -813,6 +884,49 @@ describe('InstanceDetailPage', () => {
 
     await waitFor(() => {
       expect(loadKeycloakProvisioningRun).toHaveBeenCalledWith('demo', 'run-history-1');
+    });
+  });
+
+  it('keeps action feedback visible across same-instance reloads after provisioning', async () => {
+    const loadInstance = vi.fn().mockResolvedValue(true);
+    const executeKeycloakProvisioning = vi.fn().mockImplementation(async () => {
+      useInstancesMock.mockReturnValue(
+        createInstancesApiState({
+          loadInstance,
+          executeKeycloakProvisioning,
+          selectedInstance: createSelectedInstance({
+            updatedAt: '2026-01-02T00:00:00.000Z',
+          }),
+        })
+      );
+      return { queued: true };
+    });
+
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        loadInstance,
+        executeKeycloakProvisioning,
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Betrieb' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Provisioning ausführen' })[0]);
+
+    await waitFor(() => {
+      expect(executeKeycloakProvisioning).toHaveBeenCalledWith('demo', {
+        intent: 'provision',
+        tenantAdminTemporaryPassword: undefined,
+      });
+    });
+    await waitFor(() => {
+      expect(loadInstance).toHaveBeenCalledWith('demo');
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText('Provisioning-Auftrag wurde gespeichert und zur Abarbeitung vorgemerkt.')
+      ).toBeTruthy();
     });
   });
 

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -34,6 +34,11 @@ type InstanceDetailPageProps = {
   readonly instanceId: string;
 };
 
+type ActionFeedback = {
+  readonly tone: 'success' | 'warning';
+  readonly message: string;
+};
+
 const formatDateTime = (value?: string) => {
   if (!value) {
     return '—';
@@ -72,6 +77,39 @@ const TenantIamStatusBadge = ({ status }: { status?: 'ready' | 'degraded' | 'blo
           : 'bg-muted text-muted-foreground';
 
   return <span className={`rounded-full px-2 py-1 text-xs font-medium ${tone}`}>{status ?? 'unknown'}</span>;
+};
+
+const readLatestKeycloakRun = (instance: ReturnType<typeof useInstances>['selectedInstance']) =>
+  instance?.latestKeycloakProvisioningRun ?? instance?.keycloakProvisioningRuns[0];
+
+const readWorkerPendingProjection = (instance: ReturnType<typeof useInstances>['selectedInstance']) =>
+  Boolean(
+    instance?.keycloakPreflight?.checks.some((check) => {
+      const details = check.details as Record<string, unknown> | undefined;
+      return details?.source === 'worker_pending';
+    })
+  );
+
+const readMissingWorkerEnvName = (instance: ReturnType<typeof useInstances>['selectedInstance']) => {
+  const preflightStep = readLatestKeycloakRun(instance)?.steps.find((step) => step.stepKey === 'worker_preflight_snapshot');
+  const details = preflightStep?.details as
+    | {
+        preflight?: {
+          checks?: Array<{
+            checkKey?: string;
+            details?: {
+              error?: string;
+            };
+          }>;
+        };
+      }
+    | undefined;
+  const keycloakAccessCheck = details?.preflight?.checks?.find((check) => check.checkKey === 'keycloak_admin_access');
+  const error = keycloakAccessCheck?.details?.error;
+  if (!error?.startsWith('Missing required env: ')) {
+    return undefined;
+  }
+  return error.replace('Missing required env: ', '').trim() || undefined;
 };
 
 const COCKPIT_STATUS_STYLES = {
@@ -145,6 +183,7 @@ const InstanceRuntimeEvidence = ({
 export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
   const instancesApi = useInstances();
   const [detailFormValues, setDetailFormValues] = React.useState<ReturnType<typeof createDetailForm> | null>(null);
+  const [actionFeedback, setActionFeedback] = React.useState<ActionFeedback | null>(null);
   const [activeWorkspaceTab, setActiveWorkspaceTab] = React.useState<'configuration' | 'operations' | 'history'>(
     'configuration'
   );
@@ -157,6 +196,8 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
   const effectiveTenantIamStatus = selectedInstance ? getEffectiveTenantIamStatus(selectedInstance) : undefined;
   const tenantSecretUserInputRequired = selectedInstance ? isTenantSecretUserInputRequired(selectedInstance.realmMode) : true;
   const configurationAssessment = selectedInstance ? evaluateInstanceConfiguration(selectedInstance, instancesApi.mutationError) : null;
+  const missingWorkerEnvName = readMissingWorkerEnvName(selectedInstance);
+  const workerPendingProjection = readWorkerPendingProjection(selectedInstance);
 
   React.useEffect(() => {
     if (!selectedInstance) {
@@ -219,10 +260,16 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
       return;
     }
 
-    await instancesApi.executeKeycloakProvisioning(selectedInstance.instanceId, {
+    const result = await instancesApi.executeKeycloakProvisioning(selectedInstance.instanceId, {
       intent,
       tenantAdminTemporaryPassword: detailFormValues.tenantAdminTemporaryPassword.trim() || undefined,
     });
+    if (result) {
+      setActionFeedback({
+        tone: 'success',
+        message: t('admin.instances.feedback.provisioningQueued'),
+      });
+    }
     await instancesApi.loadInstance(selectedInstance.instanceId);
     setDetailFormValues((current) => (current ? { ...current, tenantAdminTemporaryPassword: '' } : current));
   };
@@ -242,15 +289,36 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
     }
 
     switch (action) {
-      case 'check_preflight':
-        await instancesApi.refreshKeycloakPreflight(selectedInstance.instanceId);
+      case 'check_preflight': {
+        const result = await instancesApi.refreshKeycloakPreflight(selectedInstance.instanceId);
+        if (result) {
+          setActionFeedback({
+            tone: 'success',
+            message: t('admin.instances.feedback.preflightUpdated'),
+          });
+        }
         return;
-      case 'check_keycloak_status':
-        await instancesApi.refreshKeycloakStatus(selectedInstance.instanceId);
+      }
+      case 'check_keycloak_status': {
+        const result = await instancesApi.refreshKeycloakStatus(selectedInstance.instanceId);
+        if (result) {
+          setActionFeedback({
+            tone: 'success',
+            message: t('admin.instances.feedback.keycloakStatusUpdated'),
+          });
+        }
         return;
-      case 'plan_provisioning':
-        await instancesApi.planKeycloakProvisioning(selectedInstance.instanceId);
+      }
+      case 'plan_provisioning': {
+        const result = await instancesApi.planKeycloakProvisioning(selectedInstance.instanceId);
+        if (result) {
+          setActionFeedback({
+            tone: 'success',
+            message: t('admin.instances.feedback.provisioningPreviewUpdated'),
+          });
+        }
         return;
+      }
       case 'execute_provisioning':
         await executeProvisioning('provision');
         return;
@@ -269,7 +337,13 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
     if (!selectedInstance) {
       return;
     }
-    await instancesApi.probeTenantIamAccess(selectedInstance.instanceId);
+    const result = await instancesApi.probeTenantIamAccess(selectedInstance.instanceId);
+    if (result) {
+      setActionFeedback({
+        tone: 'success',
+        message: t('admin.instances.feedback.tenantIamProbeUpdated'),
+      });
+    }
   };
 
   const runDetailAction = async (action: DetailWorkflowAction) => {
@@ -304,6 +378,34 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
           <Link to="/admin/instances">{t('admin.instances.actions.back')}</Link>
         </Button>
       </header>
+
+      {actionFeedback ? (
+        <Alert
+          className={
+            actionFeedback.tone === 'success'
+              ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-900'
+              : 'border-amber-500/40 bg-amber-500/10 text-amber-950'
+          }
+        >
+          <AlertDescription>{actionFeedback.message}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {missingWorkerEnvName ? (
+        <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+          <AlertDescription>
+            {t('admin.instances.feedback.workerEnvMissing', {
+              envName: missingWorkerEnvName,
+            })}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {workerPendingProjection && !missingWorkerEnvName ? (
+        <Alert className="border-amber-500/40 bg-amber-500/10 text-amber-950">
+          <AlertDescription>{t('admin.instances.feedback.workerProjectionHint')}</AlertDescription>
+        </Alert>
+      ) : null}
 
       {instancesApi.mutationError && instancesApi.mutationError.code !== 'keycloak_unavailable' ? (
         <Alert className="border-destructive/40 bg-destructive/10 text-destructive">

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -79,9 +79,6 @@ const TenantIamStatusBadge = ({ status }: { status?: 'ready' | 'degraded' | 'blo
   return <span className={`rounded-full px-2 py-1 text-xs font-medium ${tone}`}>{status ?? 'unknown'}</span>;
 };
 
-const readLatestKeycloakRun = (instance: ReturnType<typeof useInstances>['selectedInstance']) =>
-  instance?.latestKeycloakProvisioningRun ?? instance?.keycloakProvisioningRuns[0];
-
 const readActualLatestKeycloakRun = (instance: ReturnType<typeof useInstances>['selectedInstance']) =>
   instance?.keycloakProvisioningRuns[0] ?? instance?.latestKeycloakProvisioningRun;
 

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -201,10 +201,12 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
 
   React.useEffect(() => {
     if (!selectedInstance) {
+      setActionFeedback(null);
       setDetailFormValues(null);
       return;
     }
 
+    setActionFeedback(null);
     setDetailFormValues(createDetailForm(selectedInstance));
     setActiveWorkspaceTab('configuration');
   }, [selectedInstance]);
@@ -260,6 +262,7 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
       return;
     }
 
+    setActionFeedback(null);
     const result = await instancesApi.executeKeycloakProvisioning(selectedInstance.instanceId, {
       intent,
       tenantAdminTemporaryPassword: detailFormValues.tenantAdminTemporaryPassword.trim() || undefined,
@@ -288,6 +291,7 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
       return;
     }
 
+    setActionFeedback(null);
     switch (action) {
       case 'check_preflight': {
         const result = await instancesApi.refreshKeycloakPreflight(selectedInstance.instanceId);
@@ -337,6 +341,7 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
     if (!selectedInstance) {
       return;
     }
+    setActionFeedback(null);
     const result = await instancesApi.probeTenantIamAccess(selectedInstance.instanceId);
     if (result) {
       setActionFeedback({

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -82,6 +82,9 @@ const TenantIamStatusBadge = ({ status }: { status?: 'ready' | 'degraded' | 'blo
 const readLatestKeycloakRun = (instance: ReturnType<typeof useInstances>['selectedInstance']) =>
   instance?.latestKeycloakProvisioningRun ?? instance?.keycloakProvisioningRuns[0];
 
+const readActualLatestKeycloakRun = (instance: ReturnType<typeof useInstances>['selectedInstance']) =>
+  instance?.keycloakProvisioningRuns[0] ?? instance?.latestKeycloakProvisioningRun;
+
 const readWorkerPendingProjection = (instance: ReturnType<typeof useInstances>['selectedInstance']) =>
   Boolean(
     instance?.keycloakPreflight?.checks.some((check) => {
@@ -91,7 +94,9 @@ const readWorkerPendingProjection = (instance: ReturnType<typeof useInstances>['
   );
 
 const readMissingWorkerEnvName = (instance: ReturnType<typeof useInstances>['selectedInstance']) => {
-  const preflightStep = readLatestKeycloakRun(instance)?.steps.find((step) => step.stepKey === 'worker_preflight_snapshot');
+  const preflightStep = readActualLatestKeycloakRun(instance)?.steps.find(
+    (step) => step.stepKey === 'worker_preflight_snapshot'
+  );
   const details = preflightStep?.details as
     | {
         preflight?: {
@@ -187,6 +192,7 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
   const [activeWorkspaceTab, setActiveWorkspaceTab] = React.useState<'configuration' | 'operations' | 'history'>(
     'configuration'
   );
+  const previousSelectedInstanceIdRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     void instancesApi.loadInstance(instanceId);
@@ -201,12 +207,16 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
 
   React.useEffect(() => {
     if (!selectedInstance) {
+      previousSelectedInstanceIdRef.current = null;
       setActionFeedback(null);
       setDetailFormValues(null);
       return;
     }
 
-    setActionFeedback(null);
+    if (previousSelectedInstanceIdRef.current !== selectedInstance.instanceId) {
+      setActionFeedback(null);
+    }
+    previousSelectedInstanceIdRef.current = selectedInstance.instanceId;
     setDetailFormValues(createDetailForm(selectedInstance));
     setActiveWorkspaceTab('configuration');
   }, [selectedInstance]);

--- a/apps/sva-studio-react/src/routes/admin/organizations/-organization-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/organizations/-organization-detail-page.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { OrganizationDetailPage } from './-organization-detail-page';
+import { OrganizationDetailPage, sortMembershipUsersByLabel } from './-organization-detail-page';
 
 const useOrganizationsMock = vi.fn();
 const listUsersMock = vi.fn();
@@ -237,6 +237,32 @@ describe('OrganizationDetailPage', () => {
     },
     15_000
   );
+
+  it('sorts membership users by their rendered label', () => {
+    expect(
+      sortMembershipUsersByLabel([
+        {
+          id: 'user-2',
+          keycloakSubject: 'kc-user-2',
+          displayName: 'Zoe Zebra',
+          email: 'zoe@example.org',
+          status: 'active',
+          roles: [],
+        },
+        {
+          id: 'user-1',
+          keycloakSubject: 'kc-user-1',
+          displayName: 'Anna Admin',
+          email: 'anna@example.org',
+          status: 'active',
+          roles: [],
+        },
+      ])
+    ).toMatchObject([
+      { id: 'user-1' },
+      { id: 'user-2' },
+    ]);
+  });
 
   it('does not reload organization detail on rerender when the load callback is stable', async () => {
     const loadOrganization = vi.fn().mockResolvedValue(organizationFixture);

--- a/apps/sva-studio-react/src/routes/admin/organizations/-organization-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/organizations/-organization-detail-page.tsx
@@ -33,6 +33,15 @@ const normalizeMembershipSearchValue = (value: string) => value.trim().toLocaleL
 const formatMembershipUserLabel = (user: IamUserListItem) =>
   user.email ? `${user.displayName} <${user.email}>` : `${user.displayName} <${user.keycloakSubject}>`;
 
+export const sortMembershipUsersByLabel = (users: readonly IamUserListItem[]): readonly IamUserListItem[] =>
+  users
+    .map((user) => ({
+      user,
+      label: formatMembershipUserLabel(user),
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label))
+    .map(({ user }) => user);
+
 const matchesMembershipSearch = (user: IamUserListItem, search: string) => {
   const normalizedSearch = normalizeMembershipSearchValue(search);
   if (!normalizedSearch) {
@@ -146,9 +155,7 @@ export const OrganizationDetailPage = ({ organizationId }: OrganizationDetailPag
           return;
         }
 
-        setMembershipUsers(
-          [...response.data].sort((left, right) => formatMembershipUserLabel(left).localeCompare(formatMembershipUserLabel(right)))
-        );
+        setMembershipUsers(sortMembershipUsersByLabel(response.data));
       } catch (cause) {
         if (!active) {
           return;

--- a/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 
-import { RoleDetailPage } from './-role-detail-page';
+import { RoleDetailPage, sortPermissionIdsByCatalog } from './-role-detail-page';
 
 const useRolesMock = vi.fn();
 const useRolePermissionsMock = vi.fn();
@@ -206,6 +206,19 @@ describe('RoleDetailPage', () => {
         permissionIds: ['perm-1', 'perm-2'],
       });
     });
+  });
+
+  it('sorts permission ids by catalog keys without depending on incoming id order', () => {
+    expect(
+      sortPermissionIdsByCatalog(
+        ['perm-2', 'perm-4', 'perm-1'],
+        [
+          { id: 'perm-1', permissionKey: 'content.read' },
+          { id: 'perm-2', permissionKey: 'content.updatePayload' },
+          { id: 'perm-4', permissionKey: 'news.read' },
+        ]
+      )
+    ).toEqual(['perm-1', 'perm-2', 'perm-4']);
   });
 
   it('can reveal technical permission details and links to the IAM cockpit', () => {

--- a/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.tsx
@@ -150,15 +150,18 @@ const summarizePermission = (permissionKey: string) => {
   };
 };
 
-const sortPermissionIdsByCatalog = (
+export const sortPermissionIdsByCatalog = (
   permissionIds: readonly string[],
   catalog: readonly { id: string; permissionKey: string }[]
-) =>
-  [...permissionIds].sort((left, right) => {
-    const leftKey = catalog.find((permission) => permission.id === left)?.permissionKey ?? left;
-    const rightKey = catalog.find((permission) => permission.id === right)?.permissionKey ?? right;
+) => {
+  const permissionKeyById = new Map(catalog.map((permission) => [permission.id, permission.permissionKey] as const));
+
+  return [...permissionIds].sort((left, right) => {
+    const leftKey = permissionKeyById.get(left) ?? left;
+    const rightKey = permissionKeyById.get(right) ?? right;
     return leftKey.localeCompare(rightKey);
   });
+};
 
 const groupPermissionsByCatalog = (
   permissions: readonly { id: string; permissionKey: string; description?: string | null }[]

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { UserEditPage } from './-user-edit-page';
+import { UserEditPage, hasUserFormChanges } from './-user-edit-page';
 import { userErrorMessage } from './-user-error-message';
 
 const useUserMock = vi.fn();
@@ -105,6 +105,31 @@ describe('UserEditPage', () => {
     render(<UserEditPage userId="user-1" />);
 
     expect(screen.getByRole('status')).toBeTruthy();
+  });
+
+  it('detects form changes without serializing the whole form', () => {
+    const baseline = {
+      firstName: 'Alice',
+      lastName: 'Admin',
+      displayName: 'Alice Admin',
+      email: 'alice@example.com',
+      phone: '',
+      position: '',
+      department: '',
+      status: 'active' as const,
+      preferredLanguage: 'de',
+      timezone: 'Europe/Berlin',
+      notes: '',
+      roleIds: ['role-1'],
+      groupIds: ['group-1'],
+      mainserverUserApplicationId: 'app-id-1',
+      mainserverUserApplicationSecret: '',
+      mainserverUserApplicationSecretSet: true,
+    };
+
+    expect(hasUserFormChanges(baseline, { ...baseline })).toBe(false);
+    expect(hasUserFormChanges(baseline, { ...baseline, displayName: 'Alice Updated' })).toBe(true);
+    expect(hasUserFormChanges(baseline, { ...baseline, roleIds: ['role-1', 'role-2'] })).toBe(true);
   });
 
   it('renders localized initial load errors when user is missing', () => {

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { UserEditPage, hasUserFormChanges } from './-user-edit-page';
+import { UserEditPage, buildGroupMembershipById, hasUserFormChanges } from './-user-edit-page';
 import { userErrorMessage } from './-user-error-message';
 
 const useUserMock = vi.fn();
@@ -130,6 +130,17 @@ describe('UserEditPage', () => {
     expect(hasUserFormChanges(baseline, { ...baseline })).toBe(false);
     expect(hasUserFormChanges(baseline, { ...baseline, displayName: 'Alice Updated' })).toBe(true);
     expect(hasUserFormChanges(baseline, { ...baseline, roleIds: ['role-1', 'role-2'] })).toBe(true);
+  });
+
+  it('builds group membership lookups by group id once for constant-time access', () => {
+    const membershipById = buildGroupMembershipById([
+      { groupId: 'group-1', groupKey: 'admins', displayName: 'Admins', groupType: 'role_bundle', origin: 'manual' as const },
+      { groupId: 'group-2', groupKey: 'authors', displayName: 'Authors', groupType: 'role_bundle', origin: 'sync' as const },
+    ]);
+
+    expect(membershipById.get('group-1')).toMatchObject({ displayName: 'Admins' });
+    expect(membershipById.get('group-2')).toMatchObject({ origin: 'sync' });
+    expect(membershipById.get('group-3')).toBeUndefined();
   });
 
   it('renders localized initial load errors when user is missing', () => {

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
@@ -191,6 +191,11 @@ const appendUnique = (values: readonly string[], nextValue: string): string[] =>
 const areStringArraysEqual = (left: readonly string[], right: readonly string[]): boolean =>
   left.length === right.length && left.every((value, index) => value === right[index]);
 
+export const buildGroupMembershipById = (
+  groups: NonNullable<ReturnType<typeof useUser>['user']>['groups'] | undefined
+): ReadonlyMap<string, NonNullable<NonNullable<ReturnType<typeof useUser>['user']>['groups']>[number]> =>
+  new Map((groups ?? []).map((entry) => [entry.groupId, entry] as const));
+
 export const hasUserFormChanges = (baseline: UserFormValues, current: UserFormValues): boolean =>
   baseline.firstName !== current.firstName ||
   baseline.lastName !== current.lastName ||
@@ -257,6 +262,7 @@ export const UserEditPage = ({ userId }: UserEditPageProps) => {
     () => (userApi.user?.permissionTrace ?? []).filter((entry) => !entry.isEffective),
     [userApi.user?.permissionTrace]
   );
+  const groupMembershipById = React.useMemo(() => buildGroupMembershipById(userApi.user?.groups), [userApi.user?.groups]);
 
   React.useEffect(() => {
     if (!hasUnsavedChanges) {
@@ -620,7 +626,7 @@ export const UserEditPage = ({ userId }: UserEditPageProps) => {
             <div className="grid gap-2 sm:grid-cols-2">
               {selectableGroups.map((group) => {
                 const selected = formValues.groupIds.includes(group.id);
-                const currentMembership = userApi.user?.groups?.find((entry) => entry.groupId === group.id);
+                const currentMembership = groupMembershipById.get(group.id);
                 return (
                   <Label key={group.id} className="flex items-start gap-2 rounded border border-border bg-background px-3 py-2 text-sm text-foreground">
                     <Checkbox

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
@@ -188,6 +188,27 @@ const describePermissionTraceSource = (entry: IamUserPermissionTraceItem) => {
 const appendUnique = (values: readonly string[], nextValue: string): string[] =>
   values.includes(nextValue) ? [...values] : [...values, nextValue];
 
+const areStringArraysEqual = (left: readonly string[], right: readonly string[]): boolean =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
+export const hasUserFormChanges = (baseline: UserFormValues, current: UserFormValues): boolean =>
+  baseline.firstName !== current.firstName ||
+  baseline.lastName !== current.lastName ||
+  baseline.displayName !== current.displayName ||
+  baseline.email !== current.email ||
+  baseline.phone !== current.phone ||
+  baseline.position !== current.position ||
+  baseline.department !== current.department ||
+  baseline.status !== current.status ||
+  baseline.preferredLanguage !== current.preferredLanguage ||
+  baseline.timezone !== current.timezone ||
+  baseline.notes !== current.notes ||
+  !areStringArraysEqual(baseline.roleIds, current.roleIds) ||
+  !areStringArraysEqual(baseline.groupIds, current.groupIds) ||
+  baseline.mainserverUserApplicationId !== current.mainserverUserApplicationId ||
+  baseline.mainserverUserApplicationSecret !== current.mainserverUserApplicationSecret ||
+  baseline.mainserverUserApplicationSecretSet !== current.mainserverUserApplicationSecretSet;
+
 export const UserEditPage = ({ userId }: UserEditPageProps) => {
   const userApi = useUser(userId);
   const rolesApi = useRoles();
@@ -223,9 +244,11 @@ export const UserEditPage = ({ userId }: UserEditPageProps) => {
     setHasLoadedTimeline(false);
   }, [userId]);
 
-  const baselineSignature = React.useMemo(() => JSON.stringify(toFormValues(userApi.user)), [userApi.user]);
-  const currentSignature = React.useMemo(() => JSON.stringify(formValues), [formValues]);
-  const hasUnsavedChanges = baselineSignature !== currentSignature;
+  const baselineFormValues = React.useMemo(() => toFormValues(userApi.user), [userApi.user]);
+  const hasUnsavedChanges = React.useMemo(
+    () => hasUserFormChanges(baselineFormValues, formValues),
+    [baselineFormValues, formValues]
+  );
   const effectivePermissionTrace = React.useMemo(
     () => (userApi.user?.permissionTrace ?? []).filter((entry) => entry.isEffective),
     [userApi.user?.permissionTrace]

--- a/packages/auth-runtime/package.json
+++ b/packages/auth-runtime/package.json
@@ -45,6 +45,7 @@
     "ioredis": "^5.10.1",
     "openid-client": "^6.4.0",
     "pg": "^8.20.0",
+    "postcss": "^8.5.11",
     "sanitize-html": "^2.17.3",
     "sharp": "^0.34.5",
     "zod": "^4.3.6"

--- a/packages/auth-runtime/src/runtime-dependencies.test.ts
+++ b/packages/auth-runtime/src/runtime-dependencies.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+};
+
+const readPackageJson = (): PackageJson => {
+  const filePath = resolve(import.meta.dirname, '..', 'package.json');
+  return JSON.parse(readFileSync(filePath, 'utf8')) as PackageJson;
+};
+
+describe('auth-runtime runtime dependencies', () => {
+  it('declares postcss when sanitize-html is used at runtime', () => {
+    const packageJson = readPackageJson();
+
+    expect(packageJson.dependencies?.['sanitize-html']).toBeDefined();
+    expect(packageJson.dependencies?.postcss).toBeDefined();
+  });
+});

--- a/packages/auth-runtime/src/runtime-dependencies.test.ts
+++ b/packages/auth-runtime/src/runtime-dependencies.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -7,8 +8,10 @@ type PackageJson = {
   dependencies?: Record<string, string>;
 };
 
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
+
 const readPackageJson = (): PackageJson => {
-  const filePath = resolve(import.meta.dirname, '..', 'package.json');
+  const filePath = resolve(currentDirectory, '..', 'package.json');
   return JSON.parse(readFileSync(filePath, 'utf8')) as PackageJson;
 };
 

--- a/packages/iam-governance/package.json
+++ b/packages/iam-governance/package.json
@@ -80,6 +80,7 @@
     "@sva/data-repositories": "workspace:*",
     "@sva/iam-core": "workspace:*",
     "@sva/server-runtime": "workspace:*",
+    "postcss": "^8.5.11",
     "sanitize-html": "^2.17.3",
     "zod": "^4.3.6"
   },

--- a/packages/iam-governance/src/runtime-dependencies.test.ts
+++ b/packages/iam-governance/src/runtime-dependencies.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+};
+
+const readPackageJson = (): PackageJson => {
+  const filePath = resolve(import.meta.dirname, '..', 'package.json');
+  return JSON.parse(readFileSync(filePath, 'utf8')) as PackageJson;
+};
+
+describe('iam-governance runtime dependencies', () => {
+  it('declares postcss when sanitize-html is used at runtime', () => {
+    const packageJson = readPackageJson();
+
+    expect(packageJson.dependencies?.['sanitize-html']).toBeDefined();
+    expect(packageJson.dependencies?.postcss).toBeDefined();
+  });
+});

--- a/packages/iam-governance/src/runtime-dependencies.test.ts
+++ b/packages/iam-governance/src/runtime-dependencies.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -7,8 +8,10 @@ type PackageJson = {
   dependencies?: Record<string, string>;
 };
 
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
+
 const readPackageJson = (): PackageJson => {
-  const filePath = resolve(import.meta.dirname, '..', 'package.json');
+  const filePath = resolve(currentDirectory, '..', 'package.json');
   return JSON.parse(readFileSync(filePath, 'utf8')) as PackageJson;
 };
 

--- a/packages/instance-registry/src/service-keycloak.ts
+++ b/packages/instance-registry/src/service-keycloak.ts
@@ -132,6 +132,35 @@ const buildLocalPreflight = (input: {
   };
 };
 
+const buildLocalStatus = (input: {
+  authClientSecretConfigured: boolean;
+  authClientSecret?: string;
+  tenantAdminClient?: {
+    clientId: string;
+    secretConfigured: boolean;
+  };
+  tenantAdminClientSecret?: string;
+}): KeycloakTenantStatus => ({
+  realmExists: false,
+  clientExists: false,
+  tenantAdminClientExists: false,
+  instanceIdMapperExists: false,
+  tenantAdminExists: false,
+  tenantAdminHasSystemAdmin: false,
+  tenantAdminHasInstanceRegistryAdmin: false,
+  tenantAdminInstanceIdMatches: false,
+  redirectUrisMatch: false,
+  logoutUrisMatch: false,
+  webOriginsMatch: false,
+  clientSecretConfigured: input.authClientSecretConfigured,
+  tenantClientSecretReadable: Boolean(input.authClientSecret),
+  clientSecretAligned: false,
+  tenantAdminClientSecretConfigured: input.tenantAdminClient?.secretConfigured ?? false,
+  tenantAdminClientSecretReadable: Boolean(input.tenantAdminClientSecret),
+  tenantAdminClientSecretAligned: false,
+  runtimeSecretSource: 'tenant',
+});
+
 const revealSecret = (
   deps: SecretReaderDeps,
   value: string | null | undefined,
@@ -194,19 +223,24 @@ export const createGetKeycloakStatusHandler =
   (deps: InstanceRegistryServiceDeps) =>
   async (instanceId: string): Promise<KeycloakTenantStatus | null> => {
     logger.debug('get_keycloak_status_started', { operation: 'get_keycloak_status', instance_id: instanceId });
-    const instance = await deps.repository.getInstanceById(instanceId);
-    if (!instance) {
+    const loaded = await loadInstanceWithSecret(deps, instanceId);
+    if (!loaded) {
       return null;
     }
 
     const runs = await deps.repository.listKeycloakProvisioningRuns(instanceId);
     const status = readSnapshotFromRun<KeycloakTenantStatus>(runs, 'status_snapshot', 'status');
-    if (!status) {
-      return null;
-    }
+    const result =
+      status ??
+      buildLocalStatus({
+        authClientSecretConfigured: loaded.instance.authClientSecretConfigured,
+        authClientSecret: loaded.authClientSecret,
+        tenantAdminClient: loaded.instance.tenantAdminClient,
+        tenantAdminClientSecret: loaded.tenantAdminClientSecret,
+      });
 
     logger.info('keycloak_status_check_completed', { operation: 'get_keycloak_status', instance_id: instanceId });
-    return status;
+    return result;
   };
 
 export const createGetKeycloakPreflightHandler =

--- a/packages/instance-registry/src/service-keycloak.ts
+++ b/packages/instance-registry/src/service-keycloak.ts
@@ -223,21 +223,24 @@ export const createGetKeycloakStatusHandler =
   (deps: InstanceRegistryServiceDeps) =>
   async (instanceId: string): Promise<KeycloakTenantStatus | null> => {
     logger.debug('get_keycloak_status_started', { operation: 'get_keycloak_status', instance_id: instanceId });
+    const runs = await deps.repository.listKeycloakProvisioningRuns(instanceId);
+    const status = readSnapshotFromRun<KeycloakTenantStatus>(runs, 'status_snapshot', 'status');
+    if (status) {
+      logger.info('keycloak_status_check_completed', { operation: 'get_keycloak_status', instance_id: instanceId });
+      return status;
+    }
+
     const loaded = await loadInstanceWithSecret(deps, instanceId);
     if (!loaded) {
       return null;
     }
 
-    const runs = await deps.repository.listKeycloakProvisioningRuns(instanceId);
-    const status = readSnapshotFromRun<KeycloakTenantStatus>(runs, 'status_snapshot', 'status');
-    const result =
-      status ??
-      buildLocalStatus({
-        authClientSecretConfigured: loaded.instance.authClientSecretConfigured,
-        authClientSecret: loaded.authClientSecret,
-        tenantAdminClient: loaded.instance.tenantAdminClient,
-        tenantAdminClientSecret: loaded.tenantAdminClientSecret,
-      });
+    const result = buildLocalStatus({
+      authClientSecretConfigured: loaded.instance.authClientSecretConfigured,
+      authClientSecret: loaded.authClientSecret,
+      tenantAdminClient: loaded.instance.tenantAdminClient,
+      tenantAdminClientSecret: loaded.tenantAdminClientSecret,
+    });
 
     logger.info('keycloak_status_check_completed', { operation: 'get_keycloak_status', instance_id: instanceId });
     return result;

--- a/packages/instance-registry/src/service-keycloak.ts
+++ b/packages/instance-registry/src/service-keycloak.ts
@@ -8,7 +8,7 @@ import type {
   KeycloakTenantStatus,
   ResolveRuntimeInstanceResult,
 } from './keycloak-types.js';
-import { buildPlan, toOverallPreflightStatus } from './provisioning-auth-evaluation.js';
+import { buildMissingRealmStatus, buildPlan, toOverallPreflightStatus } from './provisioning-auth-evaluation.js';
 import { toListItem } from './service-helpers.js';
 import { createExecuteKeycloakProvisioningHandler, createReconcileKeycloakHandler } from './service-keycloak-execution.js';
 
@@ -140,26 +140,13 @@ const buildLocalStatus = (input: {
     secretConfigured: boolean;
   };
   tenantAdminClientSecret?: string;
-}): KeycloakTenantStatus => ({
-  realmExists: false,
-  clientExists: false,
-  tenantAdminClientExists: false,
-  instanceIdMapperExists: false,
-  tenantAdminExists: false,
-  tenantAdminHasSystemAdmin: false,
-  tenantAdminHasInstanceRegistryAdmin: false,
-  tenantAdminInstanceIdMatches: false,
-  redirectUrisMatch: false,
-  logoutUrisMatch: false,
-  webOriginsMatch: false,
-  clientSecretConfigured: input.authClientSecretConfigured,
-  tenantClientSecretReadable: Boolean(input.authClientSecret),
-  clientSecretAligned: false,
-  tenantAdminClientSecretConfigured: input.tenantAdminClient?.secretConfigured ?? false,
-  tenantAdminClientSecretReadable: Boolean(input.tenantAdminClientSecret),
-  tenantAdminClientSecretAligned: false,
-  runtimeSecretSource: 'tenant',
-});
+}): KeycloakTenantStatus =>
+  buildMissingRealmStatus(
+    input.authClientSecretConfigured,
+    input.authClientSecret,
+    input.tenantAdminClient,
+    input.tenantAdminClientSecret
+  );
 
 const revealSecret = (
   deps: SecretReaderDeps,
@@ -223,6 +210,11 @@ export const createGetKeycloakStatusHandler =
   (deps: InstanceRegistryServiceDeps) =>
   async (instanceId: string): Promise<KeycloakTenantStatus | null> => {
     logger.debug('get_keycloak_status_started', { operation: 'get_keycloak_status', instance_id: instanceId });
+    const instance = await deps.repository.getInstanceById(instanceId);
+    if (!instance) {
+      return null;
+    }
+
     const runs = await deps.repository.listKeycloakProvisioningRuns(instanceId);
     const status = readSnapshotFromRun<KeycloakTenantStatus>(runs, 'status_snapshot', 'status');
     if (status) {
@@ -230,16 +222,18 @@ export const createGetKeycloakStatusHandler =
       return status;
     }
 
-    const loaded = await loadInstanceWithSecret(deps, instanceId);
-    if (!loaded) {
-      return null;
+    let authClientSecret: string | undefined;
+    let tenantAdminClientSecret: string | undefined;
+    if (deps.revealSecret) {
+      authClientSecret = await loadRepositoryAuthClientSecret(deps, deps.repository, instance.instanceId);
+      tenantAdminClientSecret = await loadRepositoryTenantAdminClientSecret(deps, deps.repository, instance.instanceId);
     }
 
     const result = buildLocalStatus({
-      authClientSecretConfigured: loaded.instance.authClientSecretConfigured,
-      authClientSecret: loaded.authClientSecret,
-      tenantAdminClient: loaded.instance.tenantAdminClient,
-      tenantAdminClientSecret: loaded.tenantAdminClientSecret,
+      authClientSecretConfigured: instance.authClientSecretConfigured,
+      authClientSecret,
+      tenantAdminClient: instance.tenantAdminClient,
+      tenantAdminClientSecret,
     });
 
     logger.info('keycloak_status_check_completed', { operation: 'get_keycloak_status', instance_id: instanceId });

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { InstanceRegistryRepository } from '@sva/data-repositories';
 
 import { createInstanceRegistryService } from './service.js';
+import { createGetKeycloakStatusHandler } from './service-keycloak.js';
 import type { InstanceRegistryServiceDeps } from './service-types.js';
 
 const baseInstance = {
@@ -212,6 +213,38 @@ describe('instance registry service facade', () => {
       expect.objectContaining({ operation: 'create', status: 'requested' })
     );
     expect(deps.invalidateHost).toHaveBeenCalledWith('demo.studio.example.org');
+  });
+
+  it('defaults the tenant admin client id on create when the form does not submit one', async () => {
+    const repository = createRepository({
+      getInstanceById: vi.fn(async () => null),
+    });
+    const deps = createDeps(repository);
+    const service = createInstanceRegistryService(deps);
+
+    await expect(
+      service.createProvisioningRequest({
+        instanceId: 'demo',
+        displayName: 'Demo',
+        parentDomain: 'studio.example.org',
+        realmMode: 'existing',
+        authRealm: 'demo',
+        authClientId: 'studio-client',
+        idempotencyKey: 'idem-1',
+      })
+    ).resolves.toEqual({
+      ok: true,
+      instance: expect.objectContaining({ instanceId: 'demo' }),
+    });
+
+    expect(repository.createInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantAdminClient: {
+          clientId: 'sva-studio-admin',
+          secretCiphertext: undefined,
+        },
+      })
+    );
   });
 
   it('handles status transitions and emits status artifacts', async () => {
@@ -455,7 +488,7 @@ describe('instance registry service facade', () => {
           requestId: 'req-probe-1',
         }),
         overall: expect.objectContaining({
-          status: 'unknown',
+          status: 'degraded',
         }),
       })
     );
@@ -730,5 +763,44 @@ describe('instance registry service facade', () => {
         }),
       })
     );
+  });
+
+  it('returns a local fallback keycloak status when no status snapshot exists yet', async () => {
+    const repository = createRepository({
+      getInstanceById: vi.fn(async () => ({
+        ...baseInstance,
+        authClientSecretConfigured: false,
+        tenantAdminClient: {
+          clientId: 'tenant-admin',
+          secretConfigured: false,
+        },
+      })),
+      listKeycloakProvisioningRuns: vi.fn(async () => []),
+      getAuthClientSecretCiphertext: vi.fn(async () => null),
+      getTenantAdminClientSecretCiphertext: vi.fn(async () => null),
+    });
+
+    const status = await createGetKeycloakStatusHandler(createDeps(repository))('demo');
+
+    expect(status).toEqual({
+      realmExists: false,
+      clientExists: false,
+      tenantAdminClientExists: false,
+      instanceIdMapperExists: false,
+      tenantAdminExists: false,
+      tenantAdminHasSystemAdmin: false,
+      tenantAdminHasInstanceRegistryAdmin: false,
+      tenantAdminInstanceIdMatches: false,
+      redirectUrisMatch: false,
+      logoutUrisMatch: false,
+      webOriginsMatch: false,
+      clientSecretConfigured: false,
+      tenantClientSecretReadable: false,
+      clientSecretAligned: false,
+      tenantAdminClientSecretConfigured: false,
+      tenantAdminClientSecretReadable: false,
+      tenantAdminClientSecretAligned: false,
+      runtimeSecretSource: 'tenant',
+    });
   });
 });

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -976,4 +976,39 @@ describe('instance registry service facade', () => {
     expect(getAuthClientSecretCiphertext).not.toHaveBeenCalled();
     expect(getTenantAdminClientSecretCiphertext).not.toHaveBeenCalled();
   });
+
+  it('returns null for keycloak status snapshots when the instance no longer exists', async () => {
+    const repository = createRepository({
+      getInstanceById: vi.fn(async () => null),
+      listKeycloakProvisioningRuns: vi.fn(async () => [
+        {
+          id: 'keycloak-run-1',
+          instanceId: 'demo',
+          mode: 'existing',
+          intent: 'provision',
+          overallStatus: 'succeeded',
+          driftSummary: 'Done',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          steps: [
+            {
+              stepKey: 'status_snapshot',
+              title: 'Status',
+              status: 'done',
+              summary: 'Snapshot vorhanden',
+              details: {
+                status: {
+                  realmExists: true,
+                },
+              },
+            },
+          ],
+        },
+      ]),
+    });
+
+    const status = await createGetKeycloakStatusHandler(createDeps(repository))('demo');
+
+    expect(status).toBeNull();
+  });
 });

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -803,4 +803,84 @@ describe('instance registry service facade', () => {
       runtimeSecretSource: 'tenant',
     });
   });
+
+  it('returns a persisted keycloak status snapshot without loading secrets', async () => {
+    const getAuthClientSecretCiphertext = vi.fn(async () => {
+      throw new Error('should_not_load_auth_secret');
+    });
+    const getTenantAdminClientSecretCiphertext = vi.fn(async () => {
+      throw new Error('should_not_load_tenant_secret');
+    });
+    const repository = createRepository({
+      listKeycloakProvisioningRuns: vi.fn(async () => [
+        {
+          id: 'keycloak-run-1',
+          instanceId: 'demo',
+          mode: 'existing',
+          intent: 'provision',
+          overallStatus: 'succeeded',
+          driftSummary: 'Done',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          steps: [
+            {
+              stepKey: 'status_snapshot',
+              title: 'Status',
+              status: 'done',
+              summary: 'Snapshot vorhanden',
+              details: {
+                status: {
+                  realmExists: true,
+                  clientExists: true,
+                  tenantAdminClientExists: true,
+                  instanceIdMapperExists: true,
+                  tenantAdminExists: true,
+                  tenantAdminHasSystemAdmin: true,
+                  tenantAdminHasInstanceRegistryAdmin: true,
+                  tenantAdminInstanceIdMatches: true,
+                  redirectUrisMatch: true,
+                  logoutUrisMatch: true,
+                  webOriginsMatch: true,
+                  clientSecretConfigured: true,
+                  tenantClientSecretReadable: true,
+                  clientSecretAligned: true,
+                  tenantAdminClientSecretConfigured: true,
+                  tenantAdminClientSecretReadable: true,
+                  tenantAdminClientSecretAligned: true,
+                  runtimeSecretSource: 'tenant',
+                },
+              },
+            },
+          ],
+        },
+      ]),
+      getAuthClientSecretCiphertext,
+      getTenantAdminClientSecretCiphertext,
+    });
+
+    const status = await createGetKeycloakStatusHandler(createDeps(repository, { revealSecret: undefined }))('demo');
+
+    expect(status).toEqual({
+      realmExists: true,
+      clientExists: true,
+      tenantAdminClientExists: true,
+      instanceIdMapperExists: true,
+      tenantAdminExists: true,
+      tenantAdminHasSystemAdmin: true,
+      tenantAdminHasInstanceRegistryAdmin: true,
+      tenantAdminInstanceIdMatches: true,
+      redirectUrisMatch: true,
+      logoutUrisMatch: true,
+      webOriginsMatch: true,
+      clientSecretConfigured: true,
+      tenantClientSecretReadable: true,
+      clientSecretAligned: true,
+      tenantAdminClientSecretConfigured: true,
+      tenantAdminClientSecretReadable: true,
+      tenantAdminClientSecretAligned: true,
+      runtimeSecretSource: 'tenant',
+    });
+    expect(getAuthClientSecretCiphertext).not.toHaveBeenCalled();
+    expect(getTenantAdminClientSecretCiphertext).not.toHaveBeenCalled();
+  });
 });

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -800,8 +800,101 @@ describe('instance registry service facade', () => {
       tenantAdminClientSecretConfigured: false,
       tenantAdminClientSecretReadable: false,
       tenantAdminClientSecretAligned: false,
-      runtimeSecretSource: 'tenant',
+      runtimeSecretSource: 'global',
     });
+  });
+
+  it('returns a local fallback keycloak status without decrypting secrets when revealSecret is unavailable', async () => {
+    const getAuthClientSecretCiphertext = vi.fn(async () => 'cipher-auth');
+    const getTenantAdminClientSecretCiphertext = vi.fn(async () => 'cipher-admin');
+    const repository = createRepository({
+      getInstanceById: vi.fn(async () => ({
+        ...baseInstance,
+        authClientSecretConfigured: true,
+        tenantAdminClient: {
+          clientId: 'tenant-admin',
+          secretConfigured: true,
+        },
+      })),
+      listKeycloakProvisioningRuns: vi.fn(async () => []),
+      getAuthClientSecretCiphertext,
+      getTenantAdminClientSecretCiphertext,
+    });
+
+    const status = await createGetKeycloakStatusHandler(createDeps(repository, { revealSecret: undefined }))('demo');
+
+    expect(status).toEqual({
+      realmExists: false,
+      clientExists: false,
+      tenantAdminClientExists: false,
+      instanceIdMapperExists: false,
+      tenantAdminExists: false,
+      tenantAdminHasSystemAdmin: false,
+      tenantAdminHasInstanceRegistryAdmin: false,
+      tenantAdminInstanceIdMatches: false,
+      redirectUrisMatch: false,
+      logoutUrisMatch: false,
+      webOriginsMatch: false,
+      clientSecretConfigured: true,
+      tenantClientSecretReadable: false,
+      clientSecretAligned: false,
+      tenantAdminClientSecretConfigured: true,
+      tenantAdminClientSecretReadable: false,
+      tenantAdminClientSecretAligned: false,
+      runtimeSecretSource: 'global',
+    });
+    expect(getAuthClientSecretCiphertext).not.toHaveBeenCalled();
+    expect(getTenantAdminClientSecretCiphertext).not.toHaveBeenCalled();
+  });
+
+  it('does not return a persisted keycloak status snapshot for unknown instances', async () => {
+    const repository = createRepository({
+      getInstanceById: vi.fn(async () => null),
+      listKeycloakProvisioningRuns: vi.fn(async () => [
+        {
+          id: 'keycloak-run-1',
+          instanceId: 'demo',
+          mode: 'existing',
+          intent: 'provision',
+          overallStatus: 'succeeded',
+          driftSummary: 'Done',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          steps: [
+            {
+              stepKey: 'status_snapshot',
+              title: 'Status',
+              status: 'done',
+              summary: 'Snapshot vorhanden',
+              details: {
+                status: {
+                  realmExists: true,
+                  clientExists: true,
+                  tenantAdminClientExists: true,
+                  instanceIdMapperExists: true,
+                  tenantAdminExists: true,
+                  tenantAdminHasSystemAdmin: true,
+                  tenantAdminHasInstanceRegistryAdmin: true,
+                  tenantAdminInstanceIdMatches: true,
+                  redirectUrisMatch: true,
+                  logoutUrisMatch: true,
+                  webOriginsMatch: true,
+                  clientSecretConfigured: true,
+                  tenantClientSecretReadable: true,
+                  clientSecretAligned: true,
+                  tenantAdminClientSecretConfigured: true,
+                  tenantAdminClientSecretReadable: true,
+                  tenantAdminClientSecretAligned: true,
+                  runtimeSecretSource: 'tenant',
+                },
+              },
+            },
+          ],
+        },
+      ]),
+    });
+
+    await expect(createGetKeycloakStatusHandler(createDeps(repository))('demo')).resolves.toBeNull();
   });
 
   it('returns a persisted keycloak status snapshot without loading secrets', async () => {

--- a/packages/instance-registry/src/service.ts
+++ b/packages/instance-registry/src/service.ts
@@ -18,6 +18,7 @@ import {
 import { createProvisioningArtifacts } from './service-provisioning.js';
 
 const logger = createSdkLogger({ component: 'iam-instance-registry-service', level: 'info' });
+const DEFAULT_TENANT_ADMIN_CLIENT_ID = 'sva-studio-admin';
 
 const invalidateHostWithLog = (
   invalidateHost: InstanceRegistryServiceDeps['invalidateHost'],
@@ -266,6 +267,7 @@ const createProvisioningRequestHandler =
 
     const normalizedParentDomain = normalizeHost(input.parentDomain);
     const primaryHostname = buildPrimaryHostname(input.instanceId, normalizedParentDomain);
+    const tenantAdminClient = input.tenantAdminClient ?? { clientId: DEFAULT_TENANT_ADMIN_CLIENT_ID };
     const instance = await deps.repository.createInstance({
       instanceId: input.instanceId,
       displayName: input.displayName,
@@ -277,10 +279,10 @@ const createProvisioningRequestHandler =
       authClientId: input.authClientId,
       authIssuerUrl: input.authIssuerUrl,
       authClientSecretCiphertext: encryptAuthClientSecret(deps, input.instanceId, input.authClientSecret),
-      tenantAdminClient: input.tenantAdminClient
+      tenantAdminClient: tenantAdminClient
         ? {
-            clientId: input.tenantAdminClient.clientId,
-            secretCiphertext: encryptTenantAdminClientSecret(deps, input.instanceId, input.tenantAdminClient.secret),
+            clientId: tenantAdminClient.clientId,
+            secretCiphertext: encryptTenantAdminClientSecret(deps, input.instanceId, tenantAdminClient.secret),
           }
         : undefined,
       tenantAdminBootstrap: input.tenantAdminBootstrap,

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -192,6 +192,42 @@ describe('createSvaMainserverService', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(4);
   });
 
+  it('evicts least recently used credential cache entries when the max size is exceeded', async () => {
+    let nowMs = 0;
+    const readCredentials = vi
+      .fn()
+      .mockResolvedValueOnce({ apiKey: 'key-1', apiSecret: 'secret-1' })
+      .mockResolvedValueOnce({ apiKey: 'key-2', apiSecret: 'secret-2' })
+      .mockResolvedValueOnce({ apiKey: 'key-1b', apiSecret: 'secret-1b' });
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async ({ instanceId }) => ({
+        ...baseConfig,
+        instanceId,
+      }),
+      readCredentials,
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+        .mockResolvedValueOnce(createJsonResponse(200, { data: { __typename: 'Query' } }))
+        .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-2', expires_in: 120 }))
+        .mockResolvedValueOnce(createJsonResponse(200, { data: { __typename: 'Query' } }))
+        .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-3', expires_in: 120 }))
+        .mockResolvedValueOnce(createJsonResponse(200, { data: { __typename: 'Query' } })),
+      now: () => nowMs,
+      credentialCacheMaxSize: 1,
+      tokenCacheMaxSize: 1,
+    });
+
+    await service.getQueryRootTypename({ instanceId: 'de-one', keycloakSubject: 'subject-1' });
+    nowMs += 1;
+    await service.getQueryRootTypename({ instanceId: 'de-two', keycloakSubject: 'subject-2' });
+    nowMs += 1;
+    await service.getQueryRootTypename({ instanceId: 'de-one', keycloakSubject: 'subject-1' });
+
+    expect(readCredentials).toHaveBeenCalledTimes(3);
+  });
+
   it('executes query and mutation diagnostics with typed responses', async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -468,19 +468,40 @@ const pruneCache = <TValue>(
   nowMs: number,
   maxSize: number
 ): void => {
+  let oldestLiveKey: string | null = null;
+  let oldestLiveTimestamp = Number.POSITIVE_INFINITY;
+
   for (const [key, entry] of cache.entries()) {
     if (entry.expiresAtMs <= nowMs) {
       cache.delete(key);
+      continue;
+    }
+
+    if (entry.lastUsedAtMs < oldestLiveTimestamp) {
+      oldestLiveTimestamp = entry.lastUsedAtMs;
+      oldestLiveKey = key;
     }
   }
 
-  if (cache.size <= maxSize) {
-    return;
-  }
+  while (cache.size > maxSize) {
+    if (oldestLiveKey !== null) {
+      cache.delete(oldestLiveKey);
+    } else {
+      const firstKey = cache.keys().next().value;
+      if (firstKey === undefined) {
+        return;
+      }
+      cache.delete(firstKey);
+    }
 
-  const oldestEntries = [...cache.entries()].sort((left, right) => left[1].lastUsedAtMs - right[1].lastUsedAtMs);
-  for (const [key] of oldestEntries.slice(0, cache.size - maxSize)) {
-    cache.delete(key);
+    oldestLiveKey = null;
+    oldestLiveTimestamp = Number.POSITIVE_INFINITY;
+    for (const [key, entry] of cache.entries()) {
+      if (entry.lastUsedAtMs < oldestLiveTimestamp) {
+        oldestLiveTimestamp = entry.lastUsedAtMs;
+        oldestLiveKey = key;
+      }
+    }
   }
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       nitro:
         specifier: 3.0.260415-beta
         version: 3.0.260415-beta(dotenv@16.4.7)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      postcss:
+        specifier: 8.5.11
+        version: 8.5.11
       react:
         specifier: ^19.2.0
         version: 19.2.5
@@ -299,6 +302,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      postcss:
+        specifier: 8.5.11
+        version: 8.5.11
       sanitize-html:
         specifier: ^2.17.3
         version: 2.17.3
@@ -449,6 +455,9 @@ importers:
       '@sva/server-runtime':
         specifier: workspace:*
         version: link:../server-runtime
+      postcss:
+        specifier: 8.5.11
+        version: 8.5.11
       sanitize-html:
         specifier: ^2.17.3
         version: 2.17.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         specifier: ^22.7.0
         version: 22.7.0
       postcss:
-        specifier: ^8.5.11
+        specifier: 8.5.11
         version: 8.5.11
       tailwindcss:
         specifier: 4.2.4
@@ -185,7 +185,7 @@ importers:
         specifier: 3.0.260415-beta
         version: 3.0.260415-beta(dotenv@16.4.7)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       postcss:
-        specifier: ^8.5.11
+        specifier: 8.5.11
         version: 8.5.11
       react:
         specifier: ^19.2.0
@@ -303,7 +303,7 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       postcss:
-        specifier: ^8.5.11
+        specifier: 8.5.11
         version: 8.5.11
       sanitize-html:
         specifier: ^2.17.3
@@ -3440,6 +3440,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         specifier: ^22.7.0
         version: 22.7.0
       postcss:
-        specifier: 8.5.11
+        specifier: ^8.5.11
         version: 8.5.11
       tailwindcss:
         specifier: 4.2.4
@@ -185,7 +185,7 @@ importers:
         specifier: 3.0.260415-beta
         version: 3.0.260415-beta(dotenv@16.4.7)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(rollup@4.59.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       postcss:
-        specifier: 8.5.11
+        specifier: ^8.5.11
         version: 8.5.11
       react:
         specifier: ^19.2.0
@@ -303,7 +303,7 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       postcss:
-        specifier: 8.5.11
+        specifier: ^8.5.11
         version: 8.5.11
       sanitize-html:
         specifier: ^2.17.3


### PR DESCRIPTION
## Problem

Die lokale Instanzverwaltung hatte drei gekoppelte Fehlerbilder im IAM-/Keycloak-Flow:

- die Instanzdetailseite fiel bei fehlender Keycloak-Evidenz auf generische Runtime-Diagnosen oder irreführende Leerzustände zurück
- das Anlegen neuer Instanzen konnte trotz vollständig ausgefülltem Formular mit `500` scheitern
- mehrere Keycloak-Aktionen wirkten in der UI reaktionslos, weil sichtbares Feedback und eine klare Einordnung von Worker-/Fallback-Zuständen fehlten

## Änderung

- robuster serverseitiger Fallback für den Keycloak-Status in der Instanzdetailansicht
- Default für `tenantAdminClient` beim Create-Flow ergänzt, damit der DB-Contract eingehalten wird
- sichtbares UI-Feedback für Preflight-, Status-, Plan- und Provisioning-Aktionen ergänzt
- Worker-/Fallback-Zustände in der Instanzdetailseite explizit als nicht-live kenntlich gemacht
- Feldhilfe für die Instanzmaske überarbeitet und gezielt mit zusätzlichen Verhaltens- und Positionierungstests abgesichert
- Runtime-Dependency-Regressionstests für `auth-runtime` und `iam-governance` ergänzt

## Root Cause

- der Create-Service übergab bei fehlendem Formwert keinen `tenantAdminClient`, obwohl die Datenbank inzwischen einen nicht-leeren `tenant_admin_client_id` verlangt
- fehlende Keycloak-Snapshots wurden im Registry-Service nicht stabil genug in einen nutzbaren Detailzustand übersetzt
- die UI unterschied nicht klar zwischen live geladenen Ergebnissen und Worker-/Fallback-Projektionen

## Wirkung

- neue Instanzen lassen sich robuster anlegen
- die Instanzdetailseite bleibt auch in Zwischen- und Fehlerzuständen bedienbar
- Operator-Aktionen geben sofort erkennbares Feedback
- der technische Zustand von Keycloak, Worker und Fallback-Projektionen ist für die Bedienung klarer lesbar

## Verifikation

- `pnpm test:pr`
