### PR TITLE
[codex] Add privacy compliance evidence docs

### DIFF
--- a/.sisyphus/evidence/README.md
+++ b/.sisyphus/evidence/README.md
@@ -1,0 +1,31 @@
+# Evidence-Ablage
+
+Diese Ablage ist für echte Evidence-Dateien gemäß
+`docs/governance/evidence-and-acceptance-protocol.md` vorgesehen.
+
+## Regeln
+
+- Nur echte Nachweise ablegen, keine Platzhalter als "fertige" Evidence
+- Dateinamen nach dem Schema `task-{N}-{scenario-slug}.{ext}`
+- geeignete Formate: `.txt`, `.json`, `.log`, `.md`
+- Evidence-Dateien nach Commit nicht löschen
+
+## Empfohlene Dateien für Arbeitspaket 1.2
+
+```text
+task-12-data-classification-review.md
+task-12-rls-role-verification.log
+task-12-field-encryption-tests.log
+task-12-log-redaction-audit.md
+task-12-governance-export.json
+task-12-consent-export.json
+task-12-compliance-gates.log
+task-12-retention-run.log
+task-12-retention-alerting.md
+task-12-incident-tabletop.md
+task-12-acceptance-summary.md
+```
+
+Bis zur tatsächlichen Ausführung in Test, Staging oder Produktion bleiben diese
+Dateien bewusst unangelegt. Vorlagen und Prüfanweisungen liegen unter
+`docs/guides/`.

--- a/dev/monitoring/grafana/dashboards/application-logs.json
+++ b/dev/monitoring/grafana/dashboards/application-logs.json
@@ -29,7 +29,7 @@
       },
       "targets": [
         {
-          "expr": "{component=~\".+\"}",
+          "expr": "{job=\"sva-studio\"}",
           "refId": "A"
         }
       ],
@@ -59,7 +59,7 @@
       },
       "targets": [
         {
-          "expr": "sum(count_over_time({level=\"error\"}[5m]))",
+          "expr": "sum(count_over_time({job=\"sva-studio\",level=\"error\"}[5m]))",
           "legendFormat": "errors",
           "refId": "A"
         }

--- a/docs/development/monitoring-stack.md
+++ b/docs/development/monitoring-stack.md
@@ -105,9 +105,14 @@ Verbotene Labels (PII / High Cardinality):
 - CPU: `sum(rate(process_cpu_seconds_total[5m])) by (job)`
 
 **LogQL:**
-- Alle Logs: `{component=~".+"}`
-- Errors (5m): `sum(count_over_time({level="error"}[5m]))`
-- Logs je Workspace: `sum(count_over_time({workspace_id=~".+"}[5m])) by (workspace_id)`
+- Alle App-Logs: `{job="sva-studio"}`
+- Errors (5m): `sum(count_over_time({job="sva-studio",level="error"}[5m]))`
+- App-Logs eines Workspace: `{job="sva-studio"} |= "\"workspace_id\":\"default\""`
+
+Hinweis zum lokalen OTEL-Pfad:
+
+- Das provisionierte Grafana-Dashboard `Application Logs` filtert bewusst auf `job="sva-studio"`.
+- Attribute wie `component` und `workspace_id` liegen bei OTEL-Logs im Log-Body bzw. als OTEL-Attribute vor und sind lokal nicht das primäre Loki-Indexlabel des Dashboards.
 
 ## Standards & Versionen
 

--- a/docs/development/observability-best-practices.md
+++ b/docs/development/observability-best-practices.md
@@ -258,11 +258,13 @@ try {
 
 ```logql
 # Alle Fehler in letzten 5 Minuten
-{level="error", workspace_id="org-123"} | json | line_format "{{.error_code}}: {{.error_message}}"
+{job="sva-studio", level="error"} |= "\"workspace_id\":\"org-123\""
 
-# Fehler pro Komponente
-sum(count_over_time({level="error"}[5m])) by (component)
+# Fehler aus dem App-Stream
+sum(count_over_time({job="sva-studio", level="error"}[5m]))
 ```
+
+Im lokalen OTEL-Setup wird der Grafana-/Loki-Zugriff primär über den App-Stream `job="sva-studio"` aufgebaut. Fachattribute wie `component` oder `workspace_id` bleiben in den OTEL-Logdaten erhalten, sind lokal aber nicht das primäre Indexlabel des Standard-Dashboards.
 
 ## Testing Observability
 

--- a/docs/guides/datenschutz-compliance-betriebsnachweise.md
+++ b/docs/guides/datenschutz-compliance-betriebsnachweise.md
@@ -1,0 +1,91 @@
+# Betriebsnachweise Datenschutz und Compliance
+
+## Zweck
+
+Dieses Dokument beschreibt, welche Nachweise in Staging oder Produktion
+erbracht werden müssen, die nicht allein aus dem Repository ableitbar sind.
+
+## 1. Retention-Betriebsnachweise
+
+Erforderliche Artefakte:
+
+- Nachweis des Schedulers oder Cronjobs
+- Log eines erfolgreichen Retention-Laufs
+- Log eines fehlgeschlagenen Laufs oder Alarmtests
+- Nachweis der Alarmierung bei Exit-Code ungleich `0`
+
+Empfohlene Ablage:
+
+- `.sisyphus/evidence/task-12-retention-scheduler.md`
+- `.sisyphus/evidence/task-12-retention-run.log`
+- `.sisyphus/evidence/task-12-retention-alerting.md`
+
+Prüfpunkte:
+
+1. `pnpm iam:retention:run` ist im Zielsystem tatsächlich geplant.
+2. Laufzeit, Exit-Code und Ergebniszahlen werden protokolliert.
+3. Alarmierung bei Fehlern ist nachvollziehbar ausgelöst oder getestet.
+4. `iam.platform_activity_logs` wird gesondert überwacht, solange kein
+   separater Archivierungspfad produktiv ist.
+
+## 2. Governance- und Consent-Exportnachweise
+
+Erforderliche Artefakte:
+
+- JSON- oder CSV-Export aus Test oder Staging
+- Nachweis, mit welcher Rolle der Export zulässig war
+- geschwärzte oder synthetische Testdaten, keine echten PII
+
+Empfohlene Ablage:
+
+- `.sisyphus/evidence/task-12-governance-export.json`
+- `.sisyphus/evidence/task-12-consent-export.json`
+- `.sisyphus/evidence/task-12-export-access-review.md`
+
+Prüfpunkte:
+
+1. Export enthält die im Runbook geforderten Pflichtfelder.
+2. Export erfolgt nur mit zulässiger Rolle.
+3. Exportdaten sind für Audit nutzbar und enthalten keine unnötigen Klartextdaten.
+
+## 3. RLS- und Rollenpfadnachweise
+
+Erforderliche Artefakte:
+
+- Prüfprotokoll für produktionsnahe DB-Rollen
+- Nachweis, dass App-Runtime nicht mit `SUPERUSER` oder `BYPASSRLS` läuft
+- Nachweis typischer Allow-/Deny-Szenarien
+
+Empfohlene Ablage:
+
+- `.sisyphus/evidence/task-12-rls-role-verification.log`
+- `.sisyphus/evidence/task-12-rls-role-summary.md`
+
+## 4. PII-freie Lognachweise
+
+Erforderliche Artefakte:
+
+- Stichprobe echter Logs oder OTEL-Events
+- Suchprotokoll nach E-Mail-, Token-, Cookie- oder Secret-Mustern
+- Bewertung der Treffer und getroffenen Redaction-Regeln
+
+Empfohlene Ablage:
+
+- `.sisyphus/evidence/task-12-log-redaction-audit.md`
+- `.sisyphus/evidence/task-12-log-redaction-search.log`
+
+## 5. Incident-/Tabletop-Nachweise
+
+Erforderliche Artefakte:
+
+- Tabletop-Protokoll mit Szenario, Rollen, Zeitlinie und Entscheidungen
+- Lessons Learned und offene Maßnahmen
+
+Empfohlene Ablage:
+
+- `.sisyphus/evidence/task-12-incident-tabletop.md`
+
+## 6. Abnahmeempfehlung
+
+Eine vollständige Abnahme sollte erst ausgesprochen werden, wenn diese
+Betriebsnachweise zusammen mit den Repo-seitigen Artefakten vorliegen.

--- a/docs/guides/datenschutz-compliance-evidence-playbook.md
+++ b/docs/guides/datenschutz-compliance-evidence-playbook.md
@@ -1,0 +1,87 @@
+# Evidence-Playbook Datenschutz und Compliance
+
+## Zweck
+
+Dieses Playbook beschreibt, wie Nachweise für Arbeitspaket 1.2 erzeugt,
+abgelegt und für eine Abnahme gebündelt werden. Es ergänzt das generische
+Evidence-Protokoll um konkrete Datenschutz- und Compliance-Kontrollziele.
+
+## Grundsatz
+
+Es werden nur echte Nachweise abgelegt. Vorlagen, Checklisten und Runbooks sind
+Vorbereitungshilfen, aber keine Evidence im engeren Sinn.
+
+## Kontrollziele
+
+Für Arbeitspaket 1.2 werden mindestens folgende Kontrollziele separat
+nachgewiesen:
+
+1. Datenklassifizierung
+2. Zugriffsschutz und Rollenpfade
+3. Verschlüsselung vertraulicher Daten
+4. PII-freie Protokollierung
+5. Auditierbarkeit von Governance- und Consent-Vorgängen
+6. wirksame Compliance-Gates in Business-Flows
+7. Retention, Archivierung und Löschung
+8. Incident- und Eskalationsfähigkeit
+
+## Evidence-Ablage
+
+Pfad:
+
+```text
+.sisyphus/evidence/
+```
+
+Empfohlene Dateinamen für dieses Arbeitspaket:
+
+```text
+task-12-data-classification-review.md
+task-12-rls-role-verification.log
+task-12-field-encryption-tests.log
+task-12-log-redaction-audit.md
+task-12-governance-export.json
+task-12-consent-export.json
+task-12-compliance-gates.log
+task-12-retention-run.log
+task-12-retention-alerting.md
+task-12-incident-tabletop.md
+task-12-acceptance-summary.md
+```
+
+Die Nummer `12` ist hier ein Vorschlag für das Arbeitspaket 1.2. Falls in
+eurem Plan bereits eine andere Task-Nummer vergeben ist, muss diese
+konsistent verwendet werden.
+
+## Evidence je Kontrollziel
+
+| Kontrollziel | Mindest-Evidence |
+| --- | --- |
+| Datenklassifizierung | Review-Report mit Verweis auf Datenobjekte und Schutzklassen |
+| Zugriffsschutz und Rollenpfade | SQL-/CLI-Prüfprotokoll aus Zielsystem oder Staging |
+| Verschlüsselung | Testlauf-Log und Konfigurationsprüfung ohne Secret-Offenlegung |
+| PII-freie Logs | Stichprobenbericht auf Basis echter Logdaten oder OTEL-Samples |
+| Governance-/Consent-Audit | Beispiel-Export in JSON/CSV/SIEM plus Rollennachweis |
+| Compliance-Gates | Testprotokoll echter Business-Flows mit Block-/Allow-Verhalten |
+| Retention | Scheduler-Nachweis, Run-Log, Alarmierungsnachweis |
+| Incident-Fähigkeit | Tabletop-Protokoll oder echter Incident-Report |
+
+## Evidence-Paket für eine Abnahme
+
+Vor einer Abnahme sollte mindestens abgelegt werden:
+
+- Nachweismatrix
+- TOM-Matrix
+- alle zugehörigen Evidence-Dateien
+- eine zusammenfassende `acceptance-summary`
+- Verweise auf Tests, Exporte und Betriebsbelege
+
+## Verbotene Scheinevidence
+
+Nicht ausreichend sind:
+
+- reine Behauptungen ohne Log, Export oder Testlauf
+- leere Template-Dateien als angeblicher Nachweis
+- Codeverweise ohne Verifikation
+- Vorlagen für Staging/Prod, die nie ausgeführt wurden
+- generische Aussagen wie "sollte funktionieren"

--- a/docs/guides/datenschutz-compliance-pruefprotokolle.md
+++ b/docs/guides/datenschutz-compliance-pruefprotokolle.md
@@ -1,0 +1,86 @@
+# Prüfprotokolle Datenschutz und Compliance
+
+## Zweck
+
+Dieses Dokument stellt konkrete Prüfschemata für umgebungsabhängige Nachweise
+bereit. Es erzeugt selbst noch keine Evidence, sondern definiert reproduzierbare
+Prüfschritte.
+
+## 1. RLS- und Rollenprüfung
+
+Ziel:
+
+- wirksame Rollenbegrenzung im Zielsystem belegen
+- Laufzeitrolle und Deny-Pfade nachvollziehen
+
+Beispielhafte Prüffragen:
+
+1. Mit welcher DB-Rolle läuft die Anwendung?
+2. Besitzt diese Rolle `SUPERUSER` oder `BYPASSRLS`?
+3. Welche RLS-Policies schützen die sensiblen IAM-Tabellen?
+4. Welche Zugriffe sind für App-Runtime erlaubt, welche verboten?
+
+Erwartete Evidence:
+
+- SQL-Output
+- kurze Auswertung
+- dokumentierte Allow-/Deny-Fälle
+
+## 2. Retention-Prüfung
+
+Ziel:
+
+- tatsächliche tägliche Ausführung und Alarmierung belegen
+
+Prüfschritte:
+
+1. Scheduler-Eintrag oder Jobdefinition dokumentieren.
+2. letzten erfolgreichen Lauf mit Zeitstempel und Ergebnissen sichern.
+3. Alarmregel oder Fehlertest dokumentieren.
+4. Wachstum und Alter von `iam.platform_activity_logs` bewerten.
+
+## 3. Governance-/Consent-Exportprüfung
+
+Ziel:
+
+- Audit-Exportfähigkeit und Zugriffsbeschränkung belegen
+
+Prüfschritte:
+
+1. Export mit berechtigter Rolle ausführen.
+2. Export mit unberechtigter Rolle als Negativtest ausführen.
+3. Ergebnis auf Pflichtfelder, Pseudonymisierung und Scope prüfen.
+
+## 4. Log-Redaction-Prüfung
+
+Ziel:
+
+- wirksame Redaction in realen Laufzeitdaten belegen
+
+Prüfschritte:
+
+1. Stichprobe aus Zielsystem oder Staging ziehen.
+2. Nach typischen Mustern suchen: E-Mail, JWT, Cookie, Bearer-Token,
+   `client_secret`, `refresh_token`, `authorization`.
+3. Treffer analysieren und als zulässig oder unzulässig bewerten.
+4. Falls unzulässige Treffer existieren, Incident oder Fix-Maßnahme eröffnen.
+
+## 5. Compliance-Gate-Business-Flows
+
+Ziel:
+
+- Nachweis, dass Schutzmaßnahmen nicht nur im Code stehen, sondern echte
+  Business-Flows kontrollieren
+
+Mindestfälle:
+
+1. geschützter IAM-Flow ohne gültige Legal-Akzeptanz wird blockiert
+2. geschützter IAM-Flow mit gültiger Akzeptanz wird erlaubt
+3. Governance-Ausnahmefall wird nur für definierte Operationen gewährt
+4. Audit-/Korrelationsdaten entstehen nachvollziehbar
+
+Empfohlene Evidence:
+
+- Testlauf-Log
+- Screenshots oder API-Responses
+- Kurzbewertung pro Fall

--- a/docs/guides/datenschutz-compliance-tom-matrix.md
+++ b/docs/guides/datenschutz-compliance-tom-matrix.md
@@ -1,0 +1,70 @@
+# TOM-Matrix Datenschutz und Compliance
+
+## Zweck
+
+Diese TOM-Matrix konkretisiert für SVA Studio die technischen und
+organisatorischen Maßnahmen für Arbeitspaket 1.2 "Datenschutz und Compliance".
+Sie dient als Referenz für Implementierung, Betrieb, Prüfung und Abnahme.
+
+## Geltungsbereich
+
+- IAM- und Governance-Funktionen des SVA Studio
+- Verarbeitung personenbezogener oder sensibler Daten in Host- und
+  serverseitigen Paketen
+- Logging-, Audit-, Consent-, Retention- und Incident-Prozesse
+
+Nicht im Detail abgedeckt sind in dieser Matrix externe
+Auftragsverarbeitungsverhältnisse, Verträge oder unternehmensweite
+Organisationsrichtlinien außerhalb des Repository-Kontexts. Diese müssen
+ergänzend dokumentiert werden.
+
+## Rollenmodell für diese Matrix
+
+| Rolle | Verantwortung |
+| --- | --- |
+| Produkt / Fachverantwortung | fachliche Anforderungen, Freigabe von Zweck und Umfang der Verarbeitung |
+| Engineering | technische Umsetzung, Tests, Doku und technische Korrekturmaßnahmen |
+| Plattform / Betrieb | Scheduler, Laufzeitbetrieb, Monitoring, Alarmierung, Backups, Zugriff auf Zielsysteme |
+| Security | Sicherheitsvorgaben, Härtung, Log-/Rollenprüfungen, Incident-Eskalation |
+| Datenschutz / Legal | rechtliche Bewertung, TOM-Prüfung, Freigabe von Datenschutz-relevanten Abweichungen |
+| Audit / Review | stichprobenartige oder formale Wirksamkeitsprüfung |
+
+## Prüffrequenzen
+
+| Kürzel | Bedeutung |
+| --- | --- |
+| kontinuierlich | durch Code, CI oder Runtime-Mechanismen bei jeder Ausführung |
+| pro Änderung | bei jeder relevanten Änderung an Code, Schema oder Konfiguration |
+| monatlich | mindestens einmal pro Monat |
+| quartalsweise | mindestens einmal pro Quartal |
+| anlassbezogen | bei Incident, Audit, Migration oder Risikoänderung |
+
+## TOM-Matrix
+
+| Kontrollbereich | Maßnahme / TOM | Ziel | Verantwortlich | Prüffrequenz | Repo-/Betriebsbeleg |
+| --- | --- | --- | --- | --- | --- |
+| Datenklassifizierung | Schutzklassen für PII, Tokens, Audit- und Strukturdaten definieren | einheitlicher Schutzbedarf und Mindestmaßnahmen | Produkt, Engineering, Datenschutz | pro Änderung | `docs/architecture/iam-datenklassifizierung.md` |
+| Datenminimierung | Session- und Auditdaten auf minimale fachlich nötige Inhalte begrenzen | unnötige PII-Verarbeitung vermeiden | Engineering, Security | pro Änderung | `docs/architecture/08-cross-cutting-concepts.md` |
+| Verschlüsselung ruhender Daten | Vertrauliche IAM-Felder nur als Ciphertext persistieren | Klartext-PII in DB verhindern | Engineering, Security | kontinuierlich, pro Änderung | `packages/core/src/security/field-encryption.ts`, `packages/auth-runtime/src/audit-db-sink.ts` |
+| Schlüsseltrennung | Schlüsselmateriel nicht in DB, sondern über Runtime-Konfiguration führen | Trennung von Daten und Schlüsseln | Plattform, Security | pro Änderung, quartalsweise | `IAM_PII_ACTIVE_KEY_ID`, `IAM_PII_KEYRING_JSON`, Architektur-Doku |
+| Zugriffsschutz | Rollen- und Scope-Prüfungen, kein privilegierter Direktpfad | unbefugten Zugriff verhindern | Engineering, Security | kontinuierlich, anlassbezogen | IAM-/Governance-Codepfade, RLS-/Rollenprüfung |
+| Audit-Trail | Governance-, Auth- und Consent-Ereignisse strukturiert persistieren | Nachvollziehbarkeit und Revisionssicherheit | Engineering, Plattform | kontinuierlich | `iam.activity_logs`, `iam.platform_activity_logs`, Governance-Exports |
+| Log-Redaction | Secrets, Tokens, E-Mails, Cookies und sensitive IDs redigieren | keine Klartext-PII in Logs | Engineering, Security | kontinuierlich, monatlich | `packages/monitoring-client/src/logging/redaction.ts` |
+| Consent-Management | Rechtstext-Versionen, Akzeptanz, Widerruf und Exportpfade dokumentieren und persistieren | Nachweis von Einwilligungen und Rechtsgrundlagen | Produkt, Engineering, Datenschutz | kontinuierlich, pro Änderung | `packages/iam-governance/src/legal-consent-export.ts`, `packages/data/migrations/0017_iam_legal_acceptance_audit.sql` |
+| Compliance-Gates | geschützte Pfade nur bei erfüllten Legal-/Governance-Voraussetzungen zulassen | Schutzmaßnahmen verbindlich erzwingen | Engineering, Security | kontinuierlich, pro Änderung | `packages/auth-runtime/src/middleware-compliance.ts` |
+| Aufbewahrung und Löschung | PII fristgerecht anonymisieren und Auditdaten archivieren | Speicherbegrenzung, DSGVO-konformer Lifecycle | Engineering, Plattform, Datenschutz | täglich, monatlich | `docs/guides/iam-retention-automation.md`, Runtime-Logs |
+| Monitoring und Alarmierung | Job-Fehler, Wachstum kritischer Tabellen, fehlgeschlagene Läufe alarmieren | Wirksamkeit im Betrieb sicherstellen | Plattform, Security | kontinuierlich, monatlich | Scheduler, Alarmregeln, Job-Logs |
+| Incident-Bearbeitung | Eskalationspfade für Datenschutz-/Governance-Vorfälle definieren | schnelle Reaktion und dokumentierte Behandlung | Security, Datenschutz, Plattform | anlassbezogen, quartalsweise | `docs/guides/security-policy.md`, `docs/guides/iam-governance-runbook.md` |
+| Evidence und Abnahme | Kontrollziele mit nachvollziehbaren Artefakten, Logs und Reports belegen | auditierbare Abnahme | Engineering, Audit, Datenschutz | pro Änderung, vor Abnahme | `docs/governance/evidence-and-acceptance-protocol.md`, `.sisyphus/evidence/` |
+
+## Offene Ergänzungen außerhalb des Repos
+
+Für eine formale Datenschutz- und Compliance-Abnahme müssen zusätzlich
+mindestens folgende organisatorische Nachweise gepflegt werden:
+
+- Benennung konkreter Rolleninhaber
+- Freigabeprozess für Datenschutz und Legal
+- Verzeichnis der Verarbeitungstätigkeiten
+- Vertrags- und AVV-Nachweise
+- Lösch- und Auskunftsprozess außerhalb reiner Codepfade
+- produktionsnahe Betriebs- und Auditprotokolle

--- a/docs/guides/datenschutz-governance-tabletop-template.md
+++ b/docs/guides/datenschutz-governance-tabletop-template.md
@@ -1,0 +1,66 @@
+# Vorlage Datenschutz-/Governance-Tabletop
+
+## Zweck
+
+Diese Vorlage dient als Nachweis einer geübten Incident- und
+Eskalationsfähigkeit für Datenschutz- und Governance-relevante Vorfälle.
+
+## Metadaten
+
+- Datum:
+- Moderator:
+- Teilnehmende Rollen:
+- Umfeld: Desktop-Übung / Staging / kombinierte Probe
+- Szenario-ID:
+
+## Szenario
+
+Beschreibe den Vorfall knapp:
+
+- betroffene Funktion:
+- betroffene Datenarten:
+- vermutete Auswirkung:
+- initialer Auslöser:
+
+Beispielszenarien:
+
+- unredactete PII in Logs entdeckt
+- unzulässiger Governance-Export
+- fehlgeschlagene Retention-Läufe über mehrere Tage
+- Rollenfehler mit unerlaubtem Zugriff auf IAM-Daten
+
+## Zeitlinie
+
+| Zeit | Ereignis | Entscheidung | Verantwortlich |
+| --- | --- | --- | --- |
+| 00:00 | Vorfall erkannt |  |  |
+| 00:15 | Triage gestartet |  |  |
+| 00:30 | Eskalation |  |  |
+| 01:00 | Sofortmaßnahme |  |  |
+
+## Prüffragen
+
+1. Wurde der Vorfall korrekt klassifiziert?
+2. Wurden Security, Datenschutz/Legal und Plattform rechtzeitig eingebunden?
+3. Waren Logs, Exporte und Auditpfade zur Analyse ausreichend?
+4. Waren Sofortmaßnahmen klar und umsetzbar?
+5. Waren Kommunikations- und Freigabewege eindeutig?
+
+## Ergebnis
+
+- Was hat funktioniert?
+- Wo gab es Lücken?
+- Welche Nachweise lagen vor?
+- Welche Nachweise fehlten?
+
+## Maßnahmen
+
+| Maßnahme | Priorität | Verantwortlich | Zieltermin |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+## Evidence
+
+Empfohlene Ablage:
+
+- `.sisyphus/evidence/task-12-incident-tabletop.md`

--- a/docs/reports/2026-05-20-nachweismatrix-datenschutz-compliance-arbeitspaket-1-2.md
+++ b/docs/reports/2026-05-20-nachweismatrix-datenschutz-compliance-arbeitspaket-1-2.md
@@ -1,0 +1,90 @@
+# Nachweismatrix Arbeitspaket 1.2 Datenschutz und Compliance
+
+## Zweck
+
+Dieses Dokument bündelt die vorhandenen Nachweise für Arbeitspaket 1.2
+"Datenschutz und Compliance" im SVA Studio. Ziel ist kein allgemeines
+Policy-Papier, sondern eine prüffähige Matrix aus Anforderung, TOM,
+Design-/Code-Beleg, Verifikation und verbleibender Restlücke.
+
+## Bewertungsmaßstab
+
+Ein Punkt gilt nur dann als belastbar nachgewiesen, wenn die Nachweiskette
+vollständig ist:
+
+1. fachliche oder regulatorische Anforderung
+2. dokumentierte Soll-Regel oder Architekturvorgabe
+3. technische Umsetzung im Code oder Schema
+4. Verifikation durch Tests, Checks oder Exporte
+5. betriebliche Evidence für den Wirkbetrieb
+
+Fehlt einer dieser Bausteine, ist der Punkt nicht voll abnahmefest, sondern
+nur teilweise nachgewiesen.
+
+## Gesamtbild
+
+Der aktuelle Stand zeigt eine tragfähige technische Grundlage für:
+
+- Datenklassifizierung und Privacy-by-Design
+- Verschlüsselung vertraulicher IAM-Felder
+- Redaction sensibler Daten in Logs
+- Auditierbare Governance- und Consent-Pfade
+- automatisierte Retention- und Anonymisierungslogik
+
+Für eine revisionssichere Abnahme des Arbeitspakets fehlen an mehreren Stellen
+noch explizite Betriebs- und Ausführungsevidenzen, etwa Job-Logs,
+Exportbeispiele, produktionsnahe Prüfnachweise oder eine formale TOM-Matrix
+mit Verantwortlichkeiten.
+
+## Nachweismatrix
+
+| Anforderung aus Arbeitspaket 1.2 | TOM / Kontrollziel | Design- und Policy-Beleg | Implementierungsbeleg | Verifikation / Prüfbarkeit | Status | Restlücke für belastbaren Umsetzungsnachweis |
+| --- | --- | --- | --- | --- | --- | --- |
+| Klare Regeln für den Umgang mit personenbezogenen und sensiblen Daten | Schutzbedarf klassifizieren und Mindestmaßnahmen verbindlich machen | [docs/architecture/iam-datenklassifizierung.md](../architecture/iam-datenklassifizierung.md) definiert Schutzklassen und Maßnahmen für PII, Tokens, Auditdaten und Rollenstrukturen | Querschnittsvorgaben in [docs/architecture/08-cross-cutting-concepts.md](../architecture/08-cross-cutting-concepts.md) verankern Privacy-, Encryption-, Retention- und Logging-Regeln | Dokumentenprüfung über Klassifizierungsmatrix und Cross-Cutting-Konzept möglich | Teilweise nachgewiesen | Es fehlt eine explizite Zuordnung aller produktiven Datenobjekte außerhalb IAM zu derselben Klassifizierungssystematik |
+| Zugriff auf sensible Daten muss beschränkt und nachvollziehbar sein | rollen- und scope-basierte Zugriffe, kein unkontrollierter Direktzugriff, Audit bei Änderungen | [docs/architecture/iam-datenklassifizierung.md](../architecture/iam-datenklassifizierung.md) fordert Zugriffsbeschränkung, Audit und RLS; [docs/guides/iam-governance-runbook.md](../guides/iam-governance-runbook.md) beschreibt Governance-Triage und Eskalation | [packages/auth-runtime/src/audit-db-sink.ts](../../packages/auth-runtime/src/audit-db-sink.ts) setzt Laufzeitrolle `iam_app` und bricht bei `SUPERUSER`/`BYPASSRLS` ab; Governance-Exports in [packages/iam-governance/src/governance-compliance-export.ts](../../packages/iam-governance/src/governance-compliance-export.ts) | Unit-Tests für Audit-Sink vorhanden in [packages/auth-runtime/src/audit-db-sink.test.ts](../../packages/auth-runtime/src/audit-db-sink.test.ts) | Teilweise nachgewiesen | Ein expliziter Nachweis der wirksamen RLS-Policies und der erlaubten Rollenpfade im Zielsystem fehlt in diesem Report noch |
+| Vertrauliche personenbezogene Daten dürfen nicht im Klartext persistiert werden | Application-Level Encryption mit Schlüsseltrennung außerhalb der Datenbank | [docs/architecture/08-cross-cutting-concepts.md](../architecture/08-cross-cutting-concepts.md) legt Column Encryption und externe Schlüsselverwaltung fest; [docs/architecture/iam-datenklassifizierung.md](../architecture/iam-datenklassifizierung.md) verlangt Ciphertext-only | AES-256-GCM-Verschlüsselung in [packages/core/src/security/field-encryption.ts](../../packages/core/src/security/field-encryption.ts); Nutzung im Audit-/Account-Pfad in [packages/auth-runtime/src/audit-db-sink.ts](../../packages/auth-runtime/src/audit-db-sink.ts) | Kryptographie-Tests in [packages/core/src/security/field-encryption.test.ts](../../packages/core/src/security/field-encryption.test.ts); Verschlüsselungsnachweis im Audit-Pfad in [packages/auth-runtime/src/audit-db-sink.test.ts](../../packages/auth-runtime/src/audit-db-sink.test.ts) | Weitgehend nachgewiesen | Für die Abnahme fehlt noch Betriebs-Evidence, dass die produktive Konfiguration mit gültigem Keyring aktiv ist und Rotation geregelt wird |
+| Protokollierung darf keine Klartext-PII oder Secrets offenlegen | strukturierte Log-Redaction für Tokens, E-Mail-Adressen, Cookies, Session-IDs und Identitätsreferenzen | [docs/architecture/08-cross-cutting-concepts.md](../architecture/08-cross-cutting-concepts.md) fordert Redaction im Server-Runtime- und OTEL-Pfad; [docs/architecture/iam-datenklassifizierung.md](../architecture/iam-datenklassifizierung.md) verbietet Klartext-PII in Logs | Redaction-Implementierung in [packages/monitoring-client/src/logging/redaction.ts](../../packages/monitoring-client/src/logging/redaction.ts); Re-Export im Server-Runtime-Paket in [packages/server-runtime/src/logging/redaction.ts](../../packages/server-runtime/src/logging/redaction.ts) | Redaction-Tests in [packages/server-runtime/src/logging/redaction.test.ts](../../packages/server-runtime/src/logging/redaction.test.ts) | Weitgehend nachgewiesen | Es fehlt noch ein betrieblicher Stichprobennachweis aus realen Logs oder OTEL-Sinks, dass keine unredacteten PII-Felder austreten |
+| Einwilligungen, Rechtstexte und Compliance-relevante Aktionen müssen revisionssicher nachvollziehbar sein | Consent- und Governance-Ereignisse vollständig, strukturiert und exportierbar speichern | [docs/guides/iam-governance-runbook.md](../guides/iam-governance-runbook.md) definiert Pflichtfelder für Nachweise; [docs/architecture/08-cross-cutting-concepts.md](../architecture/08-cross-cutting-concepts.md) fordert auditierbare Governance-Pfade | Revisionsrelevante Felder in Migration [packages/data/migrations/0017_iam_legal_acceptance_audit.sql](../../packages/data/migrations/0017_iam_legal_acceptance_audit.sql); Consent-Export in [packages/iam-governance/src/legal-consent-export.ts](../../packages/iam-governance/src/legal-consent-export.ts); Governance-Export in [packages/iam-governance/src/governance-compliance-export.ts](../../packages/iam-governance/src/governance-compliance-export.ts) | Exportlogik ist direkt test- und abfragbar; das Runbook definiert die Prüffelder für Audit-Nachweise | Weitgehend nachgewiesen | Für die Abnahme fehlen abgelegte Beispiel-Exports aus einer Test- oder Staging-Instanz sowie der Nachweis, wer auf diese Exporte zugreifen darf |
+| Schutzmaßnahmen müssen an kritischen Stellen verbindlich erzwungen werden | Compliance-Gates dürfen nicht nur dokumentiert, sondern müssen im Request-Pfad erzwungen werden | [docs/architecture/08-cross-cutting-concepts.md](../architecture/08-cross-cutting-concepts.md) verlangt Governance-Gates und Legal-Akzeptanzflüsse | [packages/auth-runtime/src/middleware-compliance.ts](../../packages/auth-runtime/src/middleware-compliance.ts) erzwingt Legal-Text-Compliance für geschützte IAM-Pfade und definiert eng begrenzte Ausnahmen | Code ist direkt prüfbar; ergänzende Handler-/Flow-Tests existieren im IAM-Governance-Paket | Teilweise nachgewiesen | Es fehlt eine zusammenhängende Testevidence je geschütztem Business-Flow, z. B. "Zugriff ohne akzeptierte Rechtstexte wird blockiert" |
+| Aufbewahrung und Löschung personenbezogener Daten müssen geregelt und technisch durchgesetzt werden | PII fristgerecht anonymisieren; Audit-Daten geregelt archivieren; irreversible Löschung kontrolliert durchführen | [docs/guides/iam-retention-automation.md](../guides/iam-retention-automation.md) beschreibt Retention-Logik; [docs/architecture/08-cross-cutting-concepts.md](../architecture/08-cross-cutting-concepts.md) fordert zweistufigen Löschprozess und Legal Hold | Operative Ausführung über `scripts/ops/run-iam-retention.mjs`, referenziert in [docs/guides/iam-retention-automation.md](../guides/iam-retention-automation.md); Archivtabellen-/Pfade werden in der Doku benannt | Nachvollziehbar über Script-Ausführung `pnpm iam:retention:run` und Monitoring-Vorgaben in der Doku | Teilweise nachgewiesen | Es fehlen konkrete Run-Logs, Scheduler-/Cron-Evidence, Alarmierungsevidence und ein Nachweis für den noch separat zu überwachenden Plattform-Audit-Pfad |
+| Datenschutzrelevante Vorfälle und Governance-Abweichungen müssen bearbeitbar und eskalierbar sein | definierte Triage-, Export- und Eskalationswege für Security, DSB/Legal und Plattform | [docs/guides/security-policy.md](../guides/security-policy.md) definiert Melde- und Bearbeitungsprozess; [docs/guides/iam-governance-runbook.md](../guides/iam-governance-runbook.md) beschreibt Triage und Eskalation | Governance- und Consent-Exportpfade im IAM-Governance-Paket liefern die operativen Datenquellen | Dokumenten- und Endpunktprüfung möglich | Teilweise nachgewiesen | Es fehlt ein geübter Incident-/Tabletop-Nachweis oder eine dokumentierte Probe eines Datenschutz-/Governance-Vorfalls |
+| Nachweise selbst müssen auditierbar und reproduzierbar sein | Evidence-Driven Acceptance mit dauerhafter Ablage der Prüfergebnisse | [docs/governance/evidence-and-acceptance-protocol.md](../governance/evidence-and-acceptance-protocol.md) definiert "No Evidence -> No Done", Dateinamensschema, Prüf- und Retention-Regeln | Das Repository enthält bereits Reports und Governance-Artefakte unter `docs/reports/`; das Protocol fordert zusätzlich eine Evidence-Ablage pro Szenario | Verifizierbar über Existenz, Inhalt und Git-Historie der Evidence-Dateien | Teilweise nachgewiesen | Für Arbeitspaket 1.2 fehlt noch eine dedizierte Evidence-Sammlung pro Kontrollziel, etwa Exporte, Logs, Testläufe und Abnahmeprotokolle unter einer konsistenten Evidence-Ablage |
+
+## Bewertung der Aussage "Haftungssicherheit" / "rechtssicherer Wirkbetrieb"
+
+Die vorhandenen Artefakte belegen, dass das Repository die wesentlichen
+technischen und konzeptionellen Grundlagen für datenschutzkonformen Betrieb
+bereits weitgehend vorbereitet hat. Besonders belastbar nachweisbar sind
+der Schutz vertraulicher IAM-Daten durch Verschlüsselung, Redaction in Logs,
+strukturierte Auditpfade sowie definierte Governance- und Retention-Konzepte.
+
+Nicht vollständig nachgewiesen ist allein durch den aktuellen Repo-Stand jedoch
+die Aussage, dass damit bereits eine vollständige "Haftungssicherheit" oder ein
+abschließend "rechtssicherer Wirkbetrieb" erreicht ist. Dafür braucht es
+zusätzliche Betriebs-, Organisations- und Abnahmeevidenz außerhalb des reinen
+Quellcodes.
+
+## Fehlende Nachweise für eine belastbare Abnahme
+
+Die folgenden Artefakte sollten ergänzend erzeugt oder gebündelt werden:
+
+- formale TOM-Matrix mit Verantwortlichkeiten, Geltungsbereich und Prüffrequenz
+- Exportbeispiele für Governance- und Consent-Nachweise aus Test oder Staging
+- protokollierte Testläufe für Legal-Compliance-Gates und DSR-/Retention-Pfade
+- Betriebsnachweise für `pnpm iam:retention:run` inklusive Scheduler, Logs und Alarmierung
+- RLS-/Rollenprüfbericht für produktionsnahe Datenbankrollen
+- Stichprobenprüfung realer Logs oder OTEL-Daten auf wirksame PII-Redaction
+- Nachweis einer Datenschutz-/Governance-Incident-Übung oder eines Tabletop-Tests
+- Evidence-Dateien pro Kontrollziel nach dem Schema aus [docs/governance/evidence-and-acceptance-protocol.md](../governance/evidence-and-acceptance-protocol.md)
+
+## Empfehlung für die Verwendung dieses Dokuments
+
+Dieses Dokument eignet sich als:
+
+- Ausgangspunkt für ein Abnahmegespräch zu Arbeitspaket 1.2
+- Basis für eine förmliche TOM- und Nachweismappe
+- Checkliste für noch fehlende Audit- und Betriebsbelege
+
+Für eine externe oder formale Prüfung sollte diese Matrix zusammen mit den
+konkret erzeugten Evidence-Dateien, Testprotokollen und Betriebsbelegen
+vorgelegt werden.

--- a/packages/monitoring-client/tests/application-logs-dashboard.test.ts
+++ b/packages/monitoring-client/tests/application-logs-dashboard.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type LogsPanelTarget = {
+  expr?: string;
+};
+
+type LogsPanel = {
+  title?: string;
+  targets?: LogsPanelTarget[];
+};
+
+type DashboardDefinition = {
+  panels?: LogsPanel[];
+};
+
+const dashboardPath = resolve(
+  process.cwd(),
+  '../../dev/monitoring/grafana/dashboards/application-logs.json'
+);
+
+const dashboard = JSON.parse(
+  readFileSync(dashboardPath, 'utf8')
+) as DashboardDefinition;
+
+describe('application logs dashboard', () => {
+  it('targets the OTEL app stream instead of docker-only component labels', () => {
+    const logsPanel = dashboard.panels?.find((panel) => panel.title === 'Application Logs');
+
+    expect(logsPanel).toBeDefined();
+    expect(logsPanel?.targets?.[0]?.expr).toBe('{job="sva-studio"}');
+  });
+});


### PR DESCRIPTION
## Summary

- adds Datenschutz-/Compliance-Leitfäden, TOM-Matrix, Tabletop-Vorlage und Nachweismatrix für Arbeitspaket 1.2
- documents the OTEL/Loki dashboard query adjustments in the monitoring docs
- adds a regression test for the provisioned application logs dashboard query

## Validation

- Local tests intentionally not run per user instruction.
