### PR TITLE
Remove fresh reauth gates from instance registry flows

### DIFF
--- a/packages/instance-registry/src/http-instance-handlers.test.ts
+++ b/packages/instance-registry/src/http-instance-handlers.test.ts
@@ -45,7 +45,7 @@ describe('http-instance-handlers', () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     deps.getRequestId.mockReturnValue('req-1');
     deps.ensurePlatformAccess.mockReturnValue(null);
     deps.validateCsrf.mockReturnValue(null);
@@ -111,6 +111,31 @@ describe('http-instance-handlers', () => {
     });
   });
 
+  it('creates instances without requiring fresh reauthentication', async () => {
+    deps.parseRequestBody.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        instanceId: 'demo',
+        displayName: 'Demo',
+        parentDomain: 'studio.example.org',
+        realmMode: 'existing',
+        authRealm: 'demo',
+        authClientId: 'sva-studio',
+      },
+    });
+    deps.requireFreshReauth.mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryHttpHandlers(deps);
+
+    const response = await handlers.createInstance(
+      new Request('https://studio.example.org/api/v1/iam/instances', { method: 'POST' }),
+      ctx
+    );
+
+    expect(response.status).toBe(201);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
+    expect(service.createProvisioningRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('maps update errors through the injected mapper', async () => {
     const thrown = new Error('tenant_auth_client_secret_missing');
     vi.mocked(service.updateInstance).mockRejectedValueOnce(thrown);
@@ -133,6 +158,30 @@ describe('http-instance-handlers', () => {
 
     expect(response.status).toBe(502);
     expect(deps.mapMutationError).toHaveBeenCalledWith(thrown);
+  });
+
+  it('updates instances without requiring fresh reauthentication', async () => {
+    deps.parseRequestBody.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        displayName: 'Demo',
+        parentDomain: 'studio.example.org',
+        realmMode: 'existing',
+        authRealm: 'demo',
+        authClientId: 'sva-studio',
+      },
+    });
+    deps.requireFreshReauth.mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryHttpHandlers(deps);
+
+    const response = await handlers.updateInstance(
+      new Request('https://studio.example.org/api/v1/iam/instances/demo', { method: 'PATCH' }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
+    expect(service.updateInstance).toHaveBeenCalledTimes(1);
   });
 
   it('returns guard failures before reading create payloads', async () => {

--- a/packages/instance-registry/src/http-instance-shared.ts
+++ b/packages/instance-registry/src/http-instance-shared.ts
@@ -56,7 +56,8 @@ export type InstanceRegistryHttpDeps<TContext> = {
 export const requireMutationGuards = <TContext>(
   deps: InstanceRegistryHttpDeps<TContext>,
   request: Request,
-  ctx: TContext
+  ctx: TContext,
+  options?: { readonly requireFreshReauth?: boolean }
 ): Response | null => {
   const accessError = deps.ensurePlatformAccess(request, ctx);
   if (accessError) {
@@ -65,6 +66,9 @@ export const requireMutationGuards = <TContext>(
   const csrfError = deps.validateCsrf(request, deps.getRequestId());
   if (csrfError) {
     return csrfError;
+  }
+  if (options?.requireFreshReauth === false) {
+    return null;
   }
   return deps.requireFreshReauth(request, ctx);
 };

--- a/packages/instance-registry/src/http-instance-write-handlers.ts
+++ b/packages/instance-registry/src/http-instance-write-handlers.ts
@@ -7,7 +7,7 @@ import { readInstanceIdOrError, requireMutationGuards, type InstanceRegistryHttp
 export const createCreateInstanceHandler =
   <TContext>(deps: InstanceRegistryHttpDeps<TContext>) =>
   async (request: Request, ctx: TContext): Promise<Response> => {
-    const guardError = requireMutationGuards(deps, request, ctx);
+    const guardError = requireMutationGuards(deps, request, ctx, { requireFreshReauth: false });
     if (guardError) {
       return guardError;
     }
@@ -47,7 +47,7 @@ export const createCreateInstanceHandler =
 export const createUpdateInstanceHandler =
   <TContext>(deps: InstanceRegistryHttpDeps<TContext>) =>
   async (request: Request, ctx: TContext): Promise<Response> => {
-    const guardError = requireMutationGuards(deps, request, ctx);
+    const guardError = requireMutationGuards(deps, request, ctx, { requireFreshReauth: false });
     if (guardError) {
       return guardError;
     }

--- a/packages/instance-registry/src/http-keycloak-handlers.test.ts
+++ b/packages/instance-registry/src/http-keycloak-handlers.test.ts
@@ -76,13 +76,15 @@ describe('http-keycloak-handlers', () => {
     expect(deps.withRegistryService).not.toHaveBeenCalled();
   });
 
-  it('passes the request context into fresh reauth checks for keycloak plans', async () => {
+  it('plans keycloak provisioning without requiring fresh reauthentication', async () => {
     const handlers = createInstanceRegistryKeycloakHttpHandlers(deps);
     const request = new Request('https://studio.example.org/api/v1/iam/instances/demo/keycloak/plan');
+    deps.requireFreshReauth.mockReturnValueOnce(new Response('reauth', { status: 403 }));
 
-    await handlers.planInstanceKeycloakProvisioning(request, ctx);
+    const response = await handlers.planInstanceKeycloakProvisioning(request, ctx);
 
-    expect(deps.requireFreshReauth).toHaveBeenCalledWith(request, ctx);
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
   });
 
   it('returns not_found when a provisioning run is missing', async () => {

--- a/packages/instance-registry/src/http-keycloak-handlers.ts
+++ b/packages/instance-registry/src/http-keycloak-handlers.ts
@@ -48,10 +48,6 @@ const guardKeycloakReadRequest = <TContext>(
     if (csrfError) {
       return csrfError;
     }
-    const reauthError = deps.requireFreshReauth(request, ctx);
-    if (reauthError) {
-      return reauthError;
-    }
   }
   return readInstanceIdOrError(deps, request);
 };

--- a/packages/instance-registry/src/http-mutation-handlers.test.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.test.ts
@@ -210,7 +210,7 @@ describe('http mutation handlers', () => {
     });
   });
 
-  it('keeps fresh reauth enforcement for reconcile mutations', async () => {
+  it('reconcileInstanceKeycloak does not require fresh reauthentication', async () => {
     vi.mocked(deps.requireFreshReauth).mockReturnValueOnce(new Response('reauth', { status: 403 }));
     const handlers = createInstanceRegistryMutationHttpHandlers(deps);
 
@@ -219,8 +219,21 @@ describe('http mutation handlers', () => {
       { userId: 'u-1' }
     );
 
-    expect(response.status).toBe(403);
-    expect(deps.parseRequestBody).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
+  });
+
+  it('executeInstanceKeycloakProvisioning does not require fresh reauthentication', async () => {
+    vi.mocked(deps.requireFreshReauth).mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.executeInstanceKeycloakProvisioning(
+      new Request('http://localhost/api/instances/inst-1/keycloak/runs'),
+      { userId: 'u-1' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
   });
 
   it('assignModule returns idempotency and instance id errors before parsing the payload', async () => {
@@ -291,6 +304,20 @@ describe('http mutation handlers', () => {
     await expect(readBody(notFoundResponse)).resolves.toMatchObject({ code: 'not_found' });
     expect(conflictResponse.status).toBe(409);
     await expect(readBody(conflictResponse)).resolves.toMatchObject({ code: 'conflict' });
+  });
+
+  it('assignModule does not require fresh reauthentication', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleId: 'news' } });
+    vi.mocked(deps.requireFreshReauth).mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.assignModule(
+      new Request('http://localhost/api/instances/inst-1/modules/assign', { method: 'POST' }),
+      { userId: 'u-1' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
   });
 
   it('revokeModule returns the refreshed instance detail on success', async () => {
@@ -367,6 +394,23 @@ describe('http mutation handlers', () => {
     await expect(readBody(conflictResponse)).resolves.toMatchObject({ code: 'conflict' });
   });
 
+  it('revokeModule does not require fresh reauthentication', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({
+      ok: true,
+      data: { moduleId: 'news', confirmation: 'REVOKE' },
+    });
+    vi.mocked(deps.requireFreshReauth).mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.revokeModule(
+      new Request('http://localhost/api/instances/inst-1/modules/revoke', { method: 'POST' }),
+      { userId: 'u-1' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
+  });
+
   it('bootstrapAdminStructure passes selected module ids into the registry service', async () => {
     const bootstrapAdminStructure = vi.fn(async () => ({
       ok: true,
@@ -418,6 +462,20 @@ describe('http mutation handlers', () => {
     expect(body.code).toBe('not_found');
   });
 
+  it('seedIamBaseline does not require fresh reauthentication', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: {} });
+    vi.mocked(deps.requireFreshReauth).mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.seedIamBaseline(
+      new Request('http://localhost/api/instances/inst-1/modules/seed-iam-baseline', { method: 'POST' }),
+      { userId: 'u-1' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
+  });
+
   it('bootstrapAdminStructure returns invalid_request for unknown modules', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleIds: ['unknown'] } });
     vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
@@ -465,6 +523,20 @@ describe('http mutation handlers', () => {
     await expect(readBody(notFoundResponse)).resolves.toMatchObject({ code: 'not_found' });
     expect(conflictResponse.status).toBe(409);
     await expect(readBody(conflictResponse)).resolves.toMatchObject({ code: 'conflict' });
+  });
+
+  it('bootstrapAdminStructure does not require fresh reauthentication', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleIds: ['news'] } });
+    vi.mocked(deps.requireFreshReauth).mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.bootstrapAdminStructure(
+      new Request('http://localhost/api/instances/inst-1/admin-bootstrap', { method: 'POST' }),
+      { userId: 'u-1' }
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
   });
 
   it('mutateInstanceStatus rejects mismatched status payloads', async () => {
@@ -556,5 +628,20 @@ describe('http mutation handlers', () => {
     await expect(readBody(notFoundResponse)).resolves.toMatchObject({ code: 'not_found' });
     expect(conflictResponse.status).toBe(409);
     await expect(readBody(conflictResponse)).resolves.toMatchObject({ code: 'conflict' });
+  });
+
+  it('mutateInstanceStatus does not require fresh reauthentication', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { status: 'active' } });
+    vi.mocked(deps.requireFreshReauth).mockReturnValueOnce(new Response('reauth', { status: 403 }));
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.mutateInstanceStatus(
+      new Request('http://localhost/api/instances/inst-1/status'),
+      { userId: 'u-1' },
+      'active'
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.requireFreshReauth).not.toHaveBeenCalled();
   });
 });

--- a/packages/instance-registry/src/http-mutation-shared.ts
+++ b/packages/instance-registry/src/http-mutation-shared.ts
@@ -83,10 +83,7 @@ export const requireMutationGuards = <TContext>(
   if (csrfError) {
     return csrfError;
   }
-  if (options?.requireFreshReauth === false) {
-    return null;
-  }
-  return deps.requireFreshReauth(request, ctx);
+  return null;
 };
 
 export const readInstanceIdOrError = <TContext>(


### PR DESCRIPTION
## Summary
- remove fresh reauth enforcement from instance create/update flows
- remove remaining fresh reauth checks from instance registry mutation and keycloak plan handlers
- update handler tests to cover the new no-reauth behavior

## Testing
- pnpm nx run instance-registry:test:unit
- pnpm nx run instance-registry:test:types