### PR TITLE
fix(auth-runtime): restore default group list pagination

### DIFF
--- a/packages/auth-runtime/src/shared/request-helpers.test.ts
+++ b/packages/auth-runtime/src/shared/request-helpers.test.ts
@@ -66,6 +66,10 @@ describe('shared request helpers', () => {
   it('reads pagination, path, instance and idempotency values', async () => {
     const request = new Request('https://example.test/api/v1/items/item-1?page=-1&pageSize=200&instanceId= instance-1 ');
     expect(readPage(request)).toEqual({ page: 1, pageSize: 100 });
+    expect(readPage(new Request('https://example.test/api/v1/items/item-1'))).toEqual({
+      page: 1,
+      pageSize: 25,
+    });
     expect(readInstanceIdFromRequest(request, 'fallback')).toBe('instance-1');
     expect(readInstanceIdFromRequest(new Request('https://example.test/api'), 'fallback')).toBe('fallback');
     expect(readPathSegment(request, 2)).toBe('items');

--- a/packages/auth-runtime/src/shared/request-helpers.ts
+++ b/packages/auth-runtime/src/shared/request-helpers.ts
@@ -81,8 +81,13 @@ export const toPayloadHash = (rawBody: string): string =>
 
 export const readPage = (request: Request): { page: number; pageSize: number } => {
   const url = new URL(request.url);
-  const page = Math.max(1, readNumber(Number(url.searchParams.get('page'))) ?? 1);
-  const pageSize = Math.max(1, Math.min(100, readNumber(Number(url.searchParams.get('pageSize'))) ?? 25));
+  const pageParam = url.searchParams.get('page');
+  const pageSizeParam = url.searchParams.get('pageSize');
+  const page = Math.max(1, readNumber(pageParam === null ? Number.NaN : Number(pageParam)) ?? 1);
+  const pageSize = Math.max(
+    1,
+    Math.min(100, readNumber(pageSizeParam === null ? Number.NaN : Number(pageSizeParam)) ?? 25)
+  );
   return { page, pageSize };
 };
 


### PR DESCRIPTION
## Summary
- fix the shared request pagination helper so missing `page` and `pageSize` params use their intended defaults
- restore the default `pageSize=25` behavior for `/api/v1/iam/groups` and other handlers using `readPage`
- add a regression test covering requests without explicit pagination params

## Verification
- pnpm nx run auth-runtime:test:unit --testFiles=src/shared/request-helpers.test.ts
- pnpm nx run auth-runtime:test:types
- pnpm nx affected --target=test:unit --files=packages/auth-runtime/src/shared/request-helpers.ts,packages/auth-runtime/src/shared/request-helpers.test.ts
- pnpm nx affected --target=test:types --files=packages/auth-runtime/src/shared/request-helpers.ts,packages/auth-runtime/src/shared/request-helpers.test.ts