### PR TITLE
fix(ops): skip provisioning worker for mock auth profiles

### DIFF
--- a/scripts/ops/runtime-env.test.ts
+++ b/scripts/ops/runtime-env.test.ts
@@ -11,6 +11,7 @@ import {
   deriveInternalVerifyMaxAttempts,
   readStudioImageVerifyEvidence,
   resolveTenantRuntimeTargets,
+  shouldRunLocalProvisioningWorker,
   runExternalSmokeWithWarmup,
   waitForRemoteSmokeWarmup,
   shouldRetryExternalSmoke,
@@ -233,6 +234,14 @@ describe('assertLoginFlow', () => {
 });
 
 describe('buildLocalProvisioningWorkerCheck', () => {
+  it('skips the provisioning worker check for mock-auth profiles', () => {
+    expect(buildLocalProvisioningWorkerCheck('local-builder', null, () => false)).toMatchObject({
+      code: 'local_provisioning_worker_not_applicable',
+      name: 'keycloak-provisioning-worker',
+      status: 'skipped',
+    });
+  });
+
   it('returns a warning when the local provisioning worker state is missing', () => {
     expect(buildLocalProvisioningWorkerCheck('local-keycloak', null, () => false)).toMatchObject({
       code: 'local_keycloak_provisioning_worker_missing',
@@ -279,6 +288,14 @@ describe('buildLocalProvisioningWorkerCheck', () => {
       code: 'local_keycloak_provisioning_worker_running',
       status: 'ok',
     });
+  });
+});
+
+describe('shouldRunLocalProvisioningWorker', () => {
+  it('runs only for local keycloak profiles', () => {
+    expect(shouldRunLocalProvisioningWorker('local-keycloak')).toBe(true);
+    expect(shouldRunLocalProvisioningWorker('local-builder')).toBe(false);
+    expect(shouldRunLocalProvisioningWorker('studio')).toBe(false);
   });
 });
 

--- a/scripts/ops/runtime-env.ts
+++ b/scripts/ops/runtime-env.ts
@@ -1532,12 +1532,12 @@ export const buildLocalProvisioningWorkerCheck = (
   workerState: LocalState | null,
   isAlive: (pid: number) => boolean = isProcessAlive,
 ): DoctorCheck => {
-  if (!getRuntimeProfileDefinition(runtimeProfile).isLocal) {
+  if (!shouldRunLocalProvisioningWorker(runtimeProfile)) {
     return toDoctorCheck(
       'keycloak-provisioning-worker',
       'skipped',
       'local_provisioning_worker_not_applicable',
-      'Provisioning-Worker-Check ist fuer Remote-Profile nicht anwendbar.',
+      'Provisioning-Worker-Check ist fuer dieses Runtime-Profil nicht anwendbar.',
     );
   }
 
@@ -1579,6 +1579,9 @@ export const buildLocalProvisioningWorkerCheck = (
     },
   );
 };
+
+export const shouldRunLocalProvisioningWorker = (runtimeProfile: RuntimeProfile) =>
+  getRuntimeProfileDefinition(runtimeProfile).isLocal && !isMockAuthRuntimeProfile(runtimeProfile);
 
 const waitForHttpOk = async (url: string, timeoutMs: number) => {
   const startedAt = Date.now();
@@ -3245,7 +3248,9 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
       bootstrapLocalAppUser(env);
       reconcileLocalInstanceRegistry(runtimeProfile, env);
       await startLocalApp(runtimeProfile, env);
-      startLocalProvisioningWorker(runtimeProfile, env);
+      if (shouldRunLocalProvisioningWorker(runtimeProfile)) {
+        startLocalProvisioningWorker(runtimeProfile, env);
+      }
       console.log(`Profil ${runtimeProfile} gestartet.`);
       return;
     case 'down':
@@ -3263,7 +3268,9 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
       stopLocalProvisioningWorker();
       stopLocalApp();
       await startLocalApp(runtimeProfile, env);
-      startLocalProvisioningWorker(runtimeProfile, env);
+      if (shouldRunLocalProvisioningWorker(runtimeProfile)) {
+        startLocalProvisioningWorker(runtimeProfile, env);
+      }
       console.log(`Profil ${runtimeProfile} aktualisiert.`);
       return;
     case 'status': {


### PR DESCRIPTION
## Summary
- skip starting the local provisioning worker for mock-auth runtime profiles such as `local-builder`
- mark the doctor check as not applicable for those profiles instead of warning about missing worker state
- add focused tests for the new applicability rule and the skipped doctor check behavior

## Validation
- `pnpm nx run tooling-testing:test:unit`
- `pnpm test:types`
