### PR TITLE
chore: improve a11y checks and split app unit target

### DIFF
--- a/apps/sva-studio-react/package.json
+++ b/apps/sva-studio-react/package.json
@@ -10,6 +10,7 @@
     "build": "pnpm run check:i18n && pnpm run check:account-ui-foundation && vite build",
     "preview": "vite preview",
     "test": "vitest run --passWithNoTests",
+    "test:a11y": "vitest run --config vitest.a11y.config.ts --passWithNoTests",
     "test:e2e": "playwright test --config playwright.config.ts"
   },
   "dependencies": {
@@ -68,6 +69,7 @@
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.2.0",
     "@vitest/coverage-v8": "^4.1.5",
+    "axe-core": "^4.11.4",
     "jsdom": "^29.1.0",
     "tooling-testing": "workspace:*",
     "typescript": "^6.0.3",

--- a/apps/sva-studio-react/project.json
+++ b/apps/sva-studio-react/project.json
@@ -105,19 +105,33 @@
       }
     },
     "test:unit": {
-      "executor": "nx:run-commands",
+      "executor": "nx:noop",
       "cache": true,
+      "dependsOn": [
+        {
+          "target": "test:unit:ui",
+          "params": "forward"
+        },
+        {
+          "target": "test:unit:routes",
+          "params": "forward"
+        },
+        {
+          "target": "test:unit:hooks",
+          "params": "forward"
+        },
+        {
+          "target": "test:unit:server",
+          "params": "forward"
+        }
+      ],
       "inputs": [
         "default",
         "^production",
         "testing",
         "frontendTooling"
       ],
-      "outputs": [],
-      "options": {
-        "cwd": "apps/sva-studio-react",
-        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
-      }
+      "outputs": []
     },
     "test:unit:ui": {
       "executor": "nx:run-commands",

--- a/apps/sva-studio-react/project.json
+++ b/apps/sva-studio-react/project.json
@@ -179,6 +179,21 @@
         "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.server.config.ts --passWithNoTests"
       }
     },
+    "test:a11y": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": [
+        "default",
+        "^production",
+        "testing",
+        "frontendTooling"
+      ],
+      "outputs": [],
+      "options": {
+        "cwd": "apps/sva-studio-react",
+        "command": "pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.a11y.config.ts --passWithNoTests"
+      }
+    },
     "test:coverage": {
       "executor": "nx:run-commands",
       "parallelism": false,

--- a/apps/sva-studio-react/src/components/ui/dialog.a11y.test.tsx
+++ b/apps/sva-studio-react/src/components/ui/dialog.a11y.test.tsx
@@ -1,0 +1,25 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, it } from 'vitest';
+
+import { expectNoA11yViolations } from '@/test/a11y';
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from './dialog';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ui/dialog accessibility', () => {
+  it('renders an accessible dialog with title and description', async () => {
+    const { container } = render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Dialogtitel</DialogTitle>
+          <DialogDescription>Dialogbeschreibung</DialogDescription>
+        </DialogContent>
+      </Dialog>
+    );
+
+    await expectNoA11yViolations(container);
+  });
+});

--- a/apps/sva-studio-react/src/components/ui/dialog.a11y.test.tsx
+++ b/apps/sva-studio-react/src/components/ui/dialog.a11y.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, it } from 'vitest';
 
 import { expectNoA11yViolations } from '@/test/a11y';
@@ -11,7 +11,7 @@ afterEach(() => {
 
 describe('ui/dialog accessibility', () => {
   it('renders an accessible dialog with title and description', async () => {
-    const { container } = render(
+    render(
       <Dialog open>
         <DialogContent>
           <DialogTitle>Dialogtitel</DialogTitle>
@@ -20,6 +20,6 @@ describe('ui/dialog accessibility', () => {
       </Dialog>
     );
 
-    await expectNoA11yViolations(container);
+    await expectNoA11yViolations(screen.getByRole('dialog'));
   });
 });

--- a/apps/sva-studio-react/src/components/ui/label.a11y.test.tsx
+++ b/apps/sva-studio-react/src/components/ui/label.a11y.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, it } from 'vitest';
+
+import { expectNoA11yViolations } from '@/test/a11y';
+
+import { Label } from './label';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ui/label accessibility', () => {
+  it('keeps explicit label and control wiring accessible', async () => {
+    const { container } = render(
+      <div>
+        <Label htmlFor="news-title">Titel</Label>
+        <input id="news-title" name="title" />
+      </div>
+    );
+
+    await expectNoA11yViolations(container);
+  });
+});

--- a/apps/sva-studio-react/src/test/a11y.test.ts
+++ b/apps/sva-studio-react/src/test/a11y.test.ts
@@ -1,0 +1,83 @@
+import axe from 'axe-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import { expectNoA11yViolations } from './a11y';
+
+type AxeRun = (context?: axe.ElementContext, options?: axe.RunOptions) => Promise<axe.AxeResults>;
+
+const { mockAxeRun } = vi.hoisted(() => ({
+  mockAxeRun: vi.fn<AxeRun>(),
+}));
+
+vi.mock('axe-core', () => ({
+  default: {
+    run: mockAxeRun,
+  },
+}));
+
+type AxeRunResult = Awaited<ReturnType<AxeRun>>;
+type AxeViolation = AxeRunResult['violations'][number];
+type AxeNodeResult = AxeViolation['nodes'][number];
+
+const createAxeResults = (violations: AxeRunResult['violations']): AxeRunResult =>
+  ({
+    violations,
+  }) as unknown as AxeRunResult;
+
+const createNodeResult = (target: string[]): AxeNodeResult =>
+  ({
+    target,
+  }) as unknown as AxeNodeResult;
+
+const createViolation = (
+  overrides: Pick<AxeViolation, 'id' | 'help' | 'nodes'> & Partial<Omit<AxeViolation, 'id' | 'help' | 'nodes'>>
+): AxeViolation => ({
+  description: '',
+  helpUrl: '',
+  impact: undefined,
+  tags: [],
+  ...overrides,
+});
+
+describe('expectNoA11yViolations', () => {
+  it('passes through when axe reports no violations', async () => {
+    mockAxeRun.mockResolvedValueOnce(createAxeResults([]));
+
+    await expect(expectNoA11yViolations(document.createElement('div'))).resolves.toBeUndefined();
+  });
+
+  it('includes violation ids, help text, and flattened targets in the assertion message', async () => {
+    mockAxeRun.mockResolvedValueOnce(
+      createAxeResults([
+        createViolation({
+          id: 'image-alt',
+          help: 'Images must have alternate text',
+          nodes: [createNodeResult(['.hero-image']), createNodeResult(['#logo-link'])],
+        }),
+      ])
+    );
+
+    await expect(expectNoA11yViolations(document.createElement('div'))).rejects.toThrowError(
+      /image-alt: Images must have alternate text \[\.hero-image, #logo-link\]/
+    );
+  });
+
+  it('omits empty target brackets when axe does not report any selectors', async () => {
+    mockAxeRun.mockResolvedValueOnce(
+      createAxeResults([
+        createViolation({
+          id: 'button-name',
+          help: 'Buttons must have discernible text',
+          nodes: [createNodeResult([])],
+        }),
+      ])
+    );
+
+    const result = await expectNoA11yViolations(document.createElement('div')).catch((error: unknown) => error);
+    const message = (result as Error).message;
+
+    expect(result).toBeInstanceOf(Error);
+    expect(message).toContain('button-name: Buttons must have discernible text');
+    expect(message).not.toContain('button-name: Buttons must have discernible text [');
+  });
+});

--- a/apps/sva-studio-react/src/test/a11y.ts
+++ b/apps/sva-studio-react/src/test/a11y.ts
@@ -1,0 +1,34 @@
+import axe from 'axe-core';
+import { expect } from 'vitest';
+
+const componentAxeOptions = {
+  rules: {
+    // Komponenten werden isoliert gerendert, daher wären globale Landmark-Regeln hier nur Rauschen.
+    region: { enabled: false },
+    // happy-dom kann visuelle Kontrastberechnung nicht belastbar simulieren.
+    'color-contrast': { enabled: false },
+  },
+} as const;
+
+const runAxe = (container: HTMLElement) => axe.run<axe.AxeResults>(container, componentAxeOptions);
+
+type AxeViolation = Awaited<ReturnType<typeof runAxe>>['violations'][number];
+type AxeNodeResult = AxeViolation['nodes'][number];
+
+const formatViolations = (violations: readonly AxeViolation[]) =>
+  violations
+    .map((violation) => {
+      const targets = violation.nodes
+        .flatMap((node: AxeNodeResult) => node.target)
+        .map((target) => target.toString())
+        .join(', ');
+
+      return `${violation.id}: ${violation.help}${targets.length > 0 ? ` [${targets}]` : ''}`;
+    })
+    .join('\n');
+
+export const expectNoA11yViolations = async (container: HTMLElement) => {
+  const results = await runAxe(container);
+
+  expect(results.violations, formatViolations(results.violations)).toEqual([]);
+};

--- a/apps/sva-studio-react/vitest.a11y.config.ts
+++ b/apps/sva-studio-react/vitest.a11y.config.ts
@@ -6,7 +6,7 @@ export default mergeConfig(
   sharedVitestConfig,
   defineConfig({
     test: {
-      include: ['src/**/*.a11y.test.{ts,tsx}', 'src/**/*.a11y.spec.{ts,tsx}'],
+      include: ['src/**/*.a11y.test.{ts,tsx}', 'src/**/*.a11y.spec.{ts,tsx}', 'src/test/a11y.test.ts'],
     },
   })
 );

--- a/apps/sva-studio-react/vitest.a11y.config.ts
+++ b/apps/sva-studio-react/vitest.a11y.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import { sharedVitestConfig } from './vitest.shared.ts';
+
+export default mergeConfig(
+  sharedVitestConfig,
+  defineConfig({
+    test: {
+      include: ['src/**/*.a11y.test.{ts,tsx}', 'src/**/*.a11y.spec.{ts,tsx}'],
+    },
+  })
+);

--- a/apps/sva-studio-react/vitest.hooks.config.ts
+++ b/apps/sva-studio-react/vitest.hooks.config.ts
@@ -9,6 +9,7 @@ export default mergeConfig(
       include: [
         'src/hooks/**/*.{test,spec}.{ts,tsx}',
         'src/lib/**/*.{test,spec}.{ts,tsx}',
+        'src/test/**/*.{test,spec}.{ts,tsx}',
       ],
       exclude: [
         'src/**/*.server.test.{ts,tsx}',

--- a/apps/sva-studio-react/vitest.ui.config.ts
+++ b/apps/sva-studio-react/vitest.ui.config.ts
@@ -11,6 +11,7 @@ export default mergeConfig(
         'src/providers/**/*.{test,spec}.{ts,tsx}',
         'src/i18n/**/*.{test,spec}.{ts,tsx}',
       ],
+      exclude: ['src/**/*.a11y.test.{ts,tsx}', 'src/**/*.a11y.spec.{ts,tsx}'],
     },
   })
 );

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -64,6 +64,12 @@ Mindesterwartung vor Merge:
 - Fokuszustände und sichtbare Beschriftungen prüfen
 - offensichtliche Screenreader-Blocker und Kontrastprobleme ausschließen
 
+Automatisierte Prüfpfade:
+
+- `pnpm test:a11y` führt komponentennahe `axe-core`-Prüfungen für `apps/sva-studio-react` aus.
+- `pnpm nx run sva-studio-react:test:e2e` deckt zusätzlich zentrale UI-Flows mit `@axe-core/playwright` im Browser ab.
+- Komponenten-A11y-Tests dürfen isolierte Landmark-Regeln und visuelle Kontrastregeln im Test-Runner gezielt ausnehmen, wenn die Umgebung diese Aspekte nicht belastbar simulieren kann. Solche Ausnahmen sind knapp zu dokumentieren und dürfen keine Laufzeitprobleme kaschieren.
+
 ## Unterstützte Browser und Assistive Technologies
 
 Die verbindliche Matrix für Browser, Geräte und Screenreader liegt unter `../BROWSER-SUPPORT.md`. Diese Richtlinie dupliziert die Matrix bewusst nicht.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:types": "pnpm clean:generated-source-artifacts && env -u NO_COLOR nx run-many -t test:types --parallel=1 && env -u NO_COLOR nx run-many -t typecheck --parallel=1 && pnpm check:server-runtime && pnpm exec tsc -p tsconfig.scripts.json --noEmit",
     "test:types:affected": "pnpm clean:generated-source-artifacts && env -u NO_COLOR nx affected --target=test:types --base=${NX_BASE:-origin/main} --parallel=1 && env -u NO_COLOR nx affected --target=typecheck --base=${NX_BASE:-origin/main} --parallel=1 && pnpm check:server-runtime:affected && pnpm exec tsc -p tsconfig.scripts.json --noEmit",
     "test": "pnpm test:unit",
+    "test:a11y": "env -u NO_COLOR nx run sva-studio-react:test:a11y",
     "test:unit": "env -u NO_COLOR nx run-many -t test:unit --parallel=1",
     "test:unit:affected": "tsx scripts/ci/affected-unit-gate.ts --base ${NX_BASE:-origin/main}",
     "test:coverage": "env -u NO_COLOR nx run-many -t test:coverage",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.7(vitest@4.1.7)
+      axe-core:
+        specifier: ^4.11.4
+        version: 4.11.4
       jsdom:
         specifier: ^29.1.0
         version: 29.1.1


### PR DESCRIPTION
## Summary
- add a dedicated `sva-studio-react:test:a11y` path with component-level `axe-core` coverage for dialog and label plus a shared a11y helper test
- document the automated accessibility test path in `docs/guides/accessibility.md`
- switch `sva-studio-react:test:unit` to an Nx orchestration target over the existing `ui`, `routes`, `hooks`, and `server` slices to keep the unit gate parallelizable without changing check names

## Why
- catch accessibility regressions for shared UI primitives earlier and more explicitly
- keep the accessibility guide aligned with the actual verification workflow
- reduce wall-clock time for the app unit gate while preserving the existing `Quality Gates / Unit` contract

## Test Plan
- [x] `pnpm nx run sva-studio-react:test:unit --testFiles=src/components/ui/dialog.a11y.test.tsx --skip-nx-cache`
- [x] `pnpm nx run sva-studio-react:test:unit --skip-nx-cache`
- [x] `pnpm nx affected --target=test:unit --base=origin/main`
- [x] `pnpm nx run sva-studio-react:test:types`
