### PR TITLE
[codex] fix studio release approval token forwarding

### DIFF
--- a/scripts/ops/studio-release-local.ts
+++ b/scripts/ops/studio-release-local.ts
@@ -28,7 +28,7 @@ const rootDir = resolve(dirname(scriptPath), '../..');
 
 const usage = () => {
   process.stderr.write(
-    'Usage: tsx scripts/ops/studio-release-local.ts --image-digest=<sha256:...> --release-mode=<app-only|schema-and-app> --rollback-hint=<text> [--image-tag=<tag>] [--maintenance-window=<text>]\n',
+    'Usage: tsx scripts/ops/studio-release-local.ts --image-digest=<sha256:...> --release-mode=<app-only|schema-and-app> --rollback-hint=<text> [--image-tag=<tag>] [--maintenance-window=<text>] [--approve-dangerous=<token>]\n',
   );
 };
 
@@ -99,6 +99,10 @@ export const buildLocalStudioReleasePlan = (
 
   if (options.imageTag) {
     deployArgs.push(`--image-tag=${options.imageTag}`);
+  }
+
+  if (cliOptions.approvalToken) {
+    deployArgs.push(`--approve-dangerous=${cliOptions.approvalToken}`);
   }
 
   return {

--- a/tooling/testing/tests/studio-release-local.test.ts
+++ b/tooling/testing/tests/studio-release-local.test.ts
@@ -84,6 +84,17 @@ describe('studio-release-local', () => {
     expect(plan.steps[0]?.env.SVA_REMOTE_OPERATOR_CONTEXT).toBe('local-operator');
   });
 
+  it('forwards the dangerous approval token to the deploy step', () => {
+    const plan = buildLocalStudioReleasePlan([
+      '--image-digest=sha256:abc',
+      '--release-mode=app-only',
+      '--rollback-hint=Redeploy previous digest',
+      '--approve-dangerous=studio:deploy:app-only',
+    ]);
+
+    expect(plan.steps[1]?.args).toContain('--approve-dangerous=studio:deploy:app-only');
+  });
+
   it('runs feedback even when a primary step fails', () => {
     const plan = buildLocalStudioReleasePlan([
       '--image-digest=sha256:abc',


### PR DESCRIPTION
## What changed
- forwards `--approve-dangerous` from `env:release:studio:local` to the inner `env:deploy:studio` step
- updates the local release wrapper usage string to document the approval token
- adds a regression test for approval-token forwarding

## Why
The local Studio release wrapper parsed `--approve-dangerous` but dropped it when building the `env:deploy:studio` invocation. That made the canonical local release path fail deterministically on guarded remote deploys, even when the operator had explicitly provided the required token.

## Impact
The documented `env:release:studio:local` path now works with guarded remote deploys instead of requiring a manual low-level fallback.

## Validation
- `pnpm exec vitest --root tooling/testing run tests/studio-release-local.test.ts --reporter=verbose --config vitest.config.ts`
- `pnpm nx run tooling-testing:test:unit`
