### PR TITLE
fix: use browser-safe legal text sanitizer in studio ui

### DIFF
--- a/apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.tsx
+++ b/apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { sanitizeLegalTextHtml } from '@sva/iam-governance/legal-text-sanitize-html';
-
 import { acceptLegalText, asIamError, getMyPendingLegalTexts, LEGAL_ACCEPTANCE_REQUIRED_EVENT } from '../lib/iam-api';
 import {
   createOperationLogger,
@@ -14,6 +12,7 @@ import {
   readLegalAcceptanceReturnTo,
   storeLegalAcceptanceReturnTo,
 } from '../lib/legal-acceptance-navigation';
+import { sanitizeLegalTextHtml } from '../lib/legal-text-html-sanitizer';
 import { t } from '../i18n';
 import { useAuth } from '../providers/auth-provider';
 import { Alert, AlertDescription } from './ui/alert';

--- a/apps/sva-studio-react/src/components/RichTextEditor.test.tsx
+++ b/apps/sva-studio-react/src/components/RichTextEditor.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { sanitizeLegalTextHtml } from '@sva/iam-governance/legal-text-sanitize-html';
+import { sanitizeLegalTextHtml } from '../lib/legal-text-html-sanitizer';
 import { RichTextEditor } from './RichTextEditor';
 
 describe('RichTextEditor', () => {

--- a/apps/sva-studio-react/src/components/RichTextEditor.tsx
+++ b/apps/sva-studio-react/src/components/RichTextEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { sanitizeLegalTextHtml } from '@sva/iam-governance/legal-text-sanitize-html';
+import { sanitizeLegalTextHtml } from '../lib/legal-text-html-sanitizer';
 
 import { Button } from './ui/button';
 

--- a/apps/sva-studio-react/src/lib/legal-text-html-sanitizer.test.ts
+++ b/apps/sva-studio-react/src/lib/legal-text-html-sanitizer.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeLegalTextHtml } from './legal-text-html-sanitizer';
+
+describe('sanitizeLegalTextHtml', () => {
+  it('removes disallowed tags and preserves safe links', () => {
+    expect(
+      sanitizeLegalTextHtml(
+        '<p>Hallo</p><script>alert(1)</script><a href="https://example.com" target="_blank">Link</a>'
+      )
+    ).toBe('<p>Hallo</p><a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a>');
+  });
+
+  it('strips unsafe href values and inline event handlers', () => {
+    expect(
+      sanitizeLegalTextHtml(
+        '<p onclick="alert(1)">Text</p><a href="javascript:alert(1)" target="_blank" rel="nofollow">Böse</a>'
+      )
+    ).toBe('<p>Text</p><a target="_blank" rel="noopener noreferrer">Böse</a>');
+  });
+
+  it('keeps relative links and falls back to an empty paragraph for empty content', () => {
+    expect(sanitizeLegalTextHtml('<a href="/hilfe">Hilfe</a>')).toBe('<a href="/hilfe">Hilfe</a>');
+    expect(sanitizeLegalTextHtml('<script>alert(1)</script>')).toBe('<p></p>');
+  });
+});

--- a/apps/sva-studio-react/src/lib/legal-text-html-sanitizer.ts
+++ b/apps/sva-studio-react/src/lib/legal-text-html-sanitizer.ts
@@ -136,12 +136,22 @@ const sanitizeBrowserHtml = (value: string): string => {
   return container.innerHTML;
 };
 
-const sanitizeWithoutBrowserDom = (value: string): string =>
+const escapeHtml = (value: string): string =>
   value
-    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, '')
-    .replace(/\son[a-z]+\s*=\s*(['"]).*?\1/gi, '')
-    .replace(/\shref\s*=\s*(['"])\s*(?:javascript:|data:).*?\1/gi, '');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+const sanitizeWithoutBrowserDom = (value: string): string => {
+  const plainText = collapseWhitespace(value);
+  if (!plainText) {
+    return '<p></p>';
+  }
+
+  return `<p>${escapeHtml(plainText)}</p>`;
+};
 
 export const sanitizeLegalTextHtml = (value: string): string => {
   const sanitized = collapseWhitespace(

--- a/apps/sva-studio-react/src/lib/legal-text-html-sanitizer.ts
+++ b/apps/sva-studio-react/src/lib/legal-text-html-sanitizer.ts
@@ -1,0 +1,152 @@
+const SAFE_BLANK_TARGET_REL = 'noopener noreferrer';
+
+const ALLOWED_TAGS = new Set([
+  'a',
+  'b',
+  'blockquote',
+  'br',
+  'div',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'li',
+  'ol',
+  'p',
+  'span',
+  'strong',
+  'u',
+  'ul',
+]);
+
+const DISCARD_WITH_CONTENT_TAGS = new Set(['script', 'style']);
+
+const collapseWhitespace = (value: string): string => {
+  let collapsed = '';
+  let previousWasWhitespace = true;
+
+  for (const character of value) {
+    const isWhitespace = character.trim().length === 0;
+    if (isWhitespace) {
+      if (!previousWasWhitespace) {
+        collapsed += ' ';
+        previousWasWhitespace = true;
+      }
+      continue;
+    }
+
+    collapsed += character;
+    previousWasWhitespace = false;
+  }
+
+  return previousWasWhitespace ? collapsed.trimEnd() : collapsed;
+};
+
+const isAllowedHref = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith('//')) {
+    return false;
+  }
+
+  if (trimmed.startsWith('/') || trimmed.startsWith('#') || trimmed.startsWith('?')) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(trimmed, 'https://studio.smart-village.app');
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' || parsed.protocol === 'mailto:';
+  } catch {
+    return false;
+  }
+};
+
+const sanitizeBrowserHtml = (value: string): string => {
+  const template = document.createElement('template');
+  template.innerHTML = value;
+
+  const sanitizeNode = (node: Node): Node | DocumentFragment | null => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return document.createTextNode(node.textContent ?? '');
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return null;
+    }
+
+    const sourceElement = node as HTMLElement;
+    const tagName = sourceElement.tagName.toLowerCase();
+
+    if (DISCARD_WITH_CONTENT_TAGS.has(tagName)) {
+      return null;
+    }
+
+    const sanitizedChildren = document.createDocumentFragment();
+
+    for (const child of Array.from(sourceElement.childNodes)) {
+      const sanitizedChild = sanitizeNode(child);
+      if (sanitizedChild) {
+        sanitizedChildren.appendChild(sanitizedChild);
+      }
+    }
+
+    if (!ALLOWED_TAGS.has(tagName)) {
+      return sanitizedChildren;
+    }
+
+    const element = document.createElement(tagName);
+
+    if (tagName === 'a') {
+      const href = sourceElement.getAttribute('href');
+      if (href && isAllowedHref(href)) {
+        element.setAttribute('href', href);
+      }
+
+      const target = sourceElement.getAttribute('target');
+      if (target) {
+        element.setAttribute('target', target);
+      }
+
+      const rel = target === '_blank'
+        ? SAFE_BLANK_TARGET_REL
+        : sourceElement.getAttribute('rel');
+      if (rel) {
+        element.setAttribute('rel', rel);
+      }
+    }
+
+    element.appendChild(sanitizedChildren);
+    return element;
+  };
+
+  const sanitizedRoot = document.createDocumentFragment();
+  for (const child of Array.from(template.content.childNodes)) {
+    const sanitizedChild = sanitizeNode(child);
+    if (sanitizedChild) {
+      sanitizedRoot.appendChild(sanitizedChild);
+    }
+  }
+
+  const container = document.createElement('div');
+  container.appendChild(sanitizedRoot);
+  return container.innerHTML;
+};
+
+const sanitizeWithoutBrowserDom = (value: string): string =>
+  value
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, '')
+    .replace(/\son[a-z]+\s*=\s*(['"]).*?\1/gi, '')
+    .replace(/\shref\s*=\s*(['"])\s*(?:javascript:|data:).*?\1/gi, '');
+
+export const sanitizeLegalTextHtml = (value: string): string => {
+  const sanitized = collapseWhitespace(
+    typeof document === 'undefined' ? sanitizeWithoutBrowserDom(value) : sanitizeBrowserHtml(value)
+  );
+
+  return sanitized.length > 0 ? sanitized : '<p></p>';
+};


### PR DESCRIPTION
## Summary
- replace the studio UI legal text sanitizer import with a browser-safe local sanitizer
- remove the browser-incompatible `sanitize-html` runtime path from the initial frontend bundle
- add regression coverage for the sanitizer and rich text editor path

## Root cause
The anonymous studio home page still loaded `legal-text-sanitize-html` in the initial browser bundle. That path came not only from `LegalTextAcceptanceDialog`, but also from `RichTextEditor`. In production the chunk threw at runtime with:

`Error: Calling require for "path" ...`

That exception aborted hydration before the auth loading state could resolve to the login button.

## Verification
- `pnpm nx run sva-studio-react:test:unit`
- `pnpm nx run sva-studio-react:typecheck`
- `pnpm nx run sva-studio-react:build --skip-nx-cache`
- local production build browser check: hydrated header renders `Login` and no `legal-text-sanitize-html-*` chunk remains in the bundle
