### PR TITLE
[codex] Add minimum QS standard for SVA Studio

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,17 @@ Kurz beschreiben:
 - Welches Problem oder welcher Kontext wird adressiert?
 -->
 
+## Anforderung / Kontext
+
+<!--
+Pflicht für jede funktionale, technische oder betriebliche Änderung:
+- Welche Anforderung, welches Problem oder welches Ziel wird adressiert?
+- Falls vorhanden: Link zu Issue, OpenSpec-Change, Ticket oder ADR
+-->
+
+- Referenz:
+- Kontext:
+
 ## Umfang
 
 - [ ] Feature
@@ -21,6 +32,14 @@ Kurz beschreiben:
 <!--
 Die wichtigsten Änderungen knapp und konkret auflisten.
 Keine Commit-Chronologie, sondern fachliche Zusammenfassung.
+-->
+
+- 
+
+## Betroffene Projekte / Packages
+
+<!--
+Explizit benennen, damit Scope, Risiko und Testtiefe schnell beurteilbar bleiben.
 -->
 
 - 
@@ -62,6 +81,12 @@ Nur echte Risiken nennen:
 - Risiko:
 - Rollback:
 
+## Risikoklasse
+
+- [ ] hoch
+- [ ] mittel
+- [ ] normal
+
 ## Dokumentation
 
 <!--
@@ -90,11 +115,13 @@ Details:
 
 ## Checkliste
 
+- [ ] Ziel, Kontext und betroffene Projekte/Packages sind im PR klar beschrieben
 - [ ] Keine hardcodierten UI-Texte eingeführt; user-facing Texte laufen über das Übersetzungssystem
 - [ ] Logging im Server-Code nutzt keine `console.*`-Statements
 - [ ] Input-Validierung und PII-Schutz berücksichtigt
 - [ ] UI-/Styling-Änderungen folgen Design-System / `shadcn/ui`
 - [ ] Accessibility-Auswirkungen geprüft
+- [ ] Testdaten, Fixtures, Seeds und Snapshots enthalten keine echten personenbezogenen Daten
 - [ ] Tests wurden ergänzt oder angepasst, falls Verhalten geändert wurde
 - [ ] `pnpm check:file-placement` ist berücksichtigt
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -83,6 +83,11 @@ Nur echte Risiken nennen:
 
 ## Risikoklasse
 
+<!--
+Genau eine Option auswaehlen.
+Wenn mehrere Projekte betroffen sind, gilt die hoechste Risikoklasse.
+-->
+
 - [ ] hoch
 - [ ] mittel
 - [ ] normal

--- a/docs/development/qs-mindeststandard-sva-studio.md
+++ b/docs/development/qs-mindeststandard-sva-studio.md
@@ -35,7 +35,7 @@ Wenn eine Änderung mehrere Klassen berührt, gilt die höchste Risikoklasse.
 | Änderungstyp | Mindestnachweis |
 | --- | --- |
 | Doku oder Governance ohne Laufzeitwirkung | `pnpm check:file-placement` und inhaltliche Reviewbarkeit |
-| Kernlogik oder Vertragsänderung | `pnpm test:types`, betroffene Unit-Tests, bei Bedarf `pnpm check:server-runtime` |
+| Kernlogik oder Vertragsänderung | `pnpm test:types` (enthaelt bereits `pnpm check:server-runtime`), betroffene Unit-Tests; der Runtime-Guard kann zusaetzlich frueh gezielt ausgefuehrt werden |
 | Datenzugriff, Auth, IAM, Routing, Server-Settings | betroffene Unit- und Type-Tests plus Integrations- oder Flow-Nachweis |
 | UI, Formulare, Navigation, Dialoge | betroffene Tests plus Accessibility-Selbstprüfung für Semantik, Labels, Tastaturbedienung und Fokus |
 | Release-, Rollout- oder Betriebslogik | passende technische Nachweise, aktualisierte Betriebsdoku und klare Rollback-Aussage |

--- a/docs/development/qs-mindeststandard-sva-studio.md
+++ b/docs/development/qs-mindeststandard-sva-studio.md
@@ -44,7 +44,7 @@ Wenn eine Änderung mehrere Klassen berührt, gilt die höchste Risikoklasse.
 
 Für neue oder geänderte UI gilt mindestens:
 
-- keine neuen hartcodierten user-facing Texte
+- keine neuen hardcodierten user-facing Texte
 - semantisch passende HTML-/UI-Struktur
 - bedienbar per Tastatur, soweit interaktiv
 - erkennbare Labels, Namen und Fokus-Zustände

--- a/docs/development/qs-mindeststandard-sva-studio.md
+++ b/docs/development/qs-mindeststandard-sva-studio.md
@@ -1,0 +1,77 @@
+# QS-Mindeststandard für SVA Studio
+
+## Ziel
+
+Dieses Dokument definiert den kleinsten verbindlichen QS-Standard für das Repository. Es soll mit vertretbarem Aufwand sicherstellen, dass Änderungen nachvollziehbar, risikoorientiert getestet und für Reviewer schnell einordenbar sind.
+
+Der Mindeststandard ergänzt bestehende Quality Gates. Er ersetzt weder `./testing-strategy.md` noch `../governance/merge-review-gates.md`.
+
+## Pflicht pro Änderung
+
+Jede Änderung mit funktionaler, technischer oder betrieblicher Wirkung muss im PR mindestens die folgenden Fragen beantworten:
+
+- Welche Anforderung, welches Problem oder welches Ziel wird adressiert?
+- Welche Projekte oder Packages sind konkret betroffen?
+- Welche Risiken entstehen durch die Änderung?
+- Welche Tests oder Nachweise wurden für den betroffenen Scope ausgeführt?
+- Welche Dokumentation wurde aktualisiert oder warum war keine Doku-Anpassung nötig?
+
+Reine Formatierungs- oder Doku-Änderungen dürfen knapper dokumentiert werden, müssen aber weiterhin klar beschreiben, was geändert wurde.
+
+## Risikoklassen
+
+Die Testtiefe richtet sich nach dem Risiko der betroffenen Änderung, nicht nach einem pauschalen Standard für alle Projekte.
+
+| Risikoklasse | Typische Projekte | Erwartung |
+| --- | --- | --- |
+| hoch | `sva-mainserver`, `auth-runtime`, `iam-admin`, `iam-core`, `iam-governance`, `instance-registry`, `data`, `routing` | klare PR-Risikoanalyse, zielgerichtete Unit-/Type-/Integrationsnachweise, bei Flow-Wirkung zusätzlich E2E- oder Smoke-Nachweis |
+| mittel | `data-client`, `monitoring-client`, `plugin-sdk`, `server-runtime`, `studio-module-iam` | fachlich passende Unit-/Type-Tests, Integrationsnachweis wenn Verträge, Runtime oder Schnittstellen betroffen sind |
+| normal | `studio-ui-react`, Fachplugins ohne Sicherheits- oder Betriebswirkung, reine Doku-/Governance-Dateien | gezielte Nachweise für den betroffenen Pfad; bei UI-Änderungen mindestens semantische und Accessibility-Prüfung |
+
+Wenn eine Änderung mehrere Klassen berührt, gilt die höchste Risikoklasse.
+
+## Mindestnachweise nach Änderungstyp
+
+| Änderungstyp | Mindestnachweis |
+| --- | --- |
+| Doku oder Governance ohne Laufzeitwirkung | `pnpm check:file-placement` und inhaltliche Reviewbarkeit |
+| Kernlogik oder Vertragsänderung | `pnpm test:types`, betroffene Unit-Tests, bei Bedarf `pnpm check:server-runtime` |
+| Datenzugriff, Auth, IAM, Routing, Server-Settings | betroffene Unit- und Type-Tests plus Integrations- oder Flow-Nachweis |
+| UI, Formulare, Navigation, Dialoge | betroffene Tests plus Accessibility-Selbstprüfung für Semantik, Labels, Tastaturbedienung und Fokus |
+| Release-, Rollout- oder Betriebslogik | passende technische Nachweise, aktualisierte Betriebsdoku und klare Rollback-Aussage |
+
+## Accessibility-Mindeststandard
+
+Für neue oder geänderte UI gilt mindestens:
+
+- keine neuen hartcodierten user-facing Texte
+- semantisch passende HTML-/UI-Struktur
+- bedienbar per Tastatur, soweit interaktiv
+- erkennbare Labels, Namen und Fokus-Zustände
+- keine bewusst eingeführte Verschlechterung gegen WCAG-/BITV-Grundanforderungen
+
+Ein vollständiges Audit ist nicht für jede kleine Änderung erforderlich. Die Auswirkungen müssen aber im PR aktiv geprüft werden.
+
+## Testdaten-Mindeststandard
+
+- Es werden keine echten personenbezogenen Daten in Tests, Fixtures, Seeds, Snapshots oder Debug-Artefakten abgelegt.
+- Testdaten sind synthetisch, anonymisiert oder hinreichend pseudonymisiert.
+- Bei Datenexporten, Logs und Screenshots ist auf PII-Schutz zu achten.
+
+## Review-Erwartung
+
+Reviewer prüfen nicht nur, ob CI grün ist, sondern ob die Änderung inhaltlich rückverfolgbar und zum Risiko passend abgesichert ist.
+
+Mindestens zu prüfen sind:
+
+- Problem und Ziel der Änderung sind verständlich beschrieben.
+- Betroffene Projekte oder Packages sind explizit benannt.
+- Risiko und Rollback sind für risikoreiche Änderungen nachvollziehbar.
+- Testnachweise passen zur Risikoklasse.
+- Relevante Doku wurde aktualisiert.
+
+## Verweise
+
+- Teststrategie: `./testing-strategy.md`
+- Merge- und Review-Gates: `../governance/merge-review-gates.md`
+- Architektur, Qualitätsziele: `../architecture/10-quality-requirements.md`

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -83,6 +83,18 @@ Nicht vollständig lokal abbildbar bleiben externe PR-Dienste wie SonarCloud, Co
 | Deployment- oder Betriebsänderung | File-Placement, relevante Tests, Rendern der Compose-Konfiguration |
 | Architektur- oder Governance-Änderung | Doku-Update plus passende technische Nachweise |
 
+## Risikoklassen nach Projektfamilie
+
+Die konkrete Testtiefe wird zusätzlich über die Risikoklasse des betroffenen Projekts oder Packages gesteuert. Details stehen in `./qs-mindeststandard-sva-studio.md`.
+
+| Risikoklasse | Typische Projekte | Erwartete Testtiefe |
+| --- | --- | --- |
+| hoch | `sva-mainserver`, `auth-runtime`, `iam-admin`, `iam-core`, `iam-governance`, `instance-registry`, `data`, `routing` | Type-, Unit- und bei Flow- oder Vertragswirkung zusätzliche Integrations- oder E2E-Nachweise |
+| mittel | `data-client`, `monitoring-client`, `plugin-sdk`, `server-runtime`, `studio-module-iam` | Type- und Unit-Tests; Integrationstests bei Schnittstellen- oder Runtime-Wirkung |
+| normal | `studio-ui-react`, fachliche Plugin-Packages, Doku- und Governance-Pfade | gezielte Nachweise für den betroffenen Scope; bei UI mindestens Accessibility-Selbstprüfung |
+
+Wenn eine Änderung mehrere Projektfamilien berührt, gilt die höchste betroffene Risikoklasse.
+
 ## E2E-Strategie
 
 E2E-Läufe sichern die kritischen Browser- und Integrationspfade ab. Das Detailsetup, die Pflichtdienste und der CI-Workflow stehen in `./app-e2e-integration-testing.md`.
@@ -123,4 +135,5 @@ Neue Features, Architekturänderungen oder neue Betriebswege müssen die betroff
 - Coverage-Governance: `./testing-coverage.md`
 - App-E2E-Integration: `./app-e2e-integration-testing.md`
 - Review-Governance: `./review-agent-governance.md`
+- QS-Mindeststandard: `./qs-mindeststandard-sva-studio.md`
 - Architekturüberblick: `../architecture/README.md`

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -85,7 +85,7 @@ Nicht vollständig lokal abbildbar bleiben externe PR-Dienste wie SonarCloud, Co
 
 ## Risikoklassen nach Projektfamilie
 
-Die konkrete Testtiefe wird zusätzlich über die Risikoklasse des betroffenen Projekts oder Packages gesteuert. Details stehen in `./qs-mindeststandard-sva-studio.md`.
+Die konkrete Testtiefe wird zusätzlich über die Risikoklasse des betroffenen Projekts oder Packages gesteuert. Der QS-Mindeststandard unter `./qs-mindeststandard-sva-studio.md` bleibt die maßgebliche Quelle; die folgende Tabelle ist bewusst nur ein Kurz-Auszug für die Testing-Perspektive.
 
 | Risikoklasse | Typische Projekte | Erwartete Testtiefe |
 | --- | --- | --- |

--- a/docs/governance/merge-review-gates.md
+++ b/docs/governance/merge-review-gates.md
@@ -34,14 +34,14 @@ Hinweis zur aktuellen Repository-Situation: `.github/workflows/app-e2e.yml` verw
 - Stale-Approval wird bei neuem Commit invalidiert; ein neuer Approve ist erforderlich.
 - Bis zur vollen organisatorischen Trennung gilt fuer kritische Pfade mindestens ein dokumentierter fachlicher Review durch die zustaendige Verantwortungsgruppe.
 
-## Mindestinhalt jedes PR
+## Mindestinhalt jedes Pull Requests
 
 Jeder PR muss unabhaengig von seiner Groesse so beschrieben sein, dass Scope, Risiko und Nachweis ohne Rueckfrage erkennbar sind. Erwartet werden mindestens:
 
 - Ziel oder adressierte Anforderung
-- betroffene Projekte oder Packages
+- Betroffene Projekte oder Packages
 - Risikoeinstufung oder konkrete Risikobeschreibung
-- tatsaechlich ausgefuehrte Tests oder begruendete Abweichung
+- Tatsaechlich ausgefuehrte Tests oder begruendete Abweichung
 - Doku-Status und bei Bedarf Rollback-Hinweis
 
 Fuer Aenderungen in kritischen Pfaden muss der PR-Text ausserdem erkennen lassen, warum die ausgewaehlten Tests dem Risiko angemessen sind. Das formale Schema dafuer steht in `../development/qs-mindeststandard-sva-studio.md`.

--- a/docs/governance/merge-review-gates.md
+++ b/docs/governance/merge-review-gates.md
@@ -34,6 +34,18 @@ Hinweis zur aktuellen Repository-Situation: `.github/workflows/app-e2e.yml` verw
 - Stale-Approval wird bei neuem Commit invalidiert; ein neuer Approve ist erforderlich.
 - Bis zur vollen organisatorischen Trennung gilt fuer kritische Pfade mindestens ein dokumentierter fachlicher Review durch die zustaendige Verantwortungsgruppe.
 
+## Mindestinhalt jedes PR
+
+Jeder PR muss unabhängig von seiner Größe so beschrieben sein, dass Scope, Risiko und Nachweis ohne Rückfrage erkennbar sind. Erwartet werden mindestens:
+
+- Ziel oder adressierte Anforderung
+- betroffene Projekte oder Packages
+- Risikoeinstufung oder konkrete Risikobeschreibung
+- tatsächlich ausgeführte Tests oder begründete Abweichung
+- Doku-Status und bei Bedarf Rollback-Hinweis
+
+Für Änderungen in kritischen Pfaden muss der PR-Text außerdem erkennen lassen, warum die ausgewählten Tests dem Risiko angemessen sind. Das formale Schema dafür steht in `../development/qs-mindeststandard-sva-studio.md`.
+
 ## Merge-Methode pro Branch-Typ
 
 | Branch-Typ | Erlaubte Merge-Methode | Regel |

--- a/docs/governance/merge-review-gates.md
+++ b/docs/governance/merge-review-gates.md
@@ -36,15 +36,15 @@ Hinweis zur aktuellen Repository-Situation: `.github/workflows/app-e2e.yml` verw
 
 ## Mindestinhalt jedes PR
 
-Jeder PR muss unabhängig von seiner Größe so beschrieben sein, dass Scope, Risiko und Nachweis ohne Rückfrage erkennbar sind. Erwartet werden mindestens:
+Jeder PR muss unabhaengig von seiner Groesse so beschrieben sein, dass Scope, Risiko und Nachweis ohne Rueckfrage erkennbar sind. Erwartet werden mindestens:
 
 - Ziel oder adressierte Anforderung
 - betroffene Projekte oder Packages
 - Risikoeinstufung oder konkrete Risikobeschreibung
-- tatsächlich ausgeführte Tests oder begründete Abweichung
+- tatsaechlich ausgefuehrte Tests oder begruendete Abweichung
 - Doku-Status und bei Bedarf Rollback-Hinweis
 
-Für Änderungen in kritischen Pfaden muss der PR-Text außerdem erkennen lassen, warum die ausgewählten Tests dem Risiko angemessen sind. Das formale Schema dafür steht in `../development/qs-mindeststandard-sva-studio.md`.
+Fuer Aenderungen in kritischen Pfaden muss der PR-Text ausserdem erkennen lassen, warum die ausgewaehlten Tests dem Risiko angemessen sind. Das formale Schema dafuer steht in `../development/qs-mindeststandard-sva-studio.md`.
 
 ## Merge-Methode pro Branch-Typ
 


### PR DESCRIPTION
## Ziel

Dieser PR führt einen leichtgewichtigen QS-Mindeststandard für SVA Studio ein, damit Änderungen im Projekt konsistenter beschrieben, risikoorientierter geprüft und für Reviewer schneller einordenbar werden.

## Änderungen

- neue Doku `docs/development/qs-mindeststandard-sva-studio.md` mit PR-Pflichtangaben, Risikoklassen, Mindestnachweisen, Accessibility-Basics und Testdaten-Regeln
- Ergänzung der `docs/development/testing-strategy.md` um eine risikobasierte Projektmatrix
- Ergänzung der `docs/governance/merge-review-gates.md` um den verbindlichen Mindestinhalt eines PRs
- Schärfung der `.github/PULL_REQUEST_TEMPLATE.md` um Kontext, betroffene Projekte/Packages, Risikoklasse und Testdaten-Check

## Wirkung

- PRs werden besser rückverfolgbar und vergleichbarer
- Testtiefe wird explizit an Risiko und betroffene Projektfamilien gekoppelt
- Review-Erwartungen werden klarer, ohne neue schwere Prozessschichten einzuführen

## Test & Verifikation

Ausgeführt:

- `pnpm check:file-placement`

Nicht ausgeführt:

- weitere technische Tests, da nur Doku- und PR-Template-Dateien geändert wurden
