### PR TITLE
fix: preserve waste master-data translation keys

### DIFF
--- a/packages/plugin-waste-management/src/plugin.translations.shared.master-data.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.shared.master-data.ts
@@ -2,7 +2,6 @@ import {
   createCrudActions,
   createCrudDialog,
   createCrudMessages,
-  createOptionalSection,
   type CrudActionsCopy,
   type CrudDialogCopy,
   type CrudMessagesCopy,
@@ -85,18 +84,15 @@ export const createMasterDataTabs = (ariaLabel: string, fractions: string, locat
   }) as const;
 
 export const createMasterDataEntityTranslations = <const TCopy extends MasterDataEntityCopy>(copy: TCopy) =>
-  createOptionalSection(
-    {
-      title: copy.title,
-      description: copy.description,
-      actions: createCrudActions(copy.actions),
-      fields: copy.fields,
-      dialog: createCrudDialog(copy.dialog),
-      messages: createCrudMessages(copy.messages),
-    } as const,
-    'meta',
-    copy.meta,
-  );
+  ({
+    title: copy.title,
+    description: copy.description,
+    actions: createCrudActions(copy.actions),
+    fields: copy.fields,
+    dialog: createCrudDialog(copy.dialog),
+    messages: createCrudMessages(copy.messages),
+    ...(copy.meta ?? {}),
+  }) as const;
 
 export const createMasterDataFractionsTranslations = <const TCopy extends MasterDataFractionsCopy>(copy: TCopy) =>
   ({

--- a/packages/plugin-waste-management/tests/plugin.translations.shared.test.ts
+++ b/packages/plugin-waste-management/tests/plugin.translations.shared.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { createWasteManagementPluginTranslationLocale } from '../src/plugin.translations.shared.base.js';
+import { createMasterDataEntityTranslations } from '../src/plugin.translations.shared.master-data.js';
 import { createWasteManagementToursTranslations } from '../src/plugin.translations.shared.scheduling.js';
 import { createWasteManagementTabsTranslations } from '../src/plugin.translations.shared.sections.js';
 
@@ -152,6 +153,43 @@ describe('waste-management translation builders', () => {
         ...tabs,
         ...tours,
       },
+    });
+  });
+
+  it('keeps master-data entity meta labels at their public translation paths', () => {
+    expect(
+      createMasterDataEntityTranslations({
+        title: 'Regions',
+        description: 'Manage regions',
+        actions: {
+          openCreate: 'Create',
+          edit: 'Edit',
+          cancel: 'Cancel',
+          create: 'Create',
+          save: 'Save',
+          saving: 'Saving',
+        },
+        fields: {
+          name: 'Name',
+        },
+        dialog: {
+          createTitle: 'Create region',
+          createDescription: 'Create a region',
+          editTitle: 'Edit region',
+          editDescription: 'Edit a region',
+        },
+        messages: {
+          createSuccess: 'Created',
+          updateSuccess: 'Updated',
+          saveError: 'Failed',
+          saveForbidden: 'Forbidden',
+        },
+        meta: {
+          regionId: 'Region ID: {{value}}',
+        },
+      })
+    ).toMatchObject({
+      regionId: 'Region ID: {{value}}',
     });
   });
 });


### PR DESCRIPTION
## Summary
- keep waste master-data entity ID labels at their existing top-level translation paths
- add a regression test for the public `masterData.<entity>.<id>` keys used by the hierarchy UI

## Why
- addresses the unresolved post-merge review thread from #423
- prevents missing translation fallbacks for hierarchy badges

## Validation
- `pnpm nx run plugin-waste-management:test:unit --testFiles=tests/plugin.translations.shared.test.ts`
- `pnpm nx run plugin-waste-management:test:types`
