### PR TITLE
feat(iam): default user creation to groups

### DIFF
--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -1902,8 +1902,13 @@ export const i18nResources = {
         createDialog: {
           title: 'Nutzer anlegen',
           description: 'Erstellt ein neues Nutzerkonto in Keycloak und IAM.',
-          roleLabel: 'Startrolle',
-          rolePlaceholder: 'Keine Rolle vorauswählen',
+          groupsLabel: 'Gruppen-Zuweisung',
+          groupsHint: 'Gruppen sind der bevorzugte Startpunkt für neue Nutzer und bündeln passende Rollen.',
+          groupsEmpty: 'Es sind keine aktiven Gruppen verfügbar.',
+          advancedRolesTitle: 'Direkte Rollen optional ergänzen',
+          advancedRolesHint:
+            'Direkte Rollen sind additive Sonderfälle und sollten nur zusätzlich zu Gruppen verwendet werden.',
+          rolePlaceholder: 'Es sind keine direkten Rollen verfügbar.',
           sendPasswordSetupEmail: 'Einladungs-E-Mail zum Passwort setzen senden',
         },
         confirm: {
@@ -4682,8 +4687,12 @@ export const i18nResources = {
         createDialog: {
           title: 'Create user',
           description: 'Creates a new user account in Keycloak and IAM.',
-          roleLabel: 'Initial role',
-          rolePlaceholder: 'No preselected role',
+          groupsLabel: 'Group assignment',
+          groupsHint: 'Groups are the preferred starting point for new users and bundle matching roles.',
+          groupsEmpty: 'No active groups are available.',
+          advancedRolesTitle: 'Optionally add direct roles',
+          advancedRolesHint: 'Direct roles are additive exceptions and should only complement groups.',
+          rolePlaceholder: 'No direct roles are available.',
           sendPasswordSetupEmail: 'Send invitation email to set password',
         },
         confirm: {

--- a/apps/sva-studio-react/src/lib/iam-api.ts
+++ b/apps/sva-studio-react/src/lib/iam-api.ts
@@ -371,6 +371,7 @@ export type CreateUserPayload = {
   readonly preferredLanguage?: string;
   readonly timezone?: string;
   readonly roleIds?: readonly string[];
+  readonly groupIds?: readonly string[];
   readonly sendPasswordSetupEmail?: boolean;
 };
 

--- a/apps/sva-studio-react/src/routes/admin/users/-user-create-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-create-page.test.tsx
@@ -213,4 +213,15 @@ describe('UserCreatePage', () => {
       )
     );
   });
+
+  it('renders empty states when no active groups or direct roles are available', () => {
+    useUsersMock.mockReturnValue(createUsersApiState());
+    useRolesMock.mockReturnValue({ roles: [] });
+    useGroupsMock.mockReturnValue({ groups: [] });
+
+    render(<UserCreatePage />);
+
+    expect(screen.getByText('Es sind keine aktiven Gruppen verfügbar.')).toBeTruthy();
+    expect(screen.getByText('Es sind keine direkten Rollen verfügbar.')).toBeTruthy();
+  });
 });

--- a/apps/sva-studio-react/src/routes/admin/users/-user-create-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-create-page.test.tsx
@@ -214,6 +214,45 @@ describe('UserCreatePage', () => {
     );
   });
 
+  it('navigates without an invite marker when the invitation was delivered normally', async () => {
+    const createUser = vi.fn().mockResolvedValue({
+      user: {
+        id: 'user-2',
+        keycloakSubject: 'subject-2',
+        displayName: 'Bob Example',
+        status: 'pending',
+        roles: [],
+        mainserverUserApplicationSecretSet: false,
+      },
+      invitation: {
+        status: 'sent',
+      },
+    });
+    useUsersMock.mockReturnValue(createUsersApiState({ createUser }));
+
+    const { container } = render(<UserCreatePage />);
+    const emailInput = container.querySelector<HTMLInputElement>('#create-user-email');
+    const firstNameInput = container.querySelector<HTMLInputElement>('#create-user-first-name');
+    const lastNameInput = container.querySelector<HTMLInputElement>('#create-user-last-name');
+
+    if (!emailInput || !firstNameInput || !lastNameInput) {
+      throw new Error('Expected create-user form inputs to be present');
+    }
+
+    fireEvent.change(emailInput, { target: { value: 'bob@example.com' } });
+    fireEvent.change(firstNameInput, { target: { value: 'Bob' } });
+    fireEvent.change(lastNameInput, { target: { value: 'Example' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Nutzer anlegen' }));
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/admin/users/$userId',
+        params: { userId: 'user-2' },
+        search: undefined,
+      })
+    );
+  });
+
   it('renders empty states when no active groups or direct roles are available', () => {
     useUsersMock.mockReturnValue(createUsersApiState());
     useRolesMock.mockReturnValue({ roles: [] });

--- a/apps/sva-studio-react/src/routes/admin/users/-user-create-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-create-page.test.tsx
@@ -7,6 +7,7 @@ import { UserCreatePage } from './-user-create-page';
 const navigateMock = vi.fn();
 const useUsersMock = vi.fn();
 const useRolesMock = vi.fn();
+const useGroupsMock = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ to, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
@@ -25,6 +26,10 @@ vi.mock('../../../hooks/use-roles', () => ({
   useRoles: () => useRolesMock(),
 }));
 
+vi.mock('../../../hooks/use-groups', () => ({
+  useGroups: () => useGroupsMock(),
+}));
+
 const createUsersApiState = (overrides: Record<string, unknown> = {}) => ({
   createUser: vi.fn(),
   error: null,
@@ -36,6 +41,9 @@ describe('UserCreatePage', () => {
     vi.clearAllMocks();
     useRolesMock.mockReturnValue({
       roles: [{ id: 'role-1', roleName: 'Editor' }],
+    });
+    useGroupsMock.mockReturnValue({
+      groups: [{ id: 'group-1', displayName: 'Redaktion', description: 'Redaktionsteam', isActive: true }],
     });
   });
 
@@ -71,7 +79,7 @@ describe('UserCreatePage', () => {
     expect(checkbox?.checked).toBe(true);
   });
 
-  it('submits the invite flag and navigates with a warning marker when invitation delivery failed', async () => {
+  it('submits selected groups as the primary assignment and navigates with a warning marker when invitation delivery failed', async () => {
     const createUser = vi.fn().mockResolvedValue({
       user: {
         id: 'user-1',
@@ -91,21 +99,23 @@ describe('UserCreatePage', () => {
     const emailInput = container.querySelector<HTMLInputElement>('#create-user-email');
     const firstNameInput = container.querySelector<HTMLInputElement>('#create-user-first-name');
     const lastNameInput = container.querySelector<HTMLInputElement>('#create-user-last-name');
-    const roleSelect = container.querySelector<HTMLSelectElement>('#create-user-role');
+    const groupCheckbox = container.querySelector<HTMLInputElement>('#create-user-group-group-1');
 
-    if (!emailInput || !firstNameInput || !lastNameInput || !roleSelect) {
+    if (!emailInput || !firstNameInput || !lastNameInput || !groupCheckbox) {
       throw new Error('Expected create-user form inputs to be present');
     }
 
     fireEvent.change(emailInput, { target: { value: 'alice@example.com' } });
     fireEvent.change(firstNameInput, { target: { value: 'Alice' } });
     fireEvent.change(lastNameInput, { target: { value: 'Example' } });
-    fireEvent.change(roleSelect, { target: { value: 'role-1' } });
+    fireEvent.click(groupCheckbox);
     fireEvent.click(screen.getByRole('button', { name: 'Nutzer anlegen' }));
 
     await waitFor(() =>
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
+          groupIds: ['group-1'],
+          roleIds: [],
           sendPasswordSetupEmail: true,
         })
       )
@@ -155,6 +165,50 @@ describe('UserCreatePage', () => {
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
           sendPasswordSetupEmail: false,
+        })
+      )
+    );
+  });
+
+  it('supports additive direct roles in the advanced section together with groups', async () => {
+    const createUser = vi.fn().mockResolvedValue({
+      user: {
+        id: 'user-1',
+        keycloakSubject: 'subject-1',
+        displayName: 'Alice Example',
+        status: 'pending',
+        roles: [],
+        mainserverUserApplicationSecretSet: false,
+      },
+      invitation: {
+        status: 'not_requested',
+      },
+    });
+    useUsersMock.mockReturnValue(createUsersApiState({ createUser }));
+
+    const { container } = render(<UserCreatePage />);
+    const emailInput = container.querySelector<HTMLInputElement>('#create-user-email');
+    const firstNameInput = container.querySelector<HTMLInputElement>('#create-user-first-name');
+    const lastNameInput = container.querySelector<HTMLInputElement>('#create-user-last-name');
+    const groupCheckbox = container.querySelector<HTMLInputElement>('#create-user-group-group-1');
+    const roleCheckbox = container.querySelector<HTMLInputElement>('#create-user-role-role-1');
+
+    if (!emailInput || !firstNameInput || !lastNameInput || !groupCheckbox || !roleCheckbox) {
+      throw new Error('Expected create-user assignment controls to be present');
+    }
+
+    fireEvent.change(emailInput, { target: { value: 'alice@example.com' } });
+    fireEvent.change(firstNameInput, { target: { value: 'Alice' } });
+    fireEvent.change(lastNameInput, { target: { value: 'Example' } });
+    fireEvent.click(groupCheckbox);
+    fireEvent.click(roleCheckbox);
+    fireEvent.click(screen.getByRole('button', { name: 'Nutzer anlegen' }));
+
+    await waitFor(() =>
+      expect(createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groupIds: ['group-1'],
+          roleIds: ['role-1'],
         })
       )
     );

--- a/apps/sva-studio-react/src/routes/admin/users/-user-create-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-create-page.tsx
@@ -8,22 +8,31 @@ import { IamRuntimeDiagnosticDetails } from '../../../components/iam-runtime-dia
 import { Checkbox } from '../../../components/ui/checkbox';
 import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
-import { Select } from '../../../components/ui/select';
+import { useGroups } from '../../../hooks/use-groups';
 import { useRoles } from '../../../hooks/use-roles';
 import { useUsers } from '../../../hooks/use-users';
 import { t } from '../../../i18n';
 import { userErrorMessage } from './-user-error-message';
 
+const appendUnique = (values: readonly string[], nextValue: string): string[] =>
+  values.includes(nextValue) ? [...values] : [...values, nextValue];
+
 export const UserCreatePage = () => {
   const navigate = useNavigate();
   const usersApi = useUsers();
   const rolesApi = useRoles();
+  const groupsApi = useGroups();
+  const selectableGroups = React.useMemo(
+    () => groupsApi.groups.filter((group) => group.isActive !== false),
+    [groupsApi.groups]
+  );
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [formValues, setFormValues] = React.useState({
     email: '',
     firstName: '',
     lastName: '',
-    roleId: '',
+    roleIds: [] as string[],
+    groupIds: [] as string[],
     sendPasswordSetupEmail: true,
   });
 
@@ -40,7 +49,8 @@ export const UserCreatePage = () => {
         firstName: formValues.firstName.trim() || undefined,
         lastName: formValues.lastName.trim() || undefined,
         displayName: `${formValues.firstName} ${formValues.lastName}`.trim() || undefined,
-        roleIds: formValues.roleId ? [formValues.roleId] : [],
+        roleIds: formValues.roleIds,
+        groupIds: formValues.groupIds,
         sendPasswordSetupEmail: formValues.sendPasswordSetupEmail,
       });
 
@@ -102,21 +112,84 @@ export const UserCreatePage = () => {
               />
             </div>
           </div>
-          <div className="grid gap-2 text-sm text-foreground">
-            <Label htmlFor="create-user-role">{t('admin.users.createDialog.roleLabel')}</Label>
-            <Select
-              id="create-user-role"
-              value={formValues.roleId}
-              onChange={(event) => setFormValues((current) => ({ ...current, roleId: event.target.value }))}
-            >
-              <option value="">{t('admin.users.createDialog.rolePlaceholder')}</option>
-              {rolesApi.roles.map((role) => (
-                <option key={role.id} value={role.id}>
-                  {role.roleName}
-                </option>
-              ))}
-            </Select>
-          </div>
+          <fieldset className="grid gap-3 rounded-lg border border-border/60 p-4">
+            <legend className="px-1 text-sm font-medium text-foreground">
+              {t('admin.users.createDialog.groupsLabel')}
+            </legend>
+            <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.groupsHint')}</p>
+            {selectableGroups.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.groupsEmpty')}</p>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2">
+                {selectableGroups.map((group) => {
+                  const selected = formValues.groupIds.includes(group.id);
+                  return (
+                    <label
+                      key={group.id}
+                      htmlFor={`create-user-group-${group.id}`}
+                      className="flex cursor-pointer items-start gap-3 rounded-md border border-border/60 p-3 text-sm text-foreground"
+                    >
+                      <Checkbox
+                        id={`create-user-group-${group.id}`}
+                        checked={selected}
+                        onChange={(event) =>
+                          setFormValues((current) => ({
+                            ...current,
+                            groupIds: event.target.checked
+                              ? appendUnique(current.groupIds, group.id)
+                              : current.groupIds.filter((entry) => entry !== group.id),
+                          }))
+                        }
+                      />
+                      <span className="space-y-1">
+                        <span className="block font-medium">{group.displayName}</span>
+                        {group.description ? (
+                          <span className="block text-xs text-muted-foreground">{group.description}</span>
+                        ) : null}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </fieldset>
+          <details className="rounded-lg border border-border/60">
+            <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-foreground">
+              {t('admin.users.createDialog.advancedRolesTitle')}
+            </summary>
+            <div className="grid gap-3 border-t border-border/60 px-4 py-4">
+              <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.advancedRolesHint')}</p>
+              <div className="grid gap-3 md:grid-cols-2">
+                {rolesApi.roles.map((role) => {
+                  const selected = formValues.roleIds.includes(role.id);
+                  return (
+                    <label
+                      key={role.id}
+                      htmlFor={`create-user-role-${role.id}`}
+                      className="flex cursor-pointer items-start gap-3 rounded-md border border-border/60 p-3 text-sm text-foreground"
+                    >
+                      <Checkbox
+                        id={`create-user-role-${role.id}`}
+                        checked={selected}
+                        onChange={(event) =>
+                          setFormValues((current) => ({
+                            ...current,
+                            roleIds: event.target.checked
+                              ? appendUnique(current.roleIds, role.id)
+                              : current.roleIds.filter((entry) => entry !== role.id),
+                          }))
+                        }
+                      />
+                      <span className="block font-medium">{role.roleName}</span>
+                    </label>
+                  );
+                })}
+              </div>
+              {rolesApi.roles.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.rolePlaceholder')}</p>
+              ) : null}
+            </div>
+          </details>
           <div className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-3 text-sm text-foreground">
             <Checkbox
               id="create-user-send-password-setup-email"

--- a/apps/sva-studio-react/src/routes/admin/users/-user-create-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-create-page.tsx
@@ -17,6 +17,112 @@ import { userErrorMessage } from './-user-error-message';
 const appendUnique = (values: readonly string[], nextValue: string): string[] =>
   values.includes(nextValue) ? [...values] : [...values, nextValue];
 
+type UserCreateFormValues = {
+  email: string;
+  firstName: string;
+  lastName: string;
+  roleIds: string[];
+  groupIds: string[];
+  sendPasswordSetupEmail: boolean;
+};
+
+type UserCreateAssignmentsProps = {
+  readonly formValues: UserCreateFormValues;
+  readonly roles: ReturnType<typeof useRoles>['roles'];
+  readonly groups: ReturnType<typeof useGroups>['groups'];
+  readonly setFormValues: React.Dispatch<React.SetStateAction<UserCreateFormValues>>;
+};
+
+const UserCreateGroupAssignments = ({
+  formValues,
+  groups,
+  setFormValues,
+}: Pick<UserCreateAssignmentsProps, 'formValues' | 'groups' | 'setFormValues'>) => (
+  <fieldset className="grid gap-3 rounded-lg border border-border/60 p-4">
+    <legend className="px-1 text-sm font-medium text-foreground">{t('admin.users.createDialog.groupsLabel')}</legend>
+    <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.groupsHint')}</p>
+    {groups.length === 0 ? (
+      <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.groupsEmpty')}</p>
+    ) : (
+      <div className="grid gap-3 md:grid-cols-2">
+        {groups.map((group) => {
+          const selected = formValues.groupIds.includes(group.id);
+          return (
+            <label
+              key={group.id}
+              htmlFor={`create-user-group-${group.id}`}
+              className="flex cursor-pointer items-start gap-3 rounded-md border border-border/60 p-3 text-sm text-foreground"
+            >
+              <Checkbox
+                id={`create-user-group-${group.id}`}
+                checked={selected}
+                onChange={(event) =>
+                  setFormValues((current) => ({
+                    ...current,
+                    groupIds: event.target.checked
+                      ? appendUnique(current.groupIds, group.id)
+                      : current.groupIds.filter((entry) => entry !== group.id),
+                  }))
+                }
+              />
+              <span className="space-y-1">
+                <span className="block font-medium">{group.displayName}</span>
+                {group.description ? (
+                  <span className="block text-xs text-muted-foreground">{group.description}</span>
+                ) : null}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    )}
+  </fieldset>
+);
+
+const UserCreateRoleAssignments = ({
+  formValues,
+  roles,
+  setFormValues,
+}: Pick<UserCreateAssignmentsProps, 'formValues' | 'roles' | 'setFormValues'>) => (
+  <details className="rounded-lg border border-border/60">
+    <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-foreground">
+      {t('admin.users.createDialog.advancedRolesTitle')}
+    </summary>
+    <div className="grid gap-3 border-t border-border/60 px-4 py-4">
+      <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.advancedRolesHint')}</p>
+      <div className="grid gap-3 md:grid-cols-2">
+        {roles.map((role) => {
+          const selected = formValues.roleIds.includes(role.id);
+          return (
+            <label
+              key={role.id}
+              htmlFor={`create-user-role-${role.id}`}
+              className="flex cursor-pointer items-start gap-3 rounded-md border border-border/60 p-3 text-sm text-foreground"
+            >
+              <Checkbox
+                id={`create-user-role-${role.id}`}
+                checked={selected}
+                onChange={(event) =>
+                  setFormValues((current) => ({
+                    ...current,
+                    roleIds: event.target.checked
+                      ? appendUnique(current.roleIds, role.id)
+                      : current.roleIds.filter((entry) => entry !== role.id),
+                  }))
+                }
+              />
+              <span className="block font-medium">{role.roleName}</span>
+            </label>
+          );
+        })}
+      </div>
+      {roles.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.rolePlaceholder')}</p>
+      ) : null}
+    </div>
+  </details>
+);
+
 export const UserCreatePage = () => {
   const navigate = useNavigate();
   const usersApi = useUsers();
@@ -27,7 +133,7 @@ export const UserCreatePage = () => {
     [groupsApi.groups]
   );
   const [isSubmitting, setIsSubmitting] = React.useState(false);
-  const [formValues, setFormValues] = React.useState({
+  const [formValues, setFormValues] = React.useState<UserCreateFormValues>({
     email: '',
     firstName: '',
     lastName: '',
@@ -112,84 +218,16 @@ export const UserCreatePage = () => {
               />
             </div>
           </div>
-          <fieldset className="grid gap-3 rounded-lg border border-border/60 p-4">
-            <legend className="px-1 text-sm font-medium text-foreground">
-              {t('admin.users.createDialog.groupsLabel')}
-            </legend>
-            <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.groupsHint')}</p>
-            {selectableGroups.length === 0 ? (
-              <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.groupsEmpty')}</p>
-            ) : (
-              <div className="grid gap-3 md:grid-cols-2">
-                {selectableGroups.map((group) => {
-                  const selected = formValues.groupIds.includes(group.id);
-                  return (
-                    <label
-                      key={group.id}
-                      htmlFor={`create-user-group-${group.id}`}
-                      className="flex cursor-pointer items-start gap-3 rounded-md border border-border/60 p-3 text-sm text-foreground"
-                    >
-                      <Checkbox
-                        id={`create-user-group-${group.id}`}
-                        checked={selected}
-                        onChange={(event) =>
-                          setFormValues((current) => ({
-                            ...current,
-                            groupIds: event.target.checked
-                              ? appendUnique(current.groupIds, group.id)
-                              : current.groupIds.filter((entry) => entry !== group.id),
-                          }))
-                        }
-                      />
-                      <span className="space-y-1">
-                        <span className="block font-medium">{group.displayName}</span>
-                        {group.description ? (
-                          <span className="block text-xs text-muted-foreground">{group.description}</span>
-                        ) : null}
-                      </span>
-                    </label>
-                  );
-                })}
-              </div>
-            )}
-          </fieldset>
-          <details className="rounded-lg border border-border/60">
-            <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium text-foreground">
-              {t('admin.users.createDialog.advancedRolesTitle')}
-            </summary>
-            <div className="grid gap-3 border-t border-border/60 px-4 py-4">
-              <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.advancedRolesHint')}</p>
-              <div className="grid gap-3 md:grid-cols-2">
-                {rolesApi.roles.map((role) => {
-                  const selected = formValues.roleIds.includes(role.id);
-                  return (
-                    <label
-                      key={role.id}
-                      htmlFor={`create-user-role-${role.id}`}
-                      className="flex cursor-pointer items-start gap-3 rounded-md border border-border/60 p-3 text-sm text-foreground"
-                    >
-                      <Checkbox
-                        id={`create-user-role-${role.id}`}
-                        checked={selected}
-                        onChange={(event) =>
-                          setFormValues((current) => ({
-                            ...current,
-                            roleIds: event.target.checked
-                              ? appendUnique(current.roleIds, role.id)
-                              : current.roleIds.filter((entry) => entry !== role.id),
-                          }))
-                        }
-                      />
-                      <span className="block font-medium">{role.roleName}</span>
-                    </label>
-                  );
-                })}
-              </div>
-              {rolesApi.roles.length === 0 ? (
-                <p className="text-sm text-muted-foreground">{t('admin.users.createDialog.rolePlaceholder')}</p>
-              ) : null}
-            </div>
-          </details>
+          <UserCreateGroupAssignments
+            formValues={formValues}
+            groups={selectableGroups}
+            setFormValues={setFormValues}
+          />
+          <UserCreateRoleAssignments
+            formValues={formValues}
+            roles={rolesApi.roles}
+            setFormValues={setFormValues}
+          />
           <div className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-3 text-sm text-foreground">
             <Checkbox
               id="create-user-send-password-setup-email"

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -558,6 +558,21 @@ Fehlerpfad:
 - Nicht existente Gruppen oder instanzfremde IDs werden mit `invalid_request` abgewiesen.
 - Läuft die Invalidation nicht sofort durch, begrenzen TTL und Recompute den Stale-Zeitraum fail-closed.
 
+### Szenario 15b: Admin legt einen Benutzer gruppenbasiert an
+
+1. Ein Admin öffnet `/admin/users/new`.
+2. Die UI bietet primär aktive Gruppen der aktuellen Instanz zur Auswahl an und führt direkte Rollen als optionale erweiterte Einstellung.
+3. Beim Speichern sendet die UI `POST /api/v1/iam/users` mit Basisprofil, optionalen `groupIds`, optionalen additiven `roleIds` und optional `sendPasswordSetupEmail`.
+4. Der Backend-Service erstellt zuerst die Identität in Keycloak und schreibt danach Account, Membership, Gruppenmitgliedschaften und direkte Rollen im Instanzkontext.
+5. Gruppen- und Rollenänderungen invalidieren die Permission-Snapshots des neuen Benutzers deterministisch über `user_group_changed` und `user_role_changed`.
+6. Wenn angefordert, stößt der Service anschließend die Keycloak-Einladungs-E-Mail zum Passwortsetzen an.
+
+Fehlerpfad:
+
+- Unbekannte oder instanzfremde Gruppen werden fail-closed mit `invalid_request` abgewiesen.
+- Scheitert der lokale Persistenzschritt nach erfolgreicher Keycloak-Anlage, deaktiviert der Service den externen Benutzer kompensierend.
+- Fehlschlägt nur die Einladungs-E-Mail, bleibt die Benutzeranlage erfolgreich und markiert den Einladungstatus als `failed`.
+
 ### Szenario 15a: Admin pflegt direkte Nutzerrechte
 
 1. Ein Admin öffnet `/admin/users/:userId` und wechselt in den Tab `Berechtigungen`.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -558,21 +558,6 @@ Fehlerpfad:
 - Nicht existente Gruppen oder instanzfremde IDs werden mit `invalid_request` abgewiesen.
 - Läuft die Invalidation nicht sofort durch, begrenzen TTL und Recompute den Stale-Zeitraum fail-closed.
 
-### Szenario 15b: Admin legt einen Benutzer gruppenbasiert an
-
-1. Ein Admin öffnet `/admin/users/new`.
-2. Die UI bietet primär aktive Gruppen der aktuellen Instanz zur Auswahl an und führt direkte Rollen als optionale erweiterte Einstellung.
-3. Beim Speichern sendet die UI `POST /api/v1/iam/users` mit Basisprofil, optionalen `groupIds`, optionalen additiven `roleIds` und optional `sendPasswordSetupEmail`.
-4. Der Backend-Service erstellt zuerst die Identität in Keycloak und schreibt danach Account, Membership, Gruppenmitgliedschaften und direkte Rollen im Instanzkontext.
-5. Gruppen- und Rollenänderungen invalidieren die Permission-Snapshots des neuen Benutzers deterministisch über `user_group_changed` und `user_role_changed`.
-6. Wenn angefordert, stößt der Service anschließend die Keycloak-Einladungs-E-Mail zum Passwortsetzen an.
-
-Fehlerpfad:
-
-- Unbekannte oder instanzfremde Gruppen werden fail-closed mit `invalid_request` abgewiesen.
-- Scheitert der lokale Persistenzschritt nach erfolgreicher Keycloak-Anlage, deaktiviert der Service den externen Benutzer kompensierend.
-- Fehlschlägt nur die Einladungs-E-Mail, bleibt die Benutzeranlage erfolgreich und markiert den Einladungstatus als `failed`.
-
 ### Szenario 15a: Admin pflegt direkte Nutzerrechte
 
 1. Ein Admin öffnet `/admin/users/:userId` und wechselt in den Tab `Berechtigungen`.
@@ -587,6 +572,21 @@ Fehlerpfad:
 - Unbekannte Permissions oder doppelte Zuordnungen im Payload werden mit `invalid_request` abgewiesen.
 - Fehlt der Admin-Kontext oder ist die Zielperson außerhalb des zulässigen Manage-Scope, endet der Vorgang fail-closed mit `forbidden`.
 - Reine Nutzerrechte-Änderungen schreiben nur Studio-IAM-Daten und lösen keinen Keycloak-Write aus.
+
+### Szenario 15b: Admin legt einen Benutzer gruppenbasiert an
+
+1. Ein Admin öffnet `/admin/users/new`.
+2. Die UI bietet primär aktive Gruppen der aktuellen Instanz zur Auswahl an und führt direkte Rollen als optionale erweiterte Einstellung.
+3. Beim Speichern sendet die UI `POST /api/v1/iam/users` mit Basisprofil, optionalen `groupIds`, optionalen additiven `roleIds` und optional `sendPasswordSetupEmail`.
+4. Der Backend-Service erstellt zuerst die Identität in Keycloak und schreibt danach Account, Membership, Gruppenmitgliedschaften und direkte Rollen im Instanzkontext.
+5. Gruppen- und Rollenänderungen invalidieren die Permission-Snapshots des neuen Benutzers deterministisch über `user_group_changed` und `user_role_changed`.
+6. Wenn angefordert, stößt der Service anschließend die Keycloak-Einladungs-E-Mail zum Passwortsetzen an.
+
+Fehlerpfad:
+
+- Unbekannte oder instanzfremde Gruppen werden fail-closed mit `invalid_request` abgewiesen.
+- Scheitert der lokale Persistenzschritt nach erfolgreicher Keycloak-Anlage, deaktiviert der Service den externen Benutzer kompensierend.
+- Fehlschlägt nur die Einladungs-E-Mail, bleibt die Benutzeranlage erfolgreich und markiert den Einladungstatus als `failed`.
 
 ### Szenario 16: Authorize wertet Geo-Hierarchie mit restriktiver Priorität aus
 

--- a/docs/guides/iam-service-api-dokumentation.md
+++ b/docs/guides/iam-service-api-dokumentation.md
@@ -62,6 +62,8 @@ Diese Anleitung beschreibt die aktuell stabilen IAM-v1-Endpunkte, Response-Envel
 - `GET /api/v1/iam/users/{userId}`
   - enthält additiv `groups[]` mit `groupId`, `groupKey`, `displayName`, `groupType`, `origin`, `validFrom`, `validTo`
 - `POST /api/v1/iam/users`
+  - akzeptiert additiv `groupIds: string[]` für initiale Gruppenmitgliedschaften im aktiven Instanzkontext
+  - akzeptiert weiterhin optionale direkte `roleIds: string[]` als additive Sonderfälle
   - akzeptiert additiv `sendPasswordSetupEmail?: boolean`
   - liefert bei erfolgreicher Anlage `data.user` plus `data.invitation.status` mit `not_requested`, `sent` oder `failed`
 - `POST /api/v1/iam/users/{userId}/send-password-setup-email`

--- a/openspec/changes/update-user-create-group-default/tasks.md
+++ b/openspec/changes/update-user-create-group-default/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Implementation
-- [ ] 1.1 Create-UI für Benutzer um primäre Gruppenauswahl erweitern und direkte Rollenwahl in einen optionalen erweiterten Bereich verschieben
-- [ ] 1.2 Benutzer-Create-Payload im Frontend um `groupIds` ergänzen und bestehende Rollen-Kompatibilität beibehalten
-- [ ] 1.3 Serverseitige Create-Schemas und Handler für optionale `groupIds` erweitern
-- [ ] 1.4 Create-Persistenz so erweitern, dass initiale Gruppenmitgliedschaften beim Anlegen geschrieben werden
-- [ ] 1.5 UI-, API- und Persistenztests für Gruppen-Standard, Rollen-Fallback und Mischfall ergänzen
-- [ ] 1.6 Betroffene Architekturdoku prüfen und bei Bedarf aktualisieren
+- [x] 1.1 Create-UI für Benutzer um primäre Gruppenauswahl erweitern und direkte Rollenwahl in einen optionalen erweiterten Bereich verschieben
+- [x] 1.2 Benutzer-Create-Payload im Frontend um `groupIds` ergänzen und bestehende Rollen-Kompatibilität beibehalten
+- [x] 1.3 Serverseitige Create-Schemas und Handler für optionale `groupIds` erweitern
+- [x] 1.4 Create-Persistenz so erweitern, dass initiale Gruppenmitgliedschaften beim Anlegen geschrieben werden
+- [x] 1.5 UI-, API- und Persistenztests für Gruppen-Standard, Rollen-Fallback und Mischfall ergänzen
+- [x] 1.6 Betroffene Architekturdoku prüfen und bei Bedarf aktualisieren

--- a/packages/auth-runtime/src/iam-account-management/schemas.ts
+++ b/packages/auth-runtime/src/iam-account-management/schemas.ts
@@ -36,7 +36,8 @@ export const createUserSchema = z.object({
   avatarUrl: z.string().url().max(1024).optional(),
   notes: z.string().trim().max(2000).optional(),
   status: z.enum(USER_STATUS).optional(),
-  roleIds: z.array(uuidLikeString('Ungültige ID.')).max(20).default([]),
+  roleIds: uniqueUuidArray(20).default([]),
+  groupIds: uniqueUuidArray(50).default([]),
   sendPasswordSetupEmail: z.boolean().optional(),
 });
 

--- a/packages/auth-runtime/src/iam-account-management/user-create-handler.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-handler.test.ts
@@ -91,11 +91,19 @@ describe('executeCreateUserWithKnownErrors', () => {
         payload: {
           email: 'alice@example.com',
           roleIds: [],
-          groupIds: [],
         },
       })
     ).rejects.toBe(knownResponse);
 
+    expect(state.executeCreateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          email: 'alice@example.com',
+          roleIds: [],
+          groupIds: [],
+        },
+      })
+    );
     expect(state.createUserMutationErrorResponse).toHaveBeenCalledWith({
       error: expect.any(Error),
       requestId: 'req-1',

--- a/packages/auth-runtime/src/iam-account-management/user-create-handler.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-handler.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  executeCreateUser: vi.fn(),
+  createUserMutationErrorResponse: vi.fn(),
+}));
+
+vi.mock('./user-create-operation.js', () => ({
+  executeCreateUser: state.executeCreateUser,
+}));
+
+vi.mock('./user-mutation-errors.js', () => ({
+  createUserMutationErrorResponse: state.createUserMutationErrorResponse,
+}));
+
+describe('executeCreateUserWithKnownErrors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clones readonly role and group ids before delegating to the create operation', async () => {
+    state.executeCreateUser.mockResolvedValue({
+      user: { id: 'user-1' },
+      invitation: { status: 'sent' },
+    });
+    state.createUserMutationErrorResponse.mockReturnValue(null);
+
+    const { executeCreateUserWithKnownErrors } = await import('./user-create-handler.js');
+    const payload = {
+      email: 'alice@example.com',
+      roleIds: ['role-1'] as const,
+      groupIds: ['group-1'] as const,
+    };
+
+    await expect(
+      executeCreateUserWithKnownErrors({
+        actor: {
+          instanceId: 'inst-1',
+          actorAccountId: 'actor-1',
+          actorRoles: ['system_admin'],
+          requestId: 'req-1',
+        },
+        actorSubject: 'subject-1',
+        identityProvider: {} as never,
+        payload,
+      })
+    ).resolves.toEqual({
+      user: { id: 'user-1' },
+      invitation: { status: 'sent' },
+    });
+
+    expect(state.executeCreateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          email: 'alice@example.com',
+          roleIds: ['role-1'],
+          groupIds: ['group-1'],
+        },
+      })
+    );
+    const delegatedPayload = state.executeCreateUser.mock.calls[0]?.[0].payload;
+    expect(delegatedPayload.roleIds).not.toBe(payload.roleIds);
+    expect(delegatedPayload.groupIds).not.toBe(payload.groupIds);
+  });
+
+  it('maps known mutation errors to thrown responses and defaults missing groups to an empty array', async () => {
+    const knownResponse = new Response(
+      JSON.stringify({
+        error: {
+          code: 'invalid_request',
+          message: 'Mindestens eine aktive Gruppe existiert nicht.',
+        },
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } }
+    );
+    state.executeCreateUser.mockRejectedValue(new Error('invalid_request:Mindestens eine aktive Gruppe existiert nicht.'));
+    state.createUserMutationErrorResponse.mockReturnValue(knownResponse);
+
+    const { executeCreateUserWithKnownErrors } = await import('./user-create-handler.js');
+
+    await expect(
+      executeCreateUserWithKnownErrors({
+        actor: {
+          instanceId: 'inst-1',
+          actorAccountId: 'actor-1',
+          actorRoles: ['system_admin'],
+          requestId: 'req-1',
+        },
+        actorSubject: 'subject-1',
+        identityProvider: {} as never,
+        payload: {
+          email: 'alice@example.com',
+          roleIds: [],
+          groupIds: [],
+        },
+      })
+    ).rejects.toBe(knownResponse);
+
+    expect(state.createUserMutationErrorResponse).toHaveBeenCalledWith({
+      error: expect.any(Error),
+      requestId: 'req-1',
+      forbiddenFallbackMessage: 'Nutzer enthält unzulässige Rollen- oder Gruppenzuweisungen.',
+    });
+  });
+
+  it('rethrows unknown create operation errors unchanged', async () => {
+    const failure = new Error('boom');
+    state.executeCreateUser.mockRejectedValue(failure);
+    state.createUserMutationErrorResponse.mockReturnValue(null);
+
+    const { executeCreateUserWithKnownErrors } = await import('./user-create-handler.js');
+
+    await expect(
+      executeCreateUserWithKnownErrors({
+        actor: {
+          instanceId: 'inst-1',
+          actorAccountId: 'actor-1',
+          actorRoles: ['system_admin'],
+        },
+        actorSubject: 'subject-1',
+        identityProvider: {} as never,
+        payload: {
+          email: 'alice@example.com',
+          roleIds: [],
+          groupIds: [],
+        },
+      })
+    ).rejects.toThrow('boom');
+  });
+});

--- a/packages/auth-runtime/src/iam-account-management/user-create-handler.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-handler.ts
@@ -106,7 +106,7 @@ const createIdpUnavailableBody = (requestId?: string) =>
 
 type CreateUserResult = Awaited<ReturnType<typeof executeCreateUser>>;
 
-const executeCreateUserWithKnownErrors: CreateUserHandlerDeps<
+export const executeCreateUserWithKnownErrors: CreateUserHandlerDeps<
   CreateUserPayload,
   IdentityProviderResolution,
   CreateUserResult

--- a/packages/auth-runtime/src/iam-account-management/user-create-handler.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-handler.ts
@@ -1,5 +1,8 @@
 import type { ApiErrorResponse } from '@sva/core';
-import { createCreateUserHandlerInternal } from '@sva/iam-admin';
+import {
+  createCreateUserHandlerInternal,
+  type CreateUserHandlerDeps,
+} from '@sva/iam-admin';
 import { getWorkspaceContext } from '@sva/server-runtime';
 
 import type { AuthenticatedRequestContext } from '../middleware.js';
@@ -24,8 +27,11 @@ import {
   resolveActorInfo,
   resolveIdentityProviderForInstance,
 } from './shared.js';
+import type { IdentityProviderResolution } from './shared-runtime.js';
 import { validateCsrf } from './csrf.js';
+import { createUserMutationErrorResponse } from './user-mutation-errors.js';
 import { executeCreateUser } from './user-create-operation.js';
+import type { CreateUserPayload } from './user-create-persistence.js';
 
 type CreateUserActorContext = {
   actor: {
@@ -98,12 +104,41 @@ const createIdpUnavailableBody = (requestId?: string) =>
     ...(requestId ? { requestId } : {}),
   }) satisfies ApiErrorResponse;
 
+type CreateUserResult = Awaited<ReturnType<typeof executeCreateUser>>;
+
+const executeCreateUserWithKnownErrors: CreateUserHandlerDeps<
+  CreateUserPayload,
+  IdentityProviderResolution,
+  CreateUserResult
+>['executeCreateUser'] = async (input) => {
+  try {
+    return await executeCreateUser({
+      ...input,
+      payload: {
+        ...input.payload,
+        roleIds: [...input.payload.roleIds],
+        groupIds: input.payload.groupIds ? [...input.payload.groupIds] : [],
+      },
+    });
+  } catch (error) {
+    const knownError = createUserMutationErrorResponse({
+      error,
+      requestId: input.actor.requestId,
+      forbiddenFallbackMessage: 'Nutzer enthält unzulässige Rollen- oder Gruppenzuweisungen.',
+    });
+    if (knownError) {
+      throw knownError;
+    }
+    throw error;
+  }
+};
+
 export const createUserInternal = createCreateUserHandlerInternal({
   asApiItem,
   completeIdempotency,
   createApiError,
   createIdpUnavailableBody,
-  executeCreateUser,
+  executeCreateUser: executeCreateUserWithKnownErrors,
   iamUserOperationsCounter,
   jsonResponse,
   parseCreateUserBody: (request) => parseRequestBody(request, createUserSchema),

--- a/packages/auth-runtime/src/iam-account-management/user-create-persistence.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-persistence.ts
@@ -4,20 +4,26 @@ import { z } from 'zod';
 import { protectField } from './encryption.js';
 import { createUserSchema } from './schemas.js';
 import {
+  assignGroups,
   assignRoles,
   emitActivityLog,
   ensureRoleAssignmentWithinActorLevel,
   notifyPermissionInvalidation,
+  resolveGroupsByIds,
+  resolveRoleIdsForGroups,
   resolveRolesByIds,
 } from './shared.js';
 
 export type CreateUserPayload = z.infer<typeof createUserSchema>;
 
 export const { persistCreatedUser } = createUserCreatePersistence({
+  assignGroups,
   assignRoles,
   emitActivityLog,
   ensureRoleAssignmentWithinActorLevel,
   notifyPermissionInvalidation,
   protectField,
+  resolveGroupsByIds,
+  resolveRoleIdsForGroups,
   resolveRolesByIds,
 });

--- a/packages/iam-admin/src/user-create-handler.test.ts
+++ b/packages/iam-admin/src/user-create-handler.test.ts
@@ -272,4 +272,38 @@ describe('createCreateUserHandlerInternal', () => {
       },
     });
   });
+
+  it('falls back to an internal error payload when a thrown response body is not valid json', async () => {
+    const deps = createDeps({
+      executeCreateUser: vi.fn(async () => {
+        throw new Response('unprocessable', {
+          status: 422,
+          headers: { 'content-type': 'text/plain' },
+        });
+      }),
+    });
+    const handler = createCreateUserHandlerInternal(deps);
+
+    const response = await handler(new Request('http://localhost/api/v1/iam/users'), ctx);
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'internal_error',
+        message: 'Nutzer konnte nicht erstellt werden.',
+      },
+    });
+    expect(deps.completeIdempotency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'FAILED',
+        responseStatus: 422,
+        responseBody: {
+          error: {
+            code: 'internal_error',
+            message: 'Nutzer konnte nicht erstellt werden.',
+          },
+        },
+      })
+    );
+  });
 });

--- a/packages/iam-admin/src/user-create-handler.test.ts
+++ b/packages/iam-admin/src/user-create-handler.test.ts
@@ -11,6 +11,7 @@ type TestPayload = {
   readonly lastName?: string;
   readonly status?: 'active' | 'inactive' | 'pending';
   readonly roleIds: readonly string[];
+  readonly groupIds?: readonly string[];
 };
 
 const actor = {
@@ -34,6 +35,7 @@ const payload = {
   firstName: 'Alice',
   status: 'active',
   roleIds: ['role-editor'],
+  groupIds: ['group-editors'],
 } satisfies TestPayload;
 
 const identityProvider = {
@@ -226,6 +228,48 @@ describe('createCreateUserHandlerInternal', () => {
     expect(deps.iamUserOperationsCounter.add).toHaveBeenCalledWith(1, {
       action: 'create_user',
       result: 'failure',
+    });
+  });
+
+  it('returns known mutation responses thrown by the create operation and stores them as failed idempotency results', async () => {
+    const invalidRequestResponse = createJsonResponse(400, {
+      error: {
+        code: 'invalid_request',
+        message: 'Mindestens eine aktive Gruppe existiert nicht.',
+      },
+      requestId: 'req-create',
+    });
+    const deps = createDeps({
+      executeCreateUser: vi.fn(async () => {
+        throw invalidRequestResponse;
+      }),
+    });
+    const handler = createCreateUserHandlerInternal(deps);
+
+    const response = await handler(new Request('http://localhost/api/v1/iam/users'), ctx);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'invalid_request',
+        message: 'Mindestens eine aktive Gruppe existiert nicht.',
+      },
+      requestId: 'req-create',
+    });
+    expect(deps.completeIdempotency).toHaveBeenCalledWith({
+      instanceId: 'de-musterhausen',
+      actorAccountId: 'actor-account-1',
+      endpoint: 'POST:/api/v1/iam/users',
+      idempotencyKey: 'idem-create-1',
+      status: 'FAILED',
+      responseStatus: 400,
+      responseBody: {
+        error: {
+          code: 'invalid_request',
+          message: 'Mindestens eine aktive Gruppe existiert nicht.',
+        },
+        requestId: 'req-create',
+      },
     });
   });
 });

--- a/packages/iam-admin/src/user-create-handler.ts
+++ b/packages/iam-admin/src/user-create-handler.ts
@@ -27,6 +27,7 @@ export type CreateUserPayloadShape = {
   readonly lastName?: string;
   readonly status?: 'active' | 'inactive' | 'pending';
   readonly roleIds: readonly string[];
+  readonly groupIds?: readonly string[];
   readonly sendPasswordSetupEmail?: boolean;
 };
 
@@ -116,6 +117,19 @@ export type CreateUserHandlerDeps<
 };
 
 const CREATE_USER_ENDPOINT = 'POST:/api/v1/iam/users';
+
+const resolveResponseBody = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.clone().json();
+  } catch {
+    return {
+      error: {
+        code: 'internal_error',
+        message: 'Nutzer konnte nicht erstellt werden.',
+      },
+    };
+  }
+};
 
 const failCreateIdempotency = async (
   deps: Pick<CreateUserHandlerDeps, 'completeIdempotency' | 'jsonResponse'>,
@@ -210,7 +224,17 @@ export const createCreateUserHandlerInternal =
       });
       deps.iamUserOperationsCounter.add(1, { action: 'create_user', result: 'success' });
       return deps.jsonResponse(201, responseBody);
-    } catch {
+    } catch (error) {
+      if (error instanceof Response) {
+        const responseBody = await resolveResponseBody(error);
+        deps.iamUserOperationsCounter.add(1, { action: 'create_user', result: 'failure' });
+        return failCreateIdempotency(deps, {
+          actor: actorContext.actor,
+          idempotencyKey: idempotencyKey.key,
+          responseStatus: error.status,
+          responseBody,
+        });
+      }
       deps.iamUserOperationsCounter.add(1, { action: 'create_user', result: 'failure' });
       return failCreateIdempotency(deps, {
         actor: actorContext.actor,

--- a/packages/iam-admin/src/user-create-persistence-support.ts
+++ b/packages/iam-admin/src/user-create-persistence-support.ts
@@ -1,0 +1,171 @@
+import type { IamUserDetail } from '@sva/core';
+
+import { getRoleExternalName } from './role-audit.js';
+import type { QueryClient } from './query-client.js';
+import type { IamGroupRow, IamRoleRow } from './types.js';
+import { mapRoles } from './user-mapping.js';
+
+type CreateUserPersistencePayload = {
+  readonly email: string;
+  readonly displayName?: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly phone?: string;
+  readonly position?: string;
+  readonly department?: string;
+  readonly avatarUrl?: string;
+  readonly preferredLanguage?: string;
+  readonly timezone?: string;
+  readonly status?: 'active' | 'inactive' | 'pending';
+  readonly notes?: string;
+  readonly roleIds: readonly string[];
+  readonly groupIds?: readonly string[];
+};
+
+type CreateUserPersistenceActor = {
+  readonly instanceId: string;
+  readonly actorAccountId: string;
+  readonly actorRoles?: readonly string[];
+  readonly requestId?: string;
+  readonly traceId?: string;
+};
+
+type CreateUserPersistenceDeps = {
+  readonly protectField: (value: string | undefined, context: string) => string | null;
+  readonly resolveGroupsByIds: (
+    client: QueryClient,
+    input: { readonly instanceId: string; readonly groupIds: readonly string[] }
+  ) => Promise<readonly IamGroupRow[]>;
+  readonly resolveRoleIdsForGroups: (
+    client: QueryClient,
+    input: { readonly instanceId: string; readonly groupIds: readonly string[] }
+  ) => Promise<readonly string[]>;
+  readonly ensureRoleAssignmentWithinActorLevel: (input: {
+    readonly client: QueryClient;
+    readonly instanceId: string;
+    readonly actorSubject: string;
+    readonly actorRoles?: readonly string[];
+    readonly roleIds: readonly string[];
+  }) => Promise<
+    { readonly ok: true; readonly roles: readonly IamRoleRow[] } | { readonly ok: false; readonly code: string; readonly message: string }
+  >;
+};
+
+export const buildDisplayName = (
+  payload: CreateUserPersistencePayload,
+  externalId: string
+): string => payload.displayName ?? ([payload.firstName, payload.lastName].filter(Boolean).join(' ') || externalId);
+
+export const buildCreateAccountParams = (
+  deps: Pick<CreateUserPersistenceDeps, 'protectField'>,
+  actor: CreateUserPersistenceActor,
+  payload: CreateUserPersistencePayload,
+  externalId: string
+): readonly (string | null)[] => [
+  actor.instanceId,
+  externalId,
+  deps.protectField(payload.email, `iam.accounts.email:${externalId}`),
+  deps.protectField(buildDisplayName(payload, externalId), `iam.accounts.display_name:${externalId}`),
+  deps.protectField(payload.firstName, `iam.accounts.first_name:${externalId}`),
+  deps.protectField(payload.lastName, `iam.accounts.last_name:${externalId}`),
+  deps.protectField(payload.phone, `iam.accounts.phone:${externalId}`),
+  payload.position ?? null,
+  payload.department ?? null,
+  payload.avatarUrl ?? null,
+  payload.preferredLanguage ?? null,
+  payload.timezone ?? null,
+  payload.status ?? 'pending',
+  payload.notes ?? null,
+];
+
+export const validateRequestedGroups = async (
+  deps: Pick<
+    CreateUserPersistenceDeps,
+    'resolveGroupsByIds' | 'resolveRoleIdsForGroups' | 'ensureRoleAssignmentWithinActorLevel'
+  >,
+  client: QueryClient,
+  input: {
+    readonly actor: CreateUserPersistenceActor;
+    readonly actorSubject: string;
+    readonly groupIds: readonly string[];
+  }
+): Promise<void> => {
+  const uniqueGroupIds = [...new Set(input.groupIds)];
+  if (uniqueGroupIds.length === 0) {
+    return;
+  }
+
+  const groups = await deps.resolveGroupsByIds(client, {
+    instanceId: input.actor.instanceId,
+    groupIds: uniqueGroupIds,
+  });
+  if (groups.length !== uniqueGroupIds.length) {
+    throw new Error('invalid_request:Mindestens eine aktive Gruppe existiert nicht.');
+  }
+
+  const groupedRoleIds = await deps.resolveRoleIdsForGroups(client, {
+    instanceId: input.actor.instanceId,
+    groupIds: uniqueGroupIds,
+  });
+  if (groupedRoleIds.length === 0) {
+    return;
+  }
+
+  const roleValidation = await deps.ensureRoleAssignmentWithinActorLevel({
+    client,
+    instanceId: input.actor.instanceId,
+    actorSubject: input.actorSubject,
+    actorRoles: input.actor.actorRoles,
+    roleIds: groupedRoleIds,
+  });
+  if (!roleValidation.ok) {
+    throw new Error(`${roleValidation.code}:${roleValidation.message}`);
+  }
+};
+
+export const resolveAssignedRoleIds = async (
+  deps: Pick<CreateUserPersistenceDeps, 'resolveRoleIdsForGroups'>,
+  client: QueryClient,
+  input: {
+    readonly instanceId: string;
+    readonly roleIds: readonly string[];
+    readonly groupIds: readonly string[];
+  }
+): Promise<readonly string[]> => {
+  const groupedRoleIds =
+    input.groupIds.length === 0
+      ? []
+      : await deps.resolveRoleIdsForGroups(client, {
+          instanceId: input.instanceId,
+          groupIds: input.groupIds,
+        });
+
+  return [...new Set([...input.roleIds, ...groupedRoleIds])];
+};
+
+export const buildCreatedUserResult = (
+  accountId: string,
+  externalId: string,
+  payload: CreateUserPersistencePayload,
+  assignedRoleRows: readonly IamRoleRow[]
+): { readonly responseData: IamUserDetail; readonly roleNames: readonly string[] } => ({
+  responseData: {
+    id: accountId,
+    keycloakSubject: externalId,
+    displayName: buildDisplayName(payload, externalId),
+    email: payload.email,
+    firstName: payload.firstName,
+    lastName: payload.lastName,
+    phone: payload.phone,
+    position: payload.position,
+    department: payload.department,
+    preferredLanguage: payload.preferredLanguage,
+    timezone: payload.timezone,
+    avatarUrl: payload.avatarUrl,
+    notes: payload.notes,
+    status: payload.status ?? 'pending',
+    roles: mapRoles(assignedRoleRows),
+    mainserverUserApplicationSecretSet: false,
+  },
+  roleNames: assignedRoleRows.map((entry) => getRoleExternalName(entry)),
+});

--- a/packages/iam-admin/src/user-create-persistence.test.ts
+++ b/packages/iam-admin/src/user-create-persistence.test.ts
@@ -194,4 +194,72 @@ describe('user-create-persistence', () => {
 
     expect(client.query).not.toHaveBeenCalled();
   });
+
+  it('skips bundled group role validation when the selected groups do not add direct roles', async () => {
+    const deps = {
+      ...createDeps(),
+      resolveRoleIdsForGroups: vi.fn(async () => []),
+    };
+    const client: QueryClient = {
+      query: vi.fn(async (text: string) => {
+        if (text.includes('RETURNING id')) {
+          return { rowCount: 1, rows: [{ id: 'account-1' }] };
+        }
+        return { rowCount: 1, rows: [] };
+      }),
+    };
+    const persistence = createUserCreatePersistence(deps);
+
+    await expect(
+      persistence.persistCreatedUser(client, {
+        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
+        actorSubject: 'subject-actor',
+        externalId: 'subject-new',
+        payload: {
+          email: 'user@example.test',
+          roleIds: [],
+          groupIds: ['group-1'],
+        },
+      })
+    ).resolves.toMatchObject({
+      responseData: expect.objectContaining({
+        id: 'account-1',
+      }),
+    });
+
+    expect(deps.ensureRoleAssignmentWithinActorLevel).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects groups that would grant bundled roles above the actor level', async () => {
+    const deps = {
+      ...createDeps(),
+      ensureRoleAssignmentWithinActorLevel: vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true as const, roles: [roleRow] })
+        .mockResolvedValueOnce({
+          ok: false as const,
+          code: 'forbidden',
+          message: 'group bundle denied',
+        }),
+    };
+    const client: QueryClient = {
+      query: vi.fn(async () => ({ rowCount: 0, rows: [] })),
+    };
+    const persistence = createUserCreatePersistence(deps);
+
+    await expect(
+      persistence.persistCreatedUser(client, {
+        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
+        actorSubject: 'subject-actor',
+        externalId: 'subject-new',
+        payload: {
+          email: 'user@example.test',
+          roleIds: ['role-1'],
+          groupIds: ['group-1'],
+        },
+      })
+    ).rejects.toThrow('forbidden:group bundle denied');
+
+    expect(client.query).not.toHaveBeenCalled();
+  });
 });

--- a/packages/iam-admin/src/user-create-persistence.test.ts
+++ b/packages/iam-admin/src/user-create-persistence.test.ts
@@ -14,16 +14,28 @@ const roleRow = {
 };
 
 const createDeps = () => ({
+  assignGroups: vi.fn(async () => undefined),
   assignRoles: vi.fn(async () => undefined),
   emitActivityLog: vi.fn(async () => undefined),
   ensureRoleAssignmentWithinActorLevel: vi.fn(async () => ({ ok: true as const, roles: [roleRow] })),
   notifyPermissionInvalidation: vi.fn(async () => undefined),
   protectField: vi.fn((value: string | undefined, context: string) => (value ? `${context}:${value}` : null)),
+  resolveGroupsByIds: vi.fn(async () => [
+    {
+      id: 'group-1',
+      group_key: 'redaktion',
+      display_name: 'Redaktion',
+      description: null,
+      group_type: 'role_bundle',
+      is_active: true,
+    },
+  ]),
+  resolveRoleIdsForGroups: vi.fn(async () => ['role-1']),
   resolveRolesByIds: vi.fn(async () => [roleRow]),
 });
 
 describe('user-create-persistence', () => {
-  it('persists a created user with membership, roles, activity log and invalidation', async () => {
+  it('persists a created user with membership, groups, roles, activity log and invalidation', async () => {
     const deps = createDeps();
     const client: QueryClient = {
       query: vi.fn(async (text: string) => {
@@ -51,6 +63,7 @@ describe('user-create-persistence', () => {
           firstName: 'Ada',
           lastName: 'Lovelace',
           roleIds: ['role-1'],
+          groupIds: ['group-1'],
         },
       })
     ).resolves.toEqual({
@@ -71,6 +84,10 @@ describe('user-create-persistence', () => {
       actorSubject: 'subject-actor',
       actorRoles: ['admin'],
       roleIds: ['role-1'],
+    });
+    expect(deps.resolveGroupsByIds).toHaveBeenCalledWith(client, {
+      instanceId: 'inst-1',
+      groupIds: ['group-1'],
     });
     expect(client.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO iam.accounts'), [
       'inst-1',
@@ -98,6 +115,12 @@ describe('user-create-persistence', () => {
       roleIds: ['role-1'],
       assignedBy: 'actor-1',
     });
+    expect(deps.assignGroups).toHaveBeenCalledWith(client, {
+      instanceId: 'inst-1',
+      accountId: 'account-1',
+      groupIds: ['group-1'],
+      origin: 'manual',
+    });
     expect(deps.emitActivityLog).toHaveBeenCalledWith(
       client,
       expect.objectContaining({
@@ -109,6 +132,11 @@ describe('user-create-persistence', () => {
       instanceId: 'inst-1',
       keycloakSubject: 'subject-new',
       trigger: 'user_role_changed',
+    });
+    expect(deps.notifyPermissionInvalidation).toHaveBeenCalledWith(client, {
+      instanceId: 'inst-1',
+      keycloakSubject: 'subject-new',
+      trigger: 'user_group_changed',
     });
   });
 
@@ -137,6 +165,32 @@ describe('user-create-persistence', () => {
         },
       })
     ).rejects.toThrow('forbidden:denied');
+
+    expect(client.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown groups before writing the account', async () => {
+    const deps = {
+      ...createDeps(),
+      resolveGroupsByIds: vi.fn(async () => []),
+    };
+    const client: QueryClient = {
+      query: vi.fn(async () => ({ rowCount: 0, rows: [] })),
+    };
+    const persistence = createUserCreatePersistence(deps);
+
+    await expect(
+      persistence.persistCreatedUser(client, {
+        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
+        actorSubject: 'subject-actor',
+        externalId: 'subject-new',
+        payload: {
+          email: 'user@example.test',
+          roleIds: [],
+          groupIds: ['missing-group'],
+        },
+      })
+    ).rejects.toThrow('invalid_request:Mindestens eine aktive Gruppe existiert nicht.');
 
     expect(client.query).not.toHaveBeenCalled();
   });

--- a/packages/iam-admin/src/user-create-persistence.test.ts
+++ b/packages/iam-admin/src/user-create-persistence.test.ts
@@ -262,4 +262,55 @@ describe('user-create-persistence', () => {
 
     expect(client.query).not.toHaveBeenCalled();
   });
+
+  it('persists users without groups and keeps explicit display names', async () => {
+    const deps = createDeps();
+    const client: QueryClient = {
+      query: vi.fn(async (text: string) => {
+        if (text.includes('RETURNING id')) {
+          return { rowCount: 1, rows: [{ id: 'account-2' }] };
+        }
+        return { rowCount: 1, rows: [] };
+      }),
+    };
+    const persistence = createUserCreatePersistence(deps);
+
+    await expect(
+      persistence.persistCreatedUser(client, {
+        actor: {
+          instanceId: 'inst-1',
+          actorAccountId: 'actor-1',
+          actorRoles: ['admin'],
+        },
+        actorSubject: 'subject-actor',
+        externalId: 'subject-new',
+        payload: {
+          email: 'user@example.test',
+          displayName: 'Ada Display',
+          roleIds: ['role-1'],
+        },
+      })
+    ).resolves.toMatchObject({
+      responseData: expect.objectContaining({
+        id: 'account-2',
+        displayName: 'Ada Display',
+      }),
+    });
+
+    expect(deps.resolveGroupsByIds).not.toHaveBeenCalled();
+    expect(deps.assignGroups).toHaveBeenCalledWith(client, {
+      instanceId: 'inst-1',
+      accountId: 'account-2',
+      groupIds: [],
+      origin: 'manual',
+    });
+    expect(deps.emitActivityLog).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          group_count: 0,
+        }),
+      })
+    );
+  });
 });

--- a/packages/iam-admin/src/user-create-persistence.test.ts
+++ b/packages/iam-admin/src/user-create-persistence.test.ts
@@ -224,10 +224,48 @@ describe('user-create-persistence', () => {
     ).resolves.toMatchObject({
       responseData: expect.objectContaining({
         id: 'account-1',
+        roles: [expect.objectContaining({ roleKey: 'editor' })],
       }),
+      roleNames: ['Editor'],
     });
 
     expect(deps.ensureRoleAssignmentWithinActorLevel).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates direct and group-derived role ids before resolving the synced role set', async () => {
+    const deps = {
+      ...createDeps(),
+      resolveRoleIdsForGroups: vi.fn(async () => ['role-1', 'role-1']),
+    };
+    const client: QueryClient = {
+      query: vi.fn(async (text: string) => {
+        if (text.includes('RETURNING id')) {
+          return { rowCount: 1, rows: [{ id: 'account-3' }] };
+        }
+        return { rowCount: 1, rows: [] };
+      }),
+    };
+    const persistence = createUserCreatePersistence(deps);
+
+    await expect(
+      persistence.persistCreatedUser(client, {
+        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
+        actorSubject: 'subject-actor',
+        externalId: 'subject-new',
+        payload: {
+          email: 'user@example.test',
+          roleIds: ['role-1'],
+          groupIds: ['group-1'],
+        },
+      })
+    ).resolves.toMatchObject({
+      roleNames: ['Editor'],
+    });
+
+    expect(deps.resolveRolesByIds).toHaveBeenCalledWith(client, {
+      instanceId: 'inst-1',
+      roleIds: ['role-1'],
+    });
   });
 
   it('rejects groups that would grant bundled roles above the actor level', async () => {

--- a/packages/iam-admin/src/user-create-persistence.ts
+++ b/packages/iam-admin/src/user-create-persistence.ts
@@ -1,9 +1,13 @@
 import type { IamUserDetail } from '@sva/core';
 
-import { getRoleExternalName } from './role-audit.js';
 import type { QueryClient } from './query-client.js';
 import type { IamGroupRow, IamRoleRow } from './types.js';
-import { mapRoles } from './user-mapping.js';
+import {
+  buildCreateAccountParams,
+  buildCreatedUserResult,
+  resolveAssignedRoleIds,
+  validateRequestedGroups,
+} from './user-create-persistence-support.js';
 
 export type CreateUserPersistencePayload = {
   readonly email: string;
@@ -133,96 +137,7 @@ VALUES ($1, $2::uuid, 'member')
 ON CONFLICT (instance_id, account_id) DO NOTHING;
 `;
 
-const buildDisplayName = (payload: CreateUserPersistencePayload, externalId: string): string =>
-  payload.displayName ?? ([payload.firstName, payload.lastName].filter(Boolean).join(' ') || externalId);
-
 export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => {
-  const validateRequestedGroups = async (
-    client: QueryClient,
-    input: {
-      readonly actor: CreateUserPersistenceActor;
-      readonly actorSubject: string;
-      readonly groupIds: readonly string[];
-    }
-  ) => {
-    const uniqueGroupIds = [...new Set(input.groupIds)];
-    if (uniqueGroupIds.length === 0) {
-      return;
-    }
-
-    const groups = await deps.resolveGroupsByIds(client, {
-      instanceId: input.actor.instanceId,
-      groupIds: uniqueGroupIds,
-    });
-    if (groups.length !== uniqueGroupIds.length) {
-      throw new Error('invalid_request:Mindestens eine aktive Gruppe existiert nicht.');
-    }
-
-    const groupedRoleIds = await deps.resolveRoleIdsForGroups(client, {
-      instanceId: input.actor.instanceId,
-      groupIds: uniqueGroupIds,
-    });
-    if (groupedRoleIds.length === 0) {
-      return;
-    }
-
-    const roleValidation = await deps.ensureRoleAssignmentWithinActorLevel({
-      client,
-      instanceId: input.actor.instanceId,
-      actorSubject: input.actorSubject,
-      actorRoles: input.actor.actorRoles,
-      roleIds: groupedRoleIds,
-    });
-    if (!roleValidation.ok) {
-      throw new Error(`${roleValidation.code}:${roleValidation.message}`);
-    }
-  };
-
-  const buildCreateAccountParams = (
-    actor: CreateUserPersistenceActor,
-    payload: CreateUserPersistencePayload,
-    externalId: string
-  ): readonly (string | null)[] => [
-    actor.instanceId,
-    externalId,
-    deps.protectField(payload.email, `iam.accounts.email:${externalId}`),
-    deps.protectField(buildDisplayName(payload, externalId), `iam.accounts.display_name:${externalId}`),
-    deps.protectField(payload.firstName, `iam.accounts.first_name:${externalId}`),
-    deps.protectField(payload.lastName, `iam.accounts.last_name:${externalId}`),
-    deps.protectField(payload.phone, `iam.accounts.phone:${externalId}`),
-    payload.position ?? null,
-    payload.department ?? null,
-    payload.avatarUrl ?? null,
-    payload.preferredLanguage ?? null,
-    payload.timezone ?? null,
-    payload.status ?? 'pending',
-    payload.notes ?? null,
-  ];
-
-  const buildCreatedUserResponse = (
-    accountId: string,
-    externalId: string,
-    payload: CreateUserPersistencePayload,
-    roleNames: ReturnType<typeof mapRoles>
-  ): IamUserDetail => ({
-    id: accountId,
-    keycloakSubject: externalId,
-    displayName: buildDisplayName(payload, externalId),
-    email: payload.email,
-    firstName: payload.firstName,
-    lastName: payload.lastName,
-    phone: payload.phone,
-    position: payload.position,
-    department: payload.department,
-    preferredLanguage: payload.preferredLanguage,
-    timezone: payload.timezone,
-    avatarUrl: payload.avatarUrl,
-    notes: payload.notes,
-    status: payload.status ?? 'pending',
-    roles: roleNames,
-    mainserverUserApplicationSecretSet: false,
-  });
-
   const persistCreatedUser = async (
     client: QueryClient,
     input: {
@@ -243,7 +158,7 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
     if (!roleValidation.ok) {
       throw new Error(`${roleValidation.code}:${roleValidation.message}`);
     }
-    await validateRequestedGroups(client, {
+    await validateRequestedGroups(deps, client, {
       actor,
       actorSubject,
       groupIds: payload.groupIds ?? [],
@@ -251,7 +166,7 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
 
     const inserted = await client.query<{ readonly id: string }>(
       INSERT_ACCOUNT_QUERY,
-      buildCreateAccountParams(actor, payload, externalId)
+      buildCreateAccountParams(deps, actor, payload, externalId)
     );
     const accountId = inserted.rows[0]?.id;
     if (!accountId) {
@@ -272,9 +187,14 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
       origin: 'manual',
     });
 
-    const assignedRoleRows = await deps.resolveRolesByIds(client, {
+    const assignedRoleIds = await resolveAssignedRoleIds(deps, client, {
       instanceId: actor.instanceId,
       roleIds: payload.roleIds,
+      groupIds: payload.groupIds ?? [],
+    });
+    const assignedRoleRows = await deps.resolveRolesByIds(client, {
+      instanceId: actor.instanceId,
+      roleIds: assignedRoleIds,
     });
 
     await deps.emitActivityLog(client, {
@@ -303,10 +223,7 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
       trigger: 'user_group_changed',
     });
 
-    return {
-      responseData: buildCreatedUserResponse(accountId, externalId, payload, mapRoles(assignedRoleRows)),
-      roleNames: assignedRoleRows.map((entry) => getRoleExternalName(entry)),
-    };
+    return buildCreatedUserResult(accountId, externalId, payload, assignedRoleRows);
   };
 
   return {

--- a/packages/iam-admin/src/user-create-persistence.ts
+++ b/packages/iam-admin/src/user-create-persistence.ts
@@ -2,7 +2,7 @@ import type { IamUserDetail } from '@sva/core';
 
 import { getRoleExternalName } from './role-audit.js';
 import type { QueryClient } from './query-client.js';
-import type { IamRoleRow } from './types.js';
+import type { IamGroupRow, IamRoleRow } from './types.js';
 import { mapRoles } from './user-mapping.js';
 
 export type CreateUserPersistencePayload = {
@@ -19,6 +19,7 @@ export type CreateUserPersistencePayload = {
   readonly status?: 'active' | 'inactive' | 'pending';
   readonly notes?: string;
   readonly roleIds: readonly string[];
+  readonly groupIds?: readonly string[];
 };
 
 export type CreateUserPersistenceActor = {
@@ -41,6 +42,15 @@ type CreateUserActivityLogInput = {
 };
 
 export type CreateUserPersistenceDeps = {
+  readonly assignGroups: (
+    client: QueryClient,
+    input: {
+      readonly instanceId: string;
+      readonly accountId: string;
+      readonly groupIds: readonly string[];
+      readonly origin?: 'manual' | 'seed' | 'sync';
+    }
+  ) => Promise<void>;
   readonly assignRoles: (
     client: QueryClient,
     input: {
@@ -67,6 +77,14 @@ export type CreateUserPersistenceDeps = {
     }
   ) => Promise<void>;
   readonly protectField: (value: string | undefined, context: string) => string | null;
+  readonly resolveGroupsByIds: (
+    client: QueryClient,
+    input: { readonly instanceId: string; readonly groupIds: readonly string[] }
+  ) => Promise<readonly IamGroupRow[]>;
+  readonly resolveRoleIdsForGroups: (
+    client: QueryClient,
+    input: { readonly instanceId: string; readonly groupIds: readonly string[] }
+  ) => Promise<readonly string[]>;
   readonly resolveRolesByIds: (
     client: QueryClient,
     input: { readonly instanceId: string; readonly roleIds: readonly string[] }
@@ -119,6 +137,47 @@ const buildDisplayName = (payload: CreateUserPersistencePayload, externalId: str
   payload.displayName ?? ([payload.firstName, payload.lastName].filter(Boolean).join(' ') || externalId);
 
 export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => {
+  const validateRequestedGroups = async (
+    client: QueryClient,
+    input: {
+      readonly actor: CreateUserPersistenceActor;
+      readonly actorSubject: string;
+      readonly groupIds: readonly string[];
+    }
+  ) => {
+    const uniqueGroupIds = [...new Set(input.groupIds)];
+    if (uniqueGroupIds.length === 0) {
+      return;
+    }
+
+    const groups = await deps.resolveGroupsByIds(client, {
+      instanceId: input.actor.instanceId,
+      groupIds: uniqueGroupIds,
+    });
+    if (groups.length !== uniqueGroupIds.length) {
+      throw new Error('invalid_request:Mindestens eine aktive Gruppe existiert nicht.');
+    }
+
+    const groupedRoleIds = await deps.resolveRoleIdsForGroups(client, {
+      instanceId: input.actor.instanceId,
+      groupIds: uniqueGroupIds,
+    });
+    if (groupedRoleIds.length === 0) {
+      return;
+    }
+
+    const roleValidation = await deps.ensureRoleAssignmentWithinActorLevel({
+      client,
+      instanceId: input.actor.instanceId,
+      actorSubject: input.actorSubject,
+      actorRoles: input.actor.actorRoles,
+      roleIds: groupedRoleIds,
+    });
+    if (!roleValidation.ok) {
+      throw new Error(`${roleValidation.code}:${roleValidation.message}`);
+    }
+  };
+
   const buildCreateAccountParams = (
     actor: CreateUserPersistenceActor,
     payload: CreateUserPersistencePayload,
@@ -184,6 +243,11 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
     if (!roleValidation.ok) {
       throw new Error(`${roleValidation.code}:${roleValidation.message}`);
     }
+    await validateRequestedGroups(client, {
+      actor,
+      actorSubject,
+      groupIds: payload.groupIds ?? [],
+    });
 
     const inserted = await client.query<{ readonly id: string }>(
       INSERT_ACCOUNT_QUERY,
@@ -201,6 +265,12 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
       roleIds: payload.roleIds,
       assignedBy: actor.actorAccountId,
     });
+    await deps.assignGroups(client, {
+      instanceId: actor.instanceId,
+      accountId,
+      groupIds: payload.groupIds ?? [],
+      origin: 'manual',
+    });
 
     const assignedRoleRows = await deps.resolveRolesByIds(client, {
       instanceId: actor.instanceId,
@@ -216,6 +286,7 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
       payload: {
         target_keycloak_subject: externalId,
         role_count: payload.roleIds.length,
+        group_count: payload.groupIds?.length ?? 0,
       },
       requestId: actor.requestId,
       traceId: actor.traceId,
@@ -225,6 +296,11 @@ export const createUserCreatePersistence = (deps: CreateUserPersistenceDeps) => 
       instanceId: actor.instanceId,
       keycloakSubject: externalId,
       trigger: 'user_role_changed',
+    });
+    await deps.notifyPermissionInvalidation(client, {
+      instanceId: actor.instanceId,
+      keycloakSubject: externalId,
+      trigger: 'user_group_changed',
     });
 
     return {


### PR DESCRIPTION
## Summary
- make group assignments the primary path in the admin user create flow
- carry `groupIds` through the frontend, auth runtime, and IAM admin persistence layers
- add targeted tests and a small page refactor to satisfy coverage and complexity gates

## Testing
- `pnpm test:pr` (with Node `22.13.0` from `.nvmrc`)
