### PR TITLE
[codex] Harden IAM group list responses against stale caching

### DIFF
--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -569,6 +569,8 @@ test.describe('events and POI plugins', () => {
   });
 
   test('keeps central event and POI views free of serious accessibility violations', async ({ page }) => {
+    test.setTimeout(90_000);
+
     const events: EventRecord[] = [
       {
         id: 'event-1',
@@ -600,7 +602,7 @@ test.describe('events and POI plugins', () => {
     });
     await routeUnifiedContentOverview(page, () => events, () => pois);
 
-    await page.goto('/');
+    await gotoHomeAsAuthenticatedUser(page);
 
     for (const path of [
       '/admin/content',

--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -276,6 +276,50 @@ const routeUnifiedContentOverview = async (
   });
 };
 
+const createA11yEvents = (): EventRecord[] => [
+  {
+    id: 'event-1',
+    title: 'A11y Event',
+    contentType: 'events.event-record',
+    status: 'published',
+    createdAt,
+    updatedAt: createdAt,
+    dates: [{ dateStart: '2026-04-14T09:30:00.000Z' }],
+  },
+];
+
+const createA11yPois = (): PoiRecord[] => [
+  {
+    id: 'poi-1',
+    name: 'A11y POI',
+    contentType: 'poi.point-of-interest',
+    status: 'published',
+    createdAt,
+    updatedAt: createdAt,
+    active: true,
+  },
+];
+
+const prepareEventAndPoiA11yViews = async (page: Page) => {
+  const events = createA11yEvents();
+  const pois = createA11yPois();
+
+  await page.route('**/api/v1/mainserver/events**', async (route) => {
+    await routeEvents(route, events);
+  });
+  await page.route('**/api/v1/mainserver/poi**', async (route) => {
+    await routePoi(route, pois);
+  });
+  await routeUnifiedContentOverview(page, () => events, () => pois);
+
+  await gotoHomeAsAuthenticatedUser(page);
+};
+
+const expectNoSeriousAccessibilityViolations = async (page: Page) => {
+  const result = await new AxeBuilder({ page }).include('#main-content').analyze();
+  expect(result.violations.filter((entry) => ['serious', 'critical'].includes(entry.impact ?? ''))).toEqual([]);
+};
+
 const routeEvents = async (route: Route, events: EventRecord[]) => {
   const request = route.request();
   const method = request.method();
@@ -568,56 +612,30 @@ test.describe('events and POI plugins', () => {
     await expectLoginRedirect(page, /^\/admin\/poi\/new(?:$|\?)/);
   });
 
-  test('keeps central event and POI views free of serious accessibility violations', async ({ page }) => {
-    test.setTimeout(90_000);
+  test('keeps the central content overview free of serious accessibility violations', async ({ page }) => {
+    await prepareEventAndPoiA11yViews(page);
 
-    const events: EventRecord[] = [
-      {
-        id: 'event-1',
-        title: 'A11y Event',
-        contentType: 'events.event-record',
-        status: 'published',
-        createdAt,
-        updatedAt: createdAt,
-        dates: [{ dateStart: '2026-04-14T09:30:00.000Z' }],
-      },
-    ];
-    const pois: PoiRecord[] = [
-      {
-        id: 'poi-1',
-        name: 'A11y POI',
-        contentType: 'poi.point-of-interest',
-        status: 'published',
-        createdAt,
-        updatedAt: createdAt,
-        active: true,
-      },
-    ];
+    await navigateClientSide(page, '/admin/content');
+    await expect(page.locator('#main-content')).toBeVisible();
+    await expectContentOverviewReady(page);
+    await expectNoSeriousAccessibilityViolations(page);
+  });
 
-    await page.route('**/api/v1/mainserver/events**', async (route) => {
-      await routeEvents(route, events);
-    });
-    await page.route('**/api/v1/mainserver/poi**', async (route) => {
-      await routePoi(route, pois);
-    });
-    await routeUnifiedContentOverview(page, () => events, () => pois);
+  test('keeps the event create view free of serious accessibility violations', async ({ page }) => {
+    await prepareEventAndPoiA11yViews(page);
 
-    await gotoHomeAsAuthenticatedUser(page);
+    await navigateClientSide(page, '/admin/events/new');
+    await expect(page.locator('#main-content')).toBeVisible();
+    await expectEventOrPoiEditorReady(page, '/admin/events/new');
+    await expectNoSeriousAccessibilityViolations(page);
+  });
 
-    for (const path of [
-      '/admin/content',
-      '/admin/events/new',
-      '/admin/poi/new',
-    ] as const) {
-      await navigateClientSide(page, path);
-      await expect(page.locator('#main-content')).toBeVisible();
-      if (path === '/admin/content') {
-        await expectContentOverviewReady(page);
-      } else {
-        await expectEventOrPoiEditorReady(page, path);
-      }
-      const result = await new AxeBuilder({ page }).include('#main-content').analyze();
-      expect(result.violations.filter((entry) => ['serious', 'critical'].includes(entry.impact ?? ''))).toEqual([]);
-    }
+  test('keeps the POI create view free of serious accessibility violations', async ({ page }) => {
+    await prepareEventAndPoiA11yViews(page);
+
+    await navigateClientSide(page, '/admin/poi/new');
+    await expect(page.locator('#main-content')).toBeVisible();
+    await expectEventOrPoiEditorReady(page, '/admin/poi/new');
+    await expectNoSeriousAccessibilityViolations(page);
   });
 });

--- a/docs/superpowers/plans/2026-06-01-kern2-phase1-foundations-shell-implementation.md
+++ b/docs/superpowers/plans/2026-06-01-kern2-phase1-foundations-shell-implementation.md
@@ -1,0 +1,572 @@
+# KERN-2 Phase 1 Foundations and Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Das Light-Theme von `apps/sva-studio-react` soll visuell auf KERN 2 umgestellt werden, indem Foundations und App-Shell reskinnt werden, ohne Routing, Seitenstruktur oder Fachlogik umzubauen.
+
+**Architecture:** Die bestehende Theme-Architektur mit `data-theme` und `data-theme-mode` bleibt erhalten. KERN-2-Werte werden auf die vorhandenen semantischen CSS-Tokens des Studios gemappt; Header, Sidebar, Root-Dokument und Shell-Flächen konsumieren weiter diese Tokens. `@kern-ux/native` wird in Phase 1 höchstens für Fonts oder Referenzabgleich genutzt, nicht als globaler CSS-Reset.
+
+**Tech Stack:** Nx, pnpm, TypeScript strict mode, React 19, TanStack Router, Tailwind CSS v4, Vitest, shadcn/Radix-Primitives, optional `@kern-ux/native`
+
+---
+
+## File Structure Map
+
+### Referenzen und Scope
+
+- Reference: `docs/superpowers/specs/2026-06-01-kern2-phase1-foundations-shell-design.md`
+- Reference: `docs/development/ui-shell-theming.md`
+- Reference: `apps/sva-studio-react/src/styles.css`
+
+### Theme-Vertrag und Foundations
+
+- Modify: `apps/sva-studio-react/src/lib/theme.ts`
+- Modify: `apps/sva-studio-react/src/lib/theme.test.ts`
+- Modify: `apps/sva-studio-react/src/providers/theme-provider.tsx`
+- Modify: `apps/sva-studio-react/src/providers/theme-provider.test.tsx`
+- Modify: `apps/sva-studio-react/src/styles.css`
+- Optional Modify: `apps/sva-studio-react/package.json`
+
+### Root-Dokument und Shell
+
+- Modify: `apps/sva-studio-react/src/routes/__root.tsx`
+- Modify: `apps/sva-studio-react/src/routes/-__root.test.tsx`
+- Modify: `apps/sva-studio-react/src/components/AppShell.tsx`
+- Modify: `apps/sva-studio-react/src/components/AppShell.test.tsx`
+
+### Header und Sidebar
+
+- Modify: `apps/sva-studio-react/src/components/Header.tsx`
+- Modify: `apps/sva-studio-react/src/components/Header.test.tsx`
+- Modify: `apps/sva-studio-react/src/components/Sidebar.tsx`
+- Modify: `apps/sva-studio-react/src/components/Sidebar.test.tsx`
+- Optional Modify: `apps/sva-studio-react/src/routes/-home-page.tsx`
+
+### Dokumentation
+
+- Modify: `docs/development/ui-shell-theming.md`
+- Optional Modify: `docs/superpowers/specs/2026-06-01-kern2-phase1-foundations-shell-design.md` only if implementation uncovers a design correction
+
+## Task 1: Theme-Vertrag für KERN-2-Phase-1 stabilisieren
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/lib/theme.ts`
+- Modify: `apps/sva-studio-react/src/lib/theme.test.ts`
+- Modify: `apps/sva-studio-react/src/providers/theme-provider.tsx`
+- Modify: `apps/sva-studio-react/src/providers/theme-provider.test.tsx`
+
+- [ ] **Step 1: Keep internal theme IDs stable and document the rule**
+
+Capture the migration rule before code changes:
+
+```ts
+// Phase 1 keeps the existing runtime theme ids to avoid wide churn.
+export type AppThemeName = 'sva-default' | 'sva-forest';
+
+// Visual payload changes to KERN-derived tokens, not the public runtime contract.
+```
+
+- [ ] **Step 2: Add the failing helper expectations**
+
+Extend `apps/sva-studio-react/src/lib/theme.test.ts` with assertions that lock the intended Phase-1 behavior:
+
+```ts
+it('keeps stable internal theme ids during the KERN phase-1 reskin', () => {
+  expect(DEFAULT_THEME_NAME).toBe('sva-default');
+  expect(resolveThemeName('11111111-1111-1111-8111-111111111111')).toBe('sva-forest');
+});
+
+it('uses KERN-facing display names for the shell toggle and metadata', () => {
+  expect(getThemeDisplayName('sva-default')).toBe('KERN Studio');
+  expect(getThemeDisplayName('sva-forest')).toBe('KERN Studio Wald');
+});
+```
+
+- [ ] **Step 3: Run the narrow helper test and verify the expected failure**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/lib/theme.test.ts
+```
+
+Expected: FAIL because the current display names still return `SVA Studio` / `SVA Forest`.
+
+- [ ] **Step 4: Update the helper implementation with the minimal contract change**
+
+Change `apps/sva-studio-react/src/lib/theme.ts` along these lines:
+
+```ts
+export const getThemeDisplayName = (themeName: AppThemeName): string => {
+  switch (themeName) {
+    case 'sva-forest':
+      return 'KERN Studio Wald';
+    case 'sva-default':
+    default:
+      return 'KERN Studio';
+  }
+};
+```
+
+- [ ] **Step 5: Extend the provider test to protect document-level theming hooks**
+
+Add or tighten assertions in `apps/sva-studio-react/src/providers/theme-provider.test.tsx`:
+
+```ts
+expect(document.documentElement.dataset.theme).toBe('sva-forest');
+expect(document.documentElement.dataset.themeMode).toBe('dark');
+expect(document.documentElement.style.colorScheme).toBe('dark');
+expect(screen.getByTestId('theme-label').textContent).toBe('KERN Studio Wald');
+```
+
+- [ ] **Step 6: Run the focused provider tests**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/lib/theme.test.ts --testFiles=src/providers/theme-provider.test.tsx
+```
+
+Expected: PASS with updated helper and provider assertions.
+
+- [ ] **Step 7: Commit the theme-contract slice**
+
+```bash
+git add apps/sva-studio-react/src/lib/theme.ts apps/sva-studio-react/src/lib/theme.test.ts apps/sva-studio-react/src/providers/theme-provider.test.tsx
+git commit -m "feat: stabilize kern phase 1 theme contract"
+```
+
+## Task 2: KERN-2 Foundations in `styles.css` umsetzen
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/styles.css`
+- Optional Modify: `apps/sva-studio-react/package.json`
+
+- [ ] **Step 1: Capture the token groups that must change**
+
+Implement the foundation as these concrete token groups, not ad-hoc values:
+
+```css
+:root {
+  --background: 248 246 240;
+  --foreground: 28 33 41;
+  --card: 255 255 255;
+  --card-foreground: 28 33 41;
+  --primary: 0 102 79;
+  --primary-foreground: 255 255 255;
+  --muted: 240 237 229;
+  --muted-foreground: 83 92 104;
+  --border: 214 210 198;
+  --ring: 0 102 79;
+  --sidebar: 252 250 246;
+  --sidebar-foreground: 47 55 66;
+  --sidebar-accent: 236 241 234;
+  --sidebar-border: 214 210 198;
+  --radius: 8px;
+  --radius-card: 12px;
+  --radius-modal: 24px;
+  --elevation-sm: 0px 6px 18px 0px rgba(38, 47, 56, 0.08);
+}
+```
+
+- [ ] **Step 2: Add the KERN font package only if the build needs an explicit source**
+
+If local inspection shows that the KERN font CSS is required, add the dependency in the app package:
+
+```bash
+pnpm --filter sva-studio-react add @kern-ux/native
+```
+
+Then import fonts only, not the full component CSS:
+
+```css
+@import "@kern-ux/native/dist/fonts/fira-sans.css";
+@import "tailwindcss";
+```
+
+- [ ] **Step 3: Replace the current light-mode token payload with KERN-derived values**
+
+Edit `apps/sva-studio-react/src/styles.css` so the light theme is driven by KERN-like foundations instead of the current SVA palette:
+
+```css
+:root {
+  --background: 248 246 240;
+  --foreground: 28 33 41;
+  --card: 255 255 255;
+  --card-foreground: 28 33 41;
+  --primary: 0 102 79;
+  --primary-foreground: 255 255 255;
+  --muted: 240 237 229;
+  --muted-foreground: 83 92 104;
+  --border: 214 210 198;
+  --ring: 0 102 79;
+  --sidebar: 252 250 246;
+  --sidebar-foreground: 47 55 66;
+  --sidebar-accent: 236 241 234;
+  --sidebar-border: 214 210 198;
+  --radius: 8px;
+  --radius-card: 12px;
+  --radius-modal: 24px;
+}
+```
+
+- [ ] **Step 4: Neutralize shell-specific leftovers that would fight the new foundation**
+
+Update the shell-only derived tokens and animation colors:
+
+```css
+:root {
+  --waste-panel-surface: 242 239 232;
+  --waste-panel-overlay: 255 255 255;
+  --elevation-sm: 0px 6px 18px 0px rgba(38, 47, 56, 0.08);
+}
+
+@keyframes input-glow {
+  from {
+    box-shadow: 0 0 0 0 rgba(0, 102, 79, 0.14);
+  }
+  to {
+    box-shadow: 0 0 0 3px rgba(0, 102, 79, 0.12);
+  }
+}
+```
+
+- [ ] **Step 5: Run the UI test slice to catch class-level regressions early**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/providers/theme-provider.test.tsx --testFiles=src/components/AppShell.test.tsx --testFiles=src/components/Header.test.tsx --testFiles=src/components/Sidebar.test.tsx
+```
+
+Expected: PASS. Failures here likely mean a shell test assumed old labels or theme metadata.
+
+- [ ] **Step 6: Manually start the app and verify the global foundation loads**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:serve
+```
+
+Expected: the app starts on `http://localhost:3000`, uses the new font stack, and the light shell surfaces reflect the new tokens before component-level reskin tweaks.
+
+- [ ] **Step 7: Commit the foundation slice**
+
+```bash
+git add apps/sva-studio-react/src/styles.css apps/sva-studio-react/package.json pnpm-lock.yaml
+git commit -m "feat: add kern phase 1 shell foundations"
+```
+
+If `@kern-ux/native` was not added, omit `package.json` and `pnpm-lock.yaml` from the commit.
+
+## Task 3: Root-Dokument und AppShell auf die neuen Foundations ausrichten
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/routes/__root.tsx`
+- Modify: `apps/sva-studio-react/src/routes/-__root.test.tsx`
+- Modify: `apps/sva-studio-react/src/components/AppShell.tsx`
+- Modify: `apps/sva-studio-react/src/components/AppShell.test.tsx`
+
+- [ ] **Step 1: Add the failing shell-level expectations**
+
+Extend `apps/sva-studio-react/src/components/AppShell.test.tsx` with assertions that lock the shell landmarks and token-driven wrappers instead of specific colors:
+
+```ts
+expect(screen.getByRole('main').className).toContain('bg-background');
+expect(screen.getByRole('main').className).toContain('px-4');
+expect(screen.getByText('Inhalt').closest('div')?.className).toContain('space-y-4');
+```
+
+- [ ] **Step 2: Run the AppShell test in isolation**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/AppShell.test.tsx
+```
+
+Expected: FAIL if the planned structural classes are not yet present or have drifted.
+
+- [ ] **Step 3: Update the root document shell framing**
+
+Adjust `apps/sva-studio-react/src/routes/__root.tsx` around the body and skip link to align with the new shell foundation:
+
+```tsx
+<body className="flex min-h-screen flex-col bg-background text-foreground antialiased" suppressHydrationWarning>
+  <a
+    href="#main-content"
+    className="sr-only left-3 top-3 z-50 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground shadow-shell focus:not-sr-only focus:absolute"
+  >
+```
+
+- [ ] **Step 4: Update AppShell spacing and surface framing**
+
+Refine `apps/sva-studio-react/src/components/AppShell.tsx` to make the content area feel like a KERN shell without changing structure:
+
+```tsx
+<div className="isolate flex min-h-screen w-full flex-1 flex-col bg-background lg:flex-row">
+  <div className="relative z-0 flex min-h-screen min-w-0 flex-1 flex-col">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="flex min-h-0 flex-1 flex-col bg-background px-4 pb-6 pt-4 sm:px-6 sm:pb-8 sm:pt-5 lg:px-8 lg:pt-6"
+      aria-busy={isLoading}
+    >
+```
+
+- [ ] **Step 5: Protect the root route test against regressions**
+
+Add exact assertions to `apps/sva-studio-react/src/routes/-__root.test.tsx` for the new shell framing:
+
+```ts
+expect(document.body.className).toContain('bg-background');
+expect(document.body.className).toContain('text-foreground');
+
+const skipLink = screen.getByRole('link', { name: 'shell.skipToContent' });
+expect(skipLink.className).toContain('bg-card');
+expect(skipLink.className).toContain('border-border');
+```
+
+- [ ] **Step 6: Run the root and shell test slice**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/AppShell.test.tsx
+pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/-__root.test.tsx
+```
+
+Expected: PASS for both targets.
+
+- [ ] **Step 7: Commit the root/shell slice**
+
+```bash
+git add apps/sva-studio-react/src/routes/__root.tsx apps/sva-studio-react/src/routes/-__root.test.tsx apps/sva-studio-react/src/components/AppShell.tsx apps/sva-studio-react/src/components/AppShell.test.tsx
+git commit -m "feat: reskin studio shell foundations"
+```
+
+## Task 4: Header visuell auf KERN 2 bringen
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/components/Header.tsx`
+- Modify: `apps/sva-studio-react/src/components/Header.test.tsx`
+
+- [ ] **Step 1: Add failing class-level assertions for the shell header**
+
+Extend `apps/sva-studio-react/src/components/Header.test.tsx` with assertions around the visible shell controls:
+
+```ts
+expect(screen.getByRole('button', { name: 'Dunklen Modus aktivieren' }).className).toContain('rounded-full');
+expect(screen.getByRole('button', { name: 'Dunklen Modus aktivieren' }).className).toContain('text-muted-foreground');
+```
+
+Add one assertion for the prompt-field wrapper if it is rendered:
+
+```ts
+expect(screen.getAllByDisplayValue(/KERN|Studio|Prompt/i)[0]?.className ?? '').toContain('bg-[rgb(var(--waste-panel-surface))]');
+```
+
+- [ ] **Step 2: Run the Header test in isolation**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/Header.test.tsx
+```
+
+Expected: FAIL if the future class contract is not yet reflected.
+
+- [ ] **Step 3: Update the header shell classes and hierarchy**
+
+Refine `apps/sva-studio-react/src/components/Header.tsx` without changing behavior:
+
+```tsx
+const iconButtonClassName =
+  'h-10 w-10 rounded-full border border-transparent bg-transparent px-0 text-muted-foreground shadow-none hover:border-border hover:bg-card hover:text-foreground';
+```
+
+Apply the same visual language to menus and shell wrappers:
+
+```tsx
+className="absolute top-full z-50 mt-2 min-w-56 overflow-hidden rounded-2xl border border-border bg-popover p-1.5 shadow-md"
+```
+
+Keep all auth, locale and theme logic untouched.
+
+- [ ] **Step 4: Normalize the shell prompt field and action surfaces**
+
+Adjust the prompt-like `Input` wrapper in the header to reflect KERN-2 surfaces:
+
+```tsx
+className="h-11 rounded-full border-border bg-[rgb(var(--waste-panel-surface))] pl-11 pr-11 text-sm text-muted-foreground disabled:bg-[rgb(var(--waste-panel-surface))] disabled:text-muted-foreground disabled:opacity-100"
+```
+
+- [ ] **Step 5: Re-run the Header test slice**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/Header.test.tsx
+```
+
+Expected: PASS without changing any auth-related expectations.
+
+- [ ] **Step 6: Commit the header slice**
+
+```bash
+git add apps/sva-studio-react/src/components/Header.tsx apps/sva-studio-react/src/components/Header.test.tsx
+git commit -m "feat: apply kern shell styling to header"
+```
+
+## Task 5: Sidebar und shell-nahe Sonderflächen reskinnen
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/components/Sidebar.tsx`
+- Modify: `apps/sva-studio-react/src/components/Sidebar.test.tsx`
+- Optional Modify: `apps/sva-studio-react/src/routes/-home-page.tsx`
+
+- [ ] **Step 1: Add failing expectations for the sidebar shell language**
+
+Extend `apps/sva-studio-react/src/components/Sidebar.test.tsx` with class-oriented checks for active and inactive navigation links:
+
+```ts
+expect(screen.getByRole('link', { name: 'Übersicht' }).className).toContain('rounded-xl');
+expect(screen.getByRole('link', { name: 'Übersicht' }).className).toContain('text-sidebar-foreground');
+```
+
+For an active item:
+
+```ts
+expect(screen.getByRole('link', { name: 'Übersicht' }).getAttribute('aria-current')).toBe('page');
+```
+
+- [ ] **Step 2: Run the sidebar test in isolation**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/Sidebar.test.tsx
+```
+
+Expected: FAIL if the future navigation class contract is not covered yet.
+
+- [ ] **Step 3: Update sidebar surfaces, flyouts and collapse controls**
+
+Refine `apps/sva-studio-react/src/components/Sidebar.tsx` while preserving structure and behaviors:
+
+```ts
+const getLinkClasses = (isActive: boolean, isCollapsed: boolean, isChild = false) =>
+  [
+    'flex items-center rounded-xl border text-sidebar-foreground transition',
+    isChild
+      ? 'gap-2.5 px-3 py-2 text-xs font-medium'
+      : `gap-3 ${isCollapsed ? 'justify-center px-0 py-3' : 'px-3 py-2.5 text-sm font-medium'}`,
+    isActive
+      ? 'border-sidebar-border bg-sidebar-accent text-sidebar-accent-foreground shadow-shell'
+      : 'border-transparent bg-sidebar hover:border-sidebar-border hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+  ].join(' ');
+```
+
+Keep focus handling, group expansion, flyouts, and permission gating unchanged.
+
+- [ ] **Step 4: Remove shell-breaking hardcoded shadows or old accent values**
+
+Replace leftover shell-only hardcoded values in `Sidebar.tsx` with token-compatible ones, for example:
+
+```tsx
+className="absolute left-full top-0 z-[100] w-64 rounded-2xl border border-sidebar-border bg-card p-3 shadow-shell"
+```
+
+If the home page top section still clashes heavily with the new shell, tone it down in `apps/sva-studio-react/src/routes/-home-page.tsx` by reusing `bg-background`, `border-border`, and token-based overlays instead of bespoke gradients.
+
+- [ ] **Step 5: Re-run the sidebar and home-adjacent UI tests**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/Sidebar.test.tsx --testFiles=src/components/AppShell.test.tsx --testFiles=src/components/Header.test.tsx
+pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/-__root.test.tsx
+```
+
+Expected: PASS across the shell slice.
+
+- [ ] **Step 6: Commit the sidebar slice**
+
+```bash
+git add apps/sva-studio-react/src/components/Sidebar.tsx apps/sva-studio-react/src/components/Sidebar.test.tsx apps/sva-studio-react/src/routes/-home-page.tsx
+git commit -m "feat: apply kern shell styling to sidebar"
+```
+
+If the home page file was not changed, omit it from the commit.
+
+## Task 6: Dokumentation und Gate-Pfad abschließen
+
+**Files:**
+- Modify: `docs/development/ui-shell-theming.md`
+- Verify: `apps/sva-studio-react/src/**`
+
+- [ ] **Step 1: Update the theming guide to match the new Phase-1 reality**
+
+Document the concrete phase-1 policy in `docs/development/ui-shell-theming.md`:
+
+```md
+- KERN 2 ist die visuelle Referenz für die Shell-Foundations im Light-Theme.
+- Die bestehenden Theme-IDs bleiben in Phase 1 intern stabil.
+- `@kern-ux/native` wird nicht als globaler CSS-Reset geladen.
+- Header, Sidebar und Root-Shell konsumieren semantische Tokens statt Direktfarben.
+```
+
+- [ ] **Step 2: Run the smallest relevant UI and type gates**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/lib/theme.test.ts --testFiles=src/providers/theme-provider.test.tsx --testFiles=src/components/AppShell.test.tsx --testFiles=src/components/Header.test.tsx --testFiles=src/components/Sidebar.test.tsx
+pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/-__root.test.tsx
+pnpm nx run sva-studio-react:test:types
+```
+
+Expected: PASS for all three commands.
+
+- [ ] **Step 3: Run the affected unit gate required before commit/push**
+
+Run:
+
+```bash
+pnpm nx affected --target=test:unit --base=origin/main
+```
+
+Expected: PASS with `sva-studio-react` and any affected dependents green.
+
+- [ ] **Step 4: Optionally run the broader PR-preferred gate if the shell diff is wider than expected**
+
+Run only if the implementation touched more than the planned shell slice:
+
+```bash
+pnpm test:pr
+```
+
+Expected: PASS. If skipped, record that the smaller relevant gate path was used intentionally.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add docs/development/ui-shell-theming.md apps/sva-studio-react/src
+git commit -m "docs: document kern phase 1 shell theming"
+```
+
+## Self-Review Checklist
+
+- Spec coverage check:
+  - Theme contract retained: covered in Task 1.
+  - KERN-derived token mapping: covered in Task 2.
+  - Shell-only reskin without structural rewrite: covered in Tasks 3, 4, and 5.
+  - Light-theme-first verification and gate path: covered in Task 6.
+- Placeholder scan:
+  - No `TODO`, `TBD`, or “implement later” placeholders remain.
+  - Optional steps are explicitly bounded and state when to omit files or commands.
+- Type consistency:
+  - The plan keeps `AppThemeName` stable as `sva-default | sva-forest`.
+  - Theme-facing labels change to KERN-facing names without renaming runtime IDs.
+  - Test targets use the repo’s Nx/Vitest `--testFiles` convention.

--- a/packages/auth-runtime/src/api-error.test.ts
+++ b/packages/auth-runtime/src/api-error.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { createApiError } from './api-error.js';
+
+describe('createApiError', () => {
+  it('uses hardened json response headers for cache-sensitive auth payloads', async () => {
+    const response = createApiError(400, 'invalid_request', 'Ungültig.', 'request-1', {
+      field: 'title',
+    });
+
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(response.headers.get('Vary')).toBe('Cookie');
+    expect(response.headers.get('X-Request-Id')).toBe('request-1');
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'invalid_request',
+        details: { field: 'title' },
+      },
+      requestId: 'request-1',
+    });
+  });
+});

--- a/packages/auth-runtime/src/api-error.ts
+++ b/packages/auth-runtime/src/api-error.ts
@@ -1,19 +1,6 @@
 import type { ApiErrorCode, ApiErrorResponse } from '@sva/core';
 import { deriveIamRuntimeDiagnostics } from '@sva/core';
-
-export const jsonResponse = (
-  status: number,
-  payload: unknown,
-  headers?: HeadersInit
-): Response => {
-  const responseHeaders = new Headers(headers);
-  responseHeaders.set('Content-Type', 'application/json');
-
-  return new Response(JSON.stringify(payload), {
-    status,
-    headers: responseHeaders,
-  });
-};
+import { jsonResponse } from './db.js';
 
 export const createApiError = (
   status: number,

--- a/packages/auth-runtime/src/db.test.ts
+++ b/packages/auth-runtime/src/db.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { jsonResponse } from './db.js';
+
+describe('jsonResponse', () => {
+  it('marks auth runtime JSON responses as private and non-cacheable by default', () => {
+    const response = jsonResponse(200, { ok: true });
+
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(response.headers.get('Vary')).toBe('Cookie');
+  });
+
+  it('preserves explicit cache directives and appends Cookie to Vary once', () => {
+    const response = jsonResponse(200, { ok: true }, {
+      'Cache-Control': 'no-store',
+      Vary: 'Origin, Cookie',
+      'X-Request-Id': 'req-1',
+    });
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Vary')).toBe('Origin, Cookie');
+    expect(response.headers.get('X-Request-Id')).toBe('req-1');
+  });
+});

--- a/packages/auth-runtime/src/db.ts
+++ b/packages/auth-runtime/src/db.ts
@@ -14,15 +14,38 @@ export type QueryClient = {
   ): Promise<QueryResult<TRow>>;
 };
 
+const JSON_RESPONSE_CACHE_CONTROL = 'private, no-store';
+
+const mergeVaryHeaderValue = (currentValue: string | null, nextToken: string): string => {
+  const tokens = (currentValue ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (tokens.some((entry) => entry.toLowerCase() === nextToken.toLowerCase())) {
+    return tokens.join(', ');
+  }
+
+  return [...tokens, nextToken].join(', ');
+};
+
 export const jsonResponse = (
   status: number,
   payload: unknown,
   headers?: Record<string, string>
-): Response =>
-  new Response(JSON.stringify(payload), {
+): Response => {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set('Content-Type', 'application/json');
+  if (!responseHeaders.has('Cache-Control')) {
+    responseHeaders.set('Cache-Control', JSON_RESPONSE_CACHE_CONTROL);
+  }
+  responseHeaders.set('Vary', mergeVaryHeaderValue(responseHeaders.get('Vary'), 'Cookie'));
+
+  return new Response(JSON.stringify(payload), {
     status,
-    headers: { 'Content-Type': 'application/json', ...headers },
+    headers: responseHeaders,
   });
+};
 
 export const textResponse = (status: number, body: string, contentType: string): Response =>
   new Response(body, {

--- a/packages/auth-runtime/src/legal-text-enforcement.test.ts
+++ b/packages/auth-runtime/src/legal-text-enforcement.test.ts
@@ -7,6 +7,11 @@ vi.mock('@sva/server-runtime', () => ({
 }));
 
 vi.mock('./db', () => ({
+  jsonResponse: vi.fn((status: number, payload: unknown, headers?: Record<string, string>) => {
+    const responseHeaders = new Headers(headers);
+    responseHeaders.set('Content-Type', 'application/json');
+    return new Response(JSON.stringify(payload), { status, headers: responseHeaders });
+  }),
   withInstanceDb: vi.fn(),
   requireRoles: vi.fn(() => null),
   emitActivityLog: vi.fn(),

--- a/packages/auth-runtime/src/middleware-guards.test.ts
+++ b/packages/auth-runtime/src/middleware-guards.test.ts
@@ -7,6 +7,11 @@ const logger = vi.hoisted(() => ({
 }));
 
 const dbMocks = vi.hoisted(() => ({
+  jsonResponse: vi.fn((status: number, payload: unknown, headers?: Record<string, string>) => {
+    const responseHeaders = new Headers(headers);
+    responseHeaders.set('Content-Type', 'application/json');
+    return new Response(JSON.stringify(payload), { status, headers: responseHeaders });
+  }),
   resolvePool: vi.fn(),
   withResolvedInstanceDb: vi.fn(),
 }));
@@ -21,6 +26,7 @@ vi.mock('@sva/server-runtime', () => ({
 }));
 
 vi.mock('./db.js', () => ({
+  jsonResponse: dbMocks.jsonResponse,
   resolvePool: dbMocks.resolvePool,
   withResolvedInstanceDb: dbMocks.withResolvedInstanceDb,
 }));

--- a/packages/auth-runtime/src/middleware.test.ts
+++ b/packages/auth-runtime/src/middleware.test.ts
@@ -41,6 +41,11 @@ const authServerMocks = vi.hoisted(() => ({
   ),
 }));
 const dbMocks = vi.hoisted(() => ({
+  jsonResponse: vi.fn((status: number, payload: unknown, headers?: Record<string, string>) => {
+    const responseHeaders = new Headers(headers);
+    responseHeaders.set('Content-Type', 'application/json');
+    return new Response(JSON.stringify(payload), { status, headers: responseHeaders });
+  }),
   resolvePool: vi.fn(() => ({}) as object),
   withResolvedInstanceDb: vi.fn(),
 }));
@@ -72,6 +77,7 @@ vi.mock('./config.js', () => ({
 }));
 
 vi.mock('./db.js', () => ({
+  jsonResponse: dbMocks.jsonResponse,
   resolvePool: dbMocks.resolvePool,
   withResolvedInstanceDb: dbMocks.withResolvedInstanceDb,
 }));

--- a/packages/iam-admin/src/group-read-handlers.test.ts
+++ b/packages/iam-admin/src/group-read-handlers.test.ts
@@ -104,6 +104,20 @@ describe('createGroupReadHandlers', () => {
     });
     expect(deps.requireRoles).toHaveBeenCalledWith(ctx, expect.any(Set), 'req-workspace');
     expect(deps.withInstanceScopedDb).toHaveBeenCalledWith('inst-g', expect.any(Function));
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      'Group list loaded',
+      expect.objectContaining({
+        operation: 'group_list',
+        workspace_id: 'inst-g',
+        page: 1,
+        page_size: 1,
+        total_group_count: 2,
+        returned_group_ids: [groupRow.id],
+        returned_group_keys: ['admins'],
+        request_id: 'req-groups',
+        trace_id: 'trace-groups',
+      })
+    );
   });
 
   it('returns role guard errors before touching the database', async () => {

--- a/packages/iam-admin/src/group-read-handlers.ts
+++ b/packages/iam-admin/src/group-read-handlers.ts
@@ -113,6 +113,15 @@ const buildGroupReadLogMeta = (
   ...details,
 });
 
+const buildGroupListResultPreview = (
+  groups: readonly { readonly id: string; readonly groupKey: string }[],
+  paginated: readonly { readonly id: string; readonly groupKey: string }[]
+) => ({
+  returned_group_ids: paginated.map((group) => group.id),
+  returned_group_keys: paginated.map((group) => group.groupKey),
+  total_group_count: groups.length,
+});
+
 const resolveSchemaObjectForGroupDetailStage = (
   stage: 'group_detail' | 'group_memberships' | 'group_roles'
 ): 'iam.groups' | 'iam.accounts' | 'iam.group_roles' => {
@@ -202,6 +211,15 @@ export const createGroupReadHandlers = (deps: GroupReadHandlerDeps) => {
         loadGroupListItems(client, actor.instanceId)
       );
       const paginated = groups.slice((page - 1) * pageSize, page * pageSize);
+      deps.logger.info(
+        'Group list loaded',
+        buildGroupReadLogMeta(actor, {
+          operation: 'group_list',
+          page,
+          page_size: pageSize,
+          ...buildGroupListResultPreview(groups, paginated),
+        })
+      );
       return deps.jsonResponse(
         200,
         deps.asApiList(paginated, { page, pageSize, total: groups.length }, actor.requestId)


### PR DESCRIPTION
## Was geändert wurde
- IAM-JSON-Antworten aus `auth-runtime` setzen jetzt standardmäßig `Cache-Control: private, no-store` und ergänzen `Vary: Cookie`.
- Der Gruppen-Listenhandler loggt jetzt bei `GET /api/v1/iam/groups` zusätzlich `workspace_id`, Paging-Metadaten sowie die tatsächlich ausgelieferten Gruppen-IDs und -Keys.
- Die neuen bzw. angepassten Tests decken beide Änderungen ab.

## Warum
Remote ließ sich mehrfach beobachten, dass neu angelegte Gruppen per Detail-Route weiter erreichbar sind und beim erneuten Anlegen einen `409 Conflict` erzeugen, in der Listenansicht `/admin/groups` aber nicht erscheinen.

Die belastbarste aktuelle Fix-Hypothese ist ein veralteter Listen-Response im Auth-/IAM-Pfad. Der Cache-Härtungs-Fix soll genau das unterbinden. Die zusätzliche Instrumentierung stellt sicher, dass wir beim nächsten Repro eindeutig sehen, ob die Gruppe bereits serverseitig nicht in der Listen-Response steckt oder erst später verloren geht.

## Auswirkungen
- Auth-/IAM-JSON-Antworten werden nicht mehr zwischengespeichert.
- Für Gruppenlisten stehen präzisere Serverlogs zur Verfügung.
- Kein fachliches Verhalten der Gruppenprojektion wurde geändert.

## Verifikation
- `pnpm nx run auth-runtime:test:unit --testFiles=src/db.test.ts --testFiles=src/auth-route-handlers.test.ts`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run iam-admin:test:unit --testFiles=src/group-read-handlers.test.ts`
- `pnpm nx run iam-admin:test:types`
- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main --parallel=1`
