### PR TITLE
feat(instance-registry): add module activation bootstrap flow

### DIFF
--- a/apps/sva-studio-react/src/hooks/use-instances.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-instances.test.tsx
@@ -19,6 +19,7 @@ const planInstanceKeycloakProvisioningMock = vi.fn();
 const executeInstanceKeycloakProvisioningMock = vi.fn();
 const probeTenantIamAccessMock = vi.fn();
 const assignInstanceModuleMock = vi.fn();
+const bootstrapInstanceAdminStructureMock = vi.fn();
 const revokeInstanceModuleMock = vi.fn();
 const seedInstanceIamBaselineMock = vi.fn();
 const createInstanceMock = vi.fn();
@@ -61,6 +62,7 @@ vi.mock('../lib/iam-api', () => ({
   executeInstanceKeycloakProvisioning: (...args: unknown[]) => executeInstanceKeycloakProvisioningMock(...args),
   probeTenantIamAccess: (...args: unknown[]) => probeTenantIamAccessMock(...args),
   assignInstanceModule: (...args: unknown[]) => assignInstanceModuleMock(...args),
+  bootstrapInstanceAdminStructure: (...args: unknown[]) => bootstrapInstanceAdminStructureMock(...args),
   revokeInstanceModule: (...args: unknown[]) => revokeInstanceModuleMock(...args),
   seedInstanceIamBaseline: (...args: unknown[]) => seedInstanceIamBaselineMock(...args),
   createInstance: (...args: unknown[]) => createInstanceMock(...args),
@@ -139,6 +141,20 @@ describe('useInstances', () => {
       },
     });
     assignInstanceModuleMock.mockResolvedValue({
+      data: {
+        instanceId: 'demo',
+        displayName: 'Demo',
+        status: 'active',
+        parentDomain: 'studio.example.org',
+        primaryHostname: 'demo.studio.example.org',
+        hostnames: [],
+        provisioningRuns: [],
+        keycloakProvisioningRuns: [],
+        auditEvents: [],
+        assignedModules: ['news'],
+      },
+    });
+    bootstrapInstanceAdminStructureMock.mockResolvedValue({
       data: {
         instanceId: 'demo',
         displayName: 'Demo',
@@ -278,6 +294,7 @@ describe('useInstances', () => {
       });
       await result.current.probeTenantIamAccess('demo');
       await result.current.reconcileKeycloak('demo', { rotateClientSecret: true });
+      await result.current.bootstrapAdminStructure('demo', ['news']);
       await result.current.activateInstance('demo');
       await result.current.suspendInstance('demo');
       await result.current.archiveInstance('demo');
@@ -287,6 +304,7 @@ describe('useInstances', () => {
     expect(updateInstanceMock).toHaveBeenCalledTimes(1);
     expect(probeTenantIamAccessMock).toHaveBeenCalledTimes(1);
     expect(reconcileInstanceKeycloakMock).toHaveBeenCalledTimes(1);
+    expect(bootstrapInstanceAdminStructureMock).toHaveBeenCalledTimes(1);
     expect(activateInstanceMock).toHaveBeenCalledTimes(1);
     expect(suspendInstanceMock).toHaveBeenCalledTimes(1);
     expect(archiveInstanceMock).toHaveBeenCalledTimes(1);
@@ -672,17 +690,36 @@ describe('useInstances', () => {
       expect(assigned).toEqual(expect.objectContaining({ assignedModules: ['news'] }));
     });
     expect(assignInstanceModuleMock).toHaveBeenCalledWith('demo', 'news');
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       const seeded = await result.current.seedIamBaseline('demo');
       expect(seeded).toEqual(expect.objectContaining({ assignedModules: ['news'] }));
     });
     expect(seedInstanceIamBaselineMock).toHaveBeenCalledWith('demo');
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(2);
 
     await act(async () => {
       const revoked = await result.current.revokeModule('demo', 'news');
       expect(revoked).toEqual(expect.objectContaining({ assignedModules: [] }));
     });
     expect(revokeInstanceModuleMock).toHaveBeenCalledWith('demo', 'news');
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(3);
+  });
+
+  it('refreshes auth state after bootstrapping the admin structure', async () => {
+    const { result } = renderHook(() => useInstances());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      const bootstrapped = await result.current.bootstrapAdminStructure('demo', ['news']);
+      expect(bootstrapped).toEqual(expect.objectContaining({ assignedModules: ['news'] }));
+    });
+
+    expect(bootstrapInstanceAdminStructureMock).toHaveBeenCalledWith('demo', ['news']);
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/sva-studio-react/src/hooks/use-instances.ts
+++ b/apps/sva-studio-react/src/hooks/use-instances.ts
@@ -6,6 +6,7 @@ import {
   assignInstanceModule,
   archiveInstance,
   asIamError,
+  bootstrapInstanceAdminStructure,
   createInstance,
   executeInstanceKeycloakProvisioning,
   getInstanceKeycloakStatus,
@@ -227,7 +228,12 @@ export const useInstances = () => {
   );
 
   const mutate = React.useCallback(
-    async <T>(action: () => Promise<{ data: T }>, instanceId?: string, operation = 'instance_mutation') => {
+    async <T>(
+      action: () => Promise<{ data: T }>,
+      instanceId?: string,
+      operation = 'instance_mutation',
+      options?: { invalidateAuthAfterSuccess?: boolean }
+    ) => {
       setMutationError(null);
       logBrowserOperationStart(instancesLogger, 'instance_mutation_started', {
         operation,
@@ -235,6 +241,9 @@ export const useInstances = () => {
       });
       try {
         const result = await action();
+        if (options?.invalidateAuthAfterSuccess) {
+          await invalidatePermissions();
+        }
         await refetch();
         if (instanceId) {
           await loadInstance(instanceId);
@@ -456,7 +465,19 @@ export const useInstances = () => {
           return response;
         },
         instanceId,
-        'assign_instance_module'
+        'assign_instance_module',
+        { invalidateAuthAfterSuccess: true }
+      ),
+    bootstrapAdminStructure: async (instanceId: string, moduleIds: readonly string[]) =>
+      mutate(
+        async () => {
+          const response = await bootstrapInstanceAdminStructure(instanceId, moduleIds);
+          setSelectedInstance(response.data);
+          return response;
+        },
+        instanceId,
+        'bootstrap_instance_admin_structure',
+        { invalidateAuthAfterSuccess: true }
       ),
     revokeModule: async (instanceId: string, moduleId: string) =>
       mutate(
@@ -466,7 +487,8 @@ export const useInstances = () => {
           return response;
         },
         instanceId,
-        'revoke_instance_module'
+        'revoke_instance_module',
+        { invalidateAuthAfterSuccess: true }
       ),
     seedIamBaseline: async (instanceId: string) =>
       mutate(
@@ -476,7 +498,8 @@ export const useInstances = () => {
           return response;
         },
         instanceId,
-        'seed_instance_iam_baseline'
+        'seed_instance_iam_baseline',
+        { invalidateAuthAfterSuccess: true }
       ),
     activateInstance: async (instanceId: string) => mutate(() => activateInstance(instanceId), instanceId, 'activate_instance'),
     suspendInstance: async (instanceId: string) => mutate(() => suspendInstance(instanceId), instanceId, 'suspend_instance'),

--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -1223,6 +1223,28 @@ export const i18nResources = {
               'Aktivieren Sie die Instanz erst nach erfolgreichem Provisioning für {{hostname}}.',
           },
         },
+        adminBootstrap: {
+          title: 'Admin-Struktur',
+          subtitlePending:
+            'Der Abschnitt ist Teil des Happy Path, wird aber erst nach erfolgreichem Registry-Create aktiv.',
+          subtitleReady:
+            'Optional Module auswählen und danach die initiale Admin-Struktur für Core und zugewiesene Module anlegen.',
+          moduleHint: 'Enthält initial die Rechte: {{value}}',
+          conflictHint:
+            'Bestehende Rollen mit gleichem Namen werden beim erneuten Bootstrap überschrieben. Bereits angelegte Sonderrollen bleiben unberührt.',
+          action: 'Admin-Struktur jetzt anlegen',
+          actionHintPending: 'Zuerst die Instanz anlegen, danach wird dieser Schritt aktiv.',
+          actionHintReady:
+            'Ohne Modulauswahl werden nur die Gruppe Admins und die Core-Admin-Rolle angelegt.',
+          success:
+            'Die initiale Admin-Struktur wurde erfolgreich angelegt. Die Instanz gilt damit im Create-Flow als fertig.',
+          modules: {
+            news: 'News',
+            events: 'Events',
+            poi: 'POI',
+            media: 'Medien',
+          },
+        },
         help: {
           sections: {
             what: 'Was ist das?',
@@ -3729,6 +3751,28 @@ export const i18nResources = {
             openDetail: 'Open the detail page to inspect the technical state of the instance.',
             runProvisioning: 'Run the Keycloak reconciliation for realm {{realm}} there.',
             activate: 'Activate the instance only after provisioning succeeded for {{hostname}}.',
+          },
+        },
+        adminBootstrap: {
+          title: 'Admin structure',
+          subtitlePending:
+            'This section stays visible in the happy path but only becomes actionable after the registry create succeeded.',
+          subtitleReady:
+            'Optionally select modules and then create the initial admin structure for Core and the assigned modules.',
+          moduleHint: 'Initially grants: {{value}}',
+          conflictHint:
+            'Existing roles with the same name are overwritten during a repeated bootstrap. Already created custom roles stay untouched.',
+          action: 'Create admin structure now',
+          actionHintPending: 'Create the instance first, then this step becomes active.',
+          actionHintReady:
+            'Without selecting modules, only the Admins group and the Core Admin role are created.',
+          success:
+            'The initial admin structure was created successfully. In the create flow, the instance is now considered complete.',
+          modules: {
+            news: 'News',
+            events: 'Events',
+            poi: 'POI',
+            media: 'Media',
           },
         },
         help: {

--- a/apps/sva-studio-react/src/lib/iam-api.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-api.test.ts
@@ -15,6 +15,7 @@ import {
   asIamError,
   activateInstance,
   assignInstanceModule,
+  bootstrapInstanceAdminStructure,
   assignGroupMembership,
   assignGroupRole,
   archiveInstance,
@@ -106,7 +107,7 @@ describe('iam-api organization helpers', () => {
     );
   });
 
-  it('sends module assignment, revoke, and baseline seed mutations to the instance IAM endpoints', async () => {
+  it('sends module assignment, bootstrap, revoke, and baseline seed mutations to the instance IAM endpoints', async () => {
     const fetchMock = vi.fn().mockImplementation(async () =>
       new Response(JSON.stringify({ data: { instanceId: 'demo' } }), {
         status: 200,
@@ -117,6 +118,7 @@ describe('iam-api organization helpers', () => {
     vi.stubGlobal('crypto', { randomUUID: () => 'uuid-test-2' });
 
     await assignInstanceModule('demo', 'news');
+    await bootstrapInstanceAdminStructure('demo', ['news', 'media']);
     await revokeInstanceModule('demo', 'news');
     await seedInstanceIamBaseline('demo');
 
@@ -130,6 +132,14 @@ describe('iam-api organization helpers', () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
+      '/api/v1/iam/instances/demo/modules/bootstrap-admin-structure',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ moduleIds: ['news', 'media'] }),
+      })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
       '/api/v1/iam/instances/demo/modules/revoke',
       expect.objectContaining({
         method: 'POST',
@@ -137,7 +147,7 @@ describe('iam-api organization helpers', () => {
       })
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
-      3,
+      4,
       '/api/v1/iam/instances/demo/modules/seed-iam-baseline',
       expect.objectContaining({
         method: 'POST',

--- a/apps/sva-studio-react/src/lib/iam-api.ts
+++ b/apps/sva-studio-react/src/lib/iam-api.ts
@@ -1322,6 +1322,16 @@ export const assignInstanceModule = async (
     true
   );
 
+export const bootstrapInstanceAdminStructure = async (
+  instanceId: string,
+  moduleIds: readonly string[]
+): Promise<ApiItemResponse<IamInstanceDetail>> =>
+  postJsonWithReauth<ApiItemResponse<IamInstanceDetail>, { moduleIds: readonly string[] }>(
+    `/api/v1/iam/instances/${instanceId}/modules/bootstrap-admin-structure`,
+    { moduleIds },
+    true
+  );
+
 export const revokeInstanceModule = async (
   instanceId: string,
   moduleId: string

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-create-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-create-page.test.tsx
@@ -230,6 +230,127 @@ describe('InstanceCreatePage', () => {
     });
   });
 
+  it('passes selected modules to the admin bootstrap and clears the finished state after form edits', async () => {
+    const createInstance = vi.fn().mockResolvedValue(
+      createCreatedInstance({
+        instanceId: 'demo',
+        authRealm: 'saas-demo',
+      })
+    );
+    const bootstrapAdminStructure = vi.fn().mockResolvedValue({
+      instanceId: 'demo',
+      displayName: 'Demo',
+      status: 'requested',
+      parentDomain: 'studio.example.org',
+      primaryHostname: 'demo.studio.example.org',
+      hostnames: [],
+      provisioningRuns: [],
+      keycloakProvisioningRuns: [],
+      auditEvents: [],
+      assignedModules: [
+        { moduleId: 'news', assignedAt: '2026-05-07T16:00:00.000Z' },
+        { moduleId: 'events', assignedAt: '2026-05-07T16:00:00.000Z' },
+      ],
+    });
+    useInstancesMock.mockReturnValue(createInstancesApiState({ createInstance, bootstrapAdminStructure }));
+
+    render(<InstanceCreatePage />);
+
+    fireEvent.change(screen.getByLabelText('Instanz-ID', { selector: '#instance-id' }), { target: { value: 'demo' } });
+    fireEvent.change(screen.getByLabelText('Anzeigename', { selector: '#instance-display-name' }), {
+      target: { value: 'Demo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.change(screen.getByLabelText('Auth-Realm', { selector: '#instance-auth-realm' }), {
+      target: { value: 'saas-demo' },
+    });
+    fireEvent.change(screen.getByLabelText('Auth-Client-ID', { selector: '#instance-auth-client-id' }), {
+      target: { value: 'tenant-client' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Instanz anlegen' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' })).toBeTruthy();
+    });
+
+    const newsCheckbox = screen.getByText('News').closest('label')?.querySelector('input');
+    const eventsCheckbox = screen.getByText('Events').closest('label')?.querySelector('input');
+    expect(newsCheckbox instanceof HTMLInputElement).toBe(true);
+    expect(eventsCheckbox instanceof HTMLInputElement).toBe(true);
+    fireEvent.click(newsCheckbox as HTMLInputElement);
+    fireEvent.click(eventsCheckbox as HTMLInputElement);
+    fireEvent.click(screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' }));
+
+    await waitFor(() => {
+      expect(bootstrapAdminStructure).toHaveBeenCalledWith('demo', ['news', 'events']);
+    });
+
+    expect(
+      screen.getByText('Die initiale Admin-Struktur wurde erfolgreich angelegt. Die Instanz gilt damit im Create-Flow als fertig.')
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /Basisdaten/u }));
+    fireEvent.change(screen.getByLabelText('Anzeigename', { selector: '#instance-display-name' }), {
+      target: { value: 'Demo aktualisiert' },
+    });
+
+    expect(
+      screen.queryByText('Die initiale Admin-Struktur wurde erfolgreich angelegt. Die Instanz gilt damit im Create-Flow als fertig.')
+    ).toBeNull();
+    expect((screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows the bootstrap mutation error after create when the admin structure step fails', async () => {
+    const createInstance = vi.fn().mockResolvedValue(
+      createCreatedInstance({
+        instanceId: 'demo',
+        authRealm: 'saas-demo',
+      })
+    );
+    const instancesApiState = createInstancesApiState() as ReturnType<typeof createInstancesApiState> & {
+      mutationError: { status: number; code: string; message: string } | null;
+    };
+    const mutableInstancesApiState = instancesApiState as { mutationError: { status: number; code: string; message: string } | null };
+    const bootstrapAdminStructure = vi.fn().mockImplementation(async () => {
+      mutableInstancesApiState.mutationError = { status: 409, code: 'conflict', message: 'bootstrap fehlgeschlagen' };
+      return null;
+    });
+    instancesApiState.createInstance = createInstance;
+    instancesApiState.bootstrapAdminStructure = bootstrapAdminStructure;
+    useInstancesMock.mockImplementation(() => instancesApiState);
+
+    render(<InstanceCreatePage />);
+
+    fireEvent.change(screen.getByLabelText('Instanz-ID', { selector: '#instance-id' }), { target: { value: 'demo' } });
+    fireEvent.change(screen.getByLabelText('Anzeigename', { selector: '#instance-display-name' }), {
+      target: { value: 'Demo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.change(screen.getByLabelText('Auth-Realm', { selector: '#instance-auth-realm' }), {
+      target: { value: 'saas-demo' },
+    });
+    fireEvent.change(screen.getByLabelText('Auth-Client-ID', { selector: '#instance-auth-client-id' }), {
+      target: { value: 'tenant-client' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Instanz anlegen' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' }));
+
+    await waitFor(() => {
+      expect(bootstrapAdminStructure).toHaveBeenCalledWith('demo', []);
+    });
+
+    expect(screen.getByText('Die gewünschte Änderung steht im Konflikt mit dem aktuellen Instanzstatus.')).toBeTruthy();
+  });
+
   it('shows step validation before moving on', () => {
     useInstancesMock.mockReturnValue(createInstancesApiState());
 
@@ -312,6 +433,103 @@ describe('InstanceCreatePage', () => {
           secret: undefined,
         },
         tenantAdminBootstrap: undefined,
+      });
+    });
+  });
+
+  it('requires secrets for existing realms and submits the optional issuer and tenant-admin fields', async () => {
+    const createInstance = vi.fn().mockResolvedValue(
+      createCreatedInstance({
+        instanceId: 'demo-existing',
+        realmMode: 'existing',
+        authRealm: 'tenant-existing',
+        authClientSecretConfigured: true,
+      })
+    );
+    useInstancesMock.mockReturnValue(createInstancesApiState({ createInstance }));
+
+    render(<InstanceCreatePage />);
+
+    fireEvent.click(screen.getAllByRole('radio')[1]!);
+    fireEvent.change(screen.getByLabelText('Instanz-ID', { selector: '#instance-id' }), {
+      target: { value: 'demo-existing' },
+    });
+    fireEvent.change(screen.getByLabelText('Anzeigename', { selector: '#instance-display-name' }), {
+      target: { value: 'Demo Existing' },
+    });
+    fireEvent.change(screen.getByLabelText('Parent-Domain', { selector: '#instance-parent-domain' }), {
+      target: { value: 'studio.example.org' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+
+    const authClientSecretInput = screen.getByLabelText('Tenant-Client-Secret', {
+      selector: '#instance-auth-client-secret',
+    }) as HTMLInputElement;
+    const tenantAdminSecretInput = screen.getByLabelText('Tenant-Admin-Client-Secret', {
+      selector: '#instance-tenant-admin-client-secret',
+    }) as HTMLInputElement;
+    expect(authClientSecretInput.disabled).toBe(false);
+    expect(tenantAdminSecretInput.disabled).toBe(false);
+    expect(
+      screen.getByText(
+        'Das Tenant-Client-Secret ist für bestehende Realms stark empfohlen, damit Status- und Drift-Prüfungen vollständig laufen.'
+      )
+    ).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Auth-Realm', { selector: '#instance-auth-realm' }), {
+      target: { value: 'tenant-existing' },
+    });
+    fireEvent.change(screen.getByLabelText('Auth-Client-ID', { selector: '#instance-auth-client-id' }), {
+      target: { value: 'tenant-client' },
+    });
+    fireEvent.change(authClientSecretInput, { target: { value: ' tenant-secret ' } });
+    fireEvent.change(screen.getByLabelText('Tenant-Admin-Client-ID', { selector: '#instance-tenant-admin-client-id' }), {
+      target: { value: ' tenant-admin-client ' },
+    });
+    fireEvent.change(tenantAdminSecretInput, { target: { value: ' tenant-admin-secret ' } });
+    fireEvent.change(screen.getByLabelText('Auth-Issuer-URL', { selector: '#instance-auth-issuer-url' }), {
+      target: { value: ' https://auth.example.org/realms/tenant-existing ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+
+    fireEvent.change(screen.getByLabelText('Admin-Benutzername', { selector: '#instance-admin-username' }), {
+      target: { value: ' tenant-admin ' },
+    });
+    fireEvent.change(screen.getByLabelText('Admin-E-Mail', { selector: '#instance-admin-email' }), {
+      target: { value: ' tenant-admin@example.org ' },
+    });
+    fireEvent.change(screen.getByLabelText('Admin-Vorname', { selector: '#instance-admin-first-name' }), {
+      target: { value: ' Tina ' },
+    });
+    fireEvent.change(screen.getByLabelText('Admin-Nachname', { selector: '#instance-admin-last-name' }), {
+      target: { value: ' Admin ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+
+    expect(screen.getByText('Bestehender Realm')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Instanz anlegen' }));
+
+    await waitFor(() => {
+      expect(createInstance).toHaveBeenCalledWith({
+        instanceId: 'demo-existing',
+        displayName: 'Demo Existing',
+        parentDomain: 'studio.example.org',
+        realmMode: 'existing',
+        authRealm: 'tenant-existing',
+        authClientId: 'tenant-client',
+        authIssuerUrl: 'https://auth.example.org/realms/tenant-existing',
+        authClientSecret: 'tenant-secret',
+        tenantAdminClient: {
+          clientId: 'tenant-admin-client',
+          secret: 'tenant-admin-secret',
+        },
+        tenantAdminBootstrap: {
+          username: 'tenant-admin',
+          email: 'tenant-admin@example.org',
+          firstName: 'Tina',
+          lastName: 'Admin',
+        },
       });
     });
   });

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-create-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-create-page.test.tsx
@@ -57,6 +57,18 @@ const createInstancesApiState = (overrides: Record<string, unknown> = {}) => ({
   clearSelectedInstance: vi.fn(),
   clearMutationError: vi.fn(),
   createInstance: vi.fn().mockResolvedValue(createCreatedInstance()),
+  bootstrapAdminStructure: vi.fn().mockResolvedValue({
+    instanceId: 'demo',
+    displayName: 'Demo',
+    status: 'requested',
+    parentDomain: 'studio.example.org',
+    primaryHostname: 'demo.studio.example.org',
+    hostnames: [],
+    provisioningRuns: [],
+    keycloakProvisioningRuns: [],
+    auditEvents: [],
+    assignedModules: [],
+  }),
   updateInstance: vi.fn().mockResolvedValue(true),
   refreshKeycloakStatus: vi.fn().mockResolvedValue(true),
   reconcileKeycloak: vi.fn().mockResolvedValue(true),
@@ -165,6 +177,57 @@ describe('InstanceCreatePage', () => {
     expect(screen.getByText('Die Instanz demo wurde in der Registry angelegt. Aktueller Status: Angefordert.')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Detailseite öffnen' }).getAttribute('href')).toBe('/admin/instances/demo');
     expect(screen.getByText('Führen Sie dort den Keycloak-Abgleich für Realm saas-demo aus.')).toBeTruthy();
+    expect(screen.getByText('Admin-Struktur')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' })).toBeTruthy();
+  });
+
+  it('runs the admin bootstrap step after a successful create', async () => {
+    const createInstance = vi.fn().mockResolvedValue(
+      createCreatedInstance({
+        instanceId: 'demo',
+        authRealm: 'saas-demo',
+      })
+    );
+    const bootstrapAdminStructure = vi.fn().mockResolvedValue({
+      instanceId: 'demo',
+      displayName: 'Demo',
+      status: 'requested',
+      parentDomain: 'studio.example.org',
+      primaryHostname: 'demo.studio.example.org',
+      hostnames: [],
+      provisioningRuns: [],
+      keycloakProvisioningRuns: [],
+      auditEvents: [],
+      assignedModules: [],
+    });
+    useInstancesMock.mockReturnValue(createInstancesApiState({ createInstance, bootstrapAdminStructure }));
+
+    render(<InstanceCreatePage />);
+
+    fireEvent.change(screen.getByLabelText('Instanz-ID', { selector: '#instance-id' }), { target: { value: 'demo' } });
+    fireEvent.change(screen.getByLabelText('Anzeigename', { selector: '#instance-display-name' }), {
+      target: { value: 'Demo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.change(screen.getByLabelText('Auth-Realm', { selector: '#instance-auth-realm' }), {
+      target: { value: 'saas-demo' },
+    });
+    fireEvent.change(screen.getByLabelText('Auth-Client-ID', { selector: '#instance-auth-client-id' }), {
+      target: { value: 'tenant-client' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Instanz anlegen' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Admin-Struktur jetzt anlegen' }));
+
+    await waitFor(() => {
+      expect(bootstrapAdminStructure).toHaveBeenCalledWith('demo', []);
+    });
   });
 
   it('shows step validation before moving on', () => {

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-create-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-create-page.tsx
@@ -9,6 +9,7 @@ import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
 import { useInstances } from '../../../hooks/use-instances';
 import { t } from '../../../i18n';
+import { studioModuleIamContracts } from '../../../lib/plugins';
 import { FieldHelp } from './-field-help';
 import {
   CREATE_WIZARD_STEPS,
@@ -27,6 +28,12 @@ import type { CreateFormValues, CreateWizardStepKey } from './-instances-shared-
 import type { IamInstanceListItem } from '@sva/core';
 
 const stepOrder = CREATE_WIZARD_STEPS.map((step) => step.key);
+const adminBootstrapModuleLabels = {
+  news: 'admin.instances.adminBootstrap.modules.news',
+  events: 'admin.instances.adminBootstrap.modules.events',
+  poi: 'admin.instances.adminBootstrap.modules.poi',
+  media: 'admin.instances.adminBootstrap.modules.media',
+} as const;
 
 const FormLabelWithHelp = ({
   htmlFor,
@@ -56,6 +63,8 @@ const ReviewRow = ({ label, value }: { label: string; value: string }) => (
 const getStepIndex = (step: CreateWizardStepKey) => stepOrder.indexOf(step);
 const getRealmModeLabel = (realmMode: 'new' | 'existing') =>
   realmMode === 'new' ? t('admin.instances.flow.realmModeNewLabel') : t('admin.instances.flow.realmModeExistingLabel');
+const getModuleLabel = (moduleId: keyof typeof adminBootstrapModuleLabels) =>
+  t(adminBootstrapModuleLabels[moduleId]);
 
 export const InstanceCreatePage = () => {
   const instancesApi = useInstances();
@@ -63,6 +72,9 @@ export const InstanceCreatePage = () => {
   const [currentStep, setCurrentStep] = React.useState<CreateWizardStepKey>('basics');
   const [stepErrors, setStepErrors] = React.useState<string[]>([]);
   const [createdInstance, setCreatedInstance] = React.useState<IamInstanceListItem | null>(null);
+  const [selectedModuleIds, setSelectedModuleIds] = React.useState<readonly string[]>([]);
+  const [isBootstrappingAdminStructure, setIsBootstrappingAdminStructure] = React.useState(false);
+  const [adminBootstrapCompleted, setAdminBootstrapCompleted] = React.useState(false);
   const [formValues, setFormValues] = React.useState(createEmptyCreateForm());
 
   React.useEffect(() => {
@@ -76,6 +88,8 @@ export const InstanceCreatePage = () => {
     setStepErrors([]);
     if (createdInstance) {
       setCreatedInstance(null);
+      setSelectedModuleIds([]);
+      setAdminBootstrapCompleted(false);
     }
   };
 
@@ -152,6 +166,34 @@ export const InstanceCreatePage = () => {
     }
 
     setCreatedInstance(created);
+    setAdminBootstrapCompleted(false);
+  };
+
+  const toggleModuleSelection = (moduleId: string) => {
+    setSelectedModuleIds((current) =>
+      current.includes(moduleId)
+        ? current.filter((value) => value !== moduleId)
+        : [...current, moduleId]
+    );
+  };
+
+  const onBootstrapAdminStructure = async () => {
+    if (!createdInstance) {
+      return;
+    }
+
+    setIsBootstrappingAdminStructure(true);
+    try {
+      const bootstrapped = await instancesApi.bootstrapAdminStructure(createdInstance.instanceId, selectedModuleIds);
+      if (!bootstrapped) {
+        return;
+      }
+
+      setCreatedInstance(bootstrapped);
+      setAdminBootstrapCompleted(true);
+    } finally {
+      setIsBootstrappingAdminStructure(false);
+    }
   };
 
   const readinessChecks = getCreateReadinessChecks(formValues);
@@ -205,6 +247,83 @@ export const InstanceCreatePage = () => {
           </AlertDescription>
         </Alert>
       ) : null}
+
+      <Card className="space-y-4 p-5">
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-foreground">{t('admin.instances.adminBootstrap.title')}</div>
+          <p className="text-sm text-muted-foreground">
+            {createdInstance
+              ? t('admin.instances.adminBootstrap.subtitleReady')
+              : t('admin.instances.adminBootstrap.subtitlePending')}
+          </p>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          {studioModuleIamContracts.map((module) => {
+            const checked = selectedModuleIds.includes(module.moduleId);
+
+            return (
+              <label
+                key={module.moduleId}
+                className={`flex items-start gap-3 rounded-lg border p-3 text-sm ${
+                  createdInstance ? 'border-border' : 'border-border/60 opacity-60'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={!createdInstance || isBootstrappingAdminStructure}
+                  onChange={() => toggleModuleSelection(module.moduleId)}
+                />
+                <span className="space-y-1">
+                  <span className="block font-medium text-foreground">
+                    {getModuleLabel(module.moduleId as keyof typeof adminBootstrapModuleLabels)}
+                  </span>
+                  <span className="block text-muted-foreground">
+                    {t('admin.instances.adminBootstrap.moduleHint', {
+                      value: module.permissionIds.join(', '),
+                    })}
+                  </span>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+
+        <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+          {t('admin.instances.adminBootstrap.conflictHint')}
+        </div>
+
+        {adminBootstrapCompleted ? (
+          <Alert>
+            <AlertDescription>{t('admin.instances.adminBootstrap.success')}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {instancesApi.mutationError && createdInstance ? (
+          <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+            <AlertDescription className="flex flex-col gap-3">
+              <span>{getErrorMessage(instancesApi.mutationError)}</span>
+              <IamRuntimeDiagnosticDetails error={instancesApi.mutationError} />
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            disabled={!createdInstance || isBootstrappingAdminStructure}
+            onClick={() => void onBootstrapAdminStructure()}
+          >
+            {t('admin.instances.adminBootstrap.action')}
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            {createdInstance
+              ? t('admin.instances.adminBootstrap.actionHintReady')
+              : t('admin.instances.adminBootstrap.actionHintPending')}
+          </p>
+        </div>
+      </Card>
 
       <Card className="space-y-5 p-4">
         <div className="grid gap-3 lg:grid-cols-4">

--- a/openspec/changes/add-instance-module-activation/design.md
+++ b/openspec/changes/add-instance-module-activation/design.md
@@ -9,7 +9,10 @@ Die neue Funktion fuehrt deshalb einen instanzbezogenen Modulvertrag ein. Dieser
 - Der Studio-Admin muss pro Instanz zentral und explizit steuern koennen, welche Module einer Instanz zugewiesen oder entzogen werden.
 - Instanz-Operatoren haben keine Moeglichkeit, diese Zuordnung selbst zu aendern.
 - Zuweisung seedet die noetige IAM-Basis fuer `Core + zugewiesene Module` in derselben Operation.
+- Der Instanz-Anlage-Flow muss einen harmonischen, aber technisch getrennten Abschnitt fuer den initialen Admin-Bootstrap anbieten.
+- Der initiale Admin-Bootstrap muss auch ohne Modulauswahl moeglich sein und dann mindestens `Admins` plus `Core Admin` anlegen.
 - Entzug entfernt modulbezogene Rechte hart und sperrt fachliche Nutzung fail-closed.
+- Modul-Sync darf Shared Roles wie `system_admin` oder `app_manager` nur in seinem eigenen Ownership-Bereich bereinigen; Core-Rechte bleiben unangetastet.
 - Das Instanz-Cockpit muss fehlende oder driftende IAM-Basis fuer zugewiesene Module sichtbar machen und dem Studio-Admin eine direkte Reparaturaktion anbieten.
 
 ## Non-Goals
@@ -75,6 +78,14 @@ Jedes Plugin, das modulbezogene Permissions oder Systemrollen in die IAM-Basis e
 
 Die Soll-Ableitung fuer `Core + zugewiesene Module` darf ausschliesslich auf diesem Vertrag und nicht auf impliziten Ableitungen aus Laufzeitdaten beruhen.
 
+### 4.2 Ownership fuer role_permissions
+
+Damit Shared Roles durch spaetere Modul-Mutationen nicht versehentlich ihre Core-Rechte verlieren, erhalten `iam.role_permissions` interne Ownership-Metadaten. Modul-Sync schreibt seine Grants mit `grant_origin_kind = module_sync` und dem zugehoerigen `grant_origin_module_id`. Bootstrap-Grants fuer `Core Admin` und modulbezogene Admin-Rollen werden als `bootstrap` markiert. Historische und Seed-Grants ohne spezielle Ownership gelten konservativ als `manual`.
+
+Cleanup bei `assignModule`, `revokeModule` und `seedIamBaseline` darf nur `module_sync`-Rows fuer die jeweils verwalteten Module entfernen. Ein generisches `DELETE` ueber alle `role_permissions` einer Shared Role ist unzulaessig, weil es Core-Rechte wie `content.read` oder `iam.role.read` mitloeschen wuerde.
+
+Fuer Bestandsinstanzen wird keine heuristische Rueckprojektion alter Modulgrants in SQL vorgenommen. Stattdessen bleibt der Datenbestand nach der Migration funktional konservativ, bis der vorhandene Reparaturpfad `IAM-Basis neu aufbauen` (`seedIamBaseline`) die Modulgrants ownership-korrekt neu schreibt.
+
 ### 5. Cockpit und Reparaturpfad
 
 Das Instanz-Cockpit zeigt einen expliziten Betriebsbefund `IAM-Basis zugewiesener Module` an. Dieser Befund ist fuer den Studio-Admin auf der Instanz-Detailseite sichtbar und wird aus dem Soll-Ist-Vergleich von:
@@ -93,7 +104,32 @@ Wenn der Sollstand fuer zugewiesene Module nicht erreicht ist, zeigt das Cockpit
 - einen Eintrag in der `Anomaly Queue`
 - eine direkte Reparaturaktion `Berechtigungen und Systemrollen neu seeden` (nur fuer den Studio-Admin sichtbar und ausfuehrbar)
 
-### 6. UI-Schnitt
+Nach Deployment der Ownership-Korrektur ist dieser Reparaturpfad fuer Bestandsinstanzen mit bereits synchronisierten Modulrechten der offizielle Weg, um alte modulbezogene Grants in den neuen Ownership-Zustand zu ueberfuehren.
+
+### 6. Initialer Admin-Bootstrap im Instanz-Flow
+
+Der Create-Flow erhaelt nach dem erfolgreichen Anlegen der Instanz einen eigenen sichtbaren Abschnitt fuer den initialen Admin-Bootstrap. Dieser Abschnitt folgt demselben Navigationsmuster wie die frueheren Abschnitte: sichtbar im Flow, aber erst nach erfolgreichem Create aktiv sinnvoll nutzbar.
+
+Der Abschnitt bietet:
+
+- eine optionale Modulauswahl, die die echte offizielle Instanz-Modulzuordnung beschreibt
+- einen Sammel-Button fuer die Initialisierung der Admin-Struktur
+- einen Warnhinweis fuer moegliche Namenskonflikte, wenn bestehende Rollen mit denselben Namen bereits vorhanden sind
+- einen Abschlussstatus, der erst nach mindestens einem erfolgreichen Bootstrap-Lauf erreicht wird
+
+Der Sammel-Button fuehrt mindestens folgende Schritte aus:
+
+1. Sicherstellen oder Anlegen der Gruppe `Admins`
+2. Erzeugen oder Ueberschreiben der Rolle `Core Admin` mit nur nicht-modulspezifischen Studio-/IAM-Basisrechten
+3. Optionales Zuweisen der ausgewaehlten Module zur Instanz
+4. Erzeugen oder Ueberschreiben sprechend benannter Modul-Admin-Rollen fuer die ausgewaehlten Module
+5. Verknuepfen der erzeugten Rollen mit der Gruppe `Admins`
+
+Wichtig ist die asymmetrische Fehlersemantik: Die Gesamtaktion wird aus Usersicht als ein Schritt angeboten, ist technisch aber nicht streng all-or-nothing. Wenn die Modulzuordnung bereits erfolgreich persistiert wurde, darf sie bestehen bleiben, auch wenn das Erzeugen oder Verknuepfen von Rollen und Gruppen spaeter im Ablauf fehlschlaegt. Dadurch bleibt die fachliche Modulaktivierung nachvollziehbar, waehrend der Admin-Bootstrap separat erneut versucht werden kann.
+
+Die so angelegten Rollen sind ausdruecklich keine unveraenderbaren Systemrollen. Sie bilden nur den kanonischen Startzustand und duerfen spaeter im IAM-UI weiter bearbeitet, umbenannt oder funktional durch neue Rollen ergaenzt werden.
+
+### 7. UI-Schnitt
 
 Die Modulverwaltung ist ein zentraler Bereich auf Studio-Root-Ebene, zugaenglich ausschliesslich fuer den Studio-Admin. Von dort werden Instanzen Module zugewiesen oder entzogen. Eine Selbststeuerung durch Instanz-Operatoren ist nicht vorgesehen.
 

--- a/openspec/changes/add-instance-module-activation/proposal.md
+++ b/openspec/changes/add-instance-module-activation/proposal.md
@@ -10,6 +10,7 @@ Fuer den Betrieb bedeutet das konkret, dass Instanzen wie `hb-meinquartier` eine
 
 - Einfuehrung einer kanonischen, persistenten Modulzuordnung `Instanz <-> Modul`
 - Neuer zentraler Admin-Bereich `Module` auf Studio-Root-Ebene, ueber den der Studio-Admin Instanzen explizit Module zuweist oder entzieht
+- Der Instanz-Anlage-Flow erhaelt nach erfolgreichem Create einen eigenen sichtbaren Abschnitt fuer den initialen Admin-Bootstrap der Instanz
 - Die Steuerung erfolgt ausschliesslich durch den Studio-Admin; Instanz-Operatoren koennen keine eigene Modul-Aktivierung oder -Deaktivierung ausloesen
 - Zuweisung eines Moduls zu einer Instanz wird zu einer atomaren Studio-Admin-Aktion:
   - Modul der Instanz zuordnen
@@ -20,6 +21,10 @@ Fuer den Betrieb bedeutet das konkret, dass Instanzen wie `hb-meinquartier` eine
   - modulbezogene Permissions hart entfernen
   - modulbezogene `role_permissions` und systemische Rollenerweiterungen hart entfernen
 - Modulbezogene IAM-Artefakte werden ueber einen kanonischen Plugin-Vertrag deklariert, damit die Soll-Ableitung fuer `Core + zugewiesene Module` deterministisch bleibt
+- Fuer den neuen Setup-Abschnitt wird eine editierbare Initialstruktur eingefuehrt:
+  - kanonische Gruppe `Admins` wird initial angelegt
+  - sprechend benannte Initialrollen fuer `Core` und optional ausgewaehlte Module werden erzeugt oder bei Namensgleichheit ueberschrieben
+  - die Initialrollen duerfen spaeter im IAM weiter bearbeitet werden
 - Fachliche Nutzung nicht zugewiesener Module wird fail-closed blockiert:
   - keine Modulrouten
   - keine Modulakektionen
@@ -27,6 +32,7 @@ Fuer den Betrieb bedeutet das konkret, dass Instanzen wie `hb-meinquartier` eine
   - keine modulbezogenen IAM-Freigaben
 - Das Instanz-Cockpit zeigt einen expliziten Befund fuer fehlende oder driftende IAM-Basis zugewiesener Module und bietet dem Studio-Admin eine direkte Reparaturaktion zum Neu-Seeden an
 - Bestehende Instanzen werden nicht implizit migriert; ihr Modulsatz ist nach Einfuehrung zunaechst leer und muss vom Studio-Admin explizit befuellt werden
+- Eine Instanz gilt im neuen Provisioning-Flow erst dann als fachlich `fertig`, wenn der initiale Admin-Bootstrap mindestens einmal erfolgreich ausgefuehrt wurde
 
 ## Impact
 

--- a/openspec/changes/add-instance-module-activation/specs/account-ui/spec.md
+++ b/openspec/changes/add-instance-module-activation/specs/account-ui/spec.md
@@ -57,3 +57,41 @@ Das System SHALL auf der Instanz-Detailseite einen expliziten Befund fuer die IA
 - **THEN** erklaert das Cockpit, dass fuer diese Instanz noch keine Module zugewiesen wurden
 - **AND** weist es darauf hin, dass die Zuweisung im zentralen Bereich `Module` erfolgt
 - **AND** wertet es den leeren Modulsatz nicht als Fehler, sondern als erwarteten Ausgangszustand
+
+### Requirement: Instanz-Anlage-Flow fuehrt einen gefuehrten Admin-Bootstrap-Abschnitt
+
+Das System SHALL im Instanz-Anlage-Flow einen eigenen Abschnitt fuer den initialen Admin-Bootstrap der neuen Instanz bereitstellen. Der Abschnitt muss sich harmonisch in den Happy Path einfuegen, aber Fehler aus Modulzuordnung, Rollenerzeugung und Gruppierung klar getrennt sichtbar machen.
+
+#### Scenario: Abschnitt zeigt Happy-Path-Bedienung mit genau einem Sammel-Button
+
+- **GIVEN** die Instanz wurde erfolgreich angelegt
+- **WHEN** der Studio-Admin den Bootstrap-Abschnitt oeffnet
+- **THEN** zeigt die UI eine optionale Modulauswahl
+- **AND** zeigt sie genau einen Sammel-Button zum Anlegen der Admin-Struktur
+- **AND** erklaert sie knapp, dass ohne Modulauswahl mindestens `Admins` und `Core Admin` angelegt werden
+
+#### Scenario: Abschnitt zeigt Warnhinweis fuer Namenskonflikte
+
+- **GIVEN** der Bootstrap-Abschnitt kann bestehende Rollen mit denselben Namen ueberschreiben
+- **WHEN** der Studio-Admin den Abschnitt betrachtet oder die Aktion vorbereitet
+- **THEN** weist die UI sichtbar darauf hin, dass gleichnamige bestehende Rollen ueberschrieben werden koennen
+- **AND** bleibt die Aktion trotzdem als Happy-Path-Sammelaktion verstaendlich
+
+### Requirement: Initiale Admin-Struktur wird mit editierbaren Rollen aufgebaut
+
+Das System SHALL ueber den Bootstrap-Abschnitt eine initiale Gruppe `Admins` sowie sprechend benannte Initialrollen fuer `Core` und optional ausgewaehlte Module anlegen. Diese Rollen sind Startartefakte und duerfen spaeter im IAM-UI bearbeitet werden.
+
+#### Scenario: Bootstrap ohne Module erzeugt editierbare Core-Struktur
+
+- **GIVEN** der Studio-Admin fuehrt den Bootstrap-Abschnitt ohne Modulauswahl aus
+- **WHEN** die Aktion erfolgreich abgeschlossen wird
+- **THEN** legt die UI-seitig beschriebene Mutation die Gruppe `Admins` und die Rolle `Core Admin` an
+- **AND** sind diese Artefakte spaeter im IAM-UI sichtbar und bearbeitbar
+
+#### Scenario: Bootstrap mit Modulen erzeugt sprechend benannte Modul-Admin-Rollen
+
+- **GIVEN** der Studio-Admin hat im Bootstrap-Abschnitt Module ausgewaehlt
+- **WHEN** die Aktion erfolgreich abgeschlossen wird
+- **THEN** erzeugt das System zusaetzlich pro ausgewaehltem Modul eine sprechend benannte Modul-Admin-Rolle
+- **AND** verknuepft es diese Rollen zusammen mit `Core Admin` mit der Gruppe `Admins`
+- **AND** bleiben die erzeugten Rollen spaeter im IAM-UI bearbeitbar

--- a/openspec/changes/add-instance-module-activation/specs/iam-access-control/spec.md
+++ b/openspec/changes/add-instance-module-activation/specs/iam-access-control/spec.md
@@ -67,6 +67,49 @@ Das System SHALL die Rekonstruktion der IAM-Basis einer Instanz deterministisch 
 - **AND** schlaegt die Operation nicht mit einem Fehler fehl
 - **AND** ist das Ergebnis identisch mit dem Ausgangszustand
 
+### Requirement: Initialer Admin-Bootstrap erzeugt editierbare Initialrollen und eine Gruppe `Admins`
+
+Das System SHALL fuer neu angelegte Instanzen einen Bootstrap-Pfad bereitstellen, der eine initiale Gruppe `Admins` sowie editierbare Initialrollen fuer `Core` und optional ausgewaehlte Module erzeugt. Diese Initialrollen sind nicht als unveraenderbare Systemrollen zu behandeln.
+
+#### Scenario: Bootstrap erzeugt Core Admin mit nur Core-Basisrechten
+
+- **GIVEN** der Studio-Admin fuehrt den initialen Bootstrap fuer eine neu angelegte Instanz aus
+- **WHEN** die Aktion erfolgreich abgeschlossen wird
+- **THEN** legt das System eine Rolle `Core Admin` mit nur nicht-modulspezifischen Studio-/IAM-Basisrechten an oder ueberschreibt sie
+- **AND** verknuepft es diese Rolle mit der Gruppe `Admins`
+- **AND** darf die Rolle spaeter im IAM bearbeitet werden
+
+#### Scenario: Bootstrap erzeugt pro ausgewaehltem Modul eine editierbare Modul-Admin-Rolle
+
+- **GIVEN** der Studio-Admin fuehrt den Bootstrap fuer eine neu angelegte Instanz mit ausgewaehlten Modulen aus
+- **WHEN** die Aktion erfolgreich abgeschlossen wird
+- **THEN** erzeugt oder ueberschreibt das System pro ausgewaehltem Modul eine sprechend benannte Modul-Admin-Rolle mit Vollzugriffsrechten fuer genau dieses Modul
+- **AND** verknuepft es diese Rolle mit der Gruppe `Admins`
+- **AND** behandelt es diese Rolle nicht als unveraenderbare Systemrolle
+
+### Requirement: Gleichnamige Initialrollen duerfen beim Bootstrap ueberschrieben werden
+
+Das System SHALL beim initialen Admin-Bootstrap bestehende gleichnamige Zielrollen ueberschreiben duerfen. Fuer abweichende Sonderbedarfe sollen Administratoren spaeter neue Rollen anlegen koennen, statt die Bootstrap-Konvention zu aendern.
+
+#### Scenario: Bootstrap ueberschreibt gleichnamige Initialrolle
+
+- **GIVEN** in der Zielinstanz existiert bereits eine Rolle mit demselben vorgesehenen Namen wie eine Bootstrap-Initialrolle
+- **WHEN** der Studio-Admin den Bootstrap erneut ausfuehrt
+- **THEN** darf das System diese gleichnamige Rolle ueberschreiben
+- **AND** bleibt das Namensschema des Bootstraps stabil
+- **AND** koennen Administratoren fuer abweichende Bedarfe zusaetzliche Rollen separat anlegen
+
+### Requirement: Modulentzug loescht erzeugte Initialrollen nicht automatisch
+
+Das System SHALL einmal durch den Bootstrap erzeugte Admin-Rollen bei einem spaeteren Modulentzug nicht automatisch loeschen, auch wenn ihre urspruengliche Modulreferenz fachlich entfaellt.
+
+#### Scenario: Modul wird entzogen, Rolle bleibt bestehen
+
+- **GIVEN** eine Modul-Admin-Rolle wurde durch den Bootstrap fuer ein Modul erzeugt
+- **WHEN** dieses Modul spaeter von der Instanz entzogen wird
+- **THEN** bleibt die einmal erzeugte Rolle als IAM-Artefakt bestehen
+- **AND** wird sie nicht automatisch geloescht
+
 ### Requirement: Audit-Events fuer Modulzuweisung, Modulentzug und Reseeding sind normativ definiert
 
 Das System SHALL fuer `instance-registry.assignModule`, `instance-registry.revokeModule` und `instance-registry.seedIamBaseline` Audit-Events mit einem normativen Mindestumfang schreiben. Das Audit-Event muss mindestens `instanceId`, `moduleId` falls modulbezogen, `actor.userId` als technische ID, `correlationId`, `before`, `after` und `outcome` enthalten. Personenbezogene Klardaten wie Name oder E-Mail duerfen nicht geloggt werden.

--- a/openspec/changes/add-instance-module-activation/specs/instance-provisioning/spec.md
+++ b/openspec/changes/add-instance-module-activation/specs/instance-provisioning/spec.md
@@ -32,6 +32,83 @@ Das System SHALL die Zuweisung eines Moduls zu einer Instanz als Studio-Admin-Mu
 - **AND** wird keine Modulzuordnung persistiert
 - **AND** wird kein IAM-Seeding ausgefuehrt
 
+### Requirement: Instanz-Anlage-Flow enthaelt einen sichtbaren Abschnitt fuer den initialen Admin-Bootstrap
+
+Das System SHALL im Instanz-Anlage-Flow nach erfolgreichem Instanz-Create einen eigenen sichtbaren Abschnitt fuer den initialen Admin-Bootstrap der Instanz bereitstellen. Der Abschnitt folgt dem Navigationsmodell der frueheren Flow-Abschnitte, ist aber erst nach erfolgreichem Create aktiv sinnvoll nutzbar.
+
+#### Scenario: Abschnitt wird erst nach erfolgreichem Create aktiv
+
+- **GIVEN** der Studio-Admin befindet sich im Instanz-Anlage-Flow
+- **WHEN** die Instanz noch nicht erfolgreich angelegt wurde
+- **THEN** ist der Abschnitt fuer den initialen Admin-Bootstrap sichtbar, aber noch nicht aktiv ausfuehrbar
+- **AND** bleibt die eigentliche Bootstrap-Aktion blockiert
+
+#### Scenario: Bootstrap-Abschnitt wird nach Create nutzbar
+
+- **GIVEN** die Instanz wurde erfolgreich angelegt
+- **WHEN** der Studio-Admin den naechsten Abschnitt des Flows aufruft
+- **THEN** kann er dort optional Module fuer die Instanz auswaehlen
+- **AND** kann er den initialen Admin-Bootstrap ueber genau einen Sammel-Button ausloesen
+
+### Requirement: Initialer Admin-Bootstrap funktioniert auch ohne Modulauswahl
+
+Das System SHALL den initialen Admin-Bootstrap auch dann zulaessen, wenn keine Module ausgewaehlt wurden. In diesem Fall muss mindestens die Core-bezogene Admin-Grundstruktur angelegt werden.
+
+#### Scenario: Bootstrap ohne Module
+
+- **GIVEN** eine Instanz wurde erfolgreich angelegt
+- **AND** der Studio-Admin hat im Bootstrap-Abschnitt keine Module ausgewaehlt
+- **WHEN** er den Sammel-Button ausloest
+- **THEN** legt das System mindestens die Gruppe `Admins` und die Rolle `Core Admin` an
+- **AND** ordnet es keine zusaetzlichen Module zu
+- **AND** gilt der Bootstrap-Lauf bei Erfolg als abgeschlossen
+
+### Requirement: Modulauswahl des Bootstrap-Abschnitts ist echte Instanzaktivierung
+
+Das System SHALL die Modulauswahl im Bootstrap-Abschnitt als echte offizielle Instanz-Modulzuordnung behandeln und nicht nur als Hilfsparameter fuer die Erzeugung initialer Rollen.
+
+#### Scenario: Ausgewaehlte Module werden der Instanz offiziell zugeordnet
+
+- **GIVEN** die Instanz wurde erfolgreich angelegt
+- **AND** der Studio-Admin waehlt im Bootstrap-Abschnitt ein oder mehrere Module aus
+- **WHEN** er den Sammel-Button ausloest
+- **THEN** werden diese Module der Instanz offiziell zugeordnet
+- **AND** sind sie nach erfolgreicher Zuordnung fachlich als aktiv behandelt
+- **AND** basiert die weitere Rollen- und Gruppeninitialisierung auf genau diesem offiziellen Modulsatz
+
+### Requirement: Instanz gilt erst nach erfolgreichem Bootstrap-Lauf als fertig
+
+Das System SHALL eine im neuen Flow angelegte Instanz erst dann als fachlich `fertig` behandeln, wenn der initiale Admin-Bootstrap mindestens einmal erfolgreich ausgefuehrt wurde.
+
+#### Scenario: Create allein macht die Instanz noch nicht fertig
+
+- **GIVEN** eine Instanz wurde erfolgreich angelegt
+- **AND** der Bootstrap-Abschnitt wurde noch nicht erfolgreich abgeschlossen
+- **WHEN** der Studio-Admin den Flow oder den Instanzstatus betrachtet
+- **THEN** behandelt das System die Instanz noch nicht als `fertig`
+- **AND** weist der Flow auf den noch ausstehenden Bootstrap-Schritt hin
+
+#### Scenario: Erfolgreicher Bootstrap markiert den Flow als fertig
+
+- **GIVEN** eine Instanz wurde erfolgreich angelegt
+- **WHEN** der Sammel-Button fuer den initialen Admin-Bootstrap mindestens einmal erfolgreich durchlaeuft
+- **THEN** behandelt das System die Instanz im neuen Flow als `fertig`
+- **AND** darf der Abschlussstatus unabhaengig davon erreicht werden, ob Module ausgewaehlt wurden oder nicht
+
+### Requirement: Bootstrap-Aktion darf bereits erfolgreiche Modulzuordnung bei Folgefehlern erhalten
+
+Das System SHALL die Bootstrap-Aktion aus Usersicht als einen zusammenhaengenden Schritt anbieten, darf aber bereits erfolgreich persistierte Modulzuordnungen bei spaeteren Fehlern im Rollen- oder Gruppenaufbau erhalten.
+
+#### Scenario: Modulzuordnung bleibt trotz nachgelagertem Rollenfehler bestehen
+
+- **GIVEN** eine Instanz wurde erfolgreich angelegt
+- **AND** der Studio-Admin hat im Bootstrap-Abschnitt Module ausgewaehlt
+- **WHEN** der Sammel-Button die Modulzuordnung erfolgreich persistiert
+- **AND** ein nachgelagerter Schritt beim Anlegen, Ueberschreiben oder Verknuepfen von Rollen und Gruppen fehlschlaegt
+- **THEN** duerfen die bereits erfolgreich zugeordneten Module bestehen bleiben
+- **AND** meldet das System den Bootstrap-Lauf insgesamt als unvollstaendig oder fehlgeschlagen zurueck
+- **AND** bietet es einen spaeteren erneuten Bootstrap-Versuch an
+
 #### Scenario: IAM-Seeding schlaegt waehrend Modulzuweisung fehl
 
 - **GIVEN** ein global bekanntes Modul ist einer Instanz noch nicht zugewiesen

--- a/openspec/changes/add-instance-module-activation/tasks.md
+++ b/openspec/changes/add-instance-module-activation/tasks.md
@@ -5,7 +5,8 @@
 - [x] 1.3 Berechtigungsvertrag fuer `instance-registry.assignModule`, `instance-registry.revokeModule` und `instance-registry.seedIamBaseline` als fully-qualified Actions mit Bindung an `studio.admin`-Rolle und `instanceId`-Scope spezifizieren; Confirmation-Anforderung fuer Entzug serverseitig absichern
 - [x] 1.4 Betroffene Capability-Deltas fuer Routing, `plugin-actions` sowie fachliche Host-/Integrationspfade (`content-management` und/oder `sva-mainserver-integration`) ergaenzen, damit fail-closed-Gating normativ vollstaendig ist
 - [x] 1.5 Rollout-, Bestandsinstanz- und Seed-Vertrag fuer initial leere Modulsaetze, lokale Fixtures und Testinstanzen spezifizieren
-- [x] 1.6 `openspec validate add-instance-module-activation --strict` ausfuehren
+- [x] 1.6 Initialen Admin-Bootstrap im Instanz-Create-Flow spezifizieren: sichtbarer Abschnitt, optionale Modulauswahl als echte Instanzzuordnung, Sammel-Button, Konflikthinweis und `fertig`-Kriterium
+- [x] 1.7 `openspec validate add-instance-module-activation --strict` ausfuehren
 
 ## 2. Canonical Module Contract and Persistence
 
@@ -21,6 +22,8 @@
 - [x] 3.3 Harte Entfernung modulbezogener Permissions, `role_permissions` und systemischer Rollenerweiterungen bei Entzug implementieren
 - [x] 3.4 Replay-, Parallelitaets- und Teilfehlerverhalten fuer Zuweisung, Entzug und Reseeding deterministisch absichern; Rollback bei Seeding-Fehler implementieren
 - [x] 3.5 Drift-Erkennung fuer fehlende Permissions, Systemrollen und `role_permissions` zugewiesener Module in einem konsistenten Diagnosemodell zusammenfuehren
+- [x] 3.6 Ownership-Metadaten fuer `iam.role_permissions` einfuehren (`manual`, `seed`, `bootstrap`, `module_sync`) und Modul-Cleanup auf moduleigene Grants begrenzen, damit Shared Roles ihre Core-Rechte behalten
+- [x] 3.7 Reparaturvertrag fuer Bestandsinstanzen festhalten: kein heuristischer SQL-Backfill fuer Modulownership; `seedIamBaseline` ist der offizielle Rebuild-Pfad nach Deployment
 
 ## 4. Runtime, Authorization and Integration Gating
 
@@ -29,6 +32,7 @@
 - [x] 4.3 Fachliche Content-, Mainserver- und weitere Integrationspfade nicht zugewiesener Module fail-closed blockieren
 - [x] 4.4 Modulspezifische Permission- und Rollenauflosung an den zugewiesenen Modulsatz koppeln, ohne Core-Rechte oder fremde Namespaces unbeabsichtigt zu beeinflussen
 - [x] 4.5 Negative und Integrations-Tests fuer nicht zugewiesene Module, geblockte Laufzeitnutzung, harte Rechteentfernung und Defense-in-Depth (Routing-Guard + IAM-Layer) ergaenzen
+- [x] 4.6 Nach erfolgreicher Modulmutation den Auth-/Permission-Sessionzustand aktualisieren, damit `assignedModules` und Plugin-Navigation ohne Neu-Login konsistent sind
 
 ## 5. UI and Studio-Admin Workflows
 

--- a/packages/auth-runtime/src/iam-instance-registry/core-mutations.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/core-mutations.ts
@@ -53,6 +53,11 @@ export const assignInstanceModuleMutation = (
   ctx: AuthenticatedRequestContext
 ): Promise<Response> => mutationHandlers.assignModule(request, ctx);
 
+export const bootstrapInstanceAdminStructureMutation = (
+  request: Request,
+  ctx: AuthenticatedRequestContext
+): Promise<Response> => mutationHandlers.bootstrapAdminStructure(request, ctx);
+
 export const revokeInstanceModuleMutation = (
   request: Request,
   ctx: AuthenticatedRequestContext

--- a/packages/auth-runtime/src/iam-instance-registry/core.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/core.ts
@@ -9,6 +9,7 @@ import type { AuthenticatedRequestContext } from '../middleware.js';
 import { ensurePlatformAccess, requireFreshReauth } from './http.js';
 import {
   assignInstanceModuleMutation,
+  bootstrapInstanceAdminStructureMutation,
   mapInstanceMutationError,
   mutateInstanceStatus,
   revokeInstanceModuleMutation,
@@ -74,6 +75,11 @@ export const assignInstanceModuleInternal = async (
   request: Request,
   ctx: AuthenticatedRequestContext
 ): Promise<Response> => assignInstanceModuleMutation(request, ctx);
+
+export const bootstrapInstanceAdminStructureInternal = async (
+  request: Request,
+  ctx: AuthenticatedRequestContext
+): Promise<Response> => bootstrapInstanceAdminStructureMutation(request, ctx);
 
 export const revokeInstanceModuleInternal = async (
   request: Request,

--- a/packages/auth-runtime/src/iam-instance-registry/server.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/server.ts
@@ -7,6 +7,7 @@ import {
   activateInstanceInternal,
   assignInstanceModuleInternal,
   archiveInstanceInternal,
+  bootstrapInstanceAdminStructureInternal,
   createInstanceInternal,
   getInstanceInternal,
   listInstancesInternal,
@@ -79,6 +80,8 @@ export const instanceRegistryHandlers = {
     withAuthenticatedRegistryHandler(request, activateInstanceInternal),
   assignInstanceModule: async (request: Request): Promise<Response> =>
     withAuthenticatedRegistryHandler(request, assignInstanceModuleInternal),
+  bootstrapInstanceAdminStructure: async (request: Request): Promise<Response> =>
+    withAuthenticatedRegistryHandler(request, bootstrapInstanceAdminStructureInternal),
   revokeInstanceModule: async (request: Request): Promise<Response> =>
     withAuthenticatedRegistryHandler(request, revokeInstanceModuleInternal),
   seedInstanceIamBaseline: async (request: Request): Promise<Response> =>

--- a/packages/auth-runtime/src/routes.ts
+++ b/packages/auth-runtime/src/routes.ts
@@ -39,6 +39,7 @@ export type AuthRoutePath =
   | '/api/v1/iam/instances/$instanceId/keycloak/reconcile'
   | '/api/v1/iam/instances/$instanceId/tenant-iam/access-probe'
   | '/api/v1/iam/instances/$instanceId/modules/assign'
+  | '/api/v1/iam/instances/$instanceId/modules/bootstrap-admin-structure'
   | '/api/v1/iam/instances/$instanceId/modules/revoke'
   | '/api/v1/iam/instances/$instanceId/modules/seed-iam-baseline'
   | '/api/v1/iam/instances/$instanceId/activate'
@@ -112,6 +113,7 @@ export const authRoutePaths = [
   '/api/v1/iam/instances/$instanceId/keycloak/reconcile',
   '/api/v1/iam/instances/$instanceId/tenant-iam/access-probe',
   '/api/v1/iam/instances/$instanceId/modules/assign',
+  '/api/v1/iam/instances/$instanceId/modules/bootstrap-admin-structure',
   '/api/v1/iam/instances/$instanceId/modules/revoke',
   '/api/v1/iam/instances/$instanceId/modules/seed-iam-baseline',
   '/api/v1/iam/instances/$instanceId/activate',

--- a/packages/core/src/instances/registry.ts
+++ b/packages/core/src/instances/registry.ts
@@ -78,7 +78,8 @@ export type InstanceAuditEvent = {
     | 'tenant_iam_access_probed'
     | 'instance_module_assigned'
     | 'instance_module_revoked'
-    | 'instance_module_iam_seeded';
+    | 'instance_module_iam_seeded'
+    | 'instance_admin_bootstrapped';
   readonly actorId?: string;
   readonly requestId?: string;
   readonly details: Readonly<Record<string, unknown>>;

--- a/packages/data-repositories/src/instance-registry/index.test.ts
+++ b/packages/data-repositories/src/instance-registry/index.test.ts
@@ -453,9 +453,76 @@ describe('instance registry repository', () => {
       })
     ).resolves.toBeUndefined();
 
-    expect(statements).toHaveLength(1);
-    expect(statements[0]?.text).toContain("permission_key LIKE 'news.%'");
-    expect(statements[0]?.text).not.toContain('permission_key NOT IN (');
+    expect(statements).toHaveLength(2);
+    expect(statements[0]?.text).toContain("role_permission.grant_origin_module_id IN ('news')");
+    expect(statements[1]?.text).toContain("permission_key LIKE 'news.%'");
+    expect(statements[1]?.text).not.toContain('permission_key NOT IN (');
+  });
+
+  it('tags module-synced role grants with ownership metadata and cleans up only module-owned rows', async () => {
+    const { executor, statements } = createQueuedExecutor([[]]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.syncAssignedModuleIam({
+        instanceId: 'tenant-a',
+        managedModuleIds: ['news', 'events'],
+        contracts: [
+          {
+            moduleId: 'news',
+            permissionIds: ['news.read'],
+            systemRoles: [{ roleName: 'system_admin', permissionIds: ['news.read'] }],
+          },
+        ],
+      })
+    ).resolves.toBeUndefined();
+
+    const rolePermissionInsert = statements.find((statement) => statement.text.includes('grant_origin_kind'));
+    expect(rolePermissionInsert?.text).toContain('grant_origin_kind');
+    expect(rolePermissionInsert?.text).toContain('grant_origin_module_id');
+    expect(rolePermissionInsert?.values).toEqual(['tenant-a', 'system_admin', 'news.read', 'module_sync', 'news']);
+
+    const rolePermissionCleanup = statements.find((statement) =>
+      statement.text.includes('DELETE FROM iam.role_permissions role_permission')
+    );
+    expect(rolePermissionCleanup?.text).toContain("role_permission.grant_origin_kind = 'module_sync'");
+    expect(rolePermissionCleanup?.text).toContain("role_permission.grant_origin_module_id IN ('news', 'events')");
+    expect(rolePermissionCleanup?.text).not.toContain('role.role_key IN');
+  });
+
+  it('tags bootstrap role grants with bootstrap ownership metadata', async () => {
+    const { executor, statements } = createQueuedExecutor([]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.syncInstanceAdminBootstrap({
+        instanceId: 'tenant-a',
+        groupKey: 'admins',
+        groupDisplayName: 'Admins',
+        coreRole: {
+          roleKey: 'core_admin',
+          displayName: 'Core Admin',
+          permissionKeys: ['content.read'],
+        },
+        moduleRoles: [
+          {
+            moduleId: 'news',
+            roleKey: 'news_admin',
+            displayName: 'News Admin',
+            permissionKeys: ['news.read'],
+          },
+        ],
+      })
+    ).resolves.toBeUndefined();
+
+    const rolePermissionInserts = statements.filter((statement) => statement.text.includes('grant_origin_kind'));
+    expect(rolePermissionInserts).toHaveLength(2);
+    for (const statement of rolePermissionInserts) {
+      expect(statement.text).toContain('grant_origin_kind');
+      expect(statement.text).toContain('grant_origin_module_id');
+      expect(statement.values.at(-2)).toBe('bootstrap');
+      expect(statement.values.at(-1)).toBeNull();
+    }
   });
 
   it('resolves hostname variants and returns null when they are missing', async () => {

--- a/packages/data-repositories/src/instance-registry/index.ts
+++ b/packages/data-repositories/src/instance-registry/index.ts
@@ -204,6 +204,16 @@ export type InstanceModuleIamContractRecord = {
   }[];
 };
 
+export type InstanceAdminBootstrapRoleRecord = {
+  readonly roleKey: string;
+  readonly displayName: string;
+  readonly permissionKeys: readonly string[];
+};
+
+export type InstanceAdminBootstrapModuleRoleRecord = InstanceAdminBootstrapRoleRecord & {
+  readonly moduleId: string;
+};
+
 export type InstanceRegistryRepository = {
   listInstances(input?: { search?: string; status?: InstanceStatus }): Promise<readonly InstanceRegistryRecord[]>;
   getInstanceById(instanceId: string): Promise<InstanceRegistryRecord | null>;
@@ -214,6 +224,13 @@ export type InstanceRegistryRepository = {
     instanceId: string;
     managedModuleIds: readonly string[];
     contracts: readonly InstanceModuleIamContractRecord[];
+  }): Promise<void>;
+  syncInstanceAdminBootstrap(input: {
+    instanceId: string;
+    groupKey: string;
+    groupDisplayName: string;
+    coreRole: InstanceAdminBootstrapRoleRecord;
+    moduleRoles: readonly InstanceAdminBootstrapModuleRoleRecord[];
   }): Promise<void>;
   getAuthClientSecretCiphertext(instanceId: string): Promise<string | null>;
   getTenantAdminClientSecretCiphertext(instanceId: string): Promise<string | null>;
@@ -542,6 +559,7 @@ WHERE instance_id = $1
     const rolePermissionPairs = contracts.flatMap((contract) =>
       contract.systemRoles.flatMap((role) =>
         role.permissionIds.map((permissionId) => ({
+          moduleId: contract.moduleId,
           roleName: role.roleName,
           permissionId,
         }))
@@ -642,11 +660,19 @@ SET
       await executor.execute(
         statement(
           `
-INSERT INTO iam.role_permissions (instance_id, role_id, permission_id)
+INSERT INTO iam.role_permissions (
+  instance_id,
+  role_id,
+  permission_id,
+  grant_origin_kind,
+  grant_origin_module_id
+)
 SELECT
   $1,
   role.id,
-  permission.id
+  permission.id,
+  $4,
+  $5
 FROM iam.roles role
 JOIN iam.permissions permission
   ON permission.instance_id = role.instance_id
@@ -655,16 +681,19 @@ WHERE role.instance_id = $1
   AND permission.permission_key = $3
 ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
 `,
-          [instanceId, pair.roleName, pair.permissionId]
+          [instanceId, pair.roleName, pair.permissionId, 'module_sync', pair.moduleId]
         )
       );
     }
 
-    if (managedRoleNames.length > 0) {
+    if (managedModuleIds.length > 0) {
       const desiredPairSql =
         rolePermissionPairs.length > 0
           ? rolePermissionPairs
-              .map((pair) => `(${quoteSqlLiteral(pair.roleName)}, ${quoteSqlLiteral(pair.permissionId)})`)
+              .map(
+                (pair) =>
+                  `(${quoteSqlLiteral(pair.moduleId)}, ${quoteSqlLiteral(pair.roleName)}, ${quoteSqlLiteral(pair.permissionId)})`
+              )
               .join(', ')
           : null;
 
@@ -678,10 +707,11 @@ WHERE role_permission.instance_id = $1
   AND role.id = role_permission.role_id
   AND permission.instance_id = role_permission.instance_id
   AND permission.id = role_permission.permission_id
-  AND role.role_key IN (${createTextList(managedRoleNames)})
+  AND role_permission.grant_origin_kind = 'module_sync'
+  AND role_permission.grant_origin_module_id IN (${createTextList(managedModuleIds)})
   ${
     desiredPairSql
-      ? `AND (role.role_key, permission.permission_key) NOT IN (${desiredPairSql})`
+      ? `AND (role_permission.grant_origin_module_id, role.role_key, permission.permission_key) NOT IN (${desiredPairSql})`
       : ''
   };
 `,
@@ -706,6 +736,200 @@ WHERE instance_id = $1
   AND (${managedPrefixConditions});
 `,
           [instanceId]
+        )
+      );
+    }
+  },
+
+  async syncInstanceAdminBootstrap({ instanceId, groupKey, groupDisplayName, coreRole, moduleRoles }) {
+    const roles = [coreRole, ...moduleRoles];
+    const permissionKeys = Array.from(new Set(roles.flatMap((role) => role.permissionKeys))).sort(compareAlphabetically);
+
+    await executor.execute(
+      statement(
+        `
+INSERT INTO iam.groups (
+  id,
+  instance_id,
+  group_key,
+  display_name,
+  description,
+  group_type,
+  is_active
+)
+VALUES (
+  gen_random_uuid(),
+  $1,
+  $2,
+  $3,
+  'Von Studio initial angelegte Admin-Gruppe',
+  'role_bundle',
+  TRUE
+)
+ON CONFLICT (instance_id, group_key) DO UPDATE
+SET
+  display_name = EXCLUDED.display_name,
+  description = EXCLUDED.description,
+  group_type = EXCLUDED.group_type,
+  is_active = TRUE,
+  updated_at = NOW();
+`,
+        [instanceId, groupKey, groupDisplayName]
+      )
+    );
+
+    for (const permissionKey of permissionKeys) {
+      await executor.execute(
+        statement(
+          `
+INSERT INTO iam.permissions (
+  id,
+  instance_id,
+  permission_key,
+  action,
+  resource_type,
+  resource_id,
+  effect,
+  scope,
+  description
+)
+VALUES (
+  gen_random_uuid(),
+  $1,
+  $2,
+  $2,
+  split_part($2, '.', 1),
+  NULL,
+  'allow',
+  '{}'::jsonb,
+  $3
+)
+ON CONFLICT (instance_id, permission_key) DO UPDATE
+SET
+  action = EXCLUDED.action,
+  resource_type = EXCLUDED.resource_type,
+  resource_id = EXCLUDED.resource_id,
+  effect = EXCLUDED.effect,
+  scope = EXCLUDED.scope,
+  description = EXCLUDED.description,
+  updated_at = NOW();
+`,
+          [instanceId, permissionKey, `Initiale Admin-Berechtigung ${permissionKey}`]
+        )
+      );
+    }
+
+    for (const role of roles) {
+      await executor.execute(
+        statement(
+          `
+INSERT INTO iam.roles (
+  id,
+  instance_id,
+  role_key,
+  role_name,
+  display_name,
+  external_role_name,
+  description,
+  is_system_role,
+  role_level,
+  managed_by,
+  sync_state,
+  last_synced_at,
+  last_error_code
+)
+VALUES (
+  gen_random_uuid(),
+  $1,
+  $2,
+  $2,
+  $3,
+  $3,
+  $4,
+  FALSE,
+  0,
+  'studio',
+  'pending',
+  NOW(),
+  NULL
+)
+ON CONFLICT (instance_id, role_key) DO UPDATE
+SET
+  role_name = EXCLUDED.role_name,
+  display_name = EXCLUDED.display_name,
+  external_role_name = EXCLUDED.external_role_name,
+  description = EXCLUDED.description,
+  is_system_role = FALSE,
+  updated_at = NOW();
+`,
+          [instanceId, role.roleKey, role.displayName, `Initiale Admin-Rolle ${role.displayName}`]
+        )
+      );
+
+      await executor.execute(
+        statement(
+          `
+DELETE FROM iam.role_permissions
+WHERE instance_id = $1
+  AND role_id = (
+    SELECT id
+    FROM iam.roles
+    WHERE instance_id = $1
+      AND role_key = $2
+    LIMIT 1
+  );
+`,
+          [instanceId, role.roleKey]
+        )
+      );
+
+      for (const permissionKey of role.permissionKeys) {
+        await executor.execute(
+          statement(
+            `
+INSERT INTO iam.role_permissions (
+  instance_id,
+  role_id,
+  permission_id,
+  grant_origin_kind,
+  grant_origin_module_id
+)
+SELECT
+  $1,
+  role.id,
+  permission.id,
+  $4,
+  $5
+FROM iam.roles role
+JOIN iam.permissions permission
+  ON permission.instance_id = role.instance_id
+WHERE role.instance_id = $1
+  AND role.role_key = $2
+  AND permission.permission_key = $3
+ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
+`,
+            [instanceId, role.roleKey, permissionKey, 'bootstrap', null]
+          )
+        );
+      }
+
+      await executor.execute(
+        statement(
+          `
+INSERT INTO iam.group_roles (instance_id, group_id, role_id)
+SELECT
+  $1,
+  iam_group.id,
+  role.id
+FROM iam.groups iam_group
+JOIN iam.roles role
+  ON role.instance_id = iam_group.instance_id
+WHERE iam_group.instance_id = $1
+  AND iam_group.group_key = $2
+  AND role.role_key = $3
+ON CONFLICT (instance_id, group_id, role_id) DO NOTHING;
+`,
+          [instanceId, groupKey, role.roleKey]
         )
       );
     }

--- a/packages/data/migrations/0038_iam_role_permission_ownership.sql
+++ b/packages/data/migrations/0038_iam_role_permission_ownership.sql
@@ -1,0 +1,55 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE iam.role_permissions
+  ADD COLUMN IF NOT EXISTS grant_origin_kind TEXT NOT NULL DEFAULT 'manual',
+  ADD COLUMN IF NOT EXISTS grant_origin_module_id TEXT;
+
+UPDATE iam.role_permissions
+SET
+  grant_origin_kind = COALESCE(NULLIF(grant_origin_kind, ''), 'manual'),
+  grant_origin_module_id = NULL
+WHERE grant_origin_kind IS NULL
+   OR grant_origin_kind = '';
+
+ALTER TABLE iam.role_permissions
+  DROP CONSTRAINT IF EXISTS role_permissions_grant_origin_kind_check;
+
+ALTER TABLE iam.role_permissions
+  ADD CONSTRAINT role_permissions_grant_origin_kind_check
+  CHECK (grant_origin_kind IN ('manual', 'seed', 'bootstrap', 'module_sync'));
+
+ALTER TABLE iam.role_permissions
+  DROP CONSTRAINT IF EXISTS role_permissions_grant_origin_module_check;
+
+ALTER TABLE iam.role_permissions
+  ADD CONSTRAINT role_permissions_grant_origin_module_check
+  CHECK (
+    (
+      grant_origin_kind = 'module_sync'
+      AND grant_origin_module_id IS NOT NULL
+      AND btrim(grant_origin_module_id) <> ''
+    )
+    OR (
+      grant_origin_kind <> 'module_sync'
+      AND grant_origin_module_id IS NULL
+    )
+  );
+
+CREATE INDEX IF NOT EXISTS idx_role_permissions_origin_module
+  ON iam.role_permissions(instance_id, grant_origin_kind, grant_origin_module_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS iam.idx_role_permissions_origin_module;
+
+ALTER TABLE iam.role_permissions
+  DROP CONSTRAINT IF EXISTS role_permissions_grant_origin_module_check;
+
+ALTER TABLE iam.role_permissions
+  DROP CONSTRAINT IF EXISTS role_permissions_grant_origin_kind_check;
+
+ALTER TABLE iam.role_permissions
+  DROP COLUMN IF EXISTS grant_origin_module_id,
+  DROP COLUMN IF EXISTS grant_origin_kind;
+-- +goose StatementEnd

--- a/packages/data/scripts/test-seeds.sh
+++ b/packages/data/scripts/test-seeds.sh
@@ -127,5 +127,7 @@ assert_count "SELECT COUNT(*) FROM iam.account_roles WHERE instance_id = 'de-mus
 assert_count "SELECT COUNT(*) FROM iam.account_organizations WHERE instance_id = 'de-musterhausen';" "10" "account organizations"
 assert_count "SELECT COUNT(*) FROM iam.account_organizations WHERE instance_id = 'de-musterhausen' AND is_default_context = true;" "7" "default organization contexts"
 assert_count "SELECT COUNT(*) FROM iam.role_permissions WHERE instance_id = 'de-musterhausen';" "105" "role permissions"
+assert_count "SELECT COUNT(*) FROM iam.role_permissions WHERE instance_id = 'de-musterhausen' AND grant_origin_kind = 'manual';" "105" "manual role permissions"
+assert_count "SELECT COUNT(*) FROM iam.role_permissions WHERE instance_id = 'de-musterhausen' AND grant_origin_module_id IS NOT NULL;" "0" "module-owned role permissions in seeds"
 
 echo "Seed idempotency integration test passed."

--- a/packages/instance-registry/src/http-contracts.test.ts
+++ b/packages/instance-registry/src/http-contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   assignModuleSchema,
+  bootstrapAdminStructureSchema,
   createInstanceSchema,
   revokeModuleSchema,
   readDetailInstanceId,
@@ -87,5 +88,11 @@ describe('http-contracts', () => {
     const result = seedIamBaselineSchema.safeParse({});
 
     expect(result.success).toBe(true);
+  });
+
+  it('accepts bootstrap payloads with optional module ids', () => {
+    expect(bootstrapAdminStructureSchema.safeParse({}).success).toBe(true);
+    expect(bootstrapAdminStructureSchema.safeParse({ moduleIds: ['news', 'events'] }).success).toBe(true);
+    expect(bootstrapAdminStructureSchema.safeParse({ moduleIds: [' ', 'news'] }).success).toBe(false);
   });
 });

--- a/packages/instance-registry/src/http-contracts.ts
+++ b/packages/instance-registry/src/http-contracts.ts
@@ -84,6 +84,10 @@ export const assignModuleSchema = z.object({
   moduleId: z.string().trim().min(1),
 });
 
+export const bootstrapAdminStructureSchema = z.object({
+  moduleIds: z.array(z.string().trim().min(1)).optional(),
+});
+
 export const revokeModuleSchema = z.object({
   moduleId: z.string().trim().min(1),
   confirmation: z.literal('REVOKE'),

--- a/packages/instance-registry/src/http-mutation-handlers.test.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.test.ts
@@ -42,6 +42,7 @@ const createDeps = (): InstanceRegistryMutationHttpDeps<TestContext> => ({
       reconcileKeycloak: vi.fn(async () => ({ realmExists: true })),
       executeKeycloakProvisioning: vi.fn(async () => ({ id: 'run-1' })),
       assignModule: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: ['news'] } })),
+      bootstrapAdminStructure: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: ['news'] } })),
       revokeModule: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: [] } })),
       seedIamBaseline: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: ['news'] } })),
       probeTenantIamAccess: vi.fn(async () => ({
@@ -244,6 +245,38 @@ describe('http mutation handlers', () => {
     });
   });
 
+  it('bootstrapAdminStructure passes selected module ids into the registry service', async () => {
+    const bootstrapAdminStructure = vi.fn(async () => ({
+      ok: true,
+      instance: { instanceId: 'inst-1', assignedModules: ['news'] },
+    }));
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleIds: ['news'] } });
+    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+      work({
+        bootstrapAdminStructure,
+      } as never)
+    );
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.bootstrapAdminStructure(
+      new Request('http://localhost/api/instances/inst-1/admin-bootstrap', { method: 'POST' }),
+      { userId: 'u-1' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(bootstrapAdminStructure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'inst-1',
+        moduleIds: ['news'],
+        idempotencyKey: 'idem-1',
+      })
+    );
+    await expect(readBody(response)).resolves.toMatchObject({
+      instanceId: 'inst-1',
+      assignedModules: ['news'],
+    });
+  });
+
   it('seedIamBaseline requires an existing instance', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: {} });
     vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
@@ -261,6 +294,25 @@ describe('http mutation handlers', () => {
 
     expect(response.status).toBe(404);
     expect(body.code).toBe('not_found');
+  });
+
+  it('bootstrapAdminStructure returns invalid_request for unknown modules', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleIds: ['unknown'] } });
+    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+      work({
+        bootstrapAdminStructure: vi.fn(async () => ({ ok: false, reason: 'unknown_module' })),
+      } as never)
+    );
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.bootstrapAdminStructure(
+      new Request('http://localhost/api/instances/inst-1/admin-bootstrap', { method: 'POST' }),
+      { userId: 'u-1' }
+    );
+    const body = await readBody(response);
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe('invalid_request');
   });
 
   it('mutateInstanceStatus rejects mismatched status payloads', async () => {

--- a/packages/instance-registry/src/http-mutation-handlers.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.ts
@@ -7,6 +7,7 @@ import {
 } from './http-mutation-actions.js';
 import {
   createAssignModuleHandler,
+  createBootstrapAdminStructureHandler,
   createMutateInstanceStatusHandler,
   createRevokeModuleHandler,
   createSeedIamBaselineHandler,
@@ -31,6 +32,7 @@ export const createInstanceRegistryMutationHttpHandlers = <TContext>(
     executeInstanceKeycloakProvisioning: createExecuteInstanceKeycloakProvisioningHandler(deps, mapMutationError),
     probeTenantIamAccess: createProbeTenantIamAccessHandler(deps, mapMutationError),
     assignModule: createAssignModuleHandler(deps),
+    bootstrapAdminStructure: createBootstrapAdminStructureHandler(deps),
     revokeModule: createRevokeModuleHandler(deps),
     seedIamBaseline: createSeedIamBaselineHandler(deps),
     mutateInstanceStatus: (

--- a/packages/instance-registry/src/http-mutation-module-actions.ts
+++ b/packages/instance-registry/src/http-mutation-module-actions.ts
@@ -1,6 +1,12 @@
 import type { InstanceStatus } from '@sva/core';
 
-import { assignModuleSchema, revokeModuleSchema, seedIamBaselineSchema, statusMutationSchema } from './http-contracts.js';
+import {
+  assignModuleSchema,
+  bootstrapAdminStructureSchema,
+  revokeModuleSchema,
+  seedIamBaselineSchema,
+  statusMutationSchema,
+} from './http-contracts.js';
 import type { InstanceRegistryMutationHttpDeps } from './http-mutation-shared.js';
 import {
   readInstanceIdOrError,
@@ -9,10 +15,12 @@ import {
 } from './http-mutation-shared.js';
 import {
   buildAssignInstanceModuleInput,
+  buildBootstrapAdminStructureInput,
   buildChangeInstanceStatusInput,
   buildRevokeInstanceModuleInput,
   buildSeedInstanceIamBaselineInput,
   type AssignInstanceModulePayload,
+  type BootstrapAdminStructurePayload,
   type RevokeInstanceModulePayload,
 } from './mutation-input-builders.js';
 
@@ -57,6 +65,52 @@ export const createAssignModuleHandler =
         return deps.createApiError(400, 'invalid_request', 'Unbekanntes Modul.', deps.getRequestId());
       }
       return deps.createApiError(409, 'conflict', 'Modul konnte nicht zugewiesen werden.', deps.getRequestId());
+    }
+
+    return deps.jsonResponse(200, deps.asApiItem(result.instance, deps.getRequestId()));
+  };
+
+export const createBootstrapAdminStructureHandler =
+  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>) =>
+  async (request: Request, ctx: TContext): Promise<Response> => {
+    const guardError = requireMutationGuards(deps, request, ctx);
+    if (guardError) {
+      return guardError;
+    }
+
+    const idempotencyKey = requireIdempotencyKeyOrError(deps, request);
+    if (idempotencyKey instanceof Response) {
+      return idempotencyKey;
+    }
+
+    const instanceId = readInstanceIdOrError(deps, request);
+    if (instanceId instanceof Response) {
+      return instanceId;
+    }
+
+    const payloadResult = await deps.parseRequestBody<BootstrapAdminStructurePayload>(request, bootstrapAdminStructureSchema);
+    if (!payloadResult.ok) {
+      return deps.createApiError(400, 'invalid_request', payloadResult.message, deps.getRequestId());
+    }
+
+    const result = await deps.withRegistryService((service) =>
+      service.bootstrapAdminStructure(
+        buildBootstrapAdminStructureInput(instanceId, payloadResult.data, {
+          idempotencyKey,
+          actorId: deps.getActor(ctx).id,
+          requestId: deps.getRequestId(),
+        })
+      )
+    );
+
+    if (!result.ok) {
+      if (result.reason === 'not_found') {
+        return deps.createApiError(404, 'not_found', 'Instanz wurde nicht gefunden.', deps.getRequestId());
+      }
+      if (result.reason === 'unknown_module') {
+        return deps.createApiError(400, 'invalid_request', 'Unbekanntes Modul.', deps.getRequestId());
+      }
+      return deps.createApiError(409, 'conflict', 'Admin-Struktur konnte nicht initialisiert werden.', deps.getRequestId());
     }
 
     return deps.jsonResponse(200, deps.asApiItem(result.instance, deps.getRequestId()));

--- a/packages/instance-registry/src/index.ts
+++ b/packages/instance-registry/src/index.ts
@@ -18,6 +18,7 @@ export type {
 } from './keycloak-types.js';
 export type {
   AssignInstanceModuleInput,
+  BootstrapAdminStructureInput,
   ChangeInstanceStatusInput,
   ChangeInstanceStatusResult,
   CreateInstanceProvisioningInput,
@@ -32,6 +33,7 @@ export type {
 } from './mutation-types.js';
 export {
   buildAssignInstanceModuleInput,
+  buildBootstrapAdminStructureInput,
   buildChangeInstanceStatusInput,
   buildCreateInstanceProvisioningInput,
   buildExecuteInstanceKeycloakProvisioningInput,
@@ -40,6 +42,7 @@ export {
   buildSeedInstanceIamBaselineInput,
   buildUpdateInstanceInput,
   type AssignInstanceModulePayload,
+  type BootstrapAdminStructurePayload,
   type CreateInstancePayload,
   type ExecuteKeycloakProvisioningPayload,
   type RevokeInstanceModulePayload,

--- a/packages/instance-registry/src/mutation-input-builders.test.ts
+++ b/packages/instance-registry/src/mutation-input-builders.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildAssignInstanceModuleInput,
+  buildBootstrapAdminStructureInput,
   buildChangeInstanceStatusInput,
   buildCreateInstanceProvisioningInput,
   buildExecuteInstanceKeycloakProvisioningInput,
@@ -135,5 +136,19 @@ describe('mutation-input-builders', () => {
         actorId: 'user-1',
         requestId: 'req-8',
       });
+
+    expect(
+      buildBootstrapAdminStructureInput(
+        'demo',
+        { moduleIds: ['news', 'events'] },
+        { idempotencyKey: 'idem-9', actorId: 'user-1', requestId: 'req-9' }
+      )
+    ).toEqual({
+      idempotencyKey: 'idem-9',
+      instanceId: 'demo',
+      moduleIds: ['news', 'events'],
+      actorId: 'user-1',
+      requestId: 'req-9',
+    });
   });
 });

--- a/packages/instance-registry/src/mutation-input-builders.ts
+++ b/packages/instance-registry/src/mutation-input-builders.ts
@@ -2,6 +2,7 @@ import type { IamInstanceKeycloakProvisioningRun, InstanceRealmMode, InstanceSta
 
 import type {
   AssignInstanceModuleInput,
+  BootstrapAdminStructureInput,
   ChangeInstanceStatusInput,
   CreateInstanceProvisioningInput,
   ExecuteInstanceKeycloakProvisioningInput,
@@ -70,6 +71,10 @@ export type AssignInstanceModulePayload = {
 export type RevokeInstanceModulePayload = {
   readonly moduleId: string;
   readonly confirmation: 'REVOKE';
+};
+
+export type BootstrapAdminStructurePayload = {
+  readonly moduleIds?: readonly string[];
 };
 
 export const buildCreateInstanceProvisioningInput = (
@@ -195,6 +200,18 @@ export const buildSeedInstanceIamBaselineInput = (
 ): SeedInstanceIamBaselineInput => ({
   idempotencyKey: context.idempotencyKey,
   instanceId,
+  actorId: context.actorId,
+  requestId: context.requestId,
+});
+
+export const buildBootstrapAdminStructureInput = (
+  instanceId: string,
+  payload: BootstrapAdminStructurePayload,
+  context: IdempotentInstanceMutationContext
+): BootstrapAdminStructureInput => ({
+  idempotencyKey: context.idempotencyKey,
+  instanceId,
+  moduleIds: payload.moduleIds ?? [],
   actorId: context.actorId,
   requestId: context.requestId,
 });

--- a/packages/instance-registry/src/mutation-types.ts
+++ b/packages/instance-registry/src/mutation-types.ts
@@ -99,6 +99,12 @@ export type SeedInstanceIamBaselineInput = InstanceRegistryMutationActor & {
   readonly instanceId: string;
 };
 
+export type BootstrapAdminStructureInput = InstanceRegistryMutationActor & {
+  readonly idempotencyKey: string;
+  readonly instanceId: string;
+  readonly moduleIds: readonly string[];
+};
+
 export type CreateInstanceProvisioningResult =
   | { readonly ok: true; readonly instance: IamInstanceListItem }
   | { readonly ok: false; readonly reason: 'already_exists' };

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -149,24 +149,33 @@ export const createBootstrapAdminStructureHandler =
       contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
     });
 
-    await deps.repository.syncInstanceAdminBootstrap({
-      instanceId: input.instanceId,
-      groupKey: ADMIN_GROUP_KEY,
-      groupDisplayName: ADMIN_GROUP_DISPLAY_NAME,
-      coreRole: {
-        roleKey: CORE_ADMIN_ROLE_KEY,
-        displayName: CORE_ADMIN_ROLE_DISPLAY_NAME,
-        permissionKeys: [...CORE_ADMIN_PERMISSION_KEYS],
-      },
-      moduleRoles: requestedModuleIds.map((moduleId) => ({
-        moduleId,
-        roleKey: toModuleAdminRoleKey(moduleId),
-        displayName: toModuleAdminRoleDisplayName(moduleId),
-        permissionKeys: [...(registry.get(moduleId)?.permissionIds ?? [])],
-      })),
-    });
+    let bootstrapCompleted = false;
+    try {
+      await deps.repository.syncInstanceAdminBootstrap({
+        instanceId: input.instanceId,
+        groupKey: ADMIN_GROUP_KEY,
+        groupDisplayName: ADMIN_GROUP_DISPLAY_NAME,
+        coreRole: {
+          roleKey: CORE_ADMIN_ROLE_KEY,
+          displayName: CORE_ADMIN_ROLE_DISPLAY_NAME,
+          permissionKeys: [...CORE_ADMIN_PERMISSION_KEYS],
+        },
+        moduleRoles: requestedModuleIds.map((moduleId) => ({
+          moduleId,
+          roleKey: toModuleAdminRoleKey(moduleId),
+          displayName: toModuleAdminRoleDisplayName(moduleId),
+          permissionKeys: [...(registry.get(moduleId)?.permissionIds ?? [])],
+        })),
+      });
+      bootstrapCompleted = true;
+    } finally {
+      await invalidateInstancePermissionSnapshots(
+        deps,
+        input.instanceId,
+        bootstrapCompleted ? 'instance_admin_bootstrapped' : 'instance_module_assigned'
+      );
+    }
 
-    await invalidateInstancePermissionSnapshots(deps, input.instanceId, 'instance_admin_bootstrapped');
     await deps.repository.appendAuditEvent({
       instanceId: input.instanceId,
       eventType: 'instance_admin_bootstrapped',

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -6,6 +6,43 @@ import {
 } from './service-shared.js';
 import type { InstanceRegistryService, InstanceRegistryServiceDeps } from './service-types.js';
 
+const ADMIN_GROUP_KEY = 'admins';
+const ADMIN_GROUP_DISPLAY_NAME = 'Admins';
+const CORE_ADMIN_ROLE_KEY = 'core_admin';
+const CORE_ADMIN_ROLE_DISPLAY_NAME = 'Core Admin';
+const CORE_ADMIN_PERMISSION_KEYS = [
+  'iam.user.read',
+  'iam.user.write',
+  'iam.role.read',
+  'iam.role.write',
+  'iam.org.read',
+  'iam.org.write',
+  'content.read',
+  'content.create',
+  'content.updateMetadata',
+  'content.publish',
+  'content.manageRevisions',
+  'integration.manage',
+  'feature.toggle',
+  'instance.registry.manage',
+  'content.updatePayload',
+  'content.changeStatus',
+  'content.archive',
+  'content.restore',
+  'content.readHistory',
+  'content.delete',
+] as const;
+
+const toTitleCase = (value: string) =>
+  value
+    .split(/[_-]+/u)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment.slice(0, 1).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+const toModuleAdminRoleKey = (moduleId: string) => `${moduleId}_admin`;
+const toModuleAdminRoleDisplayName = (moduleId: string) => `${toTitleCase(moduleId)} Admin`;
+
 const createModuleAssignRollbackError = (
   instanceId: string,
   moduleId: string,
@@ -73,6 +110,74 @@ export const createAssignModuleHandler =
         moduleId: input.moduleId,
         assignedModules: assignedModuleIds,
         outcome: 'assigned',
+      },
+    });
+
+    const detail = await createGetInstanceDetail(deps)(input.instanceId);
+    return detail ? { ok: true, instance: detail } : { ok: false, reason: 'not_found' };
+  };
+
+export const createBootstrapAdminStructureHandler =
+  (deps: InstanceRegistryServiceDeps): InstanceRegistryService['bootstrapAdminStructure'] =>
+  async (input) => {
+    const instance = await deps.repository.getInstanceById(input.instanceId);
+    if (!instance) {
+      return { ok: false, reason: 'not_found' };
+    }
+
+    const registry = requireModuleIamRegistry(deps);
+    const requestedModuleIds = Array.from(new Set(input.moduleIds.map((moduleId) => moduleId.trim()).filter(Boolean))).sort();
+
+    if (requestedModuleIds.some((moduleId) => !registry.has(moduleId))) {
+      return { ok: false, reason: 'unknown_module' };
+    }
+
+    const currentAssignedModuleIds = new Set(await deps.repository.listAssignedModules(input.instanceId));
+    for (const moduleId of requestedModuleIds) {
+      if (!currentAssignedModuleIds.has(moduleId)) {
+        const inserted = await deps.repository.assignModule(input.instanceId, moduleId);
+        if (!inserted) {
+          return { ok: false, reason: 'conflict' };
+        }
+      }
+    }
+
+    const assignedModuleIds = await deps.repository.listAssignedModules(input.instanceId);
+    await deps.repository.syncAssignedModuleIam({
+      instanceId: input.instanceId,
+      managedModuleIds: [...registry.keys()],
+      contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
+    });
+
+    await deps.repository.syncInstanceAdminBootstrap({
+      instanceId: input.instanceId,
+      groupKey: ADMIN_GROUP_KEY,
+      groupDisplayName: ADMIN_GROUP_DISPLAY_NAME,
+      coreRole: {
+        roleKey: CORE_ADMIN_ROLE_KEY,
+        displayName: CORE_ADMIN_ROLE_DISPLAY_NAME,
+        permissionKeys: [...CORE_ADMIN_PERMISSION_KEYS],
+      },
+      moduleRoles: requestedModuleIds.map((moduleId) => ({
+        moduleId,
+        roleKey: toModuleAdminRoleKey(moduleId),
+        displayName: toModuleAdminRoleDisplayName(moduleId),
+        permissionKeys: [...(registry.get(moduleId)?.permissionIds ?? [])],
+      })),
+    });
+
+    await invalidateInstancePermissionSnapshots(deps, input.instanceId, 'instance_admin_bootstrapped');
+    await deps.repository.appendAuditEvent({
+      instanceId: input.instanceId,
+      eventType: 'instance_admin_bootstrapped',
+      actorId: input.actorId,
+      requestId: input.requestId,
+      details: {
+        assignedModules: assignedModuleIds,
+        selectedModuleIds: requestedModuleIds,
+        groupKey: ADMIN_GROUP_KEY,
+        coreRoleKey: CORE_ADMIN_ROLE_KEY,
+        outcome: 'bootstrapped',
       },
     });
 

--- a/packages/instance-registry/src/service-types.ts
+++ b/packages/instance-registry/src/service-types.ts
@@ -9,6 +9,7 @@ import type {
 import type { InstanceRegistryRepository } from '@sva/data-repositories';
 import type {
   AssignInstanceModuleInput,
+  BootstrapAdminStructureInput,
   ChangeInstanceStatusInput,
   ChangeInstanceStatusResult,
   CreateInstanceProvisioningInput,
@@ -66,6 +67,7 @@ export type InstanceRegistryService = {
   planKeycloakProvisioning(instanceId: string): Promise<KeycloakTenantPlan | null>;
   executeKeycloakProvisioning(input: ExecuteInstanceKeycloakProvisioningInput): Promise<KeycloakTenantProvisioningRun | null>;
   assignModule(input: AssignInstanceModuleInput): Promise<InstanceModuleMutationResult>;
+  bootstrapAdminStructure(input: BootstrapAdminStructureInput): Promise<InstanceModuleMutationResult>;
   revokeModule(input: RevokeInstanceModuleInput): Promise<InstanceModuleMutationResult>;
   seedIamBaseline(input: SeedInstanceIamBaselineInput): Promise<InstanceModuleMutationResult>;
   probeTenantIamAccess(input: {

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -50,6 +50,7 @@ const createRepository = (overrides: Partial<InstanceRegistryRepository> = {}): 
     assignModule: vi.fn(async () => true),
     revokeModule: vi.fn(async () => true),
     syncAssignedModuleIam: vi.fn(async () => undefined),
+    syncInstanceAdminBootstrap: vi.fn(async () => undefined),
     getAuthClientSecretCiphertext: vi.fn(async () => 'auth-cipher'),
     getTenantAdminClientSecretCiphertext: vi.fn(async () => 'tenant-admin-cipher'),
     resolveHostname: vi.fn(async () => baseInstance),
@@ -550,6 +551,109 @@ describe('instance registry service facade', () => {
           moduleId: 'events',
           outcome: 'assigned',
         }),
+      })
+    );
+  });
+
+  it('bootstraps the editable admin structure and assigns selected modules first', async () => {
+    const repository = createRepository({
+      assignModule: vi.fn(async () => true),
+      listAssignedModules: vi.fn().mockResolvedValueOnce(['news']).mockResolvedValueOnce(['news', 'events']),
+      syncInstanceAdminBootstrap: vi.fn(async () => undefined),
+      getInstanceById: vi
+        .fn()
+        .mockResolvedValueOnce(baseInstance)
+        .mockResolvedValueOnce({ ...baseInstance, assignedModules: ['news', 'events'] }),
+    });
+    const service = createInstanceRegistryService(createDeps(repository));
+
+    await expect(
+      service.bootstrapAdminStructure({
+        instanceId: 'demo',
+        moduleIds: ['news', 'events'],
+        idempotencyKey: 'idem-bootstrap-1',
+        actorId: 'actor-1',
+        requestId: 'req-bootstrap-1',
+      })
+    ).resolves.toEqual({
+      ok: true,
+      instance: expect.objectContaining({
+        assignedModules: ['news', 'events'],
+      }),
+    });
+
+    expect(repository.assignModule).toHaveBeenCalledTimes(1);
+    expect(repository.assignModule).toHaveBeenCalledWith('demo', 'events');
+    expect(repository.syncAssignedModuleIam).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'demo',
+        managedModuleIds: ['news', 'events'],
+      })
+    );
+    expect(repository.syncInstanceAdminBootstrap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'demo',
+        groupKey: 'admins',
+        groupDisplayName: 'Admins',
+        coreRole: expect.objectContaining({
+          roleKey: 'core_admin',
+          displayName: 'Core Admin',
+          permissionKeys: expect.arrayContaining(['instance.registry.manage']),
+        }),
+        moduleRoles: expect.arrayContaining([
+          expect.objectContaining({
+            moduleId: 'news',
+            roleKey: 'news_admin',
+            displayName: 'News Admin',
+            permissionKeys: ['news.read', 'news.create', 'news.update', 'news.delete'],
+          }),
+          expect.objectContaining({
+            moduleId: 'events',
+            roleKey: 'events_admin',
+            displayName: 'Events Admin',
+            permissionKeys: ['events.read'],
+          }),
+        ]),
+      })
+    );
+    expect(repository.appendAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'instance_admin_bootstrapped',
+        details: expect.objectContaining({
+          assignedModules: ['news', 'events'],
+          groupKey: 'admins',
+        }),
+      })
+    );
+  });
+
+  it('keeps successfully assigned modules when admin bootstrap role sync fails', async () => {
+    const repository = createRepository({
+      assignModule: vi.fn(async () => true),
+      listAssignedModules: vi.fn(async () => ['news']),
+      syncInstanceAdminBootstrap: vi.fn(async () => {
+        throw new Error('admin_bootstrap_failed');
+      }),
+      getInstanceById: vi.fn(async () => baseInstance),
+    });
+    const service = createInstanceRegistryService(createDeps(repository));
+
+    await expect(
+      service.bootstrapAdminStructure({
+        instanceId: 'demo',
+        moduleIds: ['news'],
+        idempotencyKey: 'idem-bootstrap-2',
+        actorId: 'actor-1',
+        requestId: 'req-bootstrap-2',
+      })
+    ).rejects.toThrow('admin_bootstrap_failed');
+
+    expect(repository.assignModule).not.toHaveBeenCalled();
+    expect(repository.revokeModule).not.toHaveBeenCalled();
+    expect(repository.syncAssignedModuleIam).toHaveBeenCalled();
+    expect(repository.appendAuditEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'instance_admin_bootstrapped',
       })
     );
   });

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -636,7 +636,8 @@ describe('instance registry service facade', () => {
       }),
       getInstanceById: vi.fn(async () => baseInstance),
     });
-    const service = createInstanceRegistryService(createDeps(repository));
+    const deps = createDeps(repository);
+    const service = createInstanceRegistryService(deps);
 
     await expect(
       service.bootstrapAdminStructure({
@@ -651,6 +652,10 @@ describe('instance registry service facade', () => {
     expect(repository.assignModule).not.toHaveBeenCalled();
     expect(repository.revokeModule).not.toHaveBeenCalled();
     expect(repository.syncAssignedModuleIam).toHaveBeenCalled();
+    expect(deps.invalidatePermissionSnapshots).toHaveBeenCalledWith({
+      instanceId: 'demo',
+      trigger: 'instance_module_assigned',
+    });
     expect(repository.appendAuditEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({
         eventType: 'instance_admin_bootstrapped',

--- a/packages/instance-registry/src/service.ts
+++ b/packages/instance-registry/src/service.ts
@@ -18,6 +18,7 @@ import {
 import { createListInstances } from './service-list.js';
 import {
   createAssignModuleHandler,
+  createBootstrapAdminStructureHandler,
   createRevokeModuleHandler,
   createSeedIamBaselineHandler,
 } from './service-module-mutations.js';
@@ -34,6 +35,7 @@ export const createInstanceRegistryService = (deps: InstanceRegistryServiceDeps)
   planKeycloakProvisioning: createPlanKeycloakProvisioningHandler(deps),
   executeKeycloakProvisioning: createExecuteKeycloakProvisioningHandler(deps),
   assignModule: createAssignModuleHandler(deps),
+  bootstrapAdminStructure: createBootstrapAdminStructureHandler(deps),
   revokeModule: createRevokeModuleHandler(deps),
   seedIamBaseline: createSeedIamBaselineHandler(deps),
   probeTenantIamAccess: createProbeTenantIamAccessHandler(deps),

--- a/packages/routing/src/auth.routes.server.test.ts
+++ b/packages/routing/src/auth.routes.server.test.ts
@@ -122,6 +122,7 @@ const authServerMocks = vi.hoisted(() => {
       reconcileInstanceKeycloak: vi.fn(async () => response('reconcileInstanceKeycloakHandler')),
       probeTenantIamAccess: vi.fn(async () => response('probeTenantIamAccessHandler')),
       assignInstanceModule: vi.fn(async () => response('assignInstanceModuleHandler')),
+      bootstrapInstanceAdminStructure: vi.fn(async () => response('bootstrapInstanceAdminStructureHandler')),
       revokeInstanceModule: vi.fn(async () => response('revokeInstanceModuleHandler')),
       seedInstanceIamBaseline: vi.fn(async () => response('seedInstanceIamBaselineHandler')),
       activateInstance: vi.fn(async () => response('activateInstanceHandler')),
@@ -314,6 +315,7 @@ describe('auth.routes.server', () => {
     expect(authServerMocks.instanceRegistryHandlers.reconcileInstanceKeycloak).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.probeTenantIamAccess).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.assignInstanceModule).toHaveBeenCalled();
+    expect(authServerMocks.instanceRegistryHandlers.bootstrapInstanceAdminStructure).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.revokeInstanceModule).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.seedInstanceIamBaseline).toHaveBeenCalled();
     expect(authServerMocks.listLegalTextsHandler).toHaveBeenCalled();

--- a/packages/routing/src/auth.routes.server.ts
+++ b/packages/routing/src/auth.routes.server.ts
@@ -461,6 +461,11 @@ const authHandlerMap = {
       return authRuntimeRoutes.instanceRegistryHandlers.assignInstanceModule(ctx.request);
     },
   },
+  '/api/v1/iam/instances/$instanceId/modules/bootstrap-admin-structure': {
+    POST: async (ctx: { request: Request }) => {
+      return authRuntimeRoutes.instanceRegistryHandlers.bootstrapInstanceAdminStructure(ctx.request);
+    },
+  },
   '/api/v1/iam/instances/$instanceId/modules/revoke': {
     POST: async (ctx: { request: Request }) => {
       return authRuntimeRoutes.instanceRegistryHandlers.revokeInstanceModule(ctx.request);


### PR DESCRIPTION
## Zusammenfassung
- erweitert die Instanz-Modulaktivierung um Admin-Bootstrap- und Aktivierungsfluesse im Backend und Frontend
- fuehrt Ownership-Metadaten fuer `iam.role_permissions` ein, damit modulverwaltete Grants Shared Roles wie `system_admin` nicht mehr von Core-Rechten befreien
- invalidiert nach Modulmutationen den Auth-/Permission-Zustand, damit `assignedModules` und Plugin-Menues ohne Neu-Login aktualisiert werden
- aktualisiert OpenSpec, HTTP-Vertraege und Tests fuer den laufenden Change `add-instance-module-activation`

## Tests
- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main`
- `pnpm nx run data:db:test:seeds`
- `pnpm nx run sva-studio-react:typecheck`
