### PR TITLE
[codex] Fix Sonar hotspot in waste master-data ids

### DIFF
--- a/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
@@ -54,7 +54,30 @@ export type LocationTourLinkBulkFormState = {
   readonly endDate: string;
 };
 
-const createId = (): string => globalThis.crypto?.randomUUID?.() ?? `fraction-${Math.random().toString(36).slice(2, 10)}`;
+let localIdCounter = 0;
+
+const createSecureRandomIdSegment = (): string | undefined => {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+  if (!cryptoApi?.getRandomValues) {
+    return undefined;
+  }
+
+  const bytes = cryptoApi.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+};
+
+const createId = (): string => {
+  const secureId = createSecureRandomIdSegment();
+  if (secureId) {
+    return `fraction-${secureId}`;
+  }
+
+  localIdCounter += 1;
+  return `fraction-local-${Date.now().toString(36)}-${localIdCounter.toString(36)}`;
+};
 const compactOptionalString = (value: string): string | undefined => (value.trim() ? value.trim() : undefined);
 
 const normalizeLocalizedTextRecord = (value: WasteLocalizedTextRecord): WasteLocalizedTextRecord | undefined => {

--- a/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const createWasteManagementLocationTourLinkMock = vi.hoisted(() => vi.fn());
 const updateWasteManagementLocationTourLinkMock = vi.hoisted(() => vi.fn());
@@ -15,7 +15,6 @@ import {
   wasteMasterDataInputMappers,
 } from '../src/waste-management.master-data.forms.js';
 import { createWasteMasterDataLocationActions } from '../src/waste-management.master-data.location-actions.js';
-import { createWasteMasterDataFractionRegionSubmissions } from '../src/waste-management.master-data.fraction-region-submissions.js';
 import {
   ResetConfirmationDialog,
   StatusNotice,
@@ -88,6 +87,10 @@ vi.mock('@sva/studio-ui-react', () => ({
 }));
 
 describe('waste management helper modules', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('covers page support helpers, download templates, and the reset dialog shell', () => {
     expect(compactOptionalString('  ')).toBeUndefined();
     expect(compactOptionalString(' value ')).toBe('value');
@@ -292,6 +295,29 @@ describe('waste management helper modules', () => {
     expect(wasteMasterDataInputMappers.resolveSingleSelectValue(form, 'cityId')).toBe('city-1');
     expect(wasteMasterDataInputMappers.resolveSingleSelectValue(form, 'tourIds')).toBe('');
     expect(wasteMasterDataInputMappers.resolveSingleSelectValue(form, 'missing')).toBe('');
+  });
+
+  it('uses cryptographically secure ids for master-data defaults', () => {
+    const randomUUID = vi.fn(() => 'secure-region-id');
+    vi.stubGlobal('crypto', { randomUUID });
+
+    expect(wasteMasterDataFormDefaults.createRegion()).toEqual({
+      id: 'fraction-secure-region-id',
+      name: '',
+    });
+  });
+
+  it('falls back to secure random bytes when randomUUID is unavailable', () => {
+    const getRandomValues = vi.fn((target: Uint8Array) => {
+      target.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      return target;
+    });
+    vi.stubGlobal('crypto', { getRandomValues });
+
+    expect(wasteMasterDataFormDefaults.createRegion()).toEqual({
+      id: 'fraction-000102030405060708090a0b0c0d0e0f',
+      name: '',
+    });
   });
 
   it('covers entity actions and location selection helpers', () => {


### PR DESCRIPTION
## Was wurde geändert?
- Der `Math.random()`-Fallback für neue Master-Data-IDs im Waste-Management-Plugin wurde entfernt.
- Die ID-Erzeugung nutzt jetzt bevorzugt `crypto.randomUUID()`, danach `crypto.getRandomValues(...)` und nur zuletzt einen nicht-zufälligen lokalen Fallback.
- Die Hilfstests decken sowohl den `randomUUID`-Pfad als auch den Byte-Fallback ab.

## Warum?
- SonarCloud meldete in `packages/plugin-waste-management/src/waste-management.master-data.forms.ts` einen Security Hotspot (`typescript:S2245`) wegen der Nutzung eines pseudorandomisierten Fallbacks.
- Für diese Formular-IDs ist ein PRNG-Fallback nicht nötig; sichere Browser-APIs oder ein deterministischer lokaler Fallback sind die robustere Wahl.

## Auswirkungen
- Keine fachliche Verhaltensänderung für das Formularhandling.
- Neue temporäre IDs werden weiterhin eindeutig erzeugt, aber ohne unsicheren Zufallsfallback.

## Validierung
- `pnpm nx run plugin-waste-management:test:unit --testFiles=packages/plugin-waste-management/tests/waste-management.helpers.test.tsx`
- `pnpm nx run plugin-waste-management:test:types`
- `pnpm nx run plugin-waste-management:lint`
