### PR TITLE
refactor: split app unit tests into targeted slices

### DIFF
--- a/apps/sva-studio-react/project.json
+++ b/apps/sva-studio-react/project.json
@@ -118,6 +118,62 @@
         "configFile": "apps/sva-studio-react/vitest.config.ts"
       }
     },
+    "test:unit:ui": {
+      "executor": "@nx/vitest:test",
+      "cache": true,
+      "inputs": [
+        "default",
+        "^production",
+        "testing",
+        "frontendTooling"
+      ],
+      "outputs": [],
+      "options": {
+        "configFile": "apps/sva-studio-react/vitest.ui.config.ts"
+      }
+    },
+    "test:unit:routes": {
+      "executor": "@nx/vitest:test",
+      "cache": true,
+      "inputs": [
+        "default",
+        "^production",
+        "testing",
+        "frontendTooling"
+      ],
+      "outputs": [],
+      "options": {
+        "configFile": "apps/sva-studio-react/vitest.routes.config.ts"
+      }
+    },
+    "test:unit:hooks": {
+      "executor": "@nx/vitest:test",
+      "cache": true,
+      "inputs": [
+        "default",
+        "^production",
+        "testing",
+        "frontendTooling"
+      ],
+      "outputs": [],
+      "options": {
+        "configFile": "apps/sva-studio-react/vitest.hooks.config.ts"
+      }
+    },
+    "test:unit:server": {
+      "executor": "@nx/vitest:test",
+      "cache": true,
+      "inputs": [
+        "default",
+        "^production",
+        "testing",
+        "frontendTooling"
+      ],
+      "outputs": [],
+      "options": {
+        "configFile": "apps/sva-studio-react/vitest.server.config.ts"
+      }
+    },
     "test:coverage": {
       "executor": "nx:run-commands",
       "parallelism": false,

--- a/apps/sva-studio-react/vitest.hooks.config.ts
+++ b/apps/sva-studio-react/vitest.hooks.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import { sharedVitestConfig } from './vitest.shared.ts';
+
+export default mergeConfig(
+  sharedVitestConfig,
+  defineConfig({
+    test: {
+      include: [
+        'src/hooks/**/*.{test,spec}.{ts,tsx}',
+        'src/lib/**/*.{test,spec}.{ts,tsx}',
+      ],
+      exclude: [
+        'src/**/*.server.test.{ts,tsx}',
+        'src/**/*-server.test.{ts,tsx}',
+        'src/server.test.{ts,tsx}',
+      ],
+    },
+  })
+);

--- a/apps/sva-studio-react/vitest.routes.config.ts
+++ b/apps/sva-studio-react/vitest.routes.config.ts
@@ -6,7 +6,10 @@ export default mergeConfig(
   sharedVitestConfig,
   defineConfig({
     test: {
-      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      include: [
+        'src/routes/**/*.{test,spec}.{ts,tsx}',
+        'src/routing/**/*.{test,spec}.{ts,tsx}',
+      ],
     },
   })
 );

--- a/apps/sva-studio-react/vitest.routes.config.ts
+++ b/apps/sva-studio-react/vitest.routes.config.ts
@@ -9,6 +9,7 @@ export default mergeConfig(
       include: [
         'src/routes/**/*.{test,spec}.{ts,tsx}',
         'src/routing/**/*.{test,spec}.{ts,tsx}',
+        'src/router*.{test,spec}.{ts,tsx}',
       ],
     },
   })

--- a/apps/sva-studio-react/vitest.server.config.ts
+++ b/apps/sva-studio-react/vitest.server.config.ts
@@ -6,7 +6,11 @@ export default mergeConfig(
   sharedVitestConfig,
   defineConfig({
     test: {
-      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      include: [
+        'src/**/*.server.test.{ts,tsx}',
+        'src/**/*-server.test.{ts,tsx}',
+        'src/server.test.{ts,tsx}',
+      ],
     },
   })
 );

--- a/apps/sva-studio-react/vitest.shared.ts
+++ b/apps/sva-studio-react/vitest.shared.ts
@@ -1,0 +1,68 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export const appRoot = fileURLToPath(new URL('.', import.meta.url));
+
+export const sharedVitestConfig = defineConfig({
+  root: appRoot,
+  resolve: {
+    tsconfigPaths: true,
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      'react-dom/server': fileURLToPath(new URL('./src/lib/react-dom-server-compat.ts', import.meta.url)),
+      '@sva/routing/server': fileURLToPath(new URL('../../packages/routing/src/index.server.ts', import.meta.url)),
+      '@sva/routing/auth': fileURLToPath(new URL('../../packages/routing/src/auth.routes.ts', import.meta.url)),
+      '@sva/routing': fileURLToPath(new URL('../../packages/routing/src/index.ts', import.meta.url)),
+      '@sva/auth-runtime/server': fileURLToPath(new URL('../../packages/auth-runtime/src/server.ts', import.meta.url)),
+      '@sva/auth-runtime/routes': fileURLToPath(new URL('../../packages/auth-runtime/src/routes.ts', import.meta.url)),
+      '@sva/auth-runtime/runtime-routes': fileURLToPath(
+        new URL('../../packages/auth-runtime/src/runtime-routes.ts', import.meta.url)
+      ),
+      '@sva/auth-runtime/runtime-health': fileURLToPath(
+        new URL('../../packages/auth-runtime/src/runtime-health.ts', import.meta.url)
+      ),
+      '@sva/auth-runtime': fileURLToPath(new URL('../../packages/auth-runtime/src/index.ts', import.meta.url)),
+      '@sva/data-repositories/server': fileURLToPath(new URL('../../packages/data-repositories/src/server.ts', import.meta.url)),
+      '@sva/data-repositories': fileURLToPath(new URL('../../packages/data-repositories/src/index.ts', import.meta.url)),
+      '@sva/iam-admin/encryption': fileURLToPath(new URL('../../packages/iam-admin/src/encryption.ts', import.meta.url)),
+      '@sva/iam-admin': fileURLToPath(new URL('../../packages/iam-admin/src/index.ts', import.meta.url)),
+      '@sva/iam-governance/legal-text-html': fileURLToPath(
+        new URL('../../packages/iam-governance/src/legal-text-html.ts', import.meta.url)
+      ),
+      '@sva/iam-governance/legal-text-sanitize-html': fileURLToPath(
+        new URL('../../packages/iam-governance/src/legal-text-sanitize-html.ts', import.meta.url)
+      ),
+      '@sva/sva-mainserver/server': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.server.ts', import.meta.url)),
+      '@sva/sva-mainserver': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.ts', import.meta.url)),
+      '@sva/instance-registry': fileURLToPath(new URL('../../packages/instance-registry/src/index.ts', import.meta.url)),
+      '@sva/plugin-waste-management': fileURLToPath(
+        new URL('../../packages/plugin-waste-management/src/index.ts', import.meta.url)
+      ),
+      '@sva/plugin-sdk': fileURLToPath(new URL('../../packages/plugin-sdk/src/index.ts', import.meta.url)),
+      '@sva/studio-module-iam': fileURLToPath(new URL('../../packages/studio-module-iam/src/index.ts', import.meta.url)),
+      '@sva/studio-ui-react': fileURLToPath(new URL('../../packages/studio-ui-react/src/index.ts', import.meta.url)),
+      '@sva/server-runtime': fileURLToPath(new URL('../../packages/server-runtime/src/index.ts', import.meta.url)),
+      '@sva/monitoring-client/server': fileURLToPath(new URL('../../packages/monitoring-client/src/server.ts', import.meta.url)),
+      '@sva/monitoring-client/logger-provider.server': fileURLToPath(
+        new URL('../../packages/monitoring-client/src/logger-provider.server.ts', import.meta.url)
+      ),
+      '@sva/monitoring-client/logging': fileURLToPath(new URL('../../packages/monitoring-client/src/logging.ts', import.meta.url)),
+      '@sva/monitoring-client': fileURLToPath(new URL('../../packages/monitoring-client/src/index.ts', import.meta.url)),
+      '@sva/core/security': fileURLToPath(new URL('../../packages/core/src/security/index.ts', import.meta.url)),
+      '@sva/core': fileURLToPath(new URL('../../packages/core/src/index.ts', import.meta.url)),
+    },
+  },
+  test: {
+    name: 'sva-studio-react',
+    environment: 'happy-dom',
+    // Serielle Ausführung reduziert Flakes in der UI-Testumgebung und stabilisiert affected-Läufe.
+    pool: 'threads',
+    fileParallelism: false,
+    maxWorkers: 1,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'json-summary', 'lcov'],
+      reportsDirectory: './coverage',
+    },
+  },
+});

--- a/apps/sva-studio-react/vitest.ui.config.ts
+++ b/apps/sva-studio-react/vitest.ui.config.ts
@@ -6,7 +6,11 @@ export default mergeConfig(
   sharedVitestConfig,
   defineConfig({
     test: {
-      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      include: [
+        'src/components/**/*.{test,spec}.{ts,tsx}',
+        'src/providers/**/*.{test,spec}.{ts,tsx}',
+        'src/i18n/**/*.{test,spec}.{ts,tsx}',
+      ],
     },
   })
 );

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -25,7 +25,7 @@ Abhängigkeiten des aktuellen Systems.
    - Theme-Bausteine: `ThemeProvider`, semantische CSS-Token und `Sheet`-Primitive für mobile Shell-Navigation
    - Auth- und Diagnose-Bausteine: `AuthProvider` fuer `/auth/me`, Silent-Recovery und den clientseitigen Grundzustand; `iam-api.ts` fuer Browser-Timeouts, `requestId`-Aufnahme und Safe-Detail-Parsing
   - Host-Standard-Bausteine fuer Admin-Ressourcen: `appAdminResources` als kanonische Capability-Deklaration, route-addressable Listensteuerung in den Admin-/Content-Seiten und duenne Label-/Routing-Bindings fuer `@sva/studio-ui-react` statt app-eigener Tabellen-Owner-Schicht
-   - Nx-Targets für `build`, `serve`, `lint`, `test:unit`, `test:coverage` und `test:e2e` über Vite-, Vitest- und Playwright-Executor
+   - Nx-Targets für `build`, `serve`, `lint`, das aggregierte `test:unit`, die gezielten App-Slices `test:unit:ui|routes|hooks|server`, `test:coverage` und `test:e2e` über Vite-, Vitest- und Playwright-Executor
 2. Core (`packages/core`)
    - generische Route-Registry Utilities (`mergeRouteFactories`, `buildRouteTree`)
    - kanonisches Inhaltsmodell für `Content`, Statusmodell und JSON-Payload-Validierung

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -268,12 +268,13 @@ gleichzeitig beeinflussen.
 
 ### Build-, Test- und Cache-Konzept der Frontend-App
 
-- `apps/sva-studio-react` nutzt dedizierte Nx-Executor für Vite (`build`, `serve`, `preview`), Vitest (`test:unit`, `test:coverage`) und Playwright (`test:e2e`)
+- `apps/sva-studio-react` nutzt dedizierte Nx-Executor für Vite (`build`, `serve`, `preview`), Vitest (`test:unit`, `test:unit:ui`, `test:unit:routes`, `test:unit:hooks`, `test:unit:server`, `test:coverage`) und Playwright (`test:e2e`)
 - `apps/sva-studio-react:verify:runtime-artifact` ist der verbindliche Final-Artifact-Check nach dem Build; er validiert den finalen `.output/server/**`-Vertrag gegen echte Health-Probes und klassifiziert Fehler als `artifact-contract-failed`, `dependency-failed`, `runtime-start-failed` oder `http-dispatch-failed`
 - Cache-relevante Frontend-Konfigurationen werden über `frontendTooling` in `nx.json` explizit modelliert
 - Environment-Einflüsse mit Build-/Serve-/E2E-Relevanz (`CODECOV_TOKEN`, `TSS_DEV_SERVER`, `CI`) werden explizit in die Nx-Hash-Bildung aufgenommen
 - Pre-Build-Checks für i18n und Account-UI-Foundation bleiben als separate Nx-Targets vor dem App-Build erzwungen
 - Die App-Unit-Tests erzwingen wegen Node-25-/`jsdom`-Instabilitäten einen einzelnen Vitest-Worker im Thread-Pool
+- Der PR-Unit-Pfad darf bei isolierten App-Änderungen gezielt nur die betroffenen App-Slices ausführen; gemischte oder unklare Änderungen fallen bewusst auf das aggregierte `test:unit`-Target zurück
 
 ### Studio-UI-Boundary und Design-System-Kapselung
 

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -36,6 +36,8 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
   - `@sva/studio-module-iam` bleibt React-frei und besteht `test:types`, `test:unit` sowie `check:runtime` als serverseitig konsumierbarer Vertrags-Edge
 - Unit-Test-Basis:
   - `pnpm test:unit` muss grün sein
+  - isolierte App-Änderungen dürfen im PR-Pfad über `sva-studio-react:test:unit:ui|routes|hooks|server` statt über die komplette App-Suite validiert werden
+  - gemischte oder nicht eindeutig klassifizierbare App-Änderungen fallen bewusst auf das aggregierte `sva-studio-react:test:unit` zurück
 - IAM-Acceptance-Gate:
   - `pnpm nx run sva-studio-react:test:acceptance` läuft als separates Delivery-Gate gegen die Testumgebung
   - Bericht mit JSON- und Markdown-Artefakt wird unter `docs/reports/` geschrieben
@@ -194,6 +196,7 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
 
 - Nicht alle Projekte haben vollwertige Unit/Coverage-Suites (teils exempt)
 - App-Tests laufen derzeit mit `--passWithNoTests`, daher eingeschränkte Aussagekraft
+- Große App-Unit-Suiten benötigen aktive Pflege ihrer Slice-Zuordnung; unklare Dateien müssen auf den Aggregat-Fallback statt auf partielle Unterabdeckung zurückfallen
 - Fehlende oder implizite Cache-Inputs für Frontend-Tooling können zu falschen Cache-Hits führen, wenn neue App-Targets nicht konsistent gepflegt werden
 - Mehrere IAM-Hotspots können fachlich weiterhin komplex sein, liegen aber nicht mehr als neue Ownership in den alten Sammelpackages.
 - Die Package-Zielarchitektur reduziert öffentliche Importflächen; verbleibende Restkomplexität wird im jeweiligen Zielpackage statt am historischen Fassadenpfad nachverfolgt.

--- a/docs/development/testing-coverage.md
+++ b/docs/development/testing-coverage.md
@@ -59,6 +59,7 @@ Das Kommando bildet den blockierenden GitHub-PR-Workflow für lokale Vorprüfung
 
 - `check:file-placement`
 - `affected` oder `full` für `lint`, `test:unit`, `test:types` und `test:coverage` abhängig vom PR-Scope
+- bei isolierten App-only-Änderungen führt der Unit-Pfad nur die betroffenen `sva-studio-react`-Slices aus; unklare oder gemischte Änderungen nutzen den sicheren Aggregat-Fallback
 - `patch-coverage-gate --base=origin/main` für geänderte, ausführbare Zeilen im PR-Diff
 - `coverage-gate` im PR-Modus mit optionalen Summary-Dateien
 - `complexity-gate`

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -49,6 +49,11 @@ Dieses Dokument beschreibt die übergeordnete Teststrategie für das Nx-Monorepo
 - `pnpm test:unit:affected`
 - bei Typänderungen zusätzlich `pnpm test:types:affected`
 - bei PR-relevanten Quality-Gate-, Coverage-, Logging-, Auth-, Routing- oder Build-Änderungen zusätzlich `pnpm test:pr`
+- bei isolierten App-Änderungen optional gezielt:
+  - `pnpm nx run sva-studio-react:test:unit:ui`
+  - `pnpm nx run sva-studio-react:test:unit:routes`
+  - `pnpm nx run sva-studio-react:test:unit:hooks`
+  - `pnpm nx run sva-studio-react:test:unit:server`
 
 ### Vor PR-Update
 
@@ -58,6 +63,7 @@ Dieses Dokument beschreibt die übergeordnete Teststrategie für das Nx-Monorepo
 
 - `pnpm check:file-placement`
 - `affected` oder `full` für `lint`, `test:unit`, `test:types`, `test:coverage` abhängig vom PR-Scope
+- bei isolierten App-only-Änderungen führt der Unit-Pfad nur die betroffenen `sva-studio-react`-Slices aus; gemischte oder unklare Änderungen fallen auf das aggregierte App-Target zurück
 - `pnpm patch-coverage-gate --base=origin/main` für New-Code-/Patch-Coverage
 - `pnpm coverage-gate` im PR-Modus
 - `pnpm complexity-gate`
@@ -132,6 +138,7 @@ Diese Strategie definiert nur die Leitplanken:
 - Reproduzierbarkeit lokal herstellen, bevor Workarounds dokumentiert werden.
 - Flaky Tests werden entweder stabilisiert oder vorübergehend explizit aus dem Pflichtpfad herausgenommen, aber nicht stillschweigend ignoriert.
 - Flake-anfällige Vitest-Targets im Pflichtpfad laufen bevorzugt seriell, wenn Parallelisierung nachweislich Race- oder Timing-Probleme erzeugt.
+- Große App-Suiten werden bei wachsendem Umfang in stabile Nx-Slices aufgeteilt, statt dauerhaft als einzelner monolithischer Target weiterzuwachsen.
 - Jede bewusste Testlücke braucht dokumentierte Folgearbeit.
 
 ## Dokumentationspflicht

--- a/nx.json
+++ b/nx.json
@@ -82,6 +82,7 @@
     "frontendTooling": [
       "{projectRoot}/vite.config.ts",
       "{projectRoot}/vitest.config.ts",
+      "{projectRoot}/vitest.*.config.ts",
       "{projectRoot}/playwright.config.ts",
       "{projectRoot}/tailwind.config.cjs",
       "{projectRoot}/postcss.config.cjs",

--- a/openspec/changes/refactor-app-unit-slices/design.md
+++ b/openspec/changes/refactor-app-unit-slices/design.md
@@ -1,0 +1,14 @@
+## Context
+
+Die App-Unit-Suite ist fachlich heterogen gewachsen und blockiert im PR-Pfad mit einem einzelnen großen Target. Das Risiko liegt nicht nur in der Laufzeit, sondern auch darin, dass einzelne Instabilitäten einen ansonsten kleinen App-Änderungsblock komplett ausbremsen.
+
+## Decision
+
+- Die App-Tests werden entlang stabiler Domänengrenzen in `ui`, `routes`, `hooks` und `server` geschnitten.
+- Das bestehende `test:unit`-Target bleibt als Vollaggregat erhalten.
+- Slice-Ausführung wird nur bei App-only-PRs verwendet; gemischte oder unklare Änderungen fallen kontrolliert auf das Aggregat zurück.
+
+## Consequences
+
+- Lokale und CI-PR-Läufe werden für isolierte App-Änderungen billiger.
+- Die Slice-Zuordnung muss konservativ bleiben; unklare Dateien dürfen nicht unterabgedeckt werden.

--- a/openspec/changes/refactor-app-unit-slices/proposal.md
+++ b/openspec/changes/refactor-app-unit-slices/proposal.md
@@ -1,0 +1,25 @@
+# Change: App-Unit-Suite in stabile Nx-Slices aufteilen
+
+## Why
+
+`sva-studio-react:test:unit` ist als einzelner großer Target zu teuer und zu flake-anfällig geworden. Für App-only-PRs sollen nur die fachlich betroffenen Unit-Slices laufen, ohne die Semantik der Voll-Läufe auf `main` zu verändern.
+
+## What Changes
+
+- Einführung gemeinsamer Vitest-Basis-Konfiguration für `sva-studio-react`
+- Aufteilung der App-Unit-Suite in die Slices `ui`, `routes`, `hooks` und `server`
+- Beibehaltung eines aggregierten `sva-studio-react:test:unit`-Targets für Voll-Läufe
+- Erweiterung des PR-Runners um app-slice-aware Unit-Ausführung und Laufzeit-Summaries
+
+## Impact
+
+- Affected specs:
+  - `monorepo-structure`
+  - `test-coverage-governance`
+- Affected code:
+  - `apps/sva-studio-react/`
+  - `scripts/ci/`
+  - `package.json`
+- Affected arc42 sections:
+  - `docs/architecture/05-building-block-view.md`
+  - `docs/architecture/10-quality-requirements.md`

--- a/openspec/changes/refactor-app-unit-slices/specs/monorepo-structure/spec.md
+++ b/openspec/changes/refactor-app-unit-slices/specs/monorepo-structure/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 
-### Requirement: App-Unit-Targets duerfen in stabile Slices aufgeteilt werden
+### Requirement: App-Unit-Targets dürfen in stabile Slices aufgeteilt werden
 Das Monorepo SHALL für große App-Test-Suiten mehrere stabile Nx-Unit-Targets neben einem aggregierten Voll-Target bereitstellen können.
 
 #### Scenario: Aggregiertes Voll-Target bleibt erhalten

--- a/openspec/changes/refactor-app-unit-slices/specs/monorepo-structure/spec.md
+++ b/openspec/changes/refactor-app-unit-slices/specs/monorepo-structure/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: App-Unit-Targets duerfen in stabile Slices aufgeteilt werden
+Das Monorepo SHALL für große App-Test-Suiten mehrere stabile Nx-Unit-Targets neben einem aggregierten Voll-Target bereitstellen können.
+
+#### Scenario: Aggregiertes Voll-Target bleibt erhalten
+- **WHEN** `sva-studio-react` seine Unit-Suite in Slices aufteilt
+- **THEN** existiert weiterhin ein aggregiertes `test:unit`-Target für volle Läufe
+- **AND** `main`- und andere Voll-Gates behalten damit ihre bisherige Semantik
+
+#### Scenario: App-Slices sind einzeln ausführbar
+- **WHEN** ein Entwickler gezielt einen App-Teilbereich validieren will
+- **THEN** kann er `test:unit:ui`, `test:unit:routes`, `test:unit:hooks` oder `test:unit:server` direkt ausführen
+- **AND** jeder Slice nutzt dieselben gemeinsamen Vitest-Basisdefaults
+
+#### Scenario: Unklare App-Datei nutzt den sicheren Fallback
+- **WHEN** eine geänderte App-Datei keinem Slice eindeutig zugeordnet werden kann
+- **THEN** wird kein partieller Slice-Lauf erzwungen
+- **AND** der PR-Pfad fällt auf das aggregierte App-Unit-Target zurück

--- a/openspec/changes/refactor-app-unit-slices/specs/test-coverage-governance/spec.md
+++ b/openspec/changes/refactor-app-unit-slices/specs/test-coverage-governance/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 
-### Requirement: PR-Unit-Pfad darf App-Unit-Slices selektiv ausfuehren
+### Requirement: PR-Unit-Pfad darf App-Unit-Slices selektiv ausführen
 Das System SHALL im PR-Pfad bei isolierten App-Änderungen nur die betroffenen App-Unit-Slices statt der kompletten App-Unit-Suite ausführen dürfen.
 
 #### Scenario: App-only-PR nutzt Slice-Ausführung

--- a/openspec/changes/refactor-app-unit-slices/specs/test-coverage-governance/spec.md
+++ b/openspec/changes/refactor-app-unit-slices/specs/test-coverage-governance/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: PR-Unit-Pfad darf App-Unit-Slices selektiv ausfuehren
+Das System SHALL im PR-Pfad bei isolierten App-Änderungen nur die betroffenen App-Unit-Slices statt der kompletten App-Unit-Suite ausführen dürfen.
+
+#### Scenario: App-only-PR nutzt Slice-Ausführung
+- **GIVEN** ein Pull Request ändert ausschließlich eindeutig zuordenbare Dateien unter `apps/sva-studio-react`
+- **WHEN** der PR-Unit-Pfad bestimmt wird
+- **THEN** werden nur die betroffenen App-Unit-Slices ausgeführt
+- **AND** andere betroffene Workspace-Projekte laufen weiterhin über den normalen affected-Mechanismus
+
+#### Scenario: Gemischter PR nutzt den sicheren Fallback
+- **GIVEN** ein Pull Request enthält App- und Nicht-App-Änderungen oder mehrdeutige App-Dateien
+- **WHEN** der PR-Unit-Pfad bestimmt wird
+- **THEN** fällt die App-Unit-Ausführung auf das aggregierte `sva-studio-react:test:unit`-Target zurück
+- **AND** der PR-Pfad vermeidet riskante Unterabdeckung
+
+#### Scenario: Laufzeit-Summary macht Drift sichtbar
+- **WHEN** der lokale PR-Runner oder ein gleichwertiger Gate-Runner ausgeführt wird
+- **THEN** schreibt er für Gates und ausgeführte App-Slices eine kurze Dauer-Zusammenfassung
+- **AND** Laufzeitdrift wird ohne gesonderte manuelle Messung sichtbar

--- a/openspec/changes/refactor-app-unit-slices/tasks.md
+++ b/openspec/changes/refactor-app-unit-slices/tasks.md
@@ -1,0 +1,12 @@
+## 1. Specification
+
+- [x] 1.1 App-Unit-Slices und aggregiertes Target in `monorepo-structure` spezifizieren
+- [x] 1.2 Slice-aware PR-Unit-Pfad in `test-coverage-governance` spezifizieren
+- [x] 1.3 `openspec validate refactor-app-unit-slices --strict` ausführen
+
+## 2. Implementation
+
+- [x] 2.1 Gemeinsame Vitest-Basis und vier Slice-Konfigurationen für `sva-studio-react` einführen
+- [x] 2.2 Neue Nx-Targets für `test:unit:ui`, `test:unit:routes`, `test:unit:hooks`, `test:unit:server` ergänzen
+- [x] 2.3 Affected-Unit-Gate und `run-pr-gate.ts` auf app-slice-aware Ausführung umstellen
+- [x] 2.4 Doku und Testabdeckung für die neuen Unit-Slices ergänzen

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:types:affected": "pnpm clean:generated-source-artifacts && env -u NO_COLOR nx affected --target=test:types --base=${NX_BASE:-origin/main} --parallel=1 && env -u NO_COLOR nx affected --target=typecheck --base=${NX_BASE:-origin/main} --parallel=1 && pnpm check:server-runtime:affected && pnpm exec tsc -p tsconfig.scripts.json --noEmit",
     "test": "pnpm test:unit",
     "test:unit": "env -u NO_COLOR nx run-many -t test:unit --parallel=1",
-    "test:unit:affected": "env -u NO_COLOR nx affected --target=test:unit --base=${NX_BASE:-origin/main} --parallel=1",
+    "test:unit:affected": "tsx scripts/ci/affected-unit-gate.ts --base ${NX_BASE:-origin/main}",
     "test:coverage": "env -u NO_COLOR nx run-many -t test:coverage",
     "test:coverage:affected": "env -u NO_COLOR nx affected --target=test:coverage --base=${NX_BASE:-origin/main}",
     "test:coverage:pr": "pnpm test:coverage:affected && pnpm patch-coverage-gate --base=${NX_BASE:-origin/main} && pnpm sonar-new-code-gate --base=${NX_BASE:-origin/main}",

--- a/scripts/ci/affected-unit-gate.test.ts
+++ b/scripts/ci/affected-unit-gate.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { planAppUnitExecution } from './affected-unit-gate.ts';
+
+describe('affected-unit-gate', () => {
+  it('skips app slicing when the app is not affected', () => {
+    expect(planAppUnitExecution(['packages/core/src/index.ts'], ['core'])).toEqual({
+      mode: 'skip',
+      reason: 'app-not-affected',
+      slices: [],
+    });
+  });
+
+  it('uses slices for app-only ui and hooks changes', () => {
+    expect(
+      planAppUnitExecution(
+        [
+          'apps/sva-studio-react/src/components/Header.tsx',
+          'apps/sva-studio-react/src/lib/theme.ts',
+        ],
+        ['sva-studio-react']
+      )
+    ).toEqual({
+      mode: 'slices',
+      reason: 'app-only-sliceable-change',
+      slices: ['hooks', 'ui'],
+    });
+  });
+
+  it('uses the aggregate app target for app config changes', () => {
+    expect(planAppUnitExecution(['apps/sva-studio-react/vitest.config.ts'], ['sva-studio-react'])).toEqual({
+      mode: 'aggregate',
+      reason: 'aggregate-app-file',
+      slices: [],
+    });
+  });
+
+  it('uses the aggregate app target for mixed workspace changes', () => {
+    expect(
+      planAppUnitExecution(
+        [
+          'apps/sva-studio-react/src/routes/-index.tsx',
+          'packages/routing/src/index.ts',
+        ],
+        ['routing', 'sva-studio-react']
+      )
+    ).toEqual({
+      mode: 'aggregate',
+      reason: 'mixed-workspace-change',
+      slices: [],
+    });
+  });
+
+  it('uses the aggregate app target when a file cannot be mapped to a safe slice', () => {
+    expect(planAppUnitExecution(['apps/sva-studio-react/src/main.tsx'], ['sva-studio-react'])).toEqual({
+      mode: 'aggregate',
+      reason: 'aggregate-app-file',
+      slices: [],
+    });
+  });
+
+  it('maps server-side app test files to the server slice', () => {
+    expect(
+      planAppUnitExecution(
+        ['apps/sva-studio-react/src/lib/instance-interfaces-server.test.ts'],
+        ['sva-studio-react']
+      )
+    ).toEqual({
+      mode: 'slices',
+      reason: 'app-only-sliceable-change',
+      slices: ['server'],
+    });
+  });
+});

--- a/scripts/ci/affected-unit-gate.test.ts
+++ b/scripts/ci/affected-unit-gate.test.ts
@@ -11,12 +11,12 @@ describe('affected-unit-gate', () => {
     });
   });
 
-  it('uses slices for app-only ui and hooks changes', () => {
+  it('uses slices for app-only ui and hook changes', () => {
     expect(
       planAppUnitExecution(
         [
           'apps/sva-studio-react/src/components/Header.tsx',
-          'apps/sva-studio-react/src/lib/theme.ts',
+          'apps/sva-studio-react/src/hooks/useTheme.ts',
         ],
         ['sva-studio-react']
       )
@@ -24,6 +24,14 @@ describe('affected-unit-gate', () => {
       mode: 'slices',
       reason: 'app-only-sliceable-change',
       slices: ['hooks', 'ui'],
+    });
+  });
+
+  it('uses the aggregate app target for shared lib changes', () => {
+    expect(planAppUnitExecution(['apps/sva-studio-react/src/lib/theme.ts'], ['sva-studio-react'])).toEqual({
+      mode: 'aggregate',
+      reason: 'aggregate-app-file',
+      slices: [],
     });
   });
 

--- a/scripts/ci/affected-unit-gate.ts
+++ b/scripts/ci/affected-unit-gate.ts
@@ -1,0 +1,258 @@
+import { execFileSync, execSync } from 'node:child_process';
+import { performance } from 'node:perf_hooks';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { isNonCodeRelevantPath, resolveChangedFiles } from './pr-scope.ts';
+
+export type AppUnitSlice = 'hooks' | 'routes' | 'server' | 'ui';
+
+export interface DurationEntry {
+  label: string;
+  durationMs: number;
+}
+
+export interface AppUnitExecutionPlan {
+  mode: 'aggregate' | 'skip' | 'slices';
+  reason: string;
+  slices: AppUnitSlice[];
+}
+
+interface AffectedUnitGateOptions {
+  base: string;
+  head: string;
+}
+
+const APP_PROJECT = 'sva-studio-react';
+
+const APP_UI_PATTERNS = [/^apps\/sva-studio-react\/src\/(?:components|providers|i18n)\//u];
+const APP_ROUTES_PATTERNS = [/^apps\/sva-studio-react\/src\/(?:routes|routing)\//u];
+const APP_SERVER_PATTERNS = [
+  /^apps\/sva-studio-react\/src\/server(?:\.test)?\.(?:ts|tsx)$/u,
+  /^apps\/sva-studio-react\/src\/lib\/.*(?:\.server|-server)(?:\.test)?\.(?:ts|tsx)$/u,
+];
+const APP_HOOKS_PATTERNS = [
+  /^apps\/sva-studio-react\/src\/hooks\//u,
+  /^apps\/sva-studio-react\/src\/lib\//u,
+];
+const APP_AGGREGATE_PATTERNS = [
+  /^apps\/sva-studio-react\/(?:package\.json|tsconfig\.json|vite\.config\.ts|vitest(?:\..+)?\.config\.ts|playwright\.config\.ts)$/u,
+  /^apps\/sva-studio-react\/(?:e2e|scripts)\//u,
+  /^apps\/sva-studio-react\/src\/(?:main|routeTreeGen|router)\.(?:ts|tsx)$/u,
+];
+
+const matchesAnyPattern = (filePath: string, patterns: readonly RegExp[]): boolean =>
+  patterns.some((pattern) => pattern.test(filePath));
+
+const parseCliOptions = (args: readonly string[]): AffectedUnitGateOptions => {
+  let base = 'origin/main';
+  let head = 'HEAD';
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+
+    if (argument === '--base') {
+      const value = args[index + 1];
+      if (!value) {
+        throw new Error('Fehlender Wert für --base');
+      }
+      base = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === '--head') {
+      const value = args[index + 1];
+      if (!value) {
+        throw new Error('Fehlender Wert für --head');
+      }
+      head = value;
+      index += 1;
+    }
+  }
+
+  return { base, head };
+};
+
+const runCommand = (command: string): number => {
+  console.log(`\n$ ${command}`);
+  const startedAt = performance.now();
+  execSync(command, {
+    env: process.env,
+    stdio: 'inherit',
+  });
+  return performance.now() - startedAt;
+};
+
+const getAffectedUnitProjects = (base: string, head: string): string[] => {
+  const nxPackageJson = require.resolve('nx/package.json');
+  const nxEntrypoint = path.join(path.dirname(nxPackageJson), 'dist', 'bin', 'nx.js');
+  const output = execFileSync(
+    process.execPath,
+    [nxEntrypoint, 'show', 'projects', '--affected', '--withTarget=test:unit', '--base', base, '--head', head, '--json'],
+    {
+      encoding: 'utf8',
+      env: process.env,
+    }
+  ).trim();
+
+  if (output.length === 0) {
+    return [];
+  }
+
+  return JSON.parse(output) as string[];
+};
+
+const classifyAppUnitSlice = (filePath: string): AppUnitSlice | null => {
+  if (matchesAnyPattern(filePath, APP_UI_PATTERNS)) {
+    return 'ui';
+  }
+  if (matchesAnyPattern(filePath, APP_ROUTES_PATTERNS)) {
+    return 'routes';
+  }
+  if (matchesAnyPattern(filePath, APP_SERVER_PATTERNS)) {
+    return 'server';
+  }
+  if (matchesAnyPattern(filePath, APP_HOOKS_PATTERNS)) {
+    return 'hooks';
+  }
+  return null;
+};
+
+export const planAppUnitExecution = (
+  changedFiles: readonly string[],
+  affectedProjects: readonly string[]
+): AppUnitExecutionPlan => {
+  if (!affectedProjects.includes(APP_PROJECT)) {
+    return {
+      mode: 'skip',
+      reason: 'app-not-affected',
+      slices: [],
+    };
+  }
+
+  const codeRelevantFiles = changedFiles.filter((filePath) => !isNonCodeRelevantPath(filePath));
+  const nonAppFiles = codeRelevantFiles.filter((filePath) => !filePath.startsWith('apps/sva-studio-react/'));
+
+  if (nonAppFiles.length > 0) {
+    return {
+      mode: 'aggregate',
+      reason: 'mixed-workspace-change',
+      slices: [],
+    };
+  }
+
+  const appFiles = codeRelevantFiles.filter((filePath) => filePath.startsWith('apps/sva-studio-react/'));
+  if (appFiles.length === 0) {
+    return {
+      mode: 'aggregate',
+      reason: 'app-affected-via-dependency',
+      slices: [],
+    };
+  }
+
+  if (appFiles.some((filePath) => matchesAnyPattern(filePath, APP_AGGREGATE_PATTERNS))) {
+    return {
+      mode: 'aggregate',
+      reason: 'aggregate-app-file',
+      slices: [],
+    };
+  }
+
+  const classifiedSlices = appFiles.map(classifyAppUnitSlice);
+  const slices = [...new Set(classifiedSlices)].filter((slice): slice is AppUnitSlice => slice !== null);
+
+  if (slices.length === 0 || classifiedSlices.some((slice) => slice === null)) {
+    return {
+      mode: 'aggregate',
+      reason: 'unclear-app-slice',
+      slices: [],
+    };
+  }
+
+  return {
+    mode: 'slices',
+    reason: 'app-only-sliceable-change',
+    slices: slices.sort(),
+  };
+};
+
+export const runAffectedUnitGate = (
+  options: AffectedUnitGateOptions,
+  reportDuration?: (entry: DurationEntry) => void
+): DurationEntry[] => {
+  const changedFiles = resolveChangedFiles(options.base, options.head);
+  const affectedProjects = getAffectedUnitProjects(options.base, options.head);
+  const durationEntries: DurationEntry[] = [];
+  const appPlan = planAppUnitExecution(changedFiles, affectedProjects);
+  const nonAppProjects = affectedProjects.filter((project) => project !== APP_PROJECT);
+
+  const recordDuration = (label: string, durationMs: number): void => {
+    const entry = { label, durationMs };
+    durationEntries.push(entry);
+    reportDuration?.(entry);
+  };
+
+  console.log(
+    JSON.stringify(
+      {
+        base: options.base,
+        head: options.head,
+        changedFiles,
+        affectedProjects,
+        appPlan,
+      },
+      null,
+      2
+    )
+  );
+
+  if (affectedProjects.length === 0) {
+    console.log('Keine betroffenen Unit-Projekte erkannt.');
+    return durationEntries;
+  }
+
+  if (nonAppProjects.length > 0) {
+    recordDuration(
+      'unit:affected-workspace',
+      runCommand(
+        `env -u NO_COLOR pnpm nx affected --target=test:unit --base=${options.base} --head=${options.head} --parallel=1 --exclude=${APP_PROJECT} --output-style=stream`
+      )
+    );
+  }
+
+  if (appPlan.mode === 'skip') {
+    return durationEntries;
+  }
+
+  if (appPlan.mode === 'aggregate') {
+    recordDuration('unit:app', runCommand(`pnpm nx run ${APP_PROJECT}:test:unit`));
+    return durationEntries;
+  }
+
+  for (const slice of appPlan.slices) {
+    recordDuration(`unit:app:${slice}`, runCommand(`pnpm nx run ${APP_PROJECT}:test:unit:${slice}`));
+  }
+
+  return durationEntries;
+};
+
+const formatDuration = (durationMs: number): string => `${(durationMs / 1000).toFixed(2)}s`;
+
+export const runAffectedUnitGateCli = (args: readonly string[]): number => {
+  const options = parseCliOptions(args);
+  const durationEntries = runAffectedUnitGate(options);
+
+  if (durationEntries.length > 0) {
+    console.log('\nAffected unit summary:');
+    for (const entry of durationEntries) {
+      console.log(`- ${entry.label}: ${formatDuration(entry.durationMs)}`);
+    }
+  }
+
+  return 0;
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(runAffectedUnitGateCli(process.argv.slice(2)));
+}

--- a/scripts/ci/affected-unit-gate.ts
+++ b/scripts/ci/affected-unit-gate.ts
@@ -1,4 +1,5 @@
 import { execFileSync, execSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { performance } from 'node:perf_hooks';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -24,6 +25,7 @@ interface AffectedUnitGateOptions {
 }
 
 const APP_PROJECT = 'sva-studio-react';
+const require = createRequire(import.meta.url);
 
 const APP_UI_PATTERNS = [/^apps\/sva-studio-react\/src\/(?:components|providers|i18n)\//u];
 const APP_ROUTES_PATTERNS = [/^apps\/sva-studio-react\/src\/(?:routes|routing)\//u];
@@ -33,11 +35,11 @@ const APP_SERVER_PATTERNS = [
 ];
 const APP_HOOKS_PATTERNS = [
   /^apps\/sva-studio-react\/src\/hooks\//u,
-  /^apps\/sva-studio-react\/src\/lib\//u,
 ];
 const APP_AGGREGATE_PATTERNS = [
   /^apps\/sva-studio-react\/(?:package\.json|tsconfig\.json|vite\.config\.ts|vitest(?:\..+)?\.config\.ts|playwright\.config\.ts)$/u,
   /^apps\/sva-studio-react\/(?:e2e|scripts)\//u,
+  /^apps\/sva-studio-react\/src\/lib\//u,
   /^apps\/sva-studio-react\/src\/(?:main|routeTreeGen|router)\.(?:ts|tsx)$/u,
 ];
 

--- a/scripts/ci/affected-unit-gate.ts
+++ b/scripts/ci/affected-unit-gate.ts
@@ -153,16 +153,21 @@ export const planAppUnitExecution = (
     };
   }
 
-  if (appFiles.some((filePath) => matchesAnyPattern(filePath, APP_AGGREGATE_PATTERNS))) {
+  const classifiedSlices = appFiles.map(classifyAppUnitSlice);
+  const slices = [...new Set(classifiedSlices)].filter((slice): slice is AppUnitSlice => slice !== null);
+
+  if (
+    appFiles.some(
+      (filePath, index) =>
+        classifiedSlices[index] === null && matchesAnyPattern(filePath, APP_AGGREGATE_PATTERNS)
+    )
+  ) {
     return {
       mode: 'aggregate',
       reason: 'aggregate-app-file',
       slices: [],
     };
   }
-
-  const classifiedSlices = appFiles.map(classifyAppUnitSlice);
-  const slices = [...new Set(classifiedSlices)].filter((slice): slice is AppUnitSlice => slice !== null);
 
   if (slices.length === 0 || classifiedSlices.some((slice) => slice === null)) {
     return {

--- a/scripts/ci/run-pr-gate.test.ts
+++ b/scripts/ci/run-pr-gate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDurationSummary } from './run-pr-gate.ts';
+
+describe('run-pr-gate', () => {
+  it('formats a readable duration summary for gates and slices', () => {
+    expect(
+      formatDurationSummary([
+        { label: 'lint:affected', durationMs: 1_230 },
+        { label: 'unit:app:routes', durationMs: 12_500 },
+      ])
+    ).toBe(['- lint:affected: 1.23s', '- unit:app:routes: 12.50s'].join('\n'));
+  });
+});

--- a/scripts/ci/run-pr-gate.ts
+++ b/scripts/ci/run-pr-gate.ts
@@ -1,7 +1,9 @@
 import { execSync } from 'node:child_process';
+import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
 
 import { classifyPrScope, resolveChangedFiles, type GateMode } from './pr-scope.ts';
+import { runAffectedUnitGate, type DurationEntry } from './affected-unit-gate.ts';
 
 interface RunPrGateOptions {
   base: string;
@@ -37,75 +39,91 @@ const parseCliOptions = (args: readonly string[]): RunPrGateOptions => {
   return { base, head };
 };
 
-const runCommand = (command: string): void => {
+const runCommand = (command: string): number => {
   console.log(`\n$ ${command}`);
+  const startedAt = performance.now();
   execSync(command, {
     stdio: 'inherit',
     env: process.env,
   });
+  return performance.now() - startedAt;
 };
 
-const runAffectedCommand = (base: string, command: string): void => {
-  runCommand(`NX_BASE=${base} ${command}`);
+const runAffectedCommand = (base: string, command: string): number => {
+  return runCommand(`NX_BASE=${base} ${command}`);
 };
 
-const runQualityGates = (base: string, mode: GateMode): void => {
+const recordDuration = (durations: DurationEntry[], label: string, durationMs: number): void => {
+  durations.push({ label, durationMs });
+};
+
+const runQualityGates = (base: string, head: string, mode: GateMode, durations: DurationEntry[]): void => {
   if (mode === 'full') {
-    runCommand('pnpm test:eslint');
-    runCommand('pnpm test:unit');
-    runCommand('pnpm test:types');
+    recordDuration(durations, 'lint', runCommand('pnpm test:eslint'));
+    recordDuration(durations, 'unit', runCommand('pnpm test:unit'));
+    recordDuration(durations, 'types', runCommand('pnpm test:types'));
     return;
   }
 
   if (mode === 'affected') {
-    runAffectedCommand(base, 'pnpm test:eslint:affected');
-    runAffectedCommand(base, 'pnpm test:unit:affected');
-    runAffectedCommand(base, 'pnpm test:types:affected');
+    recordDuration(durations, 'lint:affected', runAffectedCommand(base, 'pnpm test:eslint:affected'));
+    for (const entry of runAffectedUnitGate({ base, head })) {
+      recordDuration(durations, entry.label, entry.durationMs);
+    }
+    recordDuration(durations, 'types:affected', runAffectedCommand(base, 'pnpm test:types:affected'));
   }
 };
 
-const runCoverageGate = (base: string, mode: GateMode): void => {
+const runCoverageGate = (base: string, mode: GateMode, durations: DurationEntry[]): void => {
   if (mode === 'full') {
-    runCommand('pnpm test:coverage');
+    recordDuration(durations, 'coverage', runCommand('pnpm test:coverage'));
   } else if (mode === 'affected') {
-    runAffectedCommand(base, 'pnpm test:coverage:affected');
+    recordDuration(durations, 'coverage:affected', runAffectedCommand(base, 'pnpm test:coverage:affected'));
   }
 
-  runCommand(`pnpm patch-coverage-gate --base=${base}`);
-  runCommand(`pnpm sonar-new-code-gate --base=${base}`);
-  runCommand('env COVERAGE_GATE_REQUIRE_SUMMARIES=0 pnpm coverage-gate');
-  runCommand('pnpm complexity-gate');
+  recordDuration(durations, 'patch-coverage', runCommand(`pnpm patch-coverage-gate --base=${base}`));
+  recordDuration(durations, 'sonar-new-code', runCommand(`pnpm sonar-new-code-gate --base=${base}`));
+  recordDuration(durations, 'coverage-gate', runCommand('env COVERAGE_GATE_REQUIRE_SUMMARIES=0 pnpm coverage-gate'));
+  recordDuration(durations, 'complexity', runCommand('pnpm complexity-gate'));
 };
 
-const runIntegrationGate = (base: string, mode: GateMode): void => {
+const runIntegrationGate = (base: string, mode: GateMode, durations: DurationEntry[]): void => {
   if (mode === 'full') {
-    runCommand('pnpm test:integration');
+    recordDuration(durations, 'integration', runCommand('pnpm test:integration'));
     return;
   }
 
   if (mode === 'affected') {
-    runCommand(
-      `env -u NO_COLOR pnpm nx affected --target=test:integration --base=${base} --exclude=monitoring-client --output-style=stream`
+    recordDuration(
+      durations,
+      'integration:affected',
+      runCommand(
+        `env -u NO_COLOR pnpm nx affected --target=test:integration --base=${base} --exclude=monitoring-client --output-style=stream`
+      )
     );
   }
 };
 
-const runAppBuildGate = (mode: GateMode): void => {
+const runAppBuildGate = (mode: GateMode, durations: DurationEntry[]): void => {
   if (mode !== 'skip') {
-    runCommand('pnpm nx run sva-studio-react:build');
+    recordDuration(durations, 'app-build', runCommand('pnpm nx run sva-studio-react:build'));
   }
 };
 
-const runE2EGate = (mode: GateMode): void => {
+const runE2EGate = (mode: GateMode, durations: DurationEntry[]): void => {
   if (mode !== 'skip') {
-    runCommand('pnpm test:e2e');
+    recordDuration(durations, 'app-e2e', runCommand('pnpm test:e2e'));
   }
 };
+
+export const formatDurationSummary = (durations: readonly DurationEntry[]): string =>
+  durations.map((entry) => `- ${entry.label}: ${(entry.durationMs / 1000).toFixed(2)}s`).join('\n');
 
 export const runPrGate = (args: readonly string[]): number => {
   const options = parseCliOptions(args);
   const changedFiles = resolveChangedFiles(options.base, options.head);
   const decision = classifyPrScope(changedFiles);
+  const durations: DurationEntry[] = [];
 
   console.log(
     JSON.stringify(
@@ -120,22 +138,27 @@ export const runPrGate = (args: readonly string[]): number => {
     )
   );
 
-  runCommand('pnpm check:file-placement');
+  recordDuration(durations, 'file-placement', runCommand('pnpm check:file-placement'));
 
   if (!decision.codeRelevant) {
     console.log('Keine code-relevanten Änderungen im PR-Scope. Weitere PR-Gates werden als No-op übersprungen.');
+    console.log('\nPR gate summary:');
+    console.log(formatDurationSummary(durations));
     return 0;
   }
 
-  runCommand('pnpm check:toolchain-consistency');
-  runCommand('pnpm clean:generated-source-artifacts');
-  runCommand('pnpm check:plugin-ui-boundary');
+  recordDuration(durations, 'toolchain-consistency', runCommand('pnpm check:toolchain-consistency'));
+  recordDuration(durations, 'clean-generated-source-artifacts', runCommand('pnpm clean:generated-source-artifacts'));
+  recordDuration(durations, 'plugin-ui-boundary', runCommand('pnpm check:plugin-ui-boundary'));
 
-  runQualityGates(options.base, decision.qualityGateMode);
-  runCoverageGate(options.base, decision.coverageMode);
-  runIntegrationGate(options.base, decision.integrationMode);
-  runAppBuildGate(decision.appBuildMode);
-  runE2EGate(decision.e2eMode);
+  runQualityGates(options.base, options.head, decision.qualityGateMode, durations);
+  runCoverageGate(options.base, decision.coverageMode, durations);
+  runIntegrationGate(options.base, decision.integrationMode, durations);
+  runAppBuildGate(decision.appBuildMode, durations);
+  runE2EGate(decision.e2eMode, durations);
+
+  console.log('\nPR gate summary:');
+  console.log(formatDurationSummary(durations));
 
   return 0;
 };

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -30,7 +30,7 @@
         "toolingScripts"
       ],
       "options": {
-        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:coverage": {
@@ -43,7 +43,7 @@
         "toolingScripts"
       ],
       "options": {
-        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -85,6 +85,11 @@ function loadRunPrGateScript(): string {
   return fs.readFileSync(path.join(rootDir, 'scripts/ci/run-pr-gate.ts'), 'utf8');
 }
 
+function loadAffectedUnitGateScript(): string {
+  const rootDir = resolveRootDir();
+  return fs.readFileSync(path.join(rootDir, 'scripts/ci/affected-unit-gate.ts'), 'utf8');
+}
+
 function loadNxJson(): { namedInputs?: Record<string, NamedInputValue[]> } {
   const rootDir = resolveRootDir();
   return JSON.parse(fs.readFileSync(path.join(rootDir, 'nx.json'), 'utf8')) as {
@@ -182,9 +187,7 @@ describe('workspace package scripts', () => {
     expect(packageJson.scripts?.['test:eslint:affected']).toBe(
       'pnpm check:plugin-ui-boundary && env -u NO_COLOR nx affected --target=lint --base=${NX_BASE:-origin/main}'
     );
-    expect(packageJson.scripts?.['test:unit:affected']).toBe(
-      'env -u NO_COLOR nx affected --target=test:unit --base=${NX_BASE:-origin/main} --parallel=1'
-    );
+    expect(packageJson.scripts?.['test:unit:affected']).toBe('tsx scripts/ci/affected-unit-gate.ts --base ${NX_BASE:-origin/main}');
     expect(packageJson.scripts?.['test:types:affected']).toBe(
       'pnpm clean:generated-source-artifacts && env -u NO_COLOR nx affected --target=test:types --base=${NX_BASE:-origin/main} --parallel=1 && env -u NO_COLOR nx affected --target=typecheck --base=${NX_BASE:-origin/main} --parallel=1 && pnpm check:server-runtime:affected && pnpm exec tsc -p tsconfig.scripts.json --noEmit'
     );
@@ -285,4 +288,13 @@ describe('workspace package scripts', () => {
     expect(coverageInputs).toContain('toolingScripts');
   });
 
+  it('keeps the affected unit gate app-slice-aware', () => {
+    const affectedUnitGate = loadAffectedUnitGateScript();
+    const runPrGateScript = loadRunPrGateScript();
+
+    expect(affectedUnitGate).toContain("export type AppUnitSlice = 'hooks' | 'routes' | 'server' | 'ui'");
+    expect(affectedUnitGate).toContain('pnpm nx run ${APP_PROJECT}:test:unit:${slice}');
+    expect(runPrGateScript).toContain('formatDurationSummary');
+    expect(runPrGateScript).toContain('for (const entry of runAffectedUnitGate({ base, head }))');
+  });
 });


### PR DESCRIPTION
# Change: App-Unit-Suite in stabile Nx-Slices aufteilen

## Why

`sva-studio-react:test:unit` ist als einzelner großer Target zu teuer und zu flake-anfällig geworden. Für App-only-PRs sollen nur die fachlich betroffenen Unit-Slices laufen, ohne die Semantik der Voll-Läufe auf `main` zu verändern.

## What Changes

- Einführung gemeinsamer Vitest-Basis-Konfiguration für `sva-studio-react`
- Aufteilung der App-Unit-Suite in die Slices `ui`, `routes`, `hooks` und `server`
- Beibehaltung eines aggregierten `sva-studio-react:test:unit`-Targets für Voll-Läufe
- Erweiterung des PR-Runners um app-slice-aware Unit-Ausführung und Laufzeit-Summaries

## Impact

- Affected specs:
  - `monorepo-structure`
  - `test-coverage-governance`
- Affected code:
  - `apps/sva-studio-react/`
  - `scripts/ci/`
  - `package.json`
- Affected arc42 sections:
  - `docs/architecture/05-building-block-view.md`
  - `docs/architecture/10-quality-requirements.md`
