### PR TITLE
refactor: harden PR test scope selection

### DIFF
--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -334,6 +334,7 @@ gleichzeitig beeinflussen.
 - Bekannte Überschreitungen bleiben nur dann zulässig, wenn sie in `trackedFindings` mit Refactoring-Ticket hinterlegt sind
 - Bei modularem IAM-Refactoring wird Restschuld am tatsächlichen Kernmodul (`core.ts` oder feingranulare Teilbausteine) und nicht am historischen Fassadenpfad dokumentiert
 - Kritische Coverage-Hotspots werden in `tooling/testing/coverage-policy.json` als `hotspotFloors` geführt
+- Workflow- und CI-Dateiänderungen werden im PR-Pfad gezielt über `tooling-testing` abgesichert und nicht automatisch durch volle Produkt-Suiten eskaliert
 - Normative Accessibility und heuristische Nutzersicht sind bewusst getrennt:
   - `ux-accessibility.agent.md` für WCAG/BITV, Fokus, Tastatur und Screenreader
   - `user-journey-usability.agent.md` für Friktion, Verständlichkeit und Aufgabenbewältigung

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -33,7 +33,7 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
   - alte Sammelimporte in neuen Consumer-Pfaden werden durch ESLint und Nx-Boundaries blockiert
   - serverseitige Zielpackages bestehen `check:runtime` und verwenden Node-ESM-konforme Runtime-Imports mit expliziter `.js`-Endung
   - `pnpm openspec validate refactor-package-target-architecture-hard-cut --strict` muss für Package-Grenzänderungen grün sein
-  - `@sva/studio-module-iam` bleibt React-frei und besteht `test:types`, `test:unit` sowie `check:runtime` als serverseitig konsumierbarer Vertrags-Edge
+- `@sva/studio-module-iam` bleibt React-frei und besteht `test:types`, `test:unit` sowie `check:runtime` als serverseitig konsumierbarer Vertrags-Edge
 - Unit-Test-Basis:
   - `pnpm test:unit` muss grün sein
 - IAM-Acceptance-Gate:
@@ -147,6 +147,7 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
   - `sva-studio-react:check:i18n` deckt Rollen- und Fehlerübersetzungen der Medienoberflächen ab
 - Coverage Governance:
   - Gate-Logik und Baselines in `scripts/ci/coverage-gate.ts` und `tooling/testing/*`
+  - Workflow- und CI-Dateien werden über `tooling-testing` targeted abgesichert und eskalieren Quality-/Coverage-Läufe nicht automatisch auf volle Produkt-Suiten
 - Complexity Governance:
   - `pnpm complexity-gate` muss für definierte zentrale/kritische Module grün sein
   - neue Schwellwertüberschreitungen ohne Ticket-Referenz blockieren den Qualitätslauf

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -33,7 +33,7 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
   - alte Sammelimporte in neuen Consumer-Pfaden werden durch ESLint und Nx-Boundaries blockiert
   - serverseitige Zielpackages bestehen `check:runtime` und verwenden Node-ESM-konforme Runtime-Imports mit expliziter `.js`-Endung
   - `pnpm openspec validate refactor-package-target-architecture-hard-cut --strict` muss für Package-Grenzänderungen grün sein
-- `@sva/studio-module-iam` bleibt React-frei und besteht `test:types`, `test:unit` sowie `check:runtime` als serverseitig konsumierbarer Vertrags-Edge
+  - `@sva/studio-module-iam` bleibt React-frei und besteht `test:types`, `test:unit` sowie `check:runtime` als serverseitig konsumierbarer Vertrags-Edge
 - Unit-Test-Basis:
   - `pnpm test:unit` muss grün sein
 - IAM-Acceptance-Gate:

--- a/docs/development/testing-coverage.md
+++ b/docs/development/testing-coverage.md
@@ -149,30 +149,30 @@ Workflow: `.github/workflows/runtime-gates.yml`
 
 | Workflow / Jobname in GitHub | Zweck | Trigger-Modell |
 | --- | --- | --- |
-| `Coverage` | Coverage für affected/full + internes Coverage-Gate | alle PRs, `main`, nightly |
-| `Complexity` | Repository-weites Komplexitäts-Gate | alle PRs, `main`, nightly |
-| `PR Integration` | scoped `test:integration` außer Monitoring-Stack | Pull Requests |
-| `Integration` | voller Integrationslauf | `main`, nightly |
-| `App E2E` | Browser-Smoke für App-Routen mit No-op bei Nicht-Relevanz | alle PRs, nightly, manuell |
+| `Runtime Gates / Coverage` | Coverage für affected/full + internes Coverage-Gate | alle PRs, `main`, nightly |
+| `Runtime Gates / Complexity` | Repository-weites Komplexitäts-Gate | alle PRs, `main`, nightly |
+| `Runtime Gates / PR Integration` | scoped `test:integration` außer Monitoring-Stack | Pull Requests |
+| `Runtime Gates / Integration` | voller Integrationslauf | `main`, nightly |
+| `App E2E / App E2E` | Browser-Smoke für App-Routen mit No-op bei Nicht-Relevanz | alle PRs, nightly, manuell |
 | `monitoring-stack` | Monitoring-spezifische Docker-/Stack-Checks | pfadbasiert |
 | `Schema Diff Gate` | Schema-Diff gegen Staging | pfadbasiert |
-| `File Placement` | Dateiplatzierungs-Regeln | alle PRs und `main` |
+| `Repository Hygiene / File Placement` | Dateiplatzierungs-Regeln | alle PRs und `main` |
 
 ### Recommended Branch-Protection-Checks
 
 Empfehlung für `main`:
 
 - immer required:
-  - `Lint`
-  - `Unit`
-  - `Types`
-  - `Coverage`
-  - `Complexity`
-  - `PR Integration` für Pull Requests
-  - `Integration` für `main`
-  - `File Placement`
+  - `Quality Gates / Lint`
+  - `Quality Gates / Unit`
+  - `Quality Gates / Types`
+  - `Runtime Gates / Coverage`
+  - `Runtime Gates / Complexity`
+  - `Runtime Gates / PR Integration` für Pull Requests
+  - `Runtime Gates / Integration` für `main`
+  - `Repository Hygiene / File Placement`
 - zusätzlich required:
-  - `App E2E`
+  - `App E2E / App E2E`
   - `monitoring-stack`
   - `Schema Diff Gate`
 

--- a/docs/development/testing-coverage.md
+++ b/docs/development/testing-coverage.md
@@ -139,7 +139,7 @@ Workflow: `.github/workflows/runtime-gates.yml`
   - Job `Complexity`: separates, blockierendes Komplexitäts-Gate
   - Job `PR Integration`: `affected`, `full` oder bewusster No-op für `test:integration`, exklusive `monitoring-client`
   - Reine Doku-/Meta-PRs starten die Workflows weiterhin, beenden die betroffenen Jobs aber bewusst früh als erfolgreicher No-op, damit Required Checks nicht im Status `expected` hängen bleiben
-  - Workflow- und CI-Dateiänderungen werden über `tooling-testing` targeted abgesichert und eskalieren Quality-/Coverage-Läufe nicht automatisch auf den vollen Produkt-Workspace
+- Workflow- und CI-Dateiänderungen werden über `tooling-testing` targeted abgesichert und eskalieren Quality-/Coverage-Läufe nicht automatisch auf den vollen Produkt-Workspace
 - Main + Nightly:
   - Job `Coverage`: `test:coverage` (voll)
   - Job `Complexity`: blockierend
@@ -156,7 +156,7 @@ Workflow: `.github/workflows/runtime-gates.yml`
 | `App E2E` | Browser-Smoke für App-Routen mit No-op bei Nicht-Relevanz | alle PRs, nightly, manuell |
 | `monitoring-stack` | Monitoring-spezifische Docker-/Stack-Checks | pfadbasiert |
 | `Schema Diff Gate` | Schema-Diff gegen Staging | pfadbasiert |
-| `check-file-placement` | Dateiplatzierungs-Regeln | alle PRs und `main` |
+| `File Placement` | Dateiplatzierungs-Regeln | alle PRs und `main` |
 
 ### Recommended Branch-Protection-Checks
 

--- a/docs/development/testing-coverage.md
+++ b/docs/development/testing-coverage.md
@@ -135,23 +135,24 @@ Wenn die Komplexität eines kritischen Hotspots steigt, darf der bestehende Floo
 Workflow: `.github/workflows/runtime-gates.yml`
 
 - Pull Requests:
-  - Job `Coverage Gate`: `affected` oder `full` für `test:coverage` gegen den PR-Base-Branch, gesteuert durch `scripts/ci/pr-scope.ts`
-  - Job `Complexity Gate`: separates, blockierendes Komplexitäts-Gate
-  - Job `PR Integration Gate`: `affected`, `full` oder bewusster No-op für `test:integration`, exklusive `monitoring-client`
+  - Job `Coverage`: `affected` oder `full` für `test:coverage` gegen den PR-Base-Branch, gesteuert durch `scripts/ci/pr-scope.ts`
+  - Job `Complexity`: separates, blockierendes Komplexitäts-Gate
+  - Job `PR Integration`: `affected`, `full` oder bewusster No-op für `test:integration`, exklusive `monitoring-client`
   - Reine Doku-/Meta-PRs starten die Workflows weiterhin, beenden die betroffenen Jobs aber bewusst früh als erfolgreicher No-op, damit Required Checks nicht im Status `expected` hängen bleiben
+  - Workflow- und CI-Dateiänderungen werden über `tooling-testing` targeted abgesichert und eskalieren Quality-/Coverage-Läufe nicht automatisch auf den vollen Produkt-Workspace
 - Main + Nightly:
-  - Job `Coverage Gate`: `test:coverage` (voll)
-  - Job `Complexity Gate`: blockierend
-  - Job `Integration Gate`: voller, verpflichtender Integrationslauf
+  - Job `Coverage`: `test:coverage` (voll)
+  - Job `Complexity`: blockierend
+  - Job `Integration`: voller, verpflichtender Integrationslauf
 
 ### PR-Workflow-Matrix
 
 | Workflow / Jobname in GitHub | Zweck | Trigger-Modell |
 | --- | --- | --- |
-| `Coverage Gate` | Coverage für affected/full + internes Coverage-Gate | alle PRs, `main`, nightly |
-| `Complexity Gate` | Repository-weites Komplexitäts-Gate | alle PRs, `main`, nightly |
-| `PR Integration Gate` | scoped `test:integration` außer Monitoring-Stack | Pull Requests |
-| `Integration Gate` | voller Integrationslauf | `main`, nightly |
+| `Coverage` | Coverage für affected/full + internes Coverage-Gate | alle PRs, `main`, nightly |
+| `Complexity` | Repository-weites Komplexitäts-Gate | alle PRs, `main`, nightly |
+| `PR Integration` | scoped `test:integration` außer Monitoring-Stack | Pull Requests |
+| `Integration` | voller Integrationslauf | `main`, nightly |
 | `App E2E` | Browser-Smoke für App-Routen mit No-op bei Nicht-Relevanz | alle PRs, nightly, manuell |
 | `monitoring-stack` | Monitoring-spezifische Docker-/Stack-Checks | pfadbasiert |
 | `Schema Diff Gate` | Schema-Diff gegen Staging | pfadbasiert |
@@ -162,14 +163,14 @@ Workflow: `.github/workflows/runtime-gates.yml`
 Empfehlung für `main`:
 
 - immer required:
-  - `Lint / lint`
-  - `Unit / unit`
-  - `Types / types`
-  - `Coverage Gate`
-  - `Complexity Gate`
-  - `PR Integration Gate` für Pull Requests
-  - `Integration Gate` für `main`
-  - `check-file-placement`
+  - `Lint`
+  - `Unit`
+  - `Types`
+  - `Coverage`
+  - `Complexity`
+  - `PR Integration` für Pull Requests
+  - `Integration` für `main`
+  - `File Placement`
 - zusätzlich required:
   - `App E2E`
   - `monitoring-stack`

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -69,7 +69,7 @@ Die PR-Selektion folgt einem einheitlichen `affected-first`-Modell:
 - Reine Doku-/Meta-Änderungen enden als erfolgreicher No-op.
 - Normale Paketänderungen laufen affected.
 - Echte globale Workspace-Dateien wie `pnpm-lock.yaml`, `nx.json`, `tsconfig.base.json`, `eslint.config.mjs`, `vitest.config.ts` und `vitest.workspace.ts` eskalieren `lint`, `unit`, `types` und `coverage` bewusst auf volle Läufe.
-- Workflow- und CI-Dateien wie `.github/workflows/**`, `scripts/ci/**`, Root-`package.json` oder `tsconfig.scripts.json` werden gezielt über `tooling-testing` abgesichert und erzwingen nicht automatisch volle Produkt-Läufe.
+- Workflow- und CI-Dateien wie `.github/workflows/**`, `.github/actions/**`, `scripts/ci/**`, Root-`package.json` oder `tsconfig.scripts.json` werden gezielt über `tooling-testing` abgesichert und erzwingen nicht automatisch volle Produkt-Läufe für `lint`, `unit`, `types` und `coverage`.
 - `integration` und `e2e` eskalieren nur bei tatsächlicher Laufzeit-, Routing-, Auth-, Transport-, Build- oder App-Flow-Wirkung.
 
 Nicht vollständig lokal abbildbar bleiben externe PR-Dienste wie SonarCloud, Codecov und CodeQL. `pnpm test:pr` deckt jetzt aber neben der Repo-Coverage auch die lokale Patch-Coverage ab und reduziert damit die häufigsten Abweichungen zwischen lokalem Stand und GitHub-Checks deutlicher.

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -68,7 +68,8 @@ Die PR-Selektion folgt einem einheitlichen `affected-first`-Modell:
 
 - Reine Doku-/Meta-Änderungen enden als erfolgreicher No-op.
 - Normale Paketänderungen laufen affected.
-- Globale Tooling-Dateien wie `pnpm-lock.yaml`, `nx.json`, `tsconfig.base.json`, `eslint.config.mjs`, `vitest.config.ts`, `vitest.workspace.ts`, Root-`package.json`, `.github/workflows/**` und `scripts/ci/**` eskalieren `lint`, `unit`, `types` und `coverage` bewusst auf volle Läufe.
+- Echte globale Workspace-Dateien wie `pnpm-lock.yaml`, `nx.json`, `tsconfig.base.json`, `eslint.config.mjs`, `vitest.config.ts` und `vitest.workspace.ts` eskalieren `lint`, `unit`, `types` und `coverage` bewusst auf volle Läufe.
+- Workflow- und CI-Dateien wie `.github/workflows/**`, `scripts/ci/**`, Root-`package.json` oder `tsconfig.scripts.json` werden gezielt über `tooling-testing` abgesichert und erzwingen nicht automatisch volle Produkt-Läufe.
 - `integration` und `e2e` eskalieren nur bei tatsächlicher Laufzeit-, Routing-, Auth-, Transport-, Build- oder App-Flow-Wirkung.
 
 Nicht vollständig lokal abbildbar bleiben externe PR-Dienste wie SonarCloud, Codecov und CodeQL. `pnpm test:pr` deckt jetzt aber neben der Repo-Coverage auch die lokale Patch-Coverage ab und reduziert damit die häufigsten Abweichungen zwischen lokalem Stand und GitHub-Checks deutlicher.

--- a/docs/governance/merge-review-gates.md
+++ b/docs/governance/merge-review-gates.md
@@ -24,7 +24,7 @@ Die folgenden Status-Checks muessen im Branch-Schutz fuer `main` als **required*
 
 Verbindliche Regel: Kein unspezifisches "CI ist gruen". Entscheidend sind genau die oben genannten Check-Namen.
 
-Die PR-Gates folgen einem einheitlichen `affected-first`-Modell: Normale Paketänderungen laufen affected, globale Tooling-Dateien eskalieren gezielt auf volle Läufe, irrelevante PRs enden bewusst als No-op-Erfolg.
+Die PR-Gates folgen einem einheitlichen `affected-first`-Modell: Normale Paketänderungen laufen affected, echte globale Workspace-Dateien eskalieren gezielt auf volle Läufe, Workflow-/CI-Dateien werden über `tooling-testing` targeted abgesichert und irrelevante PRs enden bewusst als No-op-Erfolg.
 
 ## Review-Anforderungen
 

--- a/nx.json
+++ b/nx.json
@@ -71,7 +71,7 @@
     "ciGateTooling": [
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/tsconfig.scripts.json",
-      "{workspaceRoot}/scripts/ci/**/*.ts",
+      "{workspaceRoot}/scripts/ci/**",
       "{workspaceRoot}/.github/workflows/**/*.yml"
     ],
     "frontendTooling": [

--- a/nx.json
+++ b/nx.json
@@ -68,6 +68,12 @@
       "{workspaceRoot}/vitest.config.ts",
       "{workspaceRoot}/vitest.workspace.ts"
     ],
+    "ciGateTooling": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/tsconfig.scripts.json",
+      "{workspaceRoot}/scripts/ci/**/*.ts",
+      "{workspaceRoot}/.github/workflows/**/*.yml"
+    ],
     "frontendTooling": [
       "{projectRoot}/vite.config.ts",
       "{projectRoot}/vitest.config.ts",

--- a/nx.json
+++ b/nx.json
@@ -72,8 +72,12 @@
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/tsconfig.scripts.json",
       "{workspaceRoot}/scripts/ci/**",
+      "{workspaceRoot}/.github/actions/**",
       "{workspaceRoot}/.github/workflows/**/*.yml",
       "{workspaceRoot}/.github/workflows/**/*.yaml"
+    ],
+    "toolingScripts": [
+      "{workspaceRoot}/scripts/**"
     ],
     "frontendTooling": [
       "{projectRoot}/vite.config.ts",

--- a/nx.json
+++ b/nx.json
@@ -72,7 +72,8 @@
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/tsconfig.scripts.json",
       "{workspaceRoot}/scripts/ci/**",
-      "{workspaceRoot}/.github/workflows/**/*.yml"
+      "{workspaceRoot}/.github/workflows/**/*.yml",
+      "{workspaceRoot}/.github/workflows/**/*.yaml"
     ],
     "frontendTooling": [
       "{projectRoot}/vite.config.ts",

--- a/openspec/changes/refactor-pr-test-scope-hardening/design.md
+++ b/openspec/changes/refactor-pr-test-scope-hardening/design.md
@@ -1,0 +1,14 @@
+## Context
+
+Die erste Ausbaustufe des `affected-first`-Modells hat das PR-Verhalten vereinheitlicht, eskaliert aber Workflow- und CI-Dateien noch zu grob auf volle Workspace-Läufe. Das verschlechtert Durchlaufzeiten und erhöht die Wahrscheinlichkeit teurer Flakes in unveränderten Produktbereichen.
+
+## Decision
+
+- `quality_gate_mode` und `coverage_mode` eskalieren nur noch bei echten globalen Workspace-Dateien auf `full`.
+- Workflow-, Root-Skript- und CI-Änderungen werden über `tooling-testing` gezielt abgesichert statt über pauschale Voll-Läufe des Produkt-Workspaces.
+- Sichtbare GitHub-Check-Namen und das Required-Check-Modell bleiben unverändert.
+
+## Consequences
+
+- PRs mit reinen Workflow-/CI-Änderungen bleiben hart validiert, aber deutlich günstiger.
+- `tooling-testing` wird ein expliziter Teil des Scope-Modells und muss seine Input-Definitionen stabil halten.

--- a/openspec/changes/refactor-pr-test-scope-hardening/proposal.md
+++ b/openspec/changes/refactor-pr-test-scope-hardening/proposal.md
@@ -1,0 +1,25 @@
+# Change: PR-Test-Scope gegen unnötige Voll-Läufe härten
+
+## Why
+
+Das aktuelle `affected-first`-Modell eskaliert PR-Gates bei Änderungen an Workflow- und CI-Dateien noch zu breit. Dadurch laufen `Lint`, `Unit`, `Types` und `Coverage` in Fällen voll, in denen gezielte Tooling-Checks ausreichen würden.
+
+## What Changes
+
+- Verfeinerung der PR-Scope-Klassifikation für Quality- und Coverage-Gates
+- Entfernung pauschaler `full`-Eskalation für Root-`package.json`, `.github/workflows/**` und `scripts/ci/**`
+- Ausbau von `tooling-testing` als gezieltes Absicherungsprojekt für CI-, Workflow- und PR-Gate-Logik
+- Fortschreibung der Test- und Governance-Dokumentation für die präzisere Eskalationspolitik
+
+## Impact
+
+- Affected specs:
+  - `test-coverage-governance`
+  - `monorepo-structure`
+- Affected code:
+  - `scripts/ci/`
+  - `tooling/testing/`
+  - `.github/workflows/`
+- Affected arc42 sections:
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/10-quality-requirements.md`

--- a/openspec/changes/refactor-pr-test-scope-hardening/specs/monorepo-structure/spec.md
+++ b/openspec/changes/refactor-pr-test-scope-hardening/specs/monorepo-structure/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Tooling-Testing deckt CI- und Workflow-Governance gezielt ab
+Das Monorepo SHALL ein dediziertes `tooling-testing`-Projekt bereitstellen, das PR-Gate-Skripte, Workflow-Kontrakte und Root-Tooling-Dateien gezielt absichert.
+
+#### Scenario: Workflow-Datei aendert den Tooling-Test-Scope
+- **WHEN** eine Datei unter `.github/workflows/**` geändert wird
+- **THEN** wird `tooling-testing` im affected-Graph berücksichtigt
+- **AND** sein Lint- und Unit-Test-Target können die Änderung gezielt validieren
+
+#### Scenario: CI-Skript aendert den Tooling-Test-Scope
+- **WHEN** eine Datei unter `scripts/ci/**` geändert wird
+- **THEN** wird `tooling-testing` im affected-Graph berücksichtigt
+- **AND** Contract-Tests für PR-Scope- und Gate-Logik laufen gegen diese Änderung
+
+#### Scenario: Root-Tooling-Datei aendert den Tooling-Test-Scope
+- **WHEN** Root-`package.json` oder `tsconfig.scripts.json` geändert werden
+- **THEN** wird `tooling-testing` im affected-Graph berücksichtigt
+- **AND** die Änderung wird nicht nur über pauschale Voll-Läufe der Produkt-Suite abgesichert

--- a/openspec/changes/refactor-pr-test-scope-hardening/specs/monorepo-structure/spec.md
+++ b/openspec/changes/refactor-pr-test-scope-hardening/specs/monorepo-structure/spec.md
@@ -3,17 +3,17 @@
 ### Requirement: Tooling-Testing deckt CI- und Workflow-Governance gezielt ab
 Das Monorepo SHALL ein dediziertes `tooling-testing`-Projekt bereitstellen, das PR-Gate-Skripte, Workflow-Kontrakte und Root-Tooling-Dateien gezielt absichert.
 
-#### Scenario: Workflow-Datei aendert den Tooling-Test-Scope
+#### Scenario: Workflow-Datei ändert den Tooling-Test-Scope
 - **WHEN** eine Datei unter `.github/workflows/**` geändert wird
 - **THEN** wird `tooling-testing` im affected-Graph berücksichtigt
 - **AND** sein Lint- und Unit-Test-Target können die Änderung gezielt validieren
 
-#### Scenario: CI-Skript aendert den Tooling-Test-Scope
+#### Scenario: CI-Skript ändert den Tooling-Test-Scope
 - **WHEN** eine Datei unter `scripts/ci/**` geändert wird
 - **THEN** wird `tooling-testing` im affected-Graph berücksichtigt
 - **AND** Contract-Tests für PR-Scope- und Gate-Logik laufen gegen diese Änderung
 
-#### Scenario: Root-Tooling-Datei aendert den Tooling-Test-Scope
+#### Scenario: Root-Tooling-Datei ändert den Tooling-Test-Scope
 - **WHEN** Root-`package.json` oder `tsconfig.scripts.json` geändert werden
 - **THEN** wird `tooling-testing` im affected-Graph berücksichtigt
 - **AND** die Änderung wird nicht nur über pauschale Voll-Läufe der Produkt-Suite abgesichert

--- a/openspec/changes/refactor-pr-test-scope-hardening/specs/test-coverage-governance/spec.md
+++ b/openspec/changes/refactor-pr-test-scope-hardening/specs/test-coverage-governance/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Trennung von Unit- und Integrationstests
+Das System SHALL infra-abhängige Integrationstests getrennt von Unit-Coverage-Gates ausführen.
+
+#### Scenario: PR-Workflow
+- **WHEN** ein Pull Request validiert wird
+- **THEN** blockieren Unit-Coverage-Gates den PR
+- **AND** Integrationstests können in PR optional separat laufen
+
+#### Scenario: Nightly/Main Workflow
+- **WHEN** Nightly oder Main-Pipeline ausgeführt wird
+- **THEN** werden Integrationstests verpflichtend ausgeführt
+- **AND** deren Ergebnis wird separat ausgewiesen
+
+#### Scenario: Workflow- und CI-Dateien eskalieren Coverage nicht pauschal auf Voll-Läufe
+- **GIVEN** ein Pull Request ändert nur `.github/workflows/**`, `scripts/ci/**` oder Root-Tooling-Metadaten ohne globale Workspace-Konfigurationsänderung
+- **WHEN** das PR-Coverage-Gate seinen Scope bestimmt
+- **THEN** eskaliert es nicht allein deshalb auf einen vollen Workspace-Coverage-Lauf
+- **AND** die Absicherung erfolgt stattdessen über gezielte Tooling-Tests und Gate-Contracts
+
+### Requirement: CI-Workflow-Optimierung via Concurrency
+Das System SHALL redundante CI-Workflow-Runs via Concurrency-Control verhindern.
+
+#### Scenario: Cancel-in-Progress für PR-Branches
+- **GIVEN** ein PR hat mehrere schnell aufeinanderfolgende Commits
+- **WHEN** neuer Commit gepusht wird während alter Workflow läuft
+- **THEN** wird alter Workflow-Run gecancelt
+- **AND** neuer Workflow startet sofort
+- **AND** CI-Ressourcen werden für aktuellsten Code frei
+
+#### Scenario: Main-Branch nie canceln
+- **WHEN** Main-Branch Coverage-Workflow läuft
+- **THEN** wird dieser niemals gecancelt (auch bei neuem Commit)
+- **AND** Deployment-kritische Workflows bleiben intakt
+
+#### Scenario: Quality- und Coverage-Eskalation bleibt globalen Workspace-Dateien vorbehalten
+- **GIVEN** ein Pull Request ändert `pnpm-lock.yaml`, `nx.json`, `tsconfig.base.json`, `eslint.config.mjs`, `vitest.config.ts` oder `vitest.workspace.ts`
+- **WHEN** das PR-Scope für Quality- und Coverage-Gates klassifiziert wird
+- **THEN** dürfen `Lint`, `Unit`, `Types` und `Coverage` auf volle Läufe eskalieren
+- **AND** andere Workflow- oder CI-Dateien lösen diese `full`-Eskalation nicht automatisch aus

--- a/openspec/changes/refactor-pr-test-scope-hardening/tasks.md
+++ b/openspec/changes/refactor-pr-test-scope-hardening/tasks.md
@@ -1,0 +1,12 @@
+## 1. Specification
+
+- [x] 1.1 PR-Scope-Härtung für `test-coverage-governance` spezifizieren
+- [x] 1.2 Ausbau von `tooling-testing` als CI- und Workflow-Absicherung in `monorepo-structure` spezifizieren
+- [x] 1.3 `openspec validate refactor-pr-test-scope-hardening --strict` ausführen
+
+## 2. Implementation
+
+- [x] 2.1 `scripts/ci/pr-scope.ts` auf gate-spezifische Eskalationsursachen umstellen
+- [x] 2.2 `tooling/testing` so erweitern, dass Workflow- und CI-Dateiänderungen affected anschlagen
+- [x] 2.3 Contract-Tests für `pr-scope.ts`, `run-pr-gate.ts` und Workflow-Scope-Verhalten ergänzen
+- [x] 2.4 Testing- und Governance-Dokumentation nachziehen

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:eslint": "pnpm check:plugin-ui-boundary && env -u NO_COLOR nx run-many -t lint",
     "test:eslint:affected": "pnpm check:plugin-ui-boundary && env -u NO_COLOR nx affected --target=lint --base=${NX_BASE:-origin/main}",
     "test:types": "pnpm clean:generated-source-artifacts && env -u NO_COLOR nx run-many -t test:types --parallel=1 && env -u NO_COLOR nx run-many -t typecheck --parallel=1 && pnpm check:server-runtime && pnpm exec tsc -p tsconfig.scripts.json --noEmit",
-    "test:types:affected": "pnpm clean:generated-source-artifacts && env -u NO_COLOR nx affected --target=test:types --base=${NX_BASE:-origin/main} --parallel=1 && env -u NO_COLOR nx affected --target=typecheck --base=${NX_BASE:-origin/main} --parallel=1 && pnpm check:server-runtime:affected",
+    "test:types:affected": "pnpm clean:generated-source-artifacts && env -u NO_COLOR nx affected --target=test:types --base=${NX_BASE:-origin/main} --parallel=1 && env -u NO_COLOR nx affected --target=typecheck --base=${NX_BASE:-origin/main} --parallel=1 && pnpm check:server-runtime:affected && pnpm exec tsc -p tsconfig.scripts.json --noEmit",
     "test": "pnpm test:unit",
     "test:unit": "env -u NO_COLOR nx run-many -t test:unit --parallel=1",
     "test:unit:affected": "env -u NO_COLOR nx affected --target=test:unit --base=${NX_BASE:-origin/main} --parallel=1",

--- a/scripts/ci/pr-scope.test.ts
+++ b/scripts/ci/pr-scope.test.ts
@@ -96,12 +96,40 @@ describe('pr-scope', () => {
 
     expectDecision(decision, {
       codeRelevant: true,
-      qualityGateMode: 'full',
-      coverageMode: 'full',
+      qualityGateMode: 'affected',
+      coverageMode: 'affected',
       integrationMode: 'full',
       e2eMode: 'skip',
       appBuildMode: 'full',
     });
+  });
+
+  it('keeps workflow-only changes on affected quality gates', () => {
+    const decision = classifyPrScope(['.github/workflows/quality-gates.yml']);
+
+    expectDecision(decision, {
+      codeRelevant: true,
+      qualityGateMode: 'affected',
+      coverageMode: 'affected',
+      integrationMode: 'full',
+      e2eMode: 'skip',
+      appBuildMode: 'full',
+    });
+    expect(decision.escalationReasons).toEqual([]);
+  });
+
+  it('keeps ci-script changes on affected quality gates', () => {
+    const decision = classifyPrScope(['scripts/ci/run-pr-gate.ts']);
+
+    expectDecision(decision, {
+      codeRelevant: true,
+      qualityGateMode: 'affected',
+      coverageMode: 'affected',
+      integrationMode: 'full',
+      e2eMode: 'full',
+      appBuildMode: 'full',
+    });
+    expect(decision.escalationReasons).toEqual([]);
   });
 
   it('includes deleted files when resolving changed files', () => {

--- a/scripts/ci/pr-scope.ts
+++ b/scripts/ci/pr-scope.ts
@@ -38,9 +38,6 @@ const qualityEscalationPatterns = [
   /^eslint\.config\.mjs$/u,
   /^vitest\.config\.ts$/u,
   /^vitest\.workspace\.ts$/u,
-  /^package\.json$/u,
-  /^\.github\/workflows\//u,
-  /^scripts\/ci\//u,
 ];
 
 const integrationRelevantPatterns = [

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -6,6 +6,10 @@
   "targets": {
     "lint": {
       "executor": "@nx/eslint:lint",
+      "inputs": [
+        "default",
+        "ciGateTooling"
+      ],
       "options": {
         "lintFilePatterns": [
           "tooling/testing/tests/**/*.{ts,tsx,js,jsx}",
@@ -15,12 +19,22 @@
     },
     "test:unit": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "testing",
+        "ciGateTooling"
+      ],
       "options": {
         "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:coverage": {
       "executor": "nx:run-commands",
+      "inputs": [
+        "default",
+        "testing",
+        "ciGateTooling"
+      ],
       "options": {
         "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -10,7 +10,8 @@
         "default",
         "^production",
         "lintTooling",
-        "ciGateTooling"
+        "ciGateTooling",
+        "toolingScripts"
       ],
       "options": {
         "lintFilePatterns": [
@@ -25,7 +26,8 @@
         "default",
         "^production",
         "testing",
-        "ciGateTooling"
+        "ciGateTooling",
+        "toolingScripts"
       ],
       "options": {
         "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
@@ -37,7 +39,8 @@
         "default",
         "^production",
         "testing",
-        "ciGateTooling"
+        "ciGateTooling",
+        "toolingScripts"
       ],
       "options": {
         "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -8,6 +8,8 @@
       "executor": "@nx/eslint:lint",
       "inputs": [
         "default",
+        "^production",
+        "lintTooling",
         "ciGateTooling"
       ],
       "options": {
@@ -21,6 +23,7 @@
       "executor": "nx:run-commands",
       "inputs": [
         "default",
+        "^production",
         "testing",
         "ciGateTooling"
       ],
@@ -32,6 +35,7 @@
       "executor": "nx:run-commands",
       "inputs": [
         "default",
+        "^production",
         "testing",
         "ciGateTooling"
       ],

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -264,6 +264,7 @@ describe('workspace package scripts', () => {
         '{workspaceRoot}/tsconfig.scripts.json',
         '{workspaceRoot}/scripts/ci/**',
         '{workspaceRoot}/.github/workflows/**/*.yml',
+        '{workspaceRoot}/.github/workflows/**/*.yaml',
       ])
     );
     expect(lintInputs).toContain('^production');

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -262,11 +262,14 @@ describe('workspace package scripts', () => {
       expect.arrayContaining([
         '{workspaceRoot}/package.json',
         '{workspaceRoot}/tsconfig.scripts.json',
-        '{workspaceRoot}/scripts/ci/**/*.ts',
+        '{workspaceRoot}/scripts/ci/**',
         '{workspaceRoot}/.github/workflows/**/*.yml',
       ])
     );
+    expect(lintInputs).toContain('^production');
+    expect(lintInputs).toContain('lintTooling');
     expect(lintInputs).toContain('ciGateTooling');
+    expect(unitInputs).toContain('^production');
     expect(unitInputs).toContain('ciGateTooling');
   });
 

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -83,6 +83,11 @@ function loadRunPrGateScript(): string {
   return fs.readFileSync(path.join(rootDir, 'scripts/ci/run-pr-gate.ts'), 'utf8');
 }
 
+function loadNxJson(): { namedInputs?: Record<string, string[]> } {
+  const rootDir = resolveRootDir();
+  return JSON.parse(fs.readFileSync(path.join(rootDir, 'nx.json'), 'utf8')) as { namedInputs?: Record<string, string[]> };
+}
+
 describe('workspace package scripts', () => {
   it('keeps patch coverage enforcement in the standard PR gate', () => {
     const packageJson = loadRootPackageJson();
@@ -245,4 +250,24 @@ describe('workspace package scripts', () => {
       ])
     );
   });
+
+  it('marks tooling-testing affected for workflow and CI-gate changes', () => {
+    const nxJson = loadNxJson();
+    const toolingTestingProject = loadToolingTestingProject();
+    const namedInput = nxJson.namedInputs?.['ciGateTooling'] ?? [];
+    const lintInputs = (toolingTestingProject.targets?.lint as { inputs?: string[] } | undefined)?.inputs ?? [];
+    const unitInputs = (toolingTestingProject.targets?.['test:unit'] as { inputs?: string[] } | undefined)?.inputs ?? [];
+
+    expect(namedInput).toEqual(
+      expect.arrayContaining([
+        '{workspaceRoot}/package.json',
+        '{workspaceRoot}/tsconfig.scripts.json',
+        '{workspaceRoot}/scripts/ci/**/*.ts',
+        '{workspaceRoot}/.github/workflows/**/*.yml',
+      ])
+    );
+    expect(lintInputs).toContain('ciGateTooling');
+    expect(unitInputs).toContain('ciGateTooling');
+  });
+
 });

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -182,7 +182,7 @@ describe('workspace package scripts', () => {
       'env -u NO_COLOR nx affected --target=test:unit --base=${NX_BASE:-origin/main} --parallel=1'
     );
     expect(packageJson.scripts?.['test:types:affected']).toBe(
-      'pnpm clean:generated-source-artifacts && env -u NO_COLOR nx affected --target=test:types --base=${NX_BASE:-origin/main} --parallel=1 && env -u NO_COLOR nx affected --target=typecheck --base=${NX_BASE:-origin/main} --parallel=1 && pnpm check:server-runtime:affected'
+      'pnpm clean:generated-source-artifacts && env -u NO_COLOR nx affected --target=test:types --base=${NX_BASE:-origin/main} --parallel=1 && env -u NO_COLOR nx affected --target=typecheck --base=${NX_BASE:-origin/main} --parallel=1 && pnpm check:server-runtime:affected && pnpm exec tsc -p tsconfig.scripts.json --noEmit'
     );
     expect(packageJson.scripts?.['check:server-runtime:affected']).toBe(
       'env -u NO_COLOR NODE_OPTIONS="${NODE_OPTIONS:-} --import=./scripts/ci/node-listener-budget.mjs" nx affected --target=check:runtime --base=${NX_BASE:-origin/main} --parallel=1'

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -21,6 +21,8 @@ interface TsConfigJson {
   include?: string[];
 }
 
+type NamedInputValue = string | { env: string };
+
 interface NxProjectJson {
   targets?: Record<string, { options?: { lintFilePatterns?: string[] } }>;
 }
@@ -83,9 +85,11 @@ function loadRunPrGateScript(): string {
   return fs.readFileSync(path.join(rootDir, 'scripts/ci/run-pr-gate.ts'), 'utf8');
 }
 
-function loadNxJson(): { namedInputs?: Record<string, string[]> } {
+function loadNxJson(): { namedInputs?: Record<string, NamedInputValue[]> } {
   const rootDir = resolveRootDir();
-  return JSON.parse(fs.readFileSync(path.join(rootDir, 'nx.json'), 'utf8')) as { namedInputs?: Record<string, string[]> };
+  return JSON.parse(fs.readFileSync(path.join(rootDir, 'nx.json'), 'utf8')) as {
+    namedInputs?: Record<string, NamedInputValue[]>;
+  };
 }
 
 describe('workspace package scripts', () => {
@@ -255,23 +259,30 @@ describe('workspace package scripts', () => {
     const nxJson = loadNxJson();
     const toolingTestingProject = loadToolingTestingProject();
     const namedInput = nxJson.namedInputs?.['ciGateTooling'] ?? [];
+    const toolingScriptsInput = nxJson.namedInputs?.['toolingScripts'] ?? [];
     const lintInputs = (toolingTestingProject.targets?.lint as { inputs?: string[] } | undefined)?.inputs ?? [];
     const unitInputs = (toolingTestingProject.targets?.['test:unit'] as { inputs?: string[] } | undefined)?.inputs ?? [];
+    const coverageInputs = (toolingTestingProject.targets?.['test:coverage'] as { inputs?: string[] } | undefined)?.inputs ?? [];
 
     expect(namedInput).toEqual(
       expect.arrayContaining([
         '{workspaceRoot}/package.json',
         '{workspaceRoot}/tsconfig.scripts.json',
+        '{workspaceRoot}/.github/actions/**',
         '{workspaceRoot}/scripts/ci/**',
         '{workspaceRoot}/.github/workflows/**/*.yml',
         '{workspaceRoot}/.github/workflows/**/*.yaml',
       ])
     );
+    expect(toolingScriptsInput).toEqual(expect.arrayContaining(['{workspaceRoot}/scripts/**']));
     expect(lintInputs).toContain('^production');
     expect(lintInputs).toContain('lintTooling');
     expect(lintInputs).toContain('ciGateTooling');
+    expect(lintInputs).toContain('toolingScripts');
     expect(unitInputs).toContain('^production');
     expect(unitInputs).toContain('ciGateTooling');
+    expect(unitInputs).toContain('toolingScripts');
+    expect(coverageInputs).toContain('toolingScripts');
   });
 
 });


### PR DESCRIPTION
# Change: PR-Test-Scope gegen unnötige Voll-Läufe härten

## Why

Das aktuelle `affected-first`-Modell eskaliert PR-Gates bei Änderungen an Workflow- und CI-Dateien noch zu breit. Dadurch laufen `Lint`, `Unit`, `Types` und `Coverage` in Fällen voll, in denen gezielte Tooling-Checks ausreichen würden.

## What Changes

- Verfeinerung der PR-Scope-Klassifikation für Quality- und Coverage-Gates
- Entfernung pauschaler `full`-Eskalation für Root-`package.json`, `.github/workflows/**` und `scripts/ci/**`
- Ausbau von `tooling-testing` als gezieltes Absicherungsprojekt für CI-, Workflow- und PR-Gate-Logik
- Fortschreibung der Test- und Governance-Dokumentation für die präzisere Eskalationspolitik

## Impact

- Affected specs:
  - `test-coverage-governance`
  - `monorepo-structure`
- Affected code:
  - `scripts/ci/`
  - `tooling/testing/`
  - `.github/workflows/`
- Affected arc42 sections:
  - `docs/architecture/08-cross-cutting-concepts.md`
  - `docs/architecture/10-quality-requirements.md`
