### PR TITLE
fix: sync injected workspace runtime artifacts for studio verify

### DIFF
--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -136,7 +136,9 @@ const expectContentOverviewReady = async (page: Page) => {
       })
       .first()
       .waitFor({ state: 'visible' }),
+    page.getByRole('button', { name: /Neuer Inhalt|content\.actions\.create/ }).waitFor({ state: 'visible' }),
     page.getByRole('link', { name: /Neuer Inhalt|content\.actions\.create/ }).waitFor({ state: 'visible' }),
+    page.getByRole('table', { name: /Inhalte|content\.table\.ariaLabel/ }).waitFor({ state: 'visible' }),
     page.getByText(/Noch keine Inhalte vorhanden|content\.empty\.title/).waitFor({ state: 'visible' }),
   ]);
 };
@@ -261,6 +263,13 @@ const routeUnifiedContentOverview = async (
         data: items,
         pagination: createPagination(items.length),
       }),
+    });
+  });
+  await page.route('**/api/v1/mainserver/news**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [], pagination: createPagination(0) }),
     });
   });
 };

--- a/apps/sva-studio-react/e2e/news-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/news-plugin.spec.ts
@@ -111,7 +111,9 @@ const expectContentOverviewReady = async (page: Page) => {
       })
       .first()
       .waitFor({ state: 'visible' }),
+    page.getByRole('button', { name: /Neuer Inhalt|content\.actions\.create/ }).waitFor({ state: 'visible' }),
     page.getByRole('link', { name: /Neuer Inhalt|content\.actions\.create/ }).waitFor({ state: 'visible' }),
+    page.getByRole('table', { name: /Inhalte|content\.table\.ariaLabel/ }).waitFor({ state: 'visible' }),
     page.getByText(/Noch keine Inhalte vorhanden|content\.empty\.title/).waitFor({ state: 'visible' }),
   ]);
 };
@@ -229,6 +231,20 @@ const routeUnifiedContentOverview = async (page: Page, newsItems: readonly NewsR
         data: mapNewsToUnifiedContent(newsItems),
         pagination: createPagination(newsItems.length),
       }),
+    });
+  });
+  await page.route('**/api/v1/mainserver/events**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [], pagination: createPagination(0) }),
+    });
+  });
+  await page.route('**/api/v1/mainserver/poi**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [], pagination: createPagination(0) }),
     });
   });
 };

--- a/apps/sva-studio-react/project.json
+++ b/apps/sva-studio-react/project.json
@@ -64,6 +64,7 @@
         "frontendTooling",
         "frontendEnvBuild",
         "{workspaceRoot}/scripts/ci/patch-runtime-artifact.ts",
+        "{workspaceRoot}/scripts/ci/sync-injected-workspace-packages.ts",
         "{workspaceRoot}/scripts/ci/run-workspace-node.sh"
       ],
       "outputs": [
@@ -71,7 +72,7 @@
       ],
       "options": {
         "cwd": "apps/sva-studio-react",
-        "command": "bash ../../scripts/ci/run-workspace-node.sh -e \"require('node:fs').mkdirSync('.output/server',{recursive:true})\" && pnpm exec vite build && bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/patch-runtime-artifact.ts ."
+        "command": "bash ../../scripts/ci/run-workspace-node.sh -e \"require('node:fs').mkdirSync('.output/server',{recursive:true})\" && pnpm exec vite build && bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/patch-runtime-artifact.ts . && bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/sync-injected-workspace-packages.ts ."
       }
     },
     "check:toolchain-consistency": {

--- a/apps/sva-studio-react/project.json
+++ b/apps/sva-studio-react/project.json
@@ -64,7 +64,6 @@
         "frontendTooling",
         "frontendEnvBuild",
         "{workspaceRoot}/scripts/ci/patch-runtime-artifact.ts",
-        "{workspaceRoot}/scripts/ci/sync-injected-workspace-packages.ts",
         "{workspaceRoot}/scripts/ci/run-workspace-node.sh"
       ],
       "outputs": [
@@ -72,7 +71,7 @@
       ],
       "options": {
         "cwd": "apps/sva-studio-react",
-        "command": "bash ../../scripts/ci/run-workspace-node.sh -e \"require('node:fs').mkdirSync('.output/server',{recursive:true})\" && pnpm exec vite build && bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/patch-runtime-artifact.ts . && bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/sync-injected-workspace-packages.ts ."
+        "command": "bash ../../scripts/ci/run-workspace-node.sh -e \"require('node:fs').mkdirSync('.output/server',{recursive:true})\" && pnpm exec vite build && bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/patch-runtime-artifact.ts ."
       }
     },
     "check:toolchain-consistency": {

--- a/packages/auth-runtime/src/iam-account-management/shared-assignment.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/shared-assignment.test.ts
@@ -96,6 +96,9 @@ describe('shared assignment helpers', () => {
     expect(calls[0]?.sql).toContain('DELETE FROM iam.account_roles');
     expect(calls[0]?.params).toEqual(['instance-1', 'account-1', ['role-1', 'role-2']]);
     expect(calls[1]?.sql).toContain('ON CONFLICT (instance_id, account_id, role_id)');
+    expect(calls[1]?.sql).toContain('FROM unnest($4::uuid[]) AS role_id');
+    expect(calls[1]?.sql).toContain('WHERE TRUE');
+    expect(calls[1]?.sql).toContain('valid_to = NULL');
     expect(calls[1]?.params).toEqual(['instance-1', 'account-1', 'actor-1', ['role-1', 'role-2']]);
   });
 
@@ -114,6 +117,8 @@ describe('shared assignment helpers', () => {
     expect(calls[0]?.sql).toContain('DELETE FROM iam.account_groups');
     expect(calls[0]?.params).toEqual(['instance-1', 'account-1', ['group-1', 'group-2']]);
     expect(calls[1]?.sql).toContain('ON CONFLICT (instance_id, account_id, group_id)');
+    expect(calls[1]?.sql).toContain(') AS unique_group_ids');
+    expect(calls[1]?.sql).toContain('WHERE TRUE');
     expect(calls[1]?.params).toEqual(['instance-1', 'account-1', 'sync', ['group-1', 'group-2']]);
   });
 });

--- a/packages/auth-runtime/src/iam-account-management/shared-assignment.ts
+++ b/packages/auth-runtime/src/iam-account-management/shared-assignment.ts
@@ -59,12 +59,13 @@ INSERT INTO iam.account_roles (
   valid_from
 )
 SELECT $1, $2::uuid, role_id, $3::uuid, NOW()
-FROM unnest($4::uuid[]) AS role_id;
+FROM unnest($4::uuid[]) AS role_id
+WHERE TRUE
 ON CONFLICT (instance_id, account_id, role_id)
 DO UPDATE
 SET assigned_by = EXCLUDED.assigned_by,
     valid_from = NOW(),
-    valid_until = NULL;
+    valid_to = NULL;
 `,
     [input.instanceId, input.accountId, input.assignedBy ?? null, diff.insertIds]
   );
@@ -130,7 +131,8 @@ SELECT $1, $2::uuid, group_id, $3, NOW()
 FROM (
   SELECT DISTINCT group_id
   FROM unnest($4::uuid[]) AS input_groups(group_id)
-) AS unique_group_ids;
+) AS unique_group_ids
+WHERE TRUE
 ON CONFLICT (instance_id, account_id, group_id)
 DO UPDATE
 SET origin = EXCLUDED.origin,

--- a/packages/auth-runtime/src/shared/request-helpers.test.ts
+++ b/packages/auth-runtime/src/shared/request-helpers.test.ts
@@ -28,6 +28,7 @@ describe('shared request helpers', () => {
     expect(readObject([])).toBeUndefined();
     expect(readObject(null)).toBeUndefined();
     expect(isUuid('11111111-1111-4111-8111-111111111111')).toBe(true);
+    expect(isUuid('22222222-2222-2222-2222-222222222222')).toBe(true);
     expect(isUuid('not-a-uuid')).toBe(false);
   });
 

--- a/packages/core/src/input-readers.test.ts
+++ b/packages/core/src/input-readers.test.ts
@@ -28,6 +28,7 @@ describe('input readers', () => {
     expect(readObject(null)).toBeUndefined();
     expect(readObject([])).toBeUndefined();
     expect(isUuid('00000000-0000-4000-8000-000000000001')).toBe(true);
+    expect(isUuid('22222222-2222-2222-2222-222222222222')).toBe(true);
     expect(isUuid('not-a-uuid')).toBe(false);
   });
 

--- a/packages/core/src/input-readers.ts
+++ b/packages/core/src/input-readers.ts
@@ -1,4 +1,6 @@
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// PostgreSQL akzeptiert kanonische UUID-Literale unabhängig von RFC-Variant/Version-Bits.
+// Unsere Seeds und Testfixtures nutzen dieses breitere Format ebenfalls.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export const readString = (value: unknown): string | undefined => {
   if (typeof value !== 'string') {

--- a/packages/data/seeds/0001_iam_personas.sql
+++ b/packages/data/seeds/0001_iam_personas.sql
@@ -15,11 +15,11 @@ VALUES (
   'de-musterhausen',
   'Seed Instance Default',
   'active',
-  'studio.smart-village.app',
-  'de-musterhausen.studio.smart-village.app',
-  'svs-intern-studio-staging',
+  'studio.localhost',
+  'de-musterhausen.studio.localhost',
+  'de-musterhausen',
   'sva-studio',
-  'sva-studio-admin',
+  'sva-studio-realm-admin',
   '{}'::jsonb
 )
 ON CONFLICT (id) DO UPDATE
@@ -36,9 +36,9 @@ SET
 
 INSERT INTO iam.instance_hostnames (hostname, instance_id, is_primary, created_by)
 SELECT
-  'de-musterhausen.studio.smart-village.app',
+  'de-musterhausen.studio.localhost',
   'de-musterhausen',
-  instances.primary_hostname = 'de-musterhausen.studio.smart-village.app',
+  instances.primary_hostname = 'de-musterhausen.studio.localhost',
   'seed:0001_iam_personas'
 FROM iam.instances AS instances
 WHERE instances.id = 'de-musterhausen'

--- a/packages/data/src/iam/seed-files.test.ts
+++ b/packages/data/src/iam/seed-files.test.ts
@@ -30,12 +30,25 @@ describe('iam seed sql contracts', () => {
     assert.doesNotMatch(sql, /tenant_admin_client_id = EXCLUDED\.tenant_admin_client_id,/);
     assert.match(
       sql,
-      /instances\.primary_hostname = 'de-musterhausen\.studio\.smart-village\.app'/
+      /instances\.primary_hostname = 'de-musterhausen\.studio\.localhost'/
     );
     assert.match(
       sql,
       /AND instances\.primary_hostname = EXCLUDED\.hostname/
     );
+  });
+
+  it('seeds de-musterhausen with the local-keycloak reference identity by default', () => {
+    const sql = readSeed('0001_iam_personas.sql');
+
+    assert.match(sql, /'de-musterhausen'/);
+    assert.match(sql, /'studio\.localhost'/);
+    assert.match(sql, /'de-musterhausen\.studio\.localhost'/);
+    assert.match(sql, /'de-musterhausen'/);
+    assert.match(sql, /'sva-studio-realm-admin'/);
+    assert.doesNotMatch(sql, /'de-musterhausen\.studio\.smart-village\.app'/);
+    assert.doesNotMatch(sql, /'svs-intern-studio-staging'/);
+    assert.doesNotMatch(sql, /'sva-studio-admin'/);
   });
 
   it('keeps 0002 non-destructive for an already provisioned instance identity', () => {

--- a/packages/data/src/iam/seed-files.test.ts
+++ b/packages/data/src/iam/seed-files.test.ts
@@ -41,11 +41,10 @@ describe('iam seed sql contracts', () => {
   it('seeds de-musterhausen with the local-keycloak reference identity by default', () => {
     const sql = readSeed('0001_iam_personas.sql');
 
-    assert.match(sql, /'de-musterhausen'/);
-    assert.match(sql, /'studio\.localhost'/);
-    assert.match(sql, /'de-musterhausen\.studio\.localhost'/);
-    assert.match(sql, /'de-musterhausen'/);
-    assert.match(sql, /'sva-studio-realm-admin'/);
+    assert.match(
+      sql,
+      /VALUES\s*\(\s*'de-musterhausen',\s*'Seed Instance Default',\s*'active',\s*'studio\.localhost',\s*'de-musterhausen\.studio\.localhost',\s*'de-musterhausen',\s*'sva-studio',\s*'sva-studio-realm-admin',\s*'\{\}'::jsonb\s*\)/
+    );
     assert.doesNotMatch(sql, /'de-musterhausen\.studio\.smart-village\.app'/);
     assert.doesNotMatch(sql, /'svs-intern-studio-staging'/);
     assert.doesNotMatch(sql, /'sva-studio-admin'/);

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -79,6 +79,11 @@ test('runtime artifact checks avoid stale images and dev JSX false positives', (
     resolve(testDirectory, '..', '..', '..', 'scripts/ci/patch-runtime-artifact.ts'),
     'utf8'
   );
+  const syncInjectedWorkspacePackages = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'scripts/ci/sync-injected-workspace-packages.ts'),
+    'utf8'
+  );
+  const studioProjectJson = readFileSync(resolve(testDirectory, '..', '..', '..', 'apps/sva-studio-react/project.json'), 'utf8');
 
   assert.match(imageVerifyScript, /docker pull "\$\{IMAGE_REF\}"/);
   assert.doesNotMatch(imageVerifyScript, /skipped-local/);
@@ -111,6 +116,16 @@ test('runtime artifact checks avoid stale images and dev JSX false positives', (
   assert.match(patchRuntimeArtifact, /finalServerEntrySource\.includes\(nitroSsrRendererImportPath\)/);
   assert.doesNotMatch(patchRuntimeArtifact, /node_modules', '\.pnpm', 'node_modules'/);
   assert.doesNotMatch(patchRuntimeArtifact, /requireFromApp\.resolve/);
+
+  assert.match(syncInjectedWorkspacePackages, /node_modules', '\.pnpm'/);
+  assert.match(syncInjectedWorkspacePackages, /await cp\(workspacePackage\.distDir, targetDistDir, \{ force: true, recursive: true \}\)/);
+  assert.match(syncInjectedWorkspacePackages, /if \(injectedCopy\.realDir === workspacePackage\.realDir\)/);
+
+  assert.match(studioProjectJson, /sync-injected-workspace-packages\.ts/);
+  assert.match(
+    studioProjectJson,
+    /patch-runtime-artifact\.ts \. && bash \.\.\/\.\.\/scripts\/ci\/run-workspace-node\.sh --import tsx \.\.\/\.\.\/scripts\/ci\/sync-injected-workspace-packages\.ts \./
+  );
 });
 
 test('portable docker runtime guard only fails when a JSX dev runtime match is present', () => {
@@ -147,6 +162,45 @@ fi`;
         }),
       /Command failed/,
     );
+  } finally {
+    rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test('injected workspace sync copies dist into pnpm store package copies', () => {
+  const tempRoot = mkdtempSync(resolve(tmpdir(), 'sync-injected-workspace-'));
+  const appDir = resolve(tempRoot, 'apps', 'demo-app');
+  const sourcePackageDir = resolve(tempRoot, 'packages', 'demo-lib');
+  const sourceDistDir = resolve(sourcePackageDir, 'dist');
+  const injectedPackageDir = resolve(
+    tempRoot,
+    'node_modules',
+    '.pnpm',
+    '@sva+demo-lib@file+packages+demo-lib',
+    'node_modules',
+    '@sva',
+    'demo-lib'
+  );
+  const syncScriptPath = resolve(testDirectory, '..', '..', '..', 'scripts', 'ci', 'sync-injected-workspace-packages.ts');
+  const workspaceNodeScriptPath = resolve(testDirectory, '..', '..', '..', 'scripts', 'ci', 'run-workspace-node.sh');
+
+  try {
+    mkdirSync(sourceDistDir, { recursive: true });
+    mkdirSync(appDir, { recursive: true });
+    mkdirSync(injectedPackageDir, { recursive: true });
+
+    writeFileSync(resolve(tempRoot, 'pnpm-workspace.yaml'), 'packages:\n  - apps/*\n  - packages/*\n');
+    writeFileSync(resolve(appDir, 'package.json'), JSON.stringify({ name: 'demo-app' }));
+    writeFileSync(resolve(sourcePackageDir, 'package.json'), JSON.stringify({ name: '@sva/demo-lib', type: 'module' }));
+    writeFileSync(resolve(sourceDistDir, 'index.js'), 'export const synced = true;\n');
+    writeFileSync(resolve(injectedPackageDir, 'package.json'), JSON.stringify({ name: '@sva/demo-lib', type: 'module' }));
+
+    execFileSync('bash', [workspaceNodeScriptPath, '--import', 'tsx', syncScriptPath, appDir], {
+      cwd: resolve(testDirectory, '..', '..', '..'),
+      stdio: 'pipe',
+    });
+
+    assert.equal(readFileSync(resolve(injectedPackageDir, 'dist', 'index.js'), 'utf8'), 'export const synced = true;\n');
   } finally {
     rmSync(tempRoot, { force: true, recursive: true });
   }

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -121,11 +121,16 @@ test('runtime artifact checks avoid stale images and dev JSX false positives', (
   assert.match(syncInjectedWorkspacePackages, /await cp\(workspacePackage\.distDir, targetDistDir, \{ force: true, recursive: true \}\)/);
   assert.match(syncInjectedWorkspacePackages, /if \(injectedCopy\.realDir === workspacePackage\.realDir\)/);
 
-  assert.match(studioProjectJson, /sync-injected-workspace-packages\.ts/);
   assert.match(
+    studioProjectJson,
+    /pnpm exec vite build && bash \.\.\/\.\.\/scripts\/ci\/run-workspace-node\.sh --import tsx \.\.\/\.\.\/scripts\/ci\/patch-runtime-artifact\.ts \./
+  );
+  assert.doesNotMatch(
     studioProjectJson,
     /patch-runtime-artifact\.ts \. && bash \.\.\/\.\.\/scripts\/ci\/run-workspace-node\.sh --import tsx \.\.\/\.\.\/scripts\/ci\/sync-injected-workspace-packages\.ts \./
   );
+  assert.match(runtimeVerifyScript, /"injected-workspace-sync": "\$\{INJECTED_WORKSPACE_SYNC_STATUS\}"/);
+  assert.match(runtimeVerifyScript, /- \\`injected-workspace-sync\\`: \\`\$\{INJECTED_WORKSPACE_SYNC_STATUS\}\\`/);
 });
 
 test('portable docker runtime guard only fails when a JSX dev runtime match is present', () => {

--- a/packages/iam-admin/src/input-readers.test.ts
+++ b/packages/iam-admin/src/input-readers.test.ts
@@ -21,6 +21,7 @@ describe('input readers', () => {
     expect(readObject(null)).toBeUndefined();
     expect(readObject([])).toBeUndefined();
     expect(isUuid('00000000-0000-4000-8000-000000000001')).toBe(true);
+    expect(isUuid('22222222-2222-2222-2222-222222222222')).toBe(true);
     expect(isUuid('not-a-uuid')).toBe(false);
   });
 });

--- a/scripts/ci/sync-injected-workspace-packages.ts
+++ b/scripts/ci/sync-injected-workspace-packages.ts
@@ -1,0 +1,162 @@
+import { cp, mkdir, readdir, readFile, realpath, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+type WorkspacePackage = {
+  dir: string;
+  distDir: string;
+  name: string;
+  realDir: string;
+};
+
+const consumerDir = path.resolve(process.argv[2] ?? process.cwd());
+
+const pathExists = async (targetPath: string) => {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const findWorkspaceRoot = async (startDir: string) => {
+  let currentDir = startDir;
+
+  while (true) {
+    if (await pathExists(path.join(currentDir, 'pnpm-workspace.yaml'))) {
+      return currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error(`Kein pnpm-Workspace oberhalb von ${startDir} gefunden.`);
+    }
+    currentDir = parentDir;
+  }
+};
+
+const readWorkspacePackage = async (packageDir: string): Promise<WorkspacePackage | null> => {
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  if (!(await pathExists(packageJsonPath))) {
+    return null;
+  }
+
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as { name?: string };
+  if (!packageJson.name) {
+    return null;
+  }
+
+  return {
+    dir: packageDir,
+    distDir: path.join(packageDir, 'dist'),
+    name: packageJson.name,
+    realDir: await realpath(packageDir),
+  };
+};
+
+const collectWorkspacePackages = async (workspaceRoot: string) => {
+  const packageRoots = ['apps', 'packages', 'tooling'];
+  const workspacePackages: WorkspacePackage[] = [];
+
+  for (const packageRoot of packageRoots) {
+    const absoluteRoot = path.join(workspaceRoot, packageRoot);
+    if (!(await pathExists(absoluteRoot))) {
+      continue;
+    }
+
+    const entries = await readdir(absoluteRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const workspacePackage = await readWorkspacePackage(path.join(absoluteRoot, entry.name));
+      if (workspacePackage) {
+        workspacePackages.push(workspacePackage);
+      }
+    }
+  }
+
+  return workspacePackages;
+};
+
+const findInjectedCopies = async (workspaceRoot: string, packageName: string) => {
+  const virtualStoreDir = path.join(workspaceRoot, 'node_modules', '.pnpm');
+  if (!(await pathExists(virtualStoreDir))) {
+    return [];
+  }
+
+  const packageSegments = packageName.split('/');
+  const virtualStoreEntries = await readdir(virtualStoreDir, { withFileTypes: true });
+  const copies = new Map<string, string>();
+
+  for (const entry of virtualStoreEntries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const candidateDir = path.join(virtualStoreDir, entry.name, 'node_modules', ...packageSegments);
+    if (!(await pathExists(candidateDir))) {
+      continue;
+    }
+
+    copies.set(await realpath(candidateDir), candidateDir);
+  }
+
+  return [...copies.entries()].map(([realDir, dir]) => ({ dir, realDir }));
+};
+
+const syncWorkspacePackage = async (workspaceRoot: string, workspacePackage: WorkspacePackage) => {
+  if (!(await pathExists(workspacePackage.distDir))) {
+    return { skipped: true, updatedCopies: 0 };
+  }
+
+  const injectedCopies = await findInjectedCopies(workspaceRoot, workspacePackage.name);
+  let updatedCopies = 0;
+
+  for (const injectedCopy of injectedCopies) {
+    if (injectedCopy.realDir === workspacePackage.realDir) {
+      continue;
+    }
+
+    const targetDistDir = path.join(injectedCopy.dir, 'dist');
+    await mkdir(injectedCopy.dir, { recursive: true });
+    await rm(targetDistDir, { recursive: true, force: true });
+    await cp(workspacePackage.distDir, targetDistDir, { force: true, recursive: true });
+    updatedCopies += 1;
+  }
+
+  return { skipped: false, updatedCopies };
+};
+
+const main = async () => {
+  const workspaceRoot = await findWorkspaceRoot(consumerDir);
+  const workspacePackages = await collectWorkspacePackages(workspaceRoot);
+
+  const results = await Promise.all(
+    workspacePackages.map(async (workspacePackage) => ({
+      name: workspacePackage.name,
+      ...(await syncWorkspacePackage(workspaceRoot, workspacePackage)),
+    }))
+  );
+
+  const updatedPackages = results.filter((result) => result.updatedCopies > 0);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        consumerDir,
+        updatedCopyCount: updatedPackages.reduce((total, result) => total + result.updatedCopies, 0),
+        updatedPackages,
+        workspaceRoot,
+      },
+      null,
+      2
+    )}\n`
+  );
+};
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/ci/verify-runtime-artifact.sh
+++ b/scripts/ci/verify-runtime-artifact.sh
@@ -88,6 +88,7 @@ SCHEMA_MIGRATIONS_STATUS="pending"
 REDIS_READY_STATUS="pending"
 KEYCLOAK_READY_STATUS="pending"
 ARTIFACT_CONTRACT_STATUS="pending"
+INJECTED_WORKSPACE_SYNC_STATUS="pending"
 APP_START_STATUS="pending"
 HEALTH_LIVE_STATUS="pending"
 HEALTH_READY_STATUS="pending"
@@ -458,6 +459,17 @@ if [ "${VERIFY_STATUS}" = "ok" ]; then
 fi
 
 if [ "${VERIFY_STATUS}" = "ok" ]; then
+  if bash "${WORKSPACE_ROOT}/scripts/ci/run-workspace-node.sh" --import tsx "${WORKSPACE_ROOT}/scripts/ci/sync-injected-workspace-packages.ts" "${APP_DIR}" >/dev/null; then
+    set_phase_var INJECTED_WORKSPACE_SYNC_STATUS ok
+    mark_phase injected-workspace-sync ok
+  else
+    set_phase_var INJECTED_WORKSPACE_SYNC_STATUS error
+    mark_phase injected-workspace-sync error
+    fail_verify artifact-contract-failed injected-workspace-sync "Die injizierten Workspace-Pakete konnten fuer den Final-Artifact-Check nicht synchronisiert werden."
+  fi
+fi
+
+if [ "${VERIFY_STATUS}" = "ok" ]; then
   (
     cd "${APP_DIR}"
     env \
@@ -591,6 +603,7 @@ cat > "${REPORT_PATH}" <<EOF
     "redis-ready": "${REDIS_READY_STATUS}",
     "keycloak-ready": "${KEYCLOAK_READY_STATUS}",
     "artifact-contract": "${ARTIFACT_CONTRACT_STATUS}",
+    "injected-workspace-sync": "${INJECTED_WORKSPACE_SYNC_STATUS}",
     "app-start": "${APP_START_STATUS}",
     "health-live": "${HEALTH_LIVE_STATUS}",
     "health-ready": "${HEALTH_READY_STATUS}",

--- a/scripts/ci/verify-runtime-artifact.sh
+++ b/scripts/ci/verify-runtime-artifact.sh
@@ -640,6 +640,7 @@ cat > "${SUMMARY_PATH}" <<EOF
 - \`redis-ready\`: \`${REDIS_READY_STATUS}\`
 - \`keycloak-ready\`: \`${KEYCLOAK_READY_STATUS}\`
 - \`artifact-contract\`: \`${ARTIFACT_CONTRACT_STATUS}\`
+- \`injected-workspace-sync\`: \`${INJECTED_WORKSPACE_SYNC_STATUS}\`
 - \`app-start\`: \`${APP_START_STATUS}\`
 - \`health-live\`: \`${HEALTH_LIVE_STATUS}\`
 - \`health-ready\`: \`${HEALTH_READY_STATUS}\`


### PR DESCRIPTION
## Problem

Der Studio-Runtime-Artifact-Build läuft mit `injectWorkspacePackages: true`, aber nach einem Clean-Install bleiben injizierte Workspace-Pakete in den `.pnpm`-Store-Kopien stale. Nach dem Build existiert `dist/` im Workspace-Package, aber nicht in den injizierten Consumer-Kopien unter `apps/sva-studio-react/node_modules/@sva/*`.

Dadurch startet der finale Node-Output zwar, aber Laufzeit-Imports wie `@sva/routing/server` und `@sva/auth-runtime/server` können im Verify-Pfad fehlschlagen. In CI äußert sich das als instabiles `GET /health/live` im Schritt `sva-studio-react:verify:runtime-artifact`.

Zusätzlich nimmt der PR die bereits vorbereitete lokale Seed-Umstellung für `de-musterhausen` mit auf die `localhost`-/`local-keycloak`-Defaults.

## Lösung

- fügt `scripts/ci/sync-injected-workspace-packages.ts` hinzu
- synchronisiert nach dem `vite build` + `patch-runtime-artifact` die `dist/`-Ordner gebauter Workspace-Pakete in injizierte `.pnpm`-Store-Kopien
- führt denselben Sync zusätzlich im Runtime-Artifact-Verify direkt vor dem Start des finalen `node .output/server/index.mjs` aus
- ergänzt Tests für den Sync-Mechanismus und die Build-Verkabelung
- richtet den Seed `0001_iam_personas.sql` auf die lokalen `studio.localhost`-/Realm-Admin-Defaults aus und ergänzt den passenden SQL-Contract-Test

## Verifikation

- `pnpm nx run data:test:unit`
- frische Minimal-Repro im separaten Worktree:
  - nach Clean-Install fehlten `apps/sva-studio-react/node_modules/@sva/auth-runtime/dist/runtime-health.js` und `@sva/routing/dist/index.server.js`
  - nach `bash scripts/ci/run-workspace-node.sh --import tsx scripts/ci/sync-injected-workspace-packages.ts /tmp/sva-inject-current/apps/sva-studio-react` wurden 13 injizierte `@sva/*`-Pakete synchronisiert und die fehlenden `dist`-Dateien waren vorhanden

## Hinweis

Der komplette lokale `pnpm nx run sva-studio-react:verify:runtime-artifact` konnte hier nicht 1:1 durchlaufen, weil die lokale Toolchain vorab an Node 25 statt `.nvmrc` 24 scheitert. Der eigentliche stale-injection-Fail wurde aber isoliert reproduziert und der Fix konkret dagegen validiert.
