### PR TITLE
feat: add local instance DB delete helper

### DIFF
--- a/docs/guides/lokale-instanz-db-initialisierung.md
+++ b/docs/guides/lokale-instanz-db-initialisierung.md
@@ -238,6 +238,60 @@ Optional:
   - `sva_app` oder `iam_app` fehlen auf der Ziel-Datenbank
   - Lösung: Bootstrap ohne `--skip-app-user-bootstrap` wiederholen
 
+## Instanz lokal hart löschen und neu bootstrapen
+
+Für einen sauberen lokalen Neustart derselben Instanz-ID steht ein reiner Konsolenpfad zur Verfügung:
+
+```bash
+pnpm env:delete:local-instance-db -- \
+  --target-instance-id=hb-meinquartier \
+  --target-db-container=sva-studio-postgres-hb \
+  --force
+```
+
+Optional:
+
+- `--dry-run` zeigt nur den lokalen Löschumfang
+- `--yes` überspringt die interaktive Bestätigung in TTY-Läufen
+- `--target-db-name` und `--target-db-user` überschreiben die Standardwerte `sva_studio` und `sva`
+
+Der Hard-Delete entfernt ausschließlich lokale Datenbankdaten der Zielinstanz:
+
+- den Instanzdatensatz in `iam.instances`
+- lokale Registry-, Hostname-, Provisioning- und Auditdaten
+- lokale IAM-Katalog-, Membership- und Integrationsdaten
+- lokale Content- und Media-Metadaten
+
+Die expliziten `DELETE`-Statements greifen direkt auf `iam.activity_logs`, `iam.content_history`, `iam.contents` und `iam.instances`. Weitere instanzgebundene lokale IAM-, Registry- und Content-Daten werden über `ON DELETE CASCADE` an `iam.instances` mitentfernt; der Schema-Guard des Skripts blockiert den Hard-Delete, falls dafür unbekannte Nicht-Cascade-Tabellen im lokalen Schema auftauchen.
+
+Bewusst **nicht** entfernt werden:
+
+- Keycloak-Realm, Keycloak-User oder andere Keycloak-Artefakte
+- Mainserver-Daten oder Mainserver-Credentials
+- physische Media- oder Blob-Storage-Objekte
+
+Wichtig:
+
+- aktive lokale Instanzen dürfen nur mit explizitem `--force` gelöscht werden
+- der Befehl ist nur für lokale Docker-Datenbanken gedacht und kein Remote-Admin-Pfad
+- für dieselbe `instanceId` ist danach ein normaler Rebootstrap über `pnpm env:bootstrap:local-instance-db -- ...` vorgesehen
+
+Beispiel für den direkten Rebootstrap nach dem Hard-Delete:
+
+```bash
+pnpm env:bootstrap:local-instance-db -- \
+  --create-db \
+  --import-schema \
+  --target-instance-id=hb-meinquartier \
+  --target-display-name="HB MeinQuartier" \
+  --target-realm=saas-hb-meinquartier \
+  --target-db-container=sva-studio-postgres-hb \
+  --source-db-container=sva-studio-postgres \
+  --source-instance-id=de-musterhausen \
+  --keycloak-admin-client-id=sva-studio-iam-service \
+  --keycloak-admin-client-secret='<secret>'
+```
+
 ## Betriebsregeln
 
 - niemals Userdaten einer anderen Instanz als vermeintlichen Seed kopieren

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "env:migrate:local-keycloak": "tsx scripts/ops/runtime-env.ts migrate local-keycloak",
     "env:doctor:local-keycloak": "tsx scripts/ops/runtime-env.ts doctor local-keycloak",
     "env:bootstrap:local-instance-db": "tsx scripts/ops/bootstrap-local-instance-db.ts",
+    "env:delete:local-instance-db": "tsx scripts/ops/delete-local-instance-db.ts",
     "env:up:local-builder": "tsx scripts/ops/runtime-env.ts up local-builder",
     "env:down:local-builder": "tsx scripts/ops/runtime-env.ts down local-builder",
     "env:update:local-builder": "tsx scripts/ops/runtime-env.ts update local-builder",

--- a/scripts/ops/delete-local-instance-db.test.ts
+++ b/scripts/ops/delete-local-instance-db.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDeleteLocalInstanceExecutionSql,
+  buildDeleteLocalInstanceSummarySql,
+  parseDeleteLocalInstanceArgs,
+  resolveUnknownNonCascadeInstanceTables,
+  shouldRequireInteractiveConfirmation,
+} from './delete-local-instance-db.ts';
+
+describe('parseDeleteLocalInstanceArgs', () => {
+  it('parses the required hard-delete options', () => {
+    expect(
+      parseDeleteLocalInstanceArgs([
+        '--target-instance-id=demo',
+        '--target-db-container=sva-studio-postgres-hb',
+        '--force',
+      ]),
+    ).toMatchObject({
+      dryRun: false,
+      force: true,
+      targetDbContainer: 'sva-studio-postgres-hb',
+      targetDbName: 'sva_studio',
+      targetDbUser: 'sva',
+      targetInstanceId: 'demo',
+      yes: false,
+    });
+  });
+
+  it('fails when the force flag is missing', () => {
+    expect(() =>
+      parseDeleteLocalInstanceArgs([
+        '--target-instance-id=demo',
+        '--target-db-container=sva-studio-postgres-hb',
+      ]),
+    ).toThrow('--force');
+  });
+
+  it('accepts dry-run and yes flags', () => {
+    expect(
+      parseDeleteLocalInstanceArgs([
+        '--target-instance-id=demo',
+        '--target-db-container=sva-studio-postgres-hb',
+        '--force',
+        '--dry-run',
+        '--yes',
+      ]),
+    ).toMatchObject({
+      dryRun: true,
+      yes: true,
+    });
+  });
+});
+
+describe('shouldRequireInteractiveConfirmation', () => {
+  it('requires confirmation in tty mode unless yes is set', () => {
+    expect(shouldRequireInteractiveConfirmation({ dryRun: false, isTty: true, yes: false })).toBe(true);
+    expect(shouldRequireInteractiveConfirmation({ dryRun: false, isTty: true, yes: true })).toBe(false);
+  });
+
+  it('skips confirmation outside tty mode and in dry-run mode', () => {
+    expect(shouldRequireInteractiveConfirmation({ dryRun: false, isTty: false, yes: false })).toBe(false);
+    expect(shouldRequireInteractiveConfirmation({ dryRun: true, isTty: true, yes: false })).toBe(false);
+  });
+});
+
+describe('delete-local-instance-db SQL planning', () => {
+  it('summarizes the root tables that need explicit cleanup', () => {
+    const sql = buildDeleteLocalInstanceSummarySql('demo');
+
+    expect(sql).toContain('FROM iam.contents');
+    expect(sql).toContain("WHERE instance_id = 'demo'");
+    expect(sql).toContain('FROM iam.content_history');
+    expect(sql).toContain('FROM iam.instances');
+    expect(sql).toContain("WHERE id = 'demo'");
+  });
+
+  it('deletes non-cascade content tables before deleting the instance row', () => {
+    const sql = buildDeleteLocalInstanceExecutionSql('demo');
+
+    const retentionModeIndex = sql.indexOf("SET LOCAL iam.retention_mode = 'true';");
+    const activityLogsDeleteIndex = sql.indexOf("DELETE FROM iam.activity_logs WHERE instance_id = 'demo';");
+    const historyDeleteIndex = sql.indexOf("DELETE FROM iam.content_history WHERE instance_id = 'demo';");
+    const contentsDeleteIndex = sql.indexOf("DELETE FROM iam.contents WHERE instance_id = 'demo';");
+    const instanceDeleteIndex = sql.indexOf("DELETE FROM iam.instances WHERE id = 'demo';");
+
+    expect(retentionModeIndex).toBeGreaterThanOrEqual(0);
+    expect(activityLogsDeleteIndex).toBeGreaterThan(retentionModeIndex);
+    expect(historyDeleteIndex).toBeGreaterThanOrEqual(0);
+    expect(historyDeleteIndex).toBeGreaterThan(activityLogsDeleteIndex);
+    expect(contentsDeleteIndex).toBeGreaterThan(historyDeleteIndex);
+    expect(instanceDeleteIndex).toBeGreaterThan(contentsDeleteIndex);
+    expect(sql).toContain('BEGIN;');
+    expect(sql).toContain('COMMIT;');
+  });
+});
+
+describe('resolveUnknownNonCascadeInstanceTables', () => {
+  it('allows the known indirect-cascade and explicit pre-delete tables', () => {
+    expect(
+      resolveUnknownNonCascadeInstanceTables([
+        'account_groups',
+        'account_organizations',
+        'account_permissions',
+        'account_roles',
+        'content_history',
+        'contents',
+        'group_roles',
+        'role_permissions',
+      ]),
+    ).toEqual([]);
+  });
+
+  it('reports unexpected non-cascade instance tables', () => {
+    expect(resolveUnknownNonCascadeInstanceTables(['contents', 'unexpected_table'])).toEqual(['unexpected_table']);
+  });
+});

--- a/scripts/ops/delete-local-instance-db.test.ts
+++ b/scripts/ops/delete-local-instance-db.test.ts
@@ -36,6 +36,40 @@ describe('parseDeleteLocalInstanceArgs', () => {
     ).toThrow('--force');
   });
 
+  it('accepts the force flag as a truthy boolean assignment', () => {
+    expect(
+      parseDeleteLocalInstanceArgs([
+        '--target-instance-id=demo',
+        '--target-db-container=sva-studio-postgres-hb',
+        '--force=true',
+      ]),
+    ).toMatchObject({
+      force: true,
+      targetInstanceId: 'demo',
+    });
+
+    expect(
+      parseDeleteLocalInstanceArgs([
+        '--target-instance-id=demo',
+        '--target-db-container=sva-studio-postgres-hb',
+        '--force=1',
+      ]),
+    ).toMatchObject({
+      force: true,
+      targetInstanceId: 'demo',
+    });
+  });
+
+  it('rejects falsy force assignments', () => {
+    expect(() =>
+      parseDeleteLocalInstanceArgs([
+        '--target-instance-id=demo',
+        '--target-db-container=sva-studio-postgres-hb',
+        '--force=false',
+      ]),
+    ).toThrow('--force');
+  });
+
   it('accepts dry-run and yes flags', () => {
     expect(
       parseDeleteLocalInstanceArgs([

--- a/scripts/ops/delete-local-instance-db.ts
+++ b/scripts/ops/delete-local-instance-db.ts
@@ -1,0 +1,318 @@
+import { createInterface } from 'node:readline/promises';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type DeleteLocalInstanceCliOptions = {
+  dryRun: boolean;
+  force: boolean;
+  targetDbContainer: string;
+  targetDbName: string;
+  targetDbUser: string;
+  targetInstanceId: string;
+  yes: boolean;
+};
+
+const KNOWN_INDIRECT_CASCADE_TABLES = [
+  'account_groups',
+  'account_organizations',
+  'account_permissions',
+  'account_roles',
+  'group_roles',
+  'role_permissions',
+] as const;
+
+const EXPLICIT_PREDELETE_TABLES = ['content_history', 'contents'] as const;
+
+const KNOWN_NON_CASCADE_INSTANCE_TABLES = new Set<string>([
+  ...KNOWN_INDIRECT_CASCADE_TABLES,
+  ...EXPLICIT_PREDELETE_TABLES,
+]);
+
+const [, , ...rawArgs] = process.argv;
+
+const rootDir = resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const entrypointPath = fileURLToPath(import.meta.url);
+
+const usage = () => {
+  process.stderr.write(`Usage: tsx scripts/ops/delete-local-instance-db.ts \\
+  --target-instance-id=<id> \\
+  --target-db-container=<docker-container> \\
+  --force \\
+  [--target-db-name=sva_studio] \\
+  [--target-db-user=sva] \\
+  [--dry-run] \\
+  [--yes]
+`);
+  process.exit(2);
+};
+
+const readOptionValue = (entry: string) => {
+  const separatorIndex = entry.indexOf('=');
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  return {
+    key: entry.slice(2, separatorIndex),
+    value: entry.slice(separatorIndex + 1),
+  };
+};
+
+export const parseDeleteLocalInstanceArgs = (args: readonly string[]): DeleteLocalInstanceCliOptions => {
+  const values = new Map<string, string>();
+  const flags = new Set<string>();
+
+  for (const entry of args) {
+    if (!entry.startsWith('--')) {
+      usage();
+    }
+
+    const option = readOptionValue(entry);
+    if (!option) {
+      flags.add(entry.slice(2));
+      continue;
+    }
+
+    values.set(option.key, option.value);
+  }
+
+  const readRequired = (key: string): string => {
+    const value = values.get(key)?.trim();
+    if (!value) {
+      throw new Error(`Missing required option --${key}=...`);
+    }
+    return value;
+  };
+
+  if (!flags.has('force')) {
+    throw new Error('Hard delete requires the explicit --force flag.');
+  }
+
+  return {
+    dryRun: flags.has('dry-run'),
+    force: true,
+    targetDbContainer: readRequired('target-db-container'),
+    targetDbName: values.get('target-db-name')?.trim() || 'sva_studio',
+    targetDbUser: values.get('target-db-user')?.trim() || 'sva',
+    targetInstanceId: readRequired('target-instance-id'),
+    yes: flags.has('yes'),
+  };
+};
+
+export const shouldRequireInteractiveConfirmation = (input: {
+  dryRun: boolean;
+  isTty: boolean;
+  yes: boolean;
+}): boolean => input.isTty && !input.dryRun && !input.yes;
+
+const sqlLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`;
+
+export const buildDeleteLocalInstanceSummarySql = (instanceId: string): string => `
+SELECT 'content_history' AS table_name, COUNT(*)::text AS row_count
+FROM iam.content_history
+WHERE instance_id = ${sqlLiteral(instanceId)}
+UNION ALL
+SELECT 'contents' AS table_name, COUNT(*)::text AS row_count
+FROM iam.contents
+WHERE instance_id = ${sqlLiteral(instanceId)}
+UNION ALL
+SELECT 'instances' AS table_name, COUNT(*)::text AS row_count
+FROM iam.instances
+WHERE id = ${sqlLiteral(instanceId)}
+ORDER BY table_name;
+`;
+
+export const buildDeleteLocalInstanceExecutionSql = (instanceId: string): string => `BEGIN;
+SET LOCAL iam.retention_mode = 'true';
+DELETE FROM iam.activity_logs WHERE instance_id = ${sqlLiteral(instanceId)};
+DELETE FROM iam.content_history WHERE instance_id = ${sqlLiteral(instanceId)};
+DELETE FROM iam.contents WHERE instance_id = ${sqlLiteral(instanceId)};
+DELETE FROM iam.instances WHERE id = ${sqlLiteral(instanceId)};
+COMMIT;
+`;
+
+const buildNonCascadeInstanceTableInspectionSql = (): string => `
+WITH instance_tables AS (
+  SELECT table_name
+  FROM information_schema.columns
+  WHERE table_schema = 'iam'
+    AND column_name = 'instance_id'
+),
+tables_without_direct_instance_fk AS (
+  SELECT instance_table.table_name
+  FROM instance_tables instance_table
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint con
+    JOIN pg_class rel
+      ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp
+      ON nsp.oid = rel.relnamespace
+    JOIN pg_class target_rel
+      ON target_rel.oid = con.confrelid
+    JOIN pg_namespace target_nsp
+      ON target_nsp.oid = target_rel.relnamespace
+    JOIN unnest(con.conkey) WITH ORDINALITY AS key_attnum(attnum, ordinality)
+      ON true
+    JOIN pg_attribute source_att
+      ON source_att.attrelid = rel.oid
+     AND source_att.attnum = key_attnum.attnum
+    WHERE con.contype = 'f'
+      AND nsp.nspname = 'iam'
+      AND rel.relname = instance_table.table_name
+      AND target_nsp.nspname = 'iam'
+      AND target_rel.relname = 'instances'
+      AND source_att.attname = 'instance_id'
+  )
+)
+SELECT table_name
+FROM tables_without_direct_instance_fk
+ORDER BY table_name;
+`;
+
+export const resolveUnknownNonCascadeInstanceTables = (tableNames: readonly string[]): string[] =>
+  [...new Set(tableNames.filter((tableName) => !KNOWN_NON_CASCADE_INSTANCE_TABLES.has(tableName)))].sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+const run = (commandName: string, args: readonly string[], input?: string) => {
+  const result = spawnSync(commandName, args, {
+    cwd: rootDir,
+    encoding: 'utf8',
+    input,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr?.trim() || `${commandName} ${args.join(' ')} failed`);
+  }
+
+  return result.stdout;
+};
+
+const dockerPsql = (container: string, dbUser: string, dbName: string, sql: string) =>
+  run('docker', ['exec', '-i', container, 'psql', '-v', 'ON_ERROR_STOP=1', '-U', dbUser, '-d', dbName], sql);
+
+const dockerPsqlQuiet = (container: string, dbUser: string, dbName: string, sql: string) =>
+  run('docker', ['exec', '-i', container, 'psql', '-At', '-F', '\t', '-U', dbUser, '-d', dbName], sql).trim();
+
+const logStep = (message: string) => {
+  process.stdout.write(`\n==> ${message}\n`);
+};
+
+const parseTabSeparatedRows = (raw: string): string[][] =>
+  raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split('\t'));
+
+const loadSummary = (options: DeleteLocalInstanceCliOptions) => {
+  const raw = dockerPsqlQuiet(
+    options.targetDbContainer,
+    options.targetDbUser,
+    options.targetDbName,
+    buildDeleteLocalInstanceSummarySql(options.targetInstanceId),
+  );
+
+  return Object.fromEntries(parseTabSeparatedRows(raw).map(([tableName, rowCount]) => [tableName, Number.parseInt(rowCount, 10)]));
+};
+
+const loadNonCascadeInstanceTables = (options: DeleteLocalInstanceCliOptions) => {
+  const raw = dockerPsqlQuiet(
+    options.targetDbContainer,
+    options.targetDbUser,
+    options.targetDbName,
+    buildNonCascadeInstanceTableInspectionSql(),
+  );
+
+  return parseTabSeparatedRows(raw).map(([tableName]) => tableName);
+};
+
+const assertKnownSchemaShape = (options: DeleteLocalInstanceCliOptions) => {
+  const nonCascadeTables = loadNonCascadeInstanceTables(options);
+  const unknownTables = resolveUnknownNonCascadeInstanceTables(nonCascadeTables);
+
+  if (unknownTables.length > 0) {
+    throw new Error(
+      `Hard delete blocked because the schema contains unknown instance-bound non-cascade tables: ${unknownTables.join(', ')}.`,
+    );
+  }
+};
+
+const assertInstanceExists = (summary: Record<string, number>, instanceId: string) => {
+  if ((summary.instances ?? 0) === 0) {
+    throw new Error(`Instance ${instanceId} does not exist in the target database.`);
+  }
+};
+
+const renderSummary = (summary: Record<string, number>) => {
+  const lines = Object.entries(summary)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([tableName, rowCount]) => `${tableName}: ${rowCount}`);
+
+  process.stdout.write(`${lines.join('\n')}\n`);
+};
+
+const confirmDeletion = async (options: DeleteLocalInstanceCliOptions) => {
+  if (!shouldRequireInteractiveConfirmation({ dryRun: options.dryRun, isTty: Boolean(process.stdin.isTTY), yes: options.yes })) {
+    return;
+  }
+
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const confirmation = await readline.question(
+      `Type the instance id "${options.targetInstanceId}" to confirm the local hard delete: `,
+    );
+
+    if (confirmation.trim() !== options.targetInstanceId) {
+      throw new Error('Interactive confirmation did not match the target instance id.');
+    }
+  } finally {
+    readline.close();
+  }
+};
+
+const executeHardDelete = (options: DeleteLocalInstanceCliOptions) => {
+  dockerPsql(
+    options.targetDbContainer,
+    options.targetDbUser,
+    options.targetDbName,
+    buildDeleteLocalInstanceExecutionSql(options.targetInstanceId),
+  );
+};
+
+const main = async () => {
+  const options = parseDeleteLocalInstanceArgs(rawArgs);
+
+  logStep(`Pruefe Schema-Sicherungen fuer ${options.targetInstanceId}`);
+  assertKnownSchemaShape(options);
+
+  logStep(`Lese lokalen Loeschumfang fuer ${options.targetInstanceId}`);
+  const summary = loadSummary(options);
+  assertInstanceExists(summary, options.targetInstanceId);
+  renderSummary(summary);
+
+  if (options.dryRun) {
+    logStep('Dry-run aktiviert; es wurden keine Daten geloescht.');
+    return;
+  }
+
+  await confirmDeletion(options);
+
+  logStep(`Loesche lokale Instanzdaten fuer ${options.targetInstanceId}`);
+  executeHardDelete(options);
+  logStep('Lokaler Hard-Delete abgeschlossen.');
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === entrypointPath) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/delete-local-instance-db.ts
+++ b/scripts/ops/delete-local-instance-db.ts
@@ -59,6 +59,11 @@ const readOptionValue = (entry: string) => {
   };
 };
 
+const isTruthyBooleanFlagValue = (value: string): boolean => {
+  const normalizedValue = value.trim().toLowerCase();
+  return normalizedValue === '1' || normalizedValue === 'true';
+};
+
 export const parseDeleteLocalInstanceArgs = (args: readonly string[]): DeleteLocalInstanceCliOptions => {
   const values = new Map<string, string>();
   const flags = new Set<string>();
@@ -85,7 +90,10 @@ export const parseDeleteLocalInstanceArgs = (args: readonly string[]): DeleteLoc
     return value;
   };
 
-  if (!flags.has('force')) {
+  const forceValue = values.get('force');
+  const hasForceFlag = flags.has('force') || (forceValue !== undefined && isTruthyBooleanFlagValue(forceValue));
+
+  if (!hasForceFlag) {
     throw new Error('Hard delete requires the explicit --force flag.');
   }
 
@@ -194,7 +202,7 @@ const dockerPsql = (container: string, dbUser: string, dbName: string, sql: stri
   run('docker', ['exec', '-i', container, 'psql', '-v', 'ON_ERROR_STOP=1', '-U', dbUser, '-d', dbName], sql);
 
 const dockerPsqlQuiet = (container: string, dbUser: string, dbName: string, sql: string) =>
-  run('docker', ['exec', '-i', container, 'psql', '-At', '-F', '\t', '-U', dbUser, '-d', dbName], sql).trim();
+  run('docker', ['exec', '-i', container, 'psql', '-v', 'ON_ERROR_STOP=1', '-At', '-F', '\t', '-U', dbUser, '-d', dbName], sql).trim();
 
 const logStep = (message: string) => {
   process.stdout.write(`\n==> ${message}\n`);


### PR DESCRIPTION
## What changed

- add a local hard-delete helper for instance-scoped IAM data under `scripts/ops/delete-local-instance-db.ts`
- add focused test coverage for argument parsing, confirmation behavior, schema guard logic, and generated SQL under `scripts/ops/delete-local-instance-db.test.ts`
- document the local instance database bootstrap and reset workflow in `docs/guides/lokale-instanz-db-initialisierung.md`
- expose the helper through `pnpm env:delete:local-instance-db`

## Why

This adds a reproducible cleanup path for local instance databases so a broken local tenant can be deleted and rebuilt without manual `psql` work. The command is intentionally scoped to local IAM data and includes explicit safety rails.

## Impact

- no production runtime behavior changes
- improves local operations for instance bootstrap/reset workflows
- adds a documented and test-covered console path for hard deletion of local instance data

## Validation

- `pnpm check:file-placement`
- `pnpm exec vitest run scripts/ops/delete-local-instance-db.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit` *(currently fails on existing repo issues outside this branch: `packages/auth-runtime/src/iam-instance-registry/provisioning-auth-state.ts` and `scripts/ops/instance-registry.ts`)*
