### PR TITLE
[codex] Add tenant admin reset quick action

### DIFF
--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.test.tsx
@@ -306,6 +306,36 @@ describe('InstanceDetailPage', () => {
     });
   });
 
+  it('shows a visible tenant-admin reset action inside the overview card and triggers the existing repair intent', async () => {
+    const executeKeycloakProvisioning = vi.fn().mockResolvedValue(true);
+    const loadInstance = vi.fn().mockResolvedValue(true);
+
+    useInstancesMock.mockReturnValue(
+      createInstancesApiState({
+        executeKeycloakProvisioning,
+        loadInstance,
+      })
+    );
+
+    render(<InstanceDetailPage instanceId="demo" />);
+
+    const overviewCard = screen.getByTestId('instance-operations-overview');
+
+    const repairButton = within(overviewCard).getByRole('button', {
+      name: 'Tenant-Admin neu setzen',
+    });
+
+    fireEvent.click(repairButton);
+
+    await waitFor(() => {
+      expect(executeKeycloakProvisioning).toHaveBeenCalledWith('demo', {
+        intent: 'reset_tenant_admin',
+        tenantAdminTemporaryPassword: undefined,
+      });
+    });
+    expect(loadInstance).toHaveBeenCalledWith('demo');
+  });
+
   it('shows a visible warning when a provisioning run stays queued without a worker', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-06T12:00:00.000Z').getTime());
 

--- a/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instance-detail-page.tsx
@@ -238,16 +238,20 @@ const OperationsOverviewCard = ({
   title,
   summary,
   primaryActionLabel,
+  secondaryActionLabel,
   onPrimaryAction,
+  onSecondaryAction,
   disabled,
 }: {
   title: string;
   summary: string;
   primaryActionLabel: string;
+  secondaryActionLabel?: string;
   onPrimaryAction: () => void;
+  onSecondaryAction?: () => void;
   disabled: boolean;
 }) => (
-  <Card className="space-y-4 p-5">
+  <Card data-testid="instance-operations-overview" className="space-y-4 p-5">
     <div className="space-y-1">
       <div className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
         {t('admin.instances.operations.overview.eyebrow')}
@@ -259,6 +263,11 @@ const OperationsOverviewCard = ({
       <Button type="button" onClick={onPrimaryAction} disabled={disabled}>
         {primaryActionLabel}
       </Button>
+      {secondaryActionLabel && onSecondaryAction ? (
+        <Button type="button" variant="outline" onClick={onSecondaryAction} disabled={disabled}>
+          {secondaryActionLabel}
+        </Button>
+      ) : null}
     </div>
   </Card>
 );
@@ -516,6 +525,10 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
     }
   };
 
+  const repairTenantAdmin = async () => {
+    await executeProvisioning('reset_tenant_admin');
+  };
+
   const probeTenantIamAccess = async () => {
     if (!selectedInstance) {
       return;
@@ -655,7 +668,13 @@ export const InstanceDetailPage = ({ instanceId }: InstanceDetailPageProps) => {
                   : t('admin.instances.operations.existing.title')}
                 summary={operationsModel.summary}
                 primaryActionLabel={primaryAction.label}
+                secondaryActionLabel={selectedInstance.tenantAdminBootstrap?.username?.trim()
+                  ? t('admin.instances.actions.resetTenantAdmin')
+                  : undefined}
                 onPrimaryAction={() => void runDetailAction(primaryAction.action)}
+                onSecondaryAction={selectedInstance.tenantAdminBootstrap?.username?.trim()
+                  ? () => void repairTenantAdmin()
+                  : undefined}
                 disabled={instancesApi.statusLoading}
               />
 


### PR DESCRIPTION
## Was geaendert wurde

- Auf der Instanz-Detailseite im Ueberblick gibt es jetzt einen sichtbaren Schnellzugriff `Tenant-Admin neu setzen`.

- Der Button nutzt den bestehenden Provisioning-Intent `reset_tenant_admin`, statt einen neuen Backend-Pfad einzufuehren.

- Ein UI-Test deckt den sichtbaren Button und das Ausloesen des bestehenden Repair-Flows ab.

## Warum
- Der initial konfigurierte Tenant-Admin braucht einen direkten, schnellen Weg, um die lokale `system_admin`-Zuweisung erneut zu synchronisieren, wenn im Tenant noch keine effektiven IAM-Berechtigungen ankommen.

## Auswirkungen

- Root-Admins koennen den konfigurierten initialen Tenant-Admin direkt aus dem Instanz-Cockpit reparieren.

- Kein neuer fachlicher Workflow; nur ein besser sichtbarer Einstieg auf den bereits vorhandenen Repair-Mechanismus.

## Validierung
- `pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/admin/instances/-instance-detail-page.test.tsx`

- Lokaler PR-Gate wurde auf ausdruecklichen Wunsch nicht vollstaendig ausgefuehrt.






