### PR TITLE
[codex] add report-only runtime guardrail visibility

### DIFF
--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/design.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/design.md
@@ -2,6 +2,8 @@
 
 Die Befunde konzentrieren sich nicht auf einzelne Defekte, sondern auf Vertragslücken zwischen Auth-Runtime, Plugin-SDK, Host-Routing und CI-Governance. Das gemeinsame Muster ist, dass Konventionen bereits existieren, aber nicht deterministisch zur Build- oder Boot-Zeit erzwungen werden.
 
+Ein erster report-only Sichtbarkeits-Slice ist inzwischen implementiert. Er verdrahtet additive Guardrail-Checks in `env:doctor:studio`, `env:precheck:studio` und `pnpm check:guardrails:report`, ohne bestehende Exit-Codes oder harte Qualitäts-Gates zu verändern. Damit gibt es jetzt echte Laufzeit- und Architektur-Befunde aus dem Workspace, noch bevor Enforcement aktiviert wurde.
+
 ## Goals / Non-Goals
 
 - Goals:
@@ -16,6 +18,7 @@ Die Befunde konzentrieren sich nicht auf einzelne Defekte, sondern auf Vertragsl
 
 ## Decisions
 
+- Decision: Der Change wird in mindestens zwei Delivery-Slices umgesetzt: zuerst Sichtbarkeit ohne Blockade, danach schrittweise Enforcement der neuen Verträge.
 - Decision: Session-Refresh bleibt serverseitig und Redis-basiert, wird aber pro `sessionId` serialisiert, sodass für parallele Requests genau ein Refresh-Schreiber gewinnt und konkurrierende Requests das Ergebnis wiederverwenden.
 - Decision: `/auth/me` bleibt der kanonische Auth-Read, gibt aber nur eine explizite Allowlist stabiler Felder aus; neue interne Session- oder Profilfelder werden nicht per Object-Spread exponiert.
 - Decision: Der Host validiert Plugin-Beiträge vor Snapshot-Publikation gegen einen kanonischen Preflight-Vertrag für Namespace, SDK-SemVer, Routen, Permission-Referenzen, Translation-Ownership und Aktivierungsstatus.
@@ -26,6 +29,12 @@ Die Befunde konzentrieren sich nicht auf einzelne Defekte, sondern auf Vertragsl
 - Decision: Kritische Module dürfen bei offenen Hotspots weder Coverage-Floors absenken noch Komplexität weiter steigern; stattdessen gilt Ratcheting plus dokumentierter Refactoring-Backlog.
 
 ## Workstreams
+
+0. Sichtbarkeit ohne Blockade
+   - Report-only Guardrail-Runner
+   - Einbindung in `doctor` und `precheck`
+   - Maschinenlesbare Guardrail-Befunde mit `wouldFailInEnforcement`
+   - Erste Triage von Drift, False Positives und funktionalem Risiko
 
 1. Auth- und Runtime-Härtung
    - Session-Refresh serialisieren
@@ -51,15 +60,32 @@ Die Befunde konzentrieren sich nicht auf einzelne Defekte, sondern auf Vertragsl
    - Hostvalidierte Invalidation-Tags für Mutationen
    - Gemeinsame Cache-Invalidierung über Core und Plugins
 
+## Aktuelle Erkenntnisse aus der report-only Phase
+
+- Plugin-Vertrag:
+  - Die Workspace-Plugins `news`, `events`, `poi` und `waste-management` dokumentieren aktuell keine explizite SDK-Kompatibilitäts-Range im sichtbaren Vertrag; der report-only Check meldet dies bereits als Migrations- und Enforcement-Vorarbeit.
+- Architekturdrift:
+  - Der aktuelle server-only Leak-Check ist bewusst heuristisch und meldet viele Treffer.
+  - Ein Teil davon ist wahrscheinlich legitim, etwa Server-Entrypoints oder bewusst serverseitige Adapter.
+  - Ein anderer Teil ist echte Architekturdrift oder ein potenzieller Bundling-Risikobereich, insbesondere bei servernahen Imports in nicht explizit server-only markierten Modulen.
+- Runtime-Boot:
+  - Der report-only Lauf sieht aktuell keinen unmittelbaren OTEL- oder Migrations-Befund, bestätigt aber nur Sichtbarkeit, nicht Enforcement.
+- Auth-Session:
+  - Vorhandene Session-/Auth-Testpfade sind sichtbar, aber die eigentliche Konkurrenzsemantik für Refreshes und die adapterübergreifende Parität sind weiterhin unimplementiert.
+- Cache-Vertrag:
+  - Die ersten Inventar-Befunde zeigen Mutations-/Refresh-Pfade ohne zentral sichtbaren Invalidierungsvertrag; das ist eher funktionales Risiko als reine Stilabweichung.
+
 ## Risks / Trade-offs
 
 - Strengere Build- und Boot-Gates können bestehende Drift sofort sichtbar machen und zunächst mehrere rote Checks freilegen.
 - Die typisierte Plugin-Route-Schnittstelle ist ein öffentlicher SDK-Vertrag und braucht eine klar dokumentierte Migrationsphase für bestehende Plugins.
 - Runtime-Aktivierungsflags für build-linked Plugins reduzieren nicht den Build-Kopplungsgrad, schaffen aber einen kontrollierbaren Betriebshebel ohne Vollumbau.
+- Die report-only Phase reduziert Delivery-Risiko, kann aber wegen heuristischer Checks zunächst gemischte Befunde aus echten Problemen, legitimen Serverfällen und False Positives liefern; deshalb ist eine explizite Triage Teil des Changes.
 
 ## Migration Plan
 
-1. Zuerst Guardrails einführen, die inkonsistente Zustände sichtbar machen, ohne sofort alle Callsites umzubauen.
-2. Danach Auth- und Plugin-Hotspots auf die neuen Verträge migrieren und Characterization-Tests für Redis-, Build-time- und Host-Routing-Pfade ergänzen.
-3. Anschließend CI-Gates scharf schalten und die verbleibenden Exemptions, Floors und Hotspots dokumentiert abbauen.
-4. Die neuen Verträge in arc42 und mindestens einer ADR für Plugin- und Runtime-Guardrails verankern.
+1. Zuerst Guardrails einführen, die inkonsistente Zustände sichtbar machen, ohne sofort alle Callsites umzubauen. Dieser Slice ist mit report-only Checks in `doctor`, `precheck` und `check:guardrails:report` gestartet.
+2. Danach die report-only Befunde triagieren: legitime Serverfälle, echte Architekturdrift und funktionales Risiko voneinander trennen.
+3. Anschließend Auth- und Plugin-Hotspots auf die neuen Verträge migrieren und Characterization-Tests für Redis-, Build-time- und Host-Routing-Pfade ergänzen.
+4. Danach CI-Gates und Boot-Verträge schrittweise von report-only auf fail-fast anheben und die verbleibenden Exemptions, Floors und Hotspots dokumentiert abbauen.
+5. Die neuen Verträge in arc42 und mindestens einer ADR für Plugin- und Runtime-Guardrails verankern.

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/proposal.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/proposal.md
@@ -6,11 +6,20 @@ Die aktuelle Architektur hat mehrere runtime-emergente und paketübergreifende R
 
 ## What Changes
 
+- Als erster Delivery-Slice wird eine report-only Sichtbarkeitsphase eingeführt: neue Guardrail-Signale erscheinen in `env:doctor:studio`, `env:precheck:studio` und `pnpm check:guardrails:report`, ohne bestehende PR-, Build- oder Deploy-Gates zu verschärfen.
 - Der Auth-Session-Pfad wird für parallele Requests, minimale `/auth/me`-Payloads und adapterübergreifende Session-Store-Parität normativ gehärtet.
 - Der Plugin-Vertrag wird an den Host gebunden: fail-fast bei Routen- und Translation-Kollisionen, SDK-Kompatibilitätsprüfung, typisierte Routenbeiträge, runtime-fähige Aktivierung und zentrale IAM-Cross-Validation.
 - Die Plattform führt harte Architektur-Gates für Dependency-Graph, i18n, server-only Importe, Interfaces-Leaks, Migrationsdrift und OTEL-Bootstrapping ein.
 - Kritische Auth-, Registry- und Routing-Hotspots erhalten strengere Coverage- und Komplexitäts-Governance inklusive Ratcheting- und No-Growth-Regeln.
 - Host und Plugins erhalten einen gemeinsamen Invalidation-Tag-Vertrag, damit Mutationen cache-konsistent über Paketgrenzen hinweg bleiben.
+
+## Current Findings
+
+- Der report-only Plugin-Contract-Check macht aktuell sichtbar, dass die Workspace-Plugins `news`, `events`, `poi` und `waste-management` zwar eine `sdkVersion`, aber noch keine explizite SDK-Kompatibilitäts-Range im sichtbaren Vertrag dokumentieren.
+- Der report-only Architektur-Check meldet derzeit viele server-only Importpfade; ein Teil davon ist bewusst serverseitige Verdrahtung, ein anderer Teil ist Architekturdrift oder potenzieller Bundling-/Boundary-Risikobereich und muss noch triagiert werden.
+- Der report-only Runtime-Boot-Check sieht aktuell keinen akuten Befund: OTEL-/Logger-Modus und die zuletzt bekannte Migration sind sichtbar, werden aber noch nicht fail-closed erzwungen.
+- Der report-only Auth-Session-Check zeigt vorhandene Characterization-Pfade, aber die eigentliche Serialisierung von Refresh-Konkurrenz und die Adapter-Paritätsprüfung bleiben offen.
+- Der report-only Cache-Contract-Check hat exemplarisch Mutations-/Refresh-Pfade ohne zentral sichtbaren Invalidierungsvertrag identifiziert, aktuell unter anderem `apps/sva-studio-react/src/hooks/use-plugin-operation-jobs.ts` und `apps/sva-studio-react/src/hooks/use-runtime-health.ts`.
 
 ## Impact
 

--- a/openspec/changes/refactor-cross-cutting-runtime-guardrails/tasks.md
+++ b/openspec/changes/refactor-cross-cutting-runtime-guardrails/tasks.md
@@ -1,3 +1,10 @@
+## 0. Sichtbarkeit ohne Blockade
+
+- [x] 0.1 Report-only Guardrail-Runner mit menschenlesbarer und JSON-fähiger Ausgabe einführen
+- [x] 0.2 `env:doctor:studio` und `env:precheck:studio` um additive Guardrail-Checks erweitern, ohne neue `error`-Gates zu erzeugen
+- [x] 0.3 Report-only Checks für Plugin-Vertrag, Architekturdrift, Runtime-Boot, Auth-Session und Cache-Vertrag verdrahten
+- [x] 0.4 Erste Befunde aus dem report-only Lauf dokumentieren und als Grundlage für spätere Enforcement-Slices festhalten
+
 ## 1. Auth- und Runtime-Härtung
 
 - [ ] 1.1 Session-Characterization-Tests für parallele Refreshes gegen Redis-Session-Store ergänzen
@@ -24,8 +31,8 @@
 ## 4. CI- und Architektur-Gates
 
 - [ ] 4.1 Dependency-Graph- oder dependency-cruiser-Snapshot als CI-Gate einführen
-- [ ] 4.2 i18n-Key-Extraktion und Missing-Key-Check in lokale Qualitätsläufe und CI aufnehmen
-- [ ] 4.3 `.server.ts`-, server-only- und `interfaces-api`-Leak-Gates als statische Prüfungen verankern
+- [ ] 4.2 i18n-Key-Extraktion und Missing-Key-Check in lokale Qualitätsläufe und CI aufnehmen (report-only Heuristik existiert bereits, Enforcement fehlt)
+- [ ] 4.3 `.server.ts`-, server-only- und `interfaces-api`-Leak-Gates als statische Prüfungen verankern (aktuell nur report-only Heuristik, inklusive Triage von False Positives)
 - [ ] 4.4 Coverage-Policy für kritische Auth-, Registry- und Routing-Pakete in Richtung `85%` ratcheten
 - [ ] 4.5 Komplexitäts-Policy für offene Auth-Hotspots auf No-Growth und verpflichtende Zerlegung umstellen
 
@@ -34,3 +41,4 @@
 - [ ] 5.1 Betroffene arc42-Abschnitte `04`, `05`, `06`, `08`, `09`, `10` und `11` aktualisieren
 - [ ] 5.2 Eine ADR für Plugin-Guardrails und Runtime-Boot-Guardrails anlegen oder fortschreiben
 - [ ] 5.3 Dokumentierte Übergangs- und Exemption-Liste für bestehende Plugin- und Qualitäts-Abweichungen pflegen
+- [ ] 5.4 Report-only Warnungen in `nur Architekturdrift`, `bewusst serverseitig`, `funktionales Risiko` triagieren und dokumentieren

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "clean:source-artifacts": "pnpm clean:generated-source-artifacts",
     "check:file-placement": "tsx scripts/ci/check-file-placement.ts",
     "check:file-placement:staged": "tsx scripts/ci/check-file-placement.ts --staged",
+    "check:guardrails:report": "tsx scripts/ci/guardrail-report.ts",
     "check:openapi:iam": "tsx scripts/ci/check-openapi-iam.ts",
     "check:server-runtime": "env -u NO_COLOR NODE_OPTIONS=\"${NODE_OPTIONS:-} --import=./scripts/ci/node-listener-budget.mjs\" nx run-many -t check:runtime --parallel=1",
     "check:server-runtime:affected": "env -u NO_COLOR NODE_OPTIONS=\"${NODE_OPTIONS:-} --import=./scripts/ci/node-listener-budget.mjs\" nx affected --target=check:runtime --base=${NX_BASE:-origin/main} --parallel=1",

--- a/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
@@ -538,6 +538,7 @@ describe('waste management helper modules', () => {
 
     const setSaving = vi.fn();
     const setMessage = vi.fn();
+    const setLastOutcome = vi.fn();
     const setDialogOpen = vi.fn();
     const setRegionDialogOpen = vi.fn();
     const loadOverview = vi.fn().mockResolvedValue(undefined);
@@ -548,6 +549,7 @@ describe('waste management helper modules', () => {
       regionForm: { id: 'region-1', name: 'Nord' },
       setSaving,
       setMessage,
+      setLastOutcome,
       setDialogOpen,
       setRegionDialogOpen,
     } as never;

--- a/scripts/ci/guardrail-report.ts
+++ b/scripts/ci/guardrail-report.ts
@@ -1,0 +1,544 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path, { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  createStudioPluginCatalogReport,
+  getWorkspacePluginModuleCandidates,
+  type StudioPluginCatalogConfigEntry,
+} from '../../apps/sva-studio-react/src/lib/plugin-catalog-loader.ts';
+import type { PluginDefinition, PluginManifest } from '../../packages/plugin-sdk/src/index.ts';
+import { studioModuleIamRegistry } from '../../packages/studio-module-iam/src/index.ts';
+
+export type GuardrailCheckStatus = 'ok' | 'skipped' | 'warn';
+
+export type GuardrailCheckResult = Readonly<{
+  id: string;
+  status: GuardrailCheckStatus;
+  code: string;
+  summary: string;
+  details: readonly string[];
+  evidence: Readonly<Record<string, unknown>>;
+  enforcementReady: boolean;
+  wouldFailInEnforcement: boolean;
+  affectedTargets: readonly string[];
+  suggestedNextStep: string | null;
+}>;
+
+export type GuardrailReport = Readonly<{
+  generatedAt: string;
+  runtimeProfile: string;
+  checks: readonly GuardrailCheckResult[];
+}>;
+
+export type GuardrailCheckContext = Readonly<{
+  env: NodeJS.ProcessEnv;
+  rootDir: string;
+  runtimeProfile: string;
+}>;
+
+export type GuardrailCheckDefinition = Readonly<{
+  id: string;
+  run: (context: GuardrailCheckContext) => Promise<GuardrailCheckResult>;
+}>;
+
+type RunGuardrailReportOptions = Readonly<{
+  checks?: readonly GuardrailCheckDefinition[];
+  env?: NodeJS.ProcessEnv;
+  rootDir?: string;
+  runtimeProfile: string;
+}>;
+
+type PluginCatalogConfigEntryJson = Readonly<{
+  pluginId: string;
+  sourceRef: string;
+  sourceType: 'installed-distribution' | 'linked-package' | 'workspace';
+  enabled: boolean;
+}>;
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+export const guardrailCheckOrder = [
+  'guardrail-plugin-contract',
+  'guardrail-architecture-drift',
+  'guardrail-runtime-boot',
+  'guardrail-auth-session',
+  'guardrail-cache-contract',
+] as const;
+
+export const createGuardrailCheckResult = (
+  input: Pick<GuardrailCheckResult, 'code' | 'id' | 'status' | 'summary'> &
+    Partial<Omit<GuardrailCheckResult, 'code' | 'id' | 'status' | 'summary'>>
+): GuardrailCheckResult => ({
+  id: input.id,
+  status: input.status,
+  code: input.code,
+  summary: input.summary,
+  details: input.details ?? [],
+  evidence: input.evidence ?? {},
+  enforcementReady: input.enforcementReady ?? false,
+  wouldFailInEnforcement: input.wouldFailInEnforcement ?? false,
+  affectedTargets: input.affectedTargets ?? [],
+  suggestedNextStep: input.suggestedNextStep ?? null,
+});
+
+const createSubcheckFailureResult = (id: string, error: unknown): GuardrailCheckResult =>
+  createGuardrailCheckResult({
+    id,
+    status: 'warn',
+    code: 'guardrail_subcheck_failed',
+    summary: 'Der report-only Guardrail-Check konnte nicht vollständig ausgewertet werden.',
+    details: [error instanceof Error ? error.message : String(error)],
+    evidence: {
+      error: error instanceof Error ? error.message : String(error),
+    },
+    affectedTargets: [id],
+    suggestedNextStep: 'Subcheck reparieren oder seine Vorbedingungen dokumentieren.',
+  });
+
+const walkFiles = (directory: string): string[] => {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'coverage' || entry.name === 'dist' || entry.name === 'node_modules') {
+        continue;
+      }
+      files.push(...walkFiles(entryPath));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+const normalizeRelativePath = (repoRoot: string, filePath: string): string =>
+  path.relative(repoRoot, filePath).split(path.sep).join('/');
+
+const readJsonFile = <T>(filePath: string): T => JSON.parse(readFileSync(filePath, 'utf8')) as T;
+
+const readWorkspacePluginCatalogEntries = (repoRoot: string): readonly StudioPluginCatalogConfigEntry[] => {
+  const catalogPath = resolve(repoRoot, 'apps/sva-studio-react/plugin-catalog.json');
+  const rawEntries = readJsonFile<readonly PluginCatalogConfigEntryJson[]>(catalogPath);
+  return rawEntries.filter((entry) => entry.sourceType === 'workspace');
+};
+
+const readWorkspacePluginManifest = (repoRoot: string, sourceRef: string): PluginManifest | undefined => {
+  const manifestPath = resolve(repoRoot, sourceRef, 'plugin.manifest.json');
+  return existsSync(manifestPath) ? readJsonFile<PluginManifest>(manifestPath) : undefined;
+};
+
+const importWorkspacePluginModule = async (
+  repoRoot: string,
+  entry: StudioPluginCatalogConfigEntry,
+  manifest: PluginManifest
+): Promise<Record<string, unknown> | undefined> => {
+  const packageRoot = resolve(repoRoot, entry.sourceRef);
+  for (const candidate of getWorkspacePluginModuleCandidates(manifest)) {
+    const modulePath = resolve(packageRoot, candidate);
+    if (!existsSync(modulePath)) {
+      continue;
+    }
+    return (await import(pathToFileURL(modulePath).href)) as Record<string, unknown>;
+  }
+
+  return undefined;
+};
+
+const collectPluginSdkCompatibilityFindings = (
+  entries: readonly StudioPluginCatalogConfigEntry[],
+  repoRoot: string
+): readonly string[] =>
+  entries.flatMap((entry) => {
+    const manifest = readWorkspacePluginManifest(repoRoot, entry.sourceRef);
+    if (!manifest) {
+      return [];
+    }
+
+    return manifest.sdkVersion?.trim()
+      ? [`${entry.pluginId}: sdkVersion ist gesetzt (${manifest.sdkVersion}), aber keine explizite SDK-Range dokumentiert.`]
+      : [`${entry.pluginId}: plugin.manifest.json enthaelt keine SDK-Kompatibilitaetsangabe.`];
+  });
+
+const collectPluginIamDrift = (plugins: readonly PluginDefinition[]): readonly string[] => {
+  const findings: string[] = [];
+
+  for (const plugin of plugins) {
+    const contract = studioModuleIamRegistry.get(plugin.id);
+    if (!contract) {
+      findings.push(`${plugin.id}: kein kanonischer Host-IAM-Vertrag im Registry-Snapshot gefunden.`);
+      continue;
+    }
+
+    const pluginPermissionIds = new Set((plugin.permissions ?? []).map((permission) => permission.id));
+    const contractPermissionIds = new Set(contract.permissionIds);
+
+    const missingInPlugin = [...contractPermissionIds].filter((permissionId) => !pluginPermissionIds.has(permissionId));
+    const unknownInPlugin = [...pluginPermissionIds].filter((permissionId) => !contractPermissionIds.has(permissionId));
+
+    if (missingInPlugin.length > 0) {
+      findings.push(`${plugin.id}: Host-IAM kennt weitere Permissions (${missingInPlugin.join(', ')}).`);
+    }
+    if (unknownInPlugin.length > 0) {
+      findings.push(`${plugin.id}: Plugin-Permissions sind im Host-IAM nicht kanonisch erfasst (${unknownInPlugin.join(', ')}).`);
+    }
+  }
+
+  return findings;
+};
+
+const buildPluginContractCheck = async (context: GuardrailCheckContext): Promise<GuardrailCheckResult> => {
+  const entries = readWorkspacePluginCatalogEntries(context.rootDir);
+  const report = await createStudioPluginCatalogReport({
+    catalogConfig: entries,
+    resolveManifest: (entry) => readWorkspacePluginManifest(context.rootDir, entry.sourceRef),
+    resolvePluginModule: (entry, manifest) => importWorkspacePluginModule(context.rootDir, entry, manifest),
+  });
+
+  const issueMessages = report.issues.map((issue) => `${issue.pluginId}: ${issue.code}: ${issue.message}`);
+  const sdkCompatibilityFindings = collectPluginSdkCompatibilityFindings(entries, context.rootDir);
+  const iamDriftFindings = collectPluginIamDrift(report.snapshot.registry.plugins);
+  const findings = [...issueMessages, ...sdkCompatibilityFindings, ...iamDriftFindings];
+
+  return createGuardrailCheckResult({
+    id: 'guardrail-plugin-contract',
+    status: findings.length > 0 ? 'warn' : 'ok',
+    code: findings.length > 0 ? 'plugin_contract_findings_visible' : 'plugin_contract_visible',
+    summary:
+      findings.length > 0
+        ? 'Plugin-Vertragsrisiken sind sichtbar, blockieren aber weder Snapshot noch Build.'
+        : 'Plugin-Vertrag ist report-only sichtbar; keine akuten Dry-Run-Befunde.',
+    details: findings,
+    evidence: {
+      issueCount: report.issues.length,
+      loadedPlugins: report.snapshot.registry.plugins.map((plugin) => plugin.id),
+      sdkCompatibilityFindings,
+      iamDriftFindings,
+    },
+    wouldFailInEnforcement: findings.length > 0,
+    affectedTargets: entries.map((entry) => entry.sourceRef),
+    suggestedNextStep:
+      findings.length > 0 ? 'Preflight-Validierung schrittweise von report-only auf fail-fast anheben.' : null,
+  });
+};
+
+const runI18nKeyCheck = (repoRoot: string): { readonly ok: boolean; readonly details: readonly string[] } => {
+  try {
+    const scriptSource = readFileSync(resolve(repoRoot, 'scripts/ci/check-i18n-keys.ts'), 'utf8');
+    if (!scriptSource.includes('missingUsageKeys')) {
+      return {
+        ok: false,
+        details: ['check-i18n-keys.ts enthaelt keine erwartete Missing-Key-Pruefung.'],
+      };
+    }
+    return { ok: true, details: [] };
+  } catch (error) {
+    return {
+      ok: false,
+      details: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+};
+
+const collectShortActionIdFindings = (repoRoot: string): readonly string[] => {
+  const findings: string[] = [];
+  const actionPattern = /\b(?:actionId|requiredAction|guard)\s*:\s*['"`]([a-z-]+)['"`]/g;
+
+  for (const directory of [
+    resolve(repoRoot, 'packages/auth-runtime/src'),
+    resolve(repoRoot, 'packages/iam-admin/src'),
+    resolve(repoRoot, 'packages/sva-mainserver/src/server'),
+  ]) {
+    for (const filePath of walkFiles(directory)) {
+      if (!/\.(ts|tsx)$/.test(filePath) || filePath.endsWith('.test.ts') || filePath.endsWith('.test.tsx')) {
+        continue;
+      }
+
+      const source = readFileSync(filePath, 'utf8');
+      for (const match of source.matchAll(actionPattern)) {
+        const rawValue = match[1] ?? '';
+        if (!rawValue.includes('.')) {
+          findings.push(`${normalizeRelativePath(repoRoot, filePath)} -> ${rawValue}`);
+        }
+      }
+    }
+  }
+
+  return findings;
+};
+
+const collectServerOnlyLeakFindings = (repoRoot: string): readonly string[] => {
+  const findings: string[] = [];
+  const importPattern = /from\s+['"`]([^'"`]+(?:\.server(?:\.[jt]sx?)?|\/server(?:\.[jt]sx?)?))['"`]/g;
+
+  for (const directory of [resolve(repoRoot, 'apps'), resolve(repoRoot, 'packages')]) {
+    for (const filePath of walkFiles(directory)) {
+      if (!/\.(ts|tsx)$/.test(filePath) || filePath.endsWith('.test.ts') || filePath.endsWith('.test.tsx')) {
+        continue;
+      }
+      if (filePath.endsWith('.server.ts') || filePath.endsWith('.server.tsx')) {
+        continue;
+      }
+
+      const source = readFileSync(filePath, 'utf8');
+      const matches = [...source.matchAll(importPattern)];
+      if (matches.length > 0) {
+        findings.push(
+          `${normalizeRelativePath(repoRoot, filePath)} -> ${matches
+            .map((match) => match[1] ?? '')
+            .filter((value) => value.length > 0)
+            .join(', ')}`
+        );
+      }
+    }
+  }
+
+  return findings;
+};
+
+const buildArchitectureDriftCheck = async (context: GuardrailCheckContext): Promise<GuardrailCheckResult> => {
+  const i18nCheck = runI18nKeyCheck(context.rootDir);
+  const shortActionIds = collectShortActionIdFindings(context.rootDir);
+  const serverOnlyLeaks = collectServerOnlyLeakFindings(context.rootDir);
+  const details = [
+    ...(!i18nCheck.ok ? i18nCheck.details : []),
+    ...shortActionIds.map((entry) => `Kurzform-Action-ID: ${entry}`),
+    ...serverOnlyLeaks.map((entry) => `Server-only Leak: ${entry}`),
+  ];
+
+  return createGuardrailCheckResult({
+    id: 'guardrail-architecture-drift',
+    status: details.length > 0 ? 'warn' : 'ok',
+    code: details.length > 0 ? 'architecture_drift_findings_visible' : 'architecture_drift_visible',
+    summary:
+      details.length > 0
+        ? 'Architekturdrift ist sichtbar, wird aber noch nicht als Build-Gate erzwungen.'
+        : 'Architekturdrift-Detektoren liefern im report-only Lauf keine Befunde.',
+    details,
+    evidence: {
+      i18nCheckOk: i18nCheck.ok,
+      shortActionIdCount: shortActionIds.length,
+      serverOnlyLeakCount: serverOnlyLeaks.length,
+      detectorsNotYetEnabled: ['dependency-graph-gate'],
+    },
+    wouldFailInEnforcement: details.length > 0,
+    affectedTargets: [
+      'scripts/ci/check-i18n-keys.ts',
+      'packages/auth-runtime/src',
+      'packages/sva-mainserver/src/server',
+    ],
+    suggestedNextStep:
+      details.length > 0 ? 'Vorhandene Drift in dedizierte statische Gates ueberfuehren und Altlasten abbauen.' : null,
+  });
+};
+
+const resolveLoggerMode = (env: NodeJS.ProcessEnv): 'console_to_loki' | 'degraded' | 'otel_to_loki' => {
+  const otelEnabled = !['false', '0'].includes((env.ENABLE_OTEL?.trim() || '').toLowerCase());
+  const consoleEnabled = ['true', '1'].includes((env.SVA_ENABLE_SERVER_CONSOLE_LOGS?.trim() || '').toLowerCase());
+
+  if (otelEnabled) {
+    return 'otel_to_loki';
+  }
+  if (consoleEnabled) {
+    return 'console_to_loki';
+  }
+  return 'degraded';
+};
+
+const buildRuntimeBootCheck = async (context: GuardrailCheckContext): Promise<GuardrailCheckResult> => {
+  const migrationFiles = walkFiles(resolve(context.rootDir, 'packages/data/migrations'))
+    .filter((filePath) => filePath.endsWith('.sql'))
+    .map((filePath) => normalizeRelativePath(context.rootDir, filePath))
+    .sort();
+  const latestMigration = migrationFiles.at(-1) ?? null;
+  const loggerMode = resolveLoggerMode(context.env);
+  const details = [
+    ...(loggerMode === 'degraded'
+      ? ['Observability waere ohne OTEL und ohne produktives Console-Logging degradiert.']
+      : []),
+    ...(latestMigration ? [`Letzte bekannte Migration: ${latestMigration}`] : ['Es wurden keine Goose-Migrationen gefunden.']),
+  ];
+
+  return createGuardrailCheckResult({
+    id: 'guardrail-runtime-boot',
+    status: loggerMode === 'degraded' || !latestMigration ? 'warn' : 'ok',
+    code: loggerMode === 'degraded' || !latestMigration ? 'runtime_boot_findings_visible' : 'runtime_boot_visible',
+    summary:
+      loggerMode === 'degraded' || !latestMigration
+        ? 'Runtime-Boot-Signale sind sichtbar; Drift oder Observability werden noch nicht fail-closed erzwungen.'
+        : 'Runtime-Boot-Signale sind sichtbar, ohne Request-Annahme oder Rollout zu blockieren.',
+    details,
+    evidence: {
+      latestMigration,
+      loggerMode,
+      otelEndpoint: context.env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim() || null,
+      runtimeProfile: context.runtimeProfile,
+    },
+    wouldFailInEnforcement: loggerMode === 'degraded' || !latestMigration,
+    affectedTargets: ['packages/data/migrations', 'packages/server-runtime/src/server/bootstrap.server.ts'],
+    suggestedNextStep:
+      loggerMode === 'degraded' || !latestMigration
+        ? 'Boot-Readiness spaeter um explizite Drift- und OTEL-Vorbedingungen erweitern.'
+        : null,
+  });
+};
+
+const buildAuthSessionCheck = async (context: GuardrailCheckContext): Promise<GuardrailCheckResult> => {
+  const requiredFiles = [
+    'packages/auth-runtime/src/redis-session.ts',
+    'packages/auth-runtime/src/auth-server/session.ts',
+    'packages/auth-runtime/src/redis-session.test.ts',
+    'packages/auth-runtime/src/session.test.ts',
+    'packages/auth-runtime/src/auth-server/session.test.ts',
+  ];
+  const existingFiles = requiredFiles.filter((entry) => existsSync(resolve(context.rootDir, entry)));
+  const missingFiles = requiredFiles.filter((entry) => !existingFiles.includes(entry));
+  const sessionTests = existingFiles.filter((entry) => entry.endsWith('.test.ts'));
+  const concurrencyHints = ['Promise.all', 'parallel', 'concurrent', 'refresh'];
+  const concurrencyEvidence = sessionTests.filter((entry) => {
+    const source = readFileSync(resolve(context.rootDir, entry), 'utf8');
+    return concurrencyHints.some((hint) => source.includes(hint));
+  });
+  const details = [
+    ...missingFiles.map((entry) => `Fehlender Characterization-Pfad: ${entry}`),
+    ...(concurrencyEvidence.length === 0
+      ? ['Keine explizite Konkurrenz-Characterization fuer Session-Refresh in den vorhandenen Session-Tests gefunden.']
+      : []),
+  ];
+
+  return createGuardrailCheckResult({
+    id: 'guardrail-auth-session',
+    status: details.length > 0 ? 'warn' : 'ok',
+    code: details.length > 0 ? 'auth_session_visibility_gaps' : 'auth_session_visible',
+    summary:
+      details.length > 0
+        ? 'Auth- und Session-Pfade sind sichtbar, aber Konkurrenz- und Adapter-Paritaet noch nicht normativ abgesichert.'
+        : 'Auth- und Session-Pfade haben sichtbare Characterization-Signale.',
+    details,
+    evidence: {
+      existingFiles,
+      concurrencyEvidence,
+    },
+    wouldFailInEnforcement: details.length > 0,
+    affectedTargets: [
+      'packages/auth-runtime/src/redis-session.ts',
+      'packages/auth-runtime/src/auth-server/session.ts',
+    ],
+    suggestedNextStep:
+      details.length > 0 ? 'Redis- und In-Memory-Adapter gegen denselben Konkurrenz-Testkatalog fahren.' : null,
+  });
+};
+
+const buildCacheContractCheck = async (context: GuardrailCheckContext): Promise<GuardrailCheckResult> => {
+  const mutationInventoryFiles = walkFiles(resolve(context.rootDir, 'apps/sva-studio-react/src/hooks'))
+    .filter((filePath) => (filePath.endsWith('.ts') || filePath.endsWith('.tsx')) && !filePath.endsWith('.test.ts') && !filePath.endsWith('.test.tsx'))
+    .filter((filePath) => {
+      const source = readFileSync(filePath, 'utf8');
+      return source.includes('mutation') || source.includes('create') || source.includes('update');
+    });
+
+  const filesWithoutCentralTags = mutationInventoryFiles
+    .filter((filePath) => {
+      const source = readFileSync(filePath, 'utf8');
+      return !source.includes('invalidate') && !source.includes('tag');
+    })
+    .map((filePath) => normalizeRelativePath(context.rootDir, filePath))
+    .slice(0, 10);
+
+  return createGuardrailCheckResult({
+    id: 'guardrail-cache-contract',
+    status: filesWithoutCentralTags.length > 0 ? 'warn' : 'ok',
+    code: filesWithoutCentralTags.length > 0 ? 'cache_contract_inventory_visible' : 'cache_contract_visible',
+    summary:
+      filesWithoutCentralTags.length > 0
+        ? 'Mutationspfade sind inventarisiert; ein gemeinsamer Invalidation-Tag-Vertrag fehlt noch sichtbar.'
+        : 'Mutationspfade sind report-only inventarisiert.',
+    details:
+      filesWithoutCentralTags.length > 0
+        ? filesWithoutCentralTags.map((entry) => `Mutation ohne zentral sichtbaren Tag-/Invalidierungshinweis: ${entry}`)
+        : ['Es wurden keine offensichtlichen Mutationspfade ohne Invalidierungshinweis gefunden.'],
+    evidence: {
+      sampledMutationFiles: mutationInventoryFiles.slice(0, 10).map((filePath) => normalizeRelativePath(context.rootDir, filePath)),
+      filesWithoutCentralTags,
+    },
+    wouldFailInEnforcement: filesWithoutCentralTags.length > 0,
+    affectedTargets: ['apps/sva-studio-react/src/hooks', 'packages/auth-runtime/src/iam-authorization'],
+    suggestedNextStep:
+      filesWithoutCentralTags.length > 0 ? 'Hostvalidierten Invalidation-Tag-Vertrag fuer Mutationen schrittweise einfuehren.' : null,
+  });
+};
+
+export const createDefaultGuardrailChecks = (): readonly GuardrailCheckDefinition[] => [
+  { id: 'guardrail-plugin-contract', run: buildPluginContractCheck },
+  { id: 'guardrail-architecture-drift', run: buildArchitectureDriftCheck },
+  { id: 'guardrail-runtime-boot', run: buildRuntimeBootCheck },
+  { id: 'guardrail-auth-session', run: buildAuthSessionCheck },
+  { id: 'guardrail-cache-contract', run: buildCacheContractCheck },
+];
+
+export const runGuardrailReport = async (options: RunGuardrailReportOptions): Promise<GuardrailReport> => {
+  const context: GuardrailCheckContext = {
+    env: options.env ?? process.env,
+    rootDir: options.rootDir ?? rootDir,
+    runtimeProfile: options.runtimeProfile,
+  };
+
+  const checks = options.checks ?? createDefaultGuardrailChecks();
+  const results: GuardrailCheckResult[] = [];
+
+  for (const check of checks) {
+    try {
+      results.push(await check.run(context));
+    } catch (error) {
+      results.push(createSubcheckFailureResult(check.id, error));
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    runtimeProfile: options.runtimeProfile,
+    checks: results,
+  };
+};
+
+const printHumanReadableReport = (report: GuardrailReport): void => {
+  console.log(`Guardrail-Report fuer ${report.runtimeProfile}`);
+  for (const check of report.checks) {
+    console.log(`[${check.status.toUpperCase()}] ${check.id}: ${check.summary}`);
+    for (const detail of check.details) {
+      console.log(`  - ${detail}`);
+    }
+  }
+};
+
+const main = async (): Promise<void> => {
+  const report = await runGuardrailReport({
+    runtimeProfile: process.env.SVA_RUNTIME_PROFILE?.trim() || 'studio',
+  });
+
+  if (['true', '1'].includes((process.env.SVA_GUARDRAIL_REPORT_JSON?.trim() || '').toLowerCase())) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  printHumanReadableReport(report);
+};
+
+const entryScriptPath = process.argv[1] ? resolve(process.argv[1]) : null;
+const currentScriptPath = fileURLToPath(import.meta.url);
+
+if (entryScriptPath === currentScriptPath) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[guardrail-report] ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/ops/runtime-env.ts
+++ b/scripts/ops/runtime-env.ts
@@ -63,6 +63,7 @@ import {
   extractComposeServiceContract,
   type ComposeDocument,
 } from './runtime/deploy-project.ts';
+import { guardrailCheckOrder, runGuardrailReport, type GuardrailReport } from '../ci/guardrail-report.ts';
 import {
   getGooseConfiguredVersion as getGooseConfiguredVersionFromConfig,
   listGooseMigrationFiles as listGooseMigrationFilesFromDir,
@@ -945,6 +946,53 @@ const toDoctorCheck = (
   message,
   ...(details ? { details } : {}),
 });
+
+type GuardrailDoctorDeps = Readonly<{
+  env?: NodeJS.ProcessEnv;
+  runGuardrailReport?: (input: { runtimeProfile: string; env?: NodeJS.ProcessEnv }) => Promise<GuardrailReport>;
+}>;
+
+const mapGuardrailReportCheckToDoctorCheck = (check: GuardrailReport['checks'][number]): DoctorCheck =>
+  toDoctorCheck(check.id, check.status, check.code, check.summary, {
+    affectedTargets: check.affectedTargets,
+    details: check.details,
+    enforcementReady: check.enforcementReady,
+    evidence: check.evidence,
+    suggestedNextStep: check.suggestedNextStep,
+    wouldFailInEnforcement: check.wouldFailInEnforcement,
+  });
+
+export const buildGuardrailDoctorChecks = async (
+  runtimeProfile: RuntimeProfile,
+  deps: GuardrailDoctorDeps = {}
+): Promise<readonly DoctorCheck[]> => {
+  const guardrailRunner =
+    deps.runGuardrailReport ?? ((input: { runtimeProfile: string; env?: NodeJS.ProcessEnv }) => runGuardrailReport(input));
+
+  try {
+    const report = await guardrailRunner({
+      runtimeProfile,
+      env: deps.env,
+    });
+    return report.checks.map(mapGuardrailReportCheckToDoctorCheck);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return guardrailCheckOrder.map((checkId) =>
+      toDoctorCheck(
+        checkId,
+        'warn',
+        'guardrail_report_unavailable',
+        'Der report-only Guardrail-Runner konnte nicht geladen werden.',
+        {
+          affectedTargets: [checkId],
+          enforcementReady: false,
+          error: message,
+          wouldFailInEnforcement: false,
+        }
+      )
+    );
+  }
+};
 
 type StudioImageVerifyEvidence = Readonly<{
   imageRef?: string;
@@ -2724,6 +2772,7 @@ const precheckAcceptance = async (
   checks.push(buildInstanceAuthConfigCheck(runtimeProfile, env));
   checks.push(buildTenantAdminClientContractCheck(runtimeProfile, env));
   checks.push(await buildInstanceHostnameMappingCheck(runtimeProfile, env));
+  checks.push(...(await buildGuardrailDoctorChecks(runtimeProfile, { env })));
   if (options) {
     checks.push(await buildAcceptanceLiveSpecCheck(runtimeProfile, env, options));
   }
@@ -2866,6 +2915,7 @@ const doctorRuntime = async (runtimeProfile: RuntimeProfile, env: NodeJS.Process
     checks.push(buildTenantAdminClientContractCheck(runtimeProfile, env));
     checks.push(await buildInstanceHostnameMappingCheck(runtimeProfile, env));
   }
+  checks.push(...(await buildGuardrailDoctorChecks(runtimeProfile, { env })));
   checks.push(buildActorDoctorCheck(runtimeProfile, env));
 
   return finalizeDoctorReport(runtimeProfile, checks);

--- a/tooling/testing/tests/guardrail-report.test.ts
+++ b/tooling/testing/tests/guardrail-report.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createGuardrailCheckResult,
+  runGuardrailReport,
+  type GuardrailCheckDefinition,
+} from '../../../scripts/ci/guardrail-report.ts';
+
+describe('guardrail-report', () => {
+  it('returns a stable JSON-friendly report shape', async () => {
+    const report = await runGuardrailReport({
+      runtimeProfile: 'studio',
+      checks: [
+        {
+          id: 'guardrail-plugin-contract',
+          run: async () =>
+            createGuardrailCheckResult({
+              id: 'guardrail-plugin-contract',
+              status: 'ok',
+              code: 'plugin_contract_ok',
+              summary: 'Plugin-Vertrag ist sichtbar.',
+            }),
+        },
+      ],
+    });
+
+    expect(report).toEqual({
+      generatedAt: expect.any(String),
+      runtimeProfile: 'studio',
+      checks: [
+        {
+          id: 'guardrail-plugin-contract',
+          status: 'ok',
+          code: 'plugin_contract_ok',
+          summary: 'Plugin-Vertrag ist sichtbar.',
+          details: [],
+          evidence: {},
+          enforcementReady: false,
+          wouldFailInEnforcement: false,
+          affectedTargets: [],
+          suggestedNextStep: null,
+        },
+      ],
+    });
+  });
+
+  it('degrades subcheck failures to warn instead of throwing', async () => {
+    const report = await runGuardrailReport({
+      runtimeProfile: 'studio',
+      checks: [
+        {
+          id: 'guardrail-architecture-drift',
+          run: async () => {
+            throw new Error('boom');
+          },
+        },
+      ],
+    });
+
+    expect(report.checks).toEqual([
+      {
+        id: 'guardrail-architecture-drift',
+        status: 'warn',
+        code: 'guardrail_subcheck_failed',
+        summary: 'Der report-only Guardrail-Check konnte nicht vollständig ausgewertet werden.',
+        details: ['boom'],
+        evidence: {
+          error: 'boom',
+        },
+        enforcementReady: false,
+        wouldFailInEnforcement: false,
+        affectedTargets: ['guardrail-architecture-drift'],
+        suggestedNextStep: 'Subcheck reparieren oder seine Vorbedingungen dokumentieren.',
+      },
+    ]);
+  });
+
+  it('preserves report-only warnings from individual checks', async () => {
+    const checks: GuardrailCheckDefinition[] = [
+      {
+        id: 'guardrail-runtime-boot',
+        run: async () =>
+          createGuardrailCheckResult({
+            id: 'guardrail-runtime-boot',
+            status: 'warn',
+            code: 'migration_head_visible_only',
+            summary: 'Der erwartete Migrationsstand ist sichtbar, aber noch nicht erzwungen.',
+            details: ['packages/data/migrations/0033_iam_instance_keycloak_provisioning_idempotency.sql'],
+            evidence: {
+              latestMigration: '0033_iam_instance_keycloak_provisioning_idempotency.sql',
+            },
+            wouldFailInEnforcement: true,
+            affectedTargets: ['packages/data/migrations'],
+            suggestedNextStep: 'Expliziten Drift-Vergleich vor Request-Annahme ergänzen.',
+          }),
+      },
+    ];
+
+    const report = await runGuardrailReport({
+      runtimeProfile: 'studio',
+      checks,
+    });
+
+    expect(report.checks[0]).toMatchObject({
+      id: 'guardrail-runtime-boot',
+      status: 'warn',
+      wouldFailInEnforcement: true,
+      affectedTargets: ['packages/data/migrations'],
+    });
+  });
+});

--- a/tooling/testing/tests/runtime-env-guardrails.test.ts
+++ b/tooling/testing/tests/runtime-env-guardrails.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildGuardrailDoctorChecks } from '../../../scripts/ops/runtime-env.ts';
+import type { GuardrailReport } from '../../../scripts/ci/guardrail-report.ts';
+
+describe('runtime-env guardrails', () => {
+  it('maps report-only guardrail findings to warn/ok/skipped doctor checks', async () => {
+    const report: GuardrailReport = {
+      generatedAt: '2026-05-16T09:00:00.000Z',
+      runtimeProfile: 'studio',
+      checks: [
+        {
+          id: 'guardrail-plugin-contract',
+          status: 'warn',
+          code: 'plugin_contract_collision_visible',
+          summary: 'Plugin-Kollisionen sind sichtbar.',
+          details: ['news -> /plugins/news'],
+          evidence: {
+            collisions: ['news'],
+          },
+          enforcementReady: false,
+          wouldFailInEnforcement: true,
+          affectedTargets: ['packages/plugin-news'],
+          suggestedNextStep: 'Preflight-Validierung scharf schalten.',
+        },
+        {
+          id: 'guardrail-runtime-boot',
+          status: 'ok',
+          code: 'runtime_boot_visible',
+          summary: 'Runtime-Boot-Signale sind sichtbar.',
+          details: [],
+          evidence: {},
+          enforcementReady: false,
+          wouldFailInEnforcement: false,
+          affectedTargets: [],
+          suggestedNextStep: null,
+        },
+        {
+          id: 'guardrail-cache-contract',
+          status: 'skipped',
+          code: 'cache_contract_not_applicable',
+          summary: 'Cache-Vertrag ist fuer dieses Profil nicht relevant.',
+          details: [],
+          evidence: {},
+          enforcementReady: false,
+          wouldFailInEnforcement: false,
+          affectedTargets: [],
+          suggestedNextStep: null,
+        },
+      ],
+    };
+
+    const checks = await buildGuardrailDoctorChecks('studio', {
+      runGuardrailReport: async () => report,
+    });
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        name: 'guardrail-plugin-contract',
+        status: 'warn',
+        code: 'plugin_contract_collision_visible',
+      }),
+      expect.objectContaining({
+        name: 'guardrail-runtime-boot',
+        status: 'ok',
+        code: 'runtime_boot_visible',
+      }),
+      expect.objectContaining({
+        name: 'guardrail-cache-contract',
+        status: 'skipped',
+        code: 'cache_contract_not_applicable',
+      }),
+    ]);
+    expect(checks[0]?.details).toMatchObject({
+      affectedTargets: ['packages/plugin-news'],
+      wouldFailInEnforcement: true,
+    });
+  });
+
+  it('returns warnings instead of throwing when the runner fails technically', async () => {
+    const checks = await buildGuardrailDoctorChecks('studio', {
+      runGuardrailReport: async () => {
+        throw new Error('runner exploded');
+      },
+    });
+
+    expect(checks).toHaveLength(5);
+    expect(checks.every((check) => check.status === 'warn')).toBe(true);
+    expect(checks.map((check) => check.name)).toEqual([
+      'guardrail-plugin-contract',
+      'guardrail-architecture-drift',
+      'guardrail-runtime-boot',
+      'guardrail-auth-session',
+      'guardrail-cache-contract',
+    ]);
+  });
+});


### PR DESCRIPTION
## Was sich geaendert hat

- fuehrt einen report-only Guardrail-Runner fuer Runtime-, Plugin-, Architektur-, Auth-Session- und Cache-Vertraege ein
- bindet die neuen Guardrail-Signale additiv in `env:doctor:studio` und `env:precheck:studio` ein
- dokumentiert den ersten Sichtbarkeits-Slice im laufenden OpenSpec-Change inklusive aktueller Erkenntnisse
- ergaenzt gezielte Tests fuer den Runner und die `runtime-env`-Abbildung

## Warum sich das geaendert hat

Der zugehoerige OpenSpec-Change ist noch nicht durchimplementiert. Dieser Slice schafft zuerst Sichtbarkeit fuer cross-cutting Runtime- und Plugin-Risiken, ohne bestehende PR-, Build- oder Deploy-Gates zu verschaerfen.

## Auswirkungen

- neue Warnsignale werden sichtbar, blockieren aber noch nichts
- `doctor` und `precheck` bekommen maschinenlesbare Guardrail-Befunde mit `wouldFailInEnforcement`
- der Change bleibt explizit in einer report-only Phase, waehrend Triage und spaeteres Enforcement noch offen sind

## Validierung

- `pnpm nx run tooling-testing:test:unit`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:guardrails:report`
