### PR TITLE
[codex] fix nx vitest testFiles forwarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,14 +38,14 @@
 - **Effizienter, zielgerichteter Test-Workflow:**
   1. **Nur affected:** `pnpm nx affected --target=test:unit` (vergleicht mit `main`-Branch)
   2. **Spezifische Packages:** `pnpm nx run sva-studio-react:test:unit`
-  3. **Spezifische Dateien via Nx/Vitest-Executor:** `pnpm nx run sva-studio-react:test:unit --testFiles=src/foo.test.tsx --testFiles=src/bar.test.tsx`
+  3. **Spezifische Dateien via Nx-Target:** `pnpm nx run sva-studio-react:test:unit --testFiles=src/foo.test.tsx --testFiles=src/bar.test.tsx`
   4. **Direkter Vitest-Fallback:** `cd packages/data && npx vitest run tests/xyz.test.tsx`
 - **Pro-Tipps:**
   - Mit `npx vitest list` verfügbare Tests vorab ansehen
   - Mit `-t "pattern"` gezielt auf Funktionalität fokussieren
   - Mit `--exclude`-Mustern Unrelevantes überspringen
   - Nx-Package-Targeting mit Vitest-File-Targeting kombinieren (maximale Präzision)
-  - Bei `@nx/vitest:test` Dateifilter nicht als Positionsargumente nach `--` übergeben, sondern immer explizit per `--testFiles=...`
+  - Dateifilter für Nx-Testtargets immer explizit per `--testFiles=...` übergeben; `@nx/vitest:test` und die Vitest-Wrapper unter `scripts/ci/run-vitest-target.ts` unterstützen dieses Format
 
 ## PR-Anweisungen
 
@@ -170,7 +170,7 @@ Behalte diesen verwalteten Block bei, damit 'openspec update' die Anweisungen ak
 
 - For navigating/exploring the workspace, invoke the `nx-workspace` skill first - it has patterns for querying projects, targets, and dependencies
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
-- For `@nx/vitest:test` targets, pass file filters with `--testFiles=...` instead of positional file arguments after `--`
+- Pass file filters for Nx test targets with `--testFiles=...` instead of positional arguments after `--`; this applies to both `@nx/vitest:test` and the Vitest run-command wrappers backed by `scripts/ci/run-vitest-target.ts`
 - Prefix nx commands with the workspace's package manager (e.g., `pnpm nx build`, `npm exec nx test`) - avoids using globally installed CLI
 - You have access to the Nx MCP server and its tools, use them to help the user
 - For Nx plugin best practices, check `node_modules/@nx/<plugin>/PLUGIN.md`. Not all plugins have this file - proceed without it if unavailable.

--- a/apps/project-report/project.json
+++ b/apps/project-report/project.json
@@ -36,7 +36,7 @@
       "outputs": [],
       "options": {
         "cwd": "apps/project-report",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:coverage": {
@@ -46,7 +46,7 @@
       "outputs": ["{projectRoot}/coverage"],
       "options": {
         "cwd": "apps/project-report",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {

--- a/apps/sva-studio-react/project.json
+++ b/apps/sva-studio-react/project.json
@@ -189,7 +189,7 @@
       ],
       "options": {
         "cwd": "apps/sva-studio-react",
-        "command": "rm -rf coverage && mkdir -p coverage/.tmp && pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts"
+        "command": "rm -rf coverage && mkdir -p coverage/.tmp && pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts"
       }
     },
     "test:integration": {

--- a/packages/auth-runtime/project.json
+++ b/packages/auth-runtime/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/auth-runtime",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -43,7 +43,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/auth-runtime",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -28,7 +28,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/core",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -41,7 +41,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/core",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/data-client/project.json
+++ b/packages/data-client/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/data-client",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/data-client",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/data-repositories/project.json
+++ b/packages/data-repositories/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/data-repositories",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/data-repositories",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/data/project.json
+++ b/packages/data/project.json
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/data",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts"
       }
     },
     "test:integration": {

--- a/packages/iam-admin/project.json
+++ b/packages/iam-admin/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/iam-admin",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/iam-admin",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/iam-core/project.json
+++ b/packages/iam-core/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/iam-core",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/iam-core",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/iam-governance/project.json
+++ b/packages/iam-governance/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/iam-governance",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/iam-governance",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/instance-registry/project.json
+++ b/packages/instance-registry/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/instance-registry",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/instance-registry",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/media/project.json
+++ b/packages/media/project.json
@@ -28,7 +28,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/media",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -41,7 +41,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/media",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/monitoring-client/project.json
+++ b/packages/monitoring-client/project.json
@@ -31,7 +31,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/monitoring-client",
-        "command": "pnpm exec vitest run tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -45,7 +45,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/monitoring-client",
-        "command": "pnpm exec vitest run tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/plugin-events/project.json
+++ b/packages/plugin-events/project.json
@@ -25,7 +25,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-events",
-        "command": "pnpm exec vitest run tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -39,7 +39,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-events",
-        "command": "pnpm exec vitest run tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/plugin-news/project.json
+++ b/packages/plugin-news/project.json
@@ -25,7 +25,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-news",
-        "command": "pnpm exec vitest run tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -39,7 +39,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-news",
-        "command": "pnpm exec vitest run tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/plugin-poi/project.json
+++ b/packages/plugin-poi/project.json
@@ -25,7 +25,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-poi",
-        "command": "pnpm exec vitest run tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -39,7 +39,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-poi",
-        "command": "pnpm exec vitest run tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/plugin-sdk/project.json
+++ b/packages/plugin-sdk/project.json
@@ -32,7 +32,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-sdk",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -45,7 +45,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-sdk",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/plugin-waste-management/project.json
+++ b/packages/plugin-waste-management/project.json
@@ -39,7 +39,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/plugin-waste-management",
-        "command": "pnpm exec vitest run tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts tests --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/routing/project.json
+++ b/packages/routing/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/routing",
-        "command": "pnpm exec vitest run"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts"
       },
       "configurations": {
         "watch": {
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/routing",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/server-runtime/project.json
+++ b/packages/server-runtime/project.json
@@ -32,7 +32,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/server-runtime",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -45,7 +45,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/server-runtime",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/studio-module-iam/project.json
+++ b/packages/studio-module-iam/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/studio-module-iam",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -42,7 +42,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/studio-module-iam",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/packages/studio-ui-react/project.json
+++ b/packages/studio-ui-react/project.json
@@ -25,7 +25,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/studio-ui-react",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:types": {
@@ -38,7 +38,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/studio-ui-react",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     }
   },

--- a/packages/sva-mainserver/project.json
+++ b/packages/sva-mainserver/project.json
@@ -29,7 +29,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/sva-mainserver",
-        "command": "pnpm exec vitest run --reporter=verbose --config vitest.config.ts"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts"
       }
     },
     "test:types": {
@@ -43,7 +43,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/sva-mainserver",
-        "command": "pnpm exec vitest run --coverage --reporter=verbose --config vitest.config.ts"
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --coverage --reporter=verbose --config vitest.config.ts"
       }
     }
   },

--- a/scripts/ci/run-vitest-target.test.ts
+++ b/scripts/ci/run-vitest-target.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeVitestRunArgs } from './run-vitest-target.ts';
+
+describe('run-vitest-target', () => {
+  it('rewrites --testFiles flags into positional vitest file filters', () => {
+    expect(
+      normalizeVitestRunArgs([
+        '--reporter=verbose',
+        '--config',
+        'vitest.config.ts',
+        '--passWithNoTests',
+        '--testFiles=src/runtime-health.test.ts',
+      ])
+    ).toEqual([
+      '--reporter=verbose',
+      '--config',
+      'vitest.config.ts',
+      '--passWithNoTests',
+      'src/runtime-health.test.ts',
+    ]);
+  });
+
+  it('supports repeated --testFiles flags', () => {
+    expect(
+      normalizeVitestRunArgs([
+        '--config',
+        'vitest.config.ts',
+        '--testFiles=src/runtime-health.test.ts',
+        '--testFiles',
+        'src/runtime-auth.test.ts',
+      ])
+    ).toEqual([
+      '--config',
+      'vitest.config.ts',
+      'src/runtime-health.test.ts',
+      'src/runtime-auth.test.ts',
+    ]);
+  });
+
+  it('keeps existing positional filters before appended test files', () => {
+    expect(
+      normalizeVitestRunArgs([
+        'tests',
+        '--coverage',
+        '--reporter=verbose',
+        '--config',
+        'vitest.config.ts',
+        '--testFiles=tests/foo.test.ts',
+      ])
+    ).toEqual([
+      'tests',
+      '--coverage',
+      '--reporter=verbose',
+      '--config',
+      'vitest.config.ts',
+      'tests/foo.test.ts',
+    ]);
+  });
+});

--- a/scripts/ci/run-vitest-target.test.ts
+++ b/scripts/ci/run-vitest-target.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeVitestRunArgs } from './run-vitest-target.ts';
+import { isRunVitestTargetEntrypoint, normalizeVitestRunArgs } from './run-vitest-target.ts';
 
 describe('run-vitest-target', () => {
   it('rewrites --testFiles flags into positional vitest file filters', () => {
@@ -17,6 +17,7 @@ describe('run-vitest-target', () => {
       '--config',
       'vitest.config.ts',
       '--passWithNoTests',
+      '--',
       'src/runtime-health.test.ts',
     ]);
   });
@@ -33,6 +34,7 @@ describe('run-vitest-target', () => {
     ).toEqual([
       '--config',
       'vitest.config.ts',
+      '--',
       'src/runtime-health.test.ts',
       'src/runtime-auth.test.ts',
     ]);
@@ -54,7 +56,40 @@ describe('run-vitest-target', () => {
       '--reporter=verbose',
       '--config',
       'vitest.config.ts',
+      '--',
       'tests/foo.test.ts',
     ]);
+  });
+
+  it('protects test file filters from options with optional values', () => {
+    expect(normalizeVitestRunArgs(['--changed', '--testFiles=src/runtime-health.test.ts'])).toEqual([
+      '--changed',
+      '--',
+      'src/runtime-health.test.ts',
+    ]);
+  });
+});
+
+describe('isRunVitestTargetEntrypoint', () => {
+  it('matches the repo standard ESM main-module guard', () => {
+    expect(
+      isRunVitestTargetEntrypoint(
+        'file:///workspace/scripts/ci/run-vitest-target.ts',
+        '/workspace/scripts/ci/run-vitest-target.ts'
+      )
+    ).toBe(true);
+  });
+
+  it('returns false when there is no entrypoint path', () => {
+    expect(isRunVitestTargetEntrypoint('file:///workspace/scripts/ci/run-vitest-target.ts', undefined)).toBe(false);
+  });
+
+  it('returns false for a different entrypoint file', () => {
+    expect(
+      isRunVitestTargetEntrypoint(
+        'file:///workspace/scripts/ci/run-vitest-target.ts',
+        '/workspace/scripts/ci/other-script.ts'
+      )
+    ).toBe(false);
   });
 });

--- a/scripts/ci/run-vitest-target.ts
+++ b/scripts/ci/run-vitest-target.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
 const TEST_FILES_FLAG = '--testFiles';
 
@@ -36,7 +37,22 @@ export const normalizeVitestRunArgs = (args: readonly string[]): string[] => {
     passthroughArgs.push(argument);
   }
 
-  return [...passthroughArgs, ...testFileArgs];
+  if (testFileArgs.length === 0) {
+    return passthroughArgs;
+  }
+
+  return [...passthroughArgs, '--', ...testFileArgs];
+};
+
+export const isRunVitestTargetEntrypoint = (
+  scriptUrl: string,
+  entrypointPath: string | undefined
+): boolean => {
+  if (!entrypointPath) {
+    return false;
+  }
+
+  return scriptUrl === pathToFileURL(entrypointPath).href;
 };
 
 export const runVitestTarget = (): never => {
@@ -53,6 +69,6 @@ export const runVitestTarget = (): never => {
   process.exit(result.status ?? 1);
 };
 
-if (import.meta.main) {
+if (isRunVitestTargetEntrypoint(import.meta.url, process.argv[1])) {
   runVitestTarget();
 }

--- a/scripts/ci/run-vitest-target.ts
+++ b/scripts/ci/run-vitest-target.ts
@@ -1,0 +1,58 @@
+import { spawnSync } from 'node:child_process';
+
+const TEST_FILES_FLAG = '--testFiles';
+
+export const normalizeVitestRunArgs = (args: readonly string[]): string[] => {
+  const passthroughArgs: string[] = [];
+  const testFileArgs: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+
+    if (argument === TEST_FILES_FLAG) {
+      const value = args[index + 1];
+      if (!value) {
+        throw new Error('Fehlender Wert für --testFiles');
+      }
+      testFileArgs.push(value);
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith(`${TEST_FILES_FLAG}=`)) {
+      const value = argument.slice(`${TEST_FILES_FLAG}=`.length);
+      if (value.length === 0) {
+        throw new Error('Fehlender Wert für --testFiles');
+      }
+      testFileArgs.push(value);
+      continue;
+    }
+
+    if (argument.startsWith('-')) {
+      passthroughArgs.push(argument);
+      continue;
+    }
+
+    passthroughArgs.push(argument);
+  }
+
+  return [...passthroughArgs, ...testFileArgs];
+};
+
+export const runVitestTarget = (): never => {
+  const result = spawnSync('pnpm', ['exec', 'vitest', 'run', ...normalizeVitestRunArgs(process.argv.slice(2))], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+};
+
+if (import.meta.main) {
+  runVitestTarget();
+}


### PR DESCRIPTION
## Was wurde geändert?
- zentralen Vitest-Wrapper unter `scripts/ci/run-vitest-target.ts` eingeführt, der `--testFiles=...` aus Nx-Target-Aufrufen für `nx:run-commands` in kompatible Vitest-Dateifilter umschreibt
- die betroffenen `test:unit`- und `test:coverage`-Targets mit `vitest run` in Apps und Libraries auf den Wrapper umgestellt
- die Arbeitsanweisung in `AGENTS.md` präzisiert und mit dem tatsächlichen Workspace-Verhalten abgeglichen
- Unit-Tests für die Argument-Normalisierung ergänzt

## Warum wurde das geändert?
Dateigenaues Unit-Test-Targeting war für viele Libraries kaputt. `nx:run-commands` hat `--testFiles` direkt an `vitest run` weitergereicht, wodurch reproduzierbar `CACError: Unknown option --testFiles` entstand. Betroffen waren unter anderem `auth-runtime`, `sva-mainserver` und weitere gleich aufgebaute Package-Targets.

## Auswirkung
- `pnpm nx run <projekt>:test:unit --testFiles=...` funktioniert jetzt sowohl für `@nx/vitest:test`-Targets als auch für die bisherigen `nx:run-commands`-Wrapper
- bestehende Positionsargumente wie `tests` bleiben erhalten
- Coverage-Läufe profitieren vom gleichen Fix

## Validierung
- `pnpm exec vitest run scripts/ci/run-vitest-target.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/runtime-health.test.ts`
- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts`
- `pnpm nx run plugin-events:test:unit --testFiles=tests/events.api.test.ts`
- `pnpm nx run auth-runtime:test:coverage --testFiles=src/runtime-health.test.ts`
- `pnpm test:pr` wurde gestartet; der Lauf war zum Zeitpunkt der PR-Erstellung noch aktiv
