### PR TITLE
fix(waste-management): generate UUID-compatible fraction ids

### DIFF
--- a/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
@@ -96,9 +96,9 @@ const createId = (): string => {
     const shift = BigInt((7 - index) * 8);
     fallbackBytes[index] = Number((timestamp >> shift) & 0xffn);
   }
-  fallbackBytes[8] = (localIdCounter >> 24) & 0xff;
-  fallbackBytes[9] = (localIdCounter >> 16) & 0xff;
-  fallbackBytes[10] = (localIdCounter >> 8) & 0xff;
+  fallbackBytes[8] = (localIdCounter >>> 24) & 0xff;
+  fallbackBytes[9] = (localIdCounter >>> 16) & 0xff;
+  fallbackBytes[10] = (localIdCounter >>> 8) & 0xff;
   fallbackBytes[11] = localIdCounter & 0xff;
   fallbackBytes[12] = 0xaa;
   fallbackBytes[13] = 0xbb;

--- a/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
@@ -56,6 +56,20 @@ export type LocationTourLinkBulkFormState = {
 
 let localIdCounter = 0;
 
+const formatUuidV4FromBytes = (bytes: Uint8Array): string => {
+  const normalized = bytes.slice(0, 16);
+  normalized[6] = ((normalized[6] ?? 0) & 0x0f) | 0x40;
+  normalized[8] = ((normalized[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(normalized, (byte) => byte.toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-');
+};
+
 const createSecureRandomIdSegment = (): string | undefined => {
   const cryptoApi = globalThis.crypto;
   if (cryptoApi?.randomUUID) {
@@ -66,17 +80,31 @@ const createSecureRandomIdSegment = (): string | undefined => {
   }
 
   const bytes = cryptoApi.getRandomValues(new Uint8Array(16));
-  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  return formatUuidV4FromBytes(bytes);
 };
 
 const createId = (): string => {
   const secureId = createSecureRandomIdSegment();
   if (secureId) {
-    return `fraction-${secureId}`;
+    return secureId;
   }
 
   localIdCounter += 1;
-  return `fraction-local-${Date.now().toString(36)}-${localIdCounter.toString(36)}`;
+  const fallbackBytes = new Uint8Array(16);
+  const timestamp = BigInt(Date.now());
+  for (let index = 0; index < 8; index += 1) {
+    const shift = BigInt((7 - index) * 8);
+    fallbackBytes[index] = Number((timestamp >> shift) & 0xffn);
+  }
+  fallbackBytes[8] = (localIdCounter >> 24) & 0xff;
+  fallbackBytes[9] = (localIdCounter >> 16) & 0xff;
+  fallbackBytes[10] = (localIdCounter >> 8) & 0xff;
+  fallbackBytes[11] = localIdCounter & 0xff;
+  fallbackBytes[12] = 0xaa;
+  fallbackBytes[13] = 0xbb;
+  fallbackBytes[14] = 0xcc;
+  fallbackBytes[15] = 0xdd;
+  return formatUuidV4FromBytes(fallbackBytes);
 };
 const compactOptionalString = (value: string): string | undefined => (value.trim() ? value.trim() : undefined);
 

--- a/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
@@ -363,7 +363,7 @@ describe('waste management helper modules', () => {
     vi.stubGlobal('crypto', { randomUUID });
 
     expect(wasteMasterDataFormDefaults.createRegion()).toEqual({
-      id: 'fraction-secure-region-id',
+      id: 'secure-region-id',
       name: '',
     });
   });
@@ -376,7 +376,7 @@ describe('waste management helper modules', () => {
     vi.stubGlobal('crypto', { getRandomValues });
 
     expect(wasteMasterDataFormDefaults.createRegion()).toEqual({
-      id: 'fraction-000102030405060708090a0b0c0d0e0f',
+      id: '00010203-0405-4607-8809-0a0b0c0d0e0f',
       name: '',
     });
   });

--- a/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
@@ -37,6 +37,8 @@ import {
 import { createWasteToursActions } from '../src/waste-management.tours.actions.js';
 import { createWasteToursAssignmentSubmitHandlers } from '../src/waste-management.tours.assignments-submissions.js';
 
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 vi.mock('../src/waste-management.api.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/waste-management.api.js')>();
   return {
@@ -359,11 +361,11 @@ describe('waste management helper modules', () => {
   });
 
   it('uses cryptographically secure ids for master-data defaults', () => {
-    const randomUUID = vi.fn(() => 'secure-region-id');
+    const randomUUID = vi.fn(() => '11111111-1111-4111-8111-111111111111');
     vi.stubGlobal('crypto', { randomUUID });
 
     expect(wasteMasterDataFormDefaults.createRegion()).toEqual({
-      id: 'secure-region-id',
+      id: '11111111-1111-4111-8111-111111111111',
       name: '',
     });
   });
@@ -377,6 +379,15 @@ describe('waste management helper modules', () => {
 
     expect(wasteMasterDataFormDefaults.createRegion()).toEqual({
       id: '00010203-0405-4607-8809-0a0b0c0d0e0f',
+      name: '',
+    });
+  });
+
+  it('falls back to a UUID-v4-shaped local id when crypto is unavailable', () => {
+    vi.stubGlobal('crypto', undefined);
+
+    expect(wasteMasterDataFormDefaults.createRegion()).toEqual({
+      id: expect.stringMatching(UUID_V4_PATTERN),
       name: '',
     });
   });


### PR DESCRIPTION
## Summary
- generate UUID-compatible ids for new waste master-data entities instead of prefixed local ids
- keep the cryptographic fallback path UUID-shaped when `randomUUID` is unavailable
- update the helper expectations to lock the new id format in place

## Verification
- pnpm nx run plugin-waste-management:test:unit --testFiles=tests/waste-management.helpers.test.tsx
- pnpm nx run plugin-waste-management:test:unit --testFiles=tests/waste-management.master-data.fraction-submissions.test.ts
- pnpm nx affected --target=test:unit --files=packages/plugin-waste-management/src/waste-management.master-data.forms.ts,packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
- pnpm nx affected --target=test:types --files=packages/plugin-waste-management/src/waste-management.master-data.forms.ts,packages/plugin-waste-management/tests/waste-management.helpers.test.tsx