### PR TITLE
[codex] Add public waste web release pipeline

### DIFF
--- a/.github/workflows/public-waste-web-release.yml
+++ b/.github/workflows/public-waste-web-release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Release Public Waste Web
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: public-waste-production
+    environment: web-waste-calendar
     env:
       PUBLIC_WASTE_BASE_URL: ${{ vars.PUBLIC_WASTE_BASE_URL }}
       PUBLIC_WASTE_STACK_NAME: ${{ vars.PUBLIC_WASTE_STACK_NAME || 'web-waste-calendar' }}

--- a/.github/workflows/public-waste-web-release.yml
+++ b/.github/workflows/public-waste-web-release.yml
@@ -21,7 +21,7 @@ jobs:
     environment: public-waste-production
     env:
       PUBLIC_WASTE_BASE_URL: ${{ vars.PUBLIC_WASTE_BASE_URL }}
-      PUBLIC_WASTE_STACK_NAME: ${{ vars.PUBLIC_WASTE_STACK_NAME || 'public-waste-calendar' }}
+      PUBLIC_WASTE_STACK_NAME: ${{ vars.PUBLIC_WASTE_STACK_NAME || 'web-waste-calendar' }}
       QUANTUM_ENDPOINT_ID: ${{ vars.QUANTUM_ENDPOINT_ID }}
       QUANTUM_HOST: ${{ vars.QUANTUM_HOST }}
       QUANTUM_API_KEY: ${{ secrets.QUANTUM_API_KEY }}

--- a/.github/workflows/public-waste-web-release.yml
+++ b/.github/workflows/public-waste-web-release.yml
@@ -1,0 +1,117 @@
+name: Public Waste Web Release
+
+on:
+  push:
+    tags:
+      - 'waste-web-v*.*.*'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: public-waste-web-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release Public Waste Web
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: public-waste-production
+    env:
+      PUBLIC_WASTE_BASE_URL: ${{ vars.PUBLIC_WASTE_BASE_URL }}
+      PUBLIC_WASTE_STACK_NAME: ${{ vars.PUBLIC_WASTE_STACK_NAME || 'public-waste-calendar' }}
+      QUANTUM_ENDPOINT_ID: ${{ vars.QUANTUM_ENDPOINT_ID }}
+      QUANTUM_HOST: ${{ vars.QUANTUM_HOST }}
+      QUANTUM_API_KEY: ${{ secrets.QUANTUM_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          filter: tree:0
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-pnpm-workspace
+
+      - name: Resolve release metadata
+        id: release
+        run: |
+          set -euo pipefail
+          if [[ ! "${GITHUB_REF}" =~ ^refs/tags/waste-web-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "Ungueltiges Release-Tag: ${GITHUB_REF}" >&2
+            exit 1
+          fi
+          version="${BASH_REMATCH[1]}"
+          image_tag="v${version}"
+          image_name="ghcr.io/smart-village-solutions/public-waste-calendar-web:${image_tag}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "image_tag=${image_tag}" >> "${GITHUB_OUTPUT}"
+          echo "image_name=${image_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify release script contract
+        run: |
+          pnpm exec vitest run scripts/ops/public-waste/portainer-release.test.ts
+          pnpm exec tsc -p tsconfig.scripts.json --noEmit
+
+      - name: Build public waste app
+        run: pnpm nx run public-waste-calendar-web:build
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Build and push public waste image
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/amd64 \
+            --progress=plain \
+            --provenance=false \
+            --sbom=false \
+            -f deploy/portainer/Dockerfile.public-waste \
+            -t "${{ steps.release.outputs.image_name }}" \
+            --push \
+            .
+
+      - name: Update Portainer stack image tag
+        run: pnpm exec tsx scripts/ops/public-waste/portainer-release.ts
+
+      - name: Wait for deployed runtime
+        run: |
+          set -euo pipefail
+          base_url="${PUBLIC_WASTE_BASE_URL%/}"
+          if [ -z "${base_url}" ]; then
+            echo "PUBLIC_WASTE_BASE_URL fehlt." >&2
+            exit 1
+          fi
+
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error "${base_url}/health/live" >/dev/null; then
+              break
+            fi
+            echo "Warte auf Runtime-Rollout (${attempt}/30)..."
+            sleep 10
+          done
+
+          curl --fail --silent --show-error "${base_url}/health/live"
+          curl --fail --silent --show-error "${base_url}/" | grep -q '<div id="root"></div>'
+          curl --fail --silent --show-error "${base_url}/api/public-waste/selection" >/dev/null
+
+      - name: Publish release summary
+        if: always()
+        run: |
+          echo 'Public-Waste-Web-Release abgeschlossen.' >> "$GITHUB_STEP_SUMMARY"
+          echo "Git-Tag: \`${GITHUB_REF_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Image-Tag: \`${{ steps.release.outputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Stack: \`${PUBLIC_WASTE_STACK_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${PUBLIC_WASTE_BASE_URL}" ]; then
+            echo "Smoke-URL: \`${PUBLIC_WASTE_BASE_URL}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.quantum
+++ b/.quantum
@@ -6,5 +6,7 @@ environments:
     compose: deploy/portainer/docker-compose.yml
   - name: demo
     compose: deploy/portainer/docker-compose.demo.yml
+  - name: public-waste
+    compose: deploy/portainer/docker-compose.public-waste.yml
   - name: studio
     compose: deploy/portainer/docker-compose.studio.yml

--- a/apps/public-waste-calendar-web/package.json
+++ b/apps/public-waste-calendar-web/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3002",
-    "build": "vite build",
+    "build": "rm -rf dist && vite build --outDir dist/client && pnpm exec tsc -p tsconfig.server.json",
     "preview": "vite preview",
+    "start": "node dist/server/server/main.js",
     "test": "vitest run --passWithNoTests",
     "test:e2e": "playwright test --config playwright.config.ts"
   },

--- a/apps/public-waste-calendar-web/project.json
+++ b/apps/public-waste-calendar-web/project.json
@@ -29,6 +29,13 @@
         "command": "pnpm run preview"
       }
     },
+    "start": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/public-waste-calendar-web",
+        "command": "pnpm run start"
+      }
+    },
     "test:unit": {
       "executor": "nx:run-commands",
       "cache": true,

--- a/apps/public-waste-calendar-web/public-waste-config.example.json
+++ b/apps/public-waste-calendar-web/public-waste-config.example.json
@@ -2,9 +2,9 @@
   "instanceId": "bb-prignitz",
   "supabase": {
     "databaseUrl": "${PUBLIC_WASTE_DATABASE_URL}",
-    "schemaName": "public"
+    "schemaName": "${PUBLIC_WASTE_SCHEMA_NAME}"
   },
   "pdf": {
-    "urlTemplate": "https://example.invalid/waste/{locationKey}/{year}.pdf"
+    "urlTemplate": "${PUBLIC_WASTE_PDF_URL_TEMPLATE}"
   }
 }

--- a/apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolvePublicWasteBootstrapState } from './public-waste-bootstrap.server.js';
+import {
+  readPublicWasteBootstrapStateFromEnvironment,
+  resolvePublicWasteBootstrapState,
+} from './public-waste-bootstrap.server.js';
 
 describe('public waste bootstrap', () => {
   it('returns a missing-config error state when no raw config is provided', () => {
@@ -19,6 +22,44 @@ describe('public waste bootstrap', () => {
     ).toMatchObject({
       status: 'error',
       reason: 'invalid_config',
+    });
+  });
+
+  it('prefers split PUBLIC_WASTE_* variables and only falls back to PUBLIC_WASTE_CONFIG_JSON when needed', () => {
+    expect(
+      readPublicWasteBootstrapStateFromEnvironment({
+        env: {
+          PUBLIC_WASTE_INSTANCE_ID: 'bb-prignitz-env',
+          PUBLIC_WASTE_DATABASE_URL: 'postgres://env',
+          PUBLIC_WASTE_SCHEMA_NAME: 'public-env',
+          PUBLIC_WASTE_PDF_URL_TEMPLATE: 'https://env.invalid/{locationKey}/{year}.pdf',
+        },
+        rawConfigJson: JSON.stringify({
+          instanceId: 'bb-prignitz-json',
+          supabase: { databaseUrl: 'postgres://json', schemaName: 'public-json' },
+          pdf: { urlTemplate: 'https://json.invalid/{locationKey}/{year}.pdf' },
+        }),
+      })
+    ).toMatchObject({
+      status: 'ready',
+      config: {
+        instanceId: 'bb-prignitz-env',
+      },
+    });
+
+    expect(
+      readPublicWasteBootstrapStateFromEnvironment({
+        rawConfigJson: JSON.stringify({
+          instanceId: 'bb-prignitz-json',
+          supabase: { databaseUrl: 'postgres://json', schemaName: 'public-json' },
+          pdf: { urlTemplate: 'https://json.invalid/{locationKey}/{year}.pdf' },
+        }),
+      })
+    ).toMatchObject({
+      status: 'ready',
+      config: {
+        instanceId: 'bb-prignitz-json',
+      },
     });
   });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.ts
@@ -1,5 +1,6 @@
 import {
   parsePublicWasteConfig,
+  readPublicWasteConfigFromEnvironment,
   type PublicWasteConfig,
 } from './public-waste-config.server.js';
 
@@ -47,9 +48,17 @@ export const resolvePublicWasteBootstrapState = (rawConfig: unknown): PublicWast
 };
 
 export const readPublicWasteBootstrapStateFromEnvironment = (input: {
+  readonly env?: NodeJS.ProcessEnv;
   readonly rawConfigJson?: string | undefined;
 } = {}): PublicWasteBootstrapState => {
-  const rawConfigJson = input.rawConfigJson ?? process.env.PUBLIC_WASTE_CONFIG_JSON;
+  const env = input.env ?? process.env;
+  const configFromEnvironment = readPublicWasteConfigFromEnvironment(env);
+
+  if (configFromEnvironment !== null) {
+    return resolvePublicWasteBootstrapState(configFromEnvironment);
+  }
+
+  const rawConfigJson = input.rawConfigJson ?? env.PUBLIC_WASTE_CONFIG_JSON;
 
   if (!rawConfigJson) {
     return resolvePublicWasteBootstrapState(undefined);

--- a/apps/public-waste-calendar-web/src/lib/public-waste-config.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-config.server.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { parsePublicWasteConfig } from './public-waste-config.server.js';
+import {
+  parsePublicWasteConfig,
+  readPublicWasteConfigFromEnvironment,
+} from './public-waste-config.server.js';
 
 describe('public waste config', () => {
   it('rejects incomplete server-only config deterministically', () => {
@@ -10,5 +13,25 @@ describe('public waste config', () => {
         supabase: { databaseUrl: '', schemaName: 'waste' },
       })
     ).toThrow('public_waste_config_invalid');
+  });
+
+  it('reads production config from split PUBLIC_WASTE_* environment variables', () => {
+    expect(
+      readPublicWasteConfigFromEnvironment({
+        PUBLIC_WASTE_INSTANCE_ID: 'bb-prignitz',
+        PUBLIC_WASTE_DATABASE_URL: 'postgres://example',
+        PUBLIC_WASTE_SCHEMA_NAME: 'public',
+        PUBLIC_WASTE_PDF_URL_TEMPLATE: 'https://example.invalid/{locationKey}/{year}.pdf',
+      })
+    ).toEqual({
+      instanceId: 'bb-prignitz',
+      supabase: {
+        databaseUrl: 'postgres://example',
+        schemaName: 'public',
+      },
+      pdf: {
+        urlTemplate: 'https://example.invalid/{locationKey}/{year}.pdf',
+      },
+    });
   });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-config.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-config.server.ts
@@ -51,3 +51,27 @@ export const parsePublicWasteConfig = (input: unknown): PublicWasteConfig => {
     },
   };
 };
+
+export const readPublicWasteConfigFromEnvironment = (
+  env: NodeJS.ProcessEnv = process.env
+): PublicWasteConfig | null => {
+  const instanceId = readString(env.PUBLIC_WASTE_INSTANCE_ID);
+  const databaseUrl = readString(env.PUBLIC_WASTE_DATABASE_URL);
+  const schemaName = readString(env.PUBLIC_WASTE_SCHEMA_NAME);
+  const urlTemplate = readString(env.PUBLIC_WASTE_PDF_URL_TEMPLATE);
+
+  if (instanceId === null || databaseUrl === null || schemaName === null || urlTemplate === null) {
+    return null;
+  }
+
+  return {
+    instanceId,
+    supabase: {
+      databaseUrl,
+      schemaName,
+    },
+    pdf: {
+      urlTemplate,
+    },
+  };
+};

--- a/apps/public-waste-calendar-web/src/server.ts
+++ b/apps/public-waste-calendar-web/src/server.ts
@@ -3,5 +3,6 @@ import { readPublicWasteBootstrapStateFromEnvironment } from './lib/public-waste
 export const publicWasteServerEntry = 'public-waste-calendar-web';
 
 export const bootstrapPublicWasteServer = (input: {
+  readonly env?: NodeJS.ProcessEnv;
   readonly rawConfigJson?: string | undefined;
 } = {}) => readPublicWasteBootstrapStateFromEnvironment(input);

--- a/apps/public-waste-calendar-web/src/server/main.ts
+++ b/apps/public-waste-calendar-web/src/server/main.ts
@@ -1,0 +1,45 @@
+import { once } from 'node:events';
+
+import { createPublicWasteHttpServer } from './public-waste-http-server.js';
+import { createPublicWasteRuntime } from './public-waste-runtime.js';
+
+const port = Number.parseInt(process.env.PORT ?? '3002', 10);
+const host = process.env.HOST ?? '0.0.0.0';
+const assetsDir = new URL('../../client/', import.meta.url);
+
+const runtime = await createPublicWasteRuntime({
+  assetsDir: assetsDir.pathname,
+  env: process.env,
+});
+const server = createPublicWasteHttpServer({ runtime });
+
+const closeServer = async (): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+  await runtime.dispose();
+};
+
+const shutdown = async (): Promise<void> => {
+  process.off('SIGINT', handleSignal);
+  process.off('SIGTERM', handleSignal);
+  await closeServer();
+};
+
+const handleSignal = (): void => {
+  void shutdown().finally(() => {
+    process.exit(0);
+  });
+};
+
+process.on('SIGINT', handleSignal);
+process.on('SIGTERM', handleSignal);
+
+server.listen(port, host);
+await once(server, 'listening');

--- a/apps/public-waste-calendar-web/src/server/public-waste-http-server.test.ts
+++ b/apps/public-waste-calendar-web/src/server/public-waste-http-server.test.ts
@@ -1,0 +1,89 @@
+import { once } from 'node:events';
+import { request as httpRequest } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPublicWasteHttpServer } from './public-waste-http-server.js';
+
+const runningServers = new Set<ReturnType<typeof createPublicWasteHttpServer>>();
+
+afterEach(async () => {
+  await Promise.all(
+    [...runningServers].map(
+      async (server) =>
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        })
+    )
+  );
+  runningServers.clear();
+});
+
+describe('public waste http server', () => {
+  it('forwards requests to the runtime handler and writes the response back', async () => {
+    const handle = vi.fn(async (request: Request) => {
+      expect(new URL(request.url).pathname).toBe('/health/live');
+      return new Response('ok', {
+        status: 200,
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+          'x-runtime': 'public-waste',
+        },
+      });
+    });
+
+    const server = createPublicWasteHttpServer({
+      runtime: {
+        handle,
+      },
+    });
+    runningServers.add(server);
+
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    const { port } = server.address() as AddressInfo;
+    const response = await new Promise<{
+      readonly status: number;
+      readonly headers: Record<string, string | string[] | undefined>;
+      readonly body: string;
+    }>((resolve, reject) => {
+      const request = httpRequest(
+        {
+          host: '127.0.0.1',
+          port,
+          path: '/health/live',
+          method: 'GET',
+        },
+        (result) => {
+          let body = '';
+          result.setEncoding('utf8');
+          result.on('data', (chunk) => {
+            body += chunk;
+          });
+          result.on('end', () => {
+            resolve({
+              status: result.statusCode ?? 0,
+              headers: result.headers,
+              body,
+            });
+          });
+        }
+      );
+
+      request.on('error', reject);
+      request.end();
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-runtime']).toBe('public-waste');
+    expect(response.body).toBe('ok');
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/public-waste-calendar-web/src/server/public-waste-http-server.ts
+++ b/apps/public-waste-calendar-web/src/server/public-waste-http-server.ts
@@ -1,0 +1,85 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+
+import type { PublicWasteRuntime } from './public-waste-runtime.js';
+
+const normalizeForwardedProto = (value: string | readonly string[] | undefined): string | null => {
+  if (typeof value === 'string') {
+    return value.split(',')[0]?.trim() ?? null;
+  }
+
+  if (Array.isArray(value)) {
+    return value[0]?.trim() ?? null;
+  }
+
+  return null;
+};
+
+const readRequestBody = async (request: IncomingMessage): Promise<Buffer> => {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+
+  return Buffer.concat(chunks);
+};
+
+const toRequest = async (request: IncomingMessage): Promise<Request> => {
+  const method = (request.method ?? 'GET').toUpperCase();
+  const protocol = normalizeForwardedProto(request.headers['x-forwarded-proto']) ?? 'http';
+  const host = request.headers.host ?? 'localhost';
+  const url = new URL(request.url ?? '/', `${protocol}://${host}`);
+  const headers = new Headers();
+
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (typeof value === 'string') {
+      headers.set(key, value);
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      headers.set(key, value.join(', '));
+    }
+  }
+
+  if (method === 'GET' || method === 'HEAD') {
+    return new Request(url, { method, headers });
+  }
+
+  const body = await readRequestBody(request);
+
+  return new Request(url, {
+    method,
+    headers,
+    body: new Uint8Array(body),
+  });
+};
+
+const writeResponse = async (nodeResponse: ServerResponse, response: Response): Promise<void> => {
+  nodeResponse.statusCode = response.status;
+  nodeResponse.statusMessage = response.statusText;
+  response.headers.forEach((value, key) => {
+    nodeResponse.setHeader(key, value);
+  });
+
+  if (!response.body) {
+    nodeResponse.end();
+    return;
+  }
+
+  nodeResponse.end(Buffer.from(await response.arrayBuffer()));
+};
+
+export const createPublicWasteHttpServer = (input: {
+  readonly runtime: Pick<PublicWasteRuntime, 'handle'>;
+}): Server =>
+  createServer(async (request, response) => {
+    try {
+      const runtimeResponse = await input.runtime.handle(await toRequest(request));
+      await writeResponse(response, runtimeResponse);
+    } catch (error) {
+      response.statusCode = 500;
+      response.setHeader('content-type', 'text/plain; charset=utf-8');
+      response.end('Internal Server Error');
+    }
+  });

--- a/apps/public-waste-calendar-web/src/server/public-waste-runtime.test.ts
+++ b/apps/public-waste-calendar-web/src/server/public-waste-runtime.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPublicWasteRuntime } from './public-waste-runtime.js';
+
+const createAssetsDir = async (): Promise<string> => {
+  const assetsDir = await mkdtemp(join(tmpdir(), 'public-waste-runtime-'));
+  await writeFile(join(assetsDir, 'index.html'), '<!doctype html><html><body>Public Waste</body></html>', 'utf8');
+  return assetsDir;
+};
+
+const cleanupPaths = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all([...cleanupPaths].map(async (path) => rm(path, { recursive: true, force: true })));
+  cleanupPaths.clear();
+});
+
+describe('public waste runtime', () => {
+  it('returns 200 for /health/live when config is valid', async () => {
+    const assetsDir = await createAssetsDir();
+    cleanupPaths.add(assetsDir);
+
+    const runtime = await createPublicWasteRuntime({
+      assetsDir,
+      env: {
+        PUBLIC_WASTE_INSTANCE_ID: 'bb-prignitz',
+        PUBLIC_WASTE_DATABASE_URL: 'postgres://example',
+        PUBLIC_WASTE_SCHEMA_NAME: 'public',
+        PUBLIC_WASTE_PDF_URL_TEMPLATE: 'https://example.invalid/{locationKey}/{year}.pdf',
+      },
+    });
+
+    const response = await runtime.handle(new Request('http://localhost/health/live'));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: 'ok',
+      app: 'public-waste-calendar-web',
+      instanceId: 'bb-prignitz',
+    });
+
+    await runtime.dispose();
+  });
+
+  it('returns 500 for API requests when runtime config is invalid', async () => {
+    const assetsDir = await createAssetsDir();
+    cleanupPaths.add(assetsDir);
+
+    const runtime = await createPublicWasteRuntime({
+      assetsDir,
+      env: {},
+    });
+
+    const response = await runtime.handle(new Request('http://localhost/api/public-waste/selection'));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'missing_config',
+    });
+
+    await runtime.dispose();
+  });
+});

--- a/apps/public-waste-calendar-web/src/server/public-waste-runtime.ts
+++ b/apps/public-waste-calendar-web/src/server/public-waste-runtime.ts
@@ -1,0 +1,232 @@
+import { readFile } from 'node:fs/promises';
+import { extname, resolve, sep } from 'node:path';
+import { Pool } from 'pg';
+
+import {
+  readPublicWasteBootstrapStateFromEnvironment,
+  type PublicWasteBootstrapState,
+} from '../lib/public-waste-bootstrap.server.js';
+import { type PublicWasteConfig } from '../lib/public-waste-config.server.js';
+import {
+  handlePublicWasteCalendarRequest,
+  handlePublicWasteIcalRequest,
+  handlePublicWasteSelectionRequest,
+} from '../lib/public-waste-endpoints.server.js';
+import { createPublicWasteRepository, type PublicWasteRepository } from '../lib/public-waste-repository.server.js';
+
+export const PUBLIC_WASTE_RUNTIME_APP_NAME = 'public-waste-calendar-web';
+
+type PublicWasteRuntimeRepository = Pick<
+  PublicWasteRepository,
+  'listSelectionOptions' | 'loadCalendarEntries' | 'loadSelectionSummary'
+>;
+
+type RepositoryHandle = {
+  readonly repository: PublicWasteRuntimeRepository;
+  readonly dispose: () => Promise<void>;
+};
+
+type RepositoryFactory = (config: PublicWasteConfig) => Promise<RepositoryHandle> | RepositoryHandle;
+
+export type PublicWasteRuntime = {
+  readonly bootstrapState: PublicWasteBootstrapState;
+  handle: (request: Request) => Promise<Response>;
+  dispose: () => Promise<void>;
+};
+
+const publicWasteApiPrefixes = [
+  '/api/public-waste/selection',
+  '/api/public-waste/calendar',
+  '/api/public-waste/ical',
+] as const;
+
+const staticMimeTypes: Readonly<Record<string, string>> = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webp': 'image/webp',
+};
+
+const jsonResponse = (payload: unknown, status = 200): Response =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+  });
+
+const createRepositoryHandle = async (config: PublicWasteConfig): Promise<RepositoryHandle> => {
+  const pool = new Pool({
+    connectionString: config.supabase.databaseUrl,
+    max: 4,
+    idleTimeoutMillis: 5_000,
+    connectionTimeoutMillis: 5_000,
+  });
+
+  return {
+    repository: createPublicWasteRepository({
+      schemaName: config.supabase.schemaName,
+      execute: async <TRow = Record<string, unknown>>(input: {
+        readonly text: string;
+        readonly values?: readonly unknown[];
+      }) => {
+        const result = await pool.query(input.text, input.values ? [...input.values] : undefined);
+        return {
+          rowCount: result.rowCount ?? 0,
+          rows: result.rows as readonly TRow[],
+        };
+      },
+    }),
+    dispose: async () => {
+      await pool.end();
+    },
+  };
+};
+
+const isPublicWasteApiPath = (pathname: string): boolean =>
+  publicWasteApiPrefixes.some((prefix) => pathname.startsWith(prefix));
+
+const createInvalidConfigResponse = (bootstrapState: PublicWasteBootstrapState): Response =>
+  jsonResponse(
+    {
+      error: bootstrapState.status === 'error' ? bootstrapState.reason : 'invalid_config',
+      message: bootstrapState.status === 'error' ? bootstrapState.message : 'Konfiguration ist ungültig.',
+    },
+    500
+  );
+
+const createMethodNotAllowedResponse = (): Response =>
+  new Response('Method Not Allowed', {
+    status: 405,
+    headers: {
+      allow: 'GET, HEAD',
+      'content-type': 'text/plain; charset=utf-8',
+    },
+  });
+
+const toHeadResponse = (response: Response): Response =>
+  new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+
+const resolveStaticAssetPath = (assetsDir: string, pathname: string): string => {
+  const relativePath =
+    pathname === '/' || extname(pathname).length === 0 ? '/index.html' : pathname;
+  const normalizedPath = relativePath.replace(/\\/g, '/');
+  const absolutePath = resolve(assetsDir, `.${normalizedPath}`);
+  const rootPath = resolve(assetsDir);
+
+  if (absolutePath !== rootPath && !absolutePath.startsWith(`${rootPath}${sep}`)) {
+    throw new Error('invalid_public_waste_asset_path');
+  }
+
+  return absolutePath;
+};
+
+const serveStaticAsset = async (input: {
+  readonly assetsDir: string;
+  readonly pathname: string;
+  readonly method: string;
+}): Promise<Response> => {
+  const filePath = resolveStaticAssetPath(input.assetsDir, input.pathname);
+
+  try {
+    const body = input.method === 'HEAD' ? null : await readFile(filePath);
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'content-type': staticMimeTypes[extname(filePath)] ?? 'application/octet-stream',
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return new Response('Not Found', {
+        status: 404,
+        headers: {
+          'content-type': 'text/plain; charset=utf-8',
+        },
+      });
+    }
+
+    throw error;
+  }
+};
+
+export const createPublicWasteRuntime = async (input: {
+  readonly assetsDir: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly createRepository?: RepositoryFactory;
+}): Promise<PublicWasteRuntime> => {
+  const bootstrapState = readPublicWasteBootstrapStateFromEnvironment({
+    env: input.env,
+  });
+  const repositoryHandle =
+    bootstrapState.status === 'ready'
+      ? await (input.createRepository ?? createRepositoryHandle)(bootstrapState.config)
+      : null;
+
+  return {
+    bootstrapState,
+    async handle(request) {
+      const url = new URL(request.url);
+      const method = request.method.toUpperCase();
+
+      if (method !== 'GET' && method !== 'HEAD') {
+        return createMethodNotAllowedResponse();
+      }
+
+      if (url.pathname === '/health/live') {
+        const response = jsonResponse({
+          status: 'ok',
+          app: PUBLIC_WASTE_RUNTIME_APP_NAME,
+          instanceId: bootstrapState.status === 'ready' ? bootstrapState.config.instanceId : null,
+        });
+
+        return method === 'HEAD' ? toHeadResponse(response) : response;
+      }
+
+      if (isPublicWasteApiPath(url.pathname)) {
+        if (bootstrapState.status !== 'ready' || !repositoryHandle) {
+          return createInvalidConfigResponse(bootstrapState);
+        }
+
+        let response: Response;
+        if (url.pathname.startsWith('/api/public-waste/selection')) {
+          response = await handlePublicWasteSelectionRequest({
+            repository: repositoryHandle.repository,
+            request,
+          });
+        } else if (url.pathname.startsWith('/api/public-waste/calendar')) {
+          response = await handlePublicWasteCalendarRequest({
+            repository: repositoryHandle.repository,
+            request,
+            pdfUrlTemplate: bootstrapState.config.pdf.urlTemplate,
+          });
+        } else {
+          response = await handlePublicWasteIcalRequest({
+            repository: repositoryHandle.repository,
+            request,
+          });
+        }
+
+        return method === 'HEAD' ? toHeadResponse(response) : response;
+      }
+
+      return serveStaticAsset({
+        assetsDir: input.assetsDir,
+        pathname: url.pathname,
+        method,
+      });
+    },
+    async dispose() {
+      await repositoryHandle?.dispose();
+    },
+  };
+};

--- a/apps/public-waste-calendar-web/tsconfig.server.json
+++ b/apps/public-waste-calendar-web/tsconfig.server.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist/server",
+    "rootDir": "src",
+    "types": ["node"],
+    "tsBuildInfoFile": "dist/.tsbuildinfo.server"
+  },
+  "include": [
+    "src/server/**/*.ts",
+    "src/lib/public-waste-api.ts",
+    "src/lib/public-waste-bootstrap.server.ts",
+    "src/lib/public-waste-calendar-occurrences.ts",
+    "src/lib/public-waste-config.server.ts",
+    "src/lib/public-waste-contract.ts",
+    "src/lib/public-waste-endpoints.server.ts",
+    "src/lib/public-waste-ical.server.ts",
+    "src/lib/public-waste-repository.server.ts"
+  ],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/config/runtime/public-waste.vars.example
+++ b/config/runtime/public-waste.vars.example
@@ -1,0 +1,15 @@
+# Portainer-Stack-Name fuer die oeffentliche Abfallkalender-Webversion.
+PUBLIC_WASTE_STACK_NAME=public-waste-calendar
+
+# SemVer-Image-Tag des dedizierten Frontend-Images.
+PUBLIC_WASTE_IMAGE_TAG=v0.0.0-dev
+
+# Oeffentlicher Host und kanonische Basis-URL.
+PUBLIC_WASTE_PUBLIC_HOST=bb-prignitz.abfallkalender.smart-village.app
+PUBLIC_WASTE_BASE_URL=https://bb-prignitz.abfallkalender.smart-village.app
+
+# Fachliche Runtime-Konfiguration.
+PUBLIC_WASTE_INSTANCE_ID=bb-prignitz
+PUBLIC_WASTE_SCHEMA_NAME=public
+PUBLIC_WASTE_DATABASE_URL=postgres://waste_app:change-me@postgres.example.invalid:5432/waste
+PUBLIC_WASTE_PDF_URL_TEMPLATE=https://example.invalid/waste/{locationKey}/{year}.pdf

--- a/config/runtime/public-waste.vars.example
+++ b/config/runtime/public-waste.vars.example
@@ -11,5 +11,5 @@ PUBLIC_WASTE_BASE_URL=https://bb-prignitz.abfallkalender.smart-village.app
 # Fachliche Runtime-Konfiguration.
 PUBLIC_WASTE_INSTANCE_ID=bb-prignitz
 PUBLIC_WASTE_SCHEMA_NAME=public
-PUBLIC_WASTE_DATABASE_URL=postgres://waste_app:change-me@postgres.example.invalid:5432/waste
+PUBLIC_WASTE_DATABASE_URL=postgres://postgres.example.invalid:5432/waste
 PUBLIC_WASTE_PDF_URL_TEMPLATE=https://example.invalid/waste/{locationKey}/{year}.pdf

--- a/config/runtime/public-waste.vars.example
+++ b/config/runtime/public-waste.vars.example
@@ -1,5 +1,5 @@
 # Portainer-Stack-Name fuer die oeffentliche Abfallkalender-Webversion.
-PUBLIC_WASTE_STACK_NAME=public-waste-calendar
+PUBLIC_WASTE_STACK_NAME=web-waste-calendar
 
 # SemVer-Image-Tag des dedizierten Frontend-Images.
 PUBLIC_WASTE_IMAGE_TAG=v0.0.0-dev

--- a/deploy/portainer/Dockerfile.public-waste
+++ b/deploy/portainer/Dockerfile.public-waste
@@ -1,0 +1,35 @@
+FROM node:24.15.0-alpine AS build
+
+WORKDIR /workspace
+
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+ENV CI=true
+ENV NX_DAEMON=false
+ENV NX_ADD_PLUGINS=false
+
+RUN npm install -g pnpm@11.3.0
+
+COPY . .
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm nx run public-waste-calendar-web:build --skip-nx-cache
+RUN pnpm --filter public-waste-calendar-web deploy --prod /workspace/.deploy/public-waste-calendar-web
+
+FROM node:24.15.0-alpine AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3002
+
+COPY --from=build --chown=node:node /workspace/.deploy/public-waste-calendar-web/package.json ./package.json
+COPY --from=build --chown=node:node /workspace/.deploy/public-waste-calendar-web/node_modules ./node_modules
+COPY --from=build --chown=node:node /workspace/apps/public-waste-calendar-web/dist ./dist
+
+USER node
+
+EXPOSE 3002
+
+CMD ["node", "dist/server/server/main.js"]

--- a/deploy/portainer/docker-compose.public-waste.yml
+++ b/deploy/portainer/docker-compose.public-waste.yml
@@ -1,0 +1,59 @@
+services:
+  app:
+    image: ghcr.io/smart-village-solutions/public-waste-calendar-web:${PUBLIC_WASTE_IMAGE_TAG}
+    environment:
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 3002
+      PUBLIC_WASTE_BASE_URL: '${PUBLIC_WASTE_BASE_URL}'
+      PUBLIC_WASTE_INSTANCE_ID: '${PUBLIC_WASTE_INSTANCE_ID}'
+      PUBLIC_WASTE_DATABASE_URL: '${PUBLIC_WASTE_DATABASE_URL}'
+      PUBLIC_WASTE_SCHEMA_NAME: '${PUBLIC_WASTE_SCHEMA_NAME}'
+      PUBLIC_WASTE_PDF_URL_TEMPLATE: '${PUBLIC_WASTE_PDF_URL_TEMPLATE}'
+    labels:
+      com.sva-studio.component: 'public-waste-app'
+      com.sva-studio.environment: 'production'
+    networks:
+      - public
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == node-005.sva
+      update_config:
+        parallelism: 1
+        delay: 10s
+        order: stop-first
+      rollback_config:
+        parallelism: 1
+        order: stop-first
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 5
+        window: 120s
+      resources:
+        reservations:
+          memory: 128M
+        limits:
+          memory: 384M
+          cpus: '0.50'
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=public
+        - traefik.public-waste.frontend.rule=Host:${PUBLIC_WASTE_PUBLIC_HOST}
+        - traefik.public-waste.frontend.priority=220
+        - traefik.public-waste.frontend.passHostHeader=true
+        - traefik.public-waste.port=3002
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - node -e "fetch('http://127.0.0.1:3002/health/live').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
+networks:
+  public:
+    external: true

--- a/deploy/portainer/docker-compose.public-waste.yml
+++ b/deploy/portainer/docker-compose.public-waste.yml
@@ -19,7 +19,7 @@ services:
       replicas: 1
       placement:
         constraints:
-          - node.hostname == node-005.sva
+          - node.hostname == node-003.sva
       update_config:
         parallelism: 1
         delay: 10s

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -247,7 +247,7 @@ Abhängigkeiten des aktuellen Systems.
    - nutzt eine reduzierte UI aus `PublicWasteApp`, `PublicWasteSelectionForm`, `PublicWasteCalendarPanels` und `PublicWasteEventDialog`
    - kapselt servernahe Verträge in `src/lib/public-waste-*.ts`, ohne neue Workspace-Kopplung zu `@sva/core` oder `@sva/data-repositories` einzuführen
    - besitzt zusätzlich eine eigene produktive Node-Runtime unter `src/server/**`, die das gebaute Frontend statisch ausliefert und die öffentlichen Read-Endpunkte `/api/public-waste/*` lokal bedient
-   - wird betrieblich über ein dediziertes Image, einen dedizierten Portainer-Stack `public-waste-calendar` und einen separaten Git-Tag-Releasepfad `waste-web-vX.Y.Z` ausgerollt, ohne den normalen Studio-Releasevertrag mitzubenutzen
+   - wird betrieblich über ein dediziertes Image, einen dedizierten Portainer-Stack `web-waste-calendar` und einen separaten Git-Tag-Releasepfad `waste-web-vX.Y.Z` ausgerollt, ohne den normalen Studio-Releasevertrag mitzubenutzen
 
 ### Foundation-Governance über Bausteingrenzen
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -246,6 +246,8 @@ Abhängigkeiten des aktuellen Systems.
    - hält Resolver, Kalenderprojektion, Demo-Runtime, Cookie-Restore, PDF-/iCal-Links und Modal-Interaktion bewusst app-lokal
    - nutzt eine reduzierte UI aus `PublicWasteApp`, `PublicWasteSelectionForm`, `PublicWasteCalendarPanels` und `PublicWasteEventDialog`
    - kapselt servernahe Verträge in `src/lib/public-waste-*.ts`, ohne neue Workspace-Kopplung zu `@sva/core` oder `@sva/data-repositories` einzuführen
+   - besitzt zusätzlich eine eigene produktive Node-Runtime unter `src/server/**`, die das gebaute Frontend statisch ausliefert und die öffentlichen Read-Endpunkte `/api/public-waste/*` lokal bedient
+   - wird betrieblich über ein dediziertes Image, einen dedizierten Portainer-Stack `public-waste-calendar` und einen separaten Git-Tag-Releasepfad `waste-web-vX.Y.Z` ausgerollt, ohne den normalen Studio-Releasevertrag mitzubenutzen
 
 ### Foundation-Governance über Bausteingrenzen
 

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -200,6 +200,16 @@ Referenzen:
 - Der Bootstrap-Pfad liest optionale Serverkonfiguration aus `PUBLIC_WASTE_CONFIG_JSON`; fehlende oder invalide Werte werden als expliziter Fehlerzustand statt als impliziter Runtime-Abbruch modelliert.
 - Für die aktuelle Entwicklungsstufe läuft die öffentliche Bürgeroberfläche mit einer app-lokalen Demo-Runtime. Der spätere produktive Datenpfad über öffentliche Read-Endpunkte bleibt davon architektonisch getrennt.
 
+### Fortschreibung 2026-06: Isolierter Releasepfad für die öffentliche Waste-Webversion
+
+- Die produktive Waste-Webversion besitzt einen eigenen Node-Laufzeitpfad unter `apps/public-waste-calendar-web/src/server/**`; der Build erzeugt ein gekapseltes Artefakt aus statischen Assets plus kleinem HTTP-Server.
+- Der produktive Stack läuft getrennt vom Studio-Stack als `public-waste-calendar` mit `deploy/portainer/docker-compose.public-waste.yml`.
+- Das zugehörige Container-Image wird getrennt unter `ghcr.io/smart-village-solutions/public-waste-calendar-web:<tag>` gebaut; Studio-Image, Studio-Stack und Studio-Workflows bleiben unberührt.
+- Die produktive Runtime-Konfiguration nutzt führend getrennte `PUBLIC_WASTE_*`-Variablen (`PUBLIC_WASTE_IMAGE_TAG`, `PUBLIC_WASTE_PUBLIC_HOST`, `PUBLIC_WASTE_BASE_URL`, `PUBLIC_WASTE_INSTANCE_ID`, `PUBLIC_WASTE_DATABASE_URL`, `PUBLIC_WASTE_SCHEMA_NAME`, `PUBLIC_WASTE_PDF_URL_TEMPLATE`).
+- `PUBLIC_WASTE_CONFIG_JSON` bleibt nur als lokaler oder kompatibilitätsbezogener Fallbackpfad erhalten und ist kein produktionsführender Betriebsvertrag.
+- Der Releasepfad wird ausschließlich über Git-Tags `waste-web-vX.Y.Z` ausgelöst. GitHub baut damit nur das Waste-Web-Image und aktualisiert im Portainer-Stack ausschließlich `PUBLIC_WASTE_IMAGE_TAG`.
+- Rollback folgt bewusst demselben einfachen Modell: vorigen SemVer-Tag in `PUBLIC_WASTE_IMAGE_TAG` eintragen und den Stack erneut deployen.
+
 ### Noch offen (Stand heute)
 
 - HA-/Skalierungsdetails für produktiven Betrieb sind nur teilweise als ADR/Doku beschrieben

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -203,7 +203,7 @@ Referenzen:
 ### Fortschreibung 2026-06: Isolierter Releasepfad für die öffentliche Waste-Webversion
 
 - Die produktive Waste-Webversion besitzt einen eigenen Node-Laufzeitpfad unter `apps/public-waste-calendar-web/src/server/**`; der Build erzeugt ein gekapseltes Artefakt aus statischen Assets plus kleinem HTTP-Server.
-- Der produktive Stack läuft getrennt vom Studio-Stack als `public-waste-calendar` mit `deploy/portainer/docker-compose.public-waste.yml`.
+- Der produktive Stack läuft getrennt vom Studio-Stack als `web-waste-calendar` mit `deploy/portainer/docker-compose.public-waste.yml`.
 - Das zugehörige Container-Image wird getrennt unter `ghcr.io/smart-village-solutions/public-waste-calendar-web:<tag>` gebaut; Studio-Image, Studio-Stack und Studio-Workflows bleiben unberührt.
 - Die produktive Runtime-Konfiguration nutzt führend getrennte `PUBLIC_WASTE_*`-Variablen (`PUBLIC_WASTE_IMAGE_TAG`, `PUBLIC_WASTE_PUBLIC_HOST`, `PUBLIC_WASTE_BASE_URL`, `PUBLIC_WASTE_INSTANCE_ID`, `PUBLIC_WASTE_DATABASE_URL`, `PUBLIC_WASTE_SCHEMA_NAME`, `PUBLIC_WASTE_PDF_URL_TEMPLATE`).
 - `PUBLIC_WASTE_CONFIG_JSON` bleibt nur als lokaler oder kompatibilitätsbezogener Fallbackpfad erhalten und ist kein produktionsführender Betriebsvertrag.

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -56,7 +56,7 @@ gleichzeitig beeinflussen.
 
 - Die öffentliche Waste-Webversion ist betriebsseitig strikt vom Studio-Releasepfad getrennt: eigenes Image, eigener Stack, eigener Workflow, eigener Variablenraum.
 - Produktive Konfiguration für diesen Pfad wird ausschließlich über getrennte `PUBLIC_WASTE_*`-Variablen modelliert; ein zusammengefasster JSON-Blob ist nur noch lokaler Fallback.
-- Git-Tags `waste-web-vX.Y.Z` sind die kanonische Freigabe für diese Bürgeroberfläche; andere Branch- oder Studio-Releases dürfen den Stack `public-waste-calendar` nicht mitverändern.
+- Git-Tags `waste-web-vX.Y.Z` sind die kanonische Freigabe für diese Bürgeroberfläche; andere Branch- oder Studio-Releases dürfen den Stack `web-waste-calendar` nicht mitverändern.
 - Der Portainer-Updatepfad verändert ausschließlich `PUBLIC_WASTE_IMAGE_TAG` und belässt alle übrigen Stack-Variablen unverändert, damit Host, Datenbankpfad und PDF-Konfiguration operativ getrennt steuerbar bleiben.
 - Für diesen speziellen Bürger-Frontend-Stack ist bewusst das einfache SemVer-Tag-Modell führend; Digest-Pinning des Studio-Referenzpfads wird hier nicht auf den Waste-Web-Stack übertragen.
 

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -52,6 +52,14 @@ gleichzeitig beeinflussen.
 - Trigger.dev ist für Studio kein zulässiger Workflow-Pfad.
 - Outbox, n8n-Anbindung, SSE/WebSocket und Broker-Pfade wie NATS bleiben explizite Folgearbeit hinter derselben Hostgrenze.
 
+### Öffentlicher Waste-Web-Releasevertrag
+
+- Die öffentliche Waste-Webversion ist betriebsseitig strikt vom Studio-Releasepfad getrennt: eigenes Image, eigener Stack, eigener Workflow, eigener Variablenraum.
+- Produktive Konfiguration für diesen Pfad wird ausschließlich über getrennte `PUBLIC_WASTE_*`-Variablen modelliert; ein zusammengefasster JSON-Blob ist nur noch lokaler Fallback.
+- Git-Tags `waste-web-vX.Y.Z` sind die kanonische Freigabe für diese Bürgeroberfläche; andere Branch- oder Studio-Releases dürfen den Stack `public-waste-calendar` nicht mitverändern.
+- Der Portainer-Updatepfad verändert ausschließlich `PUBLIC_WASTE_IMAGE_TAG` und belässt alle übrigen Stack-Variablen unverändert, damit Host, Datenbankpfad und PDF-Konfiguration operativ getrennt steuerbar bleiben.
+- Für diesen speziellen Bürger-Frontend-Stack ist bewusst das einfache SemVer-Tag-Modell führend; Digest-Pinning des Studio-Referenzpfads wird hier nicht auf den Waste-Web-Stack übertragen.
+
 ### Security und Privacy
 
 - OIDC Authorization Code Flow mit PKCE

--- a/docs/guides/deployment-overview.md
+++ b/docs/guides/deployment-overview.md
@@ -62,7 +62,7 @@ Wichtig:
 Der öffentliche Webkalender bildet einen davon getrennten Rollout-Pfad:
 
 - Compose-Datei: `../../deploy/portainer/docker-compose.public-waste.yml`
-- Stack typischerweise: `public-waste-calendar`
+- Stack typischerweise: `web-waste-calendar`
 - Quantum-Environment: `public-waste`
 - Workflow: `.github/workflows/public-waste-web-release.yml`
 - Trigger: Git-Tag `waste-web-vX.Y.Z`

--- a/docs/guides/deployment-overview.md
+++ b/docs/guides/deployment-overview.md
@@ -4,7 +4,7 @@ Dieses Dokument ist der kanonische Einstieg für Deployment- und Betriebsfragen.
 
 ## Zielbild
 
-SVA Studio kennt aktuell vier relevante Betriebsmodi:
+SVA Studio kennt aktuell fünf relevante Betriebsmodi:
 
 | Modus | Zweck | Primäre Dokumente |
 | --- | --- | --- |
@@ -12,6 +12,7 @@ SVA Studio kennt aktuell vier relevante Betriebsmodi:
 | Swarm-Referenzprofil | kanonischer Betriebsweg mit Swarm-Secrets und Traefik-v2+-Labels | `./swarm-deployment-guide.md`, `./swarm-deployment-runbook.md` |
 | Demo-Profil | vereinfachter Stack ohne Secret-Provisioning, mit Traefik-v1-kompatiblen Labels | `./swarm-deployment-guide.md`, `./swarm-deployment-runbook.md` |
 | Studio-Remoteprofil | produktionsnaher Betrieb als eigener Stack auf `studio.smart-village.app` | `./swarm-deployment-guide.md`, `../development/runtime-profile-betrieb.md` |
+| Public-Waste-Remoteprofil | isolierter Releasepfad für die öffentliche Abfallkalender-Webversion | `./public-waste-web-release-runbook.md`, `../architecture/07-deployment-view.md` |
 
 ## Profilwahl
 
@@ -56,6 +57,23 @@ Wichtig:
 - für `studio` ist der kanonische Ablauf jetzt zweigeteilt: GitHub liefert Build und Verify, der finale mutierende Rollout läuft lokal über `pnpm env:release:studio:local`
 - direkte `quantum-cli`-, Portainer- oder Ad-hoc-Shellpfade bleiben Notfall- oder Diagnosewerkzeuge und sind kein offizieller Standard
 
+### Public-Waste-Remoteprofil
+
+Der öffentliche Webkalender bildet einen davon getrennten Rollout-Pfad:
+
+- Compose-Datei: `../../deploy/portainer/docker-compose.public-waste.yml`
+- Stack typischerweise: `public-waste-calendar`
+- Quantum-Environment: `public-waste`
+- Workflow: `.github/workflows/public-waste-web-release.yml`
+- Trigger: Git-Tag `waste-web-vX.Y.Z`
+
+Wichtig:
+
+- der Workflow baut nur `public-waste-calendar-web` und nicht das Studio-Image
+- Portainer verwaltet die fachlichen Laufzeitwerte über getrennte `PUBLIC_WASTE_*`-Variablen
+- der GitHub-Releasepfad aktualisiert im Stack nur `PUBLIC_WASTE_IMAGE_TAG`
+- Rollback erfolgt durch Rücksetzen von `PUBLIC_WASTE_IMAGE_TAG` auf den vorherigen SemVer-Tag
+
 ## Standardablauf für Releases
 
 1. Image mit konkretem Tag bereitstellen.
@@ -78,6 +96,12 @@ Für `studio` zusätzlich wichtig:
 - ein gesunder Stack ersetzt nicht die Prüfung, ob sich `APP_DB_USER` tatsächlich gegen `POSTGRES_DB` anmelden kann
 - `env:precheck:studio` blockiert Images, deren Registry-Manifest kein `linux/amd64` ausweist
 - `env:precheck:studio` und `/health/ready` blockieren jetzt auch kritische IAM-Schema-Drifts für die Tenant-Registry, z. B. fehlende Artefakte aus `0025_iam_instance_registry_provisioning.sql` oder `0027_iam_instance_keycloak_bootstrap.sql`
+
+Für `public-waste` zusätzlich wichtig:
+
+- die produktive Runtime liest führend `PUBLIC_WASTE_INSTANCE_ID`, `PUBLIC_WASTE_DATABASE_URL`, `PUBLIC_WASTE_SCHEMA_NAME` und `PUBLIC_WASTE_PDF_URL_TEMPLATE`
+- `PUBLIC_WASTE_CONFIG_JSON` ist kein operativer Sollzustand mehr
+- der Release-Workflow führt nach dem Stack-Update Smoke-Checks gegen `/health/live`, `/` und `/api/public-waste/selection` aus
 
 Die operativen Details und Beispielkommandos stehen unter `./swarm-deployment-runbook.md`.
 
@@ -146,6 +170,7 @@ Wenn eine Änderung ein neues Schema voraussetzt, ist ein reiner Image-Rollback 
 
 - Swarm-Leitfaden: `./swarm-deployment-guide.md`
 - Swarm-Runbook: `./swarm-deployment-runbook.md`
+- Public-Waste-Runbook: `./public-waste-web-release-runbook.md`
 - Tenant-Realm-Bootstrap: `./keycloak-tenant-realm-bootstrap.md`
 - Verteilungssicht: `../architecture/07-deployment-view.md`
 - Monitoring-Details: `../development/monitoring-stack.md`

--- a/docs/guides/public-waste-web-release-runbook.md
+++ b/docs/guides/public-waste-web-release-runbook.md
@@ -8,7 +8,7 @@ mitverändern.
 ## Zielbild
 
 - eigenes Image: `ghcr.io/smart-village-solutions/public-waste-calendar-web`
-- eigener Stack: `public-waste-calendar`
+- eigener Stack: `web-waste-calendar`
 - eigene Compose-Datei: `deploy/portainer/docker-compose.public-waste.yml`
 - eigener Workflow: `.github/workflows/public-waste-web-release.yml`
 - eigener Trigger: Git-Tag `waste-web-vX.Y.Z`
@@ -42,7 +42,7 @@ benötigt:
 
 Empfohlener Wert für `PUBLIC_WASTE_STACK_NAME`:
 
-- `public-waste-calendar`
+- `web-waste-calendar`
 
 ## Normaler Releasepfad
 
@@ -51,7 +51,7 @@ Empfohlener Wert für `PUBLIC_WASTE_STACK_NAME`:
 3. Tag pushen.
 4. GitHub baut und publiziert das Image `ghcr.io/smart-village-solutions/public-waste-calendar-web:v1.2.3`.
 5. Der Workflow aktualisiert in Portainer nur `PUBLIC_WASTE_IMAGE_TAG=v1.2.3`.
-6. Der Stack `public-waste-calendar` wird neu ausgerollt.
+6. Der Stack `web-waste-calendar` wird neu ausgerollt.
 7. Smoke-Checks gegen `/health/live`, `/` und `/api/public-waste/selection` bestätigen den Rollout.
 
 Beispiel:
@@ -95,7 +95,7 @@ Dann in Portainer:
 ## Betriebsgrenzen
 
 - Der Waste-Web-Workflow darf weder `SVA_IMAGE_TAG` noch `SVA_IMAGE_REF` oder `SVA_IMAGE_DIGEST` verändern.
-- Der Stack `public-waste-calendar` darf nicht aus dem Studio-Stack abgeleitet werden.
+- Der Stack `web-waste-calendar` darf nicht aus dem Studio-Stack abgeleitet werden.
 - Änderungen an diesem Pfad betreffen nur die öffentliche Abfallkalender-Webversion, nicht das normale Studio.
 
 ## Referenzen

--- a/docs/guides/public-waste-web-release-runbook.md
+++ b/docs/guides/public-waste-web-release-runbook.md
@@ -1,0 +1,107 @@
+# Public-Waste-Web-Release-Runbook
+
+Dieses Runbook beschreibt den isolierten Releasepfad für die öffentliche
+Webversion des Abfallkalenders. Es gilt nur für
+`apps/public-waste-calendar-web` und darf den normalen Studio-Stack nicht
+mitverändern.
+
+## Zielbild
+
+- eigenes Image: `ghcr.io/smart-village-solutions/public-waste-calendar-web`
+- eigener Stack: `public-waste-calendar`
+- eigene Compose-Datei: `deploy/portainer/docker-compose.public-waste.yml`
+- eigener Workflow: `.github/workflows/public-waste-web-release.yml`
+- eigener Trigger: Git-Tag `waste-web-vX.Y.Z`
+
+## Führende Laufzeitvariablen in Portainer
+
+Diese Variablen werden im Portainer-Stack gepflegt:
+
+- `PUBLIC_WASTE_IMAGE_TAG`
+- `PUBLIC_WASTE_PUBLIC_HOST`
+- `PUBLIC_WASTE_BASE_URL`
+- `PUBLIC_WASTE_INSTANCE_ID`
+- `PUBLIC_WASTE_DATABASE_URL`
+- `PUBLIC_WASTE_SCHEMA_NAME`
+- `PUBLIC_WASTE_PDF_URL_TEMPLATE`
+
+`PUBLIC_WASTE_CONFIG_JSON` ist kein produktionsführender Vertrag mehr. Der
+Wert darf nur für lokale Entwicklung oder Legacy-Kompatibilität bestehen
+bleiben.
+
+## Voraussetzungen in GitHub
+
+Für den Releaseworkflow werden mindestens diese GitHub-Konfigurationen
+benötigt:
+
+- Secret `QUANTUM_API_KEY`
+- Variable `QUANTUM_HOST`
+- Variable `QUANTUM_ENDPOINT_ID`
+- Variable `PUBLIC_WASTE_STACK_NAME`
+- Variable `PUBLIC_WASTE_BASE_URL`
+
+Empfohlener Wert für `PUBLIC_WASTE_STACK_NAME`:
+
+- `public-waste-calendar`
+
+## Normaler Releasepfad
+
+1. Änderungen für `public-waste-calendar-web` auf `main` bringen.
+2. SemVer-Tag erzeugen, zum Beispiel `waste-web-v1.2.3`.
+3. Tag pushen.
+4. GitHub baut und publiziert das Image `ghcr.io/smart-village-solutions/public-waste-calendar-web:v1.2.3`.
+5. Der Workflow aktualisiert in Portainer nur `PUBLIC_WASTE_IMAGE_TAG=v1.2.3`.
+6. Der Stack `public-waste-calendar` wird neu ausgerollt.
+7. Smoke-Checks gegen `/health/live`, `/` und `/api/public-waste/selection` bestätigen den Rollout.
+
+Beispiel:
+
+```bash
+git tag waste-web-v1.2.3
+git push origin waste-web-v1.2.3
+```
+
+## Lokale Vorab-Prüfungen
+
+Vor Änderungen am Releasepfad oder bei Betriebsanpassungen sind mindestens
+diese Checks sinnvoll:
+
+```bash
+pnpm exec vitest run scripts/ops/public-waste/portainer-release.test.ts
+pnpm exec tsc -p tsconfig.scripts.json --noEmit
+pnpm nx run public-waste-calendar-web:build
+docker compose --env-file config/runtime/public-waste.vars.example -f deploy/portainer/docker-compose.public-waste.yml config
+docker build -f deploy/portainer/Dockerfile.public-waste -t public-waste-calendar-web:dev .
+```
+
+## Rollback
+
+Rollback folgt bewusst demselben einfachen Tag-Modell:
+
+1. Den vorherigen funktionierenden SemVer-Tag bestimmen.
+2. `PUBLIC_WASTE_IMAGE_TAG` im Portainer-Stack auf diesen Tag zurücksetzen.
+3. Den Stack erneut deployen.
+4. Smoke-Checks erneut ausführen.
+
+Beispiel:
+
+- fehlerhafte Version: `v1.2.3`
+- Rollback-Ziel: `v1.2.2`
+
+Dann in Portainer:
+
+- `PUBLIC_WASTE_IMAGE_TAG=v1.2.2`
+
+## Betriebsgrenzen
+
+- Der Waste-Web-Workflow darf weder `SVA_IMAGE_TAG` noch `SVA_IMAGE_REF` oder `SVA_IMAGE_DIGEST` verändern.
+- Der Stack `public-waste-calendar` darf nicht aus dem Studio-Stack abgeleitet werden.
+- Änderungen an diesem Pfad betreffen nur die öffentliche Abfallkalender-Webversion, nicht das normale Studio.
+
+## Referenzen
+
+- `../../deploy/portainer/docker-compose.public-waste.yml`
+- `../../deploy/portainer/Dockerfile.public-waste`
+- `../../config/runtime/public-waste.vars.example`
+- `../../scripts/ops/public-waste/portainer-release.ts`
+- `../../.github/workflows/public-waste-web-release.yml`

--- a/docs/superpowers/plans/2026-06-05-public-waste-web-release.md
+++ b/docs/superpowers/plans/2026-06-05-public-waste-web-release.md
@@ -1,0 +1,658 @@
+# Public Waste Web Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an isolated production release path for `apps/public-waste-calendar-web` that deploys the public waste calendar via Git tags like `waste-web-v1.2.3` without changing the normal Studio stack or workflows.
+
+**Architecture:** Introduce a dedicated production runtime for the public waste app, a dedicated Swarm/Portainer stack definition, and a dedicated GitHub Actions workflow that builds a separate image and updates only `PUBLIC_WASTE_IMAGE_TAG` in the `public-waste-calendar` stack. Keep runtime config in split `PUBLIC_WASTE_*` variables and preserve `PUBLIC_WASTE_CONFIG_JSON` only as a local/dev compatibility fallback.
+
+**Tech Stack:** Nx, pnpm, Vite, React, Node.js 24, TypeScript, Vitest, Playwright, Docker Swarm, Portainer API, GitHub Actions, OpenSpec
+
+---
+
+### Task 1: Formalize the Change Contract in OpenSpec
+
+**Files:**
+- Create: `openspec/changes/add-public-waste-web-release-pipeline/proposal.md`
+- Create: `openspec/changes/add-public-waste-web-release-pipeline/tasks.md`
+- Create: `openspec/changes/add-public-waste-web-release-pipeline/specs/public-waste-calendar/spec.md`
+- Create: `openspec/changes/add-public-waste-web-release-pipeline/specs/deployment-topology/spec.md`
+- Create: `openspec/changes/add-public-waste-web-release-pipeline/specs/architecture-documentation/spec.md`
+- Reference: `docs/superpowers/specs/2026-06-05-public-waste-web-release-design.md`
+
+- [ ] **Step 1: Scaffold the OpenSpec change directory**
+
+```bash
+mkdir -p \
+  openspec/changes/add-public-waste-web-release-pipeline/specs/public-waste-calendar \
+  openspec/changes/add-public-waste-web-release-pipeline/specs/deployment-topology \
+  openspec/changes/add-public-waste-web-release-pipeline/specs/architecture-documentation
+```
+
+- [ ] **Step 2: Draft the proposal with explicit Studio isolation**
+
+```md
+# Change: Öffentlicher Releasepfad für den Abfallkalender
+
+## Why
+Die öffentliche Webversion des Abfallkalenders benötigt einen eigenen
+Release- und Deployvertrag, damit Releases nicht über den normalen
+Studio-Stack laufen und operative Änderungen am Bürger-Frontend den
+bestehenden Studio-Betrieb nicht beeinflussen.
+
+## What Changes
+- eigener Produktionspfad für `apps/public-waste-calendar-web`
+- eigener Swarm-/Portainer-Stack `public-waste-calendar`
+- Git-Tag-getriebener Releaseworkflow `waste-web-vX.Y.Z`
+- produktive Runtime-Konfiguration über einzelne `PUBLIC_WASTE_*`-Variablen
+- **BREAKING (betrieblich):** produktionsführende Konfiguration ist nicht mehr
+  `PUBLIC_WASTE_CONFIG_JSON`, sondern aufgetrennte Variablen
+
+## Impact
+- Affected specs: `public-waste-calendar`, `deployment-topology`, `architecture-documentation`
+- Affected code: `apps/public-waste-calendar-web`, `deploy/portainer/*`, `.github/workflows/*`, `scripts/ops/*`
+- Affected arc42 sections: `05-building-block-view`, `07-deployment-view`, `08-cross-cutting-concepts`
+```
+
+- [ ] **Step 3: Add spec deltas for capability, deployment, and docs**
+
+```md
+## ADDED Requirements
+### Requirement: Öffentliche Abfallkalender-App hat einen isolierten Releasepfad
+Das System SHALL für `public-waste-calendar` einen eigenen Releasepfad
+bereitstellen, der weder den `studio`-Stack noch den `studio`-Releaseworkflow
+mitverwendet.
+
+#### Scenario: Git-Tag triggert nur den öffentlichen Waste-Release
+- **WHEN** ein Git-Tag `waste-web-v1.2.3` gepusht wird
+- **THEN** baut und deployt das System nur die öffentliche Waste-Web-Runtime
+- **AND** der normale Studio-Releasepfad bleibt unberührt
+```
+
+- [ ] **Step 4: Validate the change**
+
+Run: `openspec validate add-public-waste-web-release-pipeline --strict`  
+Expected: `Change 'add-public-waste-web-release-pipeline' is valid`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openspec/changes/add-public-waste-web-release-pipeline
+git commit -m "spec: add public waste web release pipeline change"
+```
+
+### Task 2: Split Production Config into `PUBLIC_WASTE_*` Variables
+
+**Files:**
+- Modify: `apps/public-waste-calendar-web/src/lib/public-waste-config.server.ts`
+- Modify: `apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.ts`
+- Modify: `apps/public-waste-calendar-web/src/server.ts`
+- Modify: `apps/public-waste-calendar-web/public-waste-config.example.json`
+- Test: `apps/public-waste-calendar-web/src/lib/public-waste-config.server.test.ts`
+- Test: `apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.test.ts`
+
+- [ ] **Step 1: Add failing tests for split env vars and JSON fallback**
+
+```ts
+it('reads production config from split PUBLIC_WASTE_* environment variables', () => {
+  expect(
+    readPublicWasteConfigFromEnvironment({
+      PUBLIC_WASTE_INSTANCE_ID: 'bb-prignitz',
+      PUBLIC_WASTE_DATABASE_URL: 'postgres://example',
+      PUBLIC_WASTE_SCHEMA_NAME: 'public',
+      PUBLIC_WASTE_PDF_URL_TEMPLATE: 'https://example.invalid/{locationKey}/{year}.pdf',
+    })
+  ).toEqual({
+    instanceId: 'bb-prignitz',
+    supabase: {
+      databaseUrl: 'postgres://example',
+      schemaName: 'public',
+    },
+    pdf: {
+      urlTemplate: 'https://example.invalid/{locationKey}/{year}.pdf',
+    },
+  });
+});
+
+it('falls back to PUBLIC_WASTE_CONFIG_JSON only when split variables are absent', () => {
+  expect(
+    readPublicWasteBootstrapStateFromEnvironment({
+      rawConfigJson: JSON.stringify({
+        instanceId: 'bb-prignitz',
+        supabase: { databaseUrl: 'postgres://example', schemaName: 'public' },
+        pdf: { urlTemplate: 'https://example.invalid/{locationKey}/{year}.pdf' },
+      }),
+    })
+  ).toMatchObject({ status: 'ready' });
+});
+```
+
+- [ ] **Step 2: Run the focused tests to confirm they fail**
+
+Run:
+
+```bash
+cd apps/public-waste-calendar-web
+pnpm exec vitest run \
+  src/lib/public-waste-config.server.test.ts \
+  src/lib/public-waste-bootstrap.server.test.ts
+```
+
+Expected: FAIL with missing `readPublicWasteConfigFromEnvironment` or wrong bootstrap precedence
+
+- [ ] **Step 3: Implement split-variable config loading**
+
+```ts
+export const readPublicWasteConfigFromEnvironment = (
+  env: NodeJS.ProcessEnv = process.env,
+): PublicWasteConfig | null => {
+  const instanceId = readString(env.PUBLIC_WASTE_INSTANCE_ID);
+  const databaseUrl = readString(env.PUBLIC_WASTE_DATABASE_URL);
+  const schemaName = readString(env.PUBLIC_WASTE_SCHEMA_NAME);
+  const urlTemplate = readString(env.PUBLIC_WASTE_PDF_URL_TEMPLATE);
+
+  if (!instanceId || !databaseUrl || !schemaName || !urlTemplate) {
+    return null;
+  }
+
+  return {
+    instanceId,
+    supabase: {
+      databaseUrl,
+      schemaName,
+    },
+    pdf: {
+      urlTemplate,
+    },
+  };
+};
+
+export const readPublicWasteBootstrapStateFromEnvironment = (input: {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly rawConfigJson?: string | undefined;
+} = {}): PublicWasteBootstrapState => {
+  const envConfig = readPublicWasteConfigFromEnvironment(input.env ?? process.env);
+  if (envConfig) {
+    return resolvePublicWasteBootstrapState(envConfig);
+  }
+
+  const rawConfigJson = input.rawConfigJson ?? (input.env ?? process.env).PUBLIC_WASTE_CONFIG_JSON;
+  // existing JSON fallback path stays here
+};
+```
+
+- [ ] **Step 4: Re-run tests and typecheck**
+
+Run:
+
+```bash
+cd apps/public-waste-calendar-web
+pnpm exec vitest run \
+  src/lib/public-waste-config.server.test.ts \
+  src/lib/public-waste-bootstrap.server.test.ts
+cd ../..
+pnpm nx run public-waste-calendar-web:test:types
+```
+
+Expected: PASS; `tsc --noEmit` completes without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  apps/public-waste-calendar-web/src/lib/public-waste-config.server.ts \
+  apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.ts \
+  apps/public-waste-calendar-web/src/server.ts \
+  apps/public-waste-calendar-web/public-waste-config.example.json \
+  apps/public-waste-calendar-web/src/lib/public-waste-config.server.test.ts \
+  apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.test.ts
+git commit -m "feat: split public waste runtime config variables"
+```
+
+### Task 3: Add a Production Node Runtime for the Public Waste App
+
+**Files:**
+- Create: `apps/public-waste-calendar-web/src/server/public-waste-runtime.ts`
+- Create: `apps/public-waste-calendar-web/src/server/public-waste-http-server.ts`
+- Create: `apps/public-waste-calendar-web/src/server/main.ts`
+- Create: `apps/public-waste-calendar-web/tsconfig.server.json`
+- Modify: `apps/public-waste-calendar-web/package.json`
+- Modify: `apps/public-waste-calendar-web/project.json`
+- Test: `apps/public-waste-calendar-web/src/server/public-waste-runtime.test.ts`
+- Test: `apps/public-waste-calendar-web/src/server/public-waste-http-server.test.ts`
+
+- [ ] **Step 1: Add failing runtime tests for `/health/live` and `/api/public-waste/*`**
+
+```ts
+it('returns 200 for /health/live when config is valid', async () => {
+  const runtime = await createPublicWasteRuntime({ env: validEnv, assetsDir: '/tmp/assets' });
+  const response = await runtime.handle(new Request('http://localhost/health/live'));
+  expect(response.status).toBe(200);
+});
+
+it('returns 500 for API requests when runtime config is invalid', async () => {
+  const runtime = await createPublicWasteRuntime({ env: {}, assetsDir: '/tmp/assets' });
+  const response = await runtime.handle(new Request('http://localhost/api/public-waste/selection'));
+  expect(response.status).toBe(500);
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify failure**
+
+Run:
+
+```bash
+cd apps/public-waste-calendar-web
+pnpm exec vitest run \
+  src/server/public-waste-runtime.test.ts \
+  src/server/public-waste-http-server.test.ts
+```
+
+Expected: FAIL because the production server files do not exist yet
+
+- [ ] **Step 3: Implement the runtime, build scripts, and server entry**
+
+```ts
+// apps/public-waste-calendar-web/src/server/public-waste-runtime.ts
+export const createPublicWasteRuntime = async (input: {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly assetsDir: string;
+}) => {
+  const bootstrapState = readPublicWasteBootstrapStateFromEnvironment({ env: input.env });
+  const pool =
+    bootstrapState.status === 'ready'
+      ? new Pool({ connectionString: bootstrapState.config.supabase.databaseUrl, max: 4 })
+      : null;
+
+  const repository =
+    bootstrapState.status === 'ready' && pool
+      ? createPublicWasteRepository({
+          schemaName: bootstrapState.config.supabase.schemaName,
+          execute: async ({ text, values }) => {
+            const result = await pool.query(text, values ? [...values] : undefined);
+            return {
+              rowCount: result.rowCount ?? 0,
+              rows: result.rows,
+            };
+          },
+        })
+      : null;
+
+  return {
+    async handle(request: Request): Promise<Response> {
+      const url = new URL(request.url);
+      if (url.pathname === '/health/live') {
+        return new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json; charset=utf-8' },
+        });
+      }
+      if (url.pathname.startsWith('/api/public-waste/')) {
+        // delegate to existing endpoint handlers
+      }
+      // fall through to static asset serving / SPA index.html
+    },
+    async close() {
+      await pool?.end();
+    },
+  };
+};
+```
+
+```json
+// apps/public-waste-calendar-web/package.json
+{
+  "scripts": {
+    "build:client": "vite build",
+    "build:server": "tsc -p tsconfig.server.json",
+    "build": "pnpm run build:client && pnpm run build:server",
+    "start": "node dist-server/server/main.js"
+  }
+}
+```
+
+- [ ] **Step 4: Build and test the production runtime**
+
+Run:
+
+```bash
+cd apps/public-waste-calendar-web
+pnpm exec vitest run \
+  src/server/public-waste-runtime.test.ts \
+  src/server/public-waste-http-server.test.ts \
+  src/lib/public-waste-endpoints.server.test.ts
+cd ../..
+pnpm nx run public-waste-calendar-web:test:types
+pnpm nx run public-waste-calendar-web:build
+```
+
+Expected: PASS; `dist/` and `dist-server/` are created
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  apps/public-waste-calendar-web/src/server/public-waste-runtime.ts \
+  apps/public-waste-calendar-web/src/server/public-waste-http-server.ts \
+  apps/public-waste-calendar-web/src/server/main.ts \
+  apps/public-waste-calendar-web/tsconfig.server.json \
+  apps/public-waste-calendar-web/package.json \
+  apps/public-waste-calendar-web/project.json \
+  apps/public-waste-calendar-web/src/server/public-waste-runtime.test.ts \
+  apps/public-waste-calendar-web/src/server/public-waste-http-server.test.ts
+git commit -m "feat: add public waste production runtime"
+```
+
+### Task 4: Define an Isolated Image and Stack for `public-waste-calendar`
+
+**Files:**
+- Create: `deploy/portainer/Dockerfile.public-waste`
+- Create: `deploy/portainer/docker-compose.public-waste.yml`
+- Create: `config/runtime/public-waste.vars.example`
+- Modify: `.quantum`
+- Test: `apps/public-waste-calendar-web/package.json`
+
+- [ ] **Step 1: Create the dedicated Dockerfile and stack compose**
+
+```dockerfile
+FROM node:24.15.0-alpine AS build
+WORKDIR /workspace
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN npm install -g pnpm@11.3.0
+COPY . .
+RUN pnpm install --frozen-lockfile
+RUN pnpm nx run public-waste-calendar-web:build --skip-nx-cache
+
+FROM node:24.15.0-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /workspace/apps/public-waste-calendar-web/dist ./dist
+COPY --from=build /workspace/apps/public-waste-calendar-web/dist-server ./dist-server
+COPY --from=build /workspace/apps/public-waste-calendar-web/node_modules ./node_modules
+EXPOSE 3002
+CMD ["node", "dist-server/server/main.js"]
+```
+
+```yaml
+version: '3.8'
+
+services:
+  app:
+    image: ghcr.io/smart-village-solutions/public-waste-calendar-web:${PUBLIC_WASTE_IMAGE_TAG}
+    environment:
+      NODE_ENV: production
+      PORT: 3002
+      HOST: 0.0.0.0
+      PUBLIC_WASTE_INSTANCE_ID: '${PUBLIC_WASTE_INSTANCE_ID}'
+      PUBLIC_WASTE_DATABASE_URL: '${PUBLIC_WASTE_DATABASE_URL}'
+      PUBLIC_WASTE_SCHEMA_NAME: '${PUBLIC_WASTE_SCHEMA_NAME}'
+      PUBLIC_WASTE_PDF_URL_TEMPLATE: '${PUBLIC_WASTE_PDF_URL_TEMPLATE}'
+      PUBLIC_WASTE_BASE_URL: '${PUBLIC_WASTE_BASE_URL}'
+    networks:
+      - public
+    deploy:
+      replicas: 1
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=public
+        - traefik.public-waste.frontend.rule=Host:${PUBLIC_WASTE_PUBLIC_HOST}
+        - traefik.public-waste.port=3002
+
+networks:
+  public:
+    external: true
+```
+
+- [ ] **Step 2: Validate the compose contract**
+
+Run:
+
+```bash
+docker compose -f deploy/portainer/docker-compose.public-waste.yml config
+```
+
+Expected: rendered compose output with `PUBLIC_WASTE_*` environment references and no schema errors
+
+- [ ] **Step 3: Add runtime profile example and Quantum environment mapping**
+
+```yaml
+# .quantum
+environments:
+  - name: public-waste
+    compose: deploy/portainer/docker-compose.public-waste.yml
+```
+
+```dotenv
+# config/runtime/public-waste.vars.example
+PUBLIC_WASTE_IMAGE_TAG=v0.0.0-dev
+PUBLIC_WASTE_PUBLIC_HOST=bb-prignitz.abfallkalender.smart-village.app
+PUBLIC_WASTE_BASE_URL=https://bb-prignitz.abfallkalender.smart-village.app
+PUBLIC_WASTE_INSTANCE_ID=bb-prignitz
+PUBLIC_WASTE_SCHEMA_NAME=public
+```
+
+- [ ] **Step 4: Build the dedicated image locally once**
+
+Run:
+
+```bash
+docker build -f deploy/portainer/Dockerfile.public-waste -t public-waste-calendar-web:dev .
+```
+
+Expected: image build finishes successfully without touching `sva-studio`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  deploy/portainer/Dockerfile.public-waste \
+  deploy/portainer/docker-compose.public-waste.yml \
+  config/runtime/public-waste.vars.example \
+  .quantum
+git commit -m "feat: add public waste stack artifacts"
+```
+
+### Task 5: Automate Git-Tag Releases and Portainer Stack Updates
+
+**Files:**
+- Create: `scripts/ops/public-waste/portainer-release.ts`
+- Create: `scripts/ops/public-waste/portainer-release.test.ts`
+- Create: `.github/workflows/public-waste-web-release.yml`
+- Modify: `tsconfig.scripts.json`
+
+- [ ] **Step 1: Add failing tests for tag validation and env-only stack update**
+
+```ts
+it('accepts waste-web SemVer tags', () => {
+  expect(parseWasteWebReleaseTag('refs/tags/waste-web-v1.2.3')).toEqual({
+    imageTag: 'v1.2.3',
+    gitTag: 'waste-web-v1.2.3',
+  });
+});
+
+it('updates only PUBLIC_WASTE_IMAGE_TAG and preserves other stack env values', () => {
+  const nextEnv = updateStackEnv(
+    [
+      { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.2' },
+      { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+    ],
+    'v1.2.3',
+  );
+
+  expect(nextEnv).toEqual([
+    { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.3' },
+    { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the script test to confirm it fails**
+
+Run:
+
+```bash
+pnpm exec vitest run scripts/ops/public-waste/portainer-release.test.ts
+```
+
+Expected: FAIL because the release script does not exist yet
+
+- [ ] **Step 3: Implement the Portainer release script and workflow**
+
+```ts
+// scripts/ops/public-waste/portainer-release.ts
+export const parseWasteWebReleaseTag = (ref: string) => {
+  const match = /^refs\/tags\/waste-web-v(\d+\.\d+\.\d+)$/.exec(ref);
+  if (!match) {
+    throw new Error(`Ungueltiges Waste-Web-Release-Tag: ${ref}`);
+  }
+
+  return {
+    gitTag: `waste-web-v${match[1]}`,
+    imageTag: `v${match[1]}`,
+  };
+};
+
+export const updateStackEnv = (
+  env: readonly { name: string; value: string }[],
+  imageTag: string,
+) =>
+  env.map((entry) =>
+    entry.name === 'PUBLIC_WASTE_IMAGE_TAG' ? { ...entry, value: imageTag } : entry,
+  );
+```
+
+```yaml
+name: Public Waste Web Release
+
+on:
+  push:
+    tags:
+      - 'waste-web-v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-pnpm-workspace
+      - run: pnpm nx run public-waste-calendar-web:build
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+      - run: docker buildx build --platform linux/amd64 -f deploy/portainer/Dockerfile.public-waste -t ghcr.io/smart-village-solutions/public-waste-calendar-web:${IMAGE_TAG} --push .
+      - run: pnpm exec tsx scripts/ops/public-waste/portainer-release.ts
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          QUANTUM_API_KEY: ${{ secrets.QUANTUM_API_KEY }}
+          QUANTUM_HOST: ${{ secrets.QUANTUM_HOST }}
+          QUANTUM_ENDPOINT_ID: ${{ secrets.QUANTUM_ENDPOINT_ID }}
+          PUBLIC_WASTE_STACK_NAME: public-waste-calendar
+```
+
+- [ ] **Step 4: Run tests and scripts typecheck**
+
+Run:
+
+```bash
+pnpm exec vitest run scripts/ops/public-waste/portainer-release.test.ts
+pnpm exec tsc -p tsconfig.scripts.json --noEmit
+```
+
+Expected: PASS; scripts compile cleanly
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  scripts/ops/public-waste/portainer-release.ts \
+  scripts/ops/public-waste/portainer-release.test.ts \
+  .github/workflows/public-waste-web-release.yml \
+  tsconfig.scripts.json
+git commit -m "feat: automate public waste web releases"
+```
+
+### Task 6: Update Docs and Run Final Verification
+
+**Files:**
+- Create: `docs/guides/public-waste-web-release-runbook.md`
+- Modify: `docs/architecture/07-deployment-view.md`
+- Modify: `docs/architecture/08-cross-cutting-concepts.md`
+- Modify: `docs/guides/deployment-overview.md`
+- Modify: `docs/architecture/05-building-block-view.md`
+- Reference: `docs/superpowers/specs/2026-06-05-public-waste-web-release-design.md`
+
+- [ ] **Step 1: Document the isolated public waste release contract**
+
+```md
+## Öffentliches Waste-Web-Release
+
+- eigener Stack: `public-waste-calendar`
+- eigener Workflow: `public-waste-web-release.yml`
+- Trigger: Git-Tag `waste-web-vX.Y.Z`
+- Versionsträger im Stack: `PUBLIC_WASTE_IMAGE_TAG`
+- produktive Runtime-Konfiguration: split `PUBLIC_WASTE_*` variables
+- keine Mitnutzung des normalen `studio`-Releasepfads
+```
+
+- [ ] **Step 2: Run the smallest relevant verification suite**
+
+Run:
+
+```bash
+cd apps/public-waste-calendar-web
+pnpm exec vitest run \
+  src/lib/public-waste-config.server.test.ts \
+  src/lib/public-waste-bootstrap.server.test.ts \
+  src/lib/public-waste-endpoints.server.test.ts \
+  src/server/public-waste-runtime.test.ts \
+  src/server/public-waste-http-server.test.ts
+cd ../..
+pnpm nx run public-waste-calendar-web:test:types
+pnpm nx run public-waste-calendar-web:build
+pnpm exec tsc -p tsconfig.scripts.json --noEmit
+docker compose -f deploy/portainer/docker-compose.public-waste.yml config
+openspec validate add-public-waste-web-release-pipeline --strict
+pnpm check:file-placement
+```
+
+Expected:
+
+- all focused Vitest files PASS
+- app typecheck PASS
+- app build PASS
+- scripts typecheck PASS
+- compose config renders successfully
+- OpenSpec validation PASS
+- file placement check PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add \
+  docs/guides/public-waste-web-release-runbook.md \
+  docs/architecture/05-building-block-view.md \
+  docs/architecture/07-deployment-view.md \
+  docs/architecture/08-cross-cutting-concepts.md \
+  docs/guides/deployment-overview.md
+git commit -m "docs: document public waste web release path"
+```
+
+## Spec Coverage Check
+
+- Isolierter Releasepfad: Task 1, Task 4, Task 5, Task 6
+- Eigener Stack `public-waste-calendar`: Task 4, Task 5, Task 6
+- Git-Tag `waste-web-vX.Y.Z`: Task 1, Task 5
+- Nur Versionsupdate im Stack: Task 5
+- Split `PUBLIC_WASTE_*` variables statt produktivem JSON blob: Task 2, Task 4, Task 6
+- Keine Studio-Beeinflussung: Task 1, Task 4, Task 5, Task 6
+- Fail-closed runtime and smoke checks: Task 3, Task 5, Task 6
+
+## Self-Review
+
+- Keine `TODO`-/`TBD`-Platzhalter im Plan
+- Alle neuen Runtime-Dateien und Workflow-Artefakte sind konkret benannt
+- Alle produktiven Änderungen sind auf `public-waste-calendar-web`, den eigenen Stack und den eigenen Workflow begrenzt
+- OpenSpec-, Architektur-, Runtime-, Deploy- und Verifikationsarbeit sind jeweils einem Task zugeordnet

--- a/docs/superpowers/plans/2026-06-05-public-waste-web-release.md
+++ b/docs/superpowers/plans/2026-06-05-public-waste-web-release.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build an isolated production release path for `apps/public-waste-calendar-web` that deploys the public waste calendar via Git tags like `waste-web-v1.2.3` without changing the normal Studio stack or workflows.
 
-**Architecture:** Introduce a dedicated production runtime for the public waste app, a dedicated Swarm/Portainer stack definition, and a dedicated GitHub Actions workflow that builds a separate image and updates only `PUBLIC_WASTE_IMAGE_TAG` in the `public-waste-calendar` stack. Keep runtime config in split `PUBLIC_WASTE_*` variables and preserve `PUBLIC_WASTE_CONFIG_JSON` only as a local/dev compatibility fallback.
+**Architecture:** Introduce a dedicated production runtime for the public waste app, a dedicated Swarm/Portainer stack definition, and a dedicated GitHub Actions workflow that builds a separate image and updates only `PUBLIC_WASTE_IMAGE_TAG` in the `web-waste-calendar` stack. Keep runtime config in split `PUBLIC_WASTE_*` variables and preserve `PUBLIC_WASTE_CONFIG_JSON` only as a local/dev compatibility fallback.
 
 **Tech Stack:** Nx, pnpm, Vite, React, Node.js 24, TypeScript, Vitest, Playwright, Docker Swarm, Portainer API, GitHub Actions, OpenSpec
 
@@ -42,14 +42,14 @@ bestehenden Studio-Betrieb nicht beeinflussen.
 
 ## What Changes
 - eigener Produktionspfad für `apps/public-waste-calendar-web`
-- eigener Swarm-/Portainer-Stack `public-waste-calendar`
+- eigener Swarm-/Portainer-Stack `web-waste-calendar`
 - Git-Tag-getriebener Releaseworkflow `waste-web-vX.Y.Z`
 - produktive Runtime-Konfiguration über einzelne `PUBLIC_WASTE_*`-Variablen
 - **BREAKING (betrieblich):** produktionsführende Konfiguration ist nicht mehr
   `PUBLIC_WASTE_CONFIG_JSON`, sondern aufgetrennte Variablen
 
 ## Impact
-- Affected specs: `public-waste-calendar`, `deployment-topology`, `architecture-documentation`
+- Affected specs: `web-waste-calendar`, `deployment-topology`, `architecture-documentation`
 - Affected code: `apps/public-waste-calendar-web`, `deploy/portainer/*`, `.github/workflows/*`, `scripts/ops/*`
 - Affected arc42 sections: `05-building-block-view`, `07-deployment-view`, `08-cross-cutting-concepts`
 ```
@@ -59,7 +59,7 @@ bestehenden Studio-Betrieb nicht beeinflussen.
 ```md
 ## ADDED Requirements
 ### Requirement: Öffentliche Abfallkalender-App hat einen isolierten Releasepfad
-Das System SHALL für `public-waste-calendar` einen eigenen Releasepfad
+Das System SHALL für `web-waste-calendar` einen eigenen Releasepfad
 bereitstellen, der weder den `studio`-Stack noch den `studio`-Releaseworkflow
 mitverwendet.
 
@@ -343,7 +343,7 @@ git add \
 git commit -m "feat: add public waste production runtime"
 ```
 
-### Task 4: Define an Isolated Image and Stack for `public-waste-calendar`
+### Task 4: Define an Isolated Image and Stack for `web-waste-calendar`
 
 **Files:**
 - Create: `deploy/portainer/Dockerfile.public-waste`
@@ -549,7 +549,7 @@ jobs:
           QUANTUM_API_KEY: ${{ secrets.QUANTUM_API_KEY }}
           QUANTUM_HOST: ${{ secrets.QUANTUM_HOST }}
           QUANTUM_ENDPOINT_ID: ${{ secrets.QUANTUM_ENDPOINT_ID }}
-          PUBLIC_WASTE_STACK_NAME: public-waste-calendar
+          PUBLIC_WASTE_STACK_NAME: web-waste-calendar
 ```
 
 - [ ] **Step 4: Run tests and scripts typecheck**
@@ -589,7 +589,7 @@ git commit -m "feat: automate public waste web releases"
 ```md
 ## Öffentliches Waste-Web-Release
 
-- eigener Stack: `public-waste-calendar`
+- eigener Stack: `web-waste-calendar`
 - eigener Workflow: `public-waste-web-release.yml`
 - Trigger: Git-Tag `waste-web-vX.Y.Z`
 - Versionsträger im Stack: `PUBLIC_WASTE_IMAGE_TAG`
@@ -643,7 +643,7 @@ git commit -m "docs: document public waste web release path"
 ## Spec Coverage Check
 
 - Isolierter Releasepfad: Task 1, Task 4, Task 5, Task 6
-- Eigener Stack `public-waste-calendar`: Task 4, Task 5, Task 6
+- Eigener Stack `web-waste-calendar`: Task 4, Task 5, Task 6
 - Git-Tag `waste-web-vX.Y.Z`: Task 1, Task 5
 - Nur Versionsupdate im Stack: Task 5
 - Split `PUBLIC_WASTE_*` variables statt produktivem JSON blob: Task 2, Task 4, Task 6

--- a/docs/superpowers/specs/2026-06-05-public-waste-web-release-design.md
+++ b/docs/superpowers/specs/2026-06-05-public-waste-web-release-design.md
@@ -9,7 +9,7 @@ Studio-Deploy getrennt bleibt.
 Ein Release soll über ein Git-Tag im Format `waste-web-vX.Y.Z`
 automatisch ausgelöst werden, ein eigenes Image mit exakt diesem
 SemVer-Tag bauen und ausschließlich den dedizierten Portainer-Stack
-`public-waste-calendar` auf diese Version aktualisieren.
+`web-waste-calendar` auf diese Version aktualisieren.
 
 ## Nicht-Ziele
 
@@ -75,7 +75,7 @@ Der Releasepfad wird ausschließlich über Git-Tags gesteuert.
 3. Workflow baut nur das Image des öffentlichen Abfallkalenders
 4. Workflow published das Image mit exakt diesem Tag
 5. Workflow aktualisiert im Portainer-Stack nur die Image-Version
-6. Workflow stößt den Rollout des Stacks `public-waste-calendar` an
+6. Workflow stößt den Rollout des Stacks `web-waste-calendar` an
 7. Workflow führt schlanke Smoke-Checks gegen den öffentlichen Host aus
 
 ### Versionsmodell
@@ -103,7 +103,7 @@ Darstellungsfrontend mit vergleichsweise einfacher Rollback-Strategie.
 ### Stack-Trennung
 
 - die App läuft in einem eigenen Portainer-Stack
-  `public-waste-calendar`
+  `web-waste-calendar`
 - dafür wird eine eigene Compose-Datei eingeführt, zum Beispiel
   `deploy/portainer/docker-compose.public-waste.yml`
 - dieser Stack darf weder aus dem `studio`-Stack abgeleitet werden noch
@@ -247,7 +247,7 @@ Der gewünschte Bedienpfad lautet im Ergebnis:
 1. Code für `public-waste-calendar-web` freigeben
 2. Git-Tag `waste-web-v1.2.3` pushen
 3. GitHub baut und publiziert das Image `:v1.2.3`
-4. GitHub aktualisiert nur den Stack `public-waste-calendar`
+4. GitHub aktualisiert nur den Stack `web-waste-calendar`
 5. Smoke-Checks bestätigen die neue Version
 
 Der öffentliche Abfallkalender erhält damit einen eigenen,

--- a/docs/superpowers/specs/2026-06-05-public-waste-web-release-design.md
+++ b/docs/superpowers/specs/2026-06-05-public-waste-web-release-design.md
@@ -1,0 +1,255 @@
+# Releasepfad für die öffentliche Abfallkalender-Webversion
+
+## Ziel
+
+Die öffentliche Webversion des Abfallkalenders soll einen eigenen,
+einfach bedienbaren Releasepfad erhalten, der vollständig vom normalen
+Studio-Deploy getrennt bleibt.
+
+Ein Release soll über ein Git-Tag im Format `waste-web-vX.Y.Z`
+automatisch ausgelöst werden, ein eigenes Image mit exakt diesem
+SemVer-Tag bauen und ausschließlich den dedizierten Portainer-Stack
+`public-waste-calendar` auf diese Version aktualisieren.
+
+## Nicht-Ziele
+
+- keine Änderung am bestehenden `studio`-Stack
+- keine Änderung am bestehenden `studio`-Image
+- keine Änderung am offiziellen `studio`-Releasevertrag
+- kein gemeinsamer Releaseworkflow für Studio und öffentlichen
+  Abfallkalender
+- kein produktionsführender JSON-Konfigurationsblob für die Runtime
+- kein Digest-Pinning als verpflichtender Betriebsvertrag für diesen
+  speziellen Bürger-Frontend-Stack
+
+## Ausgangslage
+
+Die App `apps/public-waste-calendar-web` ist heute als eigenständige
+öffentliche Capability angelegt, besitzt aber noch keinen sauberen,
+produktiven Release- und Swarm-Betriebsvertrag.
+
+Gleichzeitig ist wichtig:
+
+- die App ist fachlich vom Studio getrennt
+- sie benötigt keinen Studio-Login
+- sie ist trotz schlanker Oberfläche keine rein statische Website,
+  sondern liefert zusätzlich öffentliche Read-Endpunkte unter
+  `/api/public-waste/*`
+
+Damit reicht ein einfacher statischer Hostingpfad nicht aus. Die App
+braucht eine eigene Runtime, aber ohne den normalen Studio-Releasepfad
+mitzubenutzen.
+
+## Leitentscheidung
+
+Die öffentliche Webversion des Abfallkalenders erhält einen vollständig
+isolierten Release- und Deploymentpfad.
+
+Diese Isolation ist die zentrale Architekturentscheidung:
+
+1. eigener Stack
+2. eigenes Image
+3. eigener Workflow
+4. eigene Runtime-Variablen
+5. keine Mitnutzung des `studio`-Releasevertrags
+
+Die einzige zulässige Gemeinsamkeit liegt auf Infrastruktur-Ebene,
+etwa derselbe Swarm-, Portainer- oder Traefik-Server. Auf App-,
+Workflow- und Konfigurationsebene bleibt die Trennung hart.
+
+## Release-Vertrag
+
+Der Releasepfad wird ausschließlich über Git-Tags gesteuert.
+
+### Trigger
+
+- Ein Push auf ein Git-Tag im Format `waste-web-vX.Y.Z` startet den
+  Releaseworkflow automatisch.
+- Das Tagformat wird strikt validiert.
+- Andere Tags oder Branch-Pushes dürfen diesen Workflow nicht auslösen.
+
+### Release-Ablauf
+
+1. Git-Tag wird erkannt
+2. Workflow validiert das Tagformat
+3. Workflow baut nur das Image des öffentlichen Abfallkalenders
+4. Workflow published das Image mit exakt diesem Tag
+5. Workflow aktualisiert im Portainer-Stack nur die Image-Version
+6. Workflow stößt den Rollout des Stacks `public-waste-calendar` an
+7. Workflow führt schlanke Smoke-Checks gegen den öffentlichen Host aus
+
+### Versionsmodell
+
+- Es wird echtes SemVer verwendet
+- Das Git-Tag ist die führende Releasebezeichnung
+- Der Portainer-Stack referenziert bewusst den Image-Tag
+- Für diesen Stack ist kein verpflichtendes Digest-Pinning vorgesehen
+
+Die Entscheidung gegen Digest-Pinning ist hier bewusst operativ
+motiviert: Der öffentliche Webkalender ist ein schlankes
+Darstellungsfrontend mit vergleichsweise einfacher Rollback-Strategie.
+
+## Technische Trennung
+
+### App- und Image-Trennung
+
+- `apps/public-waste-calendar-web` bleibt die einzige App-Quelle für
+  diese Bürgeroberfläche
+- die App erhält ein eigenes Container-Image
+- das Image wird nicht in das bestehende `sva-studio`-Image eingebaut
+- der bisherige Studio-Dockerfile und die bisherigen Studio-Workflows
+  bleiben fachlich unangetastet
+
+### Stack-Trennung
+
+- die App läuft in einem eigenen Portainer-Stack
+  `public-waste-calendar`
+- dafür wird eine eigene Compose-Datei eingeführt, zum Beispiel
+  `deploy/portainer/docker-compose.public-waste.yml`
+- dieser Stack darf weder aus dem `studio`-Stack abgeleitet werden noch
+  dessen Variablenraum mitverwenden
+
+### Variablen-Trennung
+
+Die Runtime nutzt einen eigenen Konfigurationsraum mit dem Prefix
+`PUBLIC_WASTE_`.
+
+Beispielhafte führende Produktionsvariablen:
+
+- `PUBLIC_WASTE_IMAGE_TAG`
+- `PUBLIC_WASTE_PUBLIC_HOST`
+- `PUBLIC_WASTE_BASE_URL`
+- `PUBLIC_WASTE_INSTANCE_ID`
+- `PUBLIC_WASTE_DATABASE_URL`
+- `PUBLIC_WASTE_SCHEMA_NAME`
+- `PUBLIC_WASTE_PDF_URL_TEMPLATE`
+
+Der bestehende JSON-Blob `PUBLIC_WASTE_CONFIG_JSON` wird für den
+Produktionsvertrag nicht als führende Quelle verwendet. Einzelne
+Variablen sind in Portainer lesbarer, gezielter änderbar und
+betriebspraktischer.
+
+Ein JSON-basierter Fallback kann für lokale Entwicklung oder
+Kompatibilität bestehen bleiben, darf aber nicht der operative
+Sollzustand des Portainer-Stacks sein.
+
+## Runtime-Vertrag
+
+Die Runtime liefert:
+
+- die öffentliche Startseite
+- die bestehende Bürgeroberfläche
+- die öffentlichen Read-Endpunkte unter `/api/public-waste/*`
+
+Die App bleibt damit eine kleine serverseitige Web-Runtime und kein
+reines Static-Site-Artefakt.
+
+Wichtig ist dabei:
+
+- kein impliziter Rückgriff auf `SVA_*`
+- keine stillschweigende Mitnutzung von Studio-Konfiguration
+- keine Vermischung von Waste-Web- und Studio-Releasevariablen
+
+## Fehlerverhalten
+
+Die Runtime arbeitet fail-closed.
+
+Das bedeutet:
+
+- fehlende Pflichtkonfiguration führt zu einem expliziten Fehlerzustand
+- ungültige Konfiguration führt zu einem expliziten Fehlerzustand
+- es gibt keinen stillen Fallback auf Studio-Konfiguration
+- es gibt keinen automatischen Rückgriff auf alternative
+  Produktionsquellen
+
+Die harte Trennung von Studio und öffentlichem Abfallkalender gilt auch
+im Fehlerfall.
+
+## Smoke-Checks
+
+Nach jedem Release werden nur schlanke, aber aussagekräftige
+Smoke-Checks ausgeführt.
+
+Mindestens erforderlich sind:
+
+- `GET /` liefert die öffentliche Oberfläche
+- `GET /health/live` oder ein äquivalenter Runtime-Health-Check ist grün
+- mindestens ein öffentlicher Read-Pfad unter `/api/public-waste/*`
+  antwortet erwartbar
+
+Diese Prüfungen sollen den Releasepfad leichtgewichtig halten, aber
+genug fachliche Sicherheit geben, dass nicht nur ein Container läuft,
+sondern die öffentliche Runtime tatsächlich antwortet.
+
+## Rollback
+
+Rollback bleibt bewusst einfach.
+
+Der operative Standardpfad ist:
+
+1. im Portainer-Stack `PUBLIC_WASTE_IMAGE_TAG` auf die vorherige
+   SemVer-Version zurücksetzen
+2. Stack erneut deployen
+3. Smoke-Checks erneut ausführen
+
+Damit folgt der Rollback demselben bewusst einfachen Tag-Modell wie der
+Vorwärts-Release.
+
+## Schutz vor Studio-Beifang
+
+Der neue Releasepfad muss explizit so gebaut sein, dass normale
+Studio-Rollouts davon unberührt bleiben.
+
+Verbindliche Leitplanken:
+
+- eigener Workflow-Dateiname
+- eigenes Trigger-Muster
+- eigener Image-Name
+- eigener Stack-Name
+- eigener Variablen-Prefix
+- keine Erweiterung des bestehenden `studio`-Workflows
+- keine Erweiterung des bestehenden `studio`-Stacks
+- keine Kopplung an `SVA_IMAGE_TAG`, `SVA_IMAGE_REF` oder
+  `SVA_IMAGE_DIGEST`
+
+Die normale Studio-Runtime darf durch einen Waste-Web-Release weder
+fachlich noch operativ beeinflusst werden.
+
+## Risiken und bewusste Trade-offs
+
+### Kein Digest-Pinning
+
+Das Tag-Modell ist operativ einfacher, aber weniger hart reproduzierbar
+als ein digest-basierter Vertrag.
+
+Dieser Nachteil wird hier bewusst akzeptiert, weil:
+
+- die App ein schlankes öffentliches Frontend ist
+- der Rollback einfach bleibt
+- die Bedienbarkeit für den Betrieb höher gewichtet wird
+
+### Zusätzlicher Deployvertrag
+
+Ein eigener Waste-Web-Stack erhöht die Zahl der Betriebsartefakte:
+
+- eigenes Image
+- eigene Compose-Datei
+- eigener Workflow
+- eigener Satz Portainer-Variablen
+
+Dieser Mehraufwand ist jedoch der Preis für die gewünschte harte
+Isolation zum normalen Studio.
+
+## Zielbild
+
+Der gewünschte Bedienpfad lautet im Ergebnis:
+
+1. Code für `public-waste-calendar-web` freigeben
+2. Git-Tag `waste-web-v1.2.3` pushen
+3. GitHub baut und publiziert das Image `:v1.2.3`
+4. GitHub aktualisiert nur den Stack `public-waste-calendar`
+5. Smoke-Checks bestätigen die neue Version
+
+Der öffentliche Abfallkalender erhält damit einen eigenen,
+leichtgewichtigen und betriebspraktischen Releasepfad, ohne den
+bestehenden Studio-Betrieb zu verändern.

--- a/openspec/changes/add-public-waste-web-release-pipeline/proposal.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/proposal.md
@@ -10,7 +10,7 @@ bestehenden Studio-Betrieb nicht beeinflussen.
 ## What Changes
 
 - eigener Produktionspfad für `apps/public-waste-calendar-web`
-- eigener Swarm-/Portainer-Stack `public-waste-calendar`
+- eigener Swarm-/Portainer-Stack `web-waste-calendar`
 - Git-Tag-getriebener Releaseworkflow `waste-web-vX.Y.Z`
 - produktive Runtime-Konfiguration über einzelne `PUBLIC_WASTE_*`-Variablen
 - eigener Produktionsserver für die öffentliche Web-App mit Health- und

--- a/openspec/changes/add-public-waste-web-release-pipeline/proposal.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/proposal.md
@@ -1,0 +1,25 @@
+# Change: Öffentlicher Releasepfad für den Abfallkalender
+
+## Why
+
+Die öffentliche Webversion des Abfallkalenders benötigt einen eigenen
+Release- und Deployvertrag, damit Releases nicht über den normalen
+Studio-Stack laufen und operative Änderungen am Bürger-Frontend den
+bestehenden Studio-Betrieb nicht beeinflussen.
+
+## What Changes
+
+- eigener Produktionspfad für `apps/public-waste-calendar-web`
+- eigener Swarm-/Portainer-Stack `public-waste-calendar`
+- Git-Tag-getriebener Releaseworkflow `waste-web-vX.Y.Z`
+- produktive Runtime-Konfiguration über einzelne `PUBLIC_WASTE_*`-Variablen
+- eigener Produktionsserver für die öffentliche Web-App mit Health- und
+  öffentlichen Read-Endpunkten
+- **BREAKING (betrieblich):** produktionsführende Konfiguration ist nicht mehr
+  `PUBLIC_WASTE_CONFIG_JSON`, sondern aufgetrennte Variablen
+
+## Impact
+
+- Affected specs: `public-waste-calendar`, `deployment-topology`, `architecture-documentation`
+- Affected code: `apps/public-waste-calendar-web`, `deploy/portainer/*`, `.github/workflows/*`, `scripts/ops/*`
+- Affected arc42 sections: `05-building-block-view`, `07-deployment-view`, `08-cross-cutting-concepts`

--- a/openspec/changes/add-public-waste-web-release-pipeline/specs/architecture-documentation/spec.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/specs/architecture-documentation/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Architektur dokumentiert isolierten Waste-Web-Releasepfad
+
+Die Architektur- und Betriebsdokumentation SHALL den Releasepfad der
+öffentlichen Waste-Web-App als vom normalen Studio getrennten Deployvertrag
+beschreiben.
+
+#### Scenario: Dokumentation beschreibt harte Stack- und Workflow-Trennung
+
+- **WHEN** ein Teammitglied den öffentlichen Waste-Web-Releasepfad nachschlägt
+- **THEN** dokumentieren `05-building-block-view`, `07-deployment-view` und `08-cross-cutting-concepts`
+  die Trennung von eigenem Image, eigenem Stack, eigenem Variablenraum und eigenem Workflow
+- **AND** die Doku grenzt diesen Vertrag explizit vom normalen `studio`-Releasepfad ab
+
+#### Scenario: Betriebsdoku erklärt tag-basierten Release und Smoke-Checks
+
+- **WHEN** ein Operator einen neuen öffentlichen Waste-Web-Release vorbereitet oder nachvollzieht
+- **THEN** beschreibt das Runbook Git-Tags `waste-web-vX.Y.Z`, den Portainer-Variablenvertrag,
+  den Stack-Rollout und die nachgelagerten Smoke-Checks
+- **AND** die Doku benennt Rollback über einen früheren `PUBLIC_WASTE_IMAGE_TAG` als Standardpfad

--- a/openspec/changes/add-public-waste-web-release-pipeline/specs/deployment-topology/spec.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/specs/deployment-topology/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Öffentliche Waste-Web-App hat einen eigenen Swarm-Stack
+
+Das System SHALL für `public-waste-calendar` einen eigenen Portainer-/Swarm-Stack
+bereitstellen, der nicht Teil des normalen `studio`-Stacks ist.
+
+#### Scenario: Öffentliche Waste-Web-App wird getrennt von Studio ausgerollt
+
+- **WHEN** ein Operator oder Workflow die öffentliche Waste-Web-App ausrollt
+- **THEN** erfolgt der Rollout gegen den dedizierten Stack `public-waste-calendar`
+- **AND** der bestehende `studio`-Stack bleibt unverändert
+- **AND** die Compose-Definition des Waste-Web-Stacks erweitert nicht die Studio-Compose
+
+### Requirement: Öffentliche Waste-Web-App nutzt tag-basiertes Image-Deployment
+
+Das System SHALL die öffentliche Waste-Web-App im produktiven Stack über einen
+parametrisierbaren Image-Tag referenzieren.
+
+#### Scenario: Git-Tag steuert den produktiven Image-Tag
+
+- **WHEN** ein Git-Tag `waste-web-v1.2.3` den öffentlichen Releaseworkflow auslöst
+- **THEN** veröffentlicht der Workflow das Waste-Web-Image mit dem Tag `v1.2.3`
+- **AND** aktualisiert im Zielstack nur die Variable `PUBLIC_WASTE_IMAGE_TAG`
+- **AND** andere Laufzeitvariablen des Stacks bleiben dabei unverändert
+
+#### Scenario: Rollback erfolgt über vorherigen SemVer-Tag
+
+- **WHEN** ein Operator einen öffentlichen Waste-Web-Release zurücknehmen muss
+- **THEN** kann der Stack auf einen früheren `PUBLIC_WASTE_IMAGE_TAG` zurückgesetzt werden
+- **AND** der Rollback benötigt keinen Eingriff in den normalen Studio-Stack
+
+### Requirement: Öffentliche Waste-Web-App verwendet isoliertes Host-Routing
+
+Das System SHALL die öffentliche Waste-Web-App über eigene Ingress-Hosts und
+eigene Runtime-Variablen routen.
+
+#### Scenario: Öffentlicher Host wird über eigenen Variablenraum aufgelöst
+
+- **WHEN** der produktive Waste-Web-Stack gerendert wird
+- **THEN** leitet die Compose-Datei den öffentlichen Host aus `PUBLIC_WASTE_PUBLIC_HOST` ab
+- **AND** die Runtime nutzt `PUBLIC_WASTE_BASE_URL` als kanonische Base-URL
+- **AND** weder Host noch Base-URL werden aus `SVA_PARENT_DOMAIN` oder `SVA_PUBLIC_BASE_URL` des Studios abgeleitet

--- a/openspec/changes/add-public-waste-web-release-pipeline/specs/deployment-topology/spec.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/specs/deployment-topology/spec.md
@@ -2,13 +2,13 @@
 
 ### Requirement: Öffentliche Waste-Web-App hat einen eigenen Swarm-Stack
 
-Das System SHALL für `public-waste-calendar` einen eigenen Portainer-/Swarm-Stack
+Das System SHALL für `web-waste-calendar` einen eigenen Portainer-/Swarm-Stack
 bereitstellen, der nicht Teil des normalen `studio`-Stacks ist.
 
 #### Scenario: Öffentliche Waste-Web-App wird getrennt von Studio ausgerollt
 
 - **WHEN** ein Operator oder Workflow die öffentliche Waste-Web-App ausrollt
-- **THEN** erfolgt der Rollout gegen den dedizierten Stack `public-waste-calendar`
+- **THEN** erfolgt der Rollout gegen den dedizierten Stack `web-waste-calendar`
 - **AND** der bestehende `studio`-Stack bleibt unverändert
 - **AND** die Compose-Definition des Waste-Web-Stacks erweitert nicht die Studio-Compose
 

--- a/openspec/changes/add-public-waste-web-release-pipeline/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/specs/public-waste-calendar/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Öffentliche Abfallkalender-App hat einen isolierten Releasepfad
 
-Das System SHALL für `public-waste-calendar` einen eigenen Releasepfad
+Das System SHALL für `web-waste-calendar` einen eigenen Releasepfad
 bereitstellen, der weder den `studio`-Stack noch den `studio`-Releaseworkflow
 mitverwendet.
 

--- a/openspec/changes/add-public-waste-web-release-pipeline/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/specs/public-waste-calendar/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Öffentliche Abfallkalender-App hat einen isolierten Releasepfad
+
+Das System SHALL für `public-waste-calendar` einen eigenen Releasepfad
+bereitstellen, der weder den `studio`-Stack noch den `studio`-Releaseworkflow
+mitverwendet.
+
+#### Scenario: Git-Tag triggert nur den öffentlichen Waste-Release
+
+- **WHEN** ein Git-Tag `waste-web-v1.2.3` gepusht wird
+- **THEN** baut und deployt das System nur die öffentliche Waste-Web-Runtime
+- **AND** der normale Studio-Releasepfad bleibt unberührt
+
+#### Scenario: Öffentliche Waste-Runtime nutzt eigenen Variablenraum
+
+- **WHEN** die öffentliche Waste-Web-Runtime produktiv gestartet wird
+- **THEN** liest sie ihre führende Konfiguration aus `PUBLIC_WASTE_*`-Variablen
+- **AND** greift nicht implizit auf `SVA_*`-Runtime-Variablen des normalen Studios zurück
+- **AND** ein JSON-basierter Konfigurationsblob bleibt höchstens ein lokaler oder kompatibler Fallback
+
+### Requirement: Öffentliche Abfallkalender-App liefert produktiven Health- und API-Vertrag
+
+Das System SHALL die öffentliche Waste-Web-App produktiv als eigene
+serverseitige Runtime mit statischen Assets, Health-Endpoint und bestehenden
+öffentlichen Read-Endpunkten ausliefern.
+
+#### Scenario: Produktionsruntime antwortet auf Health-Check
+
+- **WHEN** ein Operator oder Releaseworkflow `GET /health/live` gegen die öffentliche Waste-Web-Runtime ausführt
+- **THEN** liefert die Runtime einen expliziten erfolgreichen Health-Befund
+- **AND** dieser Befund ist unabhängig vom normalen Studio-Health-Pfad
+
+#### Scenario: Produktiver Release prüft einen öffentlichen Read-Pfad
+
+- **WHEN** ein Release der öffentlichen Waste-Web-Runtime abgeschlossen wird
+- **THEN** prüft der Smoke-Test neben der Startseite mindestens einen öffentlichen `/api/public-waste/*`-Pfad
+- **AND** bewertet damit nicht nur das Vorhandensein eines laufenden Containers, sondern den fachlichen Read-Vertrag

--- a/openspec/changes/add-public-waste-web-release-pipeline/tasks.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spezifikation und Runtime-Vertrag
+
+- [ ] 1.1 OpenSpec-Deltas für isolierten Releasepfad, Stack-Trennung und Dokumentationspflicht ergänzen
+- [ ] 1.2 Produktionskonfiguration der öffentlichen Waste-Web-App auf einzelne `PUBLIC_WASTE_*`-Variablen umstellen und `PUBLIC_WASTE_CONFIG_JSON` nur als Fallback erhalten
+- [ ] 1.3 Produktionsruntime mit Health-Endpoint und bestehenden `/api/public-waste/*`-Handlern implementieren
+
+## 2. Deployment-Artefakte
+
+- [ ] 2.1 Eigenes Dockerfile und eigene Swarm-Compose-Datei für `public-waste-calendar` ergänzen
+- [ ] 2.2 Quantum-/Runtime-Beispielkonfiguration für den isolierten Waste-Web-Stack dokumentieren
+- [ ] 2.3 GitHub-Workflow für Git-Tags `waste-web-vX.Y.Z` ergänzen, der nur das Waste-Web-Image baut und den Waste-Web-Stack ausrollt
+- [ ] 2.4 Dedizierten Portainer-/Quantum-Scriptpfad ergänzen, der nur `PUBLIC_WASTE_IMAGE_TAG` im Zielstack aktualisiert
+
+## 3. Verifikation und Dokumentation
+
+- [ ] 3.1 Fokus-Tests, Typechecks, Compose-Render und OpenSpec-Validierung grün ziehen
+- [ ] 3.2 arc42-Abschnitte `05`, `07` und `08` sowie Deploy-Guide/Runbook für den isolierten Waste-Web-Releasepfad fortschreiben

--- a/openspec/changes/add-public-waste-web-release-pipeline/tasks.md
+++ b/openspec/changes/add-public-waste-web-release-pipeline/tasks.md
@@ -6,7 +6,7 @@
 
 ## 2. Deployment-Artefakte
 
-- [ ] 2.1 Eigenes Dockerfile und eigene Swarm-Compose-Datei für `public-waste-calendar` ergänzen
+- [ ] 2.1 Eigenes Dockerfile und eigene Swarm-Compose-Datei für `web-waste-calendar` ergänzen
 - [ ] 2.2 Quantum-/Runtime-Beispielkonfiguration für den isolierten Waste-Web-Stack dokumentieren
 - [ ] 2.3 GitHub-Workflow für Git-Tags `waste-web-vX.Y.Z` ergänzen, der nur das Waste-Web-Image baut und den Waste-Web-Stack ausrollt
 - [ ] 2.4 Dedizierten Portainer-/Quantum-Scriptpfad ergänzen, der nur `PUBLIC_WASTE_IMAGE_TAG` im Zielstack aktualisiert

--- a/scripts/ops/public-waste/portainer-release.test.ts
+++ b/scripts/ops/public-waste/portainer-release.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  parseWasteWebReleaseTag,
+  releasePublicWasteStack,
+  updateStackEnv,
+} from './portainer-release.ts';
+
+describe('public waste portainer release', () => {
+  it('accepts waste-web SemVer tags', () => {
+    expect(parseWasteWebReleaseTag('refs/tags/waste-web-v1.2.3')).toEqual({
+      gitTag: 'waste-web-v1.2.3',
+      imageTag: 'v1.2.3',
+      version: '1.2.3',
+    });
+  });
+
+  it('updates only PUBLIC_WASTE_IMAGE_TAG and preserves other stack env values', () => {
+    expect(
+      updateStackEnv(
+        [
+          { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.2' },
+          { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+        ],
+        'v1.2.3'
+      )
+    ).toEqual([
+      { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.3' },
+      { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+    ]);
+  });
+
+  it('updates the remote stack payload without changing unrelated env values', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              Id: 42,
+              Name: 'public-waste-calendar',
+              EndpointId: 7,
+            },
+          ])
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            Id: 42,
+            Name: 'public-waste-calendar',
+            EndpointId: 7,
+            Env: [
+              { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.2' },
+              { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+            ],
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            StackFileContent: "version: '3.8'\nservices:\n  app:\n    image: ghcr.io/example/public-waste:v1.2.2\n",
+          })
+        )
+      )
+      .mockResolvedValueOnce(new Response('{}'));
+
+    const result = await releasePublicWasteStack(
+      {
+        GITHUB_REF: 'refs/tags/waste-web-v1.2.3',
+        PUBLIC_WASTE_STACK_NAME: 'public-waste-calendar',
+        QUANTUM_API_KEY: 'secret',
+        QUANTUM_ENDPOINT_ID: '7',
+        QUANTUM_HOST: 'https://portainer.example.invalid',
+      },
+      {
+        commandExists: vi.fn().mockReturnValue(false),
+        fetch,
+        runCapture: vi.fn(),
+      }
+    );
+
+    expect(result).toMatchObject({
+      gitTag: 'waste-web-v1.2.3',
+      imageTag: 'v1.2.3',
+      previousImageTag: 'v1.2.2',
+      stackId: 42,
+      stackName: 'public-waste-calendar',
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(4);
+
+    const updateCall = fetch.mock.calls[3];
+    expect(updateCall?.[0]).toBe('https://portainer.example.invalid/api/stacks/42?endpointId=7');
+    expect(updateCall?.[1]).toMatchObject({
+      method: 'PUT',
+      headers: {
+        'X-API-Key': 'secret',
+        'content-type': 'application/json',
+      },
+    });
+    expect(JSON.parse(String(updateCall?.[1]?.body))).toEqual({
+      Env: [
+        { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.3' },
+        { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+      ],
+      Prune: false,
+      StackFileContent: "version: '3.8'\nservices:\n  app:\n    image: ghcr.io/example/public-waste:v1.2.2\n",
+    });
+  });
+});

--- a/scripts/ops/public-waste/portainer-release.test.ts
+++ b/scripts/ops/public-waste/portainer-release.test.ts
@@ -38,7 +38,7 @@ describe('public waste portainer release', () => {
           JSON.stringify([
             {
               Id: 42,
-              Name: 'public-waste-calendar',
+              Name: 'web-waste-calendar',
               EndpointId: 7,
             },
           ])
@@ -48,7 +48,7 @@ describe('public waste portainer release', () => {
         new Response(
           JSON.stringify({
             Id: 42,
-            Name: 'public-waste-calendar',
+            Name: 'web-waste-calendar',
             EndpointId: 7,
             Env: [
               { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.2' },
@@ -69,7 +69,7 @@ describe('public waste portainer release', () => {
     const result = await releasePublicWasteStack(
       {
         GITHUB_REF: 'refs/tags/waste-web-v1.2.3',
-        PUBLIC_WASTE_STACK_NAME: 'public-waste-calendar',
+        PUBLIC_WASTE_STACK_NAME: 'web-waste-calendar',
         QUANTUM_API_KEY: 'secret',
         QUANTUM_ENDPOINT_ID: '7',
         QUANTUM_HOST: 'https://portainer.example.invalid',
@@ -86,7 +86,7 @@ describe('public waste portainer release', () => {
       imageTag: 'v1.2.3',
       previousImageTag: 'v1.2.2',
       stackId: 42,
-      stackName: 'public-waste-calendar',
+      stackName: 'web-waste-calendar',
     });
 
     expect(fetch).toHaveBeenCalledTimes(4);

--- a/scripts/ops/public-waste/portainer-release.ts
+++ b/scripts/ops/public-waste/portainer-release.ts
@@ -1,0 +1,238 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { commandExists, runCapture } from '../runtime/process.ts';
+import { resolveQuantumOperatorEnv, resolveRemoteDockerEndpointId } from '../runtime/remote-portainer.ts';
+
+type StackEnvEntry = {
+  readonly name: string;
+  readonly value: string;
+};
+
+type PortainerStackEnvRecord = {
+  readonly Name?: string;
+  readonly Value?: string;
+  readonly name?: string;
+  readonly value?: string;
+};
+
+type PortainerStackRecord = {
+  readonly EndpointId?: number;
+  readonly Env?: readonly PortainerStackEnvRecord[];
+  readonly Id?: number;
+  readonly Name?: string;
+};
+
+type ReleaseDeps = {
+  readonly commandExists: (commandName: string) => boolean;
+  readonly fetch: typeof fetch;
+  readonly runCapture: (commandName: string, args: readonly string[], env?: NodeJS.ProcessEnv) => string;
+};
+
+type ReleaseResult = {
+  readonly endpointId: number;
+  readonly gitTag: string;
+  readonly imageTag: string;
+  readonly previousImageTag: string | null;
+  readonly stackId: number;
+  readonly stackName: string;
+  readonly version: string;
+};
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const currentScriptPath = fileURLToPath(import.meta.url);
+
+const defaultDeps: ReleaseDeps = {
+  commandExists: (commandName) => commandExists(rootDir, commandName),
+  fetch: globalThis.fetch.bind(globalThis),
+  runCapture: (commandName, args, env) => runCapture(rootDir, commandName, args, env),
+};
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/u, '');
+
+const requireEnvValue = (value: string | undefined, key: string): string => {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${key} fehlt.`);
+  }
+
+  return normalized;
+};
+
+const normalizeStackEnv = (env: readonly PortainerStackEnvRecord[] | undefined): StackEnvEntry[] =>
+  (env ?? [])
+    .map((entry) => ({
+      name: entry.name ?? entry.Name ?? '',
+      value: entry.value ?? entry.Value ?? '',
+    }))
+    .filter((entry) => entry.name.length > 0);
+
+const parseStackFileContent = (rawText: string): string => {
+  try {
+    const parsed = JSON.parse(rawText) as unknown;
+
+    if (typeof parsed === 'string') {
+      return parsed;
+    }
+
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'StackFileContent' in parsed &&
+      typeof parsed.StackFileContent === 'string'
+    ) {
+      return parsed.StackFileContent;
+    }
+  } catch {
+    return rawText;
+  }
+
+  return rawText;
+};
+
+const portainerRequest = async (input: {
+  readonly deps: ReleaseDeps;
+  readonly host: string;
+  readonly apiKey: string;
+  readonly path: string;
+  readonly init?: RequestInit;
+}): Promise<Response> => {
+  const response = await input.deps.fetch(`${trimTrailingSlash(input.host)}${input.path}`, {
+    ...input.init,
+    headers: {
+      'X-API-Key': input.apiKey,
+      ...(input.init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.text()).trim();
+    throw new Error(
+      `Portainer-API ${input.path} antwortet mit ${response.status}.${errorBody ? ` ${errorBody}` : ''}`
+    );
+  }
+
+  return response;
+};
+
+export const parseWasteWebReleaseTag = (ref: string) => {
+  const match = /^refs\/tags\/waste-web-v(\d+\.\d+\.\d+)$/u.exec(ref.trim());
+  if (!match) {
+    throw new Error(`Ungueltiges Waste-Web-Release-Tag: ${ref}`);
+  }
+
+  return {
+    gitTag: `waste-web-v${match[1]}`,
+    imageTag: `v${match[1]}`,
+    version: match[1],
+  } as const;
+};
+
+export const updateStackEnv = (env: readonly StackEnvEntry[], imageTag: string): StackEnvEntry[] => {
+  const nextEnv = [...env];
+  const imageTagIndex = nextEnv.findIndex((entry) => entry.name === 'PUBLIC_WASTE_IMAGE_TAG');
+
+  if (imageTagIndex === -1) {
+    nextEnv.push({
+      name: 'PUBLIC_WASTE_IMAGE_TAG',
+      value: imageTag,
+    });
+    return nextEnv;
+  }
+
+  nextEnv[imageTagIndex] = {
+    name: 'PUBLIC_WASTE_IMAGE_TAG',
+    value: imageTag,
+  };
+  return nextEnv;
+};
+
+export const releasePublicWasteStack = async (
+  env: NodeJS.ProcessEnv = process.env,
+  deps: ReleaseDeps = defaultDeps
+): Promise<ReleaseResult> => {
+  const release = parseWasteWebReleaseTag(requireEnvValue(env.GITHUB_REF, 'GITHUB_REF'));
+  const operatorEnv = resolveQuantumOperatorEnv(env);
+  const host = trimTrailingSlash(operatorEnv.QUANTUM_HOST?.trim() || 'https://console.planetary-quantum.com');
+  const apiKey = requireEnvValue(operatorEnv.QUANTUM_API_KEY, 'QUANTUM_API_KEY');
+  const stackName = requireEnvValue(
+    env.PUBLIC_WASTE_STACK_NAME ?? operatorEnv.PUBLIC_WASTE_STACK_NAME,
+    'PUBLIC_WASTE_STACK_NAME'
+  );
+  const endpointId = resolveRemoteDockerEndpointId(deps, operatorEnv, env.PORTAINER_ENDPOINT_NAME?.trim() || 'sva');
+
+  const stacksResponse = await portainerRequest({
+    deps,
+    host,
+    apiKey,
+    path: '/api/stacks',
+  });
+  const stacks = (await stacksResponse.json()) as PortainerStackRecord[];
+  const stack = stacks.find(
+    (candidate) => candidate.Name === stackName && (candidate.EndpointId === undefined || candidate.EndpointId === endpointId)
+  );
+
+  if (!stack?.Id) {
+    throw new Error(`Portainer-Stack ${stackName} wurde nicht gefunden.`);
+  }
+
+  const stackDetailsResponse = await portainerRequest({
+    deps,
+    host,
+    apiKey,
+    path: `/api/stacks/${String(stack.Id)}`,
+  });
+  const stackDetails = (await stackDetailsResponse.json()) as PortainerStackRecord;
+
+  const stackFileResponse = await portainerRequest({
+    deps,
+    host,
+    apiKey,
+    path: `/api/stacks/${String(stack.Id)}/file`,
+  });
+  const stackFileContent = parseStackFileContent(await stackFileResponse.text());
+
+  const currentEnv = normalizeStackEnv(stackDetails.Env ?? stack.Env);
+  const previousImageTag = currentEnv.find((entry) => entry.name === 'PUBLIC_WASTE_IMAGE_TAG')?.value ?? null;
+  const nextEnv = updateStackEnv(currentEnv, release.imageTag);
+
+  await portainerRequest({
+    deps,
+    host,
+    apiKey,
+    path: `/api/stacks/${String(stack.Id)}?endpointId=${String(endpointId)}`,
+    init: {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        Env: nextEnv,
+        Prune: false,
+        StackFileContent: stackFileContent,
+      }),
+    },
+  });
+
+  return {
+    ...release,
+    endpointId,
+    previousImageTag,
+    stackId: stack.Id,
+    stackName,
+  };
+};
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  releasePublicWasteStack()
+    .then((result) => {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exit(1);
+    });
+}
+
+export type { ReleaseDeps, ReleaseResult, StackEnvEntry };


### PR DESCRIPTION
## Summary
- add a dedicated production runtime and release pipeline for `apps/public-waste-calendar-web`
- add isolated Portainer/Swarm deployment assets for the `web-waste-calendar` stack on `node-003.sva`
- document the rollout path, runtime configuration, and architecture updates for the public waste web app

## Test Plan
- [x] `pnpm exec vitest run scripts/ops/public-waste/portainer-release.test.ts`
- [x] `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- [x] `pnpm nx run public-waste-calendar-web:build`
- [x] GitHub Actions release run `waste-web-v0.1.0`
- [x] Smoke checks against `https://bb-prignitz.abfallkalender.smart-village.app`
