### PR TITLE
[codex] Fix plugin worker boot flag

### DIFF
--- a/apps/sva-studio-react/src/server.test.ts
+++ b/apps/sva-studio-react/src/server.test.ts
@@ -334,11 +334,12 @@ describe('server transport', () => {
     expect(startFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('does not bootstrap the plugin worker when the runtime flag disables it', async () => {
+  it('does not import or register plugin operation handlers when the runtime flag disables the worker', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('SVA_PLUGIN_OPERATION_WORKER_ENABLED', 'false');
 
     const startFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    registerStudioPluginOperationHandlersMock.mockRejectedValue(new Error('missing runtime requirement'));
     dispatchMainserverNewsRequestMock.mockResolvedValue(null);
     dispatchMainserverEventsRequestMock.mockResolvedValue(null);
     dispatchMainserverPoiRequestMock.mockResolvedValue(null);
@@ -350,6 +351,7 @@ describe('server transport', () => {
 
     await expect(response.text()).resolves.toBe('ok');
     expect(ensurePluginOperationWorkerStartedMock).not.toHaveBeenCalled();
+    expect(registerStudioPluginOperationHandlersMock).not.toHaveBeenCalled();
   });
 
   it('retries worker bootstrap after a transient startup failure and logs the failure', async () => {

--- a/apps/sva-studio-react/src/server.test.ts
+++ b/apps/sva-studio-react/src/server.test.ts
@@ -334,7 +334,41 @@ describe('server transport', () => {
     expect(startFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('does not import or register plugin operation handlers when the runtime flag disables the worker', async () => {
+  it('waits for plugin operation handlers before dispatching auth routes', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    let resolveHandlerRegistration: (() => void) | undefined;
+    const handlerRegistrationPromise = new Promise<void>((resolve) => {
+      resolveHandlerRegistration = resolve;
+    });
+    const authResponse = new Response('auth', { status: 200 });
+
+    registerStudioPluginOperationHandlersMock.mockImplementation(() => handlerRegistrationPromise);
+    dispatchMainserverNewsRequestMock.mockResolvedValue(null);
+    dispatchMainserverEventsRequestMock.mockResolvedValue(null);
+    dispatchMainserverPoiRequestMock.mockResolvedValue(null);
+    dispatchAuthRouteRequestMock.mockResolvedValue(authResponse);
+    createStartHandlerMock.mockReturnValue(vi.fn().mockResolvedValue(new Response('start', { status: 200 })));
+
+    const mod = await import('./server');
+    const responsePromise = mod.default.fetch(new Request('http://localhost:3000/api/v1/plugin-operations/jobs'));
+
+    const requestStateBeforeRegistration = await Promise.race([
+      Promise.resolve(responsePromise).then(() => 'resolved'),
+      new Promise<'pending'>((resolve) => {
+        setTimeout(() => resolve('pending'), 0);
+      }),
+    ]);
+
+    expect(requestStateBeforeRegistration).toBe('pending');
+
+    resolveHandlerRegistration?.();
+
+    await expect(responsePromise).resolves.toBe(authResponse);
+    expect(dispatchAuthRouteRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register plugin operation handlers when the runtime flag disables the worker', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('SVA_PLUGIN_OPERATION_WORKER_ENABLED', 'false');
 
@@ -352,6 +386,44 @@ describe('server transport', () => {
     await expect(response.text()).resolves.toBe('ok');
     expect(ensurePluginOperationWorkerStartedMock).not.toHaveBeenCalled();
     expect(registerStudioPluginOperationHandlersMock).not.toHaveBeenCalled();
+  });
+
+  it('retries plugin operation handler registration after a transient import-time failure', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const startFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('first', { status: 200 }))
+      .mockResolvedValueOnce(new Response('second', { status: 200 }));
+    const logger = { info: vi.fn() };
+    const registrationError = new Error('missing runtime requirement');
+
+    registerStudioPluginOperationHandlersMock
+      .mockRejectedValueOnce(registrationError)
+      .mockResolvedValueOnce(undefined);
+    dispatchMainserverNewsRequestMock.mockResolvedValue(null);
+    dispatchMainserverEventsRequestMock.mockResolvedValue(null);
+    dispatchMainserverPoiRequestMock.mockResolvedValue(null);
+    dispatchAuthRouteRequestMock.mockResolvedValue(null);
+    createStartHandlerMock.mockReturnValue(startFetch);
+    createSdkLoggerMock.mockReturnValue(logger);
+
+    const mod = await import('./server');
+
+    const firstResponse = await mod.default.fetch(new Request('http://localhost:3000/admin/users'));
+    const secondResponse = await mod.default.fetch(new Request('http://localhost:3000/admin/groups'));
+
+    await expect(firstResponse.text()).resolves.toBe('first');
+    await expect(secondResponse.text()).resolves.toBe('second');
+    expect(registerStudioPluginOperationHandlersMock).toHaveBeenCalledTimes(2);
+    expect(ensurePluginOperationWorkerStartedMock).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Plugin worker bootstrap failed',
+      expect.objectContaining({
+        operation: 'plugin_operation_worker_bootstrap',
+        error: 'missing runtime requirement',
+      })
+    );
   });
 
   it('retries worker bootstrap after a transient startup failure and logs the failure', async () => {

--- a/apps/sva-studio-react/src/server.ts
+++ b/apps/sva-studio-react/src/server.ts
@@ -113,6 +113,7 @@ const ensurePluginOperationHandlersRegistered = async (): Promise<void> => {
     await registerPluginOperationHandlers();
   })().catch((error) => {
     pluginOperationHandlerRegistrationPromise = null;
+    registerStudioPluginOperationHandlersPromise = null;
     throw error;
   });
 
@@ -206,6 +207,10 @@ const instrumentedFetch: RequestHandler<Register> = async (...args) => {
       status: mainserverPoiResponse.status,
     });
     return mainserverPoiResponse;
+  }
+
+  if (pluginOperationWorkerEnabled) {
+    await ensurePluginOperationHandlersRegistered();
   }
 
   const dispatchAuthRouteRequest = await getDispatchAuthRouteRequest();

--- a/apps/sva-studio-react/src/server.ts
+++ b/apps/sva-studio-react/src/server.ts
@@ -9,14 +9,11 @@ import {
   readServerFunctionResponseBodyForDiagnostics,
   resolveServerFunctionBranchDecision,
 } from './lib/server-function-request-diagnostics.server';
-import { registerStudioPluginOperationHandlers } from './lib/plugin-operation-runtime.server';
 
 const startFetch = createStartHandler(defaultStreamHandler);
 const diagnosticsEnabled = (process.env.NODE_ENV ?? 'development') === 'development';
 const serverFnBase = normalizeServerFnBase(process.env.TSS_SERVER_FN_BASE);
 const pluginOperationWorkerEnabled = process.env.SVA_PLUGIN_OPERATION_WORKER_ENABLED !== 'false';
-
-await registerStudioPluginOperationHandlers();
 
 type WorkspaceContext = {
   readonly requestId?: string | null;
@@ -51,6 +48,9 @@ let dispatchAuthRouteRequestPromise: Promise<typeof import('@sva/routing/server'
 let ensurePluginOperationWorkerStartedPromise:
   | Promise<typeof import('@sva/auth-runtime/server')['ensurePluginOperationWorkerStarted']>
   | null = null;
+let registerStudioPluginOperationHandlersPromise:
+  | Promise<typeof import('./lib/plugin-operation-runtime.server')['registerStudioPluginOperationHandlers']>
+  | null = null;
 let dispatchMainserverNewsRequestPromise:
   | Promise<typeof import('./lib/mainserver-news-api.server')['dispatchMainserverNewsRequest']>
   | null = null;
@@ -60,6 +60,7 @@ let dispatchMainserverEventsRequestPromise:
 let dispatchMainserverPoiRequestPromise:
   | Promise<typeof import('./lib/mainserver-poi-api.server')['dispatchMainserverPoiRequest']>
   | null = null;
+let pluginOperationHandlerRegistrationPromise: Promise<void> | null = null;
 let pluginOperationWorkerBootstrapPromise: Promise<void> | null = null;
 const getSdk = async (): Promise<RequestContextSdk> => {
   sdkPromise ??= import('@sva/server-runtime') as Promise<RequestContextSdk>;
@@ -76,6 +77,13 @@ const getEnsurePluginOperationWorkerStarted = async () => {
     (mod) => mod.ensurePluginOperationWorkerStarted
   );
   return ensurePluginOperationWorkerStartedPromise;
+};
+
+const getRegisterStudioPluginOperationHandlers = async () => {
+  registerStudioPluginOperationHandlersPromise ??= import('./lib/plugin-operation-runtime.server').then(
+    (mod) => mod.registerStudioPluginOperationHandlers
+  );
+  return registerStudioPluginOperationHandlersPromise;
 };
 
 const getDispatchMainserverNewsRequest = async () => {
@@ -99,6 +107,18 @@ const getDispatchMainserverPoiRequest = async () => {
   return dispatchMainserverPoiRequestPromise;
 };
 
+const ensurePluginOperationHandlersRegistered = async (): Promise<void> => {
+  pluginOperationHandlerRegistrationPromise ??= (async () => {
+    const registerPluginOperationHandlers = await getRegisterStudioPluginOperationHandlers();
+    await registerPluginOperationHandlers();
+  })().catch((error) => {
+    pluginOperationHandlerRegistrationPromise = null;
+    throw error;
+  });
+
+  await pluginOperationHandlerRegistrationPromise;
+};
+
 const startPluginOperationWorkerInBackground = (): void => {
   if (!pluginOperationWorkerEnabled) {
     return;
@@ -110,6 +130,7 @@ const startPluginOperationWorkerInBackground = (): void => {
 
   pluginOperationWorkerBootstrapPromise = (async () => {
     try {
+      await ensurePluginOperationHandlersRegistered();
       const startWorker = await getEnsurePluginOperationWorkerStarted();
       await startWorker();
     } catch (error) {


### PR DESCRIPTION
## Zusammenfassung
- verschiebt die Registrierung der Plugin-Operation-Handler aus dem Modulimport in den Worker-Bootstrap
- lädt `plugin-operation-runtime.server` nur noch per dynamischem Import, wenn der Worker tatsächlich aktiviert ist
- ergänzt einen Regressionstest dafür, dass `SVA_PLUGIN_OPERATION_WORKER_ENABLED=false` weder Import noch Registrierung auslöst

## Root Cause
`server.ts` hat die Handler bisher bereits beim Modulimport registriert. Dadurch konnte der Server trotz deaktiviertem Worker schon beim Boot an Registrierungsfehlern im Plugin-Operation-Runtime-Pfad scheitern.

## Verifikation
- `pnpm nx run sva-studio-react:test:unit:server --testFiles=src/server.test.ts`
- `pnpm nx run sva-studio-react:test:types`
