### PR TITLE
[codex] Refresh IAM permission snapshots and reactivate users from list

### DIFF
--- a/apps/sva-studio-react/src/i18n/resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources.ts
@@ -2102,6 +2102,7 @@ export const i18nResources = {
           create: 'Nutzer anlegen',
           creating: 'Nutzer wird angelegt ...',
           edit: 'Bearbeiten',
+          activate: 'Aktivieren',
           deactivate: 'Deaktivieren',
           bulkDeactivate: 'Auswahl deaktivieren',
           syncKeycloak: 'Aus Keycloak synchronisieren',
@@ -2137,6 +2138,8 @@ export const i18nResources = {
           sendPasswordSetupEmail: 'Einladungs-E-Mail zum Passwort setzen senden',
         },
         confirm: {
+          activateTitle: 'Nutzer aktivieren',
+          activateDescription: 'Die ausgewählte Person wird wieder aktiviert.',
           singleTitle: 'Nutzer deaktivieren',
           singleDescription: 'Die ausgewählte Person wird deaktiviert.',
           bulkTitle: 'Mehrere Nutzer deaktivieren',
@@ -5306,6 +5309,7 @@ export const i18nResources = {
           create: 'Create user',
           creating: 'Creating user ...',
           edit: 'Edit',
+          activate: 'Activate',
           deactivate: 'Deactivate',
           bulkDeactivate: 'Deactivate selection',
           syncKeycloak: 'Sync from Keycloak',
@@ -5340,6 +5344,8 @@ export const i18nResources = {
           sendPasswordSetupEmail: 'Send invitation email to set password',
         },
         confirm: {
+          activateTitle: 'Activate user',
+          activateDescription: 'The selected user will be activated again.',
           singleTitle: 'Deactivate user',
           singleDescription: 'The selected user will be deactivated.',
           bulkTitle: 'Deactivate multiple users',

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -273,6 +273,36 @@ describe('UserListPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Deaktivieren' }));
 
     await waitFor(() => expect(deactivateUser).toHaveBeenCalledWith('user-1'));
+  });
+
+  it('shows an activation action for inactive users and confirms single-user activation', async () => {
+    const updateUser = vi.fn().mockResolvedValue({ id: 'user-1', status: 'active' });
+    useUsersMock.mockReturnValue(
+      createUsersApiState({
+        updateUser,
+        users: [
+          {
+            id: 'user-1',
+            keycloakSubject: 'subject-1',
+            displayName: 'Alice',
+            email: 'alice@example.com',
+            status: 'inactive',
+            lastLoginAt: '2026-03-04T10:00:00Z',
+            roles: [{ roleId: 'role-1', roleName: 'system_admin', roleLevel: 90 }],
+          },
+        ],
+      })
+    );
+
+    render(<UserListPage />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Aktivieren' })[0]!);
+
+    expect(screen.getByText('Die ausgewählte Person wird wieder aktiviert.')).toBeTruthy();
+
+    fireEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Aktivieren' }));
+
+    await waitFor(() => expect(updateUser).toHaveBeenCalledWith('user-1', { status: 'active' }));
   });
 
   it('renders platform user management on root scope without tenant mutations', () => {

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -70,19 +70,28 @@ const renderDiagnosticCodes = (diagnostics: readonly IamKeycloakObjectDiagnostic
     </span>
   ) : null;
 
+type StatusActionDialogState =
+  | {
+      action: 'activate';
+      mode: 'single';
+      userId: string;
+    }
+  | {
+      action: 'deactivate';
+      mode: 'single';
+      userId: string;
+    }
+  | {
+      action: 'deactivate';
+      mode: 'bulk';
+      userIds: string[];
+    };
+
 export const UserListPage = () => {
   const studioDataTableLabels = createStudioDataTableLabels();
   const usersApi = useUsers();
 
-  const [statusActionDialog, setStatusActionDialog] = React.useState<
-    | {
-        action: 'activate' | 'deactivate';
-        mode: 'single' | 'bulk';
-        userId?: string;
-        userIds?: string[];
-      }
-    | null
-  >(null);
+  const [statusActionDialog, setStatusActionDialog] = React.useState<StatusActionDialogState | null>(null);
   const [syncStatus, setSyncStatus] = React.useState<'idle' | 'pending' | 'success' | 'empty' | 'error'>('idle');
   const [syncResult, setSyncResult] = React.useState<IamUserImportSyncReport | null>(null);
   const [syncError, setSyncError] = React.useState<Parameters<typeof userErrorMessage>[0]>(null);
@@ -98,19 +107,17 @@ export const UserListPage = () => {
       return;
     }
 
-    if (action.action === 'activate' && action.mode === 'single' && action.userId) {
+    if (action.action === 'activate') {
       await usersApi.updateUser(action.userId, { status: 'active' });
       return;
     }
 
-    if (action.action === 'deactivate' && action.mode === 'single' && action.userId) {
+    if (action.mode === 'single') {
       await usersApi.deactivateUser(action.userId);
       return;
     }
 
-    if (action.action === 'deactivate' && action.mode === 'bulk' && action.userIds) {
-      await usersApi.bulkDeactivate(action.userIds);
-    }
+    await usersApi.bulkDeactivate(action.userIds);
   };
 
   const onSyncUsers = async () => {

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -74,9 +74,15 @@ export const UserListPage = () => {
   const studioDataTableLabels = createStudioDataTableLabels();
   const usersApi = useUsers();
 
-  const [deactivateDialog, setDeactivateDialog] = React.useState<{ mode: 'single' | 'bulk'; userId?: string; userIds?: string[] } | null>(
-    null
-  );
+  const [statusActionDialog, setStatusActionDialog] = React.useState<
+    | {
+        action: 'activate' | 'deactivate';
+        mode: 'single' | 'bulk';
+        userId?: string;
+        userIds?: string[];
+      }
+    | null
+  >(null);
   const [syncStatus, setSyncStatus] = React.useState<'idle' | 'pending' | 'success' | 'empty' | 'error'>('idle');
   const [syncResult, setSyncResult] = React.useState<IamUserImportSyncReport | null>(null);
   const [syncError, setSyncError] = React.useState<Parameters<typeof userErrorMessage>[0]>(null);
@@ -84,20 +90,25 @@ export const UserListPage = () => {
   const isPlatformScope = user !== null && !user.instanceId;
   const isAuthLoading = user === null;
 
-  const onConfirmDeactivate = async () => {
-    const action = deactivateDialog;
-    setDeactivateDialog(null);
+  const onConfirmStatusAction = async () => {
+    const action = statusActionDialog;
+    setStatusActionDialog(null);
 
     if (!action) {
       return;
     }
 
-    if (action.mode === 'single' && action.userId) {
+    if (action.action === 'activate' && action.mode === 'single' && action.userId) {
+      await usersApi.updateUser(action.userId, { status: 'active' });
+      return;
+    }
+
+    if (action.action === 'deactivate' && action.mode === 'single' && action.userId) {
       await usersApi.deactivateUser(action.userId);
       return;
     }
 
-    if (action.mode === 'bulk' && action.userIds) {
+    if (action.action === 'deactivate' && action.mode === 'bulk' && action.userIds) {
       await usersApi.bulkDeactivate(action.userIds);
     }
   };
@@ -232,7 +243,8 @@ export const UserListPage = () => {
                     label: t('admin.users.actions.bulkDeactivate'),
                     variant: 'destructive',
                     onClick: ({ selectedRows }) =>
-                      setDeactivateDialog({
+                      setStatusActionDialog({
+                        action: 'deactivate',
                         mode: 'bulk',
                         userIds: selectedRows.map((user) => user.id),
                       }),
@@ -297,11 +309,17 @@ export const UserListPage = () => {
               <Button
                 type="button"
                 size="sm"
-                variant="destructive"
+                variant={user.status === 'inactive' ? 'outline' : 'destructive'}
                 disabled={user.editability === 'blocked' || user.editability === 'read_only'}
-                onClick={() => setDeactivateDialog({ mode: 'single', userId: user.id })}
+                onClick={() =>
+                  setStatusActionDialog({
+                    action: user.status === 'inactive' ? 'activate' : 'deactivate',
+                    mode: 'single',
+                    userId: user.id,
+                  })
+                }
               >
-                {t('admin.users.actions.deactivate')}
+                {t(user.status === 'inactive' ? 'admin.users.actions.activate' : 'admin.users.actions.deactivate')}
               </Button>
             </>
           )}
@@ -432,21 +450,27 @@ export const UserListPage = () => {
       </footer>
 
       <ConfirmDialog
-        open={Boolean(deactivateDialog)}
+        open={Boolean(statusActionDialog)}
         title={t(
-          deactivateDialog?.mode === 'bulk'
-            ? 'admin.users.confirm.bulkTitle'
-            : 'admin.users.confirm.singleTitle'
+          statusActionDialog?.action === 'activate'
+            ? 'admin.users.confirm.activateTitle'
+            : statusActionDialog?.mode === 'bulk'
+              ? 'admin.users.confirm.bulkTitle'
+              : 'admin.users.confirm.singleTitle'
         )}
         description={t(
-          deactivateDialog?.mode === 'bulk'
-            ? 'admin.users.confirm.bulkDescription'
-            : 'admin.users.confirm.singleDescription'
+          statusActionDialog?.action === 'activate'
+            ? 'admin.users.confirm.activateDescription'
+            : statusActionDialog?.mode === 'bulk'
+              ? 'admin.users.confirm.bulkDescription'
+              : 'admin.users.confirm.singleDescription'
         )}
-        confirmLabel={t('admin.users.actions.deactivate')}
+        confirmLabel={t(
+          statusActionDialog?.action === 'activate' ? 'admin.users.actions.activate' : 'admin.users.actions.deactivate'
+        )}
         cancelLabel={t('account.actions.cancel')}
-        onCancel={() => setDeactivateDialog(null)}
-        onConfirm={() => void onConfirmDeactivate()}
+        onCancel={() => setStatusActionDialog(null)}
+        onConfirm={() => void onConfirmStatusAction()}
       />
     </section>
   );

--- a/packages/auth-runtime/src/auth-server/callback.test.ts
+++ b/packages/auth-runtime/src/auth-server/callback.test.ts
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => ({
   getScopeFromAuthConfig: vi.fn(),
   buildSessionUser: vi.fn(),
   resolveSessionExpiry: vi.fn(),
+  withInstanceDb: vi.fn(),
+  notifyPermissionInvalidation: vi.fn(),
 }));
 
 vi.mock('@sva/server-runtime', () => ({
@@ -32,6 +34,19 @@ vi.mock('../config.js', () => ({
 vi.mock('../jit-provisioning.js', () => ({
   jitProvisionAccount: mocks.jitProvisionAccount,
 }));
+
+vi.mock('../db.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db.js')>();
+  return {
+    ...actual,
+    withInstanceDb: (...args: Parameters<typeof actual.withInstanceDb>) => {
+      if (mocks.withInstanceDb.getMockImplementation()) {
+        return mocks.withInstanceDb(...args);
+      }
+      return actual.withInstanceDb(...args);
+    },
+  };
+});
 
 vi.mock('../log-context.js', () => ({
   buildLogContext: vi.fn(() => ({ trace_id: 'trace-test' })),
@@ -64,6 +79,21 @@ vi.mock('./shared.js', () => ({
   resolveSessionExpiry: mocks.resolveSessionExpiry,
 }));
 
+vi.mock('../iam-account-management/shared-activity.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../iam-account-management/shared-activity.js')>();
+  return {
+    ...actual,
+    notifyPermissionInvalidation: (
+      ...args: Parameters<typeof actual.notifyPermissionInvalidation>
+    ) => {
+      if (mocks.notifyPermissionInvalidation.getMockImplementation()) {
+        return mocks.notifyPermissionInvalidation(...args);
+      }
+      return actual.notifyPermissionInvalidation(...args);
+    },
+  };
+});
+
 const authConfig = {
   kind: 'platform' as const,
   issuer: 'https://issuer.example/realms/test',
@@ -85,6 +115,9 @@ const authConfig = {
 describe('handleCallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
+    mocks.withInstanceDb.mockReset();
+    mocks.notifyPermissionInvalidation.mockReset();
 
     mocks.getAuthConfig.mockReturnValue(authConfig);
     mocks.getOidcConfig.mockResolvedValue({ issuer: authConfig.issuer });
@@ -99,6 +132,8 @@ describe('handleCallback', () => {
     });
     mocks.createSession.mockResolvedValue(undefined);
     mocks.jitProvisionAccount.mockResolvedValue(undefined);
+    mocks.notifyPermissionInvalidation.mockResolvedValue(undefined);
+    mocks.withInstanceDb.mockImplementation(async (_instanceId, work) => work({ query: vi.fn() }));
     mocks.authorizationCodeGrant.mockResolvedValue({
       access_token: 'access-token',
       refresh_token: 'refresh-token',
@@ -263,6 +298,32 @@ describe('handleCallback', () => {
         instance_id: 'de-test',
         error: 'jit unavailable',
       })
+    );
+  });
+
+  it('invalidates permission snapshots for the authenticated subject after a successful callback', async () => {
+    const { handleCallback } = await import('./callback.js');
+
+    await handleCallback({
+      code: 'code-1',
+      state: 'state-1',
+      authConfig,
+      loginState: {
+        kind: 'platform',
+        codeVerifier: 'verifier',
+        nonce: 'nonce',
+        createdAt: Date.now(),
+      },
+    });
+
+    expect(mocks.withInstanceDb).toHaveBeenCalledWith('de-test', expect.any(Function));
+    expect(mocks.notifyPermissionInvalidation).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.any(Function) }),
+      {
+        instanceId: 'de-test',
+        keycloakSubject: 'kc-user-1',
+        trigger: 'user_login',
+      }
     );
   });
 

--- a/packages/auth-runtime/src/auth-server/callback.test.ts
+++ b/packages/auth-runtime/src/auth-server/callback.test.ts
@@ -19,8 +19,7 @@ const mocks = vi.hoisted(() => ({
   getScopeFromAuthConfig: vi.fn(),
   buildSessionUser: vi.fn(),
   resolveSessionExpiry: vi.fn(),
-  withInstanceDb: vi.fn(),
-  notifyPermissionInvalidation: vi.fn(),
+  runPostLoginTasks: vi.fn(),
 }));
 
 vi.mock('@sva/server-runtime', () => ({
@@ -35,18 +34,9 @@ vi.mock('../jit-provisioning.js', () => ({
   jitProvisionAccount: mocks.jitProvisionAccount,
 }));
 
-vi.mock('../db.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../db.js')>();
-  return {
-    ...actual,
-    withInstanceDb: (...args: Parameters<typeof actual.withInstanceDb>) => {
-      if (mocks.withInstanceDb.getMockImplementation()) {
-        return mocks.withInstanceDb(...args);
-      }
-      return actual.withInstanceDb(...args);
-    },
-  };
-});
+vi.mock('./post-login-tasks.js', () => ({
+  runPostLoginTasks: mocks.runPostLoginTasks,
+}));
 
 vi.mock('../log-context.js', () => ({
   buildLogContext: vi.fn(() => ({ trace_id: 'trace-test' })),
@@ -79,21 +69,6 @@ vi.mock('./shared.js', () => ({
   resolveSessionExpiry: mocks.resolveSessionExpiry,
 }));
 
-vi.mock('../iam-account-management/shared-activity.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../iam-account-management/shared-activity.js')>();
-  return {
-    ...actual,
-    notifyPermissionInvalidation: (
-      ...args: Parameters<typeof actual.notifyPermissionInvalidation>
-    ) => {
-      if (mocks.notifyPermissionInvalidation.getMockImplementation()) {
-        return mocks.notifyPermissionInvalidation(...args);
-      }
-      return actual.notifyPermissionInvalidation(...args);
-    },
-  };
-});
-
 const authConfig = {
   kind: 'platform' as const,
   issuer: 'https://issuer.example/realms/test',
@@ -116,8 +91,6 @@ describe('handleCallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    mocks.withInstanceDb.mockReset();
-    mocks.notifyPermissionInvalidation.mockReset();
 
     mocks.getAuthConfig.mockReturnValue(authConfig);
     mocks.getOidcConfig.mockResolvedValue({ issuer: authConfig.issuer });
@@ -132,8 +105,7 @@ describe('handleCallback', () => {
     });
     mocks.createSession.mockResolvedValue(undefined);
     mocks.jitProvisionAccount.mockResolvedValue(undefined);
-    mocks.notifyPermissionInvalidation.mockResolvedValue(undefined);
-    mocks.withInstanceDb.mockImplementation(async (_instanceId, work) => work({ query: vi.fn() }));
+    mocks.runPostLoginTasks.mockResolvedValue(undefined);
     mocks.authorizationCodeGrant.mockResolvedValue({
       access_token: 'access-token',
       refresh_token: 'refresh-token',
@@ -257,19 +229,14 @@ describe('handleCallback', () => {
         freshReauthAt: undefined,
       })
     );
-    expect(mocks.jitProvisionAccount).toHaveBeenCalledWith({
-      instanceId: 'de-test',
-      keycloakSubject: 'kc-user-1',
-    });
+    expect(mocks.runPostLoginTasks).toHaveBeenCalledWith('de-test', 'kc-user-1');
     expect(result.retryPerformed).toBe(true);
     expect(result.sessionId).toBeTypeOf('string');
     expect(result.loginState).toMatchObject({ kind: 'platform', silent: true });
   });
 
-  it('logs and swallows jit provisioning failures after session creation', async () => {
+  it('returns the authenticated session after post-login tasks were triggered', async () => {
     const { handleCallback } = await import('./callback.js');
-
-    mocks.jitProvisionAccount.mockRejectedValueOnce(new Error('jit unavailable'));
 
     const result = await handleCallback({
       code: 'code-1',
@@ -290,18 +257,10 @@ describe('handleCallback', () => {
         freshReauthAt: undefined,
       })
     );
-    expect(mocks.logger.error).toHaveBeenCalledWith(
-      'JIT provisioning failed after callback',
-      expect.objectContaining({
-        operation: 'jit_provision',
-        user_id: 'kc-user-1',
-        instance_id: 'de-test',
-        error: 'jit unavailable',
-      })
-    );
+    expect(mocks.runPostLoginTasks).toHaveBeenCalledWith('de-test', 'kc-user-1');
   });
 
-  it('invalidates permission snapshots for the authenticated subject after a successful callback', async () => {
+  it('runs post-login tasks for the authenticated subject after a successful callback', async () => {
     const { handleCallback } = await import('./callback.js');
 
     await handleCallback({
@@ -316,15 +275,7 @@ describe('handleCallback', () => {
       },
     });
 
-    expect(mocks.withInstanceDb).toHaveBeenCalledWith('de-test', expect.any(Function));
-    expect(mocks.notifyPermissionInvalidation).toHaveBeenCalledWith(
-      expect.objectContaining({ query: expect.any(Function) }),
-      {
-        instanceId: 'de-test',
-        keycloakSubject: 'kc-user-1',
-        trigger: 'user_login',
-      }
-    );
+    expect(mocks.runPostLoginTasks).toHaveBeenCalledWith('de-test', 'kc-user-1');
   });
 
   it('stamps fresh reauth only for explicit reauth callbacks with a fresh auth_time claim', async () => {

--- a/packages/auth-runtime/src/auth-server/callback.ts
+++ b/packages/auth-runtime/src/auth-server/callback.ts
@@ -3,11 +3,13 @@ import { createSdkLogger } from '@sva/server-runtime';
 import { z } from 'zod';
 
 import { getAuthConfig } from '../config.js';
+import { withInstanceDb } from '../db.js';
 import { jitProvisionAccount } from '../jit-provisioning.js';
 import { buildLogContext } from '../log-context.js';
 import { client, getOidcConfig, invalidateOidcConfig } from '../oidc.js';
 import { consumeLoginState, createSession, getSessionControlState } from '../redis-session.js';
 import { isRetryableTokenExchangeError } from '../error-guards.js';
+import { notifyPermissionInvalidation } from '../iam-account-management/shared-activity.js';
 import { getScopeFromAuthConfig } from '../scope.js';
 import type { AuthConfig, InstanceScopeRef, LoginState, PlatformScopeRef, ScopeKind } from '../types.js';
 import { buildSessionUser, resolveSessionExpiry } from './shared.js';
@@ -204,6 +206,30 @@ const syncJitProvisioning = async (instanceId: string | undefined, keycloakSubje
   }
 };
 
+const invalidatePermissionSnapshotAfterLogin = async (instanceId: string | undefined, keycloakSubject: string) => {
+  if (!instanceId) {
+    return;
+  }
+
+  try {
+    await withInstanceDb(instanceId, (client) =>
+      notifyPermissionInvalidation(client, {
+        instanceId,
+        keycloakSubject,
+        trigger: 'user_login',
+      })
+    );
+  } catch (error) {
+    logger.error('Permission snapshot invalidation failed after callback', {
+      operation: 'permission_invalidation',
+      user_id: keycloakSubject,
+      instance_id: instanceId,
+      error: error instanceof Error ? error.message : String(error),
+      ...buildLogContext(instanceId),
+    });
+  }
+};
+
 const exchangeAuthorizationCode = async (input: {
   authConfig: AuthConfig;
   callbackUrl: URL;
@@ -290,6 +316,7 @@ export const handleCallback = async (params: {
   });
 
   await syncJitProvisioning(persisted.user.instanceId, persisted.user.id);
+  await invalidatePermissionSnapshotAfterLogin(persisted.user.instanceId, persisted.user.id);
 
   logger.debug('Session created for authenticated user', {
     operation: 'session_create',

--- a/packages/auth-runtime/src/auth-server/callback.ts
+++ b/packages/auth-runtime/src/auth-server/callback.ts
@@ -3,15 +3,13 @@ import { createSdkLogger } from '@sva/server-runtime';
 import { z } from 'zod';
 
 import { getAuthConfig } from '../config.js';
-import { withInstanceDb } from '../db.js';
-import { jitProvisionAccount } from '../jit-provisioning.js';
 import { buildLogContext } from '../log-context.js';
 import { client, getOidcConfig, invalidateOidcConfig } from '../oidc.js';
 import { consumeLoginState, createSession, getSessionControlState } from '../redis-session.js';
 import { isRetryableTokenExchangeError } from '../error-guards.js';
-import { notifyPermissionInvalidation } from '../iam-account-management/shared-activity.js';
 import { getScopeFromAuthConfig } from '../scope.js';
 import type { AuthConfig, InstanceScopeRef, LoginState, PlatformScopeRef, ScopeKind } from '../types.js';
+import { runPostLoginTasks } from './post-login-tasks.js';
 import { buildSessionUser, resolveSessionExpiry } from './shared.js';
 
 const logger = createSdkLogger({ component: 'iam-auth', level: 'info' });
@@ -192,44 +190,6 @@ const persistSession = async (input: {
   return { sessionId, user, expiresAt };
 };
 
-const syncJitProvisioning = async (instanceId: string | undefined, keycloakSubject: string) => {
-  try {
-    await jitProvisionAccount({ instanceId, keycloakSubject });
-  } catch (error) {
-    logger.error('JIT provisioning failed after callback', {
-      operation: 'jit_provision',
-      user_id: keycloakSubject,
-      instance_id: instanceId,
-      error: error instanceof Error ? error.message : String(error),
-      ...buildLogContext(instanceId),
-    });
-  }
-};
-
-const invalidatePermissionSnapshotAfterLogin = async (instanceId: string | undefined, keycloakSubject: string) => {
-  if (!instanceId) {
-    return;
-  }
-
-  try {
-    await withInstanceDb(instanceId, (client) =>
-      notifyPermissionInvalidation(client, {
-        instanceId,
-        keycloakSubject,
-        trigger: 'user_login',
-      })
-    );
-  } catch (error) {
-    logger.error('Permission snapshot invalidation failed after callback', {
-      operation: 'permission_invalidation',
-      user_id: keycloakSubject,
-      instance_id: instanceId,
-      error: error instanceof Error ? error.message : String(error),
-      ...buildLogContext(instanceId),
-    });
-  }
-};
-
 const exchangeAuthorizationCode = async (input: {
   authConfig: AuthConfig;
   callbackUrl: URL;
@@ -315,8 +275,7 @@ export const handleCallback = async (params: {
     }),
   });
 
-  await syncJitProvisioning(persisted.user.instanceId, persisted.user.id);
-  await invalidatePermissionSnapshotAfterLogin(persisted.user.instanceId, persisted.user.id);
+  await runPostLoginTasks(persisted.user.instanceId, persisted.user.id);
 
   logger.debug('Session created for authenticated user', {
     operation: 'session_create',

--- a/packages/auth-runtime/src/auth-server/post-login-tasks.test.ts
+++ b/packages/auth-runtime/src/auth-server/post-login-tasks.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  logger: {
+    error: vi.fn(),
+  },
+  jitProvisionAccount: vi.fn(),
+  withInstanceDb: vi.fn(),
+  notifyPermissionInvalidation: vi.fn(),
+}));
+
+vi.mock('@sva/server-runtime', () => ({
+  createSdkLogger: () => mocks.logger,
+}));
+
+vi.mock('../jit-provisioning.js', () => ({
+  jitProvisionAccount: mocks.jitProvisionAccount,
+}));
+
+vi.mock('../db.js', () => ({
+  withInstanceDb: mocks.withInstanceDb,
+}));
+
+vi.mock('../iam-account-management/shared-activity.js', () => ({
+  notifyPermissionInvalidation: mocks.notifyPermissionInvalidation,
+}));
+
+vi.mock('../log-context.js', () => ({
+  buildLogContext: vi.fn(() => ({ trace_id: 'trace-test' })),
+}));
+
+describe('runPostLoginTasks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.jitProvisionAccount.mockResolvedValue(undefined);
+    mocks.notifyPermissionInvalidation.mockResolvedValue(undefined);
+    mocks.withInstanceDb.mockImplementation(async (_instanceId, work) => work({ query: vi.fn() }));
+  });
+
+  it('runs jit provisioning and invalidates permission snapshots for instance users', async () => {
+    const { runPostLoginTasks } = await import('./post-login-tasks.js');
+
+    await runPostLoginTasks('de-test', 'kc-user-1');
+
+    expect(mocks.jitProvisionAccount).toHaveBeenCalledWith({
+      instanceId: 'de-test',
+      keycloakSubject: 'kc-user-1',
+    });
+    expect(mocks.withInstanceDb).toHaveBeenCalledWith('de-test', expect.any(Function));
+    expect(mocks.notifyPermissionInvalidation).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.any(Function) }),
+      {
+        instanceId: 'de-test',
+        keycloakSubject: 'kc-user-1',
+        trigger: 'user_login',
+      }
+    );
+  });
+
+  it('skips permission invalidation when the session has no instance context', async () => {
+    const { runPostLoginTasks } = await import('./post-login-tasks.js');
+
+    await runPostLoginTasks(undefined, 'kc-user-1');
+
+    expect(mocks.jitProvisionAccount).toHaveBeenCalledWith({
+      instanceId: undefined,
+      keycloakSubject: 'kc-user-1',
+    });
+    expect(mocks.withInstanceDb).not.toHaveBeenCalled();
+    expect(mocks.notifyPermissionInvalidation).not.toHaveBeenCalled();
+  });
+
+  it('logs and swallows jit provisioning failures before continuing with invalidation', async () => {
+    const { runPostLoginTasks } = await import('./post-login-tasks.js');
+
+    mocks.jitProvisionAccount.mockRejectedValueOnce(new Error('jit unavailable'));
+
+    await runPostLoginTasks('de-test', 'kc-user-1');
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'JIT provisioning failed after callback',
+      expect.objectContaining({
+        operation: 'jit_provision',
+        user_id: 'kc-user-1',
+        instance_id: 'de-test',
+        error: 'jit unavailable',
+      })
+    );
+    expect(mocks.withInstanceDb).toHaveBeenCalledWith('de-test', expect.any(Function));
+  });
+});

--- a/packages/auth-runtime/src/auth-server/post-login-tasks.ts
+++ b/packages/auth-runtime/src/auth-server/post-login-tasks.ts
@@ -1,0 +1,44 @@
+import { createSdkLogger } from '@sva/server-runtime';
+
+import { withInstanceDb } from '../db.js';
+import { jitProvisionAccount } from '../jit-provisioning.js';
+import { notifyPermissionInvalidation } from '../iam-account-management/shared-activity.js';
+import { buildLogContext } from '../log-context.js';
+
+const logger = createSdkLogger({ component: 'iam-auth', level: 'info' });
+
+export const runPostLoginTasks = async (instanceId: string | undefined, keycloakSubject: string) => {
+  try {
+    await jitProvisionAccount({ instanceId, keycloakSubject });
+  } catch (error) {
+    logger.error('JIT provisioning failed after callback', {
+      operation: 'jit_provision',
+      user_id: keycloakSubject,
+      instance_id: instanceId,
+      error: error instanceof Error ? error.message : String(error),
+      ...buildLogContext(instanceId),
+    });
+  }
+
+  if (!instanceId) {
+    return;
+  }
+
+  try {
+    await withInstanceDb(instanceId, (client) =>
+      notifyPermissionInvalidation(client, {
+        instanceId,
+        keycloakSubject,
+        trigger: 'user_login',
+      })
+    );
+  } catch (error) {
+    logger.error('Permission snapshot invalidation failed after callback', {
+      operation: 'permission_invalidation',
+      user_id: keycloakSubject,
+      instance_id: instanceId,
+      error: error instanceof Error ? error.message : String(error),
+      ...buildLogContext(instanceId),
+    });
+  }
+};

--- a/packages/auth-runtime/src/iam-groups/handlers.ts
+++ b/packages/auth-runtime/src/iam-groups/handlers.ts
@@ -16,6 +16,7 @@ import {
 import { validateCsrf } from '../iam-account-management/csrf.js';
 import {
   emitActivityLog,
+  notifyPermissionInvalidation,
   requireRoles,
   resolveActorInfo,
   withInstanceScopedDb,
@@ -47,6 +48,7 @@ const groupMutationHandlers = createGroupMutationHandlers({
   isUuid,
   jsonResponse,
   logger,
+  notifyPermissionInvalidation,
   parseRequestBody,
   publishGroupEvent,
   randomUUID,

--- a/packages/iam-admin/src/group-mutation-handlers.test.ts
+++ b/packages/iam-admin/src/group-mutation-handlers.test.ts
@@ -50,6 +50,7 @@ const createDeps = (
       error: vi.fn(),
       info: vi.fn(),
     },
+    notifyPermissionInvalidation: vi.fn(async () => undefined),
     parseRequestBody: vi.fn(async () => ({
       ok: true as const,
       data: {
@@ -501,6 +502,14 @@ describe('createGroupMutationHandlers', () => {
         payload: { group_id: groupId, account_id: 'account-1' },
       })
     );
+    expect(deps.notifyPermissionInvalidation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        instanceId: 'inst-g',
+        keycloakSubject: 'kc-user-1',
+        trigger: 'user_group_changed',
+      })
+    );
   });
 
   it('logs and maps unexpected membership assignment failures', async () => {
@@ -577,6 +586,14 @@ describe('createGroupMutationHandlers', () => {
       expect.objectContaining({
         eventType: 'iam_group_member_removed',
         payload: { group_id: groupId, account_id: 'account-1' },
+      })
+    );
+    expect(deps.notifyPermissionInvalidation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        instanceId: 'inst-g',
+        keycloakSubject: 'kc-user-1',
+        trigger: 'user_group_changed',
       })
     );
   });

--- a/packages/iam-admin/src/group-mutation-handlers.ts
+++ b/packages/iam-admin/src/group-mutation-handlers.ts
@@ -173,6 +173,18 @@ const readGroupIdOrError = (
   return groupId;
 };
 
+const invalidateMembershipPermissionSnapshot = (
+  deps: GroupMutationHandlerDeps,
+  client: GroupQueryClient,
+  actor: GroupMutationActor,
+  keycloakSubject: string
+) =>
+  deps.notifyPermissionInvalidation(client, {
+    instanceId: actor.instanceId,
+    keycloakSubject,
+    trigger: 'user_group_changed',
+  });
+
 const resolveAccountId = async (
   client: GroupQueryClient,
   input: { readonly instanceId: string; readonly keycloakSubject: string }
@@ -657,11 +669,7 @@ ON CONFLICT (instance_id, account_id, group_id) DO UPDATE
           traceId: actor.traceId,
         });
 
-        await deps.notifyPermissionInvalidation(client, {
-          instanceId: actor.instanceId,
-          keycloakSubject: body.data.keycloakSubject,
-          trigger: 'user_group_changed',
-        });
+        await invalidateMembershipPermissionSnapshot(deps, client, actor, body.data.keycloakSubject);
       });
 
       deps.logger.info('Group membership assigned', {
@@ -751,11 +759,7 @@ WHERE instance_id = $1
           traceId: actor.traceId,
         });
 
-        await deps.notifyPermissionInvalidation(client, {
-          instanceId: actor.instanceId,
-          keycloakSubject: body.data.keycloakSubject,
-          trigger: 'user_group_changed',
-        });
+        await invalidateMembershipPermissionSnapshot(deps, client, actor, body.data.keycloakSubject);
       });
 
       deps.logger.info('Group membership removed', {

--- a/packages/iam-admin/src/group-mutation-handlers.ts
+++ b/packages/iam-admin/src/group-mutation-handlers.ts
@@ -102,6 +102,14 @@ export type GroupMutationHandlerDeps = {
   readonly isUuid: (value: string) => boolean;
   readonly jsonResponse: (status: number, payload: unknown) => Response;
   readonly logger: GroupMutationLogger;
+  readonly notifyPermissionInvalidation: (
+    client: GroupQueryClient,
+    input: {
+      readonly instanceId: string;
+      readonly keycloakSubject?: string;
+      readonly trigger: 'user_group_changed';
+    }
+  ) => Promise<void>;
   readonly parseRequestBody: <TData>(
     request: Request,
     schema: z.ZodType<TData>
@@ -648,6 +656,12 @@ ON CONFLICT (instance_id, account_id, group_id) DO UPDATE
           requestId: actor.requestId,
           traceId: actor.traceId,
         });
+
+        await deps.notifyPermissionInvalidation(client, {
+          instanceId: actor.instanceId,
+          keycloakSubject: body.data.keycloakSubject,
+          trigger: 'user_group_changed',
+        });
       });
 
       deps.logger.info('Group membership assigned', {
@@ -735,6 +749,12 @@ WHERE instance_id = $1
           payload: { group_id: groupId, account_id: accountId },
           requestId: actor.requestId,
           traceId: actor.traceId,
+        });
+
+        await deps.notifyPermissionInvalidation(client, {
+          instanceId: actor.instanceId,
+          keycloakSubject: body.data.keycloakSubject,
+          trigger: 'user_group_changed',
         });
       });
 


### PR DESCRIPTION
## Was sich ändert

Dieser PR behebt zwei eng zusammenhängende IAM/Admin-Probleme:

- Permission-Snapshots werden nach gruppenbasierten Berechtigungsänderungen und nach einem erfolgreichen Login gezielt invalidiert.
- Inaktive Accounts können in der Accountübersicht wieder aktiviert werden, inklusive Bestätigungsdialog.

## Warum das nötig ist

Nach Gruppenänderungen oder einem frischen Login konnte ein laufender App-Prozess noch veraltete Permission-Snapshots ausliefern. Das führte lokal dazu, dass Nutzer trotz vorhandener Rollen und Gruppen keine `permissionActions` sahen.

Zusätzlich war die Reaktivierung von Accounts bisher nur in der Detailansicht möglich, nicht aber direkt in der Übersicht.

## Auswirkungen

- Rechteänderungen aus Gruppenmitgliedschaften werden im laufenden System schneller sichtbar.
- Ein neuer Login leert den Permission-Cache für das betroffene Subject ebenfalls.
- Admins können deaktivierte Accounts jetzt direkt aus der Listenansicht wieder aktivieren.

## Root Cause

- Die neuen Group-Membership-Handler schrieben `iam.account_groups`, haben aber keinen Permission-Invalidation-Hook ausgelöst.
- Der erfolgreiche Auth-Callback erzeugte die Session, invalidierte aber den Permission-Snapshot des Subjects nicht.
- Die User-Liste hatte nur einen Deaktivieren-Pfad, obwohl die zugrunde liegende Statusmutation auch `active` unterstützt.

## Validierung

- `pnpm nx run iam-admin:test:unit --testFiles=src/group-mutation-handlers.test.ts`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/auth-server/callback.test.ts`
- `pnpm nx run iam-admin:test:types`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run auth-runtime:check:runtime`
- `pnpm nx run sva-studio-react:test:unit --testFiles=src/routes/admin/users/-user-list-page.test.tsx`
- `pnpm nx run sva-studio-react:test:types`
