### PR TITLE
fix(ci): make sva-studio-react type checks hermetic

### DIFF
--- a/apps/sva-studio-react/project.json
+++ b/apps/sva-studio-react/project.json
@@ -202,6 +202,9 @@
     "test:types": {
       "executor": "nx:run-commands",
       "cache": true,
+      "dependsOn": [
+        "^build"
+      ],
       "inputs": [
         "default",
         "^production",
@@ -216,6 +219,9 @@
     "typecheck": {
       "executor": "nx:run-commands",
       "cache": true,
+      "dependsOn": [
+        "^build"
+      ],
       "inputs": [
         "default",
         "^production",

--- a/apps/sva-studio-react/tsconfig.json
+++ b/apps/sva-studio-react/tsconfig.json
@@ -32,7 +32,7 @@
       "@sva/auth-runtime/routes": ["../../packages/auth-runtime/src/routes.ts"],
       "@sva/auth-runtime/runtime-health": ["../../packages/auth-runtime/src/runtime-health.ts"],
       "@sva/auth-runtime/runtime-routes": ["../../packages/auth-runtime/src/runtime-routes.ts"],
-      "@sva/auth-runtime/server": ["../../packages/auth-runtime/src/server.ts"],
+      "@sva/auth-runtime/server": ["../../packages/auth-runtime/dist/server.d.ts"],
       "@sva/data-repositories": ["../../packages/data-repositories/src/index.ts"],
       "@sva/data-repositories/server": ["../../packages/data-repositories/src/server.ts"],
       "@sva/iam-admin": ["../../packages/iam-admin/src/index.ts"],


### PR DESCRIPTION
Dieser PR macht die Type-Checks von `sva-studio-react` hermetisch und behebt das inkonsistente Verhalten im `Types`-Check, das wir zwischen PR `413` und PR `414` gesehen haben.

Die Ursache war, dass `sva-studio-react` beim App-Typecheck `@sva/auth-runtime/server` auf `src/server.ts` aufgelöst hat. Dadurch wurde Implementierungscode aus `auth-runtime` samt transitiver Workspace-Imports in den App-`tsc`-Lauf hineingezogen.

Das führte dazu, dass PR `413` im `Types`-Check scheiterte, obwohl dort nur Header-bezogene React-Dateien geändert wurden, während PR `414` grün war, weil dessen affected-CI-Scope die abhängigen Workspace-Packages vorher bereits gebaut hatte.

## Änderungen

- `@sva/auth-runtime/server` in `apps/sva-studio-react/tsconfig.json` von `src/server.ts` auf `dist/server.d.ts` umgestellt
- `^build` als Abhängigkeit ergänzt für:
  - `sva-studio-react:test:types`
  - `sva-studio-react:typecheck`

## Warum

Damit orientiert sich `sva-studio-react` an dem gebauten öffentlichen Typvertrag von `@sva/auth-runtime` statt an internen Server-Implementierungsdetails.

Außerdem wird die Ausführungsreihenfolge in Nx explizit gemacht, sodass benötigte Workspace-Deklarationen vor dem App-Typecheck zuverlässig erzeugt werden.

## Ergebnis

- `sva-studio-react:test:types` läuft jetzt deterministisch
- `sva-studio-react:typecheck` läuft jetzt deterministisch
- App-Typechecks scheitern nicht mehr an fremden transitiven Source-Problemen in Server-Packages
- das Verhalten ist jetzt konsistent mit bestehenden Paketgrenzen, wie sie bereits in `routing` und `sva-mainserver` verwendet werden

## Verifikation

Erfolgreich ausgeführt:

- `pnpm nx run sva-studio-react:test:types --skipNxCache`
- `pnpm nx run sva-studio-react:typecheck --skipNxCache`