### PR TITLE
fix(auth-runtime): correct workspace type path mappings

### DIFF
--- a/packages/auth-runtime/tsconfig.lib.json
+++ b/packages/auth-runtime/tsconfig.lib.json
@@ -8,103 +8,102 @@
     "rootDir": "src",
     "types": ["node"],
     "paths": {
-      "@sva/core": ["../../packages/core/dist/index.d.ts"],
-      "@sva/data-repositories": ["../../packages/data-repositories/dist/index.d.ts"],
-      "@sva/data-repositories/server": ["../../packages/data-repositories/dist/server.d.ts"],
-      "@sva/iam-admin": ["../../packages/iam-admin/dist/index.d.ts"],
-      "@sva/iam-core": ["../../packages/iam-core/dist/index.d.ts"],
+      "@sva/core": ["packages/core/dist/index.d.ts"],
+      "@sva/data-repositories": ["packages/data-repositories/dist/index.d.ts"],
+      "@sva/data-repositories/server": ["packages/data-repositories/dist/server.d.ts"],
+      "@sva/iam-admin": ["packages/iam-admin/dist/index.d.ts"],
+      "@sva/iam-core": ["packages/iam-core/dist/index.d.ts"],
       "@sva/iam-governance/dsr-export-flows": [
-        "../../packages/iam-governance/dist/dsr-export-flows.d.ts"
+        "packages/iam-governance/dist/dsr-export-flows.d.ts"
       ],
       "@sva/iam-governance/dsr-export-payload": [
-        "../../packages/iam-governance/dist/dsr-export-payload.d.ts"
+        "packages/iam-governance/dist/dsr-export-payload.d.ts"
       ],
       "@sva/iam-governance/dsr-export-status": [
-        "../../packages/iam-governance/dist/dsr-export-status.d.ts"
+        "packages/iam-governance/dist/dsr-export-status.d.ts"
       ],
       "@sva/iam-governance/dsr-maintenance": [
-        "../../packages/iam-governance/dist/dsr-maintenance.d.ts"
+        "packages/iam-governance/dist/dsr-maintenance.d.ts"
       ],
       "@sva/iam-governance/dsr-read-models-internal": [
-        "../../packages/iam-governance/dist/dsr-read-models-internal.d.ts"
+        "packages/iam-governance/dist/dsr-read-models-internal.d.ts"
       ],
       "@sva/iam-governance/governance-compliance-export": [
-        "../../packages/iam-governance/dist/governance-compliance-export.d.ts"
+        "packages/iam-governance/dist/governance-compliance-export.d.ts"
       ],
       "@sva/iam-governance/governance-workflow-executor": [
-        "../../packages/iam-governance/dist/governance-workflow-executor.d.ts"
+        "packages/iam-governance/dist/governance-workflow-executor.d.ts"
       ],
       "@sva/iam-governance/governance-workflow-policy": [
-        "../../packages/iam-governance/dist/governance-workflow-policy.d.ts"
+        "packages/iam-governance/dist/governance-workflow-policy.d.ts"
       ],
       "@sva/iam-governance/legal-text-http-handlers": [
-        "../../packages/iam-governance/dist/legal-text-http-handlers.d.ts"
+        "packages/iam-governance/dist/legal-text-http-handlers.d.ts"
       ],
       "@sva/iam-governance/legal-text-mutation-handlers": [
-        "../../packages/iam-governance/dist/legal-text-mutation-handlers.d.ts"
+        "packages/iam-governance/dist/legal-text-mutation-handlers.d.ts"
       ],
       "@sva/iam-governance/legal-text-repository": [
-        "../../packages/iam-governance/dist/legal-text-repository.d.ts"
+        "packages/iam-governance/dist/legal-text-repository.d.ts"
       ],
       "@sva/iam-governance/legal-text-repository-shared": [
-        "../../packages/iam-governance/dist/legal-text-repository-shared.d.ts"
+        "packages/iam-governance/dist/legal-text-repository-shared.d.ts"
       ],
       "@sva/iam-governance/legal-text-request-context": [
-        "../../packages/iam-governance/dist/legal-text-request-context.d.ts"
+        "packages/iam-governance/dist/legal-text-request-context.d.ts"
       ],
-      "@sva/iam-governance": ["../../packages/iam-governance/dist/index.d.ts"],
+      "@sva/iam-governance": ["packages/iam-governance/dist/index.d.ts"],
       "@sva/instance-registry/http-contracts": [
-        "../../packages/instance-registry/dist/http-contracts.d.ts"
+        "packages/instance-registry/dist/http-contracts.d.ts"
       ],
-      "@sva/instance-registry/http-guards": ["../../packages/instance-registry/dist/http-guards.d.ts"],
+      "@sva/instance-registry/http-guards": ["packages/instance-registry/dist/http-guards.d.ts"],
       "@sva/instance-registry/http-instance-handlers": [
-        "../../packages/instance-registry/dist/http-instance-handlers.d.ts"
+        "packages/instance-registry/dist/http-instance-handlers.d.ts"
       ],
       "@sva/instance-registry/http-keycloak-handlers": [
-        "../../packages/instance-registry/dist/http-keycloak-handlers.d.ts"
+        "packages/instance-registry/dist/http-keycloak-handlers.d.ts"
       ],
       "@sva/instance-registry/http-mutation-handlers": [
-        "../../packages/instance-registry/dist/http-mutation-handlers.d.ts"
+        "packages/instance-registry/dist/http-mutation-handlers.d.ts"
       ],
       "@sva/instance-registry/keycloak-types": [
-        "../../packages/instance-registry/dist/keycloak-types.d.ts"
+        "packages/instance-registry/dist/keycloak-types.d.ts"
       ],
       "@sva/instance-registry/provisioning-auth": [
-        "../../packages/instance-registry/dist/provisioning-auth.d.ts"
+        "packages/instance-registry/dist/provisioning-auth.d.ts"
       ],
       "@sva/instance-registry/provisioning-auth-state": [
-        "../../packages/instance-registry/dist/provisioning-auth-state.d.ts"
+        "packages/instance-registry/dist/provisioning-auth-state.d.ts"
       ],
       "@sva/instance-registry/provisioning-worker": [
-        "../../packages/instance-registry/dist/provisioning-worker.d.ts"
+        "packages/instance-registry/dist/provisioning-worker.d.ts"
       ],
       "@sva/instance-registry/runtime-resolution": [
-        "../../packages/instance-registry/dist/runtime-resolution.d.ts"
+        "packages/instance-registry/dist/runtime-resolution.d.ts"
       ],
       "@sva/instance-registry/runtime-wiring": [
-        "../../packages/instance-registry/dist/runtime-wiring.d.ts"
+        "packages/instance-registry/dist/runtime-wiring.d.ts"
       ],
-      "@sva/instance-registry/service": ["../../packages/instance-registry/dist/service.d.ts"],
+      "@sva/instance-registry/service": ["packages/instance-registry/dist/service.d.ts"],
       "@sva/instance-registry/service-detail": [
-        "../../packages/instance-registry/dist/service-detail.d.ts"
+        "packages/instance-registry/dist/service-detail.d.ts"
       ],
       "@sva/instance-registry/service-keycloak": [
-        "../../packages/instance-registry/dist/service-keycloak.d.ts"
+        "packages/instance-registry/dist/service-keycloak.d.ts"
       ],
       "@sva/instance-registry/service-keycloak-execution": [
-        "../../packages/instance-registry/dist/service-keycloak-execution.d.ts"
+        "packages/instance-registry/dist/service-keycloak-execution.d.ts"
       ],
       "@sva/instance-registry/service-keycloak-execution-shared": [
-        "../../packages/instance-registry/dist/service-keycloak-execution-shared.d.ts"
+        "packages/instance-registry/dist/service-keycloak-execution-shared.d.ts"
       ],
       "@sva/instance-registry/service-types": [
-        "../../packages/instance-registry/dist/service-types.d.ts"
+        "packages/instance-registry/dist/service-types.d.ts"
       ],
-      "@sva/instance-registry": ["../../packages/instance-registry/dist/index.d.ts"],
-      "@sva/media": ["../../packages/media/dist/index.d.ts"],
-      "@sva/server-runtime": ["../../packages/server-runtime/dist/index.d.ts"]
-      ,
-      "@sva/studio-module-iam": ["../../packages/studio-module-iam/dist/index.d.ts"]
+      "@sva/instance-registry": ["packages/instance-registry/dist/index.d.ts"],
+      "@sva/media": ["packages/media/dist/index.d.ts"],
+      "@sva/server-runtime": ["packages/server-runtime/dist/index.d.ts"],
+      "@sva/studio-module-iam": ["packages/studio-module-iam/dist/index.d.ts"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/packages/auth-runtime/tsconfig.lib.json
+++ b/packages/auth-runtime/tsconfig.lib.json
@@ -8,103 +8,103 @@
     "rootDir": "src",
     "types": ["node"],
     "paths": {
-      "@sva/core": ["packages/core/dist/index.d.ts"],
-      "@sva/data-repositories": ["packages/data-repositories/dist/index.d.ts"],
-      "@sva/data-repositories/server": ["packages/data-repositories/dist/server.d.ts"],
-      "@sva/iam-admin": ["packages/iam-admin/dist/index.d.ts"],
-      "@sva/iam-core": ["packages/iam-core/dist/index.d.ts"],
+      "@sva/core": ["../../packages/core/dist/index.d.ts"],
+      "@sva/data-repositories": ["../../packages/data-repositories/dist/index.d.ts"],
+      "@sva/data-repositories/server": ["../../packages/data-repositories/dist/server.d.ts"],
+      "@sva/iam-admin": ["../../packages/iam-admin/dist/index.d.ts"],
+      "@sva/iam-core": ["../../packages/iam-core/dist/index.d.ts"],
       "@sva/iam-governance/dsr-export-flows": [
-        "packages/iam-governance/dist/dsr-export-flows.d.ts"
+        "../../packages/iam-governance/dist/dsr-export-flows.d.ts"
       ],
       "@sva/iam-governance/dsr-export-payload": [
-        "packages/iam-governance/dist/dsr-export-payload.d.ts"
+        "../../packages/iam-governance/dist/dsr-export-payload.d.ts"
       ],
       "@sva/iam-governance/dsr-export-status": [
-        "packages/iam-governance/dist/dsr-export-status.d.ts"
+        "../../packages/iam-governance/dist/dsr-export-status.d.ts"
       ],
       "@sva/iam-governance/dsr-maintenance": [
-        "packages/iam-governance/dist/dsr-maintenance.d.ts"
+        "../../packages/iam-governance/dist/dsr-maintenance.d.ts"
       ],
       "@sva/iam-governance/dsr-read-models-internal": [
-        "packages/iam-governance/dist/dsr-read-models-internal.d.ts"
+        "../../packages/iam-governance/dist/dsr-read-models-internal.d.ts"
       ],
       "@sva/iam-governance/governance-compliance-export": [
-        "packages/iam-governance/dist/governance-compliance-export.d.ts"
+        "../../packages/iam-governance/dist/governance-compliance-export.d.ts"
       ],
       "@sva/iam-governance/governance-workflow-executor": [
-        "packages/iam-governance/dist/governance-workflow-executor.d.ts"
+        "../../packages/iam-governance/dist/governance-workflow-executor.d.ts"
       ],
       "@sva/iam-governance/governance-workflow-policy": [
-        "packages/iam-governance/dist/governance-workflow-policy.d.ts"
+        "../../packages/iam-governance/dist/governance-workflow-policy.d.ts"
       ],
       "@sva/iam-governance/legal-text-http-handlers": [
-        "packages/iam-governance/dist/legal-text-http-handlers.d.ts"
+        "../../packages/iam-governance/dist/legal-text-http-handlers.d.ts"
       ],
       "@sva/iam-governance/legal-text-mutation-handlers": [
-        "packages/iam-governance/dist/legal-text-mutation-handlers.d.ts"
+        "../../packages/iam-governance/dist/legal-text-mutation-handlers.d.ts"
       ],
       "@sva/iam-governance/legal-text-repository": [
-        "packages/iam-governance/dist/legal-text-repository.d.ts"
+        "../../packages/iam-governance/dist/legal-text-repository.d.ts"
       ],
       "@sva/iam-governance/legal-text-repository-shared": [
-        "packages/iam-governance/dist/legal-text-repository-shared.d.ts"
+        "../../packages/iam-governance/dist/legal-text-repository-shared.d.ts"
       ],
       "@sva/iam-governance/legal-text-request-context": [
-        "packages/iam-governance/dist/legal-text-request-context.d.ts"
+        "../../packages/iam-governance/dist/legal-text-request-context.d.ts"
       ],
-      "@sva/iam-governance": ["packages/iam-governance/dist/index.d.ts"],
+      "@sva/iam-governance": ["../../packages/iam-governance/dist/index.d.ts"],
       "@sva/instance-registry/http-contracts": [
-        "packages/instance-registry/dist/http-contracts.d.ts"
+        "../../packages/instance-registry/dist/http-contracts.d.ts"
       ],
-      "@sva/instance-registry/http-guards": ["packages/instance-registry/dist/http-guards.d.ts"],
+      "@sva/instance-registry/http-guards": ["../../packages/instance-registry/dist/http-guards.d.ts"],
       "@sva/instance-registry/http-instance-handlers": [
-        "packages/instance-registry/dist/http-instance-handlers.d.ts"
+        "../../packages/instance-registry/dist/http-instance-handlers.d.ts"
       ],
       "@sva/instance-registry/http-keycloak-handlers": [
-        "packages/instance-registry/dist/http-keycloak-handlers.d.ts"
+        "../../packages/instance-registry/dist/http-keycloak-handlers.d.ts"
       ],
       "@sva/instance-registry/http-mutation-handlers": [
-        "packages/instance-registry/dist/http-mutation-handlers.d.ts"
+        "../../packages/instance-registry/dist/http-mutation-handlers.d.ts"
       ],
       "@sva/instance-registry/keycloak-types": [
-        "packages/instance-registry/dist/keycloak-types.d.ts"
+        "../../packages/instance-registry/dist/keycloak-types.d.ts"
       ],
       "@sva/instance-registry/provisioning-auth": [
-        "packages/instance-registry/dist/provisioning-auth.d.ts"
+        "../../packages/instance-registry/dist/provisioning-auth.d.ts"
       ],
       "@sva/instance-registry/provisioning-auth-state": [
-        "packages/instance-registry/dist/provisioning-auth-state.d.ts"
+        "../../packages/instance-registry/dist/provisioning-auth-state.d.ts"
       ],
       "@sva/instance-registry/provisioning-worker": [
-        "packages/instance-registry/dist/provisioning-worker.d.ts"
+        "../../packages/instance-registry/dist/provisioning-worker.d.ts"
       ],
       "@sva/instance-registry/runtime-resolution": [
-        "packages/instance-registry/dist/runtime-resolution.d.ts"
+        "../../packages/instance-registry/dist/runtime-resolution.d.ts"
       ],
       "@sva/instance-registry/runtime-wiring": [
-        "packages/instance-registry/dist/runtime-wiring.d.ts"
+        "../../packages/instance-registry/dist/runtime-wiring.d.ts"
       ],
-      "@sva/instance-registry/service": ["packages/instance-registry/dist/service.d.ts"],
+      "@sva/instance-registry/service": ["../../packages/instance-registry/dist/service.d.ts"],
       "@sva/instance-registry/service-detail": [
-        "packages/instance-registry/dist/service-detail.d.ts"
+        "../../packages/instance-registry/dist/service-detail.d.ts"
       ],
       "@sva/instance-registry/service-keycloak": [
-        "packages/instance-registry/dist/service-keycloak.d.ts"
+        "../../packages/instance-registry/dist/service-keycloak.d.ts"
       ],
       "@sva/instance-registry/service-keycloak-execution": [
-        "packages/instance-registry/dist/service-keycloak-execution.d.ts"
+        "../../packages/instance-registry/dist/service-keycloak-execution.d.ts"
       ],
       "@sva/instance-registry/service-keycloak-execution-shared": [
-        "packages/instance-registry/dist/service-keycloak-execution-shared.d.ts"
+        "../../packages/instance-registry/dist/service-keycloak-execution-shared.d.ts"
       ],
       "@sva/instance-registry/service-types": [
-        "packages/instance-registry/dist/service-types.d.ts"
+        "../../packages/instance-registry/dist/service-types.d.ts"
       ],
-      "@sva/instance-registry": ["packages/instance-registry/dist/index.d.ts"],
-      "@sva/media": ["packages/media/dist/index.d.ts"],
-      "@sva/server-runtime": ["packages/server-runtime/dist/index.d.ts"]
+      "@sva/instance-registry": ["../../packages/instance-registry/dist/index.d.ts"],
+      "@sva/media": ["../../packages/media/dist/index.d.ts"],
+      "@sva/server-runtime": ["../../packages/server-runtime/dist/index.d.ts"]
       ,
-      "@sva/studio-module-iam": ["packages/studio-module-iam/dist/index.d.ts"]
+      "@sva/studio-module-iam": ["../../packages/studio-module-iam/dist/index.d.ts"]
     }
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
## Kontext
Die rebasierten Dependabot-PRs liefen nach dem Rebase in den Types-Gate, weil packages/auth-runtime/tsconfig.lib.json auf package-lokale dist-Typ-Pfade zeigte. Diese Pfade waren relativ zur Datei falsch und brachen insbesondere die @sva/instance-registry-Subpath-Aufloesung.

## Aenderung
- korrigiert die dist-basierten Workspace-Path-Mappings in packages/auth-runtime/tsconfig.lib.json auf repo-relative ../../packages/...-Pfade

## Verifikation
- pnpm nx run auth-runtime:test:types
- pnpm nx run auth-runtime:test:unit