### PR TITLE
ci: scope CodeQL PR trigger to code changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,22 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/codeql/**'
+      - '**/*.js'
+      - '**/*.cjs'
+      - '**/*.mjs'
+      - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.cts'
+      - '**/*.mts'
+      - '**/*.tsx'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'nx.json'
   schedule:
     - cron: '44 22 * * 3'
   workflow_dispatch:


### PR DESCRIPTION
## Zusammenfassung
- begrenzt den CodeQL-pull_request-Trigger auf code- und scanrelevante Änderungen
- deckt dabei auch .github/codeql sowie JS/TS-Dateien außerhalb von apps/ und packages/ ab
- behält CodeQL auf push nach main, schedule und workflow_dispatch unverändert bei

## Testen
- nicht lokal ausgeführt; Änderung betrifft nur den Workflow-Trigger und zeigt Wirkung beim nächsten passenden PR-Lauf
