### PR TITLE
fix(studio): keep the app shell stable during navigation

### DIFF
--- a/apps/sva-studio-react/src/components/AppShell.test.tsx
+++ b/apps/sva-studio-react/src/components/AppShell.test.tsx
@@ -61,7 +61,11 @@ vi.mock('./RuntimeHealthIndicator', () => ({
 }));
 
 vi.mock('./Sidebar', () => ({
-  default: () => <aside aria-label="Seitenleiste">Sidebar</aside>,
+  default: ({ isLoading = false }: { isLoading?: boolean }) => (
+    <aside aria-label="Seitenleiste">
+      <span>{isLoading ? 'Sidebar Loading' : 'Sidebar Ready'}</span>
+    </aside>
+  ),
 }));
 
 /**
@@ -130,15 +134,21 @@ describe('AppShell', () => {
     expect(screen.queryByTestId('runtime-health-indicator')).toBeNull();
   });
 
-  it('zeigt Skeleton-Content im Ladezustand', () => {
+  it('haelt die Shell im Ladezustand gemountet und lokalisiert Pending auf den Contentbereich', async () => {
     render(
       <AppShell isLoading>
         <div>Inhalt</div>
       </AppShell>
     );
 
-    expect(screen.getByLabelText('Inhalt lädt')).toBeTruthy();
-    expect(screen.queryByText('Inhalt')).toBeNull();
+    const main = screen.getByRole('main');
+
+    expect(await screen.findByText('Sidebar Ready')).toBeTruthy();
+    expect(await screen.findByRole('link', { name: 'Mein Konto' })).toBeTruthy();
+    expect(screen.queryByText('Sidebar Loading')).toBeNull();
+    expect(within(main).getByLabelText('Inhalt lädt')).toBeTruthy();
+    expect(main.getAttribute('aria-busy')).toBe('true');
+    expect(within(main).queryByText('Inhalt')).toBeNull();
   });
 
   it('versteckt die Sidebar fuer nicht eingeloggte Nutzer', () => {

--- a/apps/sva-studio-react/src/components/AppShell.tsx
+++ b/apps/sva-studio-react/src/components/AppShell.tsx
@@ -126,7 +126,6 @@ export default function AppShell({
         ? (sidebarSlot ?? (
         <React.Suspense fallback={null}>
           <LazySidebar
-            isLoading={isLoading}
             isMobileOpen={isMobileSidebarOpen}
             onMobileOpenChange={onMobileSidebarOpenChange}
           />
@@ -135,7 +134,6 @@ export default function AppShell({
         : null}
       <div className="relative z-0 flex min-h-screen min-w-0 flex-1 flex-col">
         <Header
-          isLoading={isLoading}
           isMobileNavigationOpen={isMobileSidebarOpen}
           onOpenMobileNavigation={
             showSidebar ? () => onMobileSidebarOpenChange?.(!isMobileSidebarOpen) : undefined

--- a/apps/sva-studio-react/src/hooks/use-contents.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-contents.test.tsx
@@ -100,6 +100,68 @@ describe('useContents', () => {
     });
   });
 
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions when the initial content list fetch fails with a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
+    listContentsMock.mockRejectedValueOnce(new Error('protected-list'));
+
+    const { result } = renderHook(() => useContents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBe(protectedError);
+      expect(result.current.contents).toEqual([]);
+    });
+
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions when a content list refetch fails with a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockImplementation((cause: unknown) => cause);
+    listContentsMock
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'content-1',
+            contentType: 'generic',
+            title: 'Startseite',
+            createdAt: '2026-03-21T10:00:00.000Z',
+            updatedAt: '2026-03-21T11:00:00.000Z',
+            author: 'Editor',
+            payload: { blocks: [] },
+            status: 'draft',
+          },
+        ],
+        pagination: { page: 1, pageSize: 1, total: 1 },
+      })
+      .mockRejectedValueOnce(new Error('protected-refetch'));
+
+    const { result } = renderHook(() => useContents());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.contents).toHaveLength(1);
+    });
+
+    asIamErrorMock.mockReturnValue(protectedError);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(protectedError);
+      expect(result.current.contents).toEqual([]);
+    });
+
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+  });
+
   it('runs bulk archive and delete actions with safe audit metadata', async () => {
     asIamErrorMock.mockImplementation((cause: unknown) => cause);
     listContentsMock.mockResolvedValue({
@@ -229,30 +291,38 @@ describe('useContents', () => {
     expect(result.current.mutationError).toBeNull();
   });
 
-  it('invalidates permissions on 403 errors and handles empty detail ids', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
-    createContentMock.mockRejectedValueOnce(new Error('forbidden'));
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])(
+    'invalidates permissions on protected create errors (status $status, code $code)',
+    async (protectedError) => {
+      asIamErrorMock.mockReturnValue(protectedError);
+      createContentMock.mockRejectedValueOnce(new Error('protected-create'));
 
-    const { result: createResult } = renderHook(() => useCreateContent());
+      const { result: createResult } = renderHook(() => useCreateContent());
 
-    await act(async () => {
-      const created = await createResult.current.createContent({
-        contentType: 'generic',
-        title: 'Landing Page',
-        payload: { hero: 'Hello' },
-        status: 'draft',
+      await act(async () => {
+        const created = await createResult.current.createContent({
+          contentType: 'generic',
+          title: 'Landing Page',
+          payload: { hero: 'Hello' },
+          status: 'draft',
+        });
+        expect(created).toBe(false);
       });
-      expect(created).toBe(false);
-    });
 
-    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+      expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+    }
+  );
 
-    const { result: detailResult } = renderHook(() => useContentDetail(null));
+  it('keeps content detail idle when no content id is provided', async () => {
+    const { result } = renderHook(() => useContentDetail(null));
+
     await waitFor(() => {
-      expect(detailResult.current.isLoading).toBe(false);
-      expect(detailResult.current.content).toBeNull();
-      expect(detailResult.current.history).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.content).toBeNull();
+      expect(result.current.history).toEqual([]);
     });
   });
 
@@ -306,21 +376,29 @@ describe('useContents', () => {
     });
   });
 
-  it('stores detail and update errors and invalidates permissions on 403', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
-    getContentMock.mockRejectedValueOnce(new Error('forbidden'));
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores detail errors and invalidates permissions on protected detail-load failures (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
+    getContentMock.mockRejectedValueOnce(new Error('protected-detail'));
     getContentHistoryMock.mockResolvedValue({ data: [], pagination: { page: 1, pageSize: 0, total: 0 } });
 
     const { result } = renderHook(() => useContentDetail('content-1'));
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe(forbiddenError);
+      expect(result.current.error).toBe(protectedError);
     });
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+  });
 
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores update errors and invalidates permissions on protected update failures (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockImplementation((cause: unknown) => cause);
     getContentMock.mockResolvedValue({
       data: {
         id: 'content-1',
@@ -339,21 +417,26 @@ describe('useContents', () => {
       pagination: { page: 1, pageSize: 0, total: 0 },
     });
 
-    await act(async () => {
-      await result.current.refetch();
+    const { result } = renderHook(() => useContentDetail('content-1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.content?.title).toBe('Startseite');
     });
 
-    updateContentMock.mockRejectedValueOnce(new Error('forbidden'));
+    asIamErrorMock.mockReturnValue(protectedError);
+    updateContentMock.mockRejectedValueOnce(new Error('protected-update'));
 
     await act(async () => {
       const updated = await result.current.updateContent({ title: 'Neu' });
       expect(updated).toBe(false);
     });
 
-    expect(result.current.mutationError).toBe(forbiddenError);
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+    expect(result.current.mutationError).toBe(protectedError);
   });
 
-  it('returns false for detail mutations without an id and clears stored mutation errors', async () => {
+  it('clears stored mutation errors for create mutations', async () => {
     const createConflict = { status: 409, code: 'conflict', message: 'Conflict' };
     asIamErrorMock.mockReturnValue(createConflict);
     createContentMock.mockRejectedValueOnce(new Error('conflict'));
@@ -378,7 +461,9 @@ describe('useContents', () => {
     });
 
     expect(createResult.current.mutationError).toBeNull();
+  });
 
+  it('returns false for detail mutations without an id and clears stored mutation errors', async () => {
     const { result: detailResult } = renderHook(() => useContentDetail(null));
 
     await waitFor(() => {

--- a/apps/sva-studio-react/src/hooks/use-contents.ts
+++ b/apps/sva-studio-react/src/hooks/use-contents.ts
@@ -71,6 +71,7 @@ export type ContentBulkMutationResult = Readonly<{
 }>;
 
 const contentsLogger = createOperationLogger('contents-hook', 'debug');
+const PERMISSION_INVALIDATED_EVENT = 'permission_invalidated_after_401_or_403';
 
 export const useContents = (): UseContentsResult => {
   const { invalidatePermissions } = useAuth();
@@ -190,9 +191,9 @@ export const useCreateContent = (): UseCreateContentResult => {
         return true;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          contentsLogger.info('permission_invalidated_after_403', {
+          contentsLogger.info(PERMISSION_INVALIDATED_EVENT, {
             operation: 'create_content',
             status: resolvedError.status,
             error_code: resolvedError.code,
@@ -253,9 +254,9 @@ export const useContentDetail = (contentId: string | null): UseContentDetailResu
       });
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
-        contentsLogger.info('permission_invalidated_after_403', {
+        contentsLogger.info(PERMISSION_INVALIDATED_EVENT, {
           operation: 'get_content_detail',
           status: resolvedError.status,
           error_code: resolvedError.code,
@@ -298,9 +299,9 @@ export const useContentDetail = (contentId: string | null): UseContentDetailResu
         return true;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          contentsLogger.info('permission_invalidated_after_403', {
+          contentsLogger.info(PERMISSION_INVALIDATED_EVENT, {
             operation: 'update_content',
             status: resolvedError.status,
             error_code: resolvedError.code,

--- a/apps/sva-studio-react/src/hooks/use-groups.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-groups.test.tsx
@@ -298,25 +298,29 @@ describe('useGroups', () => {
     expect(removeGroupMembershipMock).toHaveBeenCalledWith('group-1', 'user-123');
   });
 
-  it('invalidates permissions when initial fetch returns 403', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
-    listGroupsMock.mockRejectedValueOnce(new Error('forbidden-list'));
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions when initial fetch returns a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
+    listGroupsMock.mockRejectedValueOnce(new Error('protected-list'));
 
     const { result } = renderHook(() => useGroups());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe(forbiddenError);
+      expect(result.current.error).toBe(protectedError);
       expect(result.current.groups).toHaveLength(0);
     });
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
   });
 
-  it('stores page error and invalidates permissions when detail fetch returns 403', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores page error and invalidates permissions when detail fetch returns a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
     listGroupsMock.mockResolvedValueOnce({
       data: [],
       pagination: {
@@ -325,7 +329,7 @@ describe('useGroups', () => {
         total: 0,
       },
     });
-    getGroupMock.mockRejectedValueOnce(new Error('forbidden-detail'));
+    getGroupMock.mockRejectedValueOnce(new Error('protected-detail'));
 
     const { result } = renderHook(() => useGroups());
 
@@ -339,7 +343,7 @@ describe('useGroups', () => {
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBeNull();
-    expect(result.current.detailError).toBe(forbiddenError);
+    expect(result.current.detailError).toBe(protectedError);
   });
 
   it('keeps list data visible when a row detail fetch fails', async () => {
@@ -428,9 +432,53 @@ describe('useGroups', () => {
     expect(authMockValue.invalidatePermissions).not.toHaveBeenCalled();
   });
 
-  it('invalidates permissions when membership removal fails with 403', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions when createGroup fails with a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
+    listGroupsMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'group-1',
+          groupKey: 'editors',
+          displayName: 'Editors',
+          description: undefined,
+          groupType: 'role_bundle',
+          isActive: true,
+          memberCount: 0,
+          roleCount: 0,
+        },
+      ],
+      pagination: {
+        page: 1,
+        pageSize: 1,
+        total: 1,
+      },
+    });
+    createGroupMock.mockRejectedValueOnce(new Error('protected-create'));
+
+    const { result } = renderHook(() => useGroups());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.groups).toHaveLength(1);
+    });
+
+    await act(async () => {
+      const created = await result.current.createGroup({ groupKey: 'editors', displayName: 'Editors' });
+      expect(created).toBeNull();
+    });
+
+    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+    expect(result.current.mutationError).toBe(protectedError);
+  });
+
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions when membership removal fails with a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
     listGroupsMock.mockResolvedValueOnce({
       data: [],
       pagination: {
@@ -454,6 +502,6 @@ describe('useGroups', () => {
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBeNull();
-    expect(result.current.mutationError).toBe(forbiddenError);
+    expect(result.current.mutationError).toBe(protectedError);
   });
 });

--- a/apps/sva-studio-react/src/hooks/use-groups.ts
+++ b/apps/sva-studio-react/src/hooks/use-groups.ts
@@ -49,6 +49,7 @@ type UseGroupsResult = {
 };
 
 const groupsLogger = createOperationLogger('groups-hook', 'debug');
+const PERMISSION_INVALIDATED_EVENT = 'permission_invalidated_after_401_or_403';
 
 type LegacyGroupMember = {
   accountId: string;
@@ -123,9 +124,9 @@ export const useGroups = (): UseGroupsResult => {
         return normalizeGroupDetail(response.data);
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          groupsLogger.info('permission_invalidated_after_403', {
+          groupsLogger.info(PERMISSION_INVALIDATED_EVENT, {
             operation: 'get_group',
             status: resolvedError.status,
             error_code: resolvedError.code,

--- a/apps/sva-studio-react/src/hooks/use-iam-admin-list.ts
+++ b/apps/sva-studio-react/src/hooks/use-iam-admin-list.ts
@@ -69,9 +69,9 @@ export const useIamAdminList = <TItem>(
       );
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
-        adminListLogger.info('permission_invalidated_after_403', {
+        adminListLogger.info('permission_invalidated_after_401_or_403', {
           operation: 'list_refetch',
           status: resolvedError.status,
           error_code: resolvedError.code,
@@ -106,9 +106,9 @@ export const useIamAdminList = <TItem>(
         return result;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          adminListLogger.info('permission_invalidated_after_403', {
+          adminListLogger.info('permission_invalidated_after_401_or_403', {
             operation: typeof meta.operation === 'string' ? meta.operation : 'mutation',
             status: resolvedError.status,
             error_code: resolvedError.code,

--- a/apps/sva-studio-react/src/hooks/use-media.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-media.test.tsx
@@ -180,19 +180,18 @@ describe('useMediaLibrary', () => {
     });
   });
 
-  it('stores API errors, clears assets, and invalidates permissions on forbidden responses', async () => {
-    listMediaMock.mockRejectedValue({
-      code: 'forbidden',
-      message: 'Forbidden',
-      status: 403,
-    });
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores API errors, clears assets, and invalidates permissions on protected responses (status $status, code $code)', async (protectedError) => {
+    listMediaMock.mockRejectedValue(protectedError);
 
     render(<MediaLibraryProbe />);
 
     await waitFor(() => {
       expect(screen.getByTestId('loading').textContent).toBe('false');
       expect(screen.getByTestId('asset-count').textContent).toBe('0');
-      expect(screen.getByTestId('error-code').textContent).toBe('forbidden');
+      expect(screen.getByTestId('error-code').textContent).toBe(protectedError.code);
     });
 
     expect(invalidatePermissionsMock).toHaveBeenCalledTimes(1);
@@ -238,27 +237,29 @@ describe('useCreateMediaUpload', () => {
     expect(screen.getByTestId('mutation-error').textContent).toBe('none');
   });
 
-  it('stores mutation errors, supports clearing them, and invalidates permissions on forbidden responses', async () => {
-    initializeMediaUploadMock.mockRejectedValue({
-      code: 'forbidden',
-      message: 'Forbidden',
-      status: 403,
-    });
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])(
+    'stores mutation errors, supports clearing them, and invalidates permissions on protected responses (status $status, code $code)',
+    async (protectedError) => {
+      initializeMediaUploadMock.mockRejectedValue(protectedError);
 
-    render(<MediaUploadProbe />);
+      render(<MediaUploadProbe />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'initialize' }));
+      fireEvent.click(screen.getByRole('button', { name: 'initialize' }));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('mutation-error').textContent).toBe('forbidden');
-    });
+      await waitFor(() => {
+        expect(screen.getByTestId('mutation-error').textContent).toBe(protectedError.code);
+      });
 
-    expect(invalidatePermissionsMock).toHaveBeenCalledTimes(1);
+      expect(invalidatePermissionsMock).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole('button', { name: 'clear' }));
+      fireEvent.click(screen.getByRole('button', { name: 'clear' }));
 
-    expect(screen.getByTestId('mutation-error').textContent).toBe('none');
-  });
+      expect(screen.getByTestId('mutation-error').textContent).toBe('none');
+    }
+  );
 });
 
 describe('useMediaDetail', () => {
@@ -357,12 +358,55 @@ describe('useMediaDetail', () => {
     });
   });
 
-  it('stores detail errors and invalidates permissions for forbidden refetch failures', async () => {
-    getMediaMock.mockRejectedValue({
-      code: 'forbidden',
-      message: 'Forbidden',
-      status: 403,
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores mutation errors and invalidates permissions for protected update failures (status $status, code $code)', async (protectedError) => {
+    getMediaMock.mockResolvedValue({
+      data: {
+        id: 'asset-2',
+        instanceId: 'instance-1',
+        storageKey: 'media/asset-2',
+        mediaType: 'image',
+        mimeType: 'image/png',
+        byteSize: 2048,
+        visibility: 'protected',
+        uploadStatus: 'processed',
+        processingStatus: 'ready',
+        metadata: { title: 'Initial' },
+        technical: {},
+      },
     });
+    getMediaUsageMock.mockResolvedValue({
+      data: {
+        assetId: 'asset-2',
+        totalReferences: 0,
+        references: [],
+      },
+    });
+    updateMediaMock.mockRejectedValue(protectedError);
+
+    render(<MediaDetailProbe assetId="asset-2" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('asset-id').textContent).toBe('asset-2');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'update' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-error').textContent).toBe(protectedError.code);
+    });
+
+    expect(invalidatePermissionsMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('asset-id').textContent).toBe('asset-2');
+  });
+
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores detail errors and invalidates permissions for protected refetch failures (status $status, code $code)', async (protectedError) => {
+    getMediaMock.mockRejectedValue(protectedError);
     getMediaUsageMock.mockResolvedValue({
       data: {
         assetId: 'asset-2',
@@ -374,7 +418,7 @@ describe('useMediaDetail', () => {
     render(<MediaDetailProbe assetId="asset-2" />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('error-code').textContent).toBe('forbidden');
+      expect(screen.getByTestId('error-code').textContent).toBe(protectedError.code);
       expect(screen.getByTestId('asset-id').textContent).toBe('none');
     });
 
@@ -425,7 +469,10 @@ describe('useMediaDetail', () => {
     });
   });
 
-  it('stores delivery and delete failures, clears mutation errors, and invalidates forbidden responses', async () => {
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores mutation errors and invalidates permissions for protected delete failures (status $status, code $code)', async (protectedError) => {
     getMediaMock.mockResolvedValue({
       data: {
         id: 'asset-2',
@@ -448,16 +495,7 @@ describe('useMediaDetail', () => {
         references: [],
       },
     });
-    getMediaDeliveryMock.mockRejectedValue({
-      code: 'forbidden',
-      message: 'Forbidden',
-      status: 403,
-    });
-    deleteMediaMock.mockRejectedValue({
-      code: 'conflict',
-      message: 'Conflict',
-      status: 409,
-    });
+    deleteMediaMock.mockRejectedValue(protectedError);
 
     render(<MediaDetailProbe assetId="asset-2" />);
 
@@ -465,23 +503,75 @@ describe('useMediaDetail', () => {
       expect(screen.getByTestId('asset-id').textContent).toBe('asset-2');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'delivery' }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('mutation-error').textContent).toBe('forbidden');
-    });
-
     fireEvent.click(screen.getByRole('button', { name: 'delete' }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('mutation-error').textContent).toBe('conflict');
+      expect(screen.getByTestId('mutation-error').textContent).toBe(protectedError.code);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'clear' }));
-
-    expect(screen.getByTestId('mutation-error').textContent).toBe('none');
     expect(invalidatePermissionsMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('asset-id').textContent).toBe('asset-2');
   });
+
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])(
+    'stores delivery and delete failures, clears mutation errors, and invalidates protected responses (status $status, code $code)',
+    async (protectedError) => {
+      getMediaMock.mockResolvedValue({
+        data: {
+          id: 'asset-2',
+          instanceId: 'instance-1',
+          storageKey: 'media/asset-2',
+          mediaType: 'image',
+          mimeType: 'image/png',
+          byteSize: 2048,
+          visibility: 'protected',
+          uploadStatus: 'processed',
+          processingStatus: 'ready',
+          metadata: { title: 'Initial' },
+          technical: {},
+        },
+      });
+      getMediaUsageMock.mockResolvedValue({
+        data: {
+          assetId: 'asset-2',
+          totalReferences: 0,
+          references: [],
+        },
+      });
+      getMediaDeliveryMock.mockRejectedValue(protectedError);
+      deleteMediaMock.mockRejectedValue({
+        code: 'conflict',
+        message: 'Conflict',
+        status: 409,
+      });
+
+      render(<MediaDetailProbe assetId="asset-2" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('asset-id').textContent).toBe('asset-2');
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'delivery' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mutation-error').textContent).toBe(protectedError.code);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'delete' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('mutation-error').textContent).toBe('conflict');
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'clear' }));
+
+      expect(screen.getByTestId('mutation-error').textContent).toBe('none');
+      expect(invalidatePermissionsMock).toHaveBeenCalledTimes(1);
+    }
+  );
 
   it('clears local detail state after successful deletion', async () => {
     getMediaMock.mockResolvedValue({

--- a/apps/sva-studio-react/src/hooks/use-media.ts
+++ b/apps/sva-studio-react/src/hooks/use-media.ts
@@ -88,7 +88,7 @@ export const useMediaLibrary = (query: MediaListQuery = {}): UseMediaLibraryResu
       });
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
       }
       setAssets([]);
@@ -138,7 +138,7 @@ export const useCreateMediaUpload = (): UseCreateMediaUploadResult => {
         return response.data;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
         }
         setMutationError(resolvedError);
@@ -195,7 +195,7 @@ export const useMediaDetail = (assetId: string | null): UseMediaDetailResult => 
       });
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
       }
       setAsset(null);
@@ -236,7 +236,7 @@ export const useMediaDetail = (assetId: string | null): UseMediaDetailResult => 
         return true;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
         }
         setMutationError(resolvedError);
@@ -262,7 +262,7 @@ export const useMediaDetail = (assetId: string | null): UseMediaDetailResult => 
       return response.data;
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
       }
       setMutationError(resolvedError);
@@ -284,7 +284,7 @@ export const useMediaDetail = (assetId: string | null): UseMediaDetailResult => 
       return true;
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
       }
       setMutationError(resolvedError);

--- a/apps/sva-studio-react/src/hooks/use-organization-context.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-organization-context.test.tsx
@@ -151,19 +151,21 @@ describe('useOrganizationContext', () => {
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
   });
 
-  it('stores the resolved error and invalidates permissions on forbidden responses', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
-    getMyOrganizationContextMock.mockRejectedValueOnce(new Error('forbidden-load'));
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('stores the resolved error and invalidates permissions on protected responses (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
+    getMyOrganizationContextMock.mockRejectedValueOnce(new Error('protected-load'));
 
     const { result } = renderHook(() => useOrganizationContext());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe(forbiddenError);
+      expect(result.current.error).toBe(protectedError);
     });
 
-    updateMyOrganizationContextMock.mockRejectedValueOnce(new Error('forbidden-switch'));
+    updateMyOrganizationContextMock.mockRejectedValueOnce(new Error('protected-switch'));
 
     await act(async () => {
       const switched = await result.current.switchOrganization('org-2');
@@ -171,6 +173,6 @@ describe('useOrganizationContext', () => {
     });
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(2);
-    expect(result.current.error).toBe(forbiddenError);
+    expect(result.current.error).toBe(protectedError);
   });
 });

--- a/apps/sva-studio-react/src/hooks/use-organization-context.ts
+++ b/apps/sva-studio-react/src/hooks/use-organization-context.ts
@@ -20,6 +20,7 @@ type UseOrganizationContextResult = {
 };
 
 const organizationContextLogger = createOperationLogger('organization-context-hook', 'debug');
+const PERMISSION_INVALIDATED_EVENT = 'permission_invalidated_after_401_or_403';
 
 export const useOrganizationContext = (): UseOrganizationContextResult => {
   const { isAuthenticated, invalidatePermissions, user } = useAuth();
@@ -50,9 +51,9 @@ export const useOrganizationContext = (): UseOrganizationContextResult => {
       });
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
-        organizationContextLogger.info('permission_invalidated_after_403', {
+        organizationContextLogger.info(PERMISSION_INVALIDATED_EVENT, {
           operation: 'get_my_organization_context',
           status: resolvedError.status,
           error_code: resolvedError.code,
@@ -103,9 +104,9 @@ export const useOrganizationContext = (): UseOrganizationContextResult => {
         return true;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          organizationContextLogger.info('permission_invalidated_after_403', {
+          organizationContextLogger.info(PERMISSION_INVALIDATED_EVENT, {
             operation: 'update_my_organization_context',
             status: resolvedError.status,
             error_code: resolvedError.code,

--- a/apps/sva-studio-react/src/hooks/use-organizations.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-organizations.test.tsx
@@ -432,23 +432,25 @@ describe('useOrganizations', () => {
     ]);
   });
 
-  it('invalidates permissions on 403 for list and mutation errors', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
-    listOrganizationsMock.mockRejectedValueOnce(new Error('forbidden-list'));
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions on protected list and mutation errors (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
+    listOrganizationsMock.mockRejectedValueOnce(new Error('protected-list'));
 
     const { result } = renderHook(() => useOrganizations());
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.error).toBe(forbiddenError);
+      expect(result.current.error).toBe(protectedError);
     });
 
     listOrganizationsMock.mockResolvedValue({
       data: [],
       pagination: { page: 1, pageSize: 25, total: 0 },
     });
-    updateOrganizationMock.mockRejectedValueOnce(new Error('forbidden-update'));
+    updateOrganizationMock.mockRejectedValueOnce(new Error('protected-update'));
 
     await act(async () => {
       await result.current.refetch();
@@ -457,17 +459,19 @@ describe('useOrganizations', () => {
     });
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(2);
-    expect(result.current.mutationError).toBe(forbiddenError);
+    expect(result.current.mutationError).toBe(protectedError);
   });
 
-  it('handles detail errors and clears transient organization state helpers', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('handles protected detail errors and clears transient organization state helpers (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
     listOrganizationsMock.mockResolvedValue({
       data: [],
       pagination: { page: 1, pageSize: 25, total: 0 },
     });
-    getOrganizationMock.mockRejectedValueOnce(new Error('forbidden-detail'));
+    getOrganizationMock.mockRejectedValueOnce(new Error('protected-detail'));
     deactivateOrganizationMock.mockResolvedValue({ data: { id: 'org-1' } });
 
     const { result } = renderHook(() => useOrganizations());
@@ -481,7 +485,7 @@ describe('useOrganizations', () => {
       expect(detail).toBeNull();
     });
 
-    expect(result.current.mutationError).toBe(forbiddenError);
+    expect(result.current.mutationError).toBe(protectedError);
 
     act(() => {
       result.current.clearMutationError();

--- a/apps/sva-studio-react/src/hooks/use-organizations.ts
+++ b/apps/sva-studio-react/src/hooks/use-organizations.ts
@@ -71,6 +71,10 @@ const DEFAULT_FILTERS: OrganizationFilters = {
 };
 
 const organizationsLogger = createOperationLogger('organizations-hook', 'debug');
+const PERMISSION_INVALIDATED_EVENT = 'permission_invalidated_after_401_or_403';
+
+const getOrganizationMutationOperation = (organizationId?: string) =>
+  organizationId ? 'organization_mutation_with_detail_reload' : 'organization_mutation';
 
 export const useOrganizations = (initial?: Partial<OrganizationFilters>): UseOrganizationsResult => {
   const { invalidatePermissions } = useAuth();
@@ -150,9 +154,9 @@ export const useOrganizations = (initial?: Partial<OrganizationFilters>): UseOrg
       return true;
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
-        organizationsLogger.info('permission_invalidated_after_403', {
+        organizationsLogger.info(PERMISSION_INVALIDATED_EVENT, {
           operation: 'list_organizations',
           status: resolvedError.status,
           error_code: resolvedError.code,
@@ -203,9 +207,9 @@ export const useOrganizations = (initial?: Partial<OrganizationFilters>): UseOrg
         return response.data;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          organizationsLogger.info('permission_invalidated_after_403', {
+          organizationsLogger.info(PERMISSION_INVALIDATED_EVENT, {
             operation: 'get_organization',
             status: resolvedError.status,
             error_code: resolvedError.code,
@@ -233,7 +237,7 @@ export const useOrganizations = (initial?: Partial<OrganizationFilters>): UseOrg
   const mutate = React.useCallback(
     async <T,>(action: () => Promise<{ data: T }>, options?: { organizationId?: string }): Promise<T | null> => {
       setMutationError(null);
-      const operation = options?.organizationId ? 'organization_mutation_with_detail_reload' : 'organization_mutation';
+      const operation = getOrganizationMutationOperation(options?.organizationId);
       logBrowserOperationStart(organizationsLogger, 'organization_mutation_started', {
         operation,
         organization_id: options?.organizationId,
@@ -257,9 +261,9 @@ export const useOrganizations = (initial?: Partial<OrganizationFilters>): UseOrg
         return result.data;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          organizationsLogger.info('permission_invalidated_after_403', {
+          organizationsLogger.info(PERMISSION_INVALIDATED_EVENT, {
             operation,
             status: resolvedError.status,
             error_code: resolvedError.code,

--- a/apps/sva-studio-react/src/hooks/use-user.test.tsx
+++ b/apps/sva-studio-react/src/hooks/use-user.test.tsx
@@ -51,17 +51,19 @@ describe('useUser', () => {
     authMockValue.invalidatePermissions.mockReset();
   });
 
-  it('invalidates permissions when loading user returns 403', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions when loading user returns a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
     getUserMock.mockRejectedValueOnce(new Error('no-access'));
 
-    const { result } = renderHook(() => useUser('user-403'));
+    const { result } = renderHook(() => useUser(`user-${protectedError.status}`));
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
       expect(result.current.user).toBeNull();
-      expect(result.current.error).toBe(forbiddenError);
+      expect(result.current.error).toBe(protectedError);
     });
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
@@ -138,9 +140,11 @@ describe('useUser', () => {
     expect(updateUserMock).toHaveBeenCalledWith('user-1', { displayName: 'User One Updated' });
   });
 
-  it('invalidates permissions when save returns 403', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])('invalidates permissions when save returns a protected error (status $status, code $code)', async (protectedError) => {
+    asIamErrorMock.mockReturnValue(protectedError);
     getUserMock.mockResolvedValueOnce({
       data: {
         id: 'user-3',
@@ -166,7 +170,7 @@ describe('useUser', () => {
 
     expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBeNull();
-    expect(result.current.mutationError).toBe(forbiddenError);
+    expect(result.current.mutationError).toBe(protectedError);
   });
 
   it('resends the password setup email successfully', async () => {
@@ -203,36 +207,41 @@ describe('useUser', () => {
     expect(authMockValue.invalidatePermissions).not.toHaveBeenCalled();
   });
 
-  it('invalidates permissions when resending the password setup email returns 403', async () => {
-    const forbiddenError = { status: 403, code: 'forbidden', message: 'Forbidden' };
-    asIamErrorMock.mockReturnValue(forbiddenError);
-    getUserMock.mockResolvedValueOnce({
-      data: {
-        id: 'user-5',
-        keycloakSubject: 'subject-5',
-        displayName: 'User Five',
-        status: 'active',
-        roles: [],
-        mainserverUserApplicationSecretSet: false,
-      },
-    });
-    sendPasswordSetupEmailMock.mockRejectedValueOnce(new Error('forbidden-resend'));
+  it.each([
+    { status: 401, code: 'unauthorized', message: 'Unauthorized' },
+    { status: 403, code: 'forbidden', message: 'Forbidden' },
+  ])(
+    'invalidates permissions when resending the password setup email returns a protected error (status $status, code $code)',
+    async (protectedError) => {
+      asIamErrorMock.mockReturnValue(protectedError);
+      getUserMock.mockResolvedValueOnce({
+        data: {
+          id: 'user-5',
+          keycloakSubject: 'subject-5',
+          displayName: 'User Five',
+          status: 'active',
+          roles: [],
+          mainserverUserApplicationSecretSet: false,
+        },
+      });
+      sendPasswordSetupEmailMock.mockRejectedValueOnce(new Error('forbidden-resend'));
 
-    const { result } = renderHook(() => useUser('user-5'));
+      const { result } = renderHook(() => useUser('user-5'));
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
 
-    await act(async () => {
-      const sent = await result.current.resendPasswordSetupEmail?.();
-      expect(sent).toBe(false);
-    });
+      await act(async () => {
+        const sent = await result.current.resendPasswordSetupEmail?.();
+        expect(sent).toBe(false);
+      });
 
-    expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
-    expect(result.current.error).toBeNull();
-    expect(result.current.mutationError).toBe(forbiddenError);
-  });
+      expect(authMockValue.invalidatePermissions).toHaveBeenCalledTimes(1);
+      expect(result.current.error).toBeNull();
+      expect(result.current.mutationError).toBe(protectedError);
+    }
+  );
 
   it('preserves mutation errors across successful refetches', async () => {
     const validationError = { status: 400, code: 'invalid', message: 'Invalid payload' };

--- a/apps/sva-studio-react/src/hooks/use-user.ts
+++ b/apps/sva-studio-react/src/hooks/use-user.ts
@@ -30,6 +30,7 @@ type UseUserResult = {
 };
 
 const userLogger = createOperationLogger('user-hook', 'debug');
+const PERMISSION_INVALIDATED_EVENT = 'permission_invalidated_after_401_or_403';
 
 export const useUser = (userId: string): UseUserResult => {
   const { invalidatePermissions } = useAuth();
@@ -59,9 +60,9 @@ export const useUser = (userId: string): UseUserResult => {
       });
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
-        userLogger.info('permission_invalidated_after_403', {
+        userLogger.info(PERMISSION_INVALIDATED_EVENT, {
           operation: 'get_user',
           status: resolvedError.status,
           error_code: resolvedError.code,
@@ -102,9 +103,9 @@ export const useUser = (userId: string): UseUserResult => {
         return response.data;
       } catch (cause) {
         const resolvedError = asIamError(cause);
-        if (resolvedError.status === 403) {
+        if (resolvedError.status === 401 || resolvedError.status === 403) {
           await invalidatePermissions();
-          userLogger.info('permission_invalidated_after_403', {
+          userLogger.info(PERMISSION_INVALIDATED_EVENT, {
             operation: 'update_user',
             status: resolvedError.status,
             error_code: resolvedError.code,
@@ -138,9 +139,9 @@ export const useUser = (userId: string): UseUserResult => {
       return true;
     } catch (cause) {
       const resolvedError = asIamError(cause);
-      if (resolvedError.status === 403) {
+      if (resolvedError.status === 401 || resolvedError.status === 403) {
         await invalidatePermissions();
-        userLogger.info('permission_invalidated_after_403', {
+        userLogger.info(PERMISSION_INVALIDATED_EVENT, {
           operation: 'send_password_setup_email',
           status: resolvedError.status,
           error_code: resolvedError.code,

--- a/apps/sva-studio-react/src/providers/auth-provider.test.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.test.tsx
@@ -853,6 +853,80 @@ describe('AuthProvider', () => {
     }
   });
 
+  it('does not start a second silent revalidation while a visibility-triggered refresh is still in flight', async () => {
+    let visibilityState: DocumentVisibilityState = 'hidden';
+    let resolveSecondFetch: ((response: Response) => void) | null = null;
+    const originalVisibilityStateDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      'visibilityState'
+    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(200, {
+          user: {
+            id: 'user-1',
+            roles: ['editor'],
+            instanceId: 'instance-1',
+          },
+        })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSecondFetch = resolve;
+          })
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    });
+
+    try {
+      render(
+        <AuthProvider>
+          <AuthProbe />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status').textContent).toBe('ready');
+      });
+
+      visibilityState = 'visible';
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      requireFetchResolver(resolveSecondFetch)(
+        createJsonResponse(200, {
+          user: {
+            id: 'user-1',
+            roles: ['editor', 'system_admin'],
+            instanceId: 'instance-1',
+          },
+        })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('user-roles').textContent).toContain('system_admin');
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      if (originalVisibilityStateDescriptor) {
+        Object.defineProperty(document, 'visibilityState', originalVisibilityStateDescriptor);
+      } else {
+        removeTestDocumentProperty('visibilityState');
+      }
+    }
+  });
+
   it('does not revalidate on visibility regain without a confirmed session snapshot', async () => {
     let visibilityState: DocumentVisibilityState = 'hidden';
     const originalVisibilityStateDescriptor = Object.getOwnPropertyDescriptor(

--- a/apps/sva-studio-react/src/providers/auth-provider.test.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.test.tsx
@@ -56,6 +56,17 @@ const requireScheduledCallback = (callback: (() => void) | null): (() => void) =
   return callback;
 };
 
+const removeTestDocumentProperty = (property: string) => {
+  Reflect.deleteProperty(document as Document & Record<string, unknown>, property);
+};
+
+const requireFetchResolver = <T,>(resolver: ((value: T) => void) | null): ((value: T) => void) => {
+  if (resolver === null) {
+    throw new Error('Expected deferred fetch resolver to be registered.');
+  }
+  return resolver;
+};
+
 vi.mock('@sva/monitoring-client/logging', () => ({
   createBrowserLogger: () => browserLoggerMock,
 }));
@@ -73,6 +84,7 @@ const AuthProbe = () => {
       <p data-testid="dev-auth-available">{auth.isDevAuthAvailable ? 'yes' : 'no'}</p>
       <p data-testid="user-id">{auth.user?.id ?? 'none'}</p>
       <p data-testid="user-roles">{auth.user?.roles.join(',') ?? 'none'}</p>
+      <p data-testid="error-code">{auth.error instanceof Error ? auth.error.message : 'none'}</p>
       <button type="button" onClick={() => void auth.refetch()}>
         refetch
       </button>
@@ -771,6 +783,230 @@ describe('AuthProvider', () => {
         signal: expect.any(AbortSignal),
       })
     );
+  });
+
+  it('revalidates the session when the document becomes visible again', async () => {
+    let visibilityState: DocumentVisibilityState = 'hidden';
+    const originalVisibilityStateDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      'visibilityState'
+    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(200, {
+          user: {
+            id: 'user-1',
+            roles: ['editor'],
+            instanceId: 'instance-1',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse(200, {
+          user: {
+            id: 'user-1',
+            roles: ['system_admin'],
+            instanceId: 'instance-1',
+          },
+        })
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    });
+
+    try {
+      render(
+        <AuthProvider>
+          <AuthProbe />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status').textContent).toBe('ready');
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      visibilityState = 'visible';
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+      expect(screen.getByTestId('user-roles').textContent).toBe('system_admin');
+    } finally {
+      if (originalVisibilityStateDescriptor) {
+        Object.defineProperty(document, 'visibilityState', originalVisibilityStateDescriptor);
+      } else {
+        removeTestDocumentProperty('visibilityState');
+      }
+    }
+  });
+
+  it('does not revalidate on visibility regain without a confirmed session snapshot', async () => {
+    let visibilityState: DocumentVisibilityState = 'hidden';
+    const originalVisibilityStateDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      'visibilityState'
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse(401, {
+        error: {
+          code: 'unauthorized',
+          message: 'expired',
+          classification: 'session_store_or_session_hydration',
+          status: 'recovery_laeuft',
+          recommendedAction: 'erneut_anmelden',
+          safeDetails: {
+            reason_code: 'session_expired',
+          },
+        },
+        requestId: 'req-auth-401',
+      })
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    });
+
+    try {
+      render(
+        <AuthProvider>
+          <AuthProbe />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('status').textContent).toBe('ready');
+      });
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: { type: 'sva-auth:silent-sso', status: 'failed' },
+        })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('authenticated').textContent).toBe('no');
+      });
+
+      visibilityState = 'visible';
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      if (originalVisibilityStateDescriptor) {
+        Object.defineProperty(document, 'visibilityState', originalVisibilityStateDescriptor);
+      } else {
+        removeTestDocumentProperty('visibilityState');
+      }
+    }
+  });
+
+  it('keeps the last confirmed user snapshot while invalidating permissions silently', async () => {
+    let resolveSecondFetch: ((response: Response) => void) | null = null;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(200, {
+          user: {
+            id: 'user-1',
+            roles: ['editor'],
+            instanceId: 'instance-1',
+          },
+        })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSecondFetch = resolve;
+          })
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-id').textContent).toBe('user-1');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'invalidate' }));
+
+    expect(screen.getByTestId('status').textContent).toBe('ready');
+    expect(screen.getByTestId('authenticated').textContent).toBe('yes');
+    expect(screen.getByTestId('user-id').textContent).toBe('user-1');
+    expect(screen.getByTestId('user-roles').textContent).toBe('editor');
+
+    requireFetchResolver(resolveSecondFetch)(
+      createJsonResponse(200, {
+        user: {
+          id: 'user-1',
+          roles: ['editor', 'iam_admin'],
+          instanceId: 'instance-1',
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-roles').textContent).toContain('iam_admin');
+    });
+  });
+
+  it('does not expose a foreground auth error when silent invalidation fails', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(200, {
+          user: {
+            id: 'user-1',
+            roles: ['editor'],
+            instanceId: 'instance-1',
+          },
+        })
+      )
+      .mockRejectedValueOnce(new Error('silent-refresh-failed'));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-id').textContent).toBe('user-1');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'invalidate' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('yes');
+    expect(screen.getByTestId('user-id').textContent).toBe('user-1');
+    expect(screen.getByTestId('error-code').textContent).toBe('none');
   });
 
   it('invalidates permissions via silent auth refresh', async () => {

--- a/apps/sva-studio-react/src/providers/auth-provider.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.tsx
@@ -204,6 +204,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [sessionRecoveryFailed, setSessionRecoveryFailed] = React.useState(false);
 
   const isMountedRef = React.useRef(true);
+  const confirmedUserRef = React.useRef<SessionUser | null>(null);
   const authFlowIdRef = React.useRef<string>(createAuthFlowId());
   const authAttemptRef = React.useRef(0);
   const sessionExpiryTimeoutRef = React.useRef<number | null>(null);
@@ -219,6 +220,10 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       }
     };
   }, []);
+
+  React.useEffect(() => {
+    confirmedUserRef.current = user;
+  }, [user]);
 
   const clearSessionExpiryTimer = React.useCallback(() => {
     if (sessionExpiryTimeoutRef.current !== null) {
@@ -511,9 +516,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         }
 
         if (!result.ok) {
+          const shouldClearConfirmedSnapshot = !silent || result.status === 401 || result.status === 403;
           if (isMountedRef.current) {
-            setUser(null);
-            setSessionExpiresAt(null);
+            if (shouldClearConfirmedSnapshot) {
+              setUser(null);
+              setSessionExpiresAt(null);
+            }
             setHasResolvedSession(true);
           }
           authLogger.info('auth_session_unauthenticated', {
@@ -559,9 +567,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
           result: 'failed',
         });
         if (isMountedRef.current) {
-          setUser(null);
-          setSessionExpiresAt(null);
-          setError(resolvedError);
+          if (!silent) {
+            setUser(null);
+            setSessionExpiresAt(null);
+            setError(resolvedError);
+          }
           setHasResolvedSession(true);
           setIsRecoveringSession(false);
         }
@@ -579,6 +589,26 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     },
     [attemptSilentSessionRecovery, logAuthDebug, nextAuthAttempt, recordTrail, startAuthFlow]
   );
+
+  React.useEffect(() => {
+    const currentDocument = globalThis.document;
+    if (!currentDocument) {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (currentDocument.visibilityState !== 'visible' || !confirmedUserRef.current) {
+        return;
+      }
+
+      void loadUser(true);
+    };
+
+    currentDocument.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      currentDocument.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [loadUser]);
 
   React.useEffect(() => {
     clearSessionExpiryTimer();

--- a/apps/sva-studio-react/src/providers/auth-provider.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.tsx
@@ -209,6 +209,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const authAttemptRef = React.useRef(0);
   const sessionExpiryTimeoutRef = React.useRef<number | null>(null);
   const lastPreExpiryRecoveryAttemptRef = React.useRef<number | null>(null);
+  const inFlightSilentLoadRef = React.useRef<Promise<void> | null>(null);
 
   React.useEffect(() => {
     isMountedRef.current = true;
@@ -394,6 +395,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const loadUser = React.useCallback(
     async (silent: boolean) => {
+      if (silent && inFlightSilentLoadRef.current) {
+        return inFlightSilentLoadRef.current;
+      }
+
+      const runLoadUser = async () => {
       const authFlowId = startAuthFlow();
       const firstAttempt = nextAuthAttempt();
       if (!silent && isMountedRef.current) {
@@ -584,6 +590,21 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       } finally {
         if (!silent && isMountedRef.current) {
           setIsLoading(false);
+        }
+      }
+      };
+
+      const loadPromise = runLoadUser();
+      if (!silent) {
+        return loadPromise;
+      }
+
+      inFlightSilentLoadRef.current = loadPromise;
+      try {
+        await loadPromise;
+      } finally {
+        if (inFlightSilentLoadRef.current === loadPromise) {
+          inFlightSilentLoadRef.current = null;
         }
       }
     },

--- a/apps/sva-studio-react/src/router.test.ts
+++ b/apps/sva-studio-react/src/router.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createRuntimeRouteTree,
+  parseRouteGuardUser,
   readRouteGuardUser,
   resolveBaseUrl,
 } from './router';
@@ -70,6 +71,49 @@ describe('createRuntimeRouteTree', () => {
     });
 
     expect(readRouteGuardUser({ user: { roles: 'not-an-array' } })).toEqual({
+      roles: [],
+      permissionActions: [],
+      permissionStatus: 'ok',
+      assignedModules: [],
+    });
+  });
+
+  it('reads degraded permission snapshots without throwing', () => {
+    expect(
+      readRouteGuardUser({
+        user: {
+          roles: ['editor'],
+          permissionActions: [],
+          permissionStatus: 'degraded',
+          assignedModules: ['news'],
+        },
+      }),
+    ).toEqual({
+      roles: ['editor'],
+      permissionActions: [],
+      permissionStatus: 'degraded',
+      assignedModules: ['news'],
+    });
+  });
+
+  it('treats malformed auth payloads as unauthenticated without throwing', () => {
+    expect(parseRouteGuardUser(null)).toBeNull();
+    expect(parseRouteGuardUser('invalid-payload')).toBeNull();
+    expect(parseRouteGuardUser({})).toBeNull();
+    expect(parseRouteGuardUser({ user: null })).toBeNull();
+    expect(parseRouteGuardUser({ user: {} })).toBeNull();
+    expect(parseRouteGuardUser({ user: [] })).toBeNull();
+  });
+
+  it('accepts authenticated payloads with stable user identifiers even without role arrays', () => {
+    expect(
+      parseRouteGuardUser({
+        user: {
+          id: 'user-1',
+          instanceId: 'instance-1',
+        },
+      }),
+    ).toEqual({
       roles: [],
       permissionActions: [],
       permissionStatus: 'ok',

--- a/apps/sva-studio-react/src/router.tsx
+++ b/apps/sva-studio-react/src/router.tsx
@@ -88,32 +88,62 @@ export const createMockRouteGuardUser = (): RouteGuardUser => ({
   ],
 });
 
-export const readRouteGuardUser = (payload: unknown): RouteGuardUser => {
-  const parsedPayload = payload as {
-    user?: {
-      roles?: unknown;
-      permissionActions?: unknown;
-      permissionStatus?: unknown;
-      assignedModules?: unknown;
-    };
+type RouteGuardUserPayload = {
+  user?: {
+    id?: unknown;
+    instanceId?: unknown;
+    roles?: unknown;
+    permissionActions?: unknown;
+    permissionStatus?: unknown;
+    assignedModules?: unknown;
   };
+};
 
-  const roles = Array.isArray(parsedPayload.user?.roles)
-    ? parsedPayload.user.roles.filter((entry): entry is string => typeof entry === 'string')
-    : [];
+const readRouteGuardPayloadUser = (payload: unknown): RouteGuardUserPayload['user'] => {
+  if (typeof payload !== 'object' || payload === null || !('user' in payload)) {
+    return undefined;
+  }
 
-  const permissionActions = Array.isArray(parsedPayload.user?.permissionActions)
-    ? parsedPayload.user.permissionActions.filter((entry): entry is string => typeof entry === 'string')
-    : [];
+  const { user } = payload as RouteGuardUserPayload;
+  if (typeof user !== 'object' || user === null || Array.isArray(user)) {
+    return undefined;
+  }
 
-  const assignedModules = Array.isArray(parsedPayload.user?.assignedModules)
-    ? parsedPayload.user.assignedModules.filter((entry): entry is string => typeof entry === 'string')
-    : [];
+  return user;
+};
 
-  const rawStatus = parsedPayload.user?.permissionStatus;
+const readStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((entry: unknown): entry is string => typeof entry === 'string') : [];
+
+export const readRouteGuardUser = (payload: unknown): RouteGuardUser => {
+  const user = readRouteGuardPayloadUser(payload);
+
+  const roles = readStringArray(user?.roles);
+  const permissionActions = readStringArray(user?.permissionActions);
+  const assignedModules = readStringArray(user?.assignedModules);
+
+  const rawStatus = user?.permissionStatus;
   const permissionStatus: 'ok' | 'degraded' = rawStatus === 'degraded' ? 'degraded' : 'ok';
 
   return { roles, permissionActions, permissionStatus, assignedModules };
+};
+
+export const parseRouteGuardUser = (payload: unknown): RouteGuardUser | null => {
+  const user = readRouteGuardPayloadUser(payload);
+
+  if (!user) {
+    return null;
+  }
+
+  const hasRecognizedUserShape =
+    typeof user.id === 'string' ||
+    typeof user.instanceId === 'string' ||
+    Array.isArray(user.roles) ||
+    Array.isArray(user.permissionActions) ||
+    Array.isArray(user.assignedModules) ||
+    typeof user.permissionStatus === 'string';
+
+  return hasRecognizedUserShape ? readRouteGuardUser(payload) : null;
 };
 
 const loadRouteGuardUserFromAuthMe = async (url: string, init?: RequestInit): Promise<RouteGuardUser | null> => {
@@ -123,7 +153,7 @@ const loadRouteGuardUserFromAuthMe = async (url: string, init?: RequestInit): Pr
     return null;
   }
 
-  return readRouteGuardUser(await response.json());
+  return parseRouteGuardUser(await response.json());
 };
 
 const getRouteGuardUser = createIsomorphicFn()
@@ -159,7 +189,7 @@ const getRouteGuardUser = createIsomorphicFn()
         fetchWithRequestTimeout(new URL('/auth/me', resolveBaseUrl()).toString(), undefined, { timeoutMs: 5_000 })
       );
       if (!result.ok) return null;
-      return readRouteGuardUser(result.payload);
+      return parseRouteGuardUser(result.payload);
     } catch {
       return null;
     }

--- a/apps/sva-studio-react/src/routes/-__root.test.tsx
+++ b/apps/sva-studio-react/src/routes/-__root.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const useRouterStateMock = vi.fn();
@@ -165,6 +166,26 @@ describe('root route document', () => {
     await waitFor(() => {
       expect(screen.getByTestId('app-shell').getAttribute('data-is-loading')).toBe('true');
     });
+  });
+
+  it('renders pending shell content as non-loading during server render to keep hydration stable', async () => {
+    useRouterStateMock.mockImplementation(({ select }) =>
+      select({
+        status: 'pending',
+        isLoading: true,
+        location: { pathname: '/admin/users' },
+      }),
+    );
+
+    const { RootDocument } = await import('./__root');
+
+    const markup = renderToStaticMarkup(
+      <RootDocument>
+        <div>content</div>
+      </RootDocument>,
+    );
+
+    expect(markup).toContain('data-is-loading="false"');
   });
 
   it('keeps the shell mounted with the current pathname during route-level pending navigation', async () => {

--- a/apps/sva-studio-react/src/routes/-__root.test.tsx
+++ b/apps/sva-studio-react/src/routes/-__root.test.tsx
@@ -145,7 +145,7 @@ describe('root route document', () => {
     });
   });
 
-  it('marks the shell as loading after hydration when the router is pending', async () => {
+  it('keeps the shell mounted and forwards route-level pending state to the content area', async () => {
     useRouterStateMock.mockImplementation(({ select }) =>
       select({
         status: 'pending',
@@ -166,4 +166,27 @@ describe('root route document', () => {
       expect(screen.getByTestId('app-shell').getAttribute('data-is-loading')).toBe('true');
     });
   });
+
+  it('keeps the shell mounted with the current pathname during route-level pending navigation', async () => {
+    useRouterStateMock.mockImplementation(({ select }) =>
+      select({
+        status: 'pending',
+        isLoading: true,
+        location: { pathname: '/admin/users' },
+      }),
+    );
+
+    const { RootDocument } = await import('./__root');
+
+    render(
+      <RootDocument>
+        <div>content</div>
+      </RootDocument>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('app-shell').getAttribute('data-current-pathname')).toBe('/admin/users');
+    });
+  });
+
 });

--- a/apps/sva-studio-react/src/routes/__root.tsx
+++ b/apps/sva-studio-react/src/routes/__root.tsx
@@ -77,7 +77,7 @@ export const rootRoute = Route;
 /**
  * Rendert das HTML-Grundgerüst mit Header, Shell-Layout und Devtools.
  *
- * Die Shell zeigt Loading-Skeletons ausschließlich bei aktiver Router-Pending-Phase.
+ * Die Shell bleibt bei normaler Route-Navigation stabil gemountet; Loading bleibt lokal im Routeninhalt.
  */
 function RootComponent() {
   return (
@@ -94,12 +94,7 @@ export function RootDocument({ children }: Readonly<{ children: React.ReactNode 
   const currentPathname = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const [isHydrated, setIsHydrated] = React.useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = React.useState(false);
-
-  React.useEffect(() => {
-    setIsHydrated(true);
-  }, []);
 
   React.useEffect(() => {
     setIsMobileSidebarOpen(false);
@@ -115,8 +110,6 @@ export function RootDocument({ children }: Readonly<{ children: React.ReactNode 
     const mainElement = globalThis.document.getElementById('main-content');
     mainElement?.focus();
   }, [currentPathname]);
-
-  const isShellLoading = isHydrated && isRouterPending;
 
   return (
     <html lang="de" suppressHydrationWarning>
@@ -142,7 +135,7 @@ export function RootDocument({ children }: Readonly<{ children: React.ReactNode 
             <ThemeProvider>
               <AppShell
                 currentPathname={currentPathname}
-                isLoading={isShellLoading}
+                isLoading={isRouterPending}
                 isMobileSidebarOpen={isMobileSidebarOpen}
                 onMobileSidebarOpenChange={setIsMobileSidebarOpen}
               >

--- a/apps/sva-studio-react/src/routes/__root.tsx
+++ b/apps/sva-studio-react/src/routes/__root.tsx
@@ -94,7 +94,12 @@ export function RootDocument({ children }: Readonly<{ children: React.ReactNode 
   const currentPathname = useRouterState({
     select: (state) => state.location.pathname,
   });
+  const [isHydrated, setIsHydrated] = React.useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsHydrated(true);
+  }, []);
 
   React.useEffect(() => {
     setIsMobileSidebarOpen(false);
@@ -135,7 +140,7 @@ export function RootDocument({ children }: Readonly<{ children: React.ReactNode 
             <ThemeProvider>
               <AppShell
                 currentPathname={currentPathname}
-                isLoading={isRouterPending}
+                isLoading={isHydrated && isRouterPending}
                 isMobileSidebarOpen={isMobileSidebarOpen}
                 onMobileSidebarOpenChange={setIsMobileSidebarOpen}
               >

--- a/packages/routing/src/protected.routes.test.ts
+++ b/packages/routing/src/protected.routes.test.ts
@@ -5,7 +5,13 @@ import { createAdminRoute, createProtectedRoute } from './protected.routes';
 
 const invokeGuard = async (
   guard: ReturnType<typeof createProtectedRoute>,
-  user: { roles: readonly string[]; permissionActions?: readonly string[] } | null,
+  user:
+    | {
+        roles: readonly string[];
+        permissionActions?: readonly string[];
+        permissionStatus?: 'ok' | 'degraded';
+      }
+    | null,
   href: string
 ) =>
   guard({
@@ -110,6 +116,18 @@ describe('protected routes', () => {
 
     await expect(
       invokeGuard(guard, { roles: ['editor'], permissionActions: ['news.read', 'events.read'] }, '/plugins/news')
+    ).resolves.toBeUndefined();
+  });
+
+  it('keeps degraded permission snapshots routable when the required permission is present', async () => {
+    const guard = createProtectedRoute({ route: '/plugins/news', requiredPermissions: ['news.read'] });
+
+    await expect(
+      invokeGuard(
+        guard,
+        { roles: ['editor'], permissionActions: ['news.read'], permissionStatus: 'degraded' },
+        '/plugins/news'
+      )
     ).resolves.toBeUndefined();
   });
 


### PR DESCRIPTION
Diese Änderung stabilisiert die Studio-App-Shell bei normaler Navigation, sodass `Sidebar` und `Header` nicht mehr in globale Pending-Zustände gezogen werden. Ladezustände bleiben auf den Inhaltsbereich der Route begrenzt, was Flackern reduziert und die Navigation ruhiger wirken lässt.

Zusätzlich wurde die Auth-/Rechte-Revalidierung vereinheitlicht: Hooks invalidieren Berechtigungen jetzt sowohl bei `401` als auch bei `403`, damit abgelaufene Sessions und echte Forbidden-Zustände gleich sauber nachgezogen werden. Die Verarbeitung von `/auth/me`-Payloads wurde robuster gemacht, und degradierte Permission-Snapshots bleiben für erlaubte Routen nutzbar.