### PR TITLE
[hotfix] Remove legal dialog preload from anonymous studio landing page

### DIFF
--- a/apps/sva-studio-react/src/components/AppShell.tsx
+++ b/apps/sva-studio-react/src/components/AppShell.tsx
@@ -60,12 +60,23 @@ const LegalTextAcceptanceDialogSlot = ({ enabled, pathname }: Readonly<{ enabled
     }
 
     let isCancelled = false;
-    void import('./LegalTextAcceptanceDialog').then((module) => {
-      if (isCancelled) {
-        return;
+
+    const loadDialogComponent = async () => {
+      try {
+        const module = await import('./LegalTextAcceptanceDialog');
+        if (isCancelled) {
+          return;
+        }
+        setDialogComponent(() => module.LegalTextAcceptanceDialog);
+      } catch {
+        if (isCancelled) {
+          return;
+        }
+        setDialogComponent(null);
       }
-      setDialogComponent(() => module.LegalTextAcceptanceDialog);
-    });
+    };
+
+    void loadDialogComponent();
 
     return () => {
       isCancelled = true;

--- a/apps/sva-studio-react/src/components/AppShell.tsx
+++ b/apps/sva-studio-react/src/components/AppShell.tsx
@@ -11,6 +11,8 @@ import Header from './Header';
 import { t } from '../i18n';
 import { useAuth } from '../providers/auth-provider';
 
+type LegalTextAcceptanceDialogComponent = typeof import('./LegalTextAcceptanceDialog').LegalTextAcceptanceDialog;
+
 type AppShellProps = Readonly<{
   children: React.ReactNode;
   currentPathname?: string;
@@ -34,13 +36,6 @@ const LazySidebar = React.lazy(async () => {
   };
 });
 
-const LazyLegalTextAcceptanceDialog = React.lazy(async () => {
-  const module = await import('./LegalTextAcceptanceDialog');
-  return {
-    default: module.LegalTextAcceptanceDialog,
-  };
-});
-
 const LazyPermissionsDegradedBanner = React.lazy(async () => {
   const module = await import('./PermissionsDegradedBanner');
   return {
@@ -54,6 +49,35 @@ export const shouldRenderLegalTextAcceptanceDialog = (input: {
   readonly isHydrated: boolean;
   readonly isAuthenticated: boolean;
 }): boolean => input.isHydrated && input.isAuthenticated;
+
+const LegalTextAcceptanceDialogSlot = ({ enabled, pathname }: Readonly<{ enabled: boolean; pathname: string }>) => {
+  const [DialogComponent, setDialogComponent] = React.useState<LegalTextAcceptanceDialogComponent | null>(null);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setDialogComponent(null);
+      return;
+    }
+
+    let isCancelled = false;
+    void import('./LegalTextAcceptanceDialog').then((module) => {
+      if (isCancelled) {
+        return;
+      }
+      setDialogComponent(() => module.LegalTextAcceptanceDialog);
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [enabled]);
+
+  if (!enabled || DialogComponent === null) {
+    return null;
+  }
+
+  return <DialogComponent pathname={pathname} />;
+};
 
 /**
  * Rendert das anwendungsweite Shell-Layout mit austauschbarem Sidebar-Slot.
@@ -138,11 +162,7 @@ export default function AppShell({
             </div>
           )}
         </main>
-        {showLegalTextAcceptanceDialog ? (
-          <React.Suspense fallback={null}>
-            <LazyLegalTextAcceptanceDialog pathname={currentPathname} />
-          </React.Suspense>
-        ) : null}
+        <LegalTextAcceptanceDialogSlot enabled={showLegalTextAcceptanceDialog} pathname={currentPathname} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Problem
The previously merged fix stopped rendering the legal text dialog for anonymous users, but the `LegalTextAcceptanceDialog` chunk was still referenced from the initial `AppShell` module graph. TanStack/Vite therefore continued to preload `legal-text-sanitize-html` on the anonymous landing page, which could still break hydration before the login button became visible.

## Fix
- remove the `React.lazy` legal dialog import from the initial `AppShell` graph
- load the dialog only after hydration and only for authenticated users via effect-driven dynamic import

## Verification
- `pnpm nx run sva-studio-react:test:unit`
- `pnpm nx run sva-studio-react:typecheck`
- `pnpm nx run sva-studio-react:build --skip-nx-cache`
- local SSR HTML check: root page no longer contains `legal-text-sanitize-html` or `LegalTextAcceptanceDialog` preload references for anonymous users
