### PR TITLE
fix: local registry readonly startup

### DIFF
--- a/.github/workflows/runtime-gates.yml
+++ b/.github/workflows/runtime-gates.yml
@@ -204,9 +204,21 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
         uses: ./.github/actions/setup-pnpm-workspace
 
+      - name: Determine PR scope
+        id: scope
+        if: github.event_name == 'pull_request' && steps.changes.outputs.relevant == 'true'
+        run: pnpm exec tsx scripts/ci/pr-scope.ts --base ${{ github.event.pull_request.base.sha }} --github-output
+
       - name: Evaluate complexity gates
         if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
-        run: pnpm complexity-gate
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            pnpm complexity-gate
+          elif [ "${{ steps.scope.outputs.quality_gate_mode }}" = "full" ]; then
+            pnpm complexity-gate
+          else
+            pnpm complexity-gate --base=${{ github.event.pull_request.base.sha }}
+          fi
 
       - name: Publish complexity summary
         if: always()
@@ -215,6 +227,11 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ steps.changes.outputs.relevant }}" != "true" ]; then
             echo 'Scope: keine code-relevanten Änderungen im Pull Request, das Gate endet bewusst als No-op-Erfolg.' >> "$GITHUB_STEP_SUMMARY"
             exit 0
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Scope: \`${{ steps.scope.outputs.quality_gate_mode }}\` gegen Base-SHA \`${{ github.event.pull_request.base.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'Scope: voller Workspace-Lauf für main/schedule.' >> "$GITHUB_STEP_SUMMARY"
           fi
           echo 'Baseline und Policy stammen aus tooling/quality/complexity-*.json.' >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/runtime-gates.yml
+++ b/.github/workflows/runtime-gates.yml
@@ -217,7 +217,7 @@ jobs:
           elif [ "${{ steps.scope.outputs.quality_gate_mode }}" = "full" ]; then
             pnpm complexity-gate
           else
-            pnpm complexity-gate --base=${{ github.event.pull_request.base.sha }}
+            pnpm complexity-gate --base ${{ github.event.pull_request.base.sha }}
           fi
 
       - name: Publish complexity summary

--- a/docs/development/runtime-profile-betrieb.md
+++ b/docs/development/runtime-profile-betrieb.md
@@ -132,6 +132,7 @@ Wichtig für den lokalen `local-keycloak`-Pfad:
 - Normale Tenant-Mutationen für Nutzer, Rollen und Gruppen laufen im lokalen Standardpfad strikt gegen denselben Tenant-Realm wie der Login-Flow, aber über den separaten `tenantAdminClient`.
 - `pnpm env:up:local-keycloak` startet neben dem Dev-Server auch den lokalen Keycloak-Provisioning-Worker. Dessen State und Log liegen unter `artifacts/runtime/`.
 - Fehlt der Worker oder ist sein Prozess stale, meldet `pnpm env:doctor:local-keycloak` einen sichtbaren `warn`-Check, damit Provisioning-Läufe nicht unbemerkt in `planned`/`queued` hängen bleiben.
+- Beim lokalen Worker-Start werden nur `planned`-Provisioning-Läufe übernommen, die nach diesem konkreten Start neu angelegt wurden. Ältere wartende Läufe werden nicht stillschweigend wieder aufgenommen.
 - `KEYCLOAK_ADMIN_REALM` und `KEYCLOAK_ADMIN_CLIENT_ID` beschreiben im lokalen Profil nur noch den Plattform-/Break-Glass-Pfad. Sie sind kein impliziter Fallback für Tenant-Alltagsverwaltung mehr.
 - Realm-Provisioning im lokalen Worker nutzt explizit `KEYCLOAK_PROVISIONER_*`, standardmäßig `master` plus `sva-studio-provisioner`. Fehlen diese Variablen, fällt der Worker weiterhin auf `KEYCLOAK_ADMIN_*` zurück; das ist für neue Tenant-Realms fachlich nicht gewollt.
 - Tenant-Logins laufen fail-closed, wenn für die aktive Instanz kein tenant-spezifisches `auth_client_secret` lesbar ist. Das globale Plattform-Secret bleibt nur für den Plattform-Host zulässig und ist kein stiller Tenant-Fallback.

--- a/docs/development/runtime-profile-betrieb.md
+++ b/docs/development/runtime-profile-betrieb.md
@@ -122,6 +122,7 @@ pnpm env:smoke:local-keycloak
 pnpm env:migrate:local-keycloak
 pnpm env:update:local-keycloak
 pnpm env:down:local-keycloak
+pnpm env:reconcile:local-instance-registry
 ```
 
 Wichtig für den lokalen `local-keycloak`-Pfad:
@@ -135,8 +136,9 @@ Wichtig für den lokalen `local-keycloak`-Pfad:
 - Realm-Provisioning im lokalen Worker nutzt explizit `KEYCLOAK_PROVISIONER_*`, standardmäßig `master` plus `sva-studio-provisioner`. Fehlen diese Variablen, fällt der Worker weiterhin auf `KEYCLOAK_ADMIN_*` zurück; das ist für neue Tenant-Realms fachlich nicht gewollt.
 - Tenant-Logins laufen fail-closed, wenn für die aktive Instanz kein tenant-spezifisches `auth_client_secret` lesbar ist. Das globale Plattform-Secret bleibt nur für den Plattform-Host zulässig und ist kein stiller Tenant-Fallback.
 - Fehlen tenantlokaler Admin-Client oder tenantlokales Secret im Instanzdatensatz, schlagen Tenant-Mutationen fail-closed mit `tenant_admin_client_not_configured` oder `tenant_admin_client_secret_missing` fehl.
-- Die lokale Registry-Reconcile behandelt geschützte Identitätsfelder (`parent_domain`, `primary_hostname`, optional `auth_realm`) standardmäßig non-destructive. Abweichende bestehende Werte werden nur gewarnt und nicht still überschrieben.
-- Für neue lokale Umgebungen oder bewusst autoritative Korrekturen kann `SVA_LOCAL_INSTANCE_IDENTITY_RECONCILE_MODE=authoritative` gesetzt werden. Dann schreibt die Reconcile diese Identitätsfelder gezielt auf das lokale Sollbild.
+- `pnpm env:up:local-keycloak` und `pnpm env:update:local-keycloak` führen auf der Instanz-Registry nur noch einen read-only Drift-Check aus. Sie schreiben keine Hostname-/Realm-/Client-Identität mehr still zurück.
+- Die explizite lokale Registry-Korrektur läuft nur noch über `pnpm env:reconcile:local-instance-registry`.
+- Für neue lokale Umgebungen oder bewusst autoritative Korrekturen kann bei diesem expliziten Reconcile-Pfad `SVA_LOCAL_INSTANCE_IDENTITY_RECONCILE_MODE=authoritative` gesetzt werden. Dann schreibt die Reconcile diese Identitätsfelder gezielt auf das lokale Sollbild.
 - Ob erkannte lokale Identitätsdrift nur gewarnt oder hart geblockt wird, steuert `SVA_LOCAL_INSTANCE_IDENTITY_DRIFT_MODE=warn|fail`. Standard ist `warn`.
 - Wenn ein echter Tenant-Login lokal zwar funktioniert, Plugin- oder Admin-Zugriffe aber trotz sichtbarer Session-Rollen scheitern, liegt häufig Drift zwischen Keycloak-Subject und lokalem `iam.accounts`-Binding vor. `pnpm env:doctor:local-keycloak` meldet das mit `missing_actor_role_assignments` oder `missing_actor_organization_membership`, sobald `SVA_DOCTOR_KEYCLOAK_SUBJECT` und `SVA_DOCTOR_INSTANCE_ID` gesetzt sind.
 - Für gezielte Reparaturen steht `pnpm env:bind:local-user -- --instance-id=<instanz> --keycloak-subject=<subject> --copy-from-keycloak-subject=seed:system_admin` bereit. Alternativ können `--role-keys=...` und `--organization-ids=...` explizit gesetzt werden.
@@ -186,13 +188,21 @@ Der Container-Entrypoint kennt zusätzlich nur noch einen expliziten Legacy-Reco
 
 - lokale Profile starten Docker Compose für Redis/Postgres und optional den Monitoring-Stack
 - lokale Profile starten zusätzlich Adminer auf `http://127.0.0.1:8080`
+- lokale Profile führen dabei nur einen read-only Drift-Check auf der Instanz-Registry aus; schreibende Registry-Reconcile ist kein Teil des Regelbetriebs mehr
 - lokale Profile starten danach den Dev-Server für `sva-studio-react`
 - Remote-Profile (`studio`) nutzen stattdessen den kanonischen Releasepfad `deploy`; direkte Remote-Deploys über `up` sind gesperrt
 
 ### `update`
 
 - lokale Profile ziehen Compose-Images neu, starten Infrastruktur erneut und starten den Dev-Server kontrolliert neu
+- lokale Profile führen dabei nur einen read-only Drift-Check auf der Instanz-Registry aus; schreibende Registry-Reconcile ist kein Teil des Regelbetriebs mehr
 - Remote-Profile (`studio`) nutzen stattdessen den kanonischen Releasepfad `deploy`; direkte Remote-Redeploys über `update` sind gesperrt
+
+### `reconcile`
+
+- nur für lokale Profile vorgesehen
+- führt die lokale Instanz-Registry-Reconcile explizit und bewusst aus
+- ist für neue lokale Setups oder autoritative Korrekturen gedacht, nicht für den normalen Entwicklungsstart
 
 ### `down`
 

--- a/docs/guides/instance-keycloak-provisioning.md
+++ b/docs/guides/instance-keycloak-provisioning.md
@@ -113,6 +113,11 @@ Die UI trennt bewusst zwischen:
 
 Zusatzaktionen wie `Tenant-Admin zurücksetzen` oder `Client-Secret rotieren` laufen als benannte Provisioning-Intents und nicht mehr als unscharfer Sammel-Reconcile.
 
+Wichtig:
+
+- `Tenant-Admin zurücksetzen` ist ein User-Pfad. Dieser Intent korrigiert Tenant-Admin-Profil, Rollen und optional das temporäre Passwort, überschreibt aber nicht nebenbei Login- oder Tenant-Admin-Client-Konfigurationen.
+- Wenn der Plan beim Schritt `Tenant-Admin-Client` ein `update` meldet, würde ein expliziter Keycloak-Abgleich diesen technischen Client auf Root-, Redirect-, Logout- oder Origin-Werte zurückführen. Diese Drift ist in der Vorschau jetzt bewusst sichtbar.
+
 ## Kompakte Betriebs-Checkliste für neue Instanzen
 
 Diese Kurzfassung ist der empfohlene operative Standardpfad für neue oder zu reparierende Instanzen unter `/admin/instances`.

--- a/docs/guides/lokale-instanz-db-initialisierung.md
+++ b/docs/guides/lokale-instanz-db-initialisierung.md
@@ -25,6 +25,7 @@ Nicht verwenden für:
 
 - reguläre lokale Standardentwicklung gegen `de-musterhausen`
 - Acceptance- oder Swarm-Serverdeployments
+- normale tägliche `pnpm env:up:local-keycloak`-Starts gegen ein bereits fertig konfiguriertes System
 
 Für die reguläre lokale Standardentwicklung gilt stattdessen:
 
@@ -192,11 +193,12 @@ Der Login-Pfad der App liest den Ziel-Realm lokal trotzdem aus der Instanz-Regis
 
 Für Tenant-Hosts reicht die Registry-Auflösung allein nicht: Zusätzlich muss das tenant-spezifische `auth_client_secret` für die Zielinstanz vorhanden und lesbar sein. Fehlt dieses Secret, blockiert der Login-Pfad bewusst fail-closed statt auf das globale Plattform-Secret auszuweichen.
 
-Wenn dieselbe lokale Umgebung später über `pnpm env:up:local-keycloak` gegen `studio.localhost` reconciled wird, gilt für geschützte Identitätsfelder standardmäßig ein non-destruktiver Vertrag:
+Wenn dieselbe lokale Umgebung später regulär über `pnpm env:up:local-keycloak` gegen `studio.localhost` gestartet wird, gilt für die Instanz-Registry jetzt ein read-only Vertrag:
 
 - bestehende abweichende Werte werden nur als Drift gemeldet
-- fehlende Werte dürfen aufgefüllt werden
-- autoritative Korrekturen laufen nur explizit über `SVA_LOCAL_INSTANCE_IDENTITY_RECONCILE_MODE=authoritative`
+- der Standardstart schreibt keine Identitätsfelder und keine Hostname-Primärzuordnung mehr zurück
+- Korrekturen laufen nur explizit über `pnpm env:reconcile:local-instance-registry`
+- autoritative Korrekturen laufen dabei nur explizit über `SVA_LOCAL_INSTANCE_IDENTITY_RECONCILE_MODE=authoritative`
 - für staging-nahe oder CI-nahe lokale Prüfpfade kann `SVA_LOCAL_INSTANCE_IDENTITY_DRIFT_MODE=fail` gesetzt werden
 
 ## Empfohlene Optionen

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "env:smoke:local-keycloak": "tsx scripts/ops/runtime-env.ts smoke local-keycloak",
     "env:migrate:local-keycloak": "tsx scripts/ops/runtime-env.ts migrate local-keycloak",
     "env:doctor:local-keycloak": "tsx scripts/ops/runtime-env.ts doctor local-keycloak",
+    "env:reconcile:local-instance-registry": "tsx scripts/ops/runtime-env.ts reconcile local-keycloak",
     "env:bind:local-user": "tsx scripts/ops/bind-local-user.ts",
     "env:bootstrap:local-instance-db": "tsx scripts/ops/bootstrap-local-instance-db.ts",
     "env:delete:local-instance-db": "tsx scripts/ops/delete-local-instance-db.ts",

--- a/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.test.ts
@@ -59,4 +59,16 @@ describe('iam-instance-registry service-keycloak-execution bindings', () => {
       undefined,
     );
   });
+
+  it('ignores an empty startup claim cutoff value after trimming', async () => {
+    process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE = '   ';
+    const subject = await import('./service-keycloak-execution.js');
+
+    await expect(subject.processNextQueuedKeycloakProvisioningRun({ repository: {} } as never)).resolves.toBeNull();
+
+    expect(state.processTargetNextQueuedKeycloakProvisioningRun).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: {}, enriched: true }),
+      undefined,
+    );
+  });
 });

--- a/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.test.ts
@@ -47,4 +47,16 @@ describe('iam-instance-registry service-keycloak-execution bindings', () => {
       { createdAtOrAfter: '2026-05-27T12:00:00.000Z' },
     );
   });
+
+  it('ignores an invalid startup claim cutoff value', async () => {
+    process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE = 'not-a-timestamp';
+    const subject = await import('./service-keycloak-execution.js');
+
+    await expect(subject.processNextQueuedKeycloakProvisioningRun({ repository: {} } as never)).resolves.toBeNull();
+
+    expect(state.processTargetNextQueuedKeycloakProvisioningRun).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: {}, enriched: true }),
+      undefined,
+    );
+  });
 });

--- a/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  processTargetNextQueuedKeycloakProvisioningRun: vi.fn(async () => null),
+  processTargetClaimedKeycloakProvisioningRun: vi.fn(),
+  createTargetExecuteKeycloakProvisioningHandler: vi.fn(),
+  createTargetReconcileKeycloakHandler: vi.fn(),
+  withAuthInstanceRegistryDeps: vi.fn((deps) => ({ ...deps, enriched: true })),
+}));
+
+vi.mock('@sva/instance-registry/service-keycloak-execution', () => ({
+  processNextQueuedKeycloakProvisioningRun: state.processTargetNextQueuedKeycloakProvisioningRun,
+  processClaimedKeycloakProvisioningRun: state.processTargetClaimedKeycloakProvisioningRun,
+  createExecuteKeycloakProvisioningHandler: state.createTargetExecuteKeycloakProvisioningHandler,
+  createReconcileKeycloakHandler: state.createTargetReconcileKeycloakHandler,
+}));
+
+vi.mock('./instance-registry-deps.js', () => ({
+  withAuthInstanceRegistryDeps: state.withAuthInstanceRegistryDeps,
+}));
+
+describe('iam-instance-registry service-keycloak-execution bindings', () => {
+  const originalClaimNotBefore = process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalClaimNotBefore === undefined) {
+      delete process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE;
+      return;
+    }
+
+    process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE = originalClaimNotBefore;
+  });
+
+  it('passes the startup claim cutoff to the target worker helper', async () => {
+    process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE = '2026-05-27T12:00:00.000Z';
+    const subject = await import('./service-keycloak-execution.js');
+
+    await expect(subject.processNextQueuedKeycloakProvisioningRun({ repository: {} } as never)).resolves.toBeNull();
+
+    expect(state.processTargetNextQueuedKeycloakProvisioningRun).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: {}, enriched: true }),
+      { createdAtOrAfter: '2026-05-27T12:00:00.000Z' },
+    );
+  });
+});

--- a/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.ts
@@ -13,7 +13,11 @@ const readWorkerClaimFilterFromEnv = (): {
   createdAtOrAfter?: string;
 } | undefined => {
   const createdAtOrAfter = process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE?.trim();
-  return createdAtOrAfter ? { createdAtOrAfter } : undefined;
+  if (!createdAtOrAfter) {
+    return undefined;
+  }
+
+  return Number.isNaN(Date.parse(createdAtOrAfter)) ? undefined : { createdAtOrAfter };
 };
 
 export const createExecuteKeycloakProvisioningHandler = (deps: InstanceRegistryServiceDeps) =>

--- a/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/service-keycloak-execution.ts
@@ -9,6 +9,13 @@ import type { InstanceRegistryServiceDeps } from '@sva/instance-registry/service
 
 import { withAuthInstanceRegistryDeps } from './instance-registry-deps.js';
 
+const readWorkerClaimFilterFromEnv = (): {
+  createdAtOrAfter?: string;
+} | undefined => {
+  const createdAtOrAfter = process.env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE?.trim();
+  return createdAtOrAfter ? { createdAtOrAfter } : undefined;
+};
+
 export const createExecuteKeycloakProvisioningHandler = (deps: InstanceRegistryServiceDeps) =>
   createTargetExecuteKeycloakProvisioningHandler(withAuthInstanceRegistryDeps(deps));
 
@@ -21,4 +28,4 @@ export const processClaimedKeycloakProvisioningRun = (
 ) => processTargetClaimedKeycloakProvisioningRun(withAuthInstanceRegistryDeps(deps), run);
 
 export const processNextQueuedKeycloakProvisioningRun = (deps: InstanceRegistryServiceDeps) =>
-  processTargetNextQueuedKeycloakProvisioningRun(withAuthInstanceRegistryDeps(deps));
+  processTargetNextQueuedKeycloakProvisioningRun(withAuthInstanceRegistryDeps(deps), readWorkerClaimFilterFromEnv());

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -653,6 +653,48 @@ describe('Keycloak admin client', () => {
     );
   });
 
+  it('updates an existing OIDC client when only flow flags drift', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(
+        createJsonResponse(200, [
+          {
+            id: 'client-1',
+            clientId: 'web-app',
+            rootUrl: 'https://new.example',
+            redirectUris: ['https://new.example/callback'],
+            webOrigins: ['https://new.example'],
+            standardFlowEnabled: true,
+            directAccessGrantsEnabled: true,
+            serviceAccountsEnabled: false,
+            attributes: { 'post.logout.redirect.uris': 'https://new.example/logout' },
+          },
+        ])
+      )
+      .mockResolvedValueOnce(createJsonResponse(200, { value: 'stable-secret' }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const client = await createClient(fetchImpl);
+
+    await client.ensureOidcClient({
+      clientId: 'web-app',
+      redirectUris: ['https://new.example/callback'],
+      postLogoutRedirectUris: ['https://new.example/logout'],
+      webOrigins: ['https://new.example'],
+      rootUrl: 'https://new.example',
+      clientSecret: 'stable-secret',
+      standardFlowEnabled: false,
+      directAccessGrantsEnabled: false,
+      serviceAccountsEnabled: true,
+    });
+
+    const updateCall = fetchImpl.mock.calls.find(
+      (call) => String(call[0]).includes('/clients/client-1') && call[1]?.method === 'PUT'
+    );
+    expect(updateCall).toBeDefined();
+  });
+
   it('creates and updates protocol mappers only when configuration changed', async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/auth-runtime/src/keycloak-admin-client/core.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.ts
@@ -1174,6 +1174,9 @@ export class KeycloakAdminClient implements IdentityProviderPort {
     }
     const requiresUpdate =
       existing.rootUrl !== payload.rootUrl ||
+      existing.standardFlowEnabled !== payload.standardFlowEnabled ||
+      existing.directAccessGrantsEnabled !== payload.directAccessGrantsEnabled ||
+      existing.serviceAccountsEnabled !== payload.serviceAccountsEnabled ||
       !areStringSetsEqual(existing.redirectUris, payload.redirectUris) ||
       !areStringSetsEqual(existing.webOrigins, payload.webOrigins) ||
       !areStringSetsEqual(readPostLogoutRedirectUris(existing.attributes), postLogoutRedirectUris);

--- a/packages/data-repositories/src/instance-registry/index.test.ts
+++ b/packages/data-repositories/src/instance-registry/index.test.ts
@@ -740,4 +740,21 @@ describe('instance registry repository', () => {
       })
     ).rejects.toThrow('keycloak_provisioning_run_idempotency_conflict');
   });
+
+  it('filters claimed keycloak provisioning runs by creation timestamp when requested', async () => {
+    const { executor, statements } = createQueuedExecutor([[keycloakRunRow], []]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.claimNextKeycloakProvisioningRun({
+        createdAtOrAfter: '2026-05-27T12:00:00.000Z',
+      })
+    ).resolves.toMatchObject({
+      id: 'kc-run-1',
+      instanceId: 'tenant-a',
+    });
+
+    expect(statements[0]?.text).toContain("AND created_at >= $1::timestamptz");
+    expect(statements[0]?.values).toEqual(['2026-05-27T12:00:00.000Z']);
+  });
 });

--- a/packages/data-repositories/src/instance-registry/index.ts
+++ b/packages/data-repositories/src/instance-registry/index.ts
@@ -257,7 +257,9 @@ export type InstanceRegistryRepository = {
   } | null>;
   listKeycloakProvisioningRuns(instanceId: string): Promise<readonly InstanceKeycloakProvisioningRun[]>;
   getKeycloakProvisioningRun(instanceId: string, runId: string): Promise<InstanceKeycloakProvisioningRun | null>;
-  claimNextKeycloakProvisioningRun(): Promise<InstanceKeycloakProvisioningRun | null>;
+  claimNextKeycloakProvisioningRun(input?: {
+    createdAtOrAfter?: string;
+  }): Promise<InstanceKeycloakProvisioningRun | null>;
   createInstance(input: {
     instanceId: string;
     displayName: string;
@@ -1331,7 +1333,9 @@ LIMIT 1;
     return mapKeycloakProvisioningRun(row, stepsByRunId[row.id] ?? []);
   },
 
-  async claimNextKeycloakProvisioningRun() {
+  async claimNextKeycloakProvisioningRun(input) {
+    const createdAtOrAfter = input?.createdAtOrAfter?.trim();
+    const createdAtFilter = createdAtOrAfter ? '    AND created_at >= $1::timestamptz\n' : '';
     const rows = await queryRows<KeycloakProvisioningRunRow>(
       executor,
       statement(
@@ -1340,6 +1344,7 @@ WITH next_run AS (
   SELECT id
   FROM iam.instance_keycloak_provisioning_runs
   WHERE overall_status = 'planned'
+${createdAtFilter}
   ORDER BY created_at ASC, id ASC
   FOR UPDATE SKIP LOCKED
   LIMIT 1
@@ -1365,7 +1370,7 @@ RETURNING
   runs.created_at::text,
   runs.updated_at::text;
 `,
-        []
+        createdAtOrAfter ? [createdAtOrAfter] : []
       )
     );
     const row = rows[0];

--- a/packages/instance-registry/src/provisioning-auth-plan.ts
+++ b/packages/instance-registry/src/provisioning-auth-plan.ts
@@ -48,6 +48,24 @@ const readClientAlignment = (state: KeycloakReadState | undefined) => {
   };
 };
 
+const readTenantAdminClientAlignment = (state: KeycloakReadState | undefined) => {
+  const expectedClient = state?.expectedTenantAdminClient;
+  const clientRepresentation = state?.tenantAdminClientRepresentation;
+  return {
+    clientRepresentation,
+    rootUrlMatch: expectedClient ? clientRepresentation?.rootUrl === expectedClient.rootUrl : false,
+    redirectUrisMatch: expectedClient
+      ? equalSets(clientRepresentation?.redirectUris ?? [], expectedClient.redirectUris)
+      : false,
+    logoutUrisMatch: expectedClient
+      ? equalSets(readPostLogoutUris(clientRepresentation?.attributes), expectedClient.postLogoutRedirectUris)
+      : false,
+    webOriginsMatch: expectedClient
+      ? equalSets(clientRepresentation?.webOrigins ?? [], expectedClient.webOrigins)
+      : false,
+  };
+};
+
 const buildClientStep = (input: {
   blocked: boolean;
   clientExists: boolean;
@@ -85,18 +103,33 @@ const areClientUrisAligned = (input: {
 const buildTenantAdminClientStep = (input: {
   blocked: boolean;
   clientExists: boolean;
-}): KeycloakTenantPlan['steps'][number] => ({
-  stepKey: 'tenant_admin_client',
-  title: 'Tenant-Admin-Client abgleichen',
-  action: input.clientExists ? 'verify' : 'create',
-  status: input.blocked ? 'blocked' : 'ready',
-  summary: input.clientExists
-    ? 'Der Tenant-Admin-Client entspricht bereits dem Sollzustand.'
-    : 'Der technische Tenant-Admin-Client wird angelegt oder ergänzt.',
-  details: {
-    clientExists: input.clientExists,
-  },
-});
+  rootUrlMatch: boolean;
+  redirectUrisMatch: boolean;
+  logoutUrisMatch: boolean;
+  webOriginsMatch: boolean;
+}): KeycloakTenantPlan['steps'][number] => {
+  const fullyAligned =
+    input.rootUrlMatch && input.redirectUrisMatch && input.logoutUrisMatch && input.webOriginsMatch;
+
+  return {
+    stepKey: 'tenant_admin_client',
+    title: 'Tenant-Admin-Client abgleichen',
+    action: !input.clientExists ? 'create' : fullyAligned ? 'verify' : 'update',
+    status: input.blocked ? 'blocked' : 'ready',
+    summary: !input.clientExists
+      ? 'Der technische Tenant-Admin-Client wird angelegt oder ergänzt.'
+      : fullyAligned
+        ? 'Der Tenant-Admin-Client entspricht bereits dem Sollzustand.'
+        : 'Der Tenant-Admin-Client wird auf Root-, Redirect-, Logout- und Origin-Werte abgeglichen.',
+    details: {
+      clientExists: input.clientExists,
+      rootUrlMatch: input.rootUrlMatch,
+      redirectUrisMatch: input.redirectUrisMatch,
+      logoutUrisMatch: input.logoutUrisMatch,
+      webOriginsMatch: input.webOriginsMatch,
+    },
+  };
+};
 
 const buildSecretStep = (blocked: boolean, secretAligned: boolean): KeycloakTenantPlan['steps'][number] => ({
   stepKey: 'secret',
@@ -205,6 +238,7 @@ export const buildPlan = (input: {
 }): KeycloakTenantPlan => {
   const blocked = input.preflight.overallStatus === 'blocked';
   const alignment = readClientAlignment(input.state);
+  const tenantAdminClientAlignment = readTenantAdminClientAlignment(input.state);
   const secretAligned = Boolean(
     input.authClientSecret &&
       input.state?.keycloakClientSecret &&
@@ -227,7 +261,11 @@ export const buildPlan = (input: {
     }),
     buildTenantAdminClientStep({
       blocked,
-      clientExists: Boolean(input.state?.tenantAdminClientRepresentation),
+      clientExists: Boolean(tenantAdminClientAlignment.clientRepresentation),
+      rootUrlMatch: tenantAdminClientAlignment.rootUrlMatch,
+      redirectUrisMatch: tenantAdminClientAlignment.redirectUrisMatch,
+      logoutUrisMatch: tenantAdminClientAlignment.logoutUrisMatch,
+      webOriginsMatch: tenantAdminClientAlignment.webOriginsMatch,
     }),
     buildSecretStep(blocked, secretAligned),
     buildTenantAdminClientSecretStep(
@@ -256,7 +294,9 @@ const resolveDriftSummary = (
     return 'Provisioning ist blockiert, bis die Vorbedingungen erfüllt sind.';
   }
 
-  const requiresChanges = steps.some((step) => step.action !== 'verify' && step.action !== 'skip');
+  const requiresChanges = steps.some(
+    (step: KeycloakTenantPlan['steps'][number]) => step.action !== 'verify' && step.action !== 'skip'
+  );
   return requiresChanges
     ? 'Keycloak und Registry weisen Drift auf und werden beim nächsten Lauf abgeglichen.'
     : 'Keycloak entspricht bereits dem im Studio gepflegten Sollzustand.';

--- a/packages/instance-registry/src/provisioning-auth-plan.ts
+++ b/packages/instance-registry/src/provisioning-auth-plan.ts
@@ -53,25 +53,13 @@ const readTenantAdminClientAlignment = (state: KeycloakReadState | undefined) =>
   const clientRepresentation = state?.tenantAdminClientRepresentation;
   return {
     clientRepresentation,
-    directAccessGrantsEnabledMatch: expectedClient
-      ? clientRepresentation?.directAccessGrantsEnabled === expectedClient.directAccessGrantsEnabled
-      : false,
+    directAccessGrantsEnabledMatch: expectedClient ? clientRepresentation?.directAccessGrantsEnabled === expectedClient.directAccessGrantsEnabled : false,
     rootUrlMatch: expectedClient ? clientRepresentation?.rootUrl === expectedClient.rootUrl : false,
-    redirectUrisMatch: expectedClient
-      ? equalSets(clientRepresentation?.redirectUris ?? [], expectedClient.redirectUris)
-      : false,
-    serviceAccountsEnabledMatch: expectedClient
-      ? clientRepresentation?.serviceAccountsEnabled === expectedClient.serviceAccountsEnabled
-      : false,
-    standardFlowEnabledMatch: expectedClient
-      ? clientRepresentation?.standardFlowEnabled === expectedClient.standardFlowEnabled
-      : false,
-    logoutUrisMatch: expectedClient
-      ? equalSets(readPostLogoutUris(clientRepresentation?.attributes), expectedClient.postLogoutRedirectUris)
-      : false,
-    webOriginsMatch: expectedClient
-      ? equalSets(clientRepresentation?.webOrigins ?? [], expectedClient.webOrigins)
-      : false,
+    redirectUrisMatch: expectedClient ? equalSets(clientRepresentation?.redirectUris ?? [], expectedClient.redirectUris) : false,
+    serviceAccountsEnabledMatch: expectedClient ? clientRepresentation?.serviceAccountsEnabled === expectedClient.serviceAccountsEnabled : false,
+    standardFlowEnabledMatch: expectedClient ? clientRepresentation?.standardFlowEnabled === expectedClient.standardFlowEnabled : false,
+    logoutUrisMatch: expectedClient ? equalSets(readPostLogoutUris(clientRepresentation?.attributes), expectedClient.postLogoutRedirectUris) : false,
+    webOriginsMatch: expectedClient ? equalSets(clientRepresentation?.webOrigins ?? [], expectedClient.webOrigins) : false,
   };
 };
 
@@ -120,14 +108,7 @@ const buildTenantAdminClientStep = (input: {
   standardFlowEnabledMatch: boolean;
   webOriginsMatch: boolean;
 }): KeycloakTenantPlan['steps'][number] => {
-  const fullyAligned =
-    input.rootUrlMatch
-    && input.redirectUrisMatch
-    && input.logoutUrisMatch
-    && input.webOriginsMatch
-    && input.standardFlowEnabledMatch
-    && input.directAccessGrantsEnabledMatch
-    && input.serviceAccountsEnabledMatch;
+  const fullyAligned = input.rootUrlMatch && input.redirectUrisMatch && input.logoutUrisMatch && input.webOriginsMatch && input.standardFlowEnabledMatch && input.directAccessGrantsEnabledMatch && input.serviceAccountsEnabledMatch;
 
   return {
     stepKey: 'tenant_admin_client',
@@ -318,9 +299,7 @@ const resolveDriftSummary = (
     return 'Provisioning ist blockiert, bis die Vorbedingungen erfüllt sind.';
   }
 
-  const requiresChanges = steps.some(
-    (step: KeycloakTenantPlan['steps'][number]) => step.action !== 'verify' && step.action !== 'skip'
-  );
+  const requiresChanges = steps.some((step: KeycloakTenantPlan['steps'][number]) => step.action !== 'verify' && step.action !== 'skip');
   return requiresChanges
     ? 'Keycloak und Registry weisen Drift auf und werden beim nächsten Lauf abgeglichen.'
     : 'Keycloak entspricht bereits dem im Studio gepflegten Sollzustand.';

--- a/packages/instance-registry/src/provisioning-auth-plan.ts
+++ b/packages/instance-registry/src/provisioning-auth-plan.ts
@@ -53,9 +53,18 @@ const readTenantAdminClientAlignment = (state: KeycloakReadState | undefined) =>
   const clientRepresentation = state?.tenantAdminClientRepresentation;
   return {
     clientRepresentation,
+    directAccessGrantsEnabledMatch: expectedClient
+      ? clientRepresentation?.directAccessGrantsEnabled === expectedClient.directAccessGrantsEnabled
+      : false,
     rootUrlMatch: expectedClient ? clientRepresentation?.rootUrl === expectedClient.rootUrl : false,
     redirectUrisMatch: expectedClient
       ? equalSets(clientRepresentation?.redirectUris ?? [], expectedClient.redirectUris)
+      : false,
+    serviceAccountsEnabledMatch: expectedClient
+      ? clientRepresentation?.serviceAccountsEnabled === expectedClient.serviceAccountsEnabled
+      : false,
+    standardFlowEnabledMatch: expectedClient
+      ? clientRepresentation?.standardFlowEnabled === expectedClient.standardFlowEnabled
       : false,
     logoutUrisMatch: expectedClient
       ? equalSets(readPostLogoutUris(clientRepresentation?.attributes), expectedClient.postLogoutRedirectUris)
@@ -103,13 +112,22 @@ const areClientUrisAligned = (input: {
 const buildTenantAdminClientStep = (input: {
   blocked: boolean;
   clientExists: boolean;
+  directAccessGrantsEnabledMatch: boolean;
   rootUrlMatch: boolean;
   redirectUrisMatch: boolean;
   logoutUrisMatch: boolean;
+  serviceAccountsEnabledMatch: boolean;
+  standardFlowEnabledMatch: boolean;
   webOriginsMatch: boolean;
 }): KeycloakTenantPlan['steps'][number] => {
   const fullyAligned =
-    input.rootUrlMatch && input.redirectUrisMatch && input.logoutUrisMatch && input.webOriginsMatch;
+    input.rootUrlMatch
+    && input.redirectUrisMatch
+    && input.logoutUrisMatch
+    && input.webOriginsMatch
+    && input.standardFlowEnabledMatch
+    && input.directAccessGrantsEnabledMatch
+    && input.serviceAccountsEnabledMatch;
 
   return {
     stepKey: 'tenant_admin_client',
@@ -123,9 +141,12 @@ const buildTenantAdminClientStep = (input: {
         : 'Der Tenant-Admin-Client wird auf Root-, Redirect-, Logout- und Origin-Werte abgeglichen.',
     details: {
       clientExists: input.clientExists,
+      directAccessGrantsEnabledMatch: input.directAccessGrantsEnabledMatch,
       rootUrlMatch: input.rootUrlMatch,
       redirectUrisMatch: input.redirectUrisMatch,
       logoutUrisMatch: input.logoutUrisMatch,
+      serviceAccountsEnabledMatch: input.serviceAccountsEnabledMatch,
+      standardFlowEnabledMatch: input.standardFlowEnabledMatch,
       webOriginsMatch: input.webOriginsMatch,
     },
   };
@@ -262,9 +283,12 @@ export const buildPlan = (input: {
     buildTenantAdminClientStep({
       blocked,
       clientExists: Boolean(tenantAdminClientAlignment.clientRepresentation),
+      directAccessGrantsEnabledMatch: tenantAdminClientAlignment.directAccessGrantsEnabledMatch,
       rootUrlMatch: tenantAdminClientAlignment.rootUrlMatch,
       redirectUrisMatch: tenantAdminClientAlignment.redirectUrisMatch,
       logoutUrisMatch: tenantAdminClientAlignment.logoutUrisMatch,
+      serviceAccountsEnabledMatch: tenantAdminClientAlignment.serviceAccountsEnabledMatch,
+      standardFlowEnabledMatch: tenantAdminClientAlignment.standardFlowEnabledMatch,
       webOriginsMatch: tenantAdminClientAlignment.webOriginsMatch,
     }),
     buildSecretStep(blocked, secretAligned),

--- a/packages/instance-registry/src/provisioning-auth-state.test.ts
+++ b/packages/instance-registry/src/provisioning-auth-state.test.ts
@@ -172,6 +172,39 @@ describe('provisioning-auth-state', () => {
     expect(client.syncRoles).toHaveBeenCalledWith('user-1', ['system_admin']);
   });
 
+  it('skips client reconciliation for tenant-admin-only reset flows', async () => {
+    const client = createClient();
+    const provision = createProvisionInstanceAuthArtifacts(() => client);
+
+    await provision({
+      instanceId: 'demo',
+      primaryHostname: 'demo.example.org',
+      realmMode: 'existing',
+      authRealm: 'demo',
+      authClientId: 'sva-studio',
+      tenantAdminClient: {
+        clientId: 'tenant-admin',
+      },
+      tenantAdminClientSecret: 'tenant-secret',
+      tenantAdminBootstrap: {
+        username: 'tenant-admin',
+        email: 'tenant-admin@example.org',
+      },
+      tenantAdminTemporaryPassword: 'tmp-password',
+      reconcileAuthClient: false,
+      reconcileTenantAdminClient: false,
+    });
+
+    expect(client.ensureOidcClient).not.toHaveBeenCalled();
+    expect(client.ensureTenantAdminServiceAccess).not.toHaveBeenCalled();
+    expect(client.createUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'tenant-admin',
+      })
+    );
+    expect(client.setUserPassword).toHaveBeenCalledWith('user-1', 'tmp-password', true);
+  });
+
   it('recovers from conflicting tenant admin creation by updating the matching email user', async () => {
     const client = createClient({
       findUserByUsername: vi.fn(async () => null),

--- a/packages/instance-registry/src/provisioning-auth-state.ts
+++ b/packages/instance-registry/src/provisioning-auth-state.ts
@@ -117,6 +117,8 @@ type ProvisionInstanceAuthArtifactsInput = {
   tenantAdminBootstrap?: TenantAdminBootstrap;
   tenantAdminTemporaryPassword?: string;
   rotateClientSecret?: boolean;
+  reconcileAuthClient?: boolean;
+  reconcileTenantAdminClient?: boolean;
 };
 
 const isConflictRequestError = (error: unknown): boolean =>
@@ -286,6 +288,8 @@ export const createProvisionInstanceAuthArtifacts =
   ): Promise<void> => {
     const client = createClient(input.authRealm);
     const expectedClient = buildExpectedClientConfig(input.primaryHostname);
+    const reconcileAuthClient = input.reconcileAuthClient ?? true;
+    const reconcileTenantAdminClient = input.reconcileTenantAdminClient ?? true;
 
     if (input.realmMode === 'new') {
       await client.ensureRealm({ displayName: input.instanceId });
@@ -295,17 +299,19 @@ export const createProvisionInstanceAuthArtifacts =
         throw new Error(`Keycloak realm ${input.authRealm} does not exist`);
       }
     }
-    await client.ensureOidcClient({
-      clientId: input.authClientId,
-      redirectUris: expectedClient.redirectUris,
-      postLogoutRedirectUris: expectedClient.postLogoutRedirectUris,
-      webOrigins: expectedClient.webOrigins,
-      rootUrl: expectedClient.rootUrl,
-      clientSecret: input.authClientSecret,
-      rotateClientSecret: input.rotateClientSecret,
-    });
+    if (reconcileAuthClient) {
+      await client.ensureOidcClient({
+        clientId: input.authClientId,
+        redirectUris: expectedClient.redirectUris,
+        postLogoutRedirectUris: expectedClient.postLogoutRedirectUris,
+        webOrigins: expectedClient.webOrigins,
+        rootUrl: expectedClient.rootUrl,
+        clientSecret: input.authClientSecret,
+        rotateClientSecret: input.rotateClientSecret,
+      });
+    }
 
-    if (input.tenantAdminClient?.clientId) {
+    if (input.tenantAdminClient?.clientId && reconcileTenantAdminClient) {
       const expectedTenantAdminClient = buildExpectedTenantAdminClientConfig(input.primaryHostname);
       await client.ensureOidcClient({
         clientId: input.tenantAdminClient.clientId,

--- a/packages/instance-registry/src/provisioning-auth-types.ts
+++ b/packages/instance-registry/src/provisioning-auth-types.ts
@@ -4,8 +4,12 @@ import { buildExpectedClientConfig, buildExpectedTenantAdminClientConfig } from 
 
 export type KeycloakClientRepresentation = {
   readonly id?: string;
+  readonly rootUrl?: string;
   readonly redirectUris?: readonly string[];
   readonly webOrigins?: readonly string[];
+  readonly standardFlowEnabled?: boolean;
+  readonly directAccessGrantsEnabled?: boolean;
+  readonly serviceAccountsEnabled?: boolean;
   readonly attributes?: Readonly<Record<string, string>>;
 } | null;
 

--- a/packages/instance-registry/src/provisioning-auth.test.ts
+++ b/packages/instance-registry/src/provisioning-auth.test.ts
@@ -159,4 +159,34 @@ describe('provisioning-auth readers', () => {
       })
     );
   });
+
+  it('marks tenant admin flow flag drift as an update in the plan preview', async () => {
+    const driftedReadState = vi.fn(async (): Promise<KeycloakReadState> => ({
+      ...(await readState(input)),
+      tenantAdminClientRepresentation: {
+        ...(await readState(input)).tenantAdminClientRepresentation,
+        directAccessGrantsEnabled: false,
+        serviceAccountsEnabled: false,
+        standardFlowEnabled: false,
+      },
+    }));
+    const preflight = createInstanceKeycloakPreflightReader(driftedReadState);
+    const plan = createInstanceKeycloakPlanReader(driftedReadState, preflight);
+
+    await expect(plan(input)).resolves.toEqual(
+      expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            stepKey: 'tenant_admin_client',
+            action: 'update',
+            details: expect.objectContaining({
+              directAccessGrantsEnabledMatch: false,
+              serviceAccountsEnabledMatch: false,
+              standardFlowEnabledMatch: false,
+            }),
+          }),
+        ]),
+      })
+    );
+  });
 });

--- a/packages/instance-registry/src/provisioning-auth.test.ts
+++ b/packages/instance-registry/src/provisioning-auth.test.ts
@@ -123,4 +123,40 @@ describe('provisioning-auth readers', () => {
     );
     await expect(plan(input)).resolves.toEqual(expect.objectContaining({ overallStatus: 'blocked' }));
   });
+
+  it('marks tenant admin client drift as an update in the plan preview', async () => {
+    const driftedReadState = vi.fn(async (): Promise<KeycloakReadState> => ({
+      ...(await readState(input)),
+      tenantAdminClientRepresentation: {
+        id: 'tenant-admin-client-1',
+        clientId: 'tenant-admin',
+        redirectUris: ['https://legacy.example.org/callback'],
+        attributes: {
+          'post.logout.redirect.uris': 'https://legacy.example.org/logout',
+        },
+        webOrigins: ['https://legacy.example.org'],
+        rootUrl: 'https://legacy.example.org',
+      },
+    }));
+    const preflight = createInstanceKeycloakPreflightReader(driftedReadState);
+    const plan = createInstanceKeycloakPlanReader(driftedReadState, preflight);
+
+    await expect(plan(input)).resolves.toEqual(
+      expect.objectContaining({
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            stepKey: 'tenant_admin_client',
+            action: 'update',
+            details: expect.objectContaining({
+              clientExists: true,
+              rootUrlMatch: false,
+              redirectUrisMatch: false,
+              logoutUrisMatch: false,
+              webOriginsMatch: false,
+            }),
+          }),
+        ]),
+      })
+    );
+  });
 });

--- a/packages/instance-registry/src/service-keycloak-execution-finalize.test.ts
+++ b/packages/instance-registry/src/service-keycloak-execution-finalize.test.ts
@@ -176,4 +176,88 @@ describe('service-keycloak-execution-finalize', () => {
       })
     );
   });
+
+  it('keeps reset_tenant_admin runs successful when unrelated client drift remains', async () => {
+    const { completeRun } = await import('./service-keycloak-execution-finalize.js');
+    const status = {
+      realmExists: true,
+      clientExists: true,
+      redirectUrisMatch: false,
+      logoutUrisMatch: false,
+      webOriginsMatch: false,
+      clientSecretAligned: false,
+      tenantAdminClientExists: false,
+      tenantAdminClientSecretAligned: false,
+      tenantAdminHasSystemAdmin: true,
+      tenantAdminHasInstanceRegistryAdmin: false,
+      tenantAdminExists: true,
+    };
+    const repository = {
+      setInstanceStatus: vi.fn().mockResolvedValue(undefined),
+      updateKeycloakProvisioningRun: vi.fn().mockResolvedValue(undefined),
+    };
+
+    state.buildProvisioningInput.mockReturnValue({ payload: 'provisioning' });
+    state.buildFinalRunSteps.mockReturnValue([
+      {
+        stepKey: 'realm',
+        title: 'Realm bearbeiten',
+        ok: true,
+        summary: 'ok',
+      },
+      {
+        stepKey: 'roles',
+        title: 'Realm-Rollen sicherstellen',
+        ok: true,
+        summary: 'ok',
+      },
+      {
+        stepKey: 'tenant_admin',
+        title: 'Tenant-Admin sicherstellen',
+        ok: true,
+        summary: 'ok',
+      },
+      {
+        stepKey: 'tenant_admin_password',
+        title: 'Temporäres Passwort setzen',
+        ok: true,
+        summary: 'ok',
+      },
+    ]);
+    state.areAllRequirementsSatisfied.mockReturnValue(false);
+    state.appendRunStep.mockResolvedValue(undefined);
+
+    const result = await completeRun(
+      {
+        repository: repository as never,
+        getKeycloakStatus: vi.fn().mockResolvedValue(status),
+      } as never,
+      {
+        loaded: {
+          instance: {
+            instanceId: 'instance-3',
+            status: 'draft',
+          },
+        } as never,
+        runId: 'run-3',
+        requestId: 'request-3',
+        actorId: 'actor-3',
+        intent: 'reset_tenant_admin',
+        tenantAdminTemporaryPassword: 'tmp-password',
+      }
+    );
+
+    expect(result).toBe('succeeded');
+    expect(repository.setInstanceStatus).toHaveBeenCalledWith({
+      instanceId: 'instance-3',
+      status: 'provisioning',
+      actorId: 'actor-3',
+      requestId: 'request-3',
+    });
+    expect(repository.updateKeycloakProvisioningRun).toHaveBeenCalledWith({
+      runId: 'run-3',
+      overallStatus: 'succeeded',
+      driftSummary: 'Provisioning erfolgreich abgeschlossen.',
+    });
+  });
 });

--- a/packages/instance-registry/src/service-keycloak-execution-finalize.ts
+++ b/packages/instance-registry/src/service-keycloak-execution-finalize.ts
@@ -51,8 +51,10 @@ export const completeRun = async (
     });
   }
 
+  const completionSatisfied = completionSteps.every((step) => step.ok);
   const finalRunStatus =
-    completionSteps.every((step) => step.ok) && areAllInstanceKeycloakRequirementsSatisfied(status)
+    completionSatisfied &&
+    (input.intent === 'reset_tenant_admin' || areAllInstanceKeycloakRequirementsSatisfied(status))
       ? 'succeeded'
       : 'failed';
 

--- a/packages/instance-registry/src/service-keycloak-execution.test.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.test.ts
@@ -322,6 +322,37 @@ describe('service-keycloak-execution', () => {
     expect(repository.getKeycloakProvisioningRun).toHaveBeenCalledWith('instance-1', 'run-1');
   });
 
+  it('surfaces blocked preflight summaries before enqueuing reconcile runs', async () => {
+    const { createReconcileKeycloakHandler } = await import('./service-keycloak-execution.js');
+    const createQueuedRun = vi.fn();
+    state.loadInstanceWithSecret.mockResolvedValue(createLoaded());
+    const handler = createReconcileKeycloakHandler({
+      repository: {} as never,
+      createQueuedRun,
+      getKeycloakPreflight: vi.fn().mockResolvedValue({
+        overallStatus: 'blocked',
+        checks: [
+          { status: 'blocked', summary: 'Realm fehlt.' },
+          { status: 'ok', summary: 'ignored' },
+          { status: 'blocked', summary: '' },
+          { status: 'blocked', summary: 'Client fehlt.' },
+        ],
+      }),
+      planKeycloakProvisioning: vi.fn().mockResolvedValue({ overallStatus: 'ok', driftSummary: 'ok' }),
+    } as never);
+
+    await expect(
+      handler({
+        instanceId: 'instance-1',
+        idempotencyKey: 'idem-1',
+        actorId: 'actor-1',
+        requestId: 'request-1',
+      })
+    ).rejects.toThrow('registry_or_provisioning_drift_blocked:Realm fehlt. Client fehlt.');
+
+    expect(createQueuedRun).not.toHaveBeenCalled();
+  });
+
   it('claims the next queued run via the repository helper', async () => {
     const { processNextQueuedKeycloakProvisioningRun } = await import('./service-keycloak-execution.js');
     const repository = {

--- a/packages/instance-registry/src/service-keycloak-execution.test.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.test.ts
@@ -255,6 +255,8 @@ describe('service-keycloak-execution', () => {
         reconcileTenantAdminClient: false,
       })
     );
+    expect(state.syncProvisionedClientSecretToRegistry).not.toHaveBeenCalled();
+    expect(state.syncRotatedClientSecretToRegistry).not.toHaveBeenCalled();
   });
 
   it('fails the run when execution throws and reloads the persisted run state', async () => {

--- a/packages/instance-registry/src/service-keycloak-execution.test.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.test.ts
@@ -222,6 +222,41 @@ describe('service-keycloak-execution', () => {
     expect(state.completeRun).toHaveBeenCalled();
   });
 
+  it('limits reset_tenant_admin runs to tenant-admin user reconciliation', async () => {
+    const { processClaimedKeycloakProvisioningRun } = await import('./service-keycloak-execution.js');
+    const repository = {
+      getKeycloakProvisioningRun: vi.fn().mockResolvedValue({ id: 'run-1', overallStatus: 'succeeded' }),
+    };
+    const provisionInstanceAuth = vi.fn().mockResolvedValue(undefined);
+    state.loadInstanceWithSecret.mockResolvedValue(createLoaded());
+    state.readQueuedTemporaryPassword.mockReturnValue('tmp-password');
+
+    await expect(
+      processClaimedKeycloakProvisioningRun(
+        {
+          repository: repository as never,
+          provisionInstanceAuth,
+          getKeycloakStatus: vi.fn(),
+          getKeycloakPreflight: vi.fn().mockResolvedValue({ overallStatus: 'ok' }),
+          planKeycloakProvisioning: vi.fn().mockResolvedValue({ overallStatus: 'ok', driftSummary: 'ok' }),
+        } as never,
+        createRun({
+          intent: 'reset_tenant_admin',
+          mode: 'existing',
+          steps: [{ stepKey: 'queued', details: {} }],
+        })
+      )
+    ).resolves.toEqual({ id: 'run-1', overallStatus: 'succeeded' });
+
+    expect(provisionInstanceAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantAdminTemporaryPassword: 'tmp-password',
+        reconcileAuthClient: false,
+        reconcileTenantAdminClient: false,
+      })
+    );
+  });
+
   it('fails the run when execution throws and reloads the persisted run state', async () => {
     const { processClaimedKeycloakProvisioningRun } = await import('./service-keycloak-execution.js');
     const repository = {
@@ -300,5 +335,25 @@ describe('service-keycloak-execution', () => {
     ).resolves.toBeNull();
 
     expect(repository.claimNextKeycloakProvisioningRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes claim filters through to the repository helper', async () => {
+    const { processNextQueuedKeycloakProvisioningRun } = await import('./service-keycloak-execution.js');
+    const repository = {
+      claimNextKeycloakProvisioningRun: vi.fn().mockResolvedValue(null),
+    };
+
+    await expect(
+      processNextQueuedKeycloakProvisioningRun(
+        {
+          repository: repository as never,
+        } as never,
+        { createdAtOrAfter: '2026-05-27T12:00:00.000Z' }
+      )
+    ).resolves.toBeNull();
+
+    expect(repository.claimNextKeycloakProvisioningRun).toHaveBeenCalledWith({
+      createdAtOrAfter: '2026-05-27T12:00:00.000Z',
+    });
   });
 });

--- a/packages/instance-registry/src/service-keycloak-execution.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.ts
@@ -88,6 +88,9 @@ const syncClientSecretAfterProvisioning = async (deps: InstanceRegistryServiceDe
     });
     return;
   }
+  if (run.intent === 'reset_tenant_admin') {
+    return;
+  }
   await syncProvisionedClientSecretToRegistry(deps, {
     loaded,
     requestId: run.requestId,

--- a/packages/instance-registry/src/service-keycloak-execution.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.ts
@@ -95,6 +95,11 @@ const syncClientSecretAfterProvisioning = async (deps: InstanceRegistryServiceDe
   });
 };
 
+const buildProvisioningExecutionOptions = (intent: InstanceKeycloakProvisioningRun['intent']) => ({
+  reconcileAuthClient: intent !== 'reset_tenant_admin',
+  reconcileTenantAdminClient: intent !== 'reset_tenant_admin',
+});
+
 const executeClaimedRun = async (deps: InstanceRegistryServiceDeps, run: InstanceKeycloakProvisioningRun, loaded: NonNullable<Awaited<ReturnType<typeof loadInstanceWithSecret>>>, tenantAdminTemporaryPassword: string | undefined, provisioningInput: ReturnType<typeof buildProvisioningInput>) => {
   const preflight = await appendPreflightSnapshot(deps, run, provisioningInput);
   const plan = await appendPlanSnapshot(deps, run, provisioningInput);
@@ -120,6 +125,7 @@ const executeClaimedRun = async (deps: InstanceRegistryServiceDeps, run: Instanc
     ...provisioningInput,
     tenantAdminTemporaryPassword,
     rotateClientSecret: run.intent === 'rotate_client_secret',
+    ...buildProvisioningExecutionOptions(run.intent),
   });
 
   await syncClientSecretAfterProvisioning(deps, run, loaded);
@@ -188,14 +194,21 @@ export const processClaimedKeycloakProvisioningRun = async (
   }
 };
 
-export const processNextQueuedKeycloakProvisioningRun = async (deps: InstanceRegistryServiceDeps) =>
+export const processNextQueuedKeycloakProvisioningRun = async (
+  deps: InstanceRegistryServiceDeps,
+  claimFilter?: {
+    createdAtOrAfter?: string;
+  }
+) =>
   processClaimedKeycloakProvisioningRun(
     deps,
     await (
       deps.repository as InstanceRegistryServiceDeps['repository'] & {
-        claimNextKeycloakProvisioningRun: () => Promise<InstanceKeycloakProvisioningRun | null>;
+        claimNextKeycloakProvisioningRun: (input?: {
+          createdAtOrAfter?: string;
+        }) => Promise<InstanceKeycloakProvisioningRun | null>;
       }
-    ).claimNextKeycloakProvisioningRun()
+    ).claimNextKeycloakProvisioningRun(claimFilter)
   );
 
 export const createExecuteKeycloakProvisioningHandler =
@@ -252,9 +265,11 @@ const ensureReconcilePreconditions = async (
   const blockingSummary =
     preflight?.overallStatus === 'blocked'
       ? preflight.checks
-          .filter((check) => check.status === 'blocked')
-          .map((check) => check.summary)
-          .filter((summary): summary is string => typeof summary === 'string' && summary.length > 0)
+          .filter(
+            (check: NonNullable<typeof preflight>['checks'][number]) => check.status === 'blocked'
+          )
+          .map((check: NonNullable<typeof preflight>['checks'][number]) => check.summary)
+          .filter((summary: string): summary is string => typeof summary === 'string' && summary.length > 0)
           .join(' ')
       : plan?.overallStatus === 'blocked'
         ? plan.driftSummary

--- a/packages/instance-registry/src/service-keycloak-execution.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.ts
@@ -255,11 +255,9 @@ const ensureReconcilePreconditions = async (
   const blockingSummary =
     preflight?.overallStatus === 'blocked'
       ? preflight.checks
-          .filter(
-            (check: NonNullable<typeof preflight>['checks'][number]) => check.status === 'blocked'
-          )
-          .map((check: NonNullable<typeof preflight>['checks'][number]) => check.summary)
-          .filter((summary: string): summary is string => typeof summary === 'string' && summary.length > 0)
+          .filter((check) => check.status === 'blocked')
+          .map((check) => check.summary)
+          .filter((summary) => summary.length > 0)
           .join(' ')
       : plan?.overallStatus === 'blocked'
         ? plan.driftSummary

--- a/packages/instance-registry/src/service-keycloak-execution.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.ts
@@ -95,10 +95,7 @@ const syncClientSecretAfterProvisioning = async (deps: InstanceRegistryServiceDe
   });
 };
 
-const buildProvisioningExecutionOptions = (intent: InstanceKeycloakProvisioningRun['intent']) => ({
-  reconcileAuthClient: intent !== 'reset_tenant_admin',
-  reconcileTenantAdminClient: intent !== 'reset_tenant_admin',
-});
+const buildProvisioningExecutionOptions = (intent: InstanceKeycloakProvisioningRun['intent']) => ({ reconcileAuthClient: intent !== 'reset_tenant_admin', reconcileTenantAdminClient: intent !== 'reset_tenant_admin' });
 
 const executeClaimedRun = async (deps: InstanceRegistryServiceDeps, run: InstanceKeycloakProvisioningRun, loaded: NonNullable<Awaited<ReturnType<typeof loadInstanceWithSecret>>>, tenantAdminTemporaryPassword: string | undefined, provisioningInput: ReturnType<typeof buildProvisioningInput>) => {
   const preflight = await appendPreflightSnapshot(deps, run, provisioningInput);
@@ -194,19 +191,12 @@ export const processClaimedKeycloakProvisioningRun = async (
   }
 };
 
-export const processNextQueuedKeycloakProvisioningRun = async (
-  deps: InstanceRegistryServiceDeps,
-  claimFilter?: {
-    createdAtOrAfter?: string;
-  }
-) =>
+export const processNextQueuedKeycloakProvisioningRun = async (deps: InstanceRegistryServiceDeps, claimFilter?: { createdAtOrAfter?: string }) =>
   processClaimedKeycloakProvisioningRun(
     deps,
     await (
       deps.repository as InstanceRegistryServiceDeps['repository'] & {
-        claimNextKeycloakProvisioningRun: (input?: {
-          createdAtOrAfter?: string;
-        }) => Promise<InstanceKeycloakProvisioningRun | null>;
+        claimNextKeycloakProvisioningRun: (input?: { createdAtOrAfter?: string }) => Promise<InstanceKeycloakProvisioningRun | null>;
       }
     ).claimNextKeycloakProvisioningRun(claimFilter)
   );

--- a/packages/instance-registry/src/service-keycloak-run-steps.test.ts
+++ b/packages/instance-registry/src/service-keycloak-run-steps.test.ts
@@ -106,7 +106,12 @@ describe('service-keycloak-run-steps', () => {
       usedTemporaryPassword: false,
     });
 
-    expect(steps.map((step) => step.stepKey)).toContain('tenant_admin_password');
+    expect(steps.map((step) => step.stepKey)).toEqual([
+      'realm',
+      'roles',
+      'tenant_admin',
+      'tenant_admin_password',
+    ]);
     expect(steps.find((step) => step.stepKey === 'tenant_admin_password')).toEqual(
       expect.objectContaining({ ok: false })
     );

--- a/packages/instance-registry/src/service-keycloak-run-steps.ts
+++ b/packages/instance-registry/src/service-keycloak-run-steps.ts
@@ -139,6 +139,15 @@ export const buildFinalRunSteps = (input: {
   intent: ExecuteInstanceKeycloakProvisioningInput['intent'];
   usedTemporaryPassword: boolean;
 }): CompletionStep[] => {
+  if (input.intent === 'reset_tenant_admin') {
+    return [
+      buildRealmCompletionStep(input.status),
+      buildRolesCompletionStep(input.status),
+      buildTenantAdminCompletionStep(input.status),
+      buildTenantAdminPasswordStep(input.usedTemporaryPassword),
+    ];
+  }
+
   const steps: CompletionStep[] = [
     buildRealmCompletionStep(input.status),
     buildClientCompletionStep(input.status),
@@ -149,7 +158,7 @@ export const buildFinalRunSteps = (input: {
     buildTenantAdminCompletionStep(input.status),
   ];
 
-  if (input.usedTemporaryPassword || input.intent === 'reset_tenant_admin') {
+  if (input.usedTemporaryPassword) {
     steps.push(buildTenantAdminPasswordStep(input.usedTemporaryPassword));
   }
 

--- a/packages/instance-registry/src/service-types.ts
+++ b/packages/instance-registry/src/service-types.ts
@@ -106,6 +106,8 @@ export type InstanceRegistryServiceDeps = {
     tenantAdminBootstrap?: TenantAdminBootstrap;
     tenantAdminTemporaryPassword?: string;
     rotateClientSecret?: boolean;
+    reconcileAuthClient?: boolean;
+    reconcileTenantAdminClient?: boolean;
   }) => Promise<void>;
   readonly getKeycloakPreflight?: (input: KeycloakProvisioningContext) => Promise<KeycloakTenantPreflight>;
   readonly planKeycloakProvisioning?: (input: KeycloakProvisioningContext) => Promise<KeycloakTenantPlan>;

--- a/scripts/ci/complexity-gate.ts
+++ b/scripts/ci/complexity-gate.ts
@@ -2,6 +2,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import ts from 'typescript';
 
@@ -104,6 +105,8 @@ interface ModuleSummary {
 export interface RunComplexityGateOptions {
   rootDir?: string;
   updateBaseline?: boolean;
+  baseRef?: string;
+  headRef?: string;
   stepSummaryPath?: string | null;
 }
 
@@ -255,6 +258,38 @@ function resolveComplexityPaths(rootDir: string): ComplexityPaths {
 
 function normalizePath(filePath: string): string {
   return filePath.split(path.sep).join('/');
+}
+
+function resolveChangedFiles(rootDir: string, baseRef: string, headRef: string): Set<string> {
+  const runDiff = (range: string): string =>
+    execFileSync('git', ['diff', '--name-only', '--diff-filter=ACDMR', range], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    }).trim();
+
+  let output = '';
+
+  try {
+    output = runDiff(`${baseRef}...${headRef}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes('no merge base')) {
+      throw error;
+    }
+    output = runDiff(`${baseRef}..${headRef}`);
+  }
+
+  if (output.length === 0) {
+    return new Set<string>();
+  }
+
+  return new Set(
+    output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map(normalizePath)
+  );
 }
 
 function globToRegExp(pattern: string): RegExp {
@@ -786,15 +821,17 @@ function writeSummary(stepSummaryPath: string | null, summaryBody: string): void
 export function runComplexityGate(options: RunComplexityGateOptions = {}): RunComplexityGateResult {
   const rootDir = options.rootDir ?? process.cwd();
   const updateBaseline = options.updateBaseline ?? false;
+  const baseRef = options.baseRef?.trim();
+  const headRef = options.headRef?.trim() || 'HEAD';
   const stepSummaryPath = options.stepSummaryPath ?? process.env.GITHUB_STEP_SUMMARY ?? null;
-  const { paths, policy, baseline, analyzedFiles } = loadComplexityData(rootDir);
+  const { paths, policy, baseline, analyzedFiles: allAnalyzedFiles } = loadComplexityData(rootDir);
 
-  if (analyzedFiles.length === 0) {
+  if (allAnalyzedFiles.length === 0) {
     throw new Error('No files matched the complexity policy');
   }
 
   if (updateBaseline) {
-    const nextBaseline = buildBaseline(analyzedFiles);
+    const nextBaseline = buildBaseline(allAnalyzedFiles);
     fs.writeFileSync(paths.baselinePath, JSON.stringify(nextBaseline, null, 2) + '\n', 'utf8');
     return {
       passed: true,
@@ -802,7 +839,33 @@ export function runComplexityGate(options: RunComplexityGateOptions = {}): RunCo
       summaryBody: '',
       trackedViolations: [],
       untrackedViolations: [],
-      analyzedFiles,
+      analyzedFiles: allAnalyzedFiles,
+    };
+  }
+
+  const changedFiles = baseRef && baseRef.length > 0 ? resolveChangedFiles(rootDir, baseRef, headRef) : null;
+  const analyzedFiles = changedFiles
+    ? allAnalyzedFiles.filter((analyzedFile) => changedFiles.has(analyzedFile.metrics.filePath))
+    : allAnalyzedFiles;
+
+  if (analyzedFiles.length === 0) {
+    const summaryBody = [
+      '## Complexity Summary',
+      '',
+      'Keine vom Diff betroffenen Dateien innerhalb des Complexity-Scopes gefunden.',
+      '',
+      'Ausgewertete Dateien: 0',
+      'Neue Findings: 0',
+      'Getrackte Findings: 0',
+    ].join('\n') + '\n';
+    writeSummary(stepSummaryPath, summaryBody);
+    return {
+      passed: true,
+      updatedBaseline: false,
+      summaryBody,
+      trackedViolations: [],
+      untrackedViolations: [],
+      analyzedFiles: [],
     };
   }
 
@@ -825,11 +888,17 @@ export function runComplexityGate(options: RunComplexityGateOptions = {}): RunCo
 export function main(): number {
   const rootDir = process.cwd();
   const updateBaseline = process.argv.includes('--update-baseline');
+  const baseIndex = process.argv.indexOf('--base');
+  const headIndex = process.argv.indexOf('--head');
+  const baseRef = baseIndex >= 0 ? process.argv[baseIndex + 1] : undefined;
+  const headRef = headIndex >= 0 ? process.argv[headIndex + 1] : undefined;
 
   try {
     const result = runComplexityGate({
       rootDir,
       updateBaseline,
+      baseRef,
+      headRef,
       stepSummaryPath: process.env.GITHUB_STEP_SUMMARY ?? null,
     });
 

--- a/scripts/ci/complexity-gate.ts
+++ b/scripts/ci/complexity-gate.ts
@@ -119,6 +119,17 @@ export interface RunComplexityGateResult {
   analyzedFiles: AnalyzedFile[];
 }
 
+export function readCliOptionValue(argv: readonly string[], optionName: string): string | undefined {
+  const directIndex = argv.indexOf(optionName);
+  if (directIndex >= 0) {
+    return argv[directIndex + 1];
+  }
+
+  const inlinePrefix = `${optionName}=`;
+  const inlineValue = argv.find((arg) => arg.startsWith(inlinePrefix));
+  return inlineValue ? inlineValue.slice(inlinePrefix.length) : undefined;
+}
+
 const ALLOWED_TRACKED_FINDING_STATUSES = new Set<TrackedFinding['status']>([
   'planned',
   'open',
@@ -888,10 +899,8 @@ export function runComplexityGate(options: RunComplexityGateOptions = {}): RunCo
 export function main(): number {
   const rootDir = process.cwd();
   const updateBaseline = process.argv.includes('--update-baseline');
-  const baseIndex = process.argv.indexOf('--base');
-  const headIndex = process.argv.indexOf('--head');
-  const baseRef = baseIndex >= 0 ? process.argv[baseIndex + 1] : undefined;
-  const headRef = headIndex >= 0 ? process.argv[headIndex + 1] : undefined;
+  const baseRef = readCliOptionValue(process.argv, '--base');
+  const headRef = readCliOptionValue(process.argv, '--head');
 
   try {
     const result = runComplexityGate({

--- a/scripts/ops/runtime-env.test.ts
+++ b/scripts/ops/runtime-env.test.ts
@@ -7,6 +7,7 @@ import {
   assertLoginFlow,
   buildKeycloakClientSecretCheck,
   buildLocalProvisioningWorkerCheck,
+  requireLocalInstanceRegistryReconciliationInput,
   shouldCheckLocalInstanceRegistryDriftBeforeCommand,
   buildStudioImageVerifyEvidenceCheck,
   deriveInternalVerifyMaxAttempts,
@@ -308,6 +309,16 @@ describe('shouldCheckLocalInstanceRegistryDriftBeforeCommand', () => {
     expect(shouldCheckLocalInstanceRegistryDriftBeforeCommand('update')).toBe(true);
     expect(shouldCheckLocalInstanceRegistryDriftBeforeCommand('reconcile')).toBe(false);
     expect(shouldCheckLocalInstanceRegistryDriftBeforeCommand('migrate')).toBe(false);
+  });
+});
+
+describe('requireLocalInstanceRegistryReconciliationInput', () => {
+  it('throws when explicit reconcile config is incomplete', () => {
+    expect(() =>
+      requireLocalInstanceRegistryReconciliationInput({
+        SVA_PARENT_DOMAIN: 'studio.example.org',
+      }),
+    ).toThrow('Lokaler Instanz-Registry-Abgleich erfordert SVA_PARENT_DOMAIN und SVA_ALLOWED_INSTANCE_IDS.');
   });
 });
 

--- a/scripts/ops/runtime-env.test.ts
+++ b/scripts/ops/runtime-env.test.ts
@@ -7,6 +7,7 @@ import {
   assertLoginFlow,
   buildKeycloakClientSecretCheck,
   buildLocalProvisioningWorkerCheck,
+  shouldCheckLocalInstanceRegistryDriftBeforeCommand,
   buildStudioImageVerifyEvidenceCheck,
   deriveInternalVerifyMaxAttempts,
   readStudioImageVerifyEvidence,
@@ -298,6 +299,15 @@ describe('shouldRunLocalProvisioningWorker', () => {
     expect(shouldRunLocalProvisioningWorker('local-keycloak')).toBe(true);
     expect(shouldRunLocalProvisioningWorker('local-builder')).toBe(false);
     expect(shouldRunLocalProvisioningWorker('studio')).toBe(false);
+  });
+});
+
+describe('shouldCheckLocalInstanceRegistryDriftBeforeCommand', () => {
+  it('keeps drift checks for read-only startup commands only', () => {
+    expect(shouldCheckLocalInstanceRegistryDriftBeforeCommand('up')).toBe(true);
+    expect(shouldCheckLocalInstanceRegistryDriftBeforeCommand('update')).toBe(true);
+    expect(shouldCheckLocalInstanceRegistryDriftBeforeCommand('reconcile')).toBe(false);
+    expect(shouldCheckLocalInstanceRegistryDriftBeforeCommand('migrate')).toBe(false);
   });
 });
 

--- a/scripts/ops/runtime-env.ts
+++ b/scripts/ops/runtime-env.ts
@@ -1655,6 +1655,10 @@ const checkLocalInstanceRegistryDrift = (runtimeProfile: RuntimeProfile, env: No
   }
 };
 
+export const shouldCheckLocalInstanceRegistryDriftBeforeCommand = (
+  runtimeCommand: Extract<RuntimeCommand, 'up' | 'update' | 'reconcile' | 'migrate'>
+) => runtimeCommand === 'up' || runtimeCommand === 'update';
+
 const reconcileLocalInstanceRegistry = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) => {
   const input = buildLocalInstanceRegistryReconciliationInput(env);
   if (!input) {
@@ -3371,7 +3375,9 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
       upLocalInfra(env);
       migrateLocalDatabase(env);
       bootstrapLocalAppUser(env);
-      checkLocalInstanceRegistryDrift(runtimeProfile, env);
+      if (shouldCheckLocalInstanceRegistryDriftBeforeCommand(runtimeCommand)) {
+        checkLocalInstanceRegistryDrift(runtimeProfile, env);
+      }
       await startLocalApp(runtimeProfile, env);
       if (shouldRunLocalProvisioningWorker(runtimeProfile)) {
         startLocalProvisioningWorker(runtimeProfile, env);
@@ -3390,7 +3396,9 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
       upLocalInfra(env);
       migrateLocalDatabase(env);
       bootstrapLocalAppUser(env);
-      checkLocalInstanceRegistryDrift(runtimeProfile, env);
+      if (shouldCheckLocalInstanceRegistryDriftBeforeCommand(runtimeCommand)) {
+        checkLocalInstanceRegistryDrift(runtimeProfile, env);
+      }
       stopLocalProvisioningWorker();
       stopLocalApp();
       await startLocalApp(runtimeProfile, env);
@@ -3424,9 +3432,8 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
       return;
     case 'reconcile':
       assertRuntimeEnv(runtimeProfile, env);
-      checkLocalInstanceRegistryDrift(runtimeProfile, env);
       reconcileLocalInstanceRegistry(runtimeProfile, env);
-      console.log(`Lokale Instanz-Registry fuer ${runtimeProfile} reconciled.`);
+      console.log(`Lokale Instanz-Registry fuer ${runtimeProfile} abgeglichen.`);
       return;
     case 'doctor': {
       const report = await doctorRuntime(runtimeProfile, env);

--- a/scripts/ops/runtime-env.ts
+++ b/scripts/ops/runtime-env.ts
@@ -1659,12 +1659,19 @@ export const shouldCheckLocalInstanceRegistryDriftBeforeCommand = (
   runtimeCommand: Extract<RuntimeCommand, 'up' | 'update' | 'reconcile' | 'migrate'>
 ) => runtimeCommand === 'up' || runtimeCommand === 'update';
 
-const reconcileLocalInstanceRegistry = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) => {
+export const requireLocalInstanceRegistryReconciliationInput = (env: NodeJS.ProcessEnv) => {
   const input = buildLocalInstanceRegistryReconciliationInput(env);
-  if (!input) {
-    return;
+  if (input) {
+    return input;
   }
 
+  throw new Error(
+    'Lokaler Instanz-Registry-Abgleich erfordert SVA_PARENT_DOMAIN und SVA_ALLOWED_INSTANCE_IDS.'
+  );
+};
+
+const reconcileLocalInstanceRegistry = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) => {
+  const input = requireLocalInstanceRegistryReconciliationInput(env);
   const sql = buildLocalInstanceRegistryReconciliationSql(input);
   createDbSqlRunner(runtimeProfile, env)(sql);
 };

--- a/scripts/ops/runtime-env.ts
+++ b/scripts/ops/runtime-env.ts
@@ -70,6 +70,7 @@ import {
 } from './runtime/goose.ts';
 import { runBootstrapJobAgainstAcceptance as runBootstrapJobAgainstAcceptanceWithDeps } from './runtime/bootstrap-job.ts';
 import {
+  buildLocalInstanceRegistryIdentitySelectSql,
   buildLocalInstanceRegistryReconciliationInput,
   buildLocalInstanceRegistryReconciliationSql,
   evaluateLocalInstanceRegistryIdentityDrift,
@@ -84,7 +85,18 @@ import {
 import { inspectRemoteServiceContract } from './runtime/remote-service-spec.ts';
 import { formatRemoteStackSnapshot, inspectRemoteStack, type RemoteStackSnapshot } from './runtime/remote-stack-state.ts';
 
-type RuntimeCommand = 'deploy' | 'doctor' | 'down' | 'migrate' | 'precheck' | 'reset' | 'smoke' | 'status' | 'up' | 'update';
+type RuntimeCommand =
+  | 'deploy'
+  | 'doctor'
+  | 'down'
+  | 'migrate'
+  | 'precheck'
+  | 'reconcile'
+  | 'reset'
+  | 'smoke'
+  | 'status'
+  | 'up'
+  | 'update';
 type DoctorCheckStatus = 'error' | 'ok' | 'skipped' | 'warn';
 
 type DoctorCheck = {
@@ -187,7 +199,7 @@ const composeBaseArgs = ['compose', '-f', 'docker-compose.yml'];
 const composeWithMonitoringArgs = ['compose', '-f', 'docker-compose.yml', '-f', 'docker-compose.monitoring.yml'];
 const usage = () => {
   console.error(
-    'Usage: tsx scripts/ops/runtime-env.ts <up|down|update|status|smoke|migrate|doctor|reset|precheck|deploy> <profile> [--json] [--local-override-file=<path>] [--release-mode=<app-only|schema-and-app>] [--image-digest=<sha256:...>] [--maintenance-window=<text>] [--rollback-hint=<text>]'
+    'Usage: tsx scripts/ops/runtime-env.ts <up|down|update|status|smoke|migrate|doctor|reconcile|reset|precheck|deploy> <profile> [--json] [--local-override-file=<path>] [--release-mode=<app-only|schema-and-app>] [--image-digest=<sha256:...>] [--maintenance-window=<text>] [--rollback-hint=<text>]'
   );
   process.exit(2);
 };
@@ -195,7 +207,9 @@ const usage = () => {
 const ensureKnownCommand = (value: RuntimeCommand | undefined): RuntimeCommand => {
   if (
     !value ||
-    !['up', 'down', 'update', 'status', 'smoke', 'migrate', 'doctor', 'reset', 'precheck', 'deploy'].includes(value)
+    !['up', 'down', 'update', 'status', 'smoke', 'migrate', 'doctor', 'reconcile', 'reset', 'precheck', 'deploy'].includes(
+      value
+    )
   ) {
     usage();
     throw new Error('Unreachable');
@@ -1619,19 +1633,14 @@ const migrateLocalDatabase = (env: NodeJS.ProcessEnv) => {
   run('pnpm', ['nx', 'run', 'data:db:migrate'], env);
 };
 
-const reconcileLocalInstanceRegistry = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) => {
+const checkLocalInstanceRegistryDrift = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) => {
   const input = buildLocalInstanceRegistryReconciliationInput(env);
   if (!input) {
     return;
   }
 
   const rows = parseJsonFromCommandOutput<LocalInstanceRegistryIdentityRow[]>(
-    createDbSqlRunner(runtimeProfile, env)(`SELECT COALESCE(json_agg(row_to_json(instance_rows) ORDER BY instance_rows.id), '[]'::json)::text
-FROM (
-  SELECT id, parent_domain, primary_hostname, auth_realm
-  FROM iam.instances
-  WHERE id = ANY(ARRAY[${input.allowedInstanceIds.map((instanceId) => sqlLiteral(instanceId)).join(', ')}]::text[])
-) AS instance_rows;`)
+    createDbSqlRunner(runtimeProfile, env)(buildLocalInstanceRegistryIdentitySelectSql(input))
   );
   const drift = evaluateLocalInstanceRegistryIdentityDrift(input, rows);
   if (drift.length > 0) {
@@ -1643,6 +1652,13 @@ FROM (
       throw new Error(message);
     }
     process.stderr.write(`${message}\n`);
+  }
+};
+
+const reconcileLocalInstanceRegistry = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) => {
+  const input = buildLocalInstanceRegistryReconciliationInput(env);
+  if (!input) {
+    return;
   }
 
   const sql = buildLocalInstanceRegistryReconciliationSql(input);
@@ -3355,7 +3371,7 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
       upLocalInfra(env);
       migrateLocalDatabase(env);
       bootstrapLocalAppUser(env);
-      reconcileLocalInstanceRegistry(runtimeProfile, env);
+      checkLocalInstanceRegistryDrift(runtimeProfile, env);
       await startLocalApp(runtimeProfile, env);
       if (shouldRunLocalProvisioningWorker(runtimeProfile)) {
         startLocalProvisioningWorker(runtimeProfile, env);
@@ -3374,7 +3390,7 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
       upLocalInfra(env);
       migrateLocalDatabase(env);
       bootstrapLocalAppUser(env);
-      reconcileLocalInstanceRegistry(runtimeProfile, env);
+      checkLocalInstanceRegistryDrift(runtimeProfile, env);
       stopLocalProvisioningWorker();
       stopLocalApp();
       await startLocalApp(runtimeProfile, env);
@@ -3405,6 +3421,12 @@ const runLocalCommand = async (runtimeProfile: RuntimeProfile, runtimeCommand: R
         }
       }
       console.log(`Migrationen fuer ${runtimeProfile} abgeschlossen.`);
+      return;
+    case 'reconcile':
+      assertRuntimeEnv(runtimeProfile, env);
+      checkLocalInstanceRegistryDrift(runtimeProfile, env);
+      reconcileLocalInstanceRegistry(runtimeProfile, env);
+      console.log(`Lokale Instanz-Registry fuer ${runtimeProfile} reconciled.`);
       return;
     case 'doctor': {
       const report = await doctorRuntime(runtimeProfile, env);
@@ -5303,8 +5325,9 @@ const runAcceptanceCommand = async (runtimeProfile: RemoteRuntimeProfile, runtim
   switch (runtimeCommand) {
     case 'up':
     case 'update':
+    case 'reconcile':
       throw new Error(
-        `Direkte Remote-Deploys ueber ${runtimeCommand} sind gesperrt. Nutze den kanonischen Pfad pnpm env:deploy:${runtimeProfile}.`
+        `Direkte Remote-Operationen ueber ${runtimeCommand} sind gesperrt. Nutze den kanonischen Pfad pnpm env:deploy:${runtimeProfile}.`
       );
     case 'down':
       assertDeterministicRemoteMutationContext(env, runtimeProfile, 'down');

--- a/scripts/ops/runtime/local-instance-registry.test.ts
+++ b/scripts/ops/runtime/local-instance-registry.test.ts
@@ -84,6 +84,8 @@ describe('buildLocalInstanceRegistryReconciliationSql', () => {
     expect(sql).toContain("parent_domain = 'studio.localhost'");
     expect(sql).toContain("primary_hostname = 'de-musterhausen.studio.localhost'");
     expect(sql).toContain("auth_realm = 'de-musterhausen'");
+    expect(sql).toContain("auth_client_id = 'sva-studio-login'");
+    expect(sql).toContain("tenant_admin_client_id = 'sva-studio-realm-admin'");
   });
 });
 

--- a/scripts/ops/runtime/local-instance-registry.test.ts
+++ b/scripts/ops/runtime/local-instance-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildLocalInstanceRegistryIdentitySelectSql,
   buildLocalInstanceRegistryReconciliationInput,
   buildLocalInstanceRegistryReconciliationSql,
   evaluateLocalInstanceRegistryIdentityDrift,
@@ -83,6 +84,17 @@ describe('buildLocalInstanceRegistryReconciliationSql', () => {
     expect(sql).toContain("parent_domain = 'studio.localhost'");
     expect(sql).toContain("primary_hostname = 'de-musterhausen.studio.localhost'");
     expect(sql).toContain("auth_realm = 'de-musterhausen'");
+  });
+});
+
+describe('buildLocalInstanceRegistryIdentitySelectSql', () => {
+  it('loads all protected identity fields for read-only drift checks', () => {
+    const sql = buildLocalInstanceRegistryIdentitySelectSql({
+      allowedInstanceIds: ['de-musterhausen'],
+    });
+
+    expect(sql).toContain('SELECT id, parent_domain, primary_hostname, auth_client_id, auth_realm, tenant_admin_client_id');
+    expect(sql).toContain("WHERE id = ANY(ARRAY['de-musterhausen']::text[])");
   });
 });
 

--- a/scripts/ops/runtime/local-instance-registry.ts
+++ b/scripts/ops/runtime/local-instance-registry.ts
@@ -149,14 +149,22 @@ export const buildLocalInstanceRegistryReconciliationSql = (
       input.reconcileMode === 'authoritative'
         ? `primary_hostname = ${sqlLiteral(primaryHostname)},`
         : `primary_hostname = COALESCE(NULLIF(primary_hostname, ''), ${sqlLiteral(primaryHostname)}),`;
+    const authClientIdAssignment =
+      input.reconcileMode === 'authoritative'
+        ? `auth_client_id = ${sqlLiteral(input.tenantAuthClientId)},`
+        : `auth_client_id = COALESCE(NULLIF(auth_client_id, ''), ${sqlLiteral(input.tenantAuthClientId)}),`;
+    const tenantAdminClientIdAssignment =
+      input.reconcileMode === 'authoritative'
+        ? `tenant_admin_client_id = ${sqlLiteral(input.tenantAdminClientId)},`
+        : `tenant_admin_client_id = COALESCE(NULLIF(tenant_admin_client_id, ''), ${sqlLiteral(input.tenantAdminClientId)}),`;
 
     return [
       `UPDATE iam.instances
 SET ${parentDomainAssignment}
     ${primaryHostnameAssignment}
     ${authRealmAssignment}
-    auth_client_id = COALESCE(NULLIF(auth_client_id, ''), ${sqlLiteral(input.tenantAuthClientId)}),
-    tenant_admin_client_id = COALESCE(NULLIF(tenant_admin_client_id, ''), ${sqlLiteral(input.tenantAdminClientId)}),
+    ${authClientIdAssignment}
+    ${tenantAdminClientIdAssignment}
     updated_at = NOW()
 WHERE id = ${sqlLiteral(instanceId)};`,
       `UPDATE iam.instance_hostnames

--- a/scripts/ops/runtime/local-instance-registry.ts
+++ b/scripts/ops/runtime/local-instance-registry.ts
@@ -121,6 +121,15 @@ export const evaluateLocalInstanceRegistryIdentityDrift = (
   });
 };
 
+export const buildLocalInstanceRegistryIdentitySelectSql = (
+  input: Pick<LocalInstanceRegistryReconciliationInput, 'allowedInstanceIds'>
+): string => `SELECT COALESCE(json_agg(row_to_json(instance_rows) ORDER BY instance_rows.id), '[]'::json)::text
+FROM (
+  SELECT id, parent_domain, primary_hostname, auth_client_id, auth_realm, tenant_admin_client_id
+  FROM iam.instances
+  WHERE id = ANY(ARRAY[${input.allowedInstanceIds.map((instanceId) => sqlLiteral(instanceId)).join(', ')}]::text[])
+) AS instance_rows;`;
+
 export const buildLocalInstanceRegistryReconciliationSql = (
   input: LocalInstanceRegistryReconciliationInput
 ): string => {

--- a/scripts/ops/runtime/local-provisioning-worker-runner.test.ts
+++ b/scripts/ops/runtime/local-provisioning-worker-runner.test.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildLocalProvisioningWorkerChildEnv,
   clearLocalWorkerStateIfOwned,
   parseLocalProvisioningWorkerRunnerArgs,
 } from './local-provisioning-worker-runner.ts';
@@ -48,5 +49,19 @@ describe('clearLocalWorkerStateIfOwned', () => {
     clearLocalWorkerStateIfOwned(stateFile, 5678);
 
     expect(JSON.parse(readFileSync(stateFile, 'utf8'))).toEqual({ pid: 1234 });
+  });
+});
+
+describe('buildLocalProvisioningWorkerChildEnv', () => {
+  it('pins the worker to runs created after the current startup', () => {
+    const env = buildLocalProvisioningWorkerChildEnv(
+      {
+        PATH: process.env.PATH,
+      },
+      '2026-05-27T12:00:00.000Z',
+    );
+
+    expect(env.SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE).toBe('2026-05-27T12:00:00.000Z');
+    expect(env.PATH).toBe(process.env.PATH);
   });
 });

--- a/scripts/ops/runtime/local-provisioning-worker-runner.ts
+++ b/scripts/ops/runtime/local-provisioning-worker-runner.ts
@@ -16,6 +16,14 @@ type RunnerArgs = {
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const runnerCommand = [process.execPath, '--import', 'tsx', 'packages/auth-runtime/src/iam-instance-registry/worker.ts'] as const;
 
+export const buildLocalProvisioningWorkerChildEnv = (
+  baseEnv: NodeJS.ProcessEnv,
+  startedAt: string = new Date().toISOString(),
+): NodeJS.ProcessEnv => ({
+  ...baseEnv,
+  SVA_KEYCLOAK_PROVISIONER_CLAIM_NOT_BEFORE: startedAt,
+});
+
 export const parseLocalProvisioningWorkerRunnerArgs = (argv: readonly string[]): RunnerArgs => {
   const parsed = new Map<string, string>();
 
@@ -77,12 +85,13 @@ export const runLocalProvisioningWorkerRunner = async (argv: readonly string[]) 
   const logFd = openSync(logFile, 'a');
   let child: ChildProcess | null = null;
   let terminating = false;
+  const startedAt = new Date().toISOString();
 
   appendRunnerLogLine(logFile, `Starte Keycloak-Provisioning-Worker fuer Profil ${profile}.`);
 
   child = spawn(runnerCommand[0], [...runnerCommand.slice(1)], {
     cwd: rootDir,
-    env: process.env,
+    env: buildLocalProvisioningWorkerChildEnv(process.env, startedAt),
     stdio: ['ignore', logFd, logFd],
   });
 

--- a/tooling/testing/tests/complexity-gate.test.ts
+++ b/tooling/testing/tests/complexity-gate.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { analyzeFile, runComplexityGate } from '../../../scripts/ci/complexity-gate.ts';
@@ -63,6 +64,32 @@ function writeSourceFile(rootDir: string, fileName: string, source: string): str
   const filePath = path.join(rootDir, 'packages/iam-target/src', fileName);
   fs.writeFileSync(filePath, source);
   return filePath;
+}
+
+function runGit(rootDir: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: rootDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Codex',
+      GIT_AUTHOR_EMAIL: 'codex@example.test',
+      GIT_COMMITTER_NAME: 'Codex',
+      GIT_COMMITTER_EMAIL: 'codex@example.test',
+    },
+  }).trim();
+}
+
+function initializeGitRepo(rootDir: string): void {
+  runGit(rootDir, ['init']);
+  runGit(rootDir, ['config', 'user.name', 'Codex']);
+  runGit(rootDir, ['config', 'user.email', 'codex@example.test']);
+}
+
+function commitAll(rootDir: string, message: string): string {
+  runGit(rootDir, ['add', '.']);
+  runGit(rootDir, ['commit', '-m', message]);
+  return runGit(rootDir, ['rev-parse', 'HEAD']);
 }
 
 afterEach(() => {
@@ -346,5 +373,70 @@ describe('complexity gate', () => {
     expect(baseline.files['packages/iam-target/src/baseline.ts'].fileLines).toBe(3);
     expect(baseline.files['packages/iam-target/src/baseline.ts'].functionLines).toBe(3);
     expect(baseline.files['packages/iam-target/src/baseline.ts'].cyclomaticComplexity).toBe(1);
+  });
+
+  it('ignores unchanged baseline violations when a base ref scopes the analysis to changed files', () => {
+    const rootDir = createTempWorkspace();
+    writePolicy(rootDir);
+    initializeGitRepo(rootDir);
+    writeSourceFile(
+      rootDir,
+      'legacy.ts',
+      [
+        'export function legacyHandler(input: string): string {',
+        '  const value = input.trim();',
+        "  if (value === '') {",
+        "    return 'fallback';",
+        '  }',
+        '  return value;',
+        '}',
+      ].join('\n')
+    );
+    writeSourceFile(rootDir, 'changed.ts', 'export const value = 1;\n');
+    const baseRef = commitAll(rootDir, 'base');
+
+    writeSourceFile(rootDir, 'changed.ts', 'export const value = 2;\n');
+    commitAll(rootDir, 'change-safe-file');
+
+    const result = runComplexityGate({ rootDir, baseRef, stepSummaryPath: null });
+
+    expect(result.passed).toBe(true);
+    expect(result.analyzedFiles).toHaveLength(1);
+    expect(result.analyzedFiles[0]?.metrics.filePath).toBe('packages/iam-target/src/changed.ts');
+    expect(result.untrackedViolations).toHaveLength(0);
+  });
+
+  it('still fails for new violations inside files changed since the provided base ref', () => {
+    const rootDir = createTempWorkspace();
+    writePolicy(rootDir);
+    initializeGitRepo(rootDir);
+    writeSourceFile(rootDir, 'changed.ts', 'export const value = 1;\n');
+    const baseRef = commitAll(rootDir, 'base');
+
+    writeSourceFile(
+      rootDir,
+      'changed.ts',
+      [
+        'export function changedHandler(input: string): string {',
+        '  const value = input.trim();',
+        "  if (value === '') {",
+        "    return 'fallback';",
+        '  }',
+        '  return value;',
+        '}',
+      ].join('\n')
+    );
+    commitAll(rootDir, 'introduce-violation');
+
+    const result = runComplexityGate({ rootDir, baseRef, stepSummaryPath: null });
+
+    expect(result.passed).toBe(false);
+    expect(result.untrackedViolations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          filePath: 'packages/iam-target/src/changed.ts',
+        }),
+      ])
+    );
   });
 });

--- a/tooling/testing/tests/complexity-gate.test.ts
+++ b/tooling/testing/tests/complexity-gate.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { analyzeFile, runComplexityGate } from '../../../scripts/ci/complexity-gate.ts';
+import { analyzeFile, readCliOptionValue, runComplexityGate } from '../../../scripts/ci/complexity-gate.ts';
 
 const createdDirs: string[] = [];
 
@@ -72,6 +72,9 @@ function runGit(rootDir: string, args: string[]): string {
     encoding: 'utf8',
     env: {
       ...process.env,
+      GIT_CONFIG_GLOBAL: os.devNull,
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_TERMINAL_PROMPT: '0',
       GIT_AUTHOR_NAME: 'Codex',
       GIT_AUTHOR_EMAIL: 'codex@example.test',
       GIT_COMMITTER_NAME: 'Codex',
@@ -177,6 +180,12 @@ describe('complexity gate', () => {
     expect(metrics.maxFunctionLines).toBe(6);
     expect(metrics.maxCyclomaticComplexity).toBe(4);
     expect(metrics.publicExports).toBe(2);
+  });
+
+  it('reads CLI option values from spaced and inline argument forms', () => {
+    expect(readCliOptionValue(['node', 'complexity-gate', '--base', 'origin/main'], '--base')).toBe('origin/main');
+    expect(readCliOptionValue(['node', 'complexity-gate', '--base=origin/main'], '--base')).toBe('origin/main');
+    expect(readCliOptionValue(['node', 'complexity-gate'], '--base')).toBeUndefined();
   });
 
   it('fails when the policy file is missing', () => {


### PR DESCRIPTION
Diese PR härtet den lokalen `local-keycloak`-Workflow so ab, dass ein normaler Entwicklungsstart keine persistierte Registry-Identität mehr verändert und keine alten Keycloak-Provisioning-Läufe stillschweigend wieder anstößt.

Zusätzlich wird das Reset-Verhalten für Keycloak präzisiert: `reset_tenant_admin` betrifft jetzt nur noch den Tenant-Admin-Benutzer und überschreibt keine manuell gepflegten Zugriffseinstellungen des Clients `sva-studio-admin` mehr.

## Änderungen

- `env:up:local-keycloak` und `env:update:local-keycloak` auf read-only für die lokale Registry umgestellt
- expliziten Befehl `env:reconcile:local-instance-registry` für bewusste lokale Registry-Korrekturen eingeführt
- Registry-Drift-Erkennung von der eigentlichen Reconcile-Ausführung getrennt
- Drift-Prüfung um `auth_client_id` und `tenant_admin_client_id` erweitert
- `reset_tenant_admin` auf User-only begrenzt, ohne Reconcile von Login-Client und Tenant-Admin-Client
- den `tenant_admin_client`-Plan so erweitert, dass echte Drift bei Client-Zugriffseinstellungen sichtbar wird
- verhindert, dass der lokale Provisioning-Worker alte `planned`-Runs aus früheren Starts automatisch wieder aufnimmt
- Runtime- und Bootstrap-Dokumentation an das neue Verhalten angepasst

## Hintergrund

Im lokalen Entwicklungsbetrieb gab es zwei problematische Nebenwirkungen:

1. `env:up:local-keycloak` konnte über Registry-Reconcile-Pfade Identitätsdaten verändern, was wie ein impliziter Reset wirkte
2. lokale Keycloak-Provisioning-Pfade konnten manuell gepflegte Client-Einstellungen überschreiben oder alte Queue-Einträge ohne explizite Benutzeraktion erneut ausführen

Diese PR macht beides expliziter und sicherer:
- Startup bleibt non-destructive
- Reconcile ist ein bewusster Schritt
- Tenant-Admin-Resets ändern keine Client-Konfiguration mehr
- alte Provisioning-Läufe werden nicht mehr implizit beim nächsten lokalen Start fortgesetzt

## Testplan

- `pnpm nx run tooling-testing:test:unit`
- `pnpm exec vitest run scripts/ops/runtime/local-instance-registry.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm nx run instance-registry:test:unit --testFiles=src/provisioning-auth-state.test.ts --testFiles=src/provisioning-auth.test.ts --testFiles=src/service-keycloak-execution.test.ts`
- `pnpm nx run data-repositories:test:unit --testFiles=src/instance-registry/index.test.ts`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/iam-instance-registry/service-keycloak-execution.test.ts`
- `pnpm exec vitest run scripts/ops/runtime/local-provisioning-worker-runner.test.ts --reporter=verbose`
- `pnpm nx run-many --target=test:types --projects=instance-registry,data-repositories,auth-runtime`
- `pnpm check:server-runtime`
- `git diff --check`

## Hinweis

Ein frischer Worktree kann jetzt mit einem leeren lokalen Docker-Volume starten, ohne dabei automatisch Instanzdaten in der Registry anzulegen oder zu reconciliieren. Das ist beabsichtigt und entspricht dem neuen expliziten Bootstrap-/Reconcile-Modell.