### PR TITLE
[codex] Fix lokale DB-Berechtigungen fuer den Plugin-Worker

### DIFF
--- a/packages/auth-runtime/src/postgres-app-user-bootstrap.test.ts
+++ b/packages/auth-runtime/src/postgres-app-user-bootstrap.test.ts
@@ -113,6 +113,15 @@ describe('postgres app user bootstrap', () => {
     expect(state.FakeClient.instances[0]?.queryImpl).toHaveBeenCalledWith(
       expect.stringContaining('CREATE ROLE "sva_app" LOGIN PASSWORD')
     );
+    expect(state.FakeClient.instances[0]?.queryImpl).toHaveBeenCalledWith(
+      'GRANT CONNECT ON DATABASE "sva_studio" TO "sva_app"'
+    );
+    expect(state.FakeClient.instances[0]?.queryImpl).toHaveBeenCalledWith(
+      'GRANT CREATE ON DATABASE "sva_studio" TO "sva_app"'
+    );
+    expect(state.FakeClient.instances[0]?.queryImpl).toHaveBeenCalledWith(
+      'GRANT USAGE, CREATE ON SCHEMA public TO "sva_app"'
+    );
     expect(state.logger.info).toHaveBeenCalledWith(
       'Bootstrapped studio app DB role',
       expect.objectContaining({

--- a/packages/auth-runtime/src/postgres-app-user-bootstrap.ts
+++ b/packages/auth-runtime/src/postgres-app-user-bootstrap.ts
@@ -57,6 +57,7 @@ const runBootstrap = async (): Promise<boolean> => {
   const quotedAppDbUser = quoteIdentifier(appDbUser);
   const quotedAppDbPassword = quoteLiteral(appDbPassword);
   const quotedRoleName = quoteLiteral(appDbUser);
+  const quotedPostgresDb = quoteIdentifier(postgresDb);
   let lastError: unknown;
 
   for (const superuserPassword of superuserPasswords) {
@@ -87,6 +88,9 @@ END
 $bootstrap$;
 `
       );
+      await client.query(`GRANT CONNECT ON DATABASE ${quotedPostgresDb} TO ${quotedAppDbUser}`);
+      await client.query(`GRANT CREATE ON DATABASE ${quotedPostgresDb} TO ${quotedAppDbUser}`);
+      await client.query(`GRANT USAGE, CREATE ON SCHEMA public TO ${quotedAppDbUser}`);
       await client.query(`GRANT iam_app TO ${quotedAppDbUser}`);
       await client.query(`GRANT USAGE ON SCHEMA iam TO ${quotedAppDbUser}`);
       await client.query(

--- a/packages/data/scripts/bootstrap-app-user.sh
+++ b/packages/data/scripts/bootstrap-app-user.sh
@@ -38,7 +38,12 @@ if ! [[ "${app_user}" =~ ^[a-zA-Z0-9_]{1,63}$ ]]; then
   exit 1
 fi
 
-"${postgres_exec[@]}" -v ON_ERROR_STOP=1 -v app_user="${app_user}" -v app_password="${app_password}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<'SQL'
+if ! [[ "${POSTGRES_DB}" =~ ^[a-zA-Z0-9_]{1,63}$ ]]; then
+  echo "POSTGRES_DB must match ^[a-zA-Z0-9_]{1,63}$."
+  exit 1
+fi
+
+"${postgres_exec[@]}" -v ON_ERROR_STOP=1 -v postgres_db="${POSTGRES_DB}" -v app_user="${app_user}" -v app_password="${app_password}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<'SQL'
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'iam_app') THEN
@@ -54,6 +59,9 @@ ALTER ROLE :"app_user" WITH LOGIN INHERIT PASSWORD :'app_password';
 CREATE ROLE :"app_user" LOGIN PASSWORD :'app_password' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT;
 \endif
 
+GRANT CONNECT ON DATABASE :"postgres_db" TO :"app_user";
+GRANT CREATE ON DATABASE :"postgres_db" TO :"app_user";
+GRANT USAGE, CREATE ON SCHEMA public TO :"app_user";
 GRANT iam_app TO :"app_user";
 GRANT USAGE ON SCHEMA iam TO :"app_user";
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA iam TO :"app_user";

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -22,7 +22,11 @@ test('bootstrap script validates usernames and uses identifier-safe grants', () 
   const script = readRepoFile('data/scripts/bootstrap-app-user.sh');
 
   assert.match(script, /IAM_DATABASE_URL username must match \^\[a-zA-Z0-9_\]\{1,63\}\$\./);
-  assert.match(script, /-v app_user="\$\{app_user\}" -v app_password="\$\{app_password\}"/);
+  assert.match(script, /POSTGRES_DB must match \^\[a-zA-Z0-9_\]\{1,63\}\$\./);
+  assert.match(script, /-v postgres_db="\$\{POSTGRES_DB\}" -v app_user="\$\{app_user\}" -v app_password="\$\{app_password\}"/);
+  assert.match(script, /GRANT CONNECT ON DATABASE :"postgres_db" TO :"app_user";/);
+  assert.match(script, /GRANT CREATE ON DATABASE :"postgres_db" TO :"app_user";/);
+  assert.match(script, /GRANT USAGE, CREATE ON SCHEMA public TO :"app_user";/);
   assert.match(script, /GRANT iam_app TO :"app_user";/);
   assert.match(script, /\\if :role_exists/);
   assert.doesNotMatch(script, /DO \\\$\\\$/);


### PR DESCRIPTION
## Was wurde geändert?

- ergänzt fehlende Datenbank- und `public`-Schema-Berechtigungen für den lokalen App-DB-User im Bootstrap-Pfad
- ergänzt dieselben Grants im Studio-Bootstrap-Fallback in `auth-runtime`
- erweitert die bestehenden Tests, damit die Rechtevergabe regressionssicher geprüft wird

## Warum?

Der lokale Plugin-Operations-Worker startete nicht, weil `graphile-worker` bereits in `runMigrations()` an fehlenden `CREATE`-Rechten für `sva_app` auf `sva_studio` und `public` scheiterte.

## Auswirkungen

- lokales `local-keycloak`-Environment startet den Plugin-Worker jetzt erfolgreich
- der Fix ändert nur den Bootstrap-Pfad für den App-DB-User und nicht die fachliche Plugin-Logik

## Validierung

- `pnpm nx run data:test:unit --testFiles=src/runtime-safety.test.ts`
- `cd packages/auth-runtime && pnpm exec vitest run src/postgres-app-user-bootstrap.test.ts --reporter=verbose --config vitest.config.ts`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run data:test:types`
