### PR TITLE
[codex] Publish current workspace changes

### DIFF
--- a/apps/sva-studio-react/src/hooks/use-instances.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-instances.test.tsx
@@ -32,6 +32,16 @@ const authMockValue = {
   invalidatePermissions: vi.fn(),
 };
 
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+};
+
 vi.mock('../lib/iam-api', () => ({
   IamHttpError: class IamHttpError extends Error {
     status: number;
@@ -468,6 +478,39 @@ describe('useInstances', () => {
     expect(authMockValue.invalidatePermissions).toHaveBeenCalled();
   });
 
+  it('invalidates permissions only once when detail and keycloak status both return forbidden', async () => {
+    getInstanceMock.mockRejectedValueOnce({
+      status: 403,
+      code: 'forbidden',
+      message: 'forbidden',
+    });
+    getInstanceKeycloakStatusMock.mockRejectedValueOnce({
+      status: 403,
+      code: 'forbidden',
+      message: 'forbidden',
+    });
+
+    const { result } = renderHook(() => useInstances());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.loadInstance('demo');
+    });
+
+    expect(result.current.mutationError).toEqual(expect.objectContaining({ status: 403, code: 'forbidden' }));
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+    expect(browserLoggerMock.info).toHaveBeenCalledTimes(1);
+    expect(browserLoggerMock.info).toHaveBeenCalledWith(
+      'permission_invalidated_after_403',
+      expect.objectContaining({
+        instance_id: 'demo',
+      })
+    );
+  });
+
   it('surfaces normalized non-keycloak detail warnings after the instance detail itself loads successfully', async () => {
     getInstanceKeycloakStatusMock.mockRejectedValueOnce({
       status: 500,
@@ -705,6 +748,79 @@ describe('useInstances', () => {
     });
     expect(revokeInstanceModuleMock).toHaveBeenCalledWith('demo', 'news');
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps the current selected instance until the post-mutation reload finishes', async () => {
+    const reloadedDetail = createDeferred<{
+      data: {
+        instanceId: string;
+        displayName: string;
+        status: string;
+        parentDomain: string;
+        primaryHostname: string;
+        hostnames: never[];
+        provisioningRuns: never[];
+        keycloakProvisioningRuns: never[];
+        auditEvents: never[];
+        assignedModules: string[];
+      };
+    }>();
+    getInstanceMock
+      .mockResolvedValueOnce({
+        data: {
+          instanceId: 'demo',
+          displayName: 'Demo',
+          status: 'active',
+          parentDomain: 'studio.example.org',
+          primaryHostname: 'demo.studio.example.org',
+          hostnames: [],
+          provisioningRuns: [],
+          keycloakProvisioningRuns: [],
+          auditEvents: [],
+          assignedModules: [],
+        },
+      })
+      .mockImplementationOnce(() => reloadedDetail.promise);
+
+    const { result } = renderHook(() => useInstances());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.loadInstance('demo');
+    });
+
+    const mutationPromise = act(async () => {
+      await result.current.assignModule('demo', 'news');
+    });
+
+    await waitFor(() => {
+      expect(assignInstanceModuleMock).toHaveBeenCalledWith('demo', 'news');
+      expect(getInstanceMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(result.current.selectedInstance?.assignedModules).toEqual([]);
+
+    reloadedDetail.resolve({
+      data: {
+        instanceId: 'demo',
+        displayName: 'Demo',
+        status: 'active',
+        parentDomain: 'studio.example.org',
+        primaryHostname: 'demo.studio.example.org',
+        hostnames: [],
+        provisioningRuns: [],
+        keycloakProvisioningRuns: [],
+        auditEvents: [],
+        assignedModules: ['news'],
+      },
+    });
+
+    await mutationPromise;
+
+    expect(result.current.selectedInstance?.assignedModules).toEqual(['news']);
   });
 
   it('refreshes auth state after bootstrapping the admin structure', async () => {

--- a/apps/sva-studio-react/src/hooks/use-instances.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-instances.test.tsx
@@ -32,7 +32,7 @@ const authMockValue = {
   invalidatePermissions: vi.fn(),
 };
 
-const createDeferred = <T>() => {
+const createDeferred = <T,>() => {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
   const promise = new Promise<T>((nextResolve, nextReject) => {

--- a/apps/sva-studio-react/src/hooks/use-instances.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-instances.test.tsx
@@ -479,6 +479,8 @@ describe('useInstances', () => {
   });
 
   it('invalidates permissions only once when detail and keycloak status both return forbidden', async () => {
+    const invalidateDeferred = createDeferred<void>();
+    authMockValue.invalidatePermissions.mockImplementationOnce(() => invalidateDeferred.promise);
     getInstanceMock.mockRejectedValueOnce({
       status: 403,
       code: 'forbidden',
@@ -496,8 +498,16 @@ describe('useInstances', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    const loadPromise = result.current.loadInstance('demo');
+
+    await waitFor(() => {
+      expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+    });
+
+    invalidateDeferred.resolve();
+
     await act(async () => {
-      await result.current.loadInstance('demo');
+      await loadPromise;
     });
 
     expect(result.current.mutationError).toEqual(expect.objectContaining({ status: 403, code: 'forbidden' }));

--- a/apps/sva-studio-react/src/hooks/use-instances.ts
+++ b/apps/sva-studio-react/src/hooks/use-instances.ts
@@ -112,6 +112,33 @@ export const useInstances = () => {
     []
   );
 
+  const invalidatePermissionsAfter403 = React.useCallback(
+    async (
+      input: {
+        operation: string;
+        status: number;
+        errorCode: string;
+        instanceId?: string;
+      },
+      state?: { invalidated: boolean }
+    ) => {
+      if (state?.invalidated) {
+        return;
+      }
+      await invalidatePermissions();
+      if (state) {
+        state.invalidated = true;
+      }
+      instancesLogger.info('permission_invalidated_after_403', {
+        operation: input.operation,
+        status: input.status,
+        error_code: input.errorCode,
+        instance_id: input.instanceId,
+      });
+    },
+    [invalidatePermissions]
+  );
+
   const refetch = React.useCallback(async () => {
     logBrowserOperationStart(instancesLogger, 'instance_list_refetch_started', {
       operation: 'list_instances',
@@ -167,6 +194,7 @@ export const useInstances = () => {
       });
       setDetailLoading(true);
       setMutationError(null);
+      const permissionInvalidationState = { invalidated: false };
       try {
         let statusError: IamHttpError | undefined;
         const [detailResponse, statusResponse] = await Promise.all([
@@ -174,13 +202,15 @@ export const useInstances = () => {
           getInstanceKeycloakStatus(instanceId).catch(async (cause) => {
             const resolvedError = asIamError(cause);
             if (resolvedError.status === 403) {
-              await invalidatePermissions();
-              instancesLogger.info('permission_invalidated_after_403', {
-                operation: 'get_instance_keycloak_status',
-                status: resolvedError.status,
-                error_code: resolvedError.code,
-                instance_id: instanceId,
-              });
+              await invalidatePermissionsAfter403(
+                {
+                  operation: 'get_instance_keycloak_status',
+                  status: resolvedError.status,
+                  errorCode: resolvedError.code,
+                  instanceId,
+                },
+                permissionInvalidationState
+              );
             }
             statusError = resolvedError;
             logBrowserOperationFailure(instancesLogger, 'instance_keycloak_status_refresh_failed', resolvedError, {
@@ -206,13 +236,15 @@ export const useInstances = () => {
       } catch (cause) {
         const resolvedError = asIamError(cause);
         if (resolvedError.status === 403) {
-          await invalidatePermissions();
-          instancesLogger.info('permission_invalidated_after_403', {
-            operation: 'get_instance_detail',
-            status: resolvedError.status,
-            error_code: resolvedError.code,
-            instance_id: instanceId,
-          });
+          await invalidatePermissionsAfter403(
+            {
+              operation: 'get_instance_detail',
+              status: resolvedError.status,
+              errorCode: resolvedError.code,
+              instanceId,
+            },
+            permissionInvalidationState
+          );
         }
         setMutationError(resolvedError);
         logBrowserOperationFailure(instancesLogger, 'instance_detail_load_failed', resolvedError, {
@@ -224,7 +256,7 @@ export const useInstances = () => {
         setDetailLoading(false);
       }
     },
-    [invalidatePermissions]
+    [invalidatePermissionsAfter403]
   );
 
   const mutate = React.useCallback(
@@ -459,44 +491,28 @@ export const useInstances = () => {
       ),
     assignModule: async (instanceId: string, moduleId: string) =>
       mutate(
-        async () => {
-          const response = await assignInstanceModule(instanceId, moduleId);
-          setSelectedInstance(response.data);
-          return response;
-        },
+        async () => assignInstanceModule(instanceId, moduleId),
         instanceId,
         'assign_instance_module',
         { invalidateAuthAfterSuccess: true }
       ),
     bootstrapAdminStructure: async (instanceId: string, moduleIds: readonly string[]) =>
       mutate(
-        async () => {
-          const response = await bootstrapInstanceAdminStructure(instanceId, moduleIds);
-          setSelectedInstance(response.data);
-          return response;
-        },
+        async () => bootstrapInstanceAdminStructure(instanceId, moduleIds),
         instanceId,
         'bootstrap_instance_admin_structure',
         { invalidateAuthAfterSuccess: true }
       ),
     revokeModule: async (instanceId: string, moduleId: string) =>
       mutate(
-        async () => {
-          const response = await revokeInstanceModule(instanceId, moduleId);
-          setSelectedInstance(response.data);
-          return response;
-        },
+        async () => revokeInstanceModule(instanceId, moduleId),
         instanceId,
         'revoke_instance_module',
         { invalidateAuthAfterSuccess: true }
       ),
     seedIamBaseline: async (instanceId: string) =>
       mutate(
-        async () => {
-          const response = await seedInstanceIamBaseline(instanceId);
-          setSelectedInstance(response.data);
-          return response;
-        },
+        async () => seedInstanceIamBaseline(instanceId),
         instanceId,
         'seed_instance_iam_baseline',
         { invalidateAuthAfterSuccess: true }

--- a/apps/sva-studio-react/src/hooks/use-instances.ts
+++ b/apps/sva-studio-react/src/hooks/use-instances.ts
@@ -125,10 +125,10 @@ export const useInstances = () => {
       if (state?.invalidated) {
         return;
       }
-      await invalidatePermissions();
       if (state) {
         state.invalidated = true;
       }
+      await invalidatePermissions();
       instancesLogger.info('permission_invalidated_after_403', {
         operation: input.operation,
         status: input.status,

--- a/apps/sva-studio-react/src/hooks/use-user.ts
+++ b/apps/sva-studio-react/src/hooks/use-user.ts
@@ -24,6 +24,7 @@ type UseUserResult = {
   readonly error: IamHttpError | null;
   readonly mutationError: IamHttpError | null;
   readonly refetch: () => Promise<void>;
+  readonly clearMutationError: () => void;
   readonly save: (payload: UpdateUserPayload) => Promise<IamUserDetail | null>;
   readonly resendPasswordSetupEmail?: () => Promise<boolean>;
 };
@@ -161,6 +162,7 @@ export const useUser = (userId: string): UseUserResult => {
     error,
     mutationError,
     refetch,
+    clearMutationError: () => setMutationError(null),
     save,
     resendPasswordSetupEmail: resendPasswordSetupEmailAction,
   };

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
@@ -741,6 +741,8 @@ describe('UserEditPage', () => {
   }, 15000);
 
   it('shows localized save errors instead of the generic load error', () => {
+    const refetch = vi.fn();
+    const clearMutationError = vi.fn();
     useUserMock.mockReturnValue({
       user: baseUser,
       isLoading: false,
@@ -750,7 +752,8 @@ describe('UserEditPage', () => {
         code: 'keycloak_unavailable',
         message: 'sync failed',
       },
-      refetch: vi.fn(),
+      refetch,
+      clearMutationError,
       save: vi.fn(),
     });
 
@@ -770,6 +773,11 @@ describe('UserEditPage', () => {
       'Die Verbindung zu Keycloak ist derzeit nicht verfügbar. Bitte später erneut versuchen.'
     );
     expect(screen.getByRole('alert').textContent).not.toContain('Nutzer konnten nicht geladen werden.');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Erneut versuchen' }));
+
+    expect(clearMutationError).toHaveBeenCalledTimes(1);
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it('renders mutation-specific client errors without the load wording', () => {

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
@@ -499,7 +499,14 @@ export const UserEditPage = ({ userId, invitationStatus }: UserEditPageProps) =>
               ? t('admin.users.actions.sendingPasswordSetupEmail')
               : t('admin.users.actions.sendPasswordSetupEmail')}
           </Button>
-          <Button type="button" variant="outline" onClick={() => void userApi.refetch()}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              userApi.clearMutationError();
+              void userApi.refetch();
+            }}
+          >
             {t('admin.users.actions.retry')}
           </Button>
         </div>

--- a/docs/guides/keycloak-tenant-realm-bootstrap.md
+++ b/docs/guides/keycloak-tenant-realm-bootstrap.md
@@ -203,6 +203,35 @@ Nur wenn die jeweilige Funktion tatsächlich benötigt wird:
 
 Diese Rollen sind bewusst nicht Teil des pauschalen Standard-Bootstraps.
 
+## Technischer Tenant-Admin-Client
+
+Zusätzlich zum menschlichen Tenant-Admin benötigt der technische Tenant-Admin-Client
+`iam.instances.tenantAdminClient.clientId` einen eigenen Service-Account im Tenant-Realm.
+
+### Minimaler Rollenvertrag für den Service-Account
+
+Dem Service-Account des Tenant-Admin-Clients werden mindestens folgende
+`realm-management`-Rollen zugewiesen:
+
+- `manage-users`
+- `view-users`
+- `view-realm`
+- `manage-realm`
+- `manage-clients`
+
+Begründung:
+
+- Die ersten vier Rollen decken tenant-lokales User- und Realm-Rollen-Management ab.
+- `manage-clients` ist erforderlich, damit Studio den referenzierten Login-Client
+  `authClientId` im Tenant-Realm lesen und Passwort-Setup-Mails mit dem richtigen
+  `client_id` auslösen kann.
+
+Nicht Ziel dieses Vertrags:
+
+- globale Plattformrechte
+- `realm-admin`
+- Identity-Provider- oder Event-Administration
+
 ## Alias-Regel
 
 Studio akzeptiert aktuell zusätzlich den Realm-Rollen-Alias:

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/design.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/design.md
@@ -1,65 +1,65 @@
 ## Context
 
-Die Befunde konzentrieren sich nicht auf einzelne Defekte, sondern auf Vertragsluecken zwischen Auth-Runtime, Plugin-SDK, Host-Routing und CI-Governance. Das gemeinsame Muster ist, dass Konventionen bereits existieren, aber nicht deterministisch zur Build- oder Boot-Zeit erzwungen werden.
+Die Befunde konzentrieren sich nicht auf einzelne Defekte, sondern auf Vertragslücken zwischen Auth-Runtime, Plugin-SDK, Host-Routing und CI-Governance. Das gemeinsame Muster ist, dass Konventionen bereits existieren, aber nicht deterministisch zur Build- oder Boot-Zeit erzwungen werden.
 
 ## Goals / Non-Goals
 
 - Goals:
-  - Serielle, deterministische Token-Refresh-Semantik fuer geteilte Redis-Sessions
-  - Ein expliziter, hostvalidierter Plugin-Vertrag fuer Routen, Permissions, Uebersetzungen und SDK-Versionen
-  - Harte Architektur-Gates fuer cross-cutting Regeln, die heute nur dokumentiert oder implizit getestet sind
-  - Schwaechere Qualitaetszonen in Auth- und Registry-Pfaden messbar und schrittweise auf Zielniveau anheben
+  - Serielle, deterministische Token-Refresh-Semantik für geteilte Redis-Sessions
+  - Ein expliziter, hostvalidierter Plugin-Vertrag für Routen, Permissions, Übersetzungen und SDK-Versionen
+  - Harte Architektur-Gates für cross-cutting Regeln, die heute nur dokumentiert oder implizit getestet sind
+  - Schwächere Qualitätszonen in Auth- und Registry-Pfaden messbar und schrittweise auf Zielniveau anheben
 - Non-Goals:
-  - Vollstaendige Runtime-Nachladung externer Plugins ohne App-Build
-  - Eine neue IAM-Engine oder ein neues Routing-System einfuehren
-  - Saemtliche Komplexitaetshotspots in einem einzigen Delivery-Slice beseitigen
+  - Vollständige Runtime-Nachladung externer Plugins ohne App-Build
+  - Eine neue IAM-Engine oder ein neues Routing-System einführen
+  - Sämtliche Komplexitätshotspots in einem einzigen Delivery-Slice beseitigen
 
 ## Decisions
 
-- Decision: Session-Refresh bleibt serverseitig und Redis-basiert, wird aber pro `sessionId` serialisiert, sodass fuer parallele Requests genau ein Refresh-Schreiber gewinnt und konkurrierende Requests das Ergebnis wiederverwenden.
+- Decision: Session-Refresh bleibt serverseitig und Redis-basiert, wird aber pro `sessionId` serialisiert, sodass für parallele Requests genau ein Refresh-Schreiber gewinnt und konkurrierende Requests das Ergebnis wiederverwenden.
 - Decision: `/auth/me` bleibt der kanonische Auth-Read, gibt aber nur eine explizite Allowlist stabiler Felder aus; neue interne Session- oder Profilfelder werden nicht per Object-Spread exponiert.
-- Decision: Der Host validiert Plugin-Beitraege vor Snapshot-Publikation gegen einen kanonischen Preflight-Vertrag fuer Namespace, SDK-SemVer, Routen, Permission-Referenzen, Translation-Ownership und Aktivierungsstatus.
-- Decision: Build-linked Plugins bleiben Teil des Host-Builds, muessen aber ueber hostkontrollierte Aktivierungsflags pro Instanz oder Umgebung deaktivierbar sein, damit Canary- und Rollback-Slices ohne Code-Fork moeglich werden.
-- Decision: Typsichere Plugin-Routen werden ueber einen deklarativen Vertrag fuer Search-Params, Path-Params und Route-Component-Bindings beschrieben; der Host behaelt Parsing-, Guard- und Route-Ownership.
-- Decision: Mutationen emittieren hostvalidierte Invalidation-Tags, damit Core-App und Plugins denselben Cache-Invalidierungsvertrag nutzen koennen.
+- Decision: Der Host validiert Plugin-Beiträge vor Snapshot-Publikation gegen einen kanonischen Preflight-Vertrag für Namespace, SDK-SemVer, Routen, Permission-Referenzen, Translation-Ownership und Aktivierungsstatus.
+- Decision: Build-linked Plugins bleiben Teil des Host-Builds, müssen aber über hostkontrollierte Aktivierungsflags pro Instanz oder Umgebung deaktivierbar sein, damit Canary- und Rollback-Slices ohne Code-Fork möglich werden.
+- Decision: Typsichere Plugin-Routen werden über einen deklarativen Vertrag für Search-Params, Path-Params und Route-Component-Bindings beschrieben; der Host behält Parsing-, Guard- und Route-Ownership.
+- Decision: Mutationen emittieren hostvalidierte Invalidation-Tags, damit Core-App und Plugins denselben Cache-Invalidierungsvertrag nutzen können.
 - Decision: Produktionsnahe Boots und Releases failen vor dem ersten Traffic bei OTEL-Unreadiness, Architekturdrift oder Migrationsdrift.
-- Decision: Kritische Module duerfen bei offenen Hotspots weder Coverage-Floors absenken noch Komplexitaet weiter steigern; stattdessen gilt Ratcheting plus dokumentierter Refactoring-Backlog.
+- Decision: Kritische Module dürfen bei offenen Hotspots weder Coverage-Floors absenken noch Komplexität weiter steigern; stattdessen gilt Ratcheting plus dokumentierter Refactoring-Backlog.
 
 ## Workstreams
 
-1. Auth- und Runtime-Haertung
+1. Auth- und Runtime-Härtung
    - Session-Refresh serialisieren
    - `/auth/me` minimieren
    - Session-Store-Adapter auf denselben Codec- und Konkurrenzvertrag bringen
    - OTEL vor Request-Annahme initialisieren
-   - Boot- und Readiness-Pruefung auf Migrationsstand ausweiten
+   - Boot- und Readiness-Prüfung auf Migrationsstand ausweiten
 
 2. Plugin-Vertrag stabilisieren
    - Routen- und Translation-Kollisionen fail-fast behandeln
    - Plugin-Permissions mit IAM-Manifest kreuzvalidieren
-   - SDK-Kompatibilitaet per SemVer-Range erzwingen
-   - Typisierten Route- und Aktivierungsvertrag einfuehren
+   - SDK-Kompatibilität per SemVer-Range erzwingen
+   - Typisierten Route- und Aktivierungsvertrag einführen
    - Vollqualifizierte Action-IDs statisch erzwingen
 
 3. CI- und Architektur-Gates verankern
    - Dependency-Graph-Snapshot in CI
    - i18n-Key-Extraktion und Missing-Key-Gate
    - `.server.ts`- und server-only Leak-Gates inklusive `interfaces-api`
-   - Kritische Coverage- und Komplexitaetsregeln verschaerfen
+   - Kritische Coverage- und Komplexitätsregeln verschärfen
 
-4. Datenkonsistenz ueber UI-Grenzen
-   - Hostvalidierte Invalidation-Tags fuer Mutationen
-   - Gemeinsame Cache-Invalidierung ueber Core und Plugins
+4. Datenkonsistenz über UI-Grenzen
+   - Hostvalidierte Invalidation-Tags für Mutationen
+   - Gemeinsame Cache-Invalidierung über Core und Plugins
 
 ## Risks / Trade-offs
 
-- Strengere Build- und Boot-Gates koennen bestehende Drift sofort sichtbar machen und zunaechst mehrere rote Checks freilegen.
-- Die typisierte Plugin-Route-Schnittstelle ist ein oeffentlicher SDK-Vertrag und braucht eine klar dokumentierte Migrationsphase fuer bestehende Plugins.
-- Runtime-Aktivierungsflags fuer build-linked Plugins reduzieren nicht den Build-Kopplungsgrad, schaffen aber einen kontrollierbaren Betriebshebel ohne Vollumbau.
+- Strengere Build- und Boot-Gates können bestehende Drift sofort sichtbar machen und zunächst mehrere rote Checks freilegen.
+- Die typisierte Plugin-Route-Schnittstelle ist ein öffentlicher SDK-Vertrag und braucht eine klar dokumentierte Migrationsphase für bestehende Plugins.
+- Runtime-Aktivierungsflags für build-linked Plugins reduzieren nicht den Build-Kopplungsgrad, schaffen aber einen kontrollierbaren Betriebshebel ohne Vollumbau.
 
 ## Migration Plan
 
-1. Zuerst Guardrails einfuehren, die inkonsistente Zustaende sichtbar machen, ohne sofort alle Callsites umzubauen.
-2. Danach Auth- und Plugin-Hotspots auf die neuen Vertraege migrieren und Characterization-Tests fuer Redis-, Build-time- und Host-Routing-Pfade ergänzen.
-3. Anschliessend CI-Gates scharf schalten und die verbleibenden Exemptions, Floors und Hotspots dokumentiert abbauen.
-4. Die neuen Vertraege in arc42 und mindestens einer ADR fuer Plugin- und Runtime-Guardrails verankern.
+1. Zuerst Guardrails einführen, die inkonsistente Zustände sichtbar machen, ohne sofort alle Callsites umzubauen.
+2. Danach Auth- und Plugin-Hotspots auf die neuen Verträge migrieren und Characterization-Tests für Redis-, Build-time- und Host-Routing-Pfade ergänzen.
+3. Anschließend CI-Gates scharf schalten und die verbleibenden Exemptions, Floors und Hotspots dokumentiert abbauen.
+4. Die neuen Verträge in arc42 und mindestens einer ADR für Plugin- und Runtime-Guardrails verankern.

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/design.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Die Befunde konzentrieren sich nicht auf einzelne Defekte, sondern auf Vertragsluecken zwischen Auth-Runtime, Plugin-SDK, Host-Routing und CI-Governance. Das gemeinsame Muster ist, dass Konventionen bereits existieren, aber nicht deterministisch zur Build- oder Boot-Zeit erzwungen werden.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Serielle, deterministische Token-Refresh-Semantik fuer geteilte Redis-Sessions
+  - Ein expliziter, hostvalidierter Plugin-Vertrag fuer Routen, Permissions, Uebersetzungen und SDK-Versionen
+  - Harte Architektur-Gates fuer cross-cutting Regeln, die heute nur dokumentiert oder implizit getestet sind
+  - Schwaechere Qualitaetszonen in Auth- und Registry-Pfaden messbar und schrittweise auf Zielniveau anheben
+- Non-Goals:
+  - Vollstaendige Runtime-Nachladung externer Plugins ohne App-Build
+  - Eine neue IAM-Engine oder ein neues Routing-System einfuehren
+  - Saemtliche Komplexitaetshotspots in einem einzigen Delivery-Slice beseitigen
+
+## Decisions
+
+- Decision: Session-Refresh bleibt serverseitig und Redis-basiert, wird aber pro `sessionId` serialisiert, sodass fuer parallele Requests genau ein Refresh-Schreiber gewinnt und konkurrierende Requests das Ergebnis wiederverwenden.
+- Decision: `/auth/me` bleibt der kanonische Auth-Read, gibt aber nur eine explizite Allowlist stabiler Felder aus; neue interne Session- oder Profilfelder werden nicht per Object-Spread exponiert.
+- Decision: Der Host validiert Plugin-Beitraege vor Snapshot-Publikation gegen einen kanonischen Preflight-Vertrag fuer Namespace, SDK-SemVer, Routen, Permission-Referenzen, Translation-Ownership und Aktivierungsstatus.
+- Decision: Build-linked Plugins bleiben Teil des Host-Builds, muessen aber ueber hostkontrollierte Aktivierungsflags pro Instanz oder Umgebung deaktivierbar sein, damit Canary- und Rollback-Slices ohne Code-Fork moeglich werden.
+- Decision: Typsichere Plugin-Routen werden ueber einen deklarativen Vertrag fuer Search-Params, Path-Params und Route-Component-Bindings beschrieben; der Host behaelt Parsing-, Guard- und Route-Ownership.
+- Decision: Mutationen emittieren hostvalidierte Invalidation-Tags, damit Core-App und Plugins denselben Cache-Invalidierungsvertrag nutzen koennen.
+- Decision: Produktionsnahe Boots und Releases failen vor dem ersten Traffic bei OTEL-Unreadiness, Architekturdrift oder Migrationsdrift.
+- Decision: Kritische Module duerfen bei offenen Hotspots weder Coverage-Floors absenken noch Komplexitaet weiter steigern; stattdessen gilt Ratcheting plus dokumentierter Refactoring-Backlog.
+
+## Workstreams
+
+1. Auth- und Runtime-Haertung
+   - Session-Refresh serialisieren
+   - `/auth/me` minimieren
+   - Session-Store-Adapter auf denselben Codec- und Konkurrenzvertrag bringen
+   - OTEL vor Request-Annahme initialisieren
+   - Boot- und Readiness-Pruefung auf Migrationsstand ausweiten
+
+2. Plugin-Vertrag stabilisieren
+   - Routen- und Translation-Kollisionen fail-fast behandeln
+   - Plugin-Permissions mit IAM-Manifest kreuzvalidieren
+   - SDK-Kompatibilitaet per SemVer-Range erzwingen
+   - Typisierten Route- und Aktivierungsvertrag einfuehren
+   - Vollqualifizierte Action-IDs statisch erzwingen
+
+3. CI- und Architektur-Gates verankern
+   - Dependency-Graph-Snapshot in CI
+   - i18n-Key-Extraktion und Missing-Key-Gate
+   - `.server.ts`- und server-only Leak-Gates inklusive `interfaces-api`
+   - Kritische Coverage- und Komplexitaetsregeln verschaerfen
+
+4. Datenkonsistenz ueber UI-Grenzen
+   - Hostvalidierte Invalidation-Tags fuer Mutationen
+   - Gemeinsame Cache-Invalidierung ueber Core und Plugins
+
+## Risks / Trade-offs
+
+- Strengere Build- und Boot-Gates koennen bestehende Drift sofort sichtbar machen und zunaechst mehrere rote Checks freilegen.
+- Die typisierte Plugin-Route-Schnittstelle ist ein oeffentlicher SDK-Vertrag und braucht eine klar dokumentierte Migrationsphase fuer bestehende Plugins.
+- Runtime-Aktivierungsflags fuer build-linked Plugins reduzieren nicht den Build-Kopplungsgrad, schaffen aber einen kontrollierbaren Betriebshebel ohne Vollumbau.
+
+## Migration Plan
+
+1. Zuerst Guardrails einfuehren, die inkonsistente Zustaende sichtbar machen, ohne sofort alle Callsites umzubauen.
+2. Danach Auth- und Plugin-Hotspots auf die neuen Vertraege migrieren und Characterization-Tests fuer Redis-, Build-time- und Host-Routing-Pfade ergänzen.
+3. Anschliessend CI-Gates scharf schalten und die verbleibenden Exemptions, Floors und Hotspots dokumentiert abbauen.
+4. Die neuen Vertraege in arc42 und mindestens einer ADR fuer Plugin- und Runtime-Guardrails verankern.

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/proposal.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/proposal.md
@@ -1,0 +1,19 @@
+# Change: Cross-Cutting Runtime- und Plugin-Guardrails refaktorieren
+
+## Why
+
+Die aktuelle Architektur hat mehrere runtime-emergente und paketuebergreifende Risiken, die durch lokale Unit-Tests nicht sichtbar werden. Besonders betroffen sind der Auth-Session-Pfad, der Plugin-Vertrag und die CI-Erzwingung zentraler Architekturregeln.
+
+## What Changes
+
+- Der Auth-Session-Pfad wird fuer parallele Requests, minimale `/auth/me`-Payloads und adapteruebergreifende Session-Store-Paritaet normativ gehaertet.
+- Der Plugin-Vertrag wird an den Host gebunden: fail-fast bei Routen- und Translation-Kollisionen, SDK-Kompatibilitaetspruefung, typisierte Routenbeitraege, runtime-faehige Aktivierung und zentrale IAM-Cross-Validation.
+- Die Plattform fuehrt harte Architektur-Gates fuer Dependency-Graph, i18n, server-only Importe, Interfaces-Leaks, Migrationsdrift und OTEL-Bootstrapping ein.
+- Kritische Auth-, Registry- und Routing-Hotspots erhalten strengere Coverage- und Komplexitaets-Governance inklusive Ratcheting- und No-Growth-Regeln.
+- Host und Plugins erhalten einen gemeinsamen Invalidation-Tag-Vertrag, damit Mutationen cache-konsistent ueber Paketgrenzen hinweg bleiben.
+
+## Impact
+
+- Affected specs: `iam-core`, `iam-access-control`, `routing`, `monorepo-structure`, `monitoring-client`, `content-management`, `deployment-topology`, `test-coverage-governance`, `complexity-quality-governance`, `architecture-documentation`
+- Affected code: `apps/sva-studio-react`, `packages/auth-runtime`, `packages/plugin-sdk`, `packages/routing`, `packages/data`, `packages/core`, `tooling/testing`, `tooling/quality`, `scripts/`
+- Affected arc42 sections: `04-solution-strategy`, `05-building-block-view`, `06-runtime-view`, `08-cross-cutting-concepts`, `09-architecture-decisions`, `10-quality-requirements`, `11-risks-and-technical-debt`

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/proposal.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/proposal.md
@@ -2,15 +2,15 @@
 
 ## Why
 
-Die aktuelle Architektur hat mehrere runtime-emergente und paketuebergreifende Risiken, die durch lokale Unit-Tests nicht sichtbar werden. Besonders betroffen sind der Auth-Session-Pfad, der Plugin-Vertrag und die CI-Erzwingung zentraler Architekturregeln.
+Die aktuelle Architektur hat mehrere runtime-emergente und paketübergreifende Risiken, die durch lokale Unit-Tests nicht sichtbar werden. Besonders betroffen sind der Auth-Session-Pfad, der Plugin-Vertrag und die CI-Erzwingung zentraler Architekturregeln.
 
 ## What Changes
 
-- Der Auth-Session-Pfad wird fuer parallele Requests, minimale `/auth/me`-Payloads und adapteruebergreifende Session-Store-Paritaet normativ gehaertet.
-- Der Plugin-Vertrag wird an den Host gebunden: fail-fast bei Routen- und Translation-Kollisionen, SDK-Kompatibilitaetspruefung, typisierte Routenbeitraege, runtime-faehige Aktivierung und zentrale IAM-Cross-Validation.
-- Die Plattform fuehrt harte Architektur-Gates fuer Dependency-Graph, i18n, server-only Importe, Interfaces-Leaks, Migrationsdrift und OTEL-Bootstrapping ein.
-- Kritische Auth-, Registry- und Routing-Hotspots erhalten strengere Coverage- und Komplexitaets-Governance inklusive Ratcheting- und No-Growth-Regeln.
-- Host und Plugins erhalten einen gemeinsamen Invalidation-Tag-Vertrag, damit Mutationen cache-konsistent ueber Paketgrenzen hinweg bleiben.
+- Der Auth-Session-Pfad wird für parallele Requests, minimale `/auth/me`-Payloads und adapterübergreifende Session-Store-Parität normativ gehärtet.
+- Der Plugin-Vertrag wird an den Host gebunden: fail-fast bei Routen- und Translation-Kollisionen, SDK-Kompatibilitätsprüfung, typisierte Routenbeiträge, runtime-fähige Aktivierung und zentrale IAM-Cross-Validation.
+- Die Plattform führt harte Architektur-Gates für Dependency-Graph, i18n, server-only Importe, Interfaces-Leaks, Migrationsdrift und OTEL-Bootstrapping ein.
+- Kritische Auth-, Registry- und Routing-Hotspots erhalten strengere Coverage- und Komplexitäts-Governance inklusive Ratcheting- und No-Growth-Regeln.
+- Host und Plugins erhalten einen gemeinsamen Invalidation-Tag-Vertrag, damit Mutationen cache-konsistent über Paketgrenzen hinweg bleiben.
 
 ## Impact
 

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/architecture-documentation/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/architecture-documentation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Cross-Cutting Guardrails sind als Zielarchitektur dokumentiert
+
+Die Architekturdokumentation SHALL cross-cutting Guardrails fuer Auth-Session-Serialisierung, Plugin-Preflight, Architektur-Gates und produktionsnahen Boot-Vertrag explizit in den betroffenen arc42-Abschnitten verankern.
+
+#### Scenario: Reviewer prueft den Guardrail-Change
+
+- **WHEN** ein Reviewer `04`, `05`, `06`, `08`, `09`, `10` und `11` der arc42-Dokumentation liest
+- **THEN** sind Session-Refresh-Serialisierung, Plugin-Preflight, Aktivierungsflags, Architektur-Gates und Boot-Checks dort nachvollziehbar beschrieben
+- **AND** die Doku macht sichtbar, welche Risiken damit reduziert und welche Restschulden bewusst vertagt werden
+
+#### Scenario: Neue ADR dokumentiert oeffentliche Vertraege
+
+- **WHEN** der Change den oeffentlichen Plugin- oder Runtime-Vertrag aendert
+- **THEN** beschreibt eine ADR die Entscheidungen zu SDK-Kompatibilitaet, typisierten Plugin-Routen, OTEL-Boot und Runtime-Aktivierung
+- **AND** `09-architecture-decisions.md` verlinkt diese Entscheidung

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/architecture-documentation/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/architecture-documentation/spec.md
@@ -2,16 +2,16 @@
 
 ### Requirement: Cross-Cutting Guardrails sind als Zielarchitektur dokumentiert
 
-Die Architekturdokumentation SHALL cross-cutting Guardrails fuer Auth-Session-Serialisierung, Plugin-Preflight, Architektur-Gates und produktionsnahen Boot-Vertrag explizit in den betroffenen arc42-Abschnitten verankern.
+Die Architekturdokumentation SHALL cross-cutting Guardrails für Auth-Session-Serialisierung, Plugin-Preflight, Architektur-Gates und produktionsnahen Boot-Vertrag explizit in den betroffenen arc42-Abschnitten verankern.
 
-#### Scenario: Reviewer prueft den Guardrail-Change
+#### Scenario: Reviewer prüft den Guardrail-Change
 
 - **WHEN** ein Reviewer `04`, `05`, `06`, `08`, `09`, `10` und `11` der arc42-Dokumentation liest
 - **THEN** sind Session-Refresh-Serialisierung, Plugin-Preflight, Aktivierungsflags, Architektur-Gates und Boot-Checks dort nachvollziehbar beschrieben
 - **AND** die Doku macht sichtbar, welche Risiken damit reduziert und welche Restschulden bewusst vertagt werden
 
-#### Scenario: Neue ADR dokumentiert oeffentliche Vertraege
+#### Scenario: Neue ADR dokumentiert öffentliche Verträge
 
-- **WHEN** der Change den oeffentlichen Plugin- oder Runtime-Vertrag aendert
-- **THEN** beschreibt eine ADR die Entscheidungen zu SDK-Kompatibilitaet, typisierten Plugin-Routen, OTEL-Boot und Runtime-Aktivierung
+- **WHEN** der Change den öffentlichen Plugin- oder Runtime-Vertrag ändert
+- **THEN** beschreibt eine ADR die Entscheidungen zu SDK-Kompatibilität, typisierten Plugin-Routen, OTEL-Boot und Runtime-Aktivierung
 - **AND** `09-architecture-decisions.md` verlinkt diese Entscheidung

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/complexity-quality-governance/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/complexity-quality-governance/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Auth- und Runtime-Hotspots unterliegen No-Growth-Regeln
+
+Das System MUST fuer als kritisch markierte Auth-, Session-, Routing- und Registry-Hotspots eine No-Growth-Regel fuer strukturelle Komplexitaet anwenden, bis die dokumentierte Zerlegung umgesetzt ist.
+
+#### Scenario: Hotspot bleibt ueber Schwellwert
+
+- **GIVEN** eine Datei oder ein Modul ist als kritischer Hotspot oberhalb des Schwellwerts markiert
+- **WHEN** ein PR diesen Hotspot weiter veraendert
+- **THEN** darf der Qualitaetslauf keine weitere Erhoehung der gemessenen Komplexitaet akzeptieren
+- **AND** der PR verweist auf das zugehoerige Refactoring-Ticket oder die Zerlegungsaufgabe
+
+#### Scenario: Hotspot wird entlang dokumentierter Verantwortung geschnitten
+
+- **WHEN** ein kritischer Hotspot in kleinere Module zerlegt wird
+- **THEN** bleibt die Zerlegung an fachlichen oder Vertragsgrenzen orientiert
+- **AND** die Policy kann den Hotspot erst nach nachweislicher Entschaerfung neu klassifizieren

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/complexity-quality-governance/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/complexity-quality-governance/spec.md
@@ -2,17 +2,17 @@
 
 ### Requirement: Auth- und Runtime-Hotspots unterliegen No-Growth-Regeln
 
-Das System MUST fuer als kritisch markierte Auth-, Session-, Routing- und Registry-Hotspots eine No-Growth-Regel fuer strukturelle Komplexitaet anwenden, bis die dokumentierte Zerlegung umgesetzt ist.
+Das System MUST für als kritisch markierte Auth-, Session-, Routing- und Registry-Hotspots eine No-Growth-Regel für strukturelle Komplexität anwenden, bis die dokumentierte Zerlegung umgesetzt ist.
 
-#### Scenario: Hotspot bleibt ueber Schwellwert
+#### Scenario: Hotspot bleibt über Schwellwert
 
 - **GIVEN** eine Datei oder ein Modul ist als kritischer Hotspot oberhalb des Schwellwerts markiert
-- **WHEN** ein PR diesen Hotspot weiter veraendert
-- **THEN** darf der Qualitaetslauf keine weitere Erhoehung der gemessenen Komplexitaet akzeptieren
-- **AND** der PR verweist auf das zugehoerige Refactoring-Ticket oder die Zerlegungsaufgabe
+- **WHEN** ein PR diesen Hotspot weiter verändert
+- **THEN** darf der Qualitätslauf keine weitere Erhöhung der gemessenen Komplexität akzeptieren
+- **AND** der PR verweist auf das zugehörige Refactoring-Ticket oder die Zerlegungsaufgabe
 
 #### Scenario: Hotspot wird entlang dokumentierter Verantwortung geschnitten
 
 - **WHEN** ein kritischer Hotspot in kleinere Module zerlegt wird
 - **THEN** bleibt die Zerlegung an fachlichen oder Vertragsgrenzen orientiert
-- **AND** die Policy kann den Hotspot erst nach nachweislicher Entschaerfung neu klassifizieren
+- **AND** die Policy kann den Hotspot erst nach nachweislicher Entschärfung neu klassifizieren

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/content-management/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/content-management/spec.md
@@ -1,19 +1,19 @@
 ## ADDED Requirements
 
-### Requirement: Hostvalidierte Invalidation-Tags fuer Mutationen
+### Requirement: Hostvalidierte Invalidation-Tags für Mutationen
 
-Das System SHALL fuer host- und pluginseitige Inhaltsmutationen einen gemeinsamen Invalidation-Tag-Vertrag bereitstellen, damit Query-Caches paketuebergreifend konsistent invalidiert werden.
+Das System SHALL für host- und pluginseitige Inhaltsmutationen einen gemeinsamen Invalidation-Tag-Vertrag bereitstellen, damit Query-Caches paketübergreifend konsistent invalidiert werden.
 
-#### Scenario: Plugin-Mutation aendert hostrelevante Daten
+#### Scenario: Plugin-Mutation ändert hostrelevante Daten
 
-- **GIVEN** ein Plugin fuehrt eine Mutation aus, die Listen-, Detail- oder Dashboard-Daten der Core-App beeinflusst
+- **GIVEN** ein Plugin führt eine Mutation aus, die Listen-, Detail- oder Dashboard-Daten der Core-App beeinflusst
 - **WHEN** die Mutation erfolgreich abgeschlossen wird
-- **THEN** emittiert der Pfad hostvalidierte Invalidation-Tags fuer die betroffenen Datenbereiche
-- **AND** die Core-App invalidiert die zugeordneten Queries zentral statt auf pluginlokale Sonderfaelle zu vertrauen
+- **THEN** emittiert der Pfad hostvalidierte Invalidation-Tags für die betroffenen Datenbereiche
+- **AND** die Core-App invalidiert die zugeordneten Queries zentral statt auf pluginlokale Sonderfälle zu vertrauen
 
 #### Scenario: Mutation ohne bekannte Invalidation-Tags
 
-- **GIVEN** eine Mutation deklariert keine oder nur ungueltige Invalidation-Tags
-- **WHEN** der Host den Mutationsvertrag validiert oder ausfuehrt
-- **THEN** faellt der Pfad auf einen dokumentierten fail-closed oder konservativen Invalidierungsmodus zurueck
+- **GIVEN** eine Mutation deklariert keine oder nur ungültige Invalidation-Tags
+- **WHEN** der Host den Mutationsvertrag validiert oder ausführt
+- **THEN** fällt der Pfad auf einen dokumentierten fail-closed oder konservativen Invalidierungsmodus zurück
 - **AND** die Mutation bleibt nicht stillschweigend cache-inkonsistent

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/content-management/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/content-management/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Hostvalidierte Invalidation-Tags fuer Mutationen
+
+Das System SHALL fuer host- und pluginseitige Inhaltsmutationen einen gemeinsamen Invalidation-Tag-Vertrag bereitstellen, damit Query-Caches paketuebergreifend konsistent invalidiert werden.
+
+#### Scenario: Plugin-Mutation aendert hostrelevante Daten
+
+- **GIVEN** ein Plugin fuehrt eine Mutation aus, die Listen-, Detail- oder Dashboard-Daten der Core-App beeinflusst
+- **WHEN** die Mutation erfolgreich abgeschlossen wird
+- **THEN** emittiert der Pfad hostvalidierte Invalidation-Tags fuer die betroffenen Datenbereiche
+- **AND** die Core-App invalidiert die zugeordneten Queries zentral statt auf pluginlokale Sonderfaelle zu vertrauen
+
+#### Scenario: Mutation ohne bekannte Invalidation-Tags
+
+- **GIVEN** eine Mutation deklariert keine oder nur ungueltige Invalidation-Tags
+- **WHEN** der Host den Mutationsvertrag validiert oder ausfuehrt
+- **THEN** faellt der Pfad auf einen dokumentierten fail-closed oder konservativen Invalidierungsmodus zurueck
+- **AND** die Mutation bleibt nicht stillschweigend cache-inkonsistent

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/deployment-topology/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/deployment-topology/spec.md
@@ -2,16 +2,16 @@
 
 ### Requirement: Runtime-Boot blockiert bei Migrationsdrift
 
-Das System MUST vor der Request-Annahme pruefen, ob die produktive Datenbank den erwarteten Migrationsstand fuer die laufende Runtime erreicht hat.
+Das System MUST vor der Request-Annahme prüfen, ob die produktive Datenbank den erwarteten Migrationsstand für die laufende Runtime erreicht hat.
 
 #### Scenario: Datenbank ist auf erwartetem Stand
 
-- **WHEN** die Runtime bootet oder ein prod-naher Release-Precheck laeuft
+- **WHEN** die Runtime bootet oder ein prod-naher Release-Precheck läuft
 - **THEN** verifiziert das System den erwarteten Migrations-Head gegen die Datenbank
 - **AND** erst danach werden Readiness und Request-Annahme freigegeben
 
 #### Scenario: Migrationsstand driftet hinter dem erwarteten Head
 
-- **WHEN** Boot oder Release-Precheck eine Abweichung zwischen erwartetem und tatsaechlichem Migrationsstand erkennen
+- **WHEN** Boot oder Release-Precheck eine Abweichung zwischen erwartetem und tatsächlichem Migrationsstand erkennen
 - **THEN** blockiert das System Request-Annahme oder Rollout
 - **AND** Readiness, Diagnoseausgabe und Release-Report benennen die Drift maschinenlesbar

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/deployment-topology/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/deployment-topology/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Runtime-Boot blockiert bei Migrationsdrift
+
+Das System MUST vor der Request-Annahme pruefen, ob die produktive Datenbank den erwarteten Migrationsstand fuer die laufende Runtime erreicht hat.
+
+#### Scenario: Datenbank ist auf erwartetem Stand
+
+- **WHEN** die Runtime bootet oder ein prod-naher Release-Precheck laeuft
+- **THEN** verifiziert das System den erwarteten Migrations-Head gegen die Datenbank
+- **AND** erst danach werden Readiness und Request-Annahme freigegeben
+
+#### Scenario: Migrationsstand driftet hinter dem erwarteten Head
+
+- **WHEN** Boot oder Release-Precheck eine Abweichung zwischen erwartetem und tatsaechlichem Migrationsstand erkennen
+- **THEN** blockiert das System Request-Annahme oder Rollout
+- **AND** Readiness, Diagnoseausgabe und Release-Report benennen die Drift maschinenlesbar

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-access-control/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-access-control/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Plugin-Permissions muessen auf kanonische IAM-Vertraege aufloesen
+
+Das System MUST Plugin-deklarierte Permissions und Actions vor der Snapshot-Publikation gegen den hosteigenen IAM-Policy- und Action-Vertrag kreuzvalidieren.
+
+#### Scenario: Plugin referenziert vorhandene Permission
+
+- **GIVEN** ein Plugin deklariert eine Permission oder Action-Anforderung wie `news.create`
+- **WHEN** der Host den Build-time-Registry-Snapshot validiert
+- **THEN** wird die Referenz nur akzeptiert, wenn eine kanonische hostbekannte IAM-Definition dafuer existiert
+- **AND** der Snapshot enthaelt die aufgeloeste, vollqualifizierte Referenz
+
+#### Scenario: Plugin referenziert unbekannte oder falsch geschriebene Permission
+
+- **GIVEN** ein Plugin deklariert eine Referenz wie `news.creat`
+- **WHEN** die Registry validiert wird
+- **THEN** bricht die Snapshot-Publikation mit einem deterministischen Validierungsfehler ab
+- **AND** der Host publiziert keine Route oder UI-Affordance, die erst zur Laufzeit mit `403` scheitert
+
+### Requirement: Vollqualifizierte Action-IDs werden statisch erzwungen
+
+Das System MUST fully-qualified Action-IDs nicht nur fuer Plugin-Beitraege, sondern auch fuer interne host- und authnahe Autorisierungspfade statisch erzwingen.
+
+#### Scenario: Interner Handler verwendet Kurzform
+
+- **WHEN** ein interner Auth-, IAM- oder Content-Pfad eine autorisierbare Action als Kurzform wie `read` oder `write` modelliert
+- **THEN** schlaegt der statische Qualitaetslauf fehl
+- **AND** die Implementierung wird auf eine vollqualifizierte Action-ID migriert
+
+#### Scenario: Nicht autorisierbarer interner Hilfswert bleibt ausserhalb des Scopes
+
+- **WHEN** ein String nicht fuer eine Autorisierungsentscheidung, Auditierung oder Guard-Auswertung verwendet wird
+- **THEN** erzwingt der Gate ihn nicht als Action-ID
+- **AND** der Gate bleibt auf autorisierungsrelevante Kontraktstellen begrenzt

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-access-control/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-access-control/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 
-### Requirement: Plugin-Permissions muessen auf kanonische IAM-Vertraege aufloesen
+### Requirement: Plugin-Permissions müssen auf kanonische IAM-Verträge auflösen
 
 Das System MUST Plugin-deklarierte Permissions und Actions vor der Snapshot-Publikation gegen den hosteigenen IAM-Policy- und Action-Vertrag kreuzvalidieren.
 
@@ -8,8 +8,8 @@ Das System MUST Plugin-deklarierte Permissions und Actions vor der Snapshot-Publ
 
 - **GIVEN** ein Plugin deklariert eine Permission oder Action-Anforderung wie `news.create`
 - **WHEN** der Host den Build-time-Registry-Snapshot validiert
-- **THEN** wird die Referenz nur akzeptiert, wenn eine kanonische hostbekannte IAM-Definition dafuer existiert
-- **AND** der Snapshot enthaelt die aufgeloeste, vollqualifizierte Referenz
+- **THEN** wird die Referenz nur akzeptiert, wenn eine kanonische hostbekannte IAM-Definition dafür existiert
+- **AND** der Snapshot enthält die aufgelöste, vollqualifizierte Referenz
 
 #### Scenario: Plugin referenziert unbekannte oder falsch geschriebene Permission
 
@@ -20,16 +20,16 @@ Das System MUST Plugin-deklarierte Permissions und Actions vor der Snapshot-Publ
 
 ### Requirement: Vollqualifizierte Action-IDs werden statisch erzwungen
 
-Das System MUST fully-qualified Action-IDs nicht nur fuer Plugin-Beitraege, sondern auch fuer interne host- und authnahe Autorisierungspfade statisch erzwingen.
+Das System MUST fully-qualified Action-IDs nicht nur für Plugin-Beiträge, sondern auch für interne host- und authnahe Autorisierungspfade statisch erzwingen.
 
 #### Scenario: Interner Handler verwendet Kurzform
 
 - **WHEN** ein interner Auth-, IAM- oder Content-Pfad eine autorisierbare Action als Kurzform wie `read` oder `write` modelliert
-- **THEN** schlaegt der statische Qualitaetslauf fehl
+- **THEN** schlägt der statische Qualitätslauf fehl
 - **AND** die Implementierung wird auf eine vollqualifizierte Action-ID migriert
 
 #### Scenario: Nicht autorisierbarer interner Hilfswert bleibt ausserhalb des Scopes
 
-- **WHEN** ein String nicht fuer eine Autorisierungsentscheidung, Auditierung oder Guard-Auswertung verwendet wird
+- **WHEN** ein String nicht für eine Autorisierungsentscheidung, Auditierung oder Guard-Auswertung verwendet wird
 - **THEN** erzwingt der Gate ihn nicht als Action-ID
 - **AND** der Gate bleibt auf autorisierungsrelevante Kontraktstellen begrenzt

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-access-control/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-access-control/spec.md
@@ -28,7 +28,7 @@ Das System MUST fully-qualified Action-IDs nicht nur für Plugin-Beiträge, sond
 - **THEN** schlägt der statische Qualitätslauf fehl
 - **AND** die Implementierung wird auf eine vollqualifizierte Action-ID migriert
 
-#### Scenario: Nicht autorisierbarer interner Hilfswert bleibt ausserhalb des Scopes
+#### Scenario: Nicht autorisierbarer interner Hilfswert bleibt außerhalb des Scopes
 
 - **WHEN** ein String nicht für eine Autorisierungsentscheidung, Auditierung oder Guard-Auswertung verwendet wird
 - **THEN** erzwingt der Gate ihn nicht als Action-ID

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-core/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-core/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Serialisierte Session-Refresh-Ausfuehrung
+
+Das System MUST fuer eine persistierte App-Session mit gemeinsamer `sessionId` konkurrierende Token-Refreshes deterministisch serialisieren.
+
+#### Scenario: Zwei parallele Requests treffen auf dieselbe abgelaufene Session
+
+- **GIVEN** zwei Requests verwenden dieselbe Redis-persistierte `sessionId`
+- **AND** der Access-Token ist abgelaufen, aber der Refresh-Token noch gueltig
+- **WHEN** beide Requests nahezu gleichzeitig Session-Hydration ausloesen
+- **THEN** fuehrt genau ein Request den Refresh gegen Keycloak aus
+- **AND** konkurrierende Requests warten auf dasselbe Refresh-Ergebnis oder lesen den aktualisierten Session-Zustand wieder
+- **AND** der Refresh-Token wird nicht mehrfach gegen den Upstream verbraucht
+
+#### Scenario: Gewinner-Refresh scheitert
+
+- **GIVEN** ein Request haelt den Refresh-Slot fuer eine `sessionId`
+- **WHEN** der Upstream-Refresh fehlschlaegt
+- **THEN** erhalten konkurrierende Requests denselben fehlgeschlagenen Session-Status
+- **AND** das System erzeugt keinen zweiten konkurrierenden Refresh-Versuch fuer denselben Sessionzustand
+
+### Requirement: Minimaler `/auth/me`-Antwortvertrag
+
+Das System SHALL fuer `/auth/me` und gleichwertige Auth-Read-Endpoints nur eine explizite Allowlist stabiler Benutzer- und Sitzungsfelder ausliefern.
+
+#### Scenario: Interne SessionUser-Felder wachsen
+
+- **WHEN** interne Profil-, Diagnose- oder Session-Felder zum serverseitigen Benutzerobjekt hinzukommen
+- **THEN** erscheinen diese Felder nicht automatisch in `/auth/me`
+- **AND** nur explizit freigegebene Felder wie Identitaets-, Scope- und UI-relevante Statusinformationen werden serialisiert
+
+#### Scenario: Auth-Read wird fuer Clients erweitert
+
+- **WHEN** ein neues Feld in `/auth/me` benoetigt wird
+- **THEN** wird es ueber die explizite Allowlist oder ein normatives Output-Schema hinzugefuegt
+- **AND** die Aenderung ist fuer Reviewer als Vertragsaenderung sichtbar
+
+### Requirement: Session-Store-Adapter teilen denselben Vertragskern
+
+Das System MUST In-Memory- und Redis-Session-Stores ueber denselben kanonischen Session-Codec, dieselbe TTL-Semantik und dieselben Konkurrenzregeln betreiben.
+
+#### Scenario: Session wird in verschiedenen Adaptern persistiert
+
+- **WHEN** dieselbe fachliche Session in In-Memory- oder Redis-Adapter gespeichert und wieder gelesen wird
+- **THEN** bleiben Tokens, Expiry-Felder, Versionsfelder und Konkurrenz-Metadaten semantisch identisch
+- **AND** adapterbedingte Unterschiede veraendern nicht das Auth-Ergebnis
+
+#### Scenario: Test- und Produktionsadapter verhalten sich konkurenzgleich
+
+- **WHEN** Characterization- oder Integrationstests gegen beide Session-Store-Adapter laufen
+- **THEN** pruefen sie dieselben Refresh-, TTL- und Invalidation-Szenarien
+- **AND** ein nur adapter-spezifisch gruener Pfad gilt nicht als ausreichender Nachweis

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-core/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-core/spec.md
@@ -46,7 +46,7 @@ Das System MUST In-Memory- und Redis-Session-Stores über denselben kanonischen 
 - **THEN** bleiben Tokens, Expiry-Felder, Versionsfelder und Konkurrenz-Metadaten semantisch identisch
 - **AND** adapterbedingte Unterschiede verändern nicht das Auth-Ergebnis
 
-#### Scenario: Test- und Produktionsadapter verhalten sich konkurenzgleich
+#### Scenario: Test- und Produktionsadapter verhalten sich konkurrenzgleich
 
 - **WHEN** Characterization- oder Integrationstests gegen beide Session-Store-Adapter laufen
 - **THEN** prüfen sie dieselben Refresh-, TTL- und Invalidation-Szenarien

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-core/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/iam-core/spec.md
@@ -1,53 +1,53 @@
 ## ADDED Requirements
 
-### Requirement: Serialisierte Session-Refresh-Ausfuehrung
+### Requirement: Serialisierte Session-Refresh-Ausführung
 
-Das System MUST fuer eine persistierte App-Session mit gemeinsamer `sessionId` konkurrierende Token-Refreshes deterministisch serialisieren.
+Das System MUST für eine persistierte App-Session mit gemeinsamer `sessionId` konkurrierende Token-Refreshes deterministisch serialisieren.
 
 #### Scenario: Zwei parallele Requests treffen auf dieselbe abgelaufene Session
 
 - **GIVEN** zwei Requests verwenden dieselbe Redis-persistierte `sessionId`
-- **AND** der Access-Token ist abgelaufen, aber der Refresh-Token noch gueltig
-- **WHEN** beide Requests nahezu gleichzeitig Session-Hydration ausloesen
-- **THEN** fuehrt genau ein Request den Refresh gegen Keycloak aus
+- **AND** der Access-Token ist abgelaufen, aber der Refresh-Token noch gültig
+- **WHEN** beide Requests nahezu gleichzeitig Session-Hydration auslösen
+- **THEN** führt genau ein Request den Refresh gegen Keycloak aus
 - **AND** konkurrierende Requests warten auf dasselbe Refresh-Ergebnis oder lesen den aktualisierten Session-Zustand wieder
 - **AND** der Refresh-Token wird nicht mehrfach gegen den Upstream verbraucht
 
 #### Scenario: Gewinner-Refresh scheitert
 
-- **GIVEN** ein Request haelt den Refresh-Slot fuer eine `sessionId`
-- **WHEN** der Upstream-Refresh fehlschlaegt
+- **GIVEN** ein Request hält den Refresh-Slot für eine `sessionId`
+- **WHEN** der Upstream-Refresh fehlschlägt
 - **THEN** erhalten konkurrierende Requests denselben fehlgeschlagenen Session-Status
-- **AND** das System erzeugt keinen zweiten konkurrierenden Refresh-Versuch fuer denselben Sessionzustand
+- **AND** das System erzeugt keinen zweiten konkurrierenden Refresh-Versuch für denselben Sessionzustand
 
 ### Requirement: Minimaler `/auth/me`-Antwortvertrag
 
-Das System SHALL fuer `/auth/me` und gleichwertige Auth-Read-Endpoints nur eine explizite Allowlist stabiler Benutzer- und Sitzungsfelder ausliefern.
+Das System SHALL für `/auth/me` und gleichwertige Auth-Read-Endpoints nur eine explizite Allowlist stabiler Benutzer- und Sitzungsfelder ausliefern.
 
 #### Scenario: Interne SessionUser-Felder wachsen
 
 - **WHEN** interne Profil-, Diagnose- oder Session-Felder zum serverseitigen Benutzerobjekt hinzukommen
 - **THEN** erscheinen diese Felder nicht automatisch in `/auth/me`
-- **AND** nur explizit freigegebene Felder wie Identitaets-, Scope- und UI-relevante Statusinformationen werden serialisiert
+- **AND** nur explizit freigegebene Felder wie Identitäts-, Scope- und UI-relevante Statusinformationen werden serialisiert
 
-#### Scenario: Auth-Read wird fuer Clients erweitert
+#### Scenario: Auth-Read wird für Clients erweitert
 
-- **WHEN** ein neues Feld in `/auth/me` benoetigt wird
-- **THEN** wird es ueber die explizite Allowlist oder ein normatives Output-Schema hinzugefuegt
-- **AND** die Aenderung ist fuer Reviewer als Vertragsaenderung sichtbar
+- **WHEN** ein neues Feld in `/auth/me` benötigt wird
+- **THEN** wird es über die explizite Allowlist oder ein normatives Output-Schema hinzugefügt
+- **AND** die Änderung ist für Reviewer als Vertragsänderung sichtbar
 
 ### Requirement: Session-Store-Adapter teilen denselben Vertragskern
 
-Das System MUST In-Memory- und Redis-Session-Stores ueber denselben kanonischen Session-Codec, dieselbe TTL-Semantik und dieselben Konkurrenzregeln betreiben.
+Das System MUST In-Memory- und Redis-Session-Stores über denselben kanonischen Session-Codec, dieselbe TTL-Semantik und dieselben Konkurrenzregeln betreiben.
 
 #### Scenario: Session wird in verschiedenen Adaptern persistiert
 
 - **WHEN** dieselbe fachliche Session in In-Memory- oder Redis-Adapter gespeichert und wieder gelesen wird
 - **THEN** bleiben Tokens, Expiry-Felder, Versionsfelder und Konkurrenz-Metadaten semantisch identisch
-- **AND** adapterbedingte Unterschiede veraendern nicht das Auth-Ergebnis
+- **AND** adapterbedingte Unterschiede verändern nicht das Auth-Ergebnis
 
 #### Scenario: Test- und Produktionsadapter verhalten sich konkurenzgleich
 
 - **WHEN** Characterization- oder Integrationstests gegen beide Session-Store-Adapter laufen
-- **THEN** pruefen sie dieselben Refresh-, TTL- und Invalidation-Szenarien
-- **AND** ein nur adapter-spezifisch gruener Pfad gilt nicht als ausreichender Nachweis
+- **THEN** prüfen sie dieselben Refresh-, TTL- und Invalidation-Szenarien
+- **AND** ein nur adapter-spezifisch grüner Pfad gilt nicht als ausreichender Nachweis

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monitoring-client/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monitoring-client/spec.md
@@ -8,7 +8,7 @@ Die Produktions-Runtime MUST OpenTelemetry und den produktiven Server-Logger abs
 
 - **WHEN** die Produktions-Runtime bootet
 - **THEN** initialisiert sie OTEL und den verpflichtenden Exportpfad vor dem ersten Request-Handling
-- **AND** fruehe Boot- und Handler-Logs gehen nicht nur an lokale Fallback-Kanäle verloren
+- **AND** frühe Boot- und Handler-Logs gehen nicht nur an lokale Fallback-Kanäle verloren
 
 #### Scenario: OTEL ist in Produktion nicht bereit
 

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monitoring-client/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monitoring-client/spec.md
@@ -2,16 +2,16 @@
 
 ### Requirement: Produktions-Boot wartet auf OTEL-Readiness vor Request-Annahme
 
-Die Produktions-Runtime MUST OpenTelemetry und den produktiven Server-Logger abschliessen, bevor die Anwendung Requests annimmt oder Handler mountet.
+Die Produktions-Runtime MUST OpenTelemetry und den produktiven Server-Logger abschließen, bevor die Anwendung Requests annimmt oder Handler mountet.
 
 #### Scenario: Produktion startet mit korrekter OTEL-Konfiguration
 
 - **WHEN** die Produktions-Runtime bootet
 - **THEN** initialisiert sie OTEL und den verpflichtenden Exportpfad vor dem ersten Request-Handling
-- **AND** fruehe Boot- und Handler-Logs gehen nicht nur an lokale Fallback-Kanaele verloren
+- **AND** fruehe Boot- und Handler-Logs gehen nicht nur an lokale Fallback-Kanäle verloren
 
 #### Scenario: OTEL ist in Produktion nicht bereit
 
 - **WHEN** die Produktions-Runtime OTEL oder den verpflichtenden Exportpfad nicht initialisieren kann
 - **THEN** bricht der Start vor der Request-Annahme fail-closed ab
-- **AND** die Anwendung laeuft nicht in einen stillen teilbeobachtbaren Zustand
+- **AND** die Anwendung läuft nicht in einen stillen teilbeobachtbaren Zustand

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monitoring-client/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monitoring-client/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Produktions-Boot wartet auf OTEL-Readiness vor Request-Annahme
+
+Die Produktions-Runtime MUST OpenTelemetry und den produktiven Server-Logger abschliessen, bevor die Anwendung Requests annimmt oder Handler mountet.
+
+#### Scenario: Produktion startet mit korrekter OTEL-Konfiguration
+
+- **WHEN** die Produktions-Runtime bootet
+- **THEN** initialisiert sie OTEL und den verpflichtenden Exportpfad vor dem ersten Request-Handling
+- **AND** fruehe Boot- und Handler-Logs gehen nicht nur an lokale Fallback-Kanaele verloren
+
+#### Scenario: OTEL ist in Produktion nicht bereit
+
+- **WHEN** die Produktions-Runtime OTEL oder den verpflichtenden Exportpfad nicht initialisieren kann
+- **THEN** bricht der Start vor der Request-Annahme fail-closed ab
+- **AND** die Anwendung laeuft nicht in einen stillen teilbeobachtbaren Zustand

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monorepo-structure/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monorepo-structure/spec.md
@@ -1,48 +1,48 @@
 ## ADDED Requirements
 
-### Requirement: Plugin-Preflight validiert SDK-Kompatibilitaet und Translation-Ownership
+### Requirement: Plugin-Preflight validiert SDK-Kompatibilität und Translation-Ownership
 
-Das Monorepo SHALL den Build-time-Plugin-Preflight um SDK-Kompatibilitaetspruefung, Translation-Ownership und Aktivierungsstatus erweitern, bevor der Registry-Snapshot publiziert wird.
+Das Monorepo SHALL den Build-time-Plugin-Preflight um SDK-Kompatibilitätsprüfung, Translation-Ownership und Aktivierungsstatus erweitern, bevor der Registry-Snapshot publiziert wird.
 
 #### Scenario: Plugin deklariert kompatible SDK-Range
 
-- **GIVEN** ein Plugin deklariert seine unterstuetzte SDK-SemVer-Range
+- **GIVEN** ein Plugin deklariert seine unterstützte SDK-SemVer-Range
 - **WHEN** der Host den Snapshot erzeugt
 - **THEN** wird das Plugin nur akzeptiert, wenn die installierte `@sva/plugin-sdk`-Version in dieser Range liegt
-- **AND** inkompatible Plugins werden mit einem deterministischen Kompatibilitaetsfehler abgewiesen
+- **AND** inkompatible Plugins werden mit einem deterministischen Kompatibilitätsfehler abgewiesen
 
 #### Scenario: Zwei aktive Plugins kollidieren auf demselben Translation-Pfad
 
 - **GIVEN** zwei aktive Plugins belegen denselben kanonischen Translation-Key oder Key-Pfad
-- **WHEN** der Preflight die Plugin-i18n-Baeume validiert
+- **WHEN** der Preflight die Plugin-i18n-Bäume validiert
 - **THEN** behandelt der Host dies als Kollision statt als stilles Last-Wins-Merge
 - **AND** der Fehler benennt Key und owning Plugins
 
 #### Scenario: Build-linked Plugin ist deaktiviert
 
-- **GIVEN** ein Plugin ist im Workspace gebaut, aber fuer eine Instanz oder Umgebung deaktiviert
-- **WHEN** der Host den aktiven Snapshot fuer diese Aktivierungsmenge erstellt
-- **THEN** bleiben seine Routen, Navigationseintraege, Translationen und Admin-Beitraege inaktiv
+- **GIVEN** ein Plugin ist im Workspace gebaut, aber für eine Instanz oder Umgebung deaktiviert
+- **WHEN** der Host den aktiven Snapshot für diese Aktivierungsmenge erstellt
+- **THEN** bleiben seine Routen, Navigationseinträge, Translationen und Admin-Beiträge inaktiv
 - **AND** der Host kann denselben Build mit unterschiedlicher Plugin-Aktivierung betreiben
 
-### Requirement: Architektur-Gates sind verbindlicher Teil des Qualitaetslaufs
+### Requirement: Architektur-Gates sind verbindlicher Teil des Qualitätslaufs
 
-Das Monorepo MUST cross-cutting Architekturregeln ueber verbindliche lokale und CI-Gates erzwingen statt nur ueber Konventionen oder Einzeltests.
+Das Monorepo MUST cross-cutting Architekturregeln über verbindliche lokale und CI-Gates erzwingen statt nur über Konventionen oder Einzeltests.
 
 #### Scenario: Dependency-Graph driftet von den Zielgrenzen weg
 
 - **WHEN** ein Projektgraph- oder Dependency-Snapshot eine unerlaubte neue Importkante zeigt
-- **THEN** schlaegt der Architektur-Gate fehl
+- **THEN** schlägt der Architektur-Gate fehl
 - **AND** der Befund benennt Quelle, Ziel und verletzte Boundary-Regel
 
-#### Scenario: Sichtbare UI-Texte oder fehlende i18n-Keys werden eingefuehrt
+#### Scenario: Sichtbare UI-Texte oder fehlende i18n-Keys werden eingeführt
 
-- **WHEN** der i18n-Qualitaetslauf fehlende, ungenutzte oder nicht extrahierte sichtbare Texte erkennt
+- **WHEN** der i18n-Qualitätslauf fehlende, ungenutzte oder nicht extrahierte sichtbare Texte erkennt
 - **THEN** blockiert der Gate den Build oder PR-Check
 - **AND** die Verletzung ist nicht nur ein Review-Hinweis
 
 #### Scenario: Server-only Modul leakt in universalen oder Client-Code
 
 - **WHEN** ein universal, clientseitig oder eager geladenes Modul direkt oder transitiv `.server.ts`, `@sva/*/server` oder gleichwertige server-only Pfade importiert
-- **THEN** schlaegt der statische Gate fehl
-- **AND** dies gilt auch fuer `interfaces-api`-aehnliche Reflexions- oder `typeof import(...)`-Pfade
+- **THEN** schlägt der statische Gate fehl
+- **AND** dies gilt auch für `interfaces-api`-ähnliche Reflexions- oder `typeof import(...)`-Pfade

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monorepo-structure/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/monorepo-structure/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Plugin-Preflight validiert SDK-Kompatibilitaet und Translation-Ownership
+
+Das Monorepo SHALL den Build-time-Plugin-Preflight um SDK-Kompatibilitaetspruefung, Translation-Ownership und Aktivierungsstatus erweitern, bevor der Registry-Snapshot publiziert wird.
+
+#### Scenario: Plugin deklariert kompatible SDK-Range
+
+- **GIVEN** ein Plugin deklariert seine unterstuetzte SDK-SemVer-Range
+- **WHEN** der Host den Snapshot erzeugt
+- **THEN** wird das Plugin nur akzeptiert, wenn die installierte `@sva/plugin-sdk`-Version in dieser Range liegt
+- **AND** inkompatible Plugins werden mit einem deterministischen Kompatibilitaetsfehler abgewiesen
+
+#### Scenario: Zwei aktive Plugins kollidieren auf demselben Translation-Pfad
+
+- **GIVEN** zwei aktive Plugins belegen denselben kanonischen Translation-Key oder Key-Pfad
+- **WHEN** der Preflight die Plugin-i18n-Baeume validiert
+- **THEN** behandelt der Host dies als Kollision statt als stilles Last-Wins-Merge
+- **AND** der Fehler benennt Key und owning Plugins
+
+#### Scenario: Build-linked Plugin ist deaktiviert
+
+- **GIVEN** ein Plugin ist im Workspace gebaut, aber fuer eine Instanz oder Umgebung deaktiviert
+- **WHEN** der Host den aktiven Snapshot fuer diese Aktivierungsmenge erstellt
+- **THEN** bleiben seine Routen, Navigationseintraege, Translationen und Admin-Beitraege inaktiv
+- **AND** der Host kann denselben Build mit unterschiedlicher Plugin-Aktivierung betreiben
+
+### Requirement: Architektur-Gates sind verbindlicher Teil des Qualitaetslaufs
+
+Das Monorepo MUST cross-cutting Architekturregeln ueber verbindliche lokale und CI-Gates erzwingen statt nur ueber Konventionen oder Einzeltests.
+
+#### Scenario: Dependency-Graph driftet von den Zielgrenzen weg
+
+- **WHEN** ein Projektgraph- oder Dependency-Snapshot eine unerlaubte neue Importkante zeigt
+- **THEN** schlaegt der Architektur-Gate fehl
+- **AND** der Befund benennt Quelle, Ziel und verletzte Boundary-Regel
+
+#### Scenario: Sichtbare UI-Texte oder fehlende i18n-Keys werden eingefuehrt
+
+- **WHEN** der i18n-Qualitaetslauf fehlende, ungenutzte oder nicht extrahierte sichtbare Texte erkennt
+- **THEN** blockiert der Gate den Build oder PR-Check
+- **AND** die Verletzung ist nicht nur ein Review-Hinweis
+
+#### Scenario: Server-only Modul leakt in universalen oder Client-Code
+
+- **WHEN** ein universal, clientseitig oder eager geladenes Modul direkt oder transitiv `.server.ts`, `@sva/*/server` oder gleichwertige server-only Pfade importiert
+- **THEN** schlaegt der statische Gate fehl
+- **AND** dies gilt auch fuer `interfaces-api`-aehnliche Reflexions- oder `typeof import(...)`-Pfade

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/routing/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/routing/spec.md
@@ -31,7 +31,7 @@ Das Routing-System SHALL Plugin-Routen über einen deklarativen, typisierten Ver
 
 #### Scenario: Plugin versucht host-owned Parsing zu ersetzen
 
-- **GIVEN** ein Plugin versucht eine Route mit eigenem Guard-, Parse- oder Materialisierungsverhalten ausserhalb des Vertrags zu liefern
+- **GIVEN** ein Plugin versucht eine Route mit eigenem Guard-, Parse- oder Materialisierungsverhalten außerhalb des Vertrags zu liefern
 - **WHEN** der Host die Definition validiert
 - **THEN** wird der Beitrag abgewiesen
 - **AND** Search-Param-Parsing, Guard-Auswertung und Route-Ownership bleiben hostkontrolliert

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/routing/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/routing/spec.md
@@ -6,28 +6,28 @@ Das Routing-System MUST kollidierende Plugin-Routen vor dem Aufbau des Route-Bau
 
 #### Scenario: Zwei Plugins beanspruchen denselben kanonischen Pfad
 
-- **GIVEN** zwei Plugin-Beitraege registrieren denselben kanonischen Routenpfad
+- **GIVEN** zwei Plugin-Beiträge registrieren denselben kanonischen Routenpfad
 - **WHEN** der Host den Route-Baum materialisiert
 - **THEN** bricht die Registrierungsphase mit einem Konfliktfehler ab
-- **AND** es wird kein teilweise inkonsistenter Route-Baum veroeffentlicht
+- **AND** es wird kein teilweise inkonsistenter Route-Baum veröffentlicht
 
 #### Scenario: Route-Konflikt bleibt auf dieselbe Aktivierungsmenge begrenzt
 
-- **GIVEN** ein Plugin ist fuer die aktuelle Instanz oder Umgebung deaktiviert
-- **WHEN** der Host aktive Plugin-Beitraege validiert
-- **THEN** prueft der Konflikt-Detektor nur die effektiv aktive Beitragsmenge
-- **AND** deaktivierte Beitraege ueberschreiben keine aktiven Routen stillschweigend
+- **GIVEN** ein Plugin ist für die aktuelle Instanz oder Umgebung deaktiviert
+- **WHEN** der Host aktive Plugin-Beiträge validiert
+- **THEN** prüft der Konflikt-Detektor nur die effektiv aktive Beitragsmenge
+- **AND** deaktivierte Beiträge überschreiben keine aktiven Routen stillschweigend
 
 ### Requirement: Typisierter Plugin-Route-Vertrag
 
-Das Routing-System SHALL Plugin-Routen ueber einen deklarativen, typisierten Vertrag fuer Search-Params, Path-Params und Component-Bindings integrieren.
+Das Routing-System SHALL Plugin-Routen über einen deklarativen, typisierten Vertrag für Search-Params, Path-Params und Component-Bindings integrieren.
 
 #### Scenario: Plugin liefert typisierte Search-Params
 
-- **GIVEN** ein Plugin deklariert Search-Params und Path-Params fuer eine Route
+- **GIVEN** ein Plugin deklariert Search-Params und Path-Params für eine Route
 - **WHEN** der Host die Route materialisiert
 - **THEN** bleiben diese Typinformationen im Hostvertrag erhalten
-- **AND** die Route-Component wird nicht ueber einen untypisierten `unknown`-Cast eingebunden
+- **AND** die Route-Component wird nicht über einen untypisierten `unknown`-Cast eingebunden
 
 #### Scenario: Plugin versucht host-owned Parsing zu ersetzen
 

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/routing/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/routing/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Fail-Fast bei Plugin-Routen-Kollisionen
+
+Das Routing-System MUST kollidierende Plugin-Routen vor dem Aufbau des Route-Baums deterministisch erkennen und die Materialisierung abbrechen.
+
+#### Scenario: Zwei Plugins beanspruchen denselben kanonischen Pfad
+
+- **GIVEN** zwei Plugin-Beitraege registrieren denselben kanonischen Routenpfad
+- **WHEN** der Host den Route-Baum materialisiert
+- **THEN** bricht die Registrierungsphase mit einem Konfliktfehler ab
+- **AND** es wird kein teilweise inkonsistenter Route-Baum veroeffentlicht
+
+#### Scenario: Route-Konflikt bleibt auf dieselbe Aktivierungsmenge begrenzt
+
+- **GIVEN** ein Plugin ist fuer die aktuelle Instanz oder Umgebung deaktiviert
+- **WHEN** der Host aktive Plugin-Beitraege validiert
+- **THEN** prueft der Konflikt-Detektor nur die effektiv aktive Beitragsmenge
+- **AND** deaktivierte Beitraege ueberschreiben keine aktiven Routen stillschweigend
+
+### Requirement: Typisierter Plugin-Route-Vertrag
+
+Das Routing-System SHALL Plugin-Routen ueber einen deklarativen, typisierten Vertrag fuer Search-Params, Path-Params und Component-Bindings integrieren.
+
+#### Scenario: Plugin liefert typisierte Search-Params
+
+- **GIVEN** ein Plugin deklariert Search-Params und Path-Params fuer eine Route
+- **WHEN** der Host die Route materialisiert
+- **THEN** bleiben diese Typinformationen im Hostvertrag erhalten
+- **AND** die Route-Component wird nicht ueber einen untypisierten `unknown`-Cast eingebunden
+
+#### Scenario: Plugin versucht host-owned Parsing zu ersetzen
+
+- **GIVEN** ein Plugin versucht eine Route mit eigenem Guard-, Parse- oder Materialisierungsverhalten ausserhalb des Vertrags zu liefern
+- **WHEN** der Host die Definition validiert
+- **THEN** wird der Beitrag abgewiesen
+- **AND** Search-Param-Parsing, Guard-Auswertung und Route-Ownership bleiben hostkontrolliert

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/test-coverage-governance/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/test-coverage-governance/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Kritische Auth- und Registry-Module ratcheten auf den globalen Coverage-Zielwert
+
+Das System SHALL fuer kritische Auth-, Registry- und Routing-Module einen dokumentierten Ratcheting-Pfad auf den globalen Coverage-Zielwert bereitstellen, statt abgesenkte Floors dauerhaft beizubehalten.
+
+#### Scenario: Kritisches Modul liegt noch unter dem Zielwert
+
+- **GIVEN** ein kritisches Modul hat einen temporaer niedrigeren Coverage-Floor als den globalen Zielwert
+- **WHEN** die Coverage-Policy gepflegt wird
+- **THEN** dokumentiert sie Zwischenstufen, Begruendung und Abbaupfad bis zum Zielwert
+- **AND** der Floor wird nicht stillschweigend auf unbestimmte Zeit als Endzustand akzeptiert
+
+#### Scenario: Kritisches Modul verbessert seine Coverage
+
+- **GIVEN** ein kritisches Modul stabil ueber seinem aktuellen Zwischenwert liegt
+- **WHEN** die Policy ueberprueft wird
+- **THEN** ratchetet der definierte Floor nach oben
+- **AND** abgesenkte Floors werden nicht aus Bequemlichkeit erneut erweitert

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/test-coverage-governance/spec.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/specs/test-coverage-governance/spec.md
@@ -2,18 +2,18 @@
 
 ### Requirement: Kritische Auth- und Registry-Module ratcheten auf den globalen Coverage-Zielwert
 
-Das System SHALL fuer kritische Auth-, Registry- und Routing-Module einen dokumentierten Ratcheting-Pfad auf den globalen Coverage-Zielwert bereitstellen, statt abgesenkte Floors dauerhaft beizubehalten.
+Das System SHALL für kritische Auth-, Registry- und Routing-Module einen dokumentierten Ratcheting-Pfad auf den globalen Coverage-Zielwert bereitstellen, statt abgesenkte Floors dauerhaft beizubehalten.
 
 #### Scenario: Kritisches Modul liegt noch unter dem Zielwert
 
-- **GIVEN** ein kritisches Modul hat einen temporaer niedrigeren Coverage-Floor als den globalen Zielwert
+- **GIVEN** ein kritisches Modul hat einen temporär niedrigeren Coverage-Floor als den globalen Zielwert
 - **WHEN** die Coverage-Policy gepflegt wird
-- **THEN** dokumentiert sie Zwischenstufen, Begruendung und Abbaupfad bis zum Zielwert
+- **THEN** dokumentiert sie Zwischenstufen, Begründung und Abbaupfad bis zum Zielwert
 - **AND** der Floor wird nicht stillschweigend auf unbestimmte Zeit als Endzustand akzeptiert
 
 #### Scenario: Kritisches Modul verbessert seine Coverage
 
-- **GIVEN** ein kritisches Modul stabil ueber seinem aktuellen Zwischenwert liegt
-- **WHEN** die Policy ueberprueft wird
+- **GIVEN** ein kritisches Modul stabil über seinem aktuellen Zwischenwert liegt
+- **WHEN** die Policy überprüft wird
 - **THEN** ratchetet der definierte Floor nach oben
 - **AND** abgesenkte Floors werden nicht aus Bequemlichkeit erneut erweitert

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/tasks.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/tasks.md
@@ -1,0 +1,36 @@
+## 1. Auth- und Runtime-Haertung
+
+- [ ] 1.1 Session-Characterization-Tests fuer parallele Refreshes gegen Redis-Session-Store ergänzen
+- [ ] 1.2 Refresh-Pfad pro `sessionId` serialisieren und konkurrierende Requests auf dasselbe Ergebnis aufloesen
+- [ ] 1.3 `/auth/me` auf explizite Response-Allowlist oder Output-Schema umstellen
+- [ ] 1.4 In-Memory- und Redis-Session-Store auf gemeinsamen Codec-, TTL- und Konkurrenzvertrag angleichen
+- [ ] 1.5 OTEL-SDK im Produktions-Bootpfad vor dem ersten Handler-Mount initialisieren
+- [ ] 1.6 Runtime-Readiness und Boot-Checks auf Datenbank-Migrationsdrift erweitern
+
+## 2. Plugin-Vertrag und Host-Grenzen
+
+- [ ] 2.1 Build-time-Registry fuer Route-Kollisionen, Translation-Kollisionen und doppelte Namespaces fail-fast haerten
+- [ ] 2.2 Plugin-Permissions gegen das kanonische IAM-Policy-Manifest kreuzvalidieren
+- [ ] 2.3 SDK-SemVer-Range-Pruefung beim Registrieren von Plugins einfuehren
+- [ ] 2.4 Typisierten Plugin-Route-Vertrag fuer Search-Params, Path-Params und Component-Bindings einfuehren
+- [ ] 2.5 Hostkontrollierte Aktivierungsflags fuer build-linked Plugins pro Instanz oder Umgebung verdrahten
+- [ ] 2.6 Vollqualifizierte Action-IDs per Lint- oder Build-Gate auch in internen Auth- und IAM-Pfaden erzwingen
+
+## 3. Daten- und Cache-Konsistenz
+
+- [ ] 3.1 Hostvalidierten Invalidation-Tag-Vertrag fuer Mutationen definieren
+- [ ] 3.2 Core-App- und Plugin-Mutationen an zentrale Query-Invalidierung anbinden
+
+## 4. CI- und Architektur-Gates
+
+- [ ] 4.1 Dependency-Graph- oder dependency-cruiser-Snapshot als CI-Gate einfuehren
+- [ ] 4.2 i18n-Key-Extraktion und Missing-Key-Check in lokale Qualitaetslaeufe und CI aufnehmen
+- [ ] 4.3 `.server.ts`-, server-only- und `interfaces-api`-Leak-Gates als statische Pruefungen verankern
+- [ ] 4.4 Coverage-Policy fuer kritische Auth-, Registry- und Routing-Pakete in Richtung `85%` ratcheten
+- [ ] 4.5 Komplexitaets-Policy fuer offene Auth-Hotspots auf No-Growth und verpflichtende Zerlegung umstellen
+
+## 5. Dokumentation und Entscheidungen
+
+- [ ] 5.1 Betroffene arc42-Abschnitte `04`, `05`, `06`, `08`, `09`, `10` und `11` aktualisieren
+- [ ] 5.2 Eine ADR fuer Plugin-Guardrails und Runtime-Boot-Guardrails anlegen oder fortschreiben
+- [ ] 5.3 Dokumentierte Uebergangs- und Exemption-Liste fuer bestehende Plugin- und Qualitaets-Abweichungen pflegen

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/tasks.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/tasks.md
@@ -1,7 +1,7 @@
-## 1. Auth- und Runtime-Haertung
+## 1. Auth- und Runtime-Härtung
 
-- [ ] 1.1 Session-Characterization-Tests fuer parallele Refreshes gegen Redis-Session-Store ergänzen
-- [ ] 1.2 Refresh-Pfad pro `sessionId` serialisieren und konkurrierende Requests auf dasselbe Ergebnis aufloesen
+- [ ] 1.1 Session-Characterization-Tests für parallele Refreshes gegen Redis-Session-Store ergänzen
+- [ ] 1.2 Refresh-Pfad pro `sessionId` serialisieren und konkurrierende Requests auf dasselbe Ergebnis auflösen
 - [ ] 1.3 `/auth/me` auf explizite Response-Allowlist oder Output-Schema umstellen
 - [ ] 1.4 In-Memory- und Redis-Session-Store auf gemeinsamen Codec-, TTL- und Konkurrenzvertrag angleichen
 - [ ] 1.5 OTEL-SDK im Produktions-Bootpfad vor dem ersten Handler-Mount initialisieren
@@ -9,28 +9,28 @@
 
 ## 2. Plugin-Vertrag und Host-Grenzen
 
-- [ ] 2.1 Build-time-Registry fuer Route-Kollisionen, Translation-Kollisionen und doppelte Namespaces fail-fast haerten
+- [ ] 2.1 Build-time-Registry für Route-Kollisionen, Translation-Kollisionen und doppelte Namespaces fail-fast härten
 - [ ] 2.2 Plugin-Permissions gegen das kanonische IAM-Policy-Manifest kreuzvalidieren
-- [ ] 2.3 SDK-SemVer-Range-Pruefung beim Registrieren von Plugins einfuehren
-- [ ] 2.4 Typisierten Plugin-Route-Vertrag fuer Search-Params, Path-Params und Component-Bindings einfuehren
-- [ ] 2.5 Hostkontrollierte Aktivierungsflags fuer build-linked Plugins pro Instanz oder Umgebung verdrahten
+- [ ] 2.3 SDK-SemVer-Range-Prüfung beim Registrieren von Plugins einführen
+- [ ] 2.4 Typisierten Plugin-Route-Vertrag für Search-Params, Path-Params und Component-Bindings einführen
+- [ ] 2.5 Hostkontrollierte Aktivierungsflags für build-linked Plugins pro Instanz oder Umgebung verdrahten
 - [ ] 2.6 Vollqualifizierte Action-IDs per Lint- oder Build-Gate auch in internen Auth- und IAM-Pfaden erzwingen
 
 ## 3. Daten- und Cache-Konsistenz
 
-- [ ] 3.1 Hostvalidierten Invalidation-Tag-Vertrag fuer Mutationen definieren
+- [ ] 3.1 Hostvalidierten Invalidation-Tag-Vertrag für Mutationen definieren
 - [ ] 3.2 Core-App- und Plugin-Mutationen an zentrale Query-Invalidierung anbinden
 
 ## 4. CI- und Architektur-Gates
 
-- [ ] 4.1 Dependency-Graph- oder dependency-cruiser-Snapshot als CI-Gate einfuehren
-- [ ] 4.2 i18n-Key-Extraktion und Missing-Key-Check in lokale Qualitaetslaeufe und CI aufnehmen
-- [ ] 4.3 `.server.ts`-, server-only- und `interfaces-api`-Leak-Gates als statische Pruefungen verankern
-- [ ] 4.4 Coverage-Policy fuer kritische Auth-, Registry- und Routing-Pakete in Richtung `85%` ratcheten
-- [ ] 4.5 Komplexitaets-Policy fuer offene Auth-Hotspots auf No-Growth und verpflichtende Zerlegung umstellen
+- [ ] 4.1 Dependency-Graph- oder dependency-cruiser-Snapshot als CI-Gate einführen
+- [ ] 4.2 i18n-Key-Extraktion und Missing-Key-Check in lokale Qualitätsläufe und CI aufnehmen
+- [ ] 4.3 `.server.ts`-, server-only- und `interfaces-api`-Leak-Gates als statische Prüfungen verankern
+- [ ] 4.4 Coverage-Policy für kritische Auth-, Registry- und Routing-Pakete in Richtung `85%` ratcheten
+- [ ] 4.5 Komplexitäts-Policy für offene Auth-Hotspots auf No-Growth und verpflichtende Zerlegung umstellen
 
 ## 5. Dokumentation und Entscheidungen
 
 - [ ] 5.1 Betroffene arc42-Abschnitte `04`, `05`, `06`, `08`, `09`, `10` und `11` aktualisieren
-- [ ] 5.2 Eine ADR fuer Plugin-Guardrails und Runtime-Boot-Guardrails anlegen oder fortschreiben
-- [ ] 5.3 Dokumentierte Uebergangs- und Exemption-Liste fuer bestehende Plugin- und Qualitaets-Abweichungen pflegen
+- [ ] 5.2 Eine ADR für Plugin-Guardrails und Runtime-Boot-Guardrails anlegen oder fortschreiben
+- [ ] 5.3 Dokumentierte Übergangs- und Exemption-Liste für bestehende Plugin- und Qualitäts-Abweichungen pflegen

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "check:plugin-ui-boundary": "tsx scripts/ci/check-plugin-ui-boundary.ts",
     "verify:runtime-artifact": "env -u NO_COLOR nx run sva-studio-react:verify:runtime-artifact",
     "test:release:studio": "pnpm test:pr && pnpm verify:runtime-artifact",
-    "test:pr": "pnpm clean:generated-source-artifacts && pnpm check:file-placement && pnpm check:plugin-ui-boundary && env COVERAGE_GATE_REQUIRE_SUMMARIES=0 pnpm nx affected --target=test:coverage --base=origin/main --output-style=stream && pnpm patch-coverage-gate --base=origin/main && pnpm sonar-new-code-gate --base=origin/main && env COVERAGE_GATE_REQUIRE_SUMMARIES=0 pnpm coverage-gate && pnpm complexity-gate && pnpm test:integration && pnpm nx run sva-studio-react:build",
+    "test:pr": "pnpm check:toolchain-consistency && pnpm clean:generated-source-artifacts && pnpm check:file-placement && pnpm check:plugin-ui-boundary && env COVERAGE_GATE_REQUIRE_SUMMARIES=0 pnpm nx affected --target=test:coverage --base=origin/main --output-style=stream && pnpm patch-coverage-gate --base=origin/main && pnpm sonar-new-code-gate --base=origin/main && env COVERAGE_GATE_REQUIRE_SUMMARIES=0 pnpm coverage-gate && pnpm complexity-gate && pnpm test:integration && pnpm nx run sva-studio-react:build",
     "test:integration": "env -u NO_COLOR nx run-many -t test:integration",
     "test:e2e": "env -u NO_COLOR nx run sva-studio-react:test:e2e",
     "test:acceptance:iam": "env -u NO_COLOR nx run sva-studio-react:test:acceptance",

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
@@ -47,6 +47,7 @@ describe('executeCreateUser', () => {
     });
     state.resolveAuthConfigForInstance.mockResolvedValue({
       clientId: 'sva-studio',
+      redirectUri: 'https://tenant.example.test/auth/callback',
       postLogoutRedirectUri: 'https://tenant.example.test/',
     });
   });
@@ -118,7 +119,7 @@ describe('executeCreateUser', () => {
     expect(identityProvider.provider.executeActionsEmail).toHaveBeenCalledWith('kc-user-1', {
       actions: ['UPDATE_PASSWORD'],
       clientId: 'sva-studio',
-      redirectUri: 'https://tenant.example.test/',
+      redirectUri: 'https://tenant.example.test/auth/callback',
     });
     expect(result.invitation.status).toBe('sent');
   });

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
@@ -125,7 +125,7 @@ const sendPasswordSetupInvitation = async (input: {
     await executeActionsEmail(input.keycloakSubject, {
       actions: ['UPDATE_PASSWORD'],
       clientId: authConfig.clientId,
-      redirectUri: authConfig.postLogoutRedirectUri,
+      redirectUri: authConfig.redirectUri,
     });
   });
 

--- a/packages/auth-runtime/src/iam-account-management/user-password-setup-email-handler.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-password-setup-email-handler.test.ts
@@ -110,6 +110,7 @@ describe('sendPasswordSetupEmailInternal', () => {
     });
     state.resolveAuthConfigForInstance.mockResolvedValue({
       clientId: 'sva-studio',
+      redirectUri: 'https://tenant.example.test/auth/callback',
       postLogoutRedirectUri: 'https://tenant.example.test/',
     });
     state.requireUserMutationIdentityProvider.mockResolvedValue({
@@ -146,7 +147,7 @@ describe('sendPasswordSetupEmailInternal', () => {
     expect(identityProvider.provider.executeActionsEmail).toHaveBeenCalledWith('kc-user-1', {
       actions: ['UPDATE_PASSWORD'],
       clientId: 'sva-studio',
-      redirectUri: 'https://tenant.example.test/',
+      redirectUri: 'https://tenant.example.test/auth/callback',
     });
     expect(state.completeIdempotency).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/auth-runtime/src/iam-account-management/user-password-setup-email-send.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-password-setup-email-send.ts
@@ -155,7 +155,7 @@ const sendPasswordSetupEmail = async (input: {
     input.executeActionsEmail(input.user.keycloakSubject, {
       actions: ['UPDATE_PASSWORD'],
       clientId: authConfig.clientId,
-      redirectUri: authConfig.postLogoutRedirectUri,
+      redirectUri: authConfig.redirectUri,
     })
   );
 };

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -517,6 +517,7 @@ describe('Keycloak admin client', () => {
           { id: 'role-view-users', name: 'view-users' },
           { id: 'role-view-realm', name: 'view-realm' },
           { id: 'role-manage-realm', name: 'manage-realm' },
+          { id: 'role-manage-clients', name: 'manage-clients' },
         ])
       )
       .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'role-view-users', name: 'view-users' }]))
@@ -535,6 +536,7 @@ describe('Keycloak admin client', () => {
       { id: 'role-manage-users', name: 'manage-users' },
       { id: 'role-view-realm', name: 'view-realm' },
       { id: 'role-manage-realm', name: 'manage-realm' },
+      { id: 'role-manage-clients', name: 'manage-clients' },
     ]);
   });
 

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -580,7 +580,6 @@ describe('Keycloak admin client', () => {
   });
 
   it('fails tenant admin service access provisioning when the target client is missing', async () => {
-    const { KeycloakAdminRequestError } = await import('./core.js');
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
@@ -588,10 +587,9 @@ describe('Keycloak admin client', () => {
 
     const client = await createClient(fetchImpl);
 
-    await expect(client.ensureTenantAdminServiceAccess('tenant-admin')).rejects.toMatchObject<KeycloakAdminRequestError>({
-      code: 'unknown_client',
-      statusCode: 404,
-    });
+    await expect(client.ensureTenantAdminServiceAccess('tenant-admin')).rejects.toMatchObject<
+      import('./core.js').KeycloakAdminRequestError
+    >({ code: 'unknown_client', statusCode: 404 });
   });
 
   it('does not regenerate a client secret during normal reconciliation when the configured secret differs', async () => {

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -540,6 +540,60 @@ describe('Keycloak admin client', () => {
     ]);
   });
 
+  it('skips tenant admin service role updates when all required roles are already assigned', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'tenant-admin-client-id', clientId: 'tenant-admin' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'realm-management-client-id', clientId: 'realm-management' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, { id: 'service-account-user-id', username: 'service-account-tenant-admin' }))
+      .mockResolvedValueOnce(
+        createJsonResponse(200, [
+          { id: 'role-manage-users', name: 'manage-users' },
+          { id: 'role-view-users', name: 'view-users' },
+          { id: 'role-view-realm', name: 'view-realm' },
+          { id: 'role-manage-realm', name: 'manage-realm' },
+          { id: 'role-manage-clients', name: 'manage-clients' },
+        ])
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse(200, [
+          { id: 'role-manage-users', name: 'manage-users' },
+          { id: 'role-view-users', name: 'view-users' },
+          { id: 'role-view-realm', name: 'view-realm' },
+          { id: 'role-manage-realm', name: 'manage-realm' },
+          { id: 'role-manage-clients', name: 'manage-clients' },
+        ])
+      );
+
+    const client = await createClient(fetchImpl);
+
+    await expect(client.ensureTenantAdminServiceAccess('tenant-admin')).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+    expect(
+      fetchImpl.mock.calls.some(
+        (call) =>
+          call[1]?.method === 'POST'
+          && String(call[0]).includes('/users/service-account-user-id/role-mappings/clients/realm-management-client-id')
+      )
+    ).toBe(false);
+  });
+
+  it('fails tenant admin service access provisioning when the target client is missing', async () => {
+    const { KeycloakAdminRequestError } = await import('./core.js');
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, []));
+
+    const client = await createClient(fetchImpl);
+
+    await expect(client.ensureTenantAdminServiceAccess('tenant-admin')).rejects.toMatchObject<KeycloakAdminRequestError>({
+      code: 'unknown_client',
+      statusCode: 404,
+    });
+  });
+
   it('does not regenerate a client secret during normal reconciliation when the configured secret differs', async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -579,6 +579,32 @@ describe('Keycloak admin client', () => {
     ).toBe(false);
   });
 
+  it('fails tenant admin service access provisioning when a required realm-management role is missing', async () => {
+    type KeycloakAdminRequestError = import('./core.js').KeycloakAdminRequestError;
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'tenant-admin-client-id', clientId: 'tenant-admin' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'realm-management-client-id', clientId: 'realm-management' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, { id: 'service-account-user-id', username: 'service-account-tenant-admin' }))
+      .mockResolvedValueOnce(
+        createJsonResponse(200, [
+          { id: 'role-manage-users', name: 'manage-users' },
+          { id: 'role-view-users', name: 'view-users' },
+          { id: 'role-view-realm', name: 'view-realm' },
+          { id: 'role-manage-realm', name: 'manage-realm' },
+        ])
+      )
+      .mockResolvedValueOnce(createJsonResponse(200, []));
+
+    const client = await createClient(fetchImpl);
+
+    await expect(client.ensureTenantAdminServiceAccess('tenant-admin')).rejects.toMatchObject<KeycloakAdminRequestError>({
+      code: 'realm_management_role_missing',
+      statusCode: 500,
+    });
+  });
+
   it('fails tenant admin service access provisioning when the target client is missing', async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -504,6 +504,40 @@ describe('Keycloak admin client', () => {
     expect(String(rotateCall?.[0])).toContain('/clients/client-1/client-secret');
   });
 
+  it('grants required realm-management client roles to the tenant admin service account', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'tenant-admin-client-id', clientId: 'tenant-admin' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'realm-management-client-id', clientId: 'realm-management' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, { id: 'service-account-user-id', username: 'service-account-tenant-admin' }))
+      .mockResolvedValueOnce(
+        createJsonResponse(200, [
+          { id: 'role-manage-users', name: 'manage-users' },
+          { id: 'role-view-users', name: 'view-users' },
+          { id: 'role-view-realm', name: 'view-realm' },
+          { id: 'role-manage-realm', name: 'manage-realm' },
+        ])
+      )
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'role-view-users', name: 'view-users' }]))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const client = await createClient(fetchImpl);
+
+    await client.ensureTenantAdminServiceAccess('tenant-admin');
+
+    const addRolesCall = fetchImpl.mock.calls[6];
+    expect(String(addRolesCall?.[0])).toContain(
+      '/users/service-account-user-id/role-mappings/clients/realm-management-client-id'
+    );
+    expect(addRolesCall?.[1]?.method).toBe('POST');
+    expect(JSON.parse(String(addRolesCall?.[1]?.body))).toEqual([
+      { id: 'role-manage-users', name: 'manage-users' },
+      { id: 'role-view-realm', name: 'view-realm' },
+      { id: 'role-manage-realm', name: 'manage-realm' },
+    ]);
+  });
+
   it('does not regenerate a client secret during normal reconciliation when the configured secret differs', async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/auth-runtime/src/keycloak-admin-client/core.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.ts
@@ -76,6 +76,7 @@ const REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES = [
   'view-users',
   'view-realm',
   'manage-realm',
+  'manage-clients',
 ] as const;
 
 type KeycloakClientRepresentation = {

--- a/packages/auth-runtime/src/keycloak-admin-client/core.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.ts
@@ -678,6 +678,17 @@ export class KeycloakAdminClient implements IdentityProviderPort {
       operation: 'list_service_account_client_roles',
     });
 
+    const availableRoleNames = new Set(availableRoles.map((role) => role.name));
+    const missingRequiredRoles = REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES.filter((roleName) => !availableRoleNames.has(roleName));
+    if (missingRequiredRoles.length > 0) {
+      throw new KeycloakAdminRequestError({
+        message: `Missing required Keycloak realm-management roles: ${missingRequiredRoles.join(', ')}`,
+        statusCode: 500,
+        code: 'realm_management_role_missing',
+        retryable: false,
+      });
+    }
+
     const currentRoleNames = new Set(currentRoleMappings.map((role) => role.name));
     const rolesToAdd = availableRoles
       .filter((role) =>

--- a/packages/auth-runtime/src/keycloak-admin-client/core.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.ts
@@ -71,6 +71,13 @@ type KeycloakRoleMapping = {
   readonly containerId?: string;
 };
 
+const REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES = [
+  'manage-users',
+  'view-users',
+  'view-realm',
+  'manage-realm',
+] as const;
+
 type KeycloakClientRepresentation = {
   readonly id: string;
   readonly clientId: string;
@@ -625,6 +632,73 @@ export class KeycloakAdminClient implements IdentityProviderPort {
   async listUserRoleNames(externalId: string): Promise<readonly string[]> {
     const currentRoleMappings = await this.readUserRoleMappings(externalId, 'list_user_roles');
     return currentRoleMappings.map((role) => role.name);
+  }
+
+  async ensureTenantAdminServiceAccess(clientId: string): Promise<void> {
+    await this.assertWriteAvailability();
+    const tenantAdminClient = await this.getOidcClientByClientId(clientId);
+    if (!tenantAdminClient) {
+      throw new KeycloakAdminRequestError({
+        message: `Unknown Keycloak client: ${clientId}`,
+        statusCode: 404,
+        code: 'unknown_client',
+        retryable: false,
+      });
+    }
+
+    const realmManagementClient = await this.getOidcClientByClientId('realm-management');
+    if (!realmManagementClient) {
+      throw new KeycloakAdminRequestError({
+        message: 'Missing Keycloak client: realm-management',
+        statusCode: 404,
+        code: 'realm_management_client_missing',
+        retryable: false,
+      });
+    }
+
+    const [serviceAccountUser, availableRoles] = await Promise.all([
+      this.executeWithResilience<KeycloakAdminUser>({
+        method: 'GET',
+        path: `/admin/realms/${encodePathSegment(this.realm)}/clients/${encodePathSegment(tenantAdminClient.id)}/service-account-user`,
+        operation: 'get_service_account_user',
+      }),
+      this.executeWithResilience<KeycloakRoleMapping[]>({
+        method: 'GET',
+        path: `/admin/realms/${encodePathSegment(this.realm)}/clients/${encodePathSegment(realmManagementClient.id)}/roles`,
+        operation: 'list_realm_management_client_roles',
+      }),
+    ]);
+
+    const currentRoleMappings = await this.executeWithResilience<KeycloakRoleMapping[]>({
+      method: 'GET',
+      path:
+        `/admin/realms/${encodePathSegment(this.realm)}/users/${encodePathSegment(serviceAccountUser.id)}`
+        + `/role-mappings/clients/${encodePathSegment(realmManagementClient.id)}`,
+      operation: 'list_service_account_client_roles',
+    });
+
+    const currentRoleNames = new Set(currentRoleMappings.map((role) => role.name));
+    const rolesToAdd = availableRoles
+      .filter((role) =>
+        REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES.includes(
+          role.name as (typeof REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES)[number]
+        )
+      )
+      .filter((role) => !currentRoleNames.has(role.name))
+      .map((role) => ({ id: role.id, name: role.name }));
+
+    if (rolesToAdd.length === 0) {
+      return;
+    }
+
+    await this.executeWithResilience<void>({
+      method: 'POST',
+      path:
+        `/admin/realms/${encodePathSegment(this.realm)}/users/${encodePathSegment(serviceAccountUser.id)}`
+        + `/role-mappings/clients/${encodePathSegment(realmManagementClient.id)}`,
+      body: JSON.stringify(rolesToAdd),
+      operation: 'grant_service_account_client_roles',
+    });
   }
 
   async getUserAttributes(

--- a/packages/data-repositories/src/instance-registry/index.test.ts
+++ b/packages/data-repositories/src/instance-registry/index.test.ts
@@ -350,6 +350,28 @@ describe('instance registry repository', () => {
     expect(statements.filter((statement) => statement.text.includes('iam.instance_hostnames'))).toHaveLength(2);
     expect(statements[0]?.values.at(17)).toBe('{}');
     expect(statements[2]?.values.at(8)).toBe(true);
+    expect(statements[0]?.text).toContain('ON CONFLICT (id) DO NOTHING');
+  });
+
+  it('returns null when createInstance loses a race against an existing instance id', async () => {
+    const { executor, statements } = createQueuedExecutor([[], []]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.createInstance({
+        instanceId: 'tenant-a',
+        displayName: 'Tenant A',
+        status: 'active',
+        parentDomain: 'example.test',
+        primaryHostname: 'tenant-a.example.test',
+        realmMode: 'shared',
+        authRealm: 'sva',
+        authClientId: 'studio',
+        actorId: 'actor-1',
+      })
+    ).resolves.toBeNull();
+
+    expect(statements[0]?.text).toContain('ON CONFLICT (id) DO NOTHING');
   });
 
   it('returns null for empty mutations and maps created runs and steps', async () => {

--- a/packages/data-repositories/src/instance-registry/index.ts
+++ b/packages/data-repositories/src/instance-registry/index.ts
@@ -284,7 +284,7 @@ export type InstanceRegistryRepository = {
     themeKey?: string;
     featureFlags?: Readonly<Record<string, boolean>>;
     mainserverConfigRef?: string;
-  }): Promise<InstanceRegistryRecord>;
+  }): Promise<InstanceRegistryRecord | null>;
   updateInstance(input: {
     instanceId: string;
     displayName: string;
@@ -1401,28 +1401,7 @@ INSERT INTO iam.instances (
   updated_by
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19::jsonb, $20, $20)
-ON CONFLICT (id) DO UPDATE
-SET
-  display_name = EXCLUDED.display_name,
-  status = EXCLUDED.status,
-  parent_domain = EXCLUDED.parent_domain,
-  primary_hostname = EXCLUDED.primary_hostname,
-  realm_mode = EXCLUDED.realm_mode,
-  auth_realm = EXCLUDED.auth_realm,
-  auth_client_id = EXCLUDED.auth_client_id,
-  auth_issuer_url = EXCLUDED.auth_issuer_url,
-  auth_client_secret_ciphertext = EXCLUDED.auth_client_secret_ciphertext,
-  tenant_admin_client_id = EXCLUDED.tenant_admin_client_id,
-  tenant_admin_client_secret_ciphertext = EXCLUDED.tenant_admin_client_secret_ciphertext,
-  tenant_admin_username = EXCLUDED.tenant_admin_username,
-  tenant_admin_email = EXCLUDED.tenant_admin_email,
-  tenant_admin_first_name = EXCLUDED.tenant_admin_first_name,
-  tenant_admin_last_name = EXCLUDED.tenant_admin_last_name,
-  theme_key = EXCLUDED.theme_key,
-  feature_flags = EXCLUDED.feature_flags,
-  mainserver_config_ref = EXCLUDED.mainserver_config_ref,
-  updated_by = EXCLUDED.updated_by,
-  updated_at = NOW()
+ON CONFLICT (id) DO NOTHING
 RETURNING
   id AS instance_id,
   display_name,
@@ -1472,6 +1451,10 @@ RETURNING
         ],
       }
     );
+
+    if (!rows[0]) {
+      return null;
+    }
 
     await executor.execute({
       text: `

--- a/packages/instance-registry/src/http-mutation-handlers.test.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.test.ts
@@ -330,6 +330,27 @@ describe('http mutation handlers', () => {
     expect(body.code).toBe('invalid_request');
   });
 
+  it('mutateInstanceStatus preserves parseRequestBody validation messages', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({
+      ok: false,
+      message: 'Request body muss ein gueltiges JSON-Objekt sein.',
+    });
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.mutateInstanceStatus(
+      new Request('http://localhost/api/instances/inst-1/status'),
+      { userId: 'u-1' },
+      'active'
+    );
+    const body = await readBody(response);
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      code: 'invalid_request',
+      message: 'Request body muss ein gueltiges JSON-Objekt sein.',
+    });
+  });
+
   it('mutateInstanceStatus returns the changed instance on success', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { status: 'suspended' } });
     vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>

--- a/packages/instance-registry/src/http-mutation-handlers.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.ts
@@ -14,7 +14,6 @@ import {
 } from './http-mutation-module-actions.js';
 import {
   createInstanceMutationErrorMapper,
-  type InstanceRegistryMutationHttpActor,
   type InstanceRegistryMutationHttpDeps,
 } from './http-mutation-shared.js';
 

--- a/packages/instance-registry/src/http-mutation-module-actions.ts
+++ b/packages/instance-registry/src/http-mutation-module-actions.ts
@@ -223,7 +223,10 @@ export const createMutateInstanceStatusHandler =
       request,
       statusMutationSchema
     );
-    if (!payloadResult.ok || payloadResult.data.status !== nextStatus) {
+    if (!payloadResult.ok) {
+      return deps.createApiError(400, 'invalid_request', payloadResult.message, deps.getRequestId());
+    }
+    if (payloadResult.data.status !== nextStatus) {
       return deps.createApiError(400, 'invalid_request', 'Ungültiger Statuswechsel.', deps.getRequestId());
     }
 

--- a/packages/instance-registry/src/provisioning-auth-state.test.ts
+++ b/packages/instance-registry/src/provisioning-auth-state.test.ts
@@ -22,6 +22,7 @@ const createClient = (overrides?: Partial<KeycloakProvisioningClient>): Keycloak
   })),
   getOidcClientSecretValue: vi.fn(async () => 'secret'),
   ensureOidcClient: vi.fn(async () => undefined),
+  ensureTenantAdminServiceAccess: vi.fn(async () => undefined),
   listClientProtocolMappers: vi.fn(async () => [{ name: 'instanceId' }]),
   ensureUserAttributeProtocolMapper: vi.fn(async () => undefined),
   ensureRealmRole: vi.fn(async () => undefined),
@@ -88,6 +89,7 @@ describe('provisioning-auth-state', () => {
     expect(client.ensureRealm).toHaveBeenCalledWith({ displayName: 'demo' });
     expect(client.ensureOidcClient).toHaveBeenCalledWith(expect.objectContaining({ clientId: 'sva-studio' }));
     expect(client.ensureOidcClient).toHaveBeenCalledWith(expect.objectContaining({ clientId: 'tenant-admin' }));
+    expect(client.ensureTenantAdminServiceAccess).toHaveBeenCalledWith('tenant-admin');
     expect(client.ensureUserAttributeProtocolMapper).not.toHaveBeenCalled();
     expect(client.createUser).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/instance-registry/src/provisioning-auth-state.ts
+++ b/packages/instance-registry/src/provisioning-auth-state.ts
@@ -40,6 +40,7 @@ export type KeycloakProvisioningClient = {
     directAccessGrantsEnabled?: boolean;
     serviceAccountsEnabled?: boolean;
   }): Promise<void>;
+  ensureTenantAdminServiceAccess(clientId: string): Promise<void>;
   listClientProtocolMappers(clientId: string): Promise<readonly { name: string }[]>;
   ensureUserAttributeProtocolMapper(input: {
     clientId: string;
@@ -317,6 +318,7 @@ export const createProvisionInstanceAuthArtifacts =
         directAccessGrantsEnabled: expectedTenantAdminClient.directAccessGrantsEnabled,
         serviceAccountsEnabled: expectedTenantAdminClient.serviceAccountsEnabled,
       });
+      await client.ensureTenantAdminServiceAccess(input.tenantAdminClient.clientId);
     }
     if (input.tenantAdminBootstrap) {
       await ensureTenantAdmin(client, {

--- a/packages/instance-registry/src/service-instance-mutations.ts
+++ b/packages/instance-registry/src/service-instance-mutations.ts
@@ -59,6 +59,14 @@ export const createProvisioningRequestHandler =
       featureFlags: input.featureFlags,
       mainserverConfigRef: input.mainserverConfigRef,
     });
+    if (!instance) {
+      instanceRegistryServiceLogger.warn('instance_create_rejected_duplicate', {
+        operation: 'create_instance',
+        instance_id: input.instanceId,
+        request_id: input.requestId,
+      });
+      return { ok: false, reason: 'already_exists' as const };
+    }
 
     await createProvisioningArtifacts(deps.repository, instance, input);
     invalidateHostWithLog(deps.invalidateHost, instance.primaryHostname, instance.instanceId);

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -66,6 +66,29 @@ const createModuleAssignRollbackError = (
   return combined;
 };
 
+const createBootstrapAssignRollbackError = (
+  instanceId: string,
+  moduleIds: readonly string[],
+  syncError: unknown,
+  rollbackError: unknown
+): Error => {
+  const message =
+    syncError instanceof Error ? syncError.message : typeof syncError === 'string' ? syncError : 'instance_module_sync_failed';
+  const combined = new Error(message) as Error & {
+    cause?: {
+      rollbackError: unknown;
+      syncError: unknown;
+    };
+  };
+  combined.message = `instance_module_bootstrap_rollback_failed:${instanceId}:${moduleIds.join(',')}:${message}`;
+  combined.cause = {
+    syncError,
+    rollbackError,
+  };
+  combined.name = 'InstanceModuleBootstrapRollbackError';
+  return combined;
+};
+
 export const createAssignModuleHandler =
   (deps: InstanceRegistryServiceDeps): InstanceRegistryService['assignModule'] =>
   async (input) => {
@@ -133,21 +156,34 @@ export const createBootstrapAdminStructureHandler =
     }
 
     const currentAssignedModuleIds = new Set(await deps.repository.listAssignedModules(input.instanceId));
+    const newlyAssignedModuleIds: string[] = [];
     for (const moduleId of requestedModuleIds) {
       if (!currentAssignedModuleIds.has(moduleId)) {
         const inserted = await deps.repository.assignModule(input.instanceId, moduleId);
-        if (!inserted) {
-          return { ok: false, reason: 'conflict' };
+        if (inserted) {
+          newlyAssignedModuleIds.push(moduleId);
         }
       }
     }
 
-    const assignedModuleIds = await deps.repository.listAssignedModules(input.instanceId);
-    await deps.repository.syncAssignedModuleIam({
-      instanceId: input.instanceId,
-      managedModuleIds: [...registry.keys()],
-      contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
-    });
+    let assignedModuleIds: readonly string[];
+    try {
+      assignedModuleIds = await deps.repository.listAssignedModules(input.instanceId);
+      await deps.repository.syncAssignedModuleIam({
+        instanceId: input.instanceId,
+        managedModuleIds: [...registry.keys()],
+        contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
+      });
+    } catch (error) {
+      try {
+        for (const moduleId of [...newlyAssignedModuleIds].reverse()) {
+          await deps.repository.revokeModule(input.instanceId, moduleId);
+        }
+      } catch (rollbackError) {
+        throw createBootstrapAssignRollbackError(input.instanceId, newlyAssignedModuleIds, error, rollbackError);
+      }
+      throw error;
+    }
 
     let bootstrapCompleted = false;
     try {

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -176,12 +176,14 @@ export const createBootstrapAdminStructureHandler =
       });
     } catch (error) {
       try {
-        for (const moduleId of [...newlyAssignedModuleIds].reverse()) {
-          const removed = await deps.repository.revokeModule(input.instanceId, moduleId);
-          if (!removed) {
-            throw new Error(`rollback_revoke_failed:${moduleId}`);
-          }
+      for (const moduleId of [...newlyAssignedModuleIds].reverse()) {
+        const removed = await deps.repository.revokeModule(input.instanceId, moduleId);
+        if (!removed) {
+          throw new Error(`rollback_revoke_failed:${moduleId}`, {
+            cause: error,
+          });
         }
+      }
       } catch (rollbackError) {
         throw createBootstrapAssignRollbackError(input.instanceId, newlyAssignedModuleIds, error, rollbackError);
       }

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -176,14 +176,14 @@ export const createBootstrapAdminStructureHandler =
       });
     } catch (error) {
       try {
-      for (const moduleId of [...newlyAssignedModuleIds].reverse()) {
-        const removed = await deps.repository.revokeModule(input.instanceId, moduleId);
-        if (!removed) {
-          throw new Error(`rollback_revoke_failed:${moduleId}`, {
-            cause: error,
-          });
+        for (const moduleId of [...newlyAssignedModuleIds].reverse()) {
+          const removed = await deps.repository.revokeModule(input.instanceId, moduleId);
+          if (!removed) {
+            const rollbackRevokeError = new Error(`rollback_revoke_failed:${moduleId}`) as Error & { cause?: unknown };
+            rollbackRevokeError.cause = error;
+            throw rollbackRevokeError;
+          }
         }
-      }
       } catch (rollbackError) {
         throw createBootstrapAssignRollbackError(input.instanceId, newlyAssignedModuleIds, error, rollbackError);
       }

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -177,7 +177,10 @@ export const createBootstrapAdminStructureHandler =
     } catch (error) {
       try {
         for (const moduleId of [...newlyAssignedModuleIds].reverse()) {
-          await deps.repository.revokeModule(input.instanceId, moduleId);
+          const removed = await deps.repository.revokeModule(input.instanceId, moduleId);
+          if (!removed) {
+            throw new Error(`rollback_revoke_failed:${moduleId}`);
+          }
         }
       } catch (rollbackError) {
         throw createBootstrapAssignRollbackError(input.instanceId, newlyAssignedModuleIds, error, rollbackError);

--- a/packages/instance-registry/src/service-provisioning.ts
+++ b/packages/instance-registry/src/service-provisioning.ts
@@ -6,9 +6,11 @@ import { createAuditDetails } from './service-helpers.js';
 
 const logger = createSdkLogger({ component: 'iam-instance-registry-provisioning', level: 'info' });
 
+type CreatedInstanceRecord = NonNullable<Awaited<ReturnType<InstanceRegistryRepository['createInstance']>>>;
+
 export const createProvisioningArtifacts = async (
   repository: InstanceRegistryRepository,
-  instance: Awaited<ReturnType<InstanceRegistryRepository['createInstance']>>,
+  instance: CreatedInstanceRecord,
   input: CreateInstanceProvisioningInput
 ): Promise<void> => {
   await repository.createProvisioningRun({
@@ -33,9 +35,9 @@ export const createProvisioningArtifacts = async (
 
 export const provisionInstanceAuth = async (
   deps: InstanceRegistryServiceDeps,
-  instance: Awaited<ReturnType<InstanceRegistryRepository['createInstance']>>,
+  instance: CreatedInstanceRecord,
   input: CreateInstanceProvisioningInput
-): Promise<Awaited<ReturnType<InstanceRegistryRepository['createInstance']>>> => {
+): Promise<CreatedInstanceRecord> => {
   if (!deps.provisionInstanceAuth) {
     return instance;
   }

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -702,7 +702,7 @@ describe('instance registry service facade', () => {
     const repository = createRepository({
       assignModule: vi.fn(async (instanceId: string, moduleId: string) => moduleId === 'events'),
       revokeModule: vi.fn(async () => true),
-      listAssignedModules: vi.fn(async () => ['news', 'events']),
+      listAssignedModules: vi.fn().mockResolvedValueOnce(['news']).mockResolvedValueOnce(['news', 'events']),
       syncAssignedModuleIam: vi.fn(async () => {
         throw new Error('sync_failed');
       }),

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -728,6 +728,44 @@ describe('instance registry service facade', () => {
     expect(deps.invalidatePermissionSnapshots).not.toHaveBeenCalled();
   });
 
+  it('throws a bootstrap rollback error when reverting newly assigned modules also fails', async () => {
+    const repository = createRepository({
+      assignModule: vi.fn(async (instanceId: string, moduleId: string) => moduleId === 'events'),
+      revokeModule: vi.fn(async () => {
+        throw new Error('rollback_failed');
+      }),
+      listAssignedModules: vi.fn().mockResolvedValueOnce(['news']).mockResolvedValueOnce(['news', 'events']),
+      syncAssignedModuleIam: vi.fn(async () => {
+        throw new Error('sync_failed');
+      }),
+      getInstanceById: vi.fn(async () => baseInstance),
+    });
+    const service = createInstanceRegistryService(createDeps(repository));
+
+    try {
+      await service.bootstrapAdminStructure({
+        instanceId: 'demo',
+        moduleIds: ['news', 'events'],
+        idempotencyKey: 'idem-bootstrap-rollback-2',
+        actorId: 'actor-1',
+        requestId: 'req-bootstrap-rollback-2',
+      });
+      expect.unreachable('bootstrapAdminStructure should throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        'instance_module_bootstrap_rollback_failed:demo:events:sync_failed'
+      );
+      expect((error as Error).name).toBe('InstanceModuleBootstrapRollbackError');
+      expect((error as Error).cause).toEqual({
+        syncError: expect.any(Error),
+        rollbackError: expect.any(Error),
+      });
+      expect(((error as Error).cause as { syncError: Error }).syncError.message).toBe('sync_failed');
+      expect(((error as Error).cause as { rollbackError: Error }).rollbackError.message).toBe('rollback_failed');
+    }
+  });
+
   it('invalidates instance permission snapshots after module IAM changes', async () => {
     const repository = createRepository({
       assignModule: vi.fn(async () => true),

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -766,6 +766,39 @@ describe('instance registry service facade', () => {
     }
   });
 
+  it('throws a bootstrap rollback error when revokeModule reports that rollback did not remove a module', async () => {
+    const repository = createRepository({
+      assignModule: vi.fn(async (instanceId: string, moduleId: string) => moduleId === 'events'),
+      revokeModule: vi.fn(async () => false),
+      listAssignedModules: vi.fn().mockResolvedValueOnce(['news']).mockResolvedValueOnce(['news', 'events']),
+      syncAssignedModuleIam: vi.fn(async () => {
+        throw new Error('sync_failed');
+      }),
+      getInstanceById: vi.fn(async () => baseInstance),
+    });
+    const service = createInstanceRegistryService(createDeps(repository));
+
+    try {
+      await service.bootstrapAdminStructure({
+        instanceId: 'demo',
+        moduleIds: ['news', 'events'],
+        idempotencyKey: 'idem-bootstrap-rollback-3',
+        actorId: 'actor-1',
+        requestId: 'req-bootstrap-rollback-3',
+      });
+      expect.unreachable('bootstrapAdminStructure should throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        'instance_module_bootstrap_rollback_failed:demo:events:sync_failed'
+      );
+      expect((error as Error).name).toBe('InstanceModuleBootstrapRollbackError');
+      expect(((error as Error).cause as { rollbackError: Error }).rollbackError.message).toBe(
+        'rollback_revoke_failed:events'
+      );
+    }
+  });
+
   it('invalidates instance permission snapshots after module IAM changes', async () => {
     const repository = createRepository({
       assignModule: vi.fn(async () => true),

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -663,6 +663,71 @@ describe('instance registry service facade', () => {
     );
   });
 
+  it('continues bootstrapping when a requested module was assigned concurrently', async () => {
+    const repository = createRepository({
+      assignModule: vi.fn(async () => false),
+      listAssignedModules: vi.fn().mockResolvedValueOnce(['news']).mockResolvedValueOnce(['news', 'events']),
+      getInstanceById: vi
+        .fn()
+        .mockResolvedValueOnce(baseInstance)
+        .mockResolvedValueOnce({ ...baseInstance, assignedModules: ['news', 'events'] }),
+    });
+    const service = createInstanceRegistryService(createDeps(repository));
+
+    await expect(
+      service.bootstrapAdminStructure({
+        instanceId: 'demo',
+        moduleIds: ['news', 'events'],
+        idempotencyKey: 'idem-bootstrap-race-1',
+        actorId: 'actor-1',
+        requestId: 'req-bootstrap-race-1',
+      })
+    ).resolves.toEqual({
+      ok: true,
+      instance: expect.objectContaining({
+        assignedModules: ['news', 'events'],
+      }),
+    });
+
+    expect(repository.assignModule).toHaveBeenCalledWith('demo', 'events');
+    expect(repository.syncAssignedModuleIam).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contracts: expect.arrayContaining([expect.objectContaining({ moduleId: 'news' }), expect.objectContaining({ moduleId: 'events' })]),
+      })
+    );
+    expect(repository.syncInstanceAdminBootstrap).toHaveBeenCalled();
+  });
+
+  it('rolls back newly assigned modules when bootstrap module IAM sync fails', async () => {
+    const repository = createRepository({
+      assignModule: vi.fn(async (instanceId: string, moduleId: string) => moduleId === 'events'),
+      revokeModule: vi.fn(async () => true),
+      listAssignedModules: vi.fn(async () => ['news', 'events']),
+      syncAssignedModuleIam: vi.fn(async () => {
+        throw new Error('sync_failed');
+      }),
+      getInstanceById: vi.fn(async () => baseInstance),
+    });
+    const deps = createDeps(repository);
+    const service = createInstanceRegistryService(deps);
+
+    await expect(
+      service.bootstrapAdminStructure({
+        instanceId: 'demo',
+        moduleIds: ['news', 'events'],
+        idempotencyKey: 'idem-bootstrap-rollback-1',
+        actorId: 'actor-1',
+        requestId: 'req-bootstrap-rollback-1',
+      })
+    ).rejects.toThrow('sync_failed');
+
+    expect(repository.assignModule).toHaveBeenCalledWith('demo', 'events');
+    expect(repository.revokeModule).toHaveBeenCalledWith('demo', 'events');
+    expect(repository.syncInstanceAdminBootstrap).not.toHaveBeenCalled();
+    expect(repository.appendAuditEvent).not.toHaveBeenCalled();
+    expect(deps.invalidatePermissionSnapshots).not.toHaveBeenCalled();
+  });
+
   it('invalidates instance permission snapshots after module IAM changes', async () => {
     const repository = createRepository({
       assignModule: vi.fn(async () => true),
@@ -831,6 +896,26 @@ describe('instance registry service facade', () => {
       expect(((error as Error).cause as { syncError: Error }).syncError.message).toBe('sync_failed');
       expect(((error as Error).cause as { rollbackError: Error }).rollbackError.message).toBe('rollback_failed');
     }
+  });
+
+  it('treats a create race during persistence as already_exists', async () => {
+    const repository = createRepository({
+      getInstanceById: vi.fn(async () => null),
+      createInstance: vi.fn(async () => null as never),
+    });
+    const service = createInstanceRegistryService(createDeps(repository));
+
+    await expect(
+      service.createProvisioningRequest({
+        instanceId: 'demo',
+        displayName: 'Demo',
+        parentDomain: 'Studio.Example.Org',
+        realmMode: 'new',
+        authRealm: 'demo',
+        authClientId: 'studio-client',
+        idempotencyKey: 'idem-race-1',
+      })
+    ).resolves.toEqual({ ok: false, reason: 'already_exists' });
   });
 
   it('revokes a module and reseeds the remaining module IAM baseline', async () => {


### PR DESCRIPTION
## What changed
This PR publishes the current local worktree as requested.

It intentionally bundles multiple ongoing changes that do not form a single narrow theme.

## Why
The goal of this PR is to preserve and share the current state of work rather than to force an artificial split into smaller topic branches.

## Notable areas touched
- Studio frontend hooks and admin user flows
- Auth runtime password setup email / Keycloak integration
- Instance registry and related data repository updates

## Root cause covered in this bundle
One included fix changes Keycloak password setup email flows to use the OIDC callback redirect URI instead of the post-logout redirect URI, which previously caused `execute-actions-email` failures with `Invalid redirect uri`.

## Validation
- `pnpm exec vitest run src/iam-account-management/user-password-setup-email-handler.test.ts --config vitest.config.ts`
- `pnpm exec vitest run src/iam-account-management/user-create-operation.test.ts --config vitest.config.ts`
- `pnpm nx run auth-runtime:test:types`
- `pnpm check:server-runtime`

## Notes
This PR is intentionally a mixed-scope draft PR per request. Reviewers should expect unrelated changes in the same diff.
