### PR TITLE
[codex] Restore IAM auth hot-path performance with immediate session revocation

### DIFF
--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -434,6 +434,9 @@ test.describe('events and POI plugins', () => {
     const pois: PoiRecord[] = [];
     const events: EventRecord[] = [];
 
+    await page.route('**/api/v1/mainserver/events**', async (route) => {
+      await routeEvents(route, events);
+    });
     await page.route('**/api/v1/mainserver/poi**', async (route) => {
       await routePoi(route, pois);
     });

--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -2,6 +2,8 @@ import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 import type { Page, Route } from '@playwright/test';
 
+import { gotoHomeAsAuthenticatedUser, gotoShellRoot } from './studio-shell.helpers';
+
 type EventRecord = {
   readonly id: string;
   title: string;
@@ -442,7 +444,7 @@ test.describe('events and POI plugins', () => {
     });
     await routeUnifiedContentOverview(page, () => events, () => pois);
 
-    await page.goto('/');
+    await gotoHomeAsAuthenticatedUser(page);
     await navigateClientSide(page, '/admin/content');
     await expectContentOverviewReady(page);
     await expectCreateContentActionReady(page);
@@ -502,7 +504,7 @@ test.describe('events and POI plugins', () => {
     });
     await routeUnifiedContentOverview(page, () => events, () => pois);
 
-    await page.goto('/');
+    await gotoHomeAsAuthenticatedUser(page);
     await navigateClientSide(page, '/admin/content');
     await expectContentOverviewReady(page);
     await expectCreateContentActionReady(page);
@@ -550,7 +552,7 @@ test.describe('events and POI plugins', () => {
     await page.route('**/auth/me', async (route) => {
       await route.fulfill({ status: 401, contentType: 'application/json', body: JSON.stringify({ error: 'unauthorized' }) });
     });
-    await page.goto('/');
+    await gotoShellRoot(page);
     await navigateClientSide(page, '/admin/content');
     await expectLoginRedirect(page, /^\/admin\/content(?:$|\?)/);
   });
@@ -561,7 +563,7 @@ test.describe('events and POI plugins', () => {
       await route.fulfill({ status: 401, contentType: 'application/json', body: JSON.stringify({ error: 'unauthorized' }) });
     });
 
-    await page.goto('/');
+    await gotoShellRoot(page);
     await navigateClientSide(page, '/admin/poi/new');
     await expectLoginRedirect(page, /^\/admin\/poi\/new(?:$|\?)/);
   });

--- a/apps/sva-studio-react/e2e/news-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/news-plugin.spec.ts
@@ -2,6 +2,8 @@ import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 import type { Page, Route } from '@playwright/test';
 
+import { gotoHomeAsAuthenticatedUser, gotoShellRoot } from './studio-shell.helpers';
+
 type NewsRecord = {
   id: string;
   title: string;
@@ -139,26 +141,6 @@ const expectLoginRedirect = async (page: Page, returnToPattern: RegExp) => {
   const authMode = loginUrl.searchParams.get('auth');
   expect(authMode === 'login' || authMode === 'dev-login' || authMode === 'mock-login' || authMode === null).toBe(true);
   expect(loginUrl.searchParams.get('returnTo')).toMatch(returnToPattern);
-};
-
-const gotoShellRoot = async (page: Page, attempts = 5) => {
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    try {
-      await page.goto('/');
-      return;
-    } catch (error) {
-      lastError = error;
-      const message = error instanceof Error ? error.message : String(error);
-      if (!message.includes('ERR_CONNECTION_REFUSED') || attempt === attempts) {
-        throw error;
-      }
-      await page.waitForTimeout(1_000);
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 };
 
 const mockSharedShellRequests = async (page: Page) => {
@@ -453,8 +435,7 @@ test.describe('news plugin', () => {
     });
     await routeUnifiedContentOverview(page, newsItems);
 
-    await gotoShellRoot(page);
-    await expect(page.getByRole('heading', { name: 'SVA Studio' })).toBeVisible();
+    await gotoHomeAsAuthenticatedUser(page);
 
     await navigateClientSide(page, '/admin/content');
     await expectContentOverviewReady(page);
@@ -567,7 +548,7 @@ test.describe('news plugin', () => {
     });
     await routeUnifiedContentOverview(page, newsItems);
 
-    await gotoShellRoot(page);
+    await gotoHomeAsAuthenticatedUser(page);
     const contentNavLink = page.getByRole('link', { name: 'Inhalte öffnen' }).first();
     await expect(contentNavLink).toBeVisible();
 
@@ -647,7 +628,7 @@ test.describe('news plugin', () => {
     });
     await routeUnifiedContentOverview(page, newsItems);
 
-    await gotoShellRoot(page);
+    await gotoHomeAsAuthenticatedUser(page);
     await navigateClientSide(page, '/admin/content');
     await expectContentOverviewReady(page);
     const listViolations = await new AxeBuilder({ page }).include('#main-content').analyze();

--- a/apps/sva-studio-react/e2e/studio-shell.helpers.ts
+++ b/apps/sva-studio-react/e2e/studio-shell.helpers.ts
@@ -1,0 +1,45 @@
+import { expect, type Page } from '@playwright/test';
+
+const escapeForRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const resolveInitials = (value: string) =>
+  value
+    .split(/[\s._-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+
+export const gotoShellRoot = async (page: Page, attempts = 5) => {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await page.goto('/');
+      return;
+    } catch (error) {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes('ERR_CONNECTION_REFUSED') || attempt === attempts) {
+        throw error;
+      }
+      await page.waitForTimeout(1_000);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+};
+
+export const gotoHomeAsAuthenticatedUser = async (page: Page, expectedUserName = 'Editor One') => {
+  const authMeResponse = page.waitForResponse(
+    (response) => response.request().method() === 'GET' && response.url().includes('/auth/me') && response.status() === 200
+  );
+  const expectedTriggerPattern = new RegExp(
+    `${escapeForRegex(expectedUserName)}|${escapeForRegex(resolveInitials(expectedUserName))}`
+  );
+
+  await gotoShellRoot(page);
+  await authMeResponse;
+  await expect(page.getByRole('heading', { name: 'SVA Studio' })).toBeVisible();
+  await expect(page.getByRole('button', { name: expectedTriggerPattern })).toBeVisible();
+};

--- a/docs/superpowers/plans/2026-05-21-studio-data-form-and-test-foundations.md
+++ b/docs/superpowers/plans/2026-05-21-studio-data-form-and-test-foundations.md
@@ -56,6 +56,14 @@
 - Modify: `packages/plugin-poi/vitest.config.ts`
 - Modify: `packages/plugin-waste-management/vitest.config.ts`
 
+### Kleine Playwright-Bruecke vor breiterem Harness-Rollout
+
+- Modify: `apps/sva-studio-react/e2e/news-plugin.spec.ts`
+- Modify: `apps/sva-studio-react/e2e/events-poi-plugin.spec.ts`
+- Create: `apps/sva-studio-react/e2e/studio-shell.helpers.ts`
+
+Hinweis: Wenn ein akuter `App E2E`-CI-Befund aus Playwright-Shell-Boot, frueher clientseitiger Navigation oder duplizierten `auth/me`-Wartebedingungen entsteht, ist ein kleiner Shared-Helper in `apps/sva-studio-react/e2e/` als Zwischenstufe zulaessig. Diese Bruecke stabilisiert bestehende Playwright-Specs, ohne den spaeteren `msw`-basierten Foundation-Rollout in `tooling/testing` vorwegzunehmen oder zu ersetzen.
+
 ### Property-based Test Foundations
 
 - Modify: `packages/core/package.json`

--- a/packages/auth-runtime/src/auth-server/callback.test.ts
+++ b/packages/auth-runtime/src/auth-server/callback.test.ts
@@ -120,6 +120,32 @@ describe('handleCallback', () => {
     expect(mocks.authorizationCodeGrant).not.toHaveBeenCalled();
   });
 
+  it('rejects new sessions for subjects with a persistent login block', async () => {
+    const { handleCallback } = await import('./callback.js');
+
+    mocks.getSessionControlState.mockResolvedValueOnce({
+      minimumSessionVersion: 2,
+      loginBlocked: true,
+      loginBlockedReason: 'account_lifecycle_blocked',
+    });
+
+    await expect(
+      handleCallback({
+        code: 'code-1',
+        state: 'state-1',
+        authConfig,
+        loginState: {
+          kind: 'platform',
+          codeVerifier: 'verifier',
+          nonce: 'nonce',
+          createdAt: Date.now(),
+        },
+      })
+    ).rejects.toThrow('Account is blocked from starting new sessions');
+
+    expect(mocks.createSession).not.toHaveBeenCalled();
+  });
+
   it('rejects instance login states without an instanceId', async () => {
     const { handleCallback } = await import('./callback.js');
 

--- a/packages/auth-runtime/src/auth-server/callback.ts
+++ b/packages/auth-runtime/src/auth-server/callback.ts
@@ -54,6 +54,8 @@ const readClaimSubject = (claims: Record<string, unknown>): string => {
   return typeof subject === 'string' ? subject : '';
 };
 
+const isLoginBlocked = (state: Awaited<ReturnType<typeof getSessionControlState>>): boolean => state?.loginBlocked === true;
+
 const normalizeLoginState = (loginState: UntrustedLoginState): LoginState => {
   if (loginState.kind === 'instance' && typeof loginState.instanceId !== 'string') {
     throw new Error('Invalid login state: missing instanceId for instance scope');
@@ -142,6 +144,9 @@ const persistSession = async (input: {
   const issuedAt = Date.now();
   const { sessionTtlMs } = input.authConfig;
   const sessionControlState = await getSessionControlState(readClaimSubject(input.claims));
+  if (isLoginBlocked(sessionControlState)) {
+    throw new Error('Account is blocked from starting new sessions');
+  }
   const sessionVersion = Math.max(sessionControlState?.minimumSessionVersion ?? 1, 1);
   const expiresAt = resolveSessionExpiry({
     expiresInSeconds: undefined,

--- a/packages/auth-runtime/src/auth-server/session.test.ts
+++ b/packages/auth-runtime/src/auth-server/session.test.ts
@@ -191,6 +191,23 @@ describe('auth server session resolution', () => {
     expect(state.deleteSession).toHaveBeenCalledWith('session-1');
   });
 
+  it('deletes sessions when the subject is blocked from starting new sessions', async () => {
+    state.getSession.mockResolvedValue(createSession({ sessionVersion: 2 }));
+    state.getSessionControlState.mockResolvedValue({
+      minimumSessionVersion: 2,
+      loginBlocked: true,
+      loginBlockedReason: 'dsr_deletion_requested',
+    });
+
+    const { resolveSessionUser } = await import('./session.js');
+
+    await expect(resolveSessionUser('session-1')).resolves.toEqual({
+      kind: 'invalid',
+      reason: 'forced_reauth',
+    });
+    expect(state.deleteSession).toHaveBeenCalledWith('session-1');
+  });
+
   it('hydrates incomplete session users from the access token on fresh sessions', async () => {
     state.getSession.mockResolvedValue(
       createSession({ user: incompleteUser, refreshToken: undefined, expiresAt: 100_000 })

--- a/packages/auth-runtime/src/auth-server/session.ts
+++ b/packages/auth-runtime/src/auth-server/session.ts
@@ -41,6 +41,10 @@ const readSessionInvalidationReason = async (
     return null;
   }
 
+  if (state.loginBlocked === true) {
+    return 'forced_reauth';
+  }
+
   const sessionVersion = session.sessionVersion ?? 1;
   const issuedAt = session.issuedAt ?? session.createdAt;
 

--- a/packages/auth-runtime/src/iam-account-management/user-bulk-deactivate-handler.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-bulk-deactivate-handler.ts
@@ -5,6 +5,7 @@ import { emitActivityLog, notifyPermissionInvalidation } from './shared-activity
 import { iamUserOperationsCounter, logger, trackKeycloakCall } from './shared-observability.js';
 import { withInstanceScopedDb } from './shared-runtime.js';
 import { resolveUsersForBulkDeactivation } from './user-bulk-query.js';
+import { revokeUserSessions } from '../session-revocation.js';
 import {
   completeBulkDeactivateFailure,
   completeBulkDeactivateSuccess,
@@ -19,6 +20,7 @@ export const bulkDeactivateInternal = createBulkDeactivateHandlerInternal({
   iamUserOperationsCounter,
   logger,
   notifyPermissionInvalidation,
+  revokeUserSessions,
   resolveActorMaxRoleLevel,
   resolveBulkDeactivateContext,
   resolveSystemAdminCount,

--- a/packages/auth-runtime/src/iam-account-management/user-deactivate-handler.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-deactivate-handler.ts
@@ -10,6 +10,7 @@ import { emitActivityLog, notifyPermissionInvalidation } from './shared-activity
 import { iamUserOperationsCounter, logger, trackKeycloakCall } from './shared-observability.js';
 import { withInstanceScopedDb } from './shared-runtime.js';
 import { resolveUserDetail } from './user-detail-query.js';
+import { revokeUserSessions } from '../session-revocation.js';
 import {
   isRecoverableUserProjectionError,
   mergeMainserverCredentialState,
@@ -42,6 +43,7 @@ export const deactivateUserInternal = createDeactivateUserHandlerInternal({
   logger,
   mergeMainserverCredentialState,
   notifyPermissionInvalidation,
+  revokeUserSessions,
   notFoundResponse: (requestId) => createApiError(404, 'not_found', 'Nutzer nicht gefunden.', requestId),
   resolveActorMaxRoleLevel,
   resolveDeactivateRequestContext,

--- a/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
@@ -11,6 +11,7 @@ import { emitActivityLog, notifyPermissionInvalidation } from './shared-activity
 import { trackKeycloakCall } from './shared-observability.js';
 import { withInstanceScopedDb, resolveIdentityProvider } from './shared-runtime.js';
 import { resolveUserDetail } from './user-detail-query.js';
+import { revokeUserSessions } from '../session-revocation.js';
 import {
   buildIdentityAttributesForUserUpdate,
 } from './user-update-identity.js';
@@ -66,6 +67,7 @@ export const { persistUpdatedUserDetail } = createUserUpdatePersistence({
   assignRoles,
   emitActivityLog,
   notifyPermissionInvalidation,
+  revokeUserSessions,
   resolveUserDetail,
   withInstanceScopedDb,
 });

--- a/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
@@ -12,6 +12,7 @@ import { trackKeycloakCall } from './shared-observability.js';
 import { withInstanceScopedDb, resolveIdentityProvider } from './shared-runtime.js';
 import { resolveUserDetail } from './user-detail-query.js';
 import { revokeUserSessions } from '../session-revocation.js';
+import { clearUserSessionLoginBlock } from '../session-revocation.js';
 import {
   buildIdentityAttributesForUserUpdate,
 } from './user-update-identity.js';
@@ -65,6 +66,7 @@ export const resolveUpdatedIdentityState = async (input: {
 export const { persistUpdatedUserDetail } = createUserUpdatePersistence({
   assignGroups,
   assignRoles,
+  clearUserSessionLoginBlock,
   emitActivityLog,
   notifyPermissionInvalidation,
   revokeUserSessions,

--- a/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
+++ b/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   listAdminDsrCases: vi.fn(),
   getAdminDsrCase: vi.fn(),
   loadDsrSelfServiceOverview: vi.fn(),
+  revokeUserSessions: vi.fn(async () => undefined),
   parseFieldEncryptionConfigFromEnv: vi.fn(() => ({ keyId: 'enc-1' })),
   encryptFieldValue: vi.fn((value: string) => `enc:${value}`),
   requireIdempotencyKey: vi.fn(() => ({ key: 'idem-1' })),
@@ -112,6 +113,10 @@ vi.mock('../middleware.js', () => ({
 
 vi.mock('../runtime-secrets.js', () => ({
   getIamDatabaseUrl: vi.fn(() => 'postgres://db.example/sva'),
+}));
+
+vi.mock('../session-revocation.js', () => ({
+  revokeUserSessions: mocks.revokeUserSessions,
 }));
 
 vi.mock('../db.js', () => ({
@@ -566,6 +571,38 @@ describe('iam data subject rights handlers', () => {
     await expect(expectJson(response)).resolves.toEqual({
       requestId: 'blocked-request-1',
       status: 'blocked_legal_hold',
+    });
+    expect(mocks.revokeUserSessions).not.toHaveBeenCalled();
+  });
+
+  it('revokes active sessions when a deletion request enters processing', async () => {
+    const { dataSubjectRequestHandler } = await import('./core.js');
+
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, _instanceId, work) =>
+      work(
+        buildDbClient({
+          account: buildAccount({ id: 'account-77', keycloak_subject: 'kc-user-1' }),
+          requestIds: ['deletion-request-1'],
+        })
+      )
+    );
+
+    const response = await dataSubjectRequestHandler(
+      new Request('http://localhost/iam/me/data-subject-rights', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'deletion', payload: { reason: 'cleanup' } }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(expectJson(response)).resolves.toEqual({
+      requestId: 'deletion-request-1',
+      status: 'processing',
+    });
+    expect(mocks.revokeUserSessions).toHaveBeenCalledWith({
+      keycloakSubject: 'kc-user-1',
+      reason: 'dsr_deletion_requested',
     });
   });
 

--- a/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
+++ b/packages/auth-runtime/src/iam-data-subject-rights/core.test.ts
@@ -577,15 +577,22 @@ describe('iam data subject rights handlers', () => {
 
   it('revokes active sessions when a deletion request enters processing', async () => {
     const { dataSubjectRequestHandler } = await import('./core.js');
+    const events: string[] = [];
 
-    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, _instanceId, work) =>
-      work(
+    mocks.revokeUserSessions.mockImplementationOnce(async () => {
+      events.push('revoke');
+    });
+    mocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolver, _instanceId, work) => {
+      events.push('tx:start');
+      const result = await work(
         buildDbClient({
           account: buildAccount({ id: 'account-77', keycloak_subject: 'kc-user-1' }),
           requestIds: ['deletion-request-1'],
         })
-      )
-    );
+      );
+      events.push('tx:end');
+      return result;
+    });
 
     const response = await dataSubjectRequestHandler(
       new Request('http://localhost/iam/me/data-subject-rights', {
@@ -604,6 +611,7 @@ describe('iam data subject rights handlers', () => {
       keycloakSubject: 'kc-user-1',
       reason: 'dsr_deletion_requested',
     });
+    expect(events).toEqual(['tx:start', 'tx:end', 'revoke']);
   });
 
   it('blocks optional processing when restriction or objection flags are active', async () => {

--- a/packages/auth-runtime/src/iam-data-subject-rights/core.ts
+++ b/packages/auth-runtime/src/iam-data-subject-rights/core.ts
@@ -49,6 +49,15 @@ const DEFAULT_DELETE_RETENTION_HOURS = 24;
 
 type DsrRequestType = 'access' | 'deletion' | 'rectification' | 'restriction' | 'objection';
 
+type DsrRequestMutationResult = {
+  requestId: string;
+  status: string;
+  afterCommitRevocation?: {
+    keycloakSubject: string;
+    reason: 'dsr_deletion_requested';
+  };
+};
+
 const resolvePool = createPoolResolver(getIamDatabaseUrl);
 const withInstanceScopedDb = async <T>(
   instanceId: string,
@@ -755,7 +764,7 @@ const performDeletionRequest = async (
     keycloakSubject: string;
     payload: Record<string, unknown>;
   }
-): Promise<{ requestId: string; status: string }> => {
+): Promise<DsrRequestMutationResult> => {
   const hasLegalHold = await isLegalHoldActive(client, {
     instanceId: input.instanceId,
     accountId: input.targetAccountId,
@@ -825,12 +834,14 @@ WHERE id = $2::uuid;
     },
   });
 
-  await revokeUserSessions({
-    keycloakSubject: input.keycloakSubject,
-    reason: 'dsr_deletion_requested',
-  });
-
-  return { requestId, status: 'processing' };
+  return {
+    requestId,
+    status: 'processing',
+    afterCommitRevocation: {
+      keycloakSubject: input.keycloakSubject,
+      reason: 'dsr_deletion_requested' as const,
+    },
+  };
 };
 
 const performRestrictionRequest = async (
@@ -841,7 +852,7 @@ const performRestrictionRequest = async (
     targetAccountId: string;
     payload: Record<string, unknown>;
   }
-): Promise<{ requestId: string; status: string }> => {
+): Promise<DsrRequestMutationResult> => {
   const reason = readString(input.payload.reason) ?? 'restriction_requested';
   await client.query(
     `
@@ -890,7 +901,7 @@ const performObjectionRequest = async (
     targetAccountId: string;
     payload: Record<string, unknown>;
   }
-): Promise<{ requestId: string; status: string }> => {
+): Promise<DsrRequestMutationResult> => {
   await client.query(
     `
 UPDATE iam.accounts
@@ -952,16 +963,18 @@ export const dataSubjectRequestHandler = async (request: Request): Promise<Respo
       }
 
       try {
-        return await withInstanceScopedDb(instanceId, async (client) => {
+        const committedResult = await withInstanceScopedDb(instanceId, async (client) => {
           const requesterAccountId = await resolveRequesterAccountId(client, {
             instanceId,
             keycloakSubject: user.id,
           });
           if (!requesterAccountId) {
-            return jsonResponse(404, { error: 'account_not_found' });
+            return {
+              response: jsonResponse(404, { error: 'account_not_found' }),
+            };
           }
 
-          let result: { requestId: string; status: string };
+          let result: DsrRequestMutationResult;
 
           if (requestType === 'deletion') {
             result = await performDeletionRequest(client, {
@@ -1008,11 +1021,20 @@ export const dataSubjectRequestHandler = async (request: Request): Promise<Respo
             },
           });
 
-          return jsonResponse(200, {
-            requestId: result.requestId,
-            status: result.status,
-          });
+          return {
+            response: jsonResponse(200, {
+              requestId: result.requestId,
+              status: result.status,
+            }),
+            afterCommitRevocation: result.afterCommitRevocation,
+          };
         });
+
+        if (committedResult.afterCommitRevocation) {
+          await revokeUserSessions(committedResult.afterCommitRevocation);
+        }
+
+        return committedResult.response;
       } catch (error) {
         return handleJsonDatabaseError('DSR self request failed', 'self_request', instanceId, error);
       }

--- a/packages/auth-runtime/src/iam-data-subject-rights/core.ts
+++ b/packages/auth-runtime/src/iam-data-subject-rights/core.ts
@@ -24,6 +24,7 @@ import { validateCsrf } from '../iam-account-management/csrf.js';
 import { getAdminDsrCase, listAdminDsrCases, loadDsrSelfServiceOverview } from '@sva/iam-governance';
 import { DsrAccountSnapshotNotFoundError } from '@sva/iam-governance/dsr-read-models-internal';
 import { readPathSegment } from '../shared/request-helpers.js';
+import { revokeUserSessions } from '../session-revocation.js';
 
 const logger = createSdkLogger({ component: 'iam-dsr', level: 'info' });
 const isExportFormat = (value: string | undefined): value is ExportFormat =>
@@ -751,6 +752,7 @@ const performDeletionRequest = async (
     instanceId: string;
     requesterAccountId: string;
     targetAccountId: string;
+    keycloakSubject: string;
     payload: Record<string, unknown>;
   }
 ): Promise<{ requestId: string; status: string }> => {
@@ -821,6 +823,11 @@ WHERE id = $2::uuid;
       retentionHours,
       slaHours: DELETE_SLA_HOURS,
     },
+  });
+
+  await revokeUserSessions({
+    keycloakSubject: input.keycloakSubject,
+    reason: 'dsr_deletion_requested',
   });
 
   return { requestId, status: 'processing' };
@@ -961,6 +968,7 @@ export const dataSubjectRequestHandler = async (request: Request): Promise<Respo
               instanceId,
               requesterAccountId,
               targetAccountId: requesterAccountId,
+              keycloakSubject: user.id,
               payload,
             });
           } else if (requestType === 'restriction') {

--- a/packages/auth-runtime/src/middleware-guards.test.ts
+++ b/packages/auth-runtime/src/middleware-guards.test.ts
@@ -110,7 +110,7 @@ describe('middleware-guards', () => {
     );
   });
 
-  it('returns null when lifecycle enforcement is bypassed and rejects blocked accounts otherwise', async () => {
+  it('returns null when lifecycle enforcement is bypassed or handled through session revocation', async () => {
     const { ensureAccountLifecycleAllowsAccess } = await import('./middleware-guards.js');
     const request = new Request('http://localhost/auth/me');
     const activeUser = {
@@ -122,36 +122,10 @@ describe('middleware-guards', () => {
     await expect(
       ensureAccountLifecycleAllowsAccess(request, activeUser, { isLocalDevelopmentAuth: true })
     ).resolves.toBeNull();
-
-    dbMocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolvePool, _instanceId, work) =>
-      work({
-        query: vi.fn(async () => ({
-          rows: [{ deletion_lifecycle_state: 'deleted' }],
-        })),
-      })
-    );
-
-    const response = await ensureAccountLifecycleAllowsAccess(request, activeUser);
-
-    expect(response?.status).toBe(403);
-    await expect(response?.json()).resolves.toMatchObject({
-      error: {
-        code: 'forbidden',
-        details: {
-          lifecycle_state: 'deleted',
-          reason_code: 'account_lifecycle_blocked',
-        },
-      },
-    });
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Auth middleware rejected request because the account lifecycle is blocked',
-      expect.objectContaining({
-        lifecycle_state: 'deleted',
-      })
-    );
+    await expect(ensureAccountLifecycleAllowsAccess(request, activeUser)).resolves.toBeNull();
   });
 
-  it('rechecks active lifecycle state on every request', async () => {
+  it('skips lifecycle database lookups on the authenticated hot path', async () => {
     const { ensureAccountLifecycleAllowsAccess } = await import('./middleware-guards.js');
     const request = new Request('http://localhost/auth/me');
     const activeUser = {
@@ -163,51 +137,8 @@ describe('middleware-guards', () => {
     await expect(ensureAccountLifecycleAllowsAccess(request, activeUser)).resolves.toBeNull();
     await expect(ensureAccountLifecycleAllowsAccess(request, activeUser)).resolves.toBeNull();
 
-    expect(dbMocks.withResolvedInstanceDb).toHaveBeenCalledTimes(2);
-  });
-
-  it('fails closed when the IAM database or the tenant account record is unavailable', async () => {
-    const { ensureAccountLifecycleAllowsAccess } = await import('./middleware-guards.js');
-    const request = new Request('http://localhost/auth/me');
-    const activeUser = {
-      id: 'user-1',
-      roles: ['editor'],
-      instanceId: 'de-musterhausen',
-    } as never;
-
-    dbMocks.resolvePool.mockReturnValueOnce(null);
-    const unavailableResponse = await ensureAccountLifecycleAllowsAccess(request, activeUser);
-
-    expect(unavailableResponse?.status).toBe(503);
-    await expect(unavailableResponse?.json()).resolves.toMatchObject({
-      error: {
-        code: 'internal_error',
-        details: {
-          dependency: 'iam_db',
-          reason_code: 'iam_db_unavailable',
-        },
-      },
-    });
-
-    dbMocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolvePool, _instanceId, work) =>
-      work({
-        query: vi.fn(async () => ({
-          rows: [],
-        })),
-      })
-    );
-
-    const missingAccountResponse = await ensureAccountLifecycleAllowsAccess(request, activeUser);
-
-    expect(missingAccountResponse?.status).toBe(403);
-    await expect(missingAccountResponse?.json()).resolves.toMatchObject({
-      error: {
-        code: 'forbidden',
-        details: {
-          reason_code: 'account_not_found',
-        },
-      },
-    });
+    expect(dbMocks.resolvePool).not.toHaveBeenCalled();
+    expect(dbMocks.withResolvedInstanceDb).not.toHaveBeenCalled();
   });
 
   it('maps session store, hydration, and unexpected middleware failures to stable api errors', async () => {

--- a/packages/auth-runtime/src/middleware-guards.ts
+++ b/packages/auth-runtime/src/middleware-guards.ts
@@ -1,7 +1,6 @@
 import { createSdkLogger } from '@sva/server-runtime';
 
 import { createApiError } from './api-error.js';
-import { resolvePool, withResolvedInstanceDb } from './db.js';
 import { buildLogContext } from './log-context.js';
 import { SessionStoreUnavailableError, SessionUserHydrationError } from './runtime-errors.js';
 import type { SessionUser } from './types.js';
@@ -18,10 +17,6 @@ const shouldLogProfileDiagnostics = (request: Request): boolean => {
   }
 
   return PROFILE_DIAGNOSTIC_PATHS.has(new URL(request.url).pathname);
-};
-
-type AccountLifecycleRow = {
-  deletion_lifecycle_state: 'active' | 'deactivated' | 'pseudonymized' | 'deleted';
 };
 
 export const logProfileDiagnosticsIfEnabled = (request: Request, user: SessionUser): void => {
@@ -61,91 +56,12 @@ export const ensureAccountLifecycleAllowsAccess = async (
   user: SessionUser,
   options?: { isLocalDevelopmentAuth?: boolean }
 ): Promise<Response | null> => {
+  void request;
+  void user;
   if (options?.isLocalDevelopmentAuth || !user.instanceId) {
     return null;
   }
-
-  const pool = resolvePool();
-  if (!pool) {
-    const logContext = buildLogContext(user.instanceId, { includeTraceId: true });
-    logger.error('Auth middleware cannot enforce account lifecycle without an IAM database connection', {
-      endpoint: request.url,
-      operation: 'auth_middleware',
-      user_id: user.id,
-      reason_code: 'iam_db_unavailable',
-      ...logContext,
-    });
-
-    return createApiError(
-      503,
-      'internal_error',
-      'Authentifizierung ist momentan nicht verfügbar, weil die IAM-Datenbank nicht erreichbar ist.',
-      logContext.request_id,
-      {
-        dependency: 'iam_db',
-        reason_code: 'iam_db_unavailable',
-      }
-    );
-  }
-
-  const accountRow = await withResolvedInstanceDb(
-    () => pool,
-    user.instanceId,
-    async (client) => {
-      const result = await client.query<AccountLifecycleRow>(
-        `
-SELECT a.deletion_lifecycle_state
-FROM iam.accounts a
-WHERE a.instance_id = $1
-  AND a.keycloak_subject = $2
-LIMIT 1;
-`,
-        [user.instanceId, user.id]
-      );
-
-      return result.rows[0] ?? null;
-    }
-  );
-
-  const logContext = buildLogContext(user.instanceId, { includeTraceId: true });
-  if (!accountRow) {
-    logger.warn('Auth middleware rejected request because the tenant account could not be resolved', {
-      endpoint: request.url,
-      operation: 'auth_middleware',
-      user_id: user.id,
-      reason_code: 'account_not_found',
-      ...logContext,
-    });
-
-    return createApiError(
-      403,
-      'forbidden',
-      'Dieses Konto ist nicht mehr aktiv.',
-      logContext.request_id,
-      {
-        reason_code: 'account_not_found',
-      }
-    );
-  }
-
-  const accountState = accountRow.deletion_lifecycle_state;
-  if (accountState === 'active') {
-    return null;
-  }
-
-  logger.warn('Auth middleware rejected request because the account lifecycle is blocked', {
-    endpoint: request.url,
-    operation: 'auth_middleware',
-    user_id: user.id,
-    lifecycle_state: accountState,
-    reason_code: 'account_lifecycle_blocked',
-    ...logContext,
-  });
-
-  return createApiError(403, 'forbidden', 'Dieses Konto ist nicht mehr aktiv.', logContext.request_id, {
-    lifecycle_state: accountState,
-    reason_code: 'account_lifecycle_blocked',
-  });
+  return null;
 };
 
 export const logUnexpectedMiddlewareError = (request: Request, error: unknown): Response => {

--- a/packages/auth-runtime/src/middleware.test.ts
+++ b/packages/auth-runtime/src/middleware.test.ts
@@ -232,7 +232,7 @@ describe('auth-runtime withAuthenticatedUser', () => {
       request,
       expect.objectContaining({ id: 'user-1' })
     );
-    expect(dbMocks.withResolvedInstanceDb).toHaveBeenCalled();
+    expect(dbMocks.withResolvedInstanceDb).not.toHaveBeenCalled();
   });
 
   it('logs middleware timing diagnostics when authorize timing debug is enabled', async () => {
@@ -255,45 +255,16 @@ describe('auth-runtime withAuthenticatedUser', () => {
     );
   });
 
-  it('fails closed when lifecycle enforcement cannot resolve the tenant account or IAM database', async () => {
+  it('does not depend on IAM lifecycle database checks for authenticated requests', async () => {
     const request = new Request('http://localhost/auth/me', {
       headers: { cookie: 'sva_auth_session=session-2' },
     });
 
     dbMocks.resolvePool.mockReturnValueOnce(null);
-    const unavailableResponse = await withAuthenticatedUser(request, () => new Response('ok'));
+    const response = await withAuthenticatedUser(request, () => new Response('ok'));
 
-    expect(unavailableResponse.status).toBe(503);
-    await expect(unavailableResponse.json()).resolves.toMatchObject({
-      error: {
-        code: 'internal_error',
-        details: {
-          dependency: 'iam_db',
-          reason_code: 'iam_db_unavailable',
-        },
-      },
-    });
-
-    dbMocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolvePool, _instanceId, work) =>
-      work({
-        query: vi.fn(async () => ({
-          rowCount: 0,
-          rows: [],
-        })),
-      })
-    );
-
-    const missingAccountResponse = await withAuthenticatedUser(request, () => new Response('ok'));
-
-    expect(missingAccountResponse.status).toBe(403);
-    await expect(missingAccountResponse.json()).resolves.toMatchObject({
-      error: {
-        code: 'forbidden',
-        details: {
-          reason_code: 'account_not_found',
-        },
-      },
-    });
+    expect(response.status).toBe(200);
+    expect(dbMocks.withResolvedInstanceDb).not.toHaveBeenCalled();
   });
 
   it('accepts requests with an active local dev auth cookie in dev auth mode', async () => {
@@ -322,43 +293,35 @@ describe('auth-runtime withAuthenticatedUser', () => {
     expect(dbMocks.withResolvedInstanceDb).not.toHaveBeenCalled();
   });
 
-  it('rejects authenticated tenant users whose account lifecycle is no longer active', async () => {
+  it('relies on revoked sessions instead of lifecycle row checks for blocked accounts', async () => {
     const request = new Request('http://localhost/auth/me', {
       headers: { cookie: 'sva_auth_session=session-4' },
     });
-    dbMocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolvePool, _instanceId, work) =>
-      work({
-        query: vi.fn(async () => ({
-          rowCount: 1,
-          rows: [{ deletion_lifecycle_state: 'deactivated' }],
-        })),
-      })
-    );
+    getSessionUserMock.mockResolvedValueOnce({ kind: 'invalid', reason: 'forced_reauth' });
 
     const response = await withAuthenticatedUser(request, () => new Response('ok'));
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
     await expect(response.json()).resolves.toMatchObject({
       error: {
-        code: 'forbidden',
-        message: 'Dieses Konto ist nicht mehr aktiv.',
+        code: 'unauthorized',
+        message: 'Die Sitzung ist nicht mehr gültig.',
         safeDetails: {
-          reason_code: 'account_lifecycle_blocked',
+          reason_code: 'forced_reauth',
         },
         details: {
-          lifecycle_state: 'deactivated',
-          reason_code: 'account_lifecycle_blocked',
+          reason_code: 'forced_reauth',
         },
       },
       requestId: 'req-auth-runtime',
     });
     expect(middlewareLogger.warn).toHaveBeenCalledWith(
-      'Auth middleware rejected request because the account lifecycle is blocked',
+      'Auth middleware rejected request because the session requires reauthentication',
       expect.objectContaining({
-        lifecycle_state: 'deactivated',
-        reason_code: 'account_lifecycle_blocked',
+        reason_code: 'forced_reauth',
       })
     );
+    expect(dbMocks.withResolvedInstanceDb).not.toHaveBeenCalled();
   });
 
   it('runs protected handlers through legal text compliance for tenant users when required', async () => {

--- a/packages/auth-runtime/src/redis-session.test.ts
+++ b/packages/auth-runtime/src/redis-session.test.ts
@@ -207,6 +207,20 @@ describe('redis-backed auth runtime session store', () => {
     await expect(getSessionControlState('user-a')).resolves.toEqual(controlState);
   });
 
+  it('persists session control state without redis expiry when no ttl is supplied', async () => {
+    const controlState: SessionControlState = {
+      minimumSessionVersion: 7,
+      forcedReauthAt: 456,
+    };
+
+    await setSessionControlState('user-persistent', controlState, null);
+
+    await expect(getSessionControlState('user-persistent')).resolves.toEqual(controlState);
+    const controlKey = [...mocks.redis.data.keys()].find((key) => key.endsWith('session_control:user-persistent'));
+    expect(controlKey).toBeDefined();
+    expect(controlKey ? mocks.redis.expirations.has(controlKey) : false).toBe(false);
+  });
+
   it('returns undefined for expired sessions and rejects missing session updates', async () => {
     await createSession(
       'expired',

--- a/packages/auth-runtime/src/redis-session.ts
+++ b/packages/auth-runtime/src/redis-session.ts
@@ -503,12 +503,16 @@ export async function getSessionControlState(userId: string): Promise<SessionCon
 export async function setSessionControlState(
   userId: string,
   state: SessionControlState,
-  ttlSeconds: number = DEFAULT_SESSION_CONTROL_TTL
+  ttlSeconds: number | null = DEFAULT_SESSION_CONTROL_TTL
 ): Promise<void> {
   await runWithRequiredRedisSessionStore({
     operation: 'set_session_control_state',
     runAgainstRedis: async () => {
       const redis = getRedisClient();
+      if (ttlSeconds === null) {
+        await redis.set(sessionControlPrefix() + userId, JSON.stringify(state));
+        return;
+      }
       await redis.set(sessionControlPrefix() + userId, JSON.stringify(state), 'EX', ttlSeconds);
     },
     runInMemoryForTests: () => {

--- a/packages/auth-runtime/src/session-revocation.test.ts
+++ b/packages/auth-runtime/src/session-revocation.test.ts
@@ -60,6 +60,30 @@ describe('session-revocation', () => {
       {
         minimumSessionVersion: 5,
         forcedReauthAt: 1_717_000_000_000,
+        loginBlocked: true,
+        loginBlockedReason: 'account_lifecycle_blocked',
+      },
+      null
+    );
+  });
+
+  it('clears reactivatable login blocks when a user becomes active again', async () => {
+    revocationMocks.getSessionControlState.mockResolvedValue({
+      minimumSessionVersion: 5,
+      forcedReauthAt: 1_716_999_999_000,
+      loginBlocked: true,
+      loginBlockedReason: 'user_status_inactivated',
+    });
+
+    const { clearUserSessionLoginBlock } = await import('./session-revocation.js');
+
+    await clearUserSessionLoginBlock('kc-user-3');
+
+    expect(revocationMocks.setSessionControlState).toHaveBeenCalledWith(
+      'kc-user-3',
+      {
+        minimumSessionVersion: 5,
+        forcedReauthAt: 1_716_999_999_000,
       },
       null
     );

--- a/packages/auth-runtime/src/session-revocation.test.ts
+++ b/packages/auth-runtime/src/session-revocation.test.ts
@@ -22,7 +22,7 @@ describe('session-revocation', () => {
     revocationMocks.getSessionControlState.mockResolvedValue(undefined);
   });
 
-  it('increments session control state and deletes all indexed sessions for the user', async () => {
+  it('increments session control state, blocks new sessions and deletes all indexed sessions for deactivated users', async () => {
     const { revokeUserSessions } = await import('./session-revocation.js');
 
     await revokeUserSessions({
@@ -35,6 +35,8 @@ describe('session-revocation', () => {
       {
         minimumSessionVersion: 2,
         forcedReauthAt: 1_717_000_000_000,
+        loginBlocked: true,
+        loginBlockedReason: 'user_deactivated',
       },
       null
     );
@@ -67,6 +69,32 @@ describe('session-revocation', () => {
     );
   });
 
+  it('preserves an existing persistent login block when a later reactivatable revocation runs', async () => {
+    revocationMocks.getSessionControlState.mockResolvedValue({
+      minimumSessionVersion: 7,
+      forcedReauthAt: 1_716_999_999_000,
+      loginBlocked: true,
+      loginBlockedReason: 'account_lifecycle_blocked',
+    });
+    const { revokeUserSessions } = await import('./session-revocation.js');
+
+    await revokeUserSessions({
+      keycloakSubject: 'kc-user-2',
+      reason: 'user_deactivated',
+    });
+
+    expect(revocationMocks.setSessionControlState).toHaveBeenCalledWith(
+      'kc-user-2',
+      {
+        minimumSessionVersion: 8,
+        forcedReauthAt: 1_717_000_000_000,
+        loginBlocked: true,
+        loginBlockedReason: 'account_lifecycle_blocked',
+      },
+      null
+    );
+  });
+
   it('clears reactivatable login blocks when a user becomes active again', async () => {
     revocationMocks.getSessionControlState.mockResolvedValue({
       minimumSessionVersion: 5,
@@ -81,6 +109,28 @@ describe('session-revocation', () => {
 
     expect(revocationMocks.setSessionControlState).toHaveBeenCalledWith(
       'kc-user-3',
+      {
+        minimumSessionVersion: 5,
+        forcedReauthAt: 1_716_999_999_000,
+      },
+      null
+    );
+  });
+
+  it('clears user deactivation login blocks when a user becomes active again', async () => {
+    revocationMocks.getSessionControlState.mockResolvedValue({
+      minimumSessionVersion: 5,
+      forcedReauthAt: 1_716_999_999_000,
+      loginBlocked: true,
+      loginBlockedReason: 'user_deactivated',
+    });
+
+    const { clearUserSessionLoginBlock } = await import('./session-revocation.js');
+
+    await clearUserSessionLoginBlock('kc-user-4');
+
+    expect(revocationMocks.setSessionControlState).toHaveBeenCalledWith(
+      'kc-user-4',
       {
         minimumSessionVersion: 5,
         forcedReauthAt: 1_716_999_999_000,

--- a/packages/auth-runtime/src/session-revocation.test.ts
+++ b/packages/auth-runtime/src/session-revocation.test.ts
@@ -35,7 +35,8 @@ describe('session-revocation', () => {
       {
         minimumSessionVersion: 2,
         forcedReauthAt: 1_717_000_000_000,
-      }
+      },
+      null
     );
     expect(revocationMocks.deleteSession).toHaveBeenCalledTimes(2);
     expect(revocationMocks.deleteSession).toHaveBeenNthCalledWith(1, 'session-a');
@@ -59,7 +60,8 @@ describe('session-revocation', () => {
       {
         minimumSessionVersion: 5,
         forcedReauthAt: 1_717_000_000_000,
-      }
+      },
+      null
     );
   });
 });

--- a/packages/auth-runtime/src/session-revocation.test.ts
+++ b/packages/auth-runtime/src/session-revocation.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const revocationMocks = vi.hoisted(() => ({
+  deleteSession: vi.fn(async () => undefined),
+  getSessionControlState: vi.fn(async () => undefined),
+  listUserSessionIds: vi.fn(async () => ['session-a', 'session-b']),
+  setSessionControlState: vi.fn(async () => undefined),
+}));
+
+vi.mock('./redis-session.js', () => ({
+  deleteSession: revocationMocks.deleteSession,
+  getSessionControlState: revocationMocks.getSessionControlState,
+  listUserSessionIds: revocationMocks.listUserSessionIds,
+  setSessionControlState: revocationMocks.setSessionControlState,
+}));
+
+describe('session-revocation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(1_717_000_000_000);
+    revocationMocks.listUserSessionIds.mockResolvedValue(['session-a', 'session-b']);
+    revocationMocks.getSessionControlState.mockResolvedValue(undefined);
+  });
+
+  it('increments session control state and deletes all indexed sessions for the user', async () => {
+    const { revokeUserSessions } = await import('./session-revocation.js');
+
+    await revokeUserSessions({
+      keycloakSubject: 'kc-user-1',
+      reason: 'user_deactivated',
+    });
+
+    expect(revocationMocks.setSessionControlState).toHaveBeenCalledWith(
+      'kc-user-1',
+      {
+        minimumSessionVersion: 2,
+        forcedReauthAt: 1_717_000_000_000,
+      }
+    );
+    expect(revocationMocks.deleteSession).toHaveBeenCalledTimes(2);
+    expect(revocationMocks.deleteSession).toHaveBeenNthCalledWith(1, 'session-a');
+    expect(revocationMocks.deleteSession).toHaveBeenNthCalledWith(2, 'session-b');
+  });
+
+  it('preserves and advances existing control state on repeated revocations', async () => {
+    revocationMocks.getSessionControlState.mockResolvedValue({
+      minimumSessionVersion: 4,
+      forcedReauthAt: 1_716_999_999_000,
+    });
+    const { revokeUserSessions } = await import('./session-revocation.js');
+
+    await revokeUserSessions({
+      keycloakSubject: 'kc-user-2',
+      reason: 'account_lifecycle_blocked',
+    });
+
+    expect(revocationMocks.setSessionControlState).toHaveBeenCalledWith(
+      'kc-user-2',
+      {
+        minimumSessionVersion: 5,
+        forcedReauthAt: 1_717_000_000_000,
+      }
+    );
+  });
+});

--- a/packages/auth-runtime/src/session-revocation.ts
+++ b/packages/auth-runtime/src/session-revocation.ts
@@ -12,6 +12,11 @@ export type SessionRevocationReason =
   | 'user_deactivated'
   | 'user_status_inactivated';
 
+type BlockingSessionRevocationReason = Extract<
+  SessionRevocationReason,
+  'account_lifecycle_blocked' | 'dsr_deletion_requested' | 'user_status_inactivated'
+>;
+
 const shouldPersistSessionControlState = (reason: SessionRevocationReason): boolean =>
   reason === 'account_lifecycle_blocked' ||
   reason === 'dsr_deletion_requested' ||
@@ -19,14 +24,34 @@ const shouldPersistSessionControlState = (reason: SessionRevocationReason): bool
   reason === 'user_deactivated' ||
   reason === 'user_status_inactivated';
 
+const toBlockingSessionRevocationReason = (
+  reason: SessionRevocationReason
+): BlockingSessionRevocationReason | null => {
+  switch (reason) {
+    case 'account_lifecycle_blocked':
+    case 'dsr_deletion_requested':
+    case 'user_status_inactivated':
+      return reason;
+    default:
+      return null;
+  }
+};
+
 export const revokeUserSessions = async (input: {
   readonly keycloakSubject: string;
   readonly reason: SessionRevocationReason;
 }): Promise<void> => {
   const currentState = await getSessionControlState(input.keycloakSubject);
+  const blockingReason = toBlockingSessionRevocationReason(input.reason);
   const nextState = {
     minimumSessionVersion: Math.max(currentState?.minimumSessionVersion ?? 1, 1) + 1,
     forcedReauthAt: Date.now(),
+    ...(blockingReason
+      ? {
+          loginBlocked: true,
+          loginBlockedReason: blockingReason,
+        }
+      : {}),
   };
 
   await setSessionControlState(
@@ -37,4 +62,22 @@ export const revokeUserSessions = async (input: {
 
   const sessionIds = await listUserSessionIds(input.keycloakSubject);
   await Promise.all(sessionIds.map(async (sessionId) => deleteSession(sessionId)));
+};
+
+export const clearUserSessionLoginBlock = async (keycloakSubject: string): Promise<void> => {
+  const currentState = await getSessionControlState(keycloakSubject);
+  if (!currentState || currentState.loginBlockedReason !== 'user_status_inactivated') {
+    return;
+  }
+
+  await setSessionControlState(
+    keycloakSubject,
+    {
+      minimumSessionVersion: currentState.minimumSessionVersion,
+      ...(typeof currentState.forcedReauthAt === 'number'
+        ? { forcedReauthAt: currentState.forcedReauthAt }
+        : {}),
+    },
+    null
+  );
 };

--- a/packages/auth-runtime/src/session-revocation.ts
+++ b/packages/auth-runtime/src/session-revocation.ts
@@ -14,7 +14,16 @@ export type SessionRevocationReason =
 
 type BlockingSessionRevocationReason = Extract<
   SessionRevocationReason,
-  'account_lifecycle_blocked' | 'dsr_deletion_requested' | 'user_status_inactivated'
+  | 'account_lifecycle_blocked'
+  | 'dsr_deletion_requested'
+  | 'user_bulk_deactivated'
+  | 'user_deactivated'
+  | 'user_status_inactivated'
+>;
+
+type ReactivatableSessionRevocationReason = Extract<
+  BlockingSessionRevocationReason,
+  'user_bulk_deactivated' | 'user_deactivated' | 'user_status_inactivated'
 >;
 
 const shouldPersistSessionControlState = (reason: SessionRevocationReason): boolean =>
@@ -30,6 +39,8 @@ const toBlockingSessionRevocationReason = (
   switch (reason) {
     case 'account_lifecycle_blocked':
     case 'dsr_deletion_requested':
+    case 'user_bulk_deactivated':
+    case 'user_deactivated':
     case 'user_status_inactivated':
       return reason;
     default:
@@ -37,19 +48,34 @@ const toBlockingSessionRevocationReason = (
   }
 };
 
+const isPersistentLoginBlockReason = (
+  reason: BlockingSessionRevocationReason | undefined
+): reason is Exclude<BlockingSessionRevocationReason, ReactivatableSessionRevocationReason> =>
+  reason === 'account_lifecycle_blocked' || reason === 'dsr_deletion_requested';
+
+const isReactivatableLoginBlockReason = (
+  reason: BlockingSessionRevocationReason | undefined
+): reason is ReactivatableSessionRevocationReason =>
+  reason === 'user_bulk_deactivated' || reason === 'user_deactivated' || reason === 'user_status_inactivated';
+
 export const revokeUserSessions = async (input: {
   readonly keycloakSubject: string;
   readonly reason: SessionRevocationReason;
 }): Promise<void> => {
   const currentState = await getSessionControlState(input.keycloakSubject);
   const blockingReason = toBlockingSessionRevocationReason(input.reason);
+  const currentBlockingReason =
+    currentState?.loginBlocked && currentState.loginBlockedReason ? currentState.loginBlockedReason : undefined;
+  const nextBlockingReason = isPersistentLoginBlockReason(currentBlockingReason)
+    ? currentBlockingReason
+    : blockingReason ?? currentBlockingReason;
   const nextState = {
     minimumSessionVersion: Math.max(currentState?.minimumSessionVersion ?? 1, 1) + 1,
     forcedReauthAt: Date.now(),
-    ...(blockingReason
+    ...(nextBlockingReason
       ? {
           loginBlocked: true,
-          loginBlockedReason: blockingReason,
+          loginBlockedReason: nextBlockingReason,
         }
       : {}),
   };
@@ -66,7 +92,7 @@ export const revokeUserSessions = async (input: {
 
 export const clearUserSessionLoginBlock = async (keycloakSubject: string): Promise<void> => {
   const currentState = await getSessionControlState(keycloakSubject);
-  if (!currentState || currentState.loginBlockedReason !== 'user_status_inactivated') {
+  if (!currentState || !isReactivatableLoginBlockReason(currentState.loginBlockedReason)) {
     return;
   }
 

--- a/packages/auth-runtime/src/session-revocation.ts
+++ b/packages/auth-runtime/src/session-revocation.ts
@@ -1,0 +1,23 @@
+import {
+  deleteSession,
+  getSessionControlState,
+  listUserSessionIds,
+  setSessionControlState,
+} from './redis-session.js';
+
+export const revokeUserSessions = async (input: {
+  readonly keycloakSubject: string;
+  readonly reason: string;
+}): Promise<void> => {
+  void input.reason;
+  const currentState = await getSessionControlState(input.keycloakSubject);
+  const nextState = {
+    minimumSessionVersion: Math.max(currentState?.minimumSessionVersion ?? 1, 1) + 1,
+    forcedReauthAt: Date.now(),
+  };
+
+  await setSessionControlState(input.keycloakSubject, nextState);
+
+  const sessionIds = await listUserSessionIds(input.keycloakSubject);
+  await Promise.all(sessionIds.map(async (sessionId) => deleteSession(sessionId)));
+};

--- a/packages/auth-runtime/src/session-revocation.ts
+++ b/packages/auth-runtime/src/session-revocation.ts
@@ -5,18 +5,35 @@ import {
   setSessionControlState,
 } from './redis-session.js';
 
+export type SessionRevocationReason =
+  | 'account_lifecycle_blocked'
+  | 'dsr_deletion_requested'
+  | 'user_bulk_deactivated'
+  | 'user_deactivated'
+  | 'user_status_inactivated';
+
+const shouldPersistSessionControlState = (reason: SessionRevocationReason): boolean =>
+  reason === 'account_lifecycle_blocked' ||
+  reason === 'dsr_deletion_requested' ||
+  reason === 'user_bulk_deactivated' ||
+  reason === 'user_deactivated' ||
+  reason === 'user_status_inactivated';
+
 export const revokeUserSessions = async (input: {
   readonly keycloakSubject: string;
-  readonly reason: string;
+  readonly reason: SessionRevocationReason;
 }): Promise<void> => {
-  void input.reason;
   const currentState = await getSessionControlState(input.keycloakSubject);
   const nextState = {
     minimumSessionVersion: Math.max(currentState?.minimumSessionVersion ?? 1, 1) + 1,
     forcedReauthAt: Date.now(),
   };
 
-  await setSessionControlState(input.keycloakSubject, nextState);
+  await setSessionControlState(
+    input.keycloakSubject,
+    nextState,
+    shouldPersistSessionControlState(input.reason) ? null : undefined
+  );
 
   const sessionIds = await listUserSessionIds(input.keycloakSubject);
   await Promise.all(sessionIds.map(async (sessionId) => deleteSession(sessionId)));

--- a/packages/auth-runtime/src/types.ts
+++ b/packages/auth-runtime/src/types.ts
@@ -64,7 +64,12 @@ export type SessionControlState = {
   minimumSessionVersion: number;
   forcedReauthAt?: number;
   loginBlocked?: boolean;
-  loginBlockedReason?: 'account_lifecycle_blocked' | 'dsr_deletion_requested' | 'user_status_inactivated';
+  loginBlockedReason?:
+    | 'account_lifecycle_blocked'
+    | 'dsr_deletion_requested'
+    | 'user_bulk_deactivated'
+    | 'user_deactivated'
+    | 'user_status_inactivated';
 };
 
 export type ForceReauthInput = {

--- a/packages/auth-runtime/src/types.ts
+++ b/packages/auth-runtime/src/types.ts
@@ -63,6 +63,8 @@ export type LoginState = RuntimeScopeRef & {
 export type SessionControlState = {
   minimumSessionVersion: number;
   forcedReauthAt?: number;
+  loginBlocked?: boolean;
+  loginBlockedReason?: 'account_lifecycle_blocked' | 'dsr_deletion_requested' | 'user_status_inactivated';
 };
 
 export type ForceReauthInput = {

--- a/packages/iam-admin/project.json
+++ b/packages/iam-admin/project.json
@@ -34,6 +34,7 @@
     },
     "test:types": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
       "options": {
         "command": "tsc -p packages/iam-admin/tsconfig.lib.json --noEmit"
       }

--- a/packages/iam-admin/src/user-bulk-deactivate-handler.test.ts
+++ b/packages/iam-admin/src/user-bulk-deactivate-handler.test.ts
@@ -140,6 +140,44 @@ describe('createBulkDeactivateHandlerInternal', () => {
     });
   });
 
+  it('revokes sessions only after the scoped db work has completed', async () => {
+    const events: string[] = [];
+    const deps = createDeps({
+      revokeUserSessions: vi.fn(async ({ keycloakSubject }) => {
+        events.push(`revoke:${keycloakSubject}`);
+      }),
+      trackKeycloakCall: vi.fn(async (_operation, work) => {
+        events.push('keycloak:start');
+        const result = await work();
+        events.push('keycloak:end');
+        return result;
+      }),
+      withInstanceScopedDb: vi.fn(async (_instanceId, work) => {
+        events.push('tx:start');
+        const result = await work({
+          query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+        });
+        events.push('tx:end');
+        return result;
+      }),
+    });
+    const handler = createBulkDeactivateHandlerInternal(deps);
+
+    const response = await handler(new Request('http://localhost/api/v1/iam/users/bulk-deactivate'), ctx);
+
+    expect(response.status).toBe(200);
+    expect(events).toEqual([
+      'tx:start',
+      'tx:end',
+      'revoke:kc-user-1',
+      'revoke:kc-user-2',
+      'keycloak:start',
+      'keycloak:start',
+      'keycloak:end',
+      'keycloak:end',
+    ]);
+  });
+
   it('returns precondition responses without running mutation work', async () => {
     const preconditionResponse = createJsonResponse(409, { error: { code: 'idempotency_key_reuse' } });
     const deps = createDeps({

--- a/packages/iam-admin/src/user-bulk-deactivate-handler.test.ts
+++ b/packages/iam-admin/src/user-bulk-deactivate-handler.test.ts
@@ -47,6 +47,7 @@ const createDeps = (overrides: Partial<BulkDeactivateHandlerDeps> = {}): BulkDea
       error: vi.fn(),
     },
     notifyPermissionInvalidation: vi.fn(async () => undefined),
+    revokeUserSessions: vi.fn(async () => undefined),
     resolveActorMaxRoleLevel: vi.fn(async () => 100),
     resolveBulkDeactivateContext: vi.fn(async () => ({
       actor,
@@ -115,6 +116,15 @@ describe('createBulkDeactivateHandlerInternal', () => {
       })
     );
     expect(deps.notifyPermissionInvalidation).toHaveBeenCalledTimes(2);
+    expect(deps.revokeUserSessions).toHaveBeenCalledTimes(2);
+    expect(deps.revokeUserSessions).toHaveBeenNthCalledWith(1, {
+      keycloakSubject: 'kc-user-1',
+      reason: 'user_bulk_deactivated',
+    });
+    expect(deps.revokeUserSessions).toHaveBeenNthCalledWith(2, {
+      keycloakSubject: 'kc-user-2',
+      reason: 'user_bulk_deactivated',
+    });
     expect(deps.trackKeycloakCall).toHaveBeenCalledTimes(2);
     expect(deps.iamUserOperationsCounter.add).toHaveBeenCalledWith(1, {
       action: 'bulk_deactivate',

--- a/packages/iam-admin/src/user-bulk-deactivate-handler.ts
+++ b/packages/iam-admin/src/user-bulk-deactivate-handler.ts
@@ -76,6 +76,10 @@ export type BulkDeactivateHandlerDeps = {
       readonly trigger: 'user_bulk_deactivated';
     }
   ) => Promise<void>;
+  readonly revokeUserSessions: (input: {
+    readonly keycloakSubject: string;
+    readonly reason: 'user_bulk_deactivated';
+  }) => Promise<void>;
   readonly resolveActorMaxRoleLevel: (
     client: QueryClient,
     input: {
@@ -194,6 +198,14 @@ WHERE instance_id = $1
           instanceId: input.actor.instanceId,
           keycloakSubject: user.keycloakSubject,
           trigger: 'user_bulk_deactivated',
+        })
+      )
+    );
+    await Promise.all(
+      users.map((user) =>
+        deps.revokeUserSessions({
+          keycloakSubject: user.keycloakSubject,
+          reason: 'user_bulk_deactivated',
         })
       )
     );

--- a/packages/iam-admin/src/user-bulk-deactivate-handler.ts
+++ b/packages/iam-admin/src/user-bulk-deactivate-handler.ts
@@ -201,14 +201,6 @@ WHERE instance_id = $1
         })
       )
     );
-    await Promise.all(
-      users.map((user) =>
-        deps.revokeUserSessions({
-          keycloakSubject: user.keycloakSubject,
-          reason: 'user_bulk_deactivated',
-        })
-      )
-    );
 
     return users;
   });
@@ -228,6 +220,15 @@ export const createBulkDeactivateHandlerInternal =
         ctx,
         userIds: uniqueUserIds,
       });
+
+      await Promise.all(
+        details.map((detail) =>
+          deps.revokeUserSessions({
+            keycloakSubject: detail.keycloakSubject,
+            reason: 'user_bulk_deactivated',
+          })
+        )
+      );
 
       await Promise.all(
         details.map((detail) =>

--- a/packages/iam-admin/src/user-deactivate-handler.test.ts
+++ b/packages/iam-admin/src/user-deactivate-handler.test.ts
@@ -146,6 +146,35 @@ describe('createDeactivateUserHandlerInternal', () => {
     });
   });
 
+  it('revokes sessions only after the scoped db work has completed', async () => {
+    const events: string[] = [];
+    const deps = createDeps({
+      revokeUserSessions: vi.fn(async () => {
+        events.push('revoke');
+      }),
+      trackKeycloakCall: vi.fn(async (_operation, work) => {
+        events.push('keycloak:start');
+        const result = await work();
+        events.push('keycloak:end');
+        return result;
+      }),
+      withInstanceScopedDb: vi.fn(async (_instanceId, work) => {
+        events.push('tx:start');
+        const result = await work({
+          query: vi.fn(async () => ({ rows: [], rowCount: 1 })),
+        });
+        events.push('tx:end');
+        return result;
+      }),
+    });
+    const handler = createDeactivateUserHandlerInternal(deps);
+
+    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${userDetail.id}`), ctx);
+
+    expect(response.status).toBe(200);
+    expect(events).toEqual(['tx:start', 'tx:end', 'revoke', 'keycloak:start', 'keycloak:end']);
+  });
+
   it('returns the precondition response without mutation work', async () => {
     const preconditionResponse = createJsonResponse(400, { error: { code: 'invalid_request' } });
     const deps = createDeps({

--- a/packages/iam-admin/src/user-deactivate-handler.test.ts
+++ b/packages/iam-admin/src/user-deactivate-handler.test.ts
@@ -72,6 +72,7 @@ const createDeps = (overrides: Partial<DeactivateUserHandlerDeps> = {}): Deactiv
       mainserverUserApplicationSecretSet: state.mainserverUserApplicationSecretSet,
     })),
     notifyPermissionInvalidation: vi.fn(async () => undefined),
+    revokeUserSessions: vi.fn(async () => undefined),
     notFoundResponse: vi.fn((requestId) => createJsonResponse(404, { error: { code: 'not_found' }, requestId })),
     resolveActorMaxRoleLevel: vi.fn(async () => 100),
     resolveDeactivateRequestContext: vi.fn(async () => ({
@@ -134,6 +135,10 @@ describe('createDeactivateUserHandlerInternal', () => {
         trigger: 'user_deactivated',
       }
     );
+    expect(deps.revokeUserSessions).toHaveBeenCalledWith({
+      keycloakSubject: 'kc-user-1',
+      reason: 'user_deactivated',
+    });
     expect(deps.trackKeycloakCall).toHaveBeenCalledWith('deactivate_user', expect.any(Function));
     expect(deps.iamUserOperationsCounter.add).toHaveBeenCalledWith(1, {
       action: 'deactivate_user',

--- a/packages/iam-admin/src/user-deactivate-handler.ts
+++ b/packages/iam-admin/src/user-deactivate-handler.ts
@@ -194,15 +194,14 @@ WHERE id = $1::uuid
       keycloakSubject: existing.keycloakSubject,
       trigger: 'user_deactivated',
     });
-    await deps.revokeUserSessions({
-      keycloakSubject: existing.keycloakSubject,
-      reason: 'user_deactivated',
-    });
 
-    return deps.resolveUserDetail(client, {
-      instanceId: input.actor.instanceId,
-      userId: input.userId,
-    });
+    return {
+      detail: await deps.resolveUserDetail(client, {
+        instanceId: input.actor.instanceId,
+        userId: input.userId,
+      }),
+      keycloakSubject: existing.keycloakSubject,
+    };
   });
 
 export const createDeactivateUserHandlerInternal =
@@ -214,15 +213,29 @@ export const createDeactivateUserHandlerInternal =
     }
 
     try {
-      const detail = await deactivateUserRecord(deps, { actor: resolved.actor, ctx, userId: resolved.userId });
+      const deactivated = await deactivateUserRecord(deps, {
+        actor: resolved.actor,
+        ctx,
+        userId: resolved.userId,
+      });
 
-      if (!detail) {
+      if (!deactivated) {
         return deps.notFoundResponse(resolved.actor.requestId);
       }
 
+      await deps.revokeUserSessions({
+        keycloakSubject: deactivated.keycloakSubject,
+        reason: 'user_deactivated',
+      });
+
       await deps.trackKeycloakCall('deactivate_user', () =>
-        resolved.identityProvider.provider.deactivateUser(detail.keycloakSubject)
+        resolved.identityProvider.provider.deactivateUser(deactivated.keycloakSubject)
       );
+
+      const detail = deactivated.detail;
+      if (!detail) {
+        return deps.notFoundResponse(resolved.actor.requestId);
+      }
 
       let projectedDetail = detail;
       try {

--- a/packages/iam-admin/src/user-deactivate-handler.ts
+++ b/packages/iam-admin/src/user-deactivate-handler.ts
@@ -88,6 +88,10 @@ export type DeactivateUserHandlerDeps = {
       readonly trigger: 'user_deactivated';
     }
   ) => Promise<void>;
+  readonly revokeUserSessions: (input: {
+    readonly keycloakSubject: string;
+    readonly reason: 'user_deactivated';
+  }) => Promise<void>;
   readonly notFoundResponse: (requestId?: string) => Response;
   readonly resolveActorMaxRoleLevel: (
     client: QueryClient,
@@ -189,6 +193,10 @@ WHERE id = $1::uuid
       instanceId: input.actor.instanceId,
       keycloakSubject: existing.keycloakSubject,
       trigger: 'user_deactivated',
+    });
+    await deps.revokeUserSessions({
+      keycloakSubject: existing.keycloakSubject,
+      reason: 'user_deactivated',
     });
 
     return deps.resolveUserDetail(client, {

--- a/packages/iam-admin/src/user-update-persistence.test.ts
+++ b/packages/iam-admin/src/user-update-persistence.test.ts
@@ -23,6 +23,7 @@ const detail = {
 const createDeps = (client: QueryClient) => ({
   assignGroups: vi.fn(async () => undefined),
   assignRoles: vi.fn(async () => undefined),
+  clearUserSessionLoginBlock: vi.fn(async () => undefined),
   emitActivityLog: vi.fn(async () => undefined),
   notifyPermissionInvalidation: vi.fn(async () => undefined),
   revokeUserSessions: vi.fn(async () => undefined),
@@ -200,5 +201,30 @@ describe('user-update-persistence', () => {
       keycloakSubject: 'kc-1',
       reason: 'user_status_inactivated',
     });
+  });
+
+  it('clears the reactivation login block when a user update activates the account', async () => {
+    const client: QueryClient = {
+      query: vi.fn(async () => ({ rowCount: 1, rows: [] })),
+    };
+    const deps = createDeps(client);
+    const persistence = createUserUpdatePersistence(deps);
+
+    await persistence.persistUpdatedUserDetail({
+      instanceId: 'inst-1',
+      actorAccountId: 'actor-1',
+      userId: 'user-1',
+      keycloakSubject: 'kc-1',
+      existingRoleIds: [],
+      existingGroupIds: [],
+      payload: {
+        status: 'active',
+      },
+      nextMainserverCredentialState: {
+        mainserverUserApplicationSecretSet: false,
+      },
+    });
+
+    expect(deps.clearUserSessionLoginBlock).toHaveBeenCalledWith('kc-1');
   });
 });

--- a/packages/iam-admin/src/user-update-persistence.test.ts
+++ b/packages/iam-admin/src/user-update-persistence.test.ts
@@ -25,6 +25,7 @@ const createDeps = (client: QueryClient) => ({
   assignRoles: vi.fn(async () => undefined),
   emitActivityLog: vi.fn(async () => undefined),
   notifyPermissionInvalidation: vi.fn(async () => undefined),
+  revokeUserSessions: vi.fn(async () => undefined),
   resolveUserDetail: vi.fn(async () => detail),
   withInstanceScopedDb: vi.fn(async (_instanceId: string, work: (queryClient: QueryClient) => Promise<unknown>) =>
     work(client)
@@ -171,5 +172,33 @@ describe('user-update-persistence', () => {
         },
       })
     ).resolves.toBeUndefined();
+  });
+
+  it('revokes existing sessions when a user update deactivates the account', async () => {
+    const client: QueryClient = {
+      query: vi.fn(async () => ({ rowCount: 1, rows: [] })),
+    };
+    const deps = createDeps(client);
+    const persistence = createUserUpdatePersistence(deps);
+
+    await persistence.persistUpdatedUserDetail({
+      instanceId: 'inst-1',
+      actorAccountId: 'actor-1',
+      userId: 'user-1',
+      keycloakSubject: 'kc-1',
+      existingRoleIds: [],
+      existingGroupIds: [],
+      payload: {
+        status: 'inactive',
+      },
+      nextMainserverCredentialState: {
+        mainserverUserApplicationSecretSet: false,
+      },
+    });
+
+    expect(deps.revokeUserSessions).toHaveBeenCalledWith({
+      keycloakSubject: 'kc-1',
+      reason: 'user_status_inactivated',
+    });
   });
 });

--- a/packages/iam-admin/src/user-update-persistence.test.ts
+++ b/packages/iam-admin/src/user-update-persistence.test.ts
@@ -179,7 +179,19 @@ describe('user-update-persistence', () => {
     const client: QueryClient = {
       query: vi.fn(async () => ({ rowCount: 1, rows: [] })),
     };
-    const deps = createDeps(client);
+    const events: string[] = [];
+    const deps = {
+      ...createDeps(client),
+      revokeUserSessions: vi.fn(async () => {
+        events.push('revoke');
+      }),
+      withInstanceScopedDb: vi.fn(async (_instanceId: string, work: (queryClient: QueryClient) => Promise<unknown>) => {
+        events.push('tx:start');
+        const result = await work(client);
+        events.push('tx:end');
+        return result;
+      }),
+    };
     const persistence = createUserUpdatePersistence(deps);
 
     await persistence.persistUpdatedUserDetail({
@@ -201,13 +213,26 @@ describe('user-update-persistence', () => {
       keycloakSubject: 'kc-1',
       reason: 'user_status_inactivated',
     });
+    expect(events).toEqual(['tx:start', 'tx:end', 'revoke']);
   });
 
   it('clears the reactivation login block when a user update activates the account', async () => {
     const client: QueryClient = {
       query: vi.fn(async () => ({ rowCount: 1, rows: [] })),
     };
-    const deps = createDeps(client);
+    const events: string[] = [];
+    const deps = {
+      ...createDeps(client),
+      clearUserSessionLoginBlock: vi.fn(async () => {
+        events.push('clear');
+      }),
+      withInstanceScopedDb: vi.fn(async (_instanceId: string, work: (queryClient: QueryClient) => Promise<unknown>) => {
+        events.push('tx:start');
+        const result = await work(client);
+        events.push('tx:end');
+        return result;
+      }),
+    };
     const persistence = createUserUpdatePersistence(deps);
 
     await persistence.persistUpdatedUserDetail({
@@ -226,5 +251,6 @@ describe('user-update-persistence', () => {
     });
 
     expect(deps.clearUserSessionLoginBlock).toHaveBeenCalledWith('kc-1');
+    expect(events).toEqual(['tx:start', 'tx:end', 'clear']);
   });
 });

--- a/packages/iam-admin/src/user-update-persistence.ts
+++ b/packages/iam-admin/src/user-update-persistence.ts
@@ -57,6 +57,7 @@ export type UserUpdatePersistenceDeps = {
       readonly assignedBy?: string;
     }
   ) => Promise<void>;
+  readonly clearUserSessionLoginBlock: (keycloakSubject: string) => Promise<void>;
   readonly emitActivityLog: (client: QueryClient, input: UserActivityLogInput) => Promise<void>;
   readonly notifyPermissionInvalidation: (
     client: QueryClient,
@@ -266,6 +267,8 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
           keycloakSubject: input.keycloakSubject,
           reason: 'user_status_inactivated',
         });
+      } else if (input.payload.status === 'active') {
+        await deps.clearUserSessionLoginBlock(input.keycloakSubject);
       }
 
       const detail = await deps.resolveUserDetail(client, {

--- a/packages/iam-admin/src/user-update-persistence.ts
+++ b/packages/iam-admin/src/user-update-persistence.ts
@@ -206,6 +206,9 @@ const invalidateUpdatedUserPermissions = async (
   });
 };
 
+const resolveUpdatedUserSessionAction = (status: UpdateUserPersistencePayload['status']) =>
+  status === 'inactive' ? ('revoke' as const) : status === 'active' ? ('clear' as const) : undefined;
+
 export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => {
   const persistUpdatedUserDetail = async (input: {
     readonly instanceId: string;
@@ -218,8 +221,8 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
     readonly existingGroupIds?: readonly string[];
     readonly payload: UpdateUserPersistencePayload;
     readonly nextMainserverCredentialState: UserMainserverCredentialState;
-  }) =>
-    deps.withInstanceScopedDb(input.instanceId, async (client) => {
+  }) => {
+    const persisted = await deps.withInstanceScopedDb(input.instanceId, async (client) => {
       if (input.payload.roleIds) {
         await deps.assignRoles(client, {
           instanceId: input.instanceId,
@@ -262,29 +265,39 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
         keycloakSubject: input.keycloakSubject,
         payload: input.payload,
       });
-      if (input.payload.status === 'inactive') {
-        await deps.revokeUserSessions({
-          keycloakSubject: input.keycloakSubject,
-          reason: 'user_status_inactivated',
-        });
-      } else if (input.payload.status === 'active') {
-        await deps.clearUserSessionLoginBlock(input.keycloakSubject);
-      }
-
       const detail = await deps.resolveUserDetail(client, {
         instanceId: input.instanceId,
         userId: input.userId,
       });
+      const sessionAction = resolveUpdatedUserSessionAction(input.payload.status);
       if (!detail) {
-        return undefined;
+        return {
+          detail: undefined,
+          sessionAction,
+        };
       }
 
       return {
-        ...detail,
-        mainserverUserApplicationId: input.nextMainserverCredentialState.mainserverUserApplicationId,
-        mainserverUserApplicationSecretSet: input.nextMainserverCredentialState.mainserverUserApplicationSecretSet,
+        detail: {
+          ...detail,
+          mainserverUserApplicationId: input.nextMainserverCredentialState.mainserverUserApplicationId,
+          mainserverUserApplicationSecretSet: input.nextMainserverCredentialState.mainserverUserApplicationSecretSet,
+        },
+        sessionAction,
       };
     });
+
+    if (persisted.sessionAction === 'revoke') {
+      await deps.revokeUserSessions({
+        keycloakSubject: input.keycloakSubject,
+        reason: 'user_status_inactivated',
+      });
+    } else if (persisted.sessionAction === 'clear') {
+      await deps.clearUserSessionLoginBlock(input.keycloakSubject);
+    }
+
+    return persisted.detail;
+  };
 
   return {
     persistUpdatedUserDetail,

--- a/packages/iam-admin/src/user-update-persistence.ts
+++ b/packages/iam-admin/src/user-update-persistence.ts
@@ -66,6 +66,10 @@ export type UserUpdatePersistenceDeps = {
       readonly trigger: string;
     }
   ) => Promise<void>;
+  readonly revokeUserSessions: (input: {
+    readonly keycloakSubject: string;
+    readonly reason: 'user_status_inactivated';
+  }) => Promise<void>;
   readonly resolveUserDetail: (
     client: QueryClient,
     input: { readonly instanceId: string; readonly userId: string }
@@ -257,6 +261,12 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
         keycloakSubject: input.keycloakSubject,
         payload: input.payload,
       });
+      if (input.payload.status === 'inactive') {
+        await deps.revokeUserSessions({
+          keycloakSubject: input.keycloakSubject,
+          reason: 'user_status_inactivated',
+        });
+      }
 
       const detail = await deps.resolveUserDetail(client, {
         instanceId: input.instanceId,

--- a/packages/iam-governance/src/deletion-rules-maintenance.test.ts
+++ b/packages/iam-governance/src/deletion-rules-maintenance.test.ts
@@ -156,22 +156,22 @@ describe('deletion-rules/maintenance', () => {
         override_content_strategy: null,
       },
     ]);
-    const revokeUserSessions = vi.fn(async () => undefined);
+    const queueUserSessionRevocation = vi.fn(async () => undefined);
 
     await runDeletionRulesMaintenance(client, {
       instanceId: 'de-test',
       dryRun: false,
       now: new Date('2026-05-20T00:00:00.000Z'),
-      revokeUserSessions,
+      queueUserSessionRevocation,
     });
 
-    expect(revokeUserSessions).toHaveBeenCalledTimes(2);
-    expect(revokeUserSessions).toHaveBeenNthCalledWith(1, {
+    expect(queueUserSessionRevocation).toHaveBeenCalledTimes(2);
+    expect(queueUserSessionRevocation).toHaveBeenNthCalledWith(1, {
       keycloakSubject: 'kc-user-1',
       nextState: 'deactivated',
       reason: 'account_lifecycle_blocked',
     });
-    expect(revokeUserSessions).toHaveBeenNthCalledWith(2, {
+    expect(queueUserSessionRevocation).toHaveBeenNthCalledWith(2, {
       keycloakSubject: 'kc-user-2',
       nextState: 'pseudonymized',
       reason: 'account_lifecycle_blocked',

--- a/packages/iam-governance/src/deletion-rules-maintenance.test.ts
+++ b/packages/iam-governance/src/deletion-rules-maintenance.test.ts
@@ -9,6 +9,7 @@ import type { QueryClient } from './query-client.js';
 
 type MaintenanceRow = {
   id: string;
+  keycloak_subject?: string;
   last_login_at: string | null;
   deletion_lifecycle_state: 'active' | 'deactivated' | 'pseudonymized' | 'deleted';
   deactivate_after_days: number | null;
@@ -24,7 +25,10 @@ const buildClient = (rows: readonly MaintenanceRow[], contentUpdates: readonly n
     if (sql.includes('FROM iam.accounts account')) {
       return {
         rowCount: rows.length,
-        rows,
+        rows: rows.map((row) => ({
+          ...row,
+          keycloak_subject: row.keycloak_subject ?? `kc-${row.id}`,
+        })),
       };
     }
 
@@ -123,6 +127,55 @@ describe('deletion-rules/maintenance', () => {
     expect(client.query.mock.calls[0]?.[0]).toContain('MAX(log.created_at)::text AS last_login_at');
     expect(client.query.mock.calls[0]?.[0]).toContain("log.event_type = 'login'");
     expect(client.query.mock.calls[0]?.[0]).toContain("log.result = 'success'");
+  });
+
+  it('revokes user sessions for persisted lifecycle transitions outside dry runs', async () => {
+    const client = buildClient([
+      {
+        id: 'account-1',
+        keycloak_subject: 'kc-user-1',
+        last_login_at: '2025-01-01T00:00:00.000Z',
+        deletion_lifecycle_state: 'active',
+        deactivate_after_days: 30,
+        pseudonymize_after_days: 60,
+        delete_after_days: 90,
+        default_content_strategy: 'retain',
+        allow_content_preference_override: true,
+        override_content_strategy: null,
+      },
+      {
+        id: 'account-2',
+        keycloak_subject: 'kc-user-2',
+        last_login_at: '2025-01-01T00:00:00.000Z',
+        deletion_lifecycle_state: 'deactivated',
+        deactivate_after_days: 30,
+        pseudonymize_after_days: 60,
+        delete_after_days: 90,
+        default_content_strategy: 'retain',
+        allow_content_preference_override: true,
+        override_content_strategy: null,
+      },
+    ]);
+    const revokeUserSessions = vi.fn(async () => undefined);
+
+    await runDeletionRulesMaintenance(client, {
+      instanceId: 'de-test',
+      dryRun: false,
+      now: new Date('2026-05-20T00:00:00.000Z'),
+      revokeUserSessions,
+    });
+
+    expect(revokeUserSessions).toHaveBeenCalledTimes(2);
+    expect(revokeUserSessions).toHaveBeenNthCalledWith(1, {
+      keycloakSubject: 'kc-user-1',
+      nextState: 'deactivated',
+      reason: 'account_lifecycle_blocked',
+    });
+    expect(revokeUserSessions).toHaveBeenNthCalledWith(2, {
+      keycloakSubject: 'kc-user-2',
+      nextState: 'pseudonymized',
+      reason: 'account_lifecycle_blocked',
+    });
   });
 
   it('marks due accounts as deactivated before pseudonymization when multiple thresholds are already exceeded', async () => {

--- a/packages/iam-governance/src/deletion-rules-maintenance.ts
+++ b/packages/iam-governance/src/deletion-rules-maintenance.ts
@@ -17,7 +17,7 @@ export type DeletionRulesMaintenanceInput = {
   instanceId: string;
   dryRun: boolean;
   now?: Date;
-  revokeUserSessions?: (input: {
+  queueUserSessionRevocation?: (input: {
     keycloakSubject: string;
     nextState: BlockingLifecycleState;
     reason: 'account_lifecycle_blocked';
@@ -281,7 +281,7 @@ export const runDeletionRulesMaintenance = async (
       accountId: candidate.row.id,
       nextState: candidate.nextState,
     });
-    await input.revokeUserSessions?.({
+    await input.queueUserSessionRevocation?.({
       keycloakSubject: candidate.row.keycloak_subject,
       nextState: candidate.nextState,
       reason: 'account_lifecycle_blocked',

--- a/packages/iam-governance/src/deletion-rules-maintenance.ts
+++ b/packages/iam-governance/src/deletion-rules-maintenance.ts
@@ -17,6 +17,11 @@ export type DeletionRulesMaintenanceInput = {
   instanceId: string;
   dryRun: boolean;
   now?: Date;
+  revokeUserSessions?: (input: {
+    keycloakSubject: string;
+    nextState: BlockingLifecycleState;
+    reason: 'account_lifecycle_blocked';
+  }) => Promise<void>;
 };
 
 export type DeletionRulesMaintenanceResult = {
@@ -37,6 +42,8 @@ const lifecycleOrder: Record<IamDeletionLifecycleState, number> = {
   deleted: 3,
 };
 
+type BlockingLifecycleState = Exclude<IamDeletionLifecycleState, 'active'>;
+
 const loadMaintenanceCandidates = async (
   client: QueryClient,
   input: { instanceId: string }
@@ -56,6 +63,7 @@ WITH last_login_events AS (
 )
 SELECT
   account.id::text AS id,
+  account.keycloak_subject,
   login_events.last_login_at,
   account.deletion_lifecycle_state,
   rules.deactivate_after_days,
@@ -88,7 +96,7 @@ const hasReachedThreshold = (lastLoginAt: string, days: number, now: Date): bool
 const resolveNextLifecycleState = (
   candidate: DeletionRulesMaintenanceCandidateRow,
   now: Date
-): IamDeletionLifecycleState | undefined => {
+): BlockingLifecycleState | undefined => {
   if (!candidate.last_login_at) {
     return undefined;
   }
@@ -272,6 +280,11 @@ export const runDeletionRulesMaintenance = async (
       instanceId: input.instanceId,
       accountId: candidate.row.id,
       nextState: candidate.nextState,
+    });
+    await input.revokeUserSessions?.({
+      keycloakSubject: candidate.row.keycloak_subject,
+      nextState: candidate.nextState,
+      reason: 'account_lifecycle_blocked',
     });
 
     const contentStrategy = resolveEffectiveDeletionContentStrategy(

--- a/packages/iam-governance/src/deletion-rules.types.ts
+++ b/packages/iam-governance/src/deletion-rules.types.ts
@@ -37,6 +37,7 @@ export type MyDeletionRulesRow = {
 
 export type DeletionRulesMaintenanceCandidateRow = {
   id: IamUuid;
+  keycloak_subject: string;
   last_login_at: string | null;
   deletion_lifecycle_state: IamDeletionLifecycleState;
   deactivate_after_days: number | null;

--- a/scripts/ops/run-iam-account-deletion-rules.mjs
+++ b/scripts/ops/run-iam-account-deletion-rules.mjs
@@ -66,18 +66,24 @@ const run = async () => {
       import(new URL('../../packages/iam-governance/src/deletion-rules-maintenance.js', import.meta.url).href),
       import(new URL('../../packages/auth-runtime/src/session-revocation.js', import.meta.url).href),
     ]);
+    const queuedSessionRevocations = [];
 
     const summary = await runDeletionRulesMaintenance(client, {
       instanceId: options.instanceId,
       dryRun: options.dryRun,
-      revokeUserSessions: async ({ keycloakSubject }) =>
-        revokeUserSessions({
-          keycloakSubject,
-          reason: 'account_lifecycle_blocked',
-        }),
+      queueUserSessionRevocation: async ({ keycloakSubject }) => {
+        queuedSessionRevocations.push(keycloakSubject);
+      },
     });
 
     await client.query('COMMIT');
+
+    for (const keycloakSubject of queuedSessionRevocations) {
+      await revokeUserSessions({
+        keycloakSubject,
+        reason: 'account_lifecycle_blocked',
+      });
+    }
     console.log(JSON.stringify(summary, null, 2));
   } catch (error) {
     if (client) {

--- a/scripts/ops/run-iam-account-deletion-rules.mjs
+++ b/scripts/ops/run-iam-account-deletion-rules.mjs
@@ -62,13 +62,19 @@ const run = async () => {
     await client.query('SET LOCAL ROLE iam_app;');
     await client.query('SELECT set_config($1, $2, true);', ['app.instance_id', options.instanceId]);
 
-    const { runDeletionRulesMaintenance } = await import(
-      new URL('../../packages/iam-governance/src/deletion-rules-maintenance.js', import.meta.url).href
-    );
+    const [{ runDeletionRulesMaintenance }, { revokeUserSessions }] = await Promise.all([
+      import(new URL('../../packages/iam-governance/src/deletion-rules-maintenance.js', import.meta.url).href),
+      import(new URL('../../packages/auth-runtime/src/session-revocation.js', import.meta.url).href),
+    ]);
 
     const summary = await runDeletionRulesMaintenance(client, {
       instanceId: options.instanceId,
       dryRun: options.dryRun,
+      revokeUserSessions: async ({ keycloakSubject }) =>
+        revokeUserSessions({
+          keycloakSubject,
+          reason: 'account_lifecycle_blocked',
+        }),
     });
 
     await client.query('COMMIT');


### PR DESCRIPTION
## What changed
This PR removes the per-request IAM account lifecycle database check from the auth middleware hot path and replaces it with immediate session revocation on relevant write paths.

Concretely:
- add a central `revokeUserSessions(...)` helper in `auth-runtime`
- revoke sessions when users are deactivated, bulk-deactivated, or updated to `inactive`
- revoke sessions when a self-service DSR deletion request enters processing
- add an optional revocation hook to `runDeletionRulesMaintenance(...)` so lifecycle maintenance can invalidate sessions without coupling `iam-governance` to `auth-runtime`
- keep the middleware fast by no longer resolving account lifecycle rows on every authenticated request
- update focused unit tests around middleware behavior and revocation-triggering mutations

## Why this changed
The earlier IAM performance improvements were effectively undone when short-lived middleware caches were removed to close a security review concern. That fixed the 500 ms post-revocation access window, but it reintroduced a slow authenticated hot path because middleware started re-reading IAM lifecycle state from the database on every request.

This PR restores the fast path without reintroducing the old cache window:
- access is invalidated at the moment the relevant account state changes
- subsequent requests fail through session revocation / forced reauth instead of a hot-path lifecycle lookup

## Impact
- authenticated IAM requests should no longer pay the extra lifecycle DB roundtrip on every call
- deactivation and similar blocking flows now terminate active sessions immediately
- governance lifecycle maintenance can now participate in the same revocation model when invoked by a runtime caller
- the auth-path change is mostly simplifying code rather than adding new moving parts

## Root cause
The regression came from moving revocation protection into the request path instead of enforcing it on the state-changing write paths.

## Validation
Passed:
- `pnpm nx run auth-runtime:test:unit --testFiles=src/iam-data-subject-rights/core.test.ts --testFiles=src/session-revocation.test.ts --testFiles=src/middleware.test.ts --testFiles=src/middleware-guards.test.ts`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run auth-runtime:lint`
- `pnpm nx run auth-runtime:check:runtime`
- `pnpm nx run iam-admin:test:unit --testFiles=src/user-deactivate-handler.test.ts --testFiles=src/user-bulk-deactivate-handler.test.ts --testFiles=src/user-update-persistence.test.ts`
- `pnpm nx run iam-admin:test:types`
- `pnpm nx run iam-governance:test:unit --testFiles=src/deletion-rules-maintenance.test.ts`
- `pnpm nx run iam-governance:test:types`
- `pnpm nx run iam-governance:lint`
- `pnpm nx run iam-governance:check:runtime`
- `pnpm nx run-many --target=lint --projects=auth-runtime,iam-admin`
- `pnpm nx run-many --target=check:runtime --projects=auth-runtime,iam-admin`

Known limit:
- `pnpm nx run sva-studio-react:test:authorize-performance` could not be rerun in this shell because the required acceptance credentials were not present
