### PR TITLE
[codex] fix(auth): clear client logout session state

### DIFF
--- a/apps/sva-studio-react/src/components/Header.test.tsx
+++ b/apps/sva-studio-react/src/components/Header.test.tsx
@@ -2,12 +2,39 @@
  * Unit-Tests für Header-Auth-Aktionen und Loading-Zustand.
  */
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAuthDiagnosticTrail, readAuthDiagnosticTrail, recordAuthDiagnosticEvent } from '../lib/auth-diagnostics';
 import Header from './Header';
 
 const useAuthMock = vi.fn();
 const useLocaleMock = vi.fn();
 const useThemeMock = vi.fn();
+const localStorageState = new Map<string, string>();
+const sessionStorageState = new Map<string, string>();
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageState.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageState.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    localStorageState.delete(key);
+  }),
+  clear: vi.fn(() => {
+    localStorageState.clear();
+  }),
+};
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => sessionStorageState.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    sessionStorageState.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    sessionStorageState.delete(key);
+  }),
+  clear: vi.fn(() => {
+    sessionStorageState.clear();
+  }),
+};
 
 vi.mock('../providers/auth-provider', () => ({
   useAuth: () => useAuthMock(),
@@ -56,7 +83,23 @@ describe('Header auth actions', () => {
     useAuthMock.mockReset();
     useThemeMock.mockReset();
     useLocaleMock.mockReset();
+    localStorageState.clear();
+    sessionStorageState.clear();
+    clearAuthDiagnosticTrail();
     vi.unstubAllEnvs();
+  });
+
+  beforeEach(() => {
+    localStorageState.clear();
+    sessionStorageState.clear();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: localStorageMock,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: sessionStorageMock,
+    });
   });
 
   it('zeigt Dev-Auth-Badge und lokalen Dev-Login im expliziten Dev-Modus', async () => {
@@ -194,6 +237,59 @@ describe('Header auth actions', () => {
     const logoutIntent = logoutForm?.querySelector('input[name="logoutIntent"]');
     expect(logoutForm?.getAttribute('method')).toBe('post');
     expect(logoutIntent?.getAttribute('value')).toBe('user');
+  });
+
+  it('räumt lokale Session-Marker vor dem Formular-Logout auf', async () => {
+    window.localStorage.setItem('sva_auth_had_session', '1');
+    recordAuthDiagnosticEvent({
+      authFlowId: 'auth-flow-logout',
+      attempt: 1,
+      event: 'auth_me_401_received',
+      requestId: 'req-logout',
+    });
+
+    useAuthMock.mockReturnValue({
+      user: {
+        id: 'user-1',
+        name: 'Test User',
+        roles: ['editor'],
+        permissionActions: ['experimental.read'],
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      hasResolvedSession: true,
+      refetch: vi.fn(),
+      logout: vi.fn(),
+      invalidatePermissions: vi.fn(),
+    });
+    useThemeMock.mockReturnValue({
+      mode: 'dark',
+      themeName: 'sva-default',
+      themeLabel: 'SVA Studio',
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+    useLocaleMock.mockReturnValue({
+      locale: 'de',
+      setLocale: vi.fn(),
+    });
+
+    render(<Header />);
+
+    const accountTrigger = await screen.findByRole('button', { name: /Test User/ });
+    accountTrigger.click();
+
+    await waitFor(() => {
+      expect(document.querySelector('form[action="/auth/logout"]')).not.toBeNull();
+    });
+    const logoutForm = document.querySelector('form[action="/auth/logout"]');
+    expect(readAuthDiagnosticTrail()).toHaveLength(1);
+
+    fireEvent.submit(logoutForm as HTMLFormElement);
+
+    expect(window.localStorage.getItem('sva_auth_had_session')).toBeNull();
+    expect(readAuthDiagnosticTrail()).toHaveLength(0);
   });
 
   it('zeigt beim Theme-Toggle den Zielmodus passend zum Icon an', async () => {

--- a/apps/sva-studio-react/src/components/Header.tsx
+++ b/apps/sva-studio-react/src/components/Header.tsx
@@ -13,6 +13,7 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { t } from '../i18n';
 import { createLoginHref, resolveCurrentReturnTo } from '../lib/auth-navigation';
+import { clearClientLogoutState } from '../lib/auth-session-state';
 import { hasExperimentalAccess } from '../lib/iam-admin-access';
 import { cn } from '../lib/utils';
 import { useAuth } from '../providers/auth-provider';
@@ -272,7 +273,7 @@ export default function Header({
           id: 'logout',
           label: t('shell.header.logout'),
           render: (
-            <form action="/auth/logout" method="post">
+            <form action="/auth/logout" method="post" onSubmit={() => clearClientLogoutState()}>
               <input type="hidden" name="logoutIntent" value="user" />
               <button
                 type="submit"

--- a/apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx
+++ b/apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { clearAuthDiagnosticTrail, readAuthDiagnosticTrail, recordAuthDiagnosticEvent } from '../lib/auth-diagnostics';
 import { LEGAL_ACCEPTANCE_REQUIRED_EVENT } from '../lib/iam-api';
 import { AuthProvider } from '../providers/auth-provider';
 import { LegalTextAcceptanceDialog } from './LegalTextAcceptanceDialog';
@@ -15,6 +16,32 @@ const browserLoggerMock = vi.hoisted(() => ({
 const getMyPendingLegalTextsMock = vi.fn();
 const acceptLegalTextMock = vi.fn();
 const asIamErrorMock = vi.fn();
+const localStorageState = new Map<string, string>();
+const sessionStorageState = new Map<string, string>();
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageState.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageState.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    localStorageState.delete(key);
+  }),
+  clear: vi.fn(() => {
+    localStorageState.clear();
+  }),
+};
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => sessionStorageState.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    sessionStorageState.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    sessionStorageState.delete(key);
+  }),
+  clear: vi.fn(() => {
+    sessionStorageState.clear();
+  }),
+};
 
 vi.mock('../lib/iam-api', async () => {
   const actual = await vi.importActual<typeof import('../lib/iam-api')>('../lib/iam-api');
@@ -37,6 +64,8 @@ describe('LegalTextAcceptanceDialog', () => {
     getMyPendingLegalTextsMock.mockReset();
     acceptLegalTextMock.mockReset();
     asIamErrorMock.mockReset();
+    localStorageState.clear();
+    sessionStorageState.clear();
     assignMock = vi.fn();
     vi.stubGlobal(
       'fetch',
@@ -59,6 +88,14 @@ describe('LegalTextAcceptanceDialog', () => {
         assign: assignMock,
       },
     });
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: localStorageMock,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: sessionStorageMock,
+    });
   });
 
   afterEach(() => {
@@ -67,6 +104,9 @@ describe('LegalTextAcceptanceDialog', () => {
     browserLoggerMock.info.mockReset();
     browserLoggerMock.warn.mockReset();
     browserLoggerMock.error.mockReset();
+    localStorageState.clear();
+    sessionStorageState.clear();
+    clearAuthDiagnosticTrail();
     vi.unstubAllGlobals();
   });
 
@@ -459,6 +499,13 @@ describe('LegalTextAcceptanceDialog', () => {
   });
 
   it('shows acceptance errors and allows retry/logout actions', async () => {
+    window.localStorage.setItem('sva_auth_had_session', '1');
+    recordAuthDiagnosticEvent({
+      authFlowId: 'auth-flow-legal-logout',
+      attempt: 1,
+      event: 'auth_me_401_received',
+      requestId: 'req-legal-logout',
+    });
     getMyPendingLegalTextsMock.mockResolvedValue({
       data: [
         {
@@ -497,6 +544,12 @@ describe('LegalTextAcceptanceDialog', () => {
     const logoutIntent = logoutForm?.querySelector('input[name="logoutIntent"]');
     expect(logoutForm?.getAttribute('method')).toBe('post');
     expect(logoutIntent?.getAttribute('value')).toBe('user');
+    expect(readAuthDiagnosticTrail().length).toBeGreaterThan(0);
+
+    fireEvent.submit(logoutForm as HTMLFormElement);
+
+    expect(window.localStorage.getItem('sva_auth_had_session')).toBeNull();
+    expect(readAuthDiagnosticTrail()).toHaveLength(0);
   });
 
 });

--- a/apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.tsx
+++ b/apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.tsx
@@ -14,6 +14,7 @@ import {
   storeLegalAcceptanceReturnTo,
 } from '../lib/legal-acceptance-navigation';
 import { sanitizeLegalTextHtml } from '../lib/legal-text-html-sanitizer';
+import { clearClientLogoutState } from '../lib/auth-session-state';
 import { t } from '../i18n';
 import { useAuth } from '../providers/auth-provider';
 import { Alert, AlertDescription } from './ui/alert';
@@ -268,7 +269,7 @@ export const LegalTextAcceptanceDialog = ({ pathname }: LegalTextAcceptanceDialo
           <Button type="button" variant="outline" onClick={() => void loadPendingTexts()} disabled={isSubmitting}>
             {t('admin.legalAcceptance.retry')}
           </Button>
-          <form action="/auth/logout" method="post">
+          <form action="/auth/logout" method="post" onSubmit={() => clearClientLogoutState()}>
             <input type="hidden" name="logoutIntent" value="user" />
             <Button type="submit" variant="outline" disabled={isSubmitting}>
               {t('admin.legalAcceptance.logout')}

--- a/apps/sva-studio-react/src/lib/auth-session-state.test.ts
+++ b/apps/sva-studio-react/src/lib/auth-session-state.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { markKnownSession, readHadKnownSession } from './auth-session-state';
+
+const localStorageState = new Map<string, string>();
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageState.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageState.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    localStorageState.delete(key);
+  }),
+};
+
+describe('auth-session-state', () => {
+  beforeEach(() => {
+    localStorageState.clear();
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    localStorageMock.removeItem.mockClear();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: localStorageMock,
+    });
+  });
+
+  afterEach(() => {
+    localStorageState.clear();
+  });
+
+  it('reads a known session marker from localStorage', () => {
+    markKnownSession();
+
+    expect(readHadKnownSession()).toBe(true);
+  });
+
+  it('returns false when localStorage.getItem throws', () => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        ...localStorageMock,
+        getItem: vi.fn(() => {
+          throw new Error('storage blocked');
+        }),
+      },
+    });
+
+    expect(readHadKnownSession()).toBe(false);
+  });
+});

--- a/apps/sva-studio-react/src/lib/auth-session-state.ts
+++ b/apps/sva-studio-react/src/lib/auth-session-state.ts
@@ -1,0 +1,35 @@
+import { clearAuthDiagnosticTrail } from './auth-diagnostics';
+
+const AUTH_KNOWN_SESSION_STORAGE_KEY = 'sva_auth_had_session';
+
+const readLocalStorage = (): Storage | null => {
+  try {
+    return globalThis.window?.localStorage ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export const readHadKnownSession = (): boolean =>
+  readLocalStorage()?.getItem(AUTH_KNOWN_SESSION_STORAGE_KEY) === '1';
+
+export const markKnownSession = (): void => {
+  try {
+    readLocalStorage()?.setItem(AUTH_KNOWN_SESSION_STORAGE_KEY, '1');
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+};
+
+export const clearKnownSession = (): void => {
+  try {
+    readLocalStorage()?.removeItem(AUTH_KNOWN_SESSION_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+};
+
+export const clearClientLogoutState = (): void => {
+  clearKnownSession();
+  clearAuthDiagnosticTrail();
+};

--- a/apps/sva-studio-react/src/lib/auth-session-state.ts
+++ b/apps/sva-studio-react/src/lib/auth-session-state.ts
@@ -10,8 +10,14 @@ const readLocalStorage = (): Storage | null => {
   }
 };
 
-export const readHadKnownSession = (): boolean =>
-  readLocalStorage()?.getItem(AUTH_KNOWN_SESSION_STORAGE_KEY) === '1';
+export const readHadKnownSession = (): boolean => {
+  try {
+    return readLocalStorage()?.getItem(AUTH_KNOWN_SESSION_STORAGE_KEY) === '1';
+  } catch {
+    // Storage methods can still throw in restricted browser contexts.
+    return false;
+  }
+};
 
 export const markKnownSession = (): void => {
   try {

--- a/apps/sva-studio-react/src/providers/auth-provider.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.tsx
@@ -13,11 +13,15 @@ import {
   logBrowserOperationSuccess,
 } from '../lib/browser-operation-logging';
 import {
-  clearAuthDiagnosticTrail,
   createAuthFlowId,
   publishAuthDiagnosticsDebugHandle,
   recordAuthDiagnosticEvent,
 } from '../lib/auth-diagnostics';
+import {
+  clearClientLogoutState,
+  markKnownSession,
+  readHadKnownSession,
+} from '../lib/auth-session-state';
 import {
   createLoginHref,
   createSessionExpiredHref,
@@ -79,7 +83,6 @@ const AUTH_LOGOUT_ENDPOINT = '/auth/logout';
 const LOGOUT_INTENT_HEADER = 'x-sva-logout-intent';
 const LOGOUT_INTENT_VALUE = 'user';
 const SILENT_SSO_MESSAGE_TYPE = 'sva-auth:silent-sso';
-const AUTH_KNOWN_SESSION_STORAGE_KEY = 'sva_auth_had_session';
 const isProductionMode = import.meta.env.PROD;
 const isTestRuntime = () =>
   import.meta.env.MODE === 'test' ||
@@ -107,30 +110,6 @@ type AuthDiagnosticMeta = Readonly<{
   safeDetails?: IamRuntimeSafeDetails;
   status?: number;
 }>;
-
-const readHadKnownSession = (): boolean => {
-  try {
-    return globalThis.window?.localStorage.getItem(AUTH_KNOWN_SESSION_STORAGE_KEY) === '1';
-  } catch {
-    return false;
-  }
-};
-
-const markKnownSession = (): void => {
-  try {
-    globalThis.window?.localStorage.setItem(AUTH_KNOWN_SESSION_STORAGE_KEY, '1');
-  } catch {
-    // Storage can be unavailable in restricted browser contexts.
-  }
-};
-
-const clearKnownSession = (): void => {
-  try {
-    globalThis.window?.localStorage.removeItem(AUTH_KNOWN_SESSION_STORAGE_KEY);
-  } catch {
-    // Storage can be unavailable in restricted browser contexts.
-  }
-};
 
 const readAuthDiagnosticMeta = (error: IamHttpError | undefined): Partial<AuthDiagnosticMeta> => ({
   classification: error?.classification,
@@ -796,8 +775,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         setIsRecoveringSession(false);
         setSessionRecoveryFailed(false);
       }
-      clearKnownSession();
-      clearAuthDiagnosticTrail();
+      clearClientLogoutState();
     }
   }, [nextAuthAttempt, recordTrail, startAuthFlow]);
 


### PR DESCRIPTION
## Was sich ändert
- extrahiert den clientseitigen Logout-Session-Cleanup in ein gemeinsames Hilfsmodul
- räumt lokale Sessionmarker und den Auth-Diagnostic-Trail sowohl im Header-Logout als auch im Legal-Text-Acceptance-Logout vor dem Formular-Submit auf
- hält die bekannte Session-Verfolgung im AuthProvider konsistent über denselben gemeinsamen Pfad

## Warum
Beim Logout blieben bislang lokale Sessionmarker und Diagnoseartefakte im Browser zurück. Das konnte nachgelagerte Session-Erkennung und Debugging verfälschen.

## Auswirkungen
- nur `apps/sva-studio-react` betroffen
- kein Backend- oder Vertragsänderungsbedarf

## Validierung
- `pnpm nx run sva-studio-react:test:unit --testFiles=src/components/Header.test.tsx --testFiles=src/components/LegalTextAcceptanceDialog.test.tsx --testFiles=src/providers/auth-provider.test.tsx`
- `pnpm nx affected --target=test:unit --base=origin/main`
