### PR TITLE
[codex] Fix waste scheduling selection and mainserver interface deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vscode/
 .idea/
 .claude/settings.local.json
+.superpowers/brainstorm/
 
 # Node/JavaScript
 node_modules/

--- a/apps/sva-studio-react/e2e/smoke.spec.ts
+++ b/apps/sva-studio-react/e2e/smoke.spec.ts
@@ -40,25 +40,7 @@ const isAcceptedAuthRedirect = (location: string | null | undefined) =>
   );
 
 const expectInterfacesShellReady = async (page: Page, timeout = 20_000) => {
-  await expect
-    .poll(
-      async () => {
-        const headingVisible = await page
-          .getByRole('heading', { name: 'Schnittstellen' })
-          .isVisible()
-          .catch(() => false);
-        if (headingVisible) {
-          return true;
-        }
-
-        return page
-          .getByText('Schnittstellen werden geladen ...')
-          .isVisible()
-          .catch(() => false);
-      },
-      { timeout }
-    )
-    .toBe(true);
+  await expect(page.getByRole('heading', { name: 'Schnittstellen', exact: true })).toBeVisible({ timeout });
 };
 
 const mockAuthenticatedPluginShell = async (page: Page) => {

--- a/apps/sva-studio-react/src/lib/interfaces-api.test.ts
+++ b/apps/sva-studio-react/src/lib/interfaces-api.test.ts
@@ -8,6 +8,7 @@ const state = vi.hoisted(() => ({
   upsertStoredInterface: vi.fn(),
   getStoredInterface: vi.fn(),
   deleteStoredInterface: vi.fn(),
+  deleteSvaMainserverSettings: vi.fn(),
   runStoredInterfaceHealthcheck: vi.fn(),
   checkStoredInterfaceHealth: vi.fn(),
   isCustomInterfaceStorageAvailable: vi.fn(),
@@ -41,6 +42,7 @@ vi.mock('@sva/sva-mainserver/server', () => ({
   ...(state.contractModuleLoads++, {}),
   loadSvaMainserverInterfacesOverview: state.loadSvaMainserverInterfacesOverview,
   saveSvaMainserverSettings: state.saveSvaMainserverSettings,
+  deleteSvaMainserverSettings: state.deleteSvaMainserverSettings,
 }));
 
 vi.mock('@sva/auth-runtime/server', () => ({
@@ -78,6 +80,7 @@ describe('interfaces app adapter', () => {
     state.upsertStoredInterface.mockReset();
     state.getStoredInterface.mockReset();
     state.deleteStoredInterface.mockReset();
+    state.deleteSvaMainserverSettings.mockReset();
     state.runStoredInterfaceHealthcheck.mockReset();
     state.checkStoredInterfaceHealth.mockReset();
     state.isCustomInterfaceStorageAvailable.mockReset();
@@ -774,6 +777,34 @@ describe('interfaces app adapter', () => {
     ).resolves.toEqual({ deleted: true });
 
     expect(state.deleteStoredInterface).toHaveBeenCalledWith('de-musterhausen', 's3-1');
+  });
+
+  it('routes mainserver interface deletions through the dedicated settings adapter', async () => {
+    state.withAuthenticatedUser.mockImplementation(
+      async (_request: Request, handler: (ctx: { user: { id: string; instanceId?: string; roles: string[] } }) => Promise<unknown>) =>
+        handler({
+          user: {
+            id: 'subject-1',
+            instanceId: 'de-musterhausen',
+            roles: ['interface_manager'],
+          },
+        })
+    );
+    state.deleteSvaMainserverSettings.mockResolvedValue(true);
+
+    const { deleteInstanceInterfaceServerFn } = await import('./interfaces-api');
+
+    await expect(
+      deleteInstanceInterfaceServerFn({
+        data: {
+          instanceId: 'de-musterhausen',
+          id: 'mainserver:de-musterhausen',
+        },
+      })
+    ).resolves.toEqual({ deleted: true });
+
+    expect(state.deleteSvaMainserverSettings).toHaveBeenCalledWith('de-musterhausen');
+    expect(state.deleteStoredInterface).not.toHaveBeenCalled();
   });
 
   it('rejects interface deletions when the store reports no deleted entry', async () => {

--- a/apps/sva-studio-react/src/lib/interfaces-api.ts
+++ b/apps/sva-studio-react/src/lib/interfaces-api.ts
@@ -738,7 +738,6 @@ export const deleteInstanceInterfaceServerFn = createServerFn({ method: 'POST' }
   .inputValidator((data: DeleteInstanceInterfaceInput) => data)
   .handler(async ({ data }): Promise<{ deleted: boolean }> => {
     const dependencies = await loadInterfacesRequestDependencies();
-    const { deleteStoredInterface } = await import('./instance-interfaces-server.js');
     return runWithAuthenticatedInterfacesUser({
       request: dependencies.request,
       fallbackMessage: 'Schnittstelle konnte nicht gelöscht werden.',
@@ -749,7 +748,12 @@ export const deleteInstanceInterfaceServerFn = createServerFn({ method: 'POST' }
           'delete_interface',
           data.instanceId
         );
-        const deleted = await deleteStoredInterface(instanceId, data.id);
+        const isMainserverDelete =
+          data.id === `mainserver:${instanceId}` || data.id === `sva-mainserver:${instanceId}`;
+        const deleted =
+          isMainserverDelete
+            ? await (await import('@sva/sva-mainserver/server')).deleteSvaMainserverSettings(instanceId)
+            : await (await import('./instance-interfaces-server.js')).deleteStoredInterface(instanceId, data.id);
         if (!deleted) {
           throw new Error('interface_not_found');
         }

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.controller.ts
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.controller.ts
@@ -210,7 +210,7 @@ export const useInterfacesPageController = () => {
   };
 
   const onConfirmDelete = async () => {
-    if (!pendingDelete || pendingDelete.type === 'mainserver') {
+    if (!pendingDelete) {
       setPendingDelete(null);
       return;
     }

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InterfacesPage } from './-interfaces-page';
@@ -372,7 +372,10 @@ describe('InterfacesPage', () => {
       expect(screen.getByText('2 Schnittstelle(n)')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Löschen' })[1]!);
+    const interfacesTable = screen.getByRole('table', { name: 'Schnittstellen der Instanz' });
+    const s3Row = within(interfacesTable).getByRole('cell', { name: 'Uploads' }).closest('tr');
+    expect(s3Row).toBeTruthy();
+    fireEvent.click(within(s3Row!).getByRole('button', { name: 'Löschen' }));
     fireEvent.click(screen.getByRole('button', { name: 'Endgültig löschen' }));
 
     await waitFor(() => {
@@ -392,7 +395,10 @@ describe('InterfacesPage', () => {
       expect(screen.getByText('1 Schnittstelle(n)')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Löschen' })[0]!);
+    const interfacesTable = screen.getByRole('table', { name: 'Schnittstellen der Instanz' });
+    const mainserverRow = within(interfacesTable).getAllByRole('cell', { name: 'SVA Mainserver' })[0]?.closest('tr');
+    expect(mainserverRow).toBeTruthy();
+    fireEvent.click(within(mainserverRow!).getByRole('button', { name: 'Löschen' }));
     fireEvent.click(screen.getByRole('button', { name: 'Endgültig löschen' }));
 
     await waitFor(() => {

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
@@ -372,12 +372,32 @@ describe('InterfacesPage', () => {
       expect(screen.getByText('2 Schnittstelle(n)')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Löschen' })[0]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Löschen' })[1]!);
     fireEvent.click(screen.getByRole('button', { name: 'Endgültig löschen' }));
 
     await waitFor(() => {
       expect(state.deleteInterface).toHaveBeenCalledWith({
         data: { id: 's3-1', instanceId: 'de-musterhausen' },
+      });
+    });
+  });
+
+  it('deletes the mainserver interface through the destructive confirm dialog', async () => {
+    state.listInterfaces.mockResolvedValue(createListResponse([mainserverEntry]));
+    state.deleteInterface.mockResolvedValue({ deleted: true });
+
+    render(<InterfacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 Schnittstelle(n)')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Löschen' })[0]!);
+    fireEvent.click(screen.getByRole('button', { name: 'Endgültig löschen' }));
+
+    await waitFor(() => {
+      expect(state.deleteInterface).toHaveBeenCalledWith({
+        data: { id: 'mainserver:de-musterhausen', instanceId: 'de-musterhausen' },
       });
     });
   });

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx
@@ -58,11 +58,9 @@ const renderInterfaceRowActions = (
     >
       {t('admin.users.actions.edit')}
     </Button>
-    {row.type === 'mainserver' ? null : (
-      <Button type="button" size="sm" variant="destructive" onClick={() => setPendingDelete(row)}>
-        {t('interfaces.edit.deleteAction')}
-      </Button>
-    )}
+    <Button type="button" size="sm" variant="destructive" onClick={() => setPendingDelete(row)}>
+      {t('interfaces.edit.deleteAction')}
+    </Button>
   </>
 );
 

--- a/apps/sva-studio-react/src/styles.css
+++ b/apps/sva-studio-react/src/styles.css
@@ -338,6 +338,10 @@
       animation: label-float 150ms ease-out forwards;
     }
 
+    .animate-row-hover {
+      @apply transition-colors duration-150 ease-out;
+    }
+
     .animate-collapse-icon:hover {
       animation: collapse-icon-rotate 200ms ease-out forwards;
     }

--- a/apps/sva-studio-react/src/styles.css
+++ b/apps/sva-studio-react/src/styles.css
@@ -204,18 +204,6 @@
       }
     }
 
-    /* 3. Table-Row-Lift: Y-Axis Scale + Shadow */
-    @keyframes table-row-lift {
-      from {
-        transform: scaleY(1);
-        box-shadow: none;
-      }
-      to {
-        transform: scaleY(1.01);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-      }
-    }
-
     /* 5. Skeleton-Shimmer: Gradient-Animation von links nach rechts */
     @keyframes skeleton-shimmer {
       0% {
@@ -320,10 +308,6 @@
 
     .animate-input-glow:focus-visible {
       animation: input-glow 200ms ease-out forwards;
-    }
-
-    .animate-row-hover:hover {
-      animation: table-row-lift 150ms ease-out forwards;
     }
 
     .animate-skeleton {

--- a/docs/superpowers/plans/2026-06-07-mainserver-interface-delete.md
+++ b/docs/superpowers/plans/2026-06-07-mainserver-interface-delete.md
@@ -1,0 +1,98 @@
+# Mainserver-Schnittstelle löschen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die SVA-Mainserver-Schnittstelle auf `/interfaces` soll löschbar sein und nach dem Bestätigen vollständig aus der Liste verschwinden.
+
+**Architecture:** Die bestehende Sonderbehandlung des Mainservers bleibt bestehen. Die UI zeigt die Löschaktion künftig auch für den Mainserver, und der API-Layer routet die Mainserver-ID auf eine dedizierte Löschfunktion im `sva-mainserver` Package statt auf den generischen Stored-Interface-Delete-Pfad.
+
+**Tech Stack:** React, TanStack Start Server Functions, Vitest, Nx, pnpm
+
+---
+
+### Task 1: Mainserver-Settings testgetrieben löschbar machen
+
+**Files:**
+- Modify: `packages/sva-mainserver/src/server/settings.test.ts`
+- Modify: `packages/sva-mainserver/src/server/settings.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Ergänze in `packages/sva-mainserver/src/server/settings.test.ts` einen Test, der einen vorhandenen Mainserver-Record lädt, `deleteSvaMainserverSettings('de-test')` aufruft und `deleteExternalInterfaceRecord` mit der erwarteten Record-ID erwartet.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx run sva-mainserver:test:unit --testFiles=packages/sva-mainserver/src/server/settings.test.ts`
+Expected: FAIL, weil `deleteSvaMainserverSettings` noch nicht existiert.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Ergänze in `packages/sva-mainserver/src/server/settings.ts` eine exportierte Funktion `deleteSvaMainserverSettings(instanceId: string): Promise<boolean>`, die den Default-Record vom Typ `sva_mainserver` lädt und bei Vorhandensein per `deleteExternalInterfaceRecord(record.id)` entfernt.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm nx run sva-mainserver:test:unit --testFiles=packages/sva-mainserver/src/server/settings.test.ts`
+Expected: PASS
+
+### Task 2: Delete-API auf dedizierten Mainserver-Pfad routen
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/lib/interfaces-api.test.ts`
+- Modify: `apps/sva-studio-react/src/lib/interfaces-api.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Ergänze in `apps/sva-studio-react/src/lib/interfaces-api.test.ts` einen Test, der `deleteInstanceInterfaceServerFn` mit `id: 'sva-mainserver:de-musterhausen'` aufruft und erwartet, dass `deleteSvaMainserverSettings('de-musterhausen')` genutzt wird, während `deleteStoredInterface` unberührt bleibt.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx run sva-studio-react:test:unit --testFiles=apps/sva-studio-react/src/lib/interfaces-api.test.ts`
+Expected: FAIL, weil die Delete-Logik den Mainserver noch nicht speziell behandelt.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Passe `apps/sva-studio-react/src/lib/interfaces-api.ts` so an, dass der Delete-Handler bei `data.id === \`sva-mainserver:${instanceId}\`` die neue Funktion `deleteSvaMainserverSettings(instanceId)` aus `@sva/sva-mainserver/server` verwendet.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm nx run sva-studio-react:test:unit --testFiles=apps/sva-studio-react/src/lib/interfaces-api.test.ts`
+Expected: PASS
+
+### Task 3: UI-Löschaktion für Mainserver freischalten
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx`
+- Modify: `apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Ergänze in `apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx` einen Test, der für einen alleinstehenden Mainserver-Eintrag den Löschbutton klickt und danach den Aufruf von `deleteInterface` mit `id: 'sva-mainserver:de-musterhausen'` erwartet.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm nx run sva-studio-react:test:unit --testFiles=apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx`
+Expected: FAIL, weil der Löschbutton für `mainserver` aktuell fehlt.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Entferne in `apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx` die UI-Bedingung, die `Löschen` für `row.type === 'mainserver'` ausblendet.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm nx run sva-studio-react:test:unit --testFiles=apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx`
+Expected: PASS
+
+### Task 4: Relevante Gates laufen lassen
+
+**Files:**
+- Test only
+
+- [ ] **Step 1: Run focused package tests**
+
+Run: `pnpm nx run-many --target=test:unit --projects=sva-mainserver,sva-studio-react`
+Expected: PASS
+
+- [ ] **Step 2: Run affected unit gate**
+
+Run: `pnpm nx affected --target=test:unit --base=origin/main`
+Expected: PASS

--- a/docs/superpowers/specs/2026-06-07-mainserver-interface-delete-design.md
+++ b/docs/superpowers/specs/2026-06-07-mainserver-interface-delete-design.md
@@ -1,0 +1,31 @@
+# Mainserver-Schnittstelle löschen Design
+
+**Ziel:** Auf der Seite `/interfaces` soll die SVA-Mainserver-Schnittstelle wie andere Schnittstellen löschbar sein. Nach dem Löschen verschwindet der Eintrag vollständig aus der Liste.
+
+**Kontext:** Die Oberfläche verwaltet Mainserver-Schnittstellen derzeit getrennt von generischen Schnittstellen. In der UI wird die Löschaktion für `mainserver` ausgeblendet, und der generische Delete-Pfad blockiert `sva-mainserver:<instanceId>` serverseitig ausdrücklich.
+
+## Anforderungen
+
+- Die Tabellenzeile für `SVA Mainserver` zeigt ebenfalls die Aktion `Löschen`.
+- Die bestehende Bestätigungsdialog-Interaktion bleibt erhalten.
+- Das Löschen entfernt die gespeicherte Mainserver-Konfiguration vollständig.
+- Der generische Delete-Pfad bleibt für normale Schnittstellen unverändert.
+
+## Architekturentscheidung
+
+Die Löschung des Mainservers bleibt ein dedizierter Pfad. Statt die generische `deleteStoredInterface`-Logik für Mainserver zu öffnen, wird im Mainserver-Settings-Modul eine eigene Löschfunktion ergänzt und in `interfaces-api` für die Mainserver-ID speziell verdrahtet.
+
+## Betroffene Dateien
+
+- `apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx`
+- `apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx`
+- `apps/sva-studio-react/src/lib/interfaces-api.ts`
+- `apps/sva-studio-react/src/lib/interfaces-api.test.ts`
+- `packages/sva-mainserver/src/server/settings.ts`
+- `packages/sva-mainserver/src/server/settings.test.ts`
+
+## Tests
+
+- UI-Test für die Löschaktion des Mainservers ergänzen.
+- API-Test für das Routing auf den dedizierten Mainserver-Delete-Pfad ergänzen.
+- Package-Test für die tatsächliche Löschung des gespeicherten Mainserver-Records ergänzen.

--- a/packages/auth-runtime/src/waste-management/core/read-handlers.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/read-handlers.test.ts
@@ -1,8 +1,26 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AuthenticatedRequestContext } from '../../middleware.js';
 
 const updateWasteVisibleStatusMock = vi.hoisted(() => vi.fn(async () => undefined));
+const loggerState = vi.hoisted(() => ({
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@sva/server-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sva/server-runtime')>();
+  return {
+    ...actual,
+    createSdkLogger: vi.fn(() => loggerState),
+    getWorkspaceContext: () => ({
+      requestId: 'req-test',
+      traceId: 'trace-test',
+      workspaceId: 'tenant-a',
+    }),
+  };
+});
 
 vi.mock('./settings-shared.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./settings-shared.js')>();
@@ -41,6 +59,11 @@ const createDeps = (action = 'waste-management.read') => ({
 });
 
 describe('waste-management read handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateWasteVisibleStatusMock.mockResolvedValue(undefined);
+  });
+
   it('loads settings and history with sanitized payloads and paging params', async () => {
     const settingsDeps = {
       ...createDeps('waste-management.settings.manage'),
@@ -252,6 +275,160 @@ describe('waste-management read handlers', () => {
 
     expect(failureResponse.status).toBe(503);
     expect(updateWasteVisibleStatusMock).toHaveBeenCalledWith(expect.any(Object), 'tenant-a', 'revalidate');
+  });
+
+  it('returns fractions data even when the visible-status update fails after a successful load', async () => {
+    updateWasteVisibleStatusMock.mockRejectedValueOnce(new Error('visible status write failed'));
+
+    const response = await wasteManagementReadHandlers.getWasteManagementMasterDataOverviewInternal(
+      new Request('https://studio.test/api/v1/waste-management/master-data?scope=fractions'),
+      actor,
+      {
+        ...createDeps(),
+        loadMasterDataFractionsOverview: vi.fn(async () => ({
+          fractions: [{ id: 'fraction-1' }],
+          regions: [],
+          cities: [],
+          streets: [],
+          houseNumbers: [],
+          collectionLocations: [],
+          locationTourLinks: [],
+        })),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        fractions: [{ id: 'fraction-1' }],
+      },
+      requestId: 'req-test',
+    });
+    expect(loggerState.warn).toHaveBeenCalledWith(
+      'Waste visible status update failed',
+      expect.objectContaining({
+        operation: 'get_waste_management_master_data_overview',
+        update_outcome: 'success',
+        instance_id: 'tenant-a',
+        request_id: 'req-test',
+        error_message: 'visible status write failed',
+      })
+    );
+  });
+
+  it('logs the original overview failure and still returns 503 when revalidation also fails', async () => {
+    updateWasteVisibleStatusMock.mockRejectedValueOnce(new Error('revalidation write failed'));
+
+    const response = await wasteManagementReadHandlers.getWasteManagementMasterDataOverviewInternal(
+      new Request('https://studio.test/api/v1/waste-management/master-data'),
+      actor,
+      {
+        ...createDeps(),
+        loadMasterDataOverview: vi.fn(async () => {
+          throw new Error('db down');
+        }),
+      }
+    );
+
+    expect(response.status).toBe(503);
+    expect(loggerState.error).toHaveBeenCalledWith(
+      'Waste master-data overview failed',
+      expect.objectContaining({
+        operation: 'get_waste_management_master_data_overview',
+        instance_id: 'tenant-a',
+        request_id: 'req-test',
+        error_message: 'db down',
+      })
+    );
+    expect(loggerState.warn).toHaveBeenCalledWith(
+      'Waste visible status update failed',
+      expect.objectContaining({
+        operation: 'get_waste_management_master_data_overview',
+        update_outcome: 'revalidate',
+        instance_id: 'tenant-a',
+        request_id: 'req-test',
+        error_message: 'revalidation write failed',
+      })
+    );
+  });
+
+  it('logs scope and entity counts when master-data loads successfully', async () => {
+    const response = await wasteManagementReadHandlers.getWasteManagementMasterDataOverviewInternal(
+      new Request('https://studio.test/api/v1/waste-management/master-data?scope=fractions'),
+      actor,
+      {
+        ...createDeps(),
+        loadMasterDataFractionsOverview: vi.fn(async () => ({
+          fractions: [{ id: 'fraction-1' }, { id: 'fraction-2' }],
+          regions: [],
+          cities: [],
+          streets: [],
+          houseNumbers: [],
+          collectionLocations: [],
+          locationTourLinks: [],
+        })),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(loggerState.info).toHaveBeenCalledWith(
+      'Waste master-data overview loaded',
+      expect.objectContaining({
+        operation: 'get_waste_management_master_data_overview',
+        master_data_scope: 'fractions',
+        fractions_count: 2,
+        regions_count: 0,
+        collection_locations_count: 0,
+        request_id: 'req-test',
+      })
+    );
+  });
+
+  it('logs response serialization failures separately for master-data responses', async () => {
+    const originalStringify = JSON.stringify;
+    const stringifySpy = vi.spyOn(JSON, 'stringify').mockImplementation(((value: unknown, replacer?: unknown, space?: unknown) => {
+      if (
+        value &&
+        typeof value === 'object' &&
+        'data' in value &&
+        Array.isArray((value as { data?: { fractions?: unknown } }).data?.fractions)
+      ) {
+        throw new Error('serialize failed');
+      }
+
+      return originalStringify(value, replacer as never, space as never);
+    }) as typeof JSON.stringify);
+
+    const response = await wasteManagementReadHandlers.getWasteManagementMasterDataOverviewInternal(
+      new Request('https://studio.test/api/v1/waste-management/master-data?scope=fractions'),
+      actor,
+      {
+        ...createDeps(),
+        loadMasterDataFractionsOverview: vi.fn(async () => ({
+          fractions: [{ id: 'fraction-1' }],
+          regions: [],
+          cities: [],
+          streets: [],
+          houseNumbers: [],
+          collectionLocations: [],
+          locationTourLinks: [],
+        })),
+      }
+    );
+
+    stringifySpy.mockRestore();
+
+    expect(response.status).toBe(503);
+    expect(loggerState.error).toHaveBeenCalledWith(
+      'Waste master-data response serialization failed',
+      expect.objectContaining({
+        operation: 'get_waste_management_master_data_overview',
+        master_data_scope: 'fractions',
+        fractions_count: 1,
+        request_id: 'req-test',
+        error_message: 'serialize failed',
+      })
+    );
   });
 
   it('uses the scoped fractions overview loader when master-data is requested with scope=fractions', async () => {

--- a/packages/auth-runtime/src/waste-management/core/read-handlers.ts
+++ b/packages/auth-runtime/src/waste-management/core/read-handlers.ts
@@ -1,3 +1,6 @@
+import { createSdkLogger } from '@sva/server-runtime';
+
+import { buildLogContext } from '../../log-context.js';
 import { asApiItem, createApiError, readPage } from '../../shared/request-helpers.js';
 import type { AuthenticatedRequestContext } from '../../middleware.js';
 import { authorizeWasteManagementAction } from './auth.js';
@@ -5,9 +8,20 @@ import { loadConfiguredWasteSettings, updateWasteVisibleStatus } from './setting
 import type { WasteManagementHandlerDeps } from './types.js';
 import { getRequestId, requireActorInstanceId, requireDeps } from './utils.js';
 
+const logger = createSdkLogger({ component: 'waste-management-auth-runtime', level: 'info' });
+
 const toOptionalTrimmedSearchParam = (request: Request, key: string): string | undefined => {
   const value = new URL(request.url).searchParams.get(key)?.trim();
   return value ? value : undefined;
+};
+
+const resolveMasterDataScope = (request: Request): 'fractions' | 'locations' | 'all' => {
+  const scope = toOptionalTrimmedSearchParam(request, 'scope');
+  if (scope === 'fractions' || scope === 'locations') {
+    return scope;
+  }
+
+  return 'all';
 };
 
 const resolveMasterDataOverview = async (
@@ -15,7 +29,7 @@ const resolveMasterDataOverview = async (
   deps: WasteManagementHandlerDeps,
   instanceId: string
 ) => {
-  const scope = toOptionalTrimmedSearchParam(request, 'scope');
+  const scope = resolveMasterDataScope(request);
   if (scope === 'fractions') {
     return requireDeps(deps.loadMasterDataFractionsOverview, 'loadMasterDataFractionsOverview')(instanceId);
   }
@@ -26,6 +40,63 @@ const resolveMasterDataOverview = async (
 
   return requireDeps(deps.loadMasterDataOverview, 'loadMasterDataOverview')(instanceId);
 };
+
+const logWasteReadFailure = (
+  operation: string,
+  message: string,
+  instanceId: string,
+  error: unknown,
+  details?: Readonly<Record<string, string | number | boolean | undefined>>
+): void => {
+  logger.error(message, {
+    operation,
+    error_type: error instanceof Error ? error.constructor.name : typeof error,
+    error_message: error instanceof Error ? error.message : String(error),
+    ...details,
+    ...buildLogContext({ kind: 'instance', instanceId }, { includeTraceId: true }),
+  });
+};
+
+const updateWasteVisibleStatusSafely = async (
+  deps: WasteManagementHandlerDeps,
+  instanceId: string,
+  outcome: 'success' | 'revalidate',
+  operation: string
+): Promise<void> => {
+  try {
+    await updateWasteVisibleStatus(deps, instanceId, outcome);
+  } catch (error) {
+    logger.warn('Waste visible status update failed', {
+      operation,
+      update_outcome: outcome,
+      error_type: error instanceof Error ? error.constructor.name : typeof error,
+      error_message: error instanceof Error ? error.message : String(error),
+      ...buildLogContext({ kind: 'instance', instanceId }, { includeTraceId: true }),
+    });
+  }
+};
+
+const buildMasterDataLogFields = (
+  scope: 'fractions' | 'locations' | 'all',
+  overview: {
+    readonly fractions: readonly unknown[];
+    readonly regions: readonly unknown[];
+    readonly cities: readonly unknown[];
+    readonly streets: readonly unknown[];
+    readonly houseNumbers: readonly unknown[];
+    readonly collectionLocations: readonly unknown[];
+    readonly locationTourLinks: readonly unknown[];
+  }
+) => ({
+  master_data_scope: scope,
+  fractions_count: overview.fractions.length,
+  regions_count: overview.regions.length,
+  cities_count: overview.cities.length,
+  streets_count: overview.streets.length,
+  house_numbers_count: overview.houseNumbers.length,
+  collection_locations_count: overview.collectionLocations.length,
+  location_tour_links_count: overview.locationTourLinks.length,
+});
 
 export const wasteManagementReadHandlers = {
   getWasteManagementSettingsInternal: async (
@@ -50,7 +121,13 @@ export const wasteManagementReadHandlers = {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
-    } catch {
+    } catch (error) {
+      logWasteReadFailure(
+        'get_waste_management_settings',
+        'Waste settings overview failed',
+        instanceId,
+        error
+      );
       return createApiError(503, 'database_unavailable', 'Die Waste-Einstellungen konnten nicht geladen werden.', requestId);
     }
   },
@@ -84,7 +161,13 @@ export const wasteManagementReadHandlers = {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
-    } catch {
+    } catch (error) {
+      logWasteReadFailure(
+        'get_waste_management_history_overview',
+        'Waste history overview failed',
+        instanceId,
+        error
+      );
       return createApiError(503, 'database_unavailable', 'Die Waste-Historie konnte nicht geladen werden.', requestId);
     }
   },
@@ -104,15 +187,56 @@ export const wasteManagementReadHandlers = {
       return instanceId;
     }
 
+    const scope = resolveMasterDataScope(request);
+
     try {
       const overview = await resolveMasterDataOverview(request, deps, instanceId);
-      await updateWasteVisibleStatus(deps, instanceId, 'success');
-      return new Response(JSON.stringify(asApiItem(overview, requestId)), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
+      const logFields = buildMasterDataLogFields(scope, overview);
+      logger.info('Waste master-data overview loaded', {
+        operation: 'get_waste_management_master_data_overview',
+        ...logFields,
+        ...buildLogContext({ kind: 'instance', instanceId }, { includeTraceId: true }),
       });
-    } catch {
-      await updateWasteVisibleStatus(deps, instanceId, 'revalidate');
+      await updateWasteVisibleStatusSafely(
+        deps,
+        instanceId,
+        'success',
+        'get_waste_management_master_data_overview'
+      );
+      try {
+        return new Response(JSON.stringify(asApiItem(overview, requestId)), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } catch (error) {
+        logWasteReadFailure(
+          'get_waste_management_master_data_overview',
+          'Waste master-data response serialization failed',
+          instanceId,
+          error,
+          logFields
+        );
+        return createApiError(
+          503,
+          'database_unavailable',
+          'Die Waste-Stammdaten konnten nicht geladen werden.',
+          requestId
+        );
+      }
+    } catch (error) {
+      logWasteReadFailure(
+        'get_waste_management_master_data_overview',
+        'Waste master-data overview failed',
+        instanceId,
+        error,
+        { master_data_scope: scope }
+      );
+      await updateWasteVisibleStatusSafely(
+        deps,
+        instanceId,
+        'revalidate',
+        'get_waste_management_master_data_overview'
+      );
       return createApiError(503, 'database_unavailable', 'Die Waste-Stammdaten konnten nicht geladen werden.', requestId);
     }
   },
@@ -134,13 +258,24 @@ export const wasteManagementReadHandlers = {
 
     try {
       const overview = await requireDeps(deps.loadToursOverview, 'loadToursOverview')(instanceId);
-      await updateWasteVisibleStatus(deps, instanceId, 'success');
+      await updateWasteVisibleStatusSafely(deps, instanceId, 'success', 'get_waste_management_tours_overview');
       return new Response(JSON.stringify(asApiItem(overview, requestId)), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
-    } catch {
-      await updateWasteVisibleStatus(deps, instanceId, 'revalidate');
+    } catch (error) {
+      logWasteReadFailure(
+        'get_waste_management_tours_overview',
+        'Waste tours overview failed',
+        instanceId,
+        error
+      );
+      await updateWasteVisibleStatusSafely(
+        deps,
+        instanceId,
+        'revalidate',
+        'get_waste_management_tours_overview'
+      );
       return createApiError(503, 'database_unavailable', 'Die Waste-Touren konnten nicht geladen werden.', requestId);
     }
   },
@@ -162,13 +297,29 @@ export const wasteManagementReadHandlers = {
 
     try {
       const overview = await requireDeps(deps.loadSchedulingOverview, 'loadSchedulingOverview')(instanceId);
-      await updateWasteVisibleStatus(deps, instanceId, 'success');
+      await updateWasteVisibleStatusSafely(
+        deps,
+        instanceId,
+        'success',
+        'get_waste_management_scheduling_overview'
+      );
       return new Response(JSON.stringify(asApiItem(overview, requestId)), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
-    } catch {
-      await updateWasteVisibleStatus(deps, instanceId, 'revalidate');
+    } catch (error) {
+      logWasteReadFailure(
+        'get_waste_management_scheduling_overview',
+        'Waste scheduling overview failed',
+        instanceId,
+        error
+      );
+      await updateWasteVisibleStatusSafely(
+        deps,
+        instanceId,
+        'revalidate',
+        'get_waste_management_scheduling_overview'
+      );
       return createApiError(
         503,
         'database_unavailable',

--- a/packages/auth-runtime/src/waste-management/core/read-handlers.ts
+++ b/packages/auth-runtime/src/waste-management/core/read-handlers.ts
@@ -98,6 +98,12 @@ const buildMasterDataLogFields = (
   location_tour_links_count: overview.locationTourLinks.length,
 });
 
+const createJsonApiItemResponse = (payload: unknown, requestId: string | undefined): Response =>
+  new Response(JSON.stringify(asApiItem(payload, requestId)), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
 export const wasteManagementReadHandlers = {
   getWasteManagementSettingsInternal: async (
     _request: Request,
@@ -117,17 +123,9 @@ export const wasteManagementReadHandlers = {
 
     try {
       const settings = await loadConfiguredWasteSettings(deps, instanceId);
-      return new Response(JSON.stringify(asApiItem(settings, requestId)), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return createJsonApiItemResponse(settings, requestId);
     } catch (error) {
-      logWasteReadFailure(
-        'get_waste_management_settings',
-        'Waste settings overview failed',
-        instanceId,
-        error
-      );
+      logWasteReadFailure('get_waste_management_settings', 'Waste settings overview failed', instanceId, error);
       return createApiError(503, 'database_unavailable', 'Die Waste-Einstellungen konnten nicht geladen werden.', requestId);
     }
   },
@@ -157,17 +155,9 @@ export const wasteManagementReadHandlers = {
         page,
         pageSize,
       });
-      return new Response(JSON.stringify(asApiItem(overview, requestId)), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return createJsonApiItemResponse(overview, requestId);
     } catch (error) {
-      logWasteReadFailure(
-        'get_waste_management_history_overview',
-        'Waste history overview failed',
-        instanceId,
-        error
-      );
+      logWasteReadFailure('get_waste_management_history_overview', 'Waste history overview failed', instanceId, error);
       return createApiError(503, 'database_unavailable', 'Die Waste-Historie konnte nicht geladen werden.', requestId);
     }
   },
@@ -197,25 +187,11 @@ export const wasteManagementReadHandlers = {
         ...logFields,
         ...buildLogContext({ kind: 'instance', instanceId }, { includeTraceId: true }),
       });
-      await updateWasteVisibleStatusSafely(
-        deps,
-        instanceId,
-        'success',
-        'get_waste_management_master_data_overview'
-      );
+      await updateWasteVisibleStatusSafely(deps, instanceId, 'success', 'get_waste_management_master_data_overview');
       try {
-        return new Response(JSON.stringify(asApiItem(overview, requestId)), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        });
+        return createJsonApiItemResponse(overview, requestId);
       } catch (error) {
-        logWasteReadFailure(
-          'get_waste_management_master_data_overview',
-          'Waste master-data response serialization failed',
-          instanceId,
-          error,
-          logFields
-        );
+        logWasteReadFailure('get_waste_management_master_data_overview', 'Waste master-data response serialization failed', instanceId, error, logFields);
         return createApiError(
           503,
           'database_unavailable',
@@ -224,19 +200,8 @@ export const wasteManagementReadHandlers = {
         );
       }
     } catch (error) {
-      logWasteReadFailure(
-        'get_waste_management_master_data_overview',
-        'Waste master-data overview failed',
-        instanceId,
-        error,
-        { master_data_scope: scope }
-      );
-      await updateWasteVisibleStatusSafely(
-        deps,
-        instanceId,
-        'revalidate',
-        'get_waste_management_master_data_overview'
-      );
+      logWasteReadFailure('get_waste_management_master_data_overview', 'Waste master-data overview failed', instanceId, error, { master_data_scope: scope });
+      await updateWasteVisibleStatusSafely(deps, instanceId, 'revalidate', 'get_waste_management_master_data_overview');
       return createApiError(503, 'database_unavailable', 'Die Waste-Stammdaten konnten nicht geladen werden.', requestId);
     }
   },
@@ -259,23 +224,10 @@ export const wasteManagementReadHandlers = {
     try {
       const overview = await requireDeps(deps.loadToursOverview, 'loadToursOverview')(instanceId);
       await updateWasteVisibleStatusSafely(deps, instanceId, 'success', 'get_waste_management_tours_overview');
-      return new Response(JSON.stringify(asApiItem(overview, requestId)), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return createJsonApiItemResponse(overview, requestId);
     } catch (error) {
-      logWasteReadFailure(
-        'get_waste_management_tours_overview',
-        'Waste tours overview failed',
-        instanceId,
-        error
-      );
-      await updateWasteVisibleStatusSafely(
-        deps,
-        instanceId,
-        'revalidate',
-        'get_waste_management_tours_overview'
-      );
+      logWasteReadFailure('get_waste_management_tours_overview', 'Waste tours overview failed', instanceId, error);
+      await updateWasteVisibleStatusSafely(deps, instanceId, 'revalidate', 'get_waste_management_tours_overview');
       return createApiError(503, 'database_unavailable', 'Die Waste-Touren konnten nicht geladen werden.', requestId);
     }
   },
@@ -297,29 +249,11 @@ export const wasteManagementReadHandlers = {
 
     try {
       const overview = await requireDeps(deps.loadSchedulingOverview, 'loadSchedulingOverview')(instanceId);
-      await updateWasteVisibleStatusSafely(
-        deps,
-        instanceId,
-        'success',
-        'get_waste_management_scheduling_overview'
-      );
-      return new Response(JSON.stringify(asApiItem(overview, requestId)), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      await updateWasteVisibleStatusSafely(deps, instanceId, 'success', 'get_waste_management_scheduling_overview');
+      return createJsonApiItemResponse(overview, requestId);
     } catch (error) {
-      logWasteReadFailure(
-        'get_waste_management_scheduling_overview',
-        'Waste scheduling overview failed',
-        instanceId,
-        error
-      );
-      await updateWasteVisibleStatusSafely(
-        deps,
-        instanceId,
-        'revalidate',
-        'get_waste_management_scheduling_overview'
-      );
+      logWasteReadFailure('get_waste_management_scheduling_overview', 'Waste scheduling overview failed', instanceId, error);
+      await updateWasteVisibleStatusSafely(deps, instanceId, 'revalidate', 'get_waste_management_scheduling_overview');
       return createApiError(
         503,
         'database_unavailable',

--- a/packages/plugin-waste-management/src/plugin.translations.de.scheduling.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.de.scheduling.ts
@@ -103,6 +103,7 @@ export const wasteManagementPluginTranslationsDEScheduling = createWasteManageme
   actions: {
     openCreate: 'Ausweichtermin anlegen',
     delete: 'Löschen',
+    deleteSelected: 'Markierte löschen',
   },
   create: {
     scope: 'Typ des Ausweichtermins',

--- a/packages/plugin-waste-management/src/plugin.translations.en.scheduling.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.en.scheduling.ts
@@ -103,6 +103,7 @@ export const wasteManagementPluginTranslationsENScheduling = createWasteManageme
   actions: {
     openCreate: 'Create scheduling shift',
     delete: 'Delete',
+    deleteSelected: 'Delete selected',
   },
   create: {
     scope: 'Shift type',

--- a/packages/plugin-waste-management/src/waste-management.scheduling-shifts-table.tsx
+++ b/packages/plugin-waste-management/src/waste-management.scheduling-shifts-table.tsx
@@ -3,6 +3,7 @@ import { usePluginTranslation } from '@sva/plugin-sdk';
 import {
   Button,
   StudioDataTable,
+  type StudioBulkAction,
 } from '@sva/studio-ui-react';
 
 import type { WasteSchedulingTableEntry } from './waste-management.scheduling.shared.js';
@@ -40,6 +41,7 @@ export const WasteSchedulingShiftsTable = ({
   onEditGlobalShiftDialog,
   onEditTourShiftDialog,
   onDeleteSchedulingRows,
+  saving,
   page,
   pageSize,
   onPageChange,
@@ -52,6 +54,20 @@ export const WasteSchedulingShiftsTable = ({
   const labels = useSchedulingTableLabels();
   const columns = useSchedulingColumns();
   const pagedRows = useMemo(() => createPagedItems({ items: entries, page, pageSize }), [entries, page, pageSize]);
+  const bulkActions = useMemo<readonly StudioBulkAction<WasteSchedulingTableEntry>[]>(
+    () => [
+      {
+        id: 'delete-selected-scheduling-rows',
+        label: pt('scheduling.actions.deleteSelected'),
+        ...(saving ? { disabled: true } : {}),
+        onClick: async ({ selectedRows, clearSelection }) => {
+          clearSelectionRef.current = clearSelection;
+          setPendingDeleteRows(selectedRows);
+        },
+      },
+    ],
+    [pt, saving]
+  );
 
   usePagedRouteSync({ page, safePage: pagedRows.safePage, onPageChange, onSyncPageChange });
 
@@ -64,6 +80,9 @@ export const WasteSchedulingShiftsTable = ({
         data={pagedRows.items}
         columns={columns}
         getRowId={(row) => `${row.kind}:${row.id}`}
+        selectionMode="multiple"
+        canSelectRow={(row) => row.canDelete}
+        bulkActions={bulkActions}
         toolbarEnd={
           <Button type="button" className="rounded-lg" onClick={onOpenCreateShiftDialog}>
             {pt('scheduling.actions.openCreate')}

--- a/packages/plugin-waste-management/tests/waste-management.scheduling-shifts-table.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.scheduling-shifts-table.test.tsx
@@ -436,7 +436,9 @@ describe('WasteSchedulingShiftsTable', () => {
     expect(screen.getByText('scheduling.bulkDeleteDialog.title')).toBeTruthy();
     expect(screen.getByText('scheduling.bulkDeleteDialog.description:2')).toBeTruthy();
 
-    fireEvent.click(screen.getByRole('button', { name: 'scheduling.bulkDeleteDialog.confirm' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'scheduling.bulkDeleteDialog.confirm' }));
+    });
 
     expect(onDeleteSchedulingRows).toHaveBeenCalledWith([
       expect.objectContaining({ kind: 'global', id: 'global-1' }),

--- a/packages/plugin-waste-management/tests/waste-management.scheduling-shifts-table.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.scheduling-shifts-table.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { WasteSchedulingShiftsTable } from '../src/waste-management.scheduling-shifts-table.js';
@@ -316,10 +316,134 @@ describe('WasteSchedulingShiftsTable', () => {
     expect(screen.getByText('scheduling.bulkDeleteDialog.title')).toBeTruthy();
     expect(screen.getByText('scheduling.bulkDeleteDialog.description:1')).toBeTruthy();
 
-    fireEvent.click(screen.getByRole('button', { name: 'scheduling.bulkDeleteDialog.confirm' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'scheduling.bulkDeleteDialog.confirm' }));
+    });
 
     expect(onDeleteSchedulingRows).toHaveBeenCalledWith([
       expect.objectContaining({ kind: 'global', id: 'global-1' }),
     ]);
+  });
+
+  it('enables multi-select only for deletable scheduling rows and opens bulk delete via toolbar action', async () => {
+    const onDeleteSchedulingRows = vi.fn(async () => undefined);
+    const clearSelection = vi.fn();
+
+    render(
+      <WasteSchedulingShiftsTable
+        entries={[
+          {
+            id: 'holiday-rule-1',
+            entryType: 'holiday-rule',
+            kind: 'holiday',
+            originalDate: '2025-12-25',
+            actualDate: undefined,
+            contextLabel: 'Weihnachten',
+            sortLabel: 'Weihnachten',
+            canDelete: false,
+            rule: {
+              id: 'holiday-rule-1',
+              holidayDate: '2025-12-25',
+              holidayName: 'Weihnachten',
+              year: 2025,
+              stateCode: 'BB',
+              sourceStatus: 'confirmed',
+              configurationStatus: 'draft',
+              conflictStatus: 'none',
+              createdAt: '2026-05-09T10:00:00.000Z',
+              updatedAt: '2026-05-09T10:00:00.000Z',
+            },
+          },
+          {
+            id: 'global-1',
+            entryType: 'global-shift',
+            kind: 'global',
+            originalDate: '2026-01-01',
+            actualDate: '2026-01-02',
+            contextLabel: 'Alle Touren',
+            sortLabel: 'Alle Touren',
+            canDelete: true,
+            shift: {
+              id: 'global-1',
+              originalDate: '2026-01-01',
+              actualDate: '2026-01-02',
+              description: 'Neujahr',
+              hasYear: true,
+              reasonType: 'holiday',
+              reasonKey: 'holiday.new-year',
+              tourIds: [],
+            },
+          },
+          {
+            id: 'tour-shift-1',
+            entryType: 'tour-shift',
+            kind: 'tour',
+            originalDate: '2026-02-01',
+            actualDate: '2026-02-03',
+            contextLabel: 'Restmüll Nord',
+            sortLabel: 'Restmüll Nord',
+            canDelete: true,
+            shift: {
+              id: 'tour-shift-1',
+              tourId: 'tour-1',
+              originalDate: '2026-02-01',
+              actualDate: '2026-02-03',
+              description: 'Baustelle',
+              hasYear: false,
+              reasonType: 'operational-disruption',
+              reasonKey: 'ops.roadwork',
+              followUpMode: 'propagate-series',
+            },
+          },
+        ] as never}
+        onOpenCreateShiftDialog={vi.fn()}
+        onEditHolidayRule={vi.fn()}
+        onEditGlobalShiftDialog={vi.fn()}
+        onEditTourShiftDialog={vi.fn()}
+        onDeleteSchedulingRows={onDeleteSchedulingRows}
+        saving={false}
+        page={1}
+        pageSize={25}
+        onPageChange={vi.fn()}
+        onSyncPageChange={vi.fn()}
+        onPageSizeChange={vi.fn()}
+      />
+    );
+
+    const tableProps = dataTableMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    const data = tableProps.data as Array<Record<string, unknown>>;
+    const canSelectRow = tableProps.canSelectRow as ((row: Record<string, unknown>) => boolean) | undefined;
+    const bulkActions = tableProps.bulkActions as Array<{
+      label: string;
+      onClick: (context: { selectedRows: Array<Record<string, unknown>>; clearSelection: () => void }) => Promise<void>;
+    }> | undefined;
+
+    expect(tableProps.selectionMode).toBe('multiple');
+    expect(canSelectRow).toBeTruthy();
+    expect(canSelectRow?.(data[0]!)).toBe(false);
+    expect(canSelectRow?.(data[1]!)).toBe(true);
+    expect(canSelectRow?.(data[2]!)).toBe(true);
+    expect(bulkActions).toHaveLength(1);
+    expect(bulkActions?.[0]?.label).toBe('scheduling.actions.deleteSelected');
+
+    await act(async () => {
+      await bulkActions?.[0]?.onClick({
+        selectedRows: [data[1]!, data[2]!],
+        clearSelection,
+      });
+    });
+
+    expect(screen.getByText('scheduling.bulkDeleteDialog.title')).toBeTruthy();
+    expect(screen.getByText('scheduling.bulkDeleteDialog.description:2')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'scheduling.bulkDeleteDialog.confirm' }));
+
+    expect(onDeleteSchedulingRows).toHaveBeenCalledWith([
+      expect.objectContaining({ kind: 'global', id: 'global-1' }),
+      expect.objectContaining({ kind: 'tour', id: 'tour-shift-1' }),
+    ]);
+    await waitFor(() => {
+      expect(clearSelection).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/studio-ui-react/src/studio-data-table.tsx
+++ b/packages/studio-ui-react/src/studio-data-table.tsx
@@ -62,6 +62,7 @@ export type StudioDataTableProps<TData> = Readonly<{
   isLoading?: boolean;
   getRowId: (row: TData) => string;
   selectionMode?: 'none' | 'multiple';
+  canSelectRow?: (row: TData) => boolean;
   sorting?: SortingState;
   onSortingChange?: (sorting: SortingState) => void;
 }>;
@@ -108,6 +109,7 @@ const renderSelectionCell = <TData,>(
   <Checkbox
     aria-label={labels.selectRow({ label: ariaLabel, rowId: row.id })}
     checked={row.getIsSelected()}
+    disabled={!row.getCanSelect()}
     ref={undefined}
     onChange={(event) => row.toggleSelected(event.target.checked)}
   />
@@ -159,6 +161,7 @@ export function StudioDataTable<TData>({
   isLoading = false,
   getRowId,
   selectionMode = 'multiple',
+  canSelectRow,
   sorting: controlledSorting,
   onSortingChange,
 }: StudioDataTableProps<TData>) {
@@ -169,6 +172,10 @@ export function StudioDataTable<TData>({
 
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const [isCompact, setIsCompact] = React.useState(false);
+  const selectionScopeKey = React.useMemo(
+    () => [...data].map((row) => getRowId(row)).sort().join('\u0000'),
+    [data, getRowId]
+  );
 
   React.useLayoutEffect(() => {
     const node = containerRef.current;
@@ -187,7 +194,7 @@ export function StudioDataTable<TData>({
 
   React.useEffect(() => {
     setRowSelection({});
-  }, [data]);
+  }, [selectionScopeKey]);
 
   const clearSelection = React.useCallback(() => {
     setRowSelection({});
@@ -264,7 +271,10 @@ export function StudioDataTable<TData>({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getRowId,
-    enableRowSelection: selectionMode === 'multiple',
+    enableRowSelection:
+      selectionMode === 'multiple'
+        ? (row) => (canSelectRow ? canSelectRow(row.original) : true)
+        : false,
     onSortingChange: handleSortingChange,
     onRowSelectionChange: setRowSelection,
     state: {
@@ -363,7 +373,10 @@ export function StudioDataTable<TData>({
           </thead>
           <tbody>
             {table.getRowModel().rows.map((row) => (
-              <tr key={row.id} className="animate-row-hover border-t border-border text-sm text-foreground hover:bg-muted/40">
+              <tr
+                key={row.id}
+                className="border-t border-border text-sm text-foreground transition-colors duration-150 hover:bg-muted/40"
+              >
                 {row.getVisibleCells().map((cell) => {
                   const meta = cell.column.columnDef.meta as { className?: string } | undefined;
                   return (

--- a/packages/studio-ui-react/src/studio-data-table.tsx
+++ b/packages/studio-ui-react/src/studio-data-table.tsx
@@ -176,6 +176,14 @@ export function StudioDataTable<TData>({
     () => [...data].map((row) => getRowId(row)).sort().join('\u0000'),
     [data, getRowId]
   );
+  const selectableScopeKey = React.useMemo(
+    () =>
+      [...data]
+        .map((row) => `${getRowId(row)}:${canSelectRow ? (canSelectRow(row) ? '1' : '0') : '1'}`)
+        .sort()
+        .join('\u0000'),
+    [canSelectRow, data, getRowId]
+  );
 
   React.useLayoutEffect(() => {
     const node = containerRef.current;
@@ -193,8 +201,26 @@ export function StudioDataTable<TData>({
   }, []);
 
   React.useEffect(() => {
-    setRowSelection({});
-  }, [selectionScopeKey]);
+    const availableRowIds = new Set(data.map((row) => getRowId(row)));
+    const selectableRowIds = new Set(
+      data.filter((row) => (canSelectRow ? canSelectRow(row) : true)).map((row) => getRowId(row))
+    );
+
+    setRowSelection((current) => {
+      let changed = false;
+      const next: RowSelectionState = {};
+
+      for (const [rowId, isSelected] of Object.entries(current)) {
+        if (isSelected && availableRowIds.has(rowId) && selectableRowIds.has(rowId)) {
+          next[rowId] = true;
+          continue;
+        }
+        changed = true;
+      }
+
+      return changed ? next : current;
+    });
+  }, [canSelectRow, data, getRowId, selectableScopeKey, selectionScopeKey]);
 
   const clearSelection = React.useCallback(() => {
     setRowSelection({});

--- a/packages/studio-ui-react/src/studio-data-table.tsx
+++ b/packages/studio-ui-react/src/studio-data-table.tsx
@@ -399,6 +399,7 @@ export function StudioDataTable<TData>({
                 <Checkbox
                   aria-label={(labels.selectMobileRow ?? labels.selectRow)({ label: ariaLabel, rowId: row.id })}
                   checked={row.getIsSelected()}
+                  disabled={!row.getCanSelect()}
                   ref={undefined}
                   onChange={(event) => row.toggleSelected(event.target.checked)}
                 />

--- a/packages/studio-ui-react/src/studio-primitives.test.tsx
+++ b/packages/studio-ui-react/src/studio-primitives.test.tsx
@@ -472,6 +472,48 @@ describe('studio-ui-react primitives', () => {
     expect((screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement).checked).toBe(true);
   });
 
+  it('prunes selected rows when an unchanged row id becomes non-selectable', () => {
+    const data = [
+      { id: 'global-1', title: 'Global', selectable: true },
+      { id: 'tour-1', title: 'Tour', selectable: true },
+    ];
+
+    const { rerender } = render(
+      <StudioDataTable
+        ariaLabel="Ausweichtermine"
+        labels={tableLabels}
+        data={data}
+        getRowId={(row) => row.id}
+        columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
+        emptyState={<p>Keine Daten</p>}
+        canSelectRow={(row) => row.selectable}
+      />
+    );
+
+    const globalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
+    fireEvent.click(globalCheckbox);
+    expect(globalCheckbox.checked).toBe(true);
+
+    rerender(
+      <StudioDataTable
+        ariaLabel="Ausweichtermine"
+        labels={tableLabels}
+        data={[
+          { id: 'global-1', title: 'Global', selectable: false },
+          { id: 'tour-1', title: 'Tour', selectable: true },
+        ]}
+        getRowId={(row) => row.id}
+        columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
+        emptyState={<p>Keine Daten</p>}
+        canSelectRow={(row) => row.selectable}
+      />
+    );
+
+    const updatedGlobalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
+    expect(updatedGlobalCheckbox.checked).toBe(false);
+    expect(updatedGlobalCheckbox.disabled).toBe(true);
+  });
+
   it('renders table sorting, row actions, toolbar content and clearable bulk actions', () => {
     const onBulk = vi.fn();
     const data = [

--- a/packages/studio-ui-react/src/studio-primitives.test.tsx
+++ b/packages/studio-ui-react/src/studio-primitives.test.tsx
@@ -394,6 +394,84 @@ describe('studio-ui-react primitives', () => {
     expect(onBulk).toHaveBeenCalledWith([{ id: 'a', title: 'Alpha' }]);
   });
 
+  it('limits row selection to eligible rows and keeps bulk selection scoped to them', () => {
+    const onBulk = vi.fn();
+    const data = [
+      { id: 'holiday-1', title: 'Feiertag', selectable: false },
+      { id: 'global-1', title: 'Global', selectable: true },
+      { id: 'tour-1', title: 'Tour', selectable: true },
+    ];
+
+    render(
+      <StudioDataTable
+        ariaLabel="Ausweichtermine"
+        labels={tableLabels}
+        data={data}
+        getRowId={(row) => row.id}
+        columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
+        emptyState={<p>Keine Daten</p>}
+        canSelectRow={(row) => row.selectable}
+        bulkActions={[{ id: 'delete', label: 'Löschen', onClick: ({ selectedRows }) => onBulk(selectedRows) }]}
+      />
+    );
+
+    const holidayCheckbox = screen.getByLabelText('Ausweichtermine holiday-1 auswählen') as HTMLInputElement;
+    const globalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
+    const tourCheckbox = screen.getByLabelText('Ausweichtermine tour-1 auswählen') as HTMLInputElement;
+
+    expect(holidayCheckbox.disabled).toBe(true);
+    expect(globalCheckbox.disabled).toBe(false);
+    expect(tourCheckbox.disabled).toBe(false);
+
+    fireEvent.click(globalCheckbox);
+    expect(globalCheckbox.checked).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Löschen' }));
+    expect(onBulk).toHaveBeenCalledWith([{ id: 'global-1', title: 'Global', selectable: true }]);
+
+    fireEvent.click(screen.getByLabelText('Alle Ausweichtermine auswählen'));
+    fireEvent.click(screen.getByRole('button', { name: 'Löschen' }));
+    expect(onBulk).toHaveBeenLastCalledWith([
+      { id: 'global-1', title: 'Global', selectable: true },
+      { id: 'tour-1', title: 'Tour', selectable: true },
+    ]);
+  });
+
+  it('keeps selected rows when the parent rerenders with the same row ids', () => {
+    const data = [
+      { id: 'global-1', title: 'Global' },
+      { id: 'tour-1', title: 'Tour' },
+    ];
+
+    const { rerender } = render(
+      <StudioDataTable
+        ariaLabel="Ausweichtermine"
+        labels={tableLabels}
+        data={data}
+        getRowId={(row) => row.id}
+        columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
+        emptyState={<p>Keine Daten</p>}
+      />
+    );
+
+    const globalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
+    fireEvent.click(globalCheckbox);
+    expect(globalCheckbox.checked).toBe(true);
+
+    rerender(
+      <StudioDataTable
+        ariaLabel="Ausweichtermine"
+        labels={tableLabels}
+        data={[...data]}
+        getRowId={(row) => row.id}
+        columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
+        emptyState={<p>Keine Daten</p>}
+      />
+    );
+
+    expect((screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement).checked).toBe(true);
+  });
+
   it('renders table sorting, row actions, toolbar content and clearable bulk actions', () => {
     const onBulk = vi.fn();
     const data = [
@@ -464,6 +542,25 @@ describe('studio-ui-react primitives', () => {
     const table = screen.getByRole('table', { name: 'News' });
     const footer = screen.getByText('Seitenfuß');
     expect(Boolean(table.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+  });
+
+  it('keeps desktop table rows height-stable on hover', () => {
+    render(
+      <StudioDataTable
+        ariaLabel="News"
+        labels={tableLabels}
+        data={[{ id: 'a', title: 'Alpha' }]}
+        getRowId={(row) => row.id}
+        columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
+        emptyState={<p>Keine Daten</p>}
+        selectionMode="none"
+      />
+    );
+
+    const bodyRow = screen.getByRole('cell', { name: 'Alpha' }).closest('tr');
+    expect(bodyRow).toBeTruthy();
+    expect(bodyRow?.className).not.toContain('animate-row-hover');
+    expect(bodyRow?.className).toContain('transition-colors');
   });
 
   it('renders table loading, empty and no-selection variants', () => {

--- a/packages/studio-ui-react/src/studio-primitives.test.tsx
+++ b/packages/studio-ui-react/src/studio-primitives.test.tsx
@@ -689,6 +689,48 @@ describe('studio-ui-react primitives', () => {
     expect(disconnect).toHaveBeenCalledTimes(1);
   });
 
+  it('disables non-selectable rows in the compact card layout', () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const disconnect = vi.fn();
+
+    globalThis.ResizeObserver = class {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+
+      observe() {
+        this.callback([{ contentRect: { width: 320 } as DOMRectReadOnly }] as ResizeObserverEntry[], this as ResizeObserver);
+      }
+
+      unobserve = vi.fn();
+
+      disconnect = disconnect;
+    } as typeof ResizeObserver;
+
+    try {
+      const { unmount } = render(
+        <StudioDataTable
+          ariaLabel="Ausweichtermine"
+          labels={tableLabels}
+          data={[
+            { id: 'holiday-1', title: 'Feiertag', selectable: false },
+            { id: 'tour-1', title: 'Tour', selectable: true },
+          ]}
+          getRowId={(row) => row.id}
+          columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
+          emptyState={<p>Keine Daten</p>}
+          canSelectRow={(row) => row.selectable}
+        />
+      );
+
+      expect((screen.getByLabelText('Ausweichtermine holiday-1 in Kartenansicht auswählen') as HTMLInputElement).disabled).toBe(true);
+      expect((screen.getByLabelText('Ausweichtermine tour-1 in Kartenansicht auswählen') as HTMLInputElement).disabled).toBe(false);
+      unmount();
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
   it('renders base controls', () => {
     render(
       <>

--- a/packages/sva-mainserver/src/server/settings.test.ts
+++ b/packages/sva-mainserver/src/server/settings.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const state = vi.hoisted(() => ({
   loadDefaultExternalInterfaceRecord: vi.fn(),
   saveExternalInterfaceRecord: vi.fn(),
+  deleteExternalInterfaceRecord: vi.fn(),
   dnsLookup: vi.fn(async () => [{ address: '203.0.113.10', family: 4 }]),
 }));
 
 vi.mock('@sva/data-repositories/server', () => ({
   loadDefaultExternalInterfaceRecord: state.loadDefaultExternalInterfaceRecord,
   saveExternalInterfaceRecord: state.saveExternalInterfaceRecord,
+  deleteExternalInterfaceRecord: state.deleteExternalInterfaceRecord,
 }));
 
 vi.mock('node:dns/promises', () => ({
@@ -19,6 +21,7 @@ describe('settings', () => {
   beforeEach(() => {
     state.loadDefaultExternalInterfaceRecord.mockReset();
     state.saveExternalInterfaceRecord.mockReset();
+    state.deleteExternalInterfaceRecord.mockReset();
     state.dnsLookup.mockReset();
     state.dnsLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
   });
@@ -256,6 +259,39 @@ describe('settings', () => {
           oauthTokenUrl: 'https://new.example.invalid/oauth/token',
         },
       })
+    );
+  });
+
+  it('deletes an existing mainserver settings record by its stored id', async () => {
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
+      id: 'sva-mainserver:de-musterhausen',
+      instanceId: 'de-musterhausen',
+      typeKey: 'sva_mainserver',
+      ownerKind: 'host',
+      ownerId: 'host',
+      displayName: 'SVA Mainserver',
+      alias: 'default',
+      enabled: true,
+      isDefault: true,
+      category: 'api',
+      baseUrl: 'https://mainserver.example/graphql',
+      authMode: 'oauth2',
+      publicConfig: {
+        graphqlBaseUrl: 'https://mainserver.example/graphql',
+        oauthTokenUrl: 'https://mainserver.example/oauth/token',
+      },
+      statusCheckKind: 'sva_mainserver',
+      visibleStatus: 'ok',
+      lastCheckedAt: '2026-03-15T10:00:00.000Z',
+    });
+    state.deleteExternalInterfaceRecord.mockResolvedValue(true);
+
+    const { deleteSvaMainserverSettings } = await import('./settings');
+
+    await expect(deleteSvaMainserverSettings('de-musterhausen')).resolves.toBe(true);
+    expect(state.deleteExternalInterfaceRecord).toHaveBeenCalledWith(
+      'de-musterhausen',
+      'sva-mainserver:de-musterhausen'
     );
   });
 

--- a/packages/sva-mainserver/src/server/settings.ts
+++ b/packages/sva-mainserver/src/server/settings.ts
@@ -1,5 +1,6 @@
 import type { ExternalInterfaceRecord, ExternalInterfaceVisibleStatus } from '@sva/core';
 import {
+  deleteExternalInterfaceRecord,
   loadDefaultExternalInterfaceRecord,
   saveExternalInterfaceRecord,
 } from '@sva/data-repositories/server';
@@ -106,6 +107,15 @@ export const saveSvaMainserverSettings = async (input: {
   await saveExternalInterfaceRecord(record);
 
   return config;
+};
+
+export const deleteSvaMainserverSettings = async (instanceId: string): Promise<boolean> => {
+  const existing = await loadDefaultExternalInterfaceRecord(instanceId, SVA_MAINSERVER_TYPE_KEY);
+  if (!existing) {
+    return false;
+  }
+
+  return deleteExternalInterfaceRecord(instanceId, existing.id);
 };
 
 const mapRecordToConfig = (record: ExternalInterfaceRecord): SvaMainserverInstanceConfig =>


### PR DESCRIPTION
## Was wurde geändert

- die Waste-Read-Handler protokollieren Fehler und degradierte Visible-Status-Updates jetzt gezielt, statt den eigentlichen Ladefehler zu verdecken
- die Scheduling-Tabelle unterstützt Mehrfachauswahl nur für löschbare Ausweichtermine und bietet eine Bulk-Löschaktion an
- `StudioDataTable` behält die Auswahl jetzt bei Parent-Rerendern mit unveränderten Zeilen-IDs, statt sie bei jeder neuen `data`-Array-Referenz zurückzusetzen
- die Hover-Zeilenhöhe der generischen Tabelle bleibt stabil, weil die alte Hover-Animation entfernt wurde
- die Interfaces-Verwaltung kann dedizierte Mainserver-Einträge jetzt auch wirklich löschen, statt die Aktion in UI und Controller zu blockieren
- der Delete-Pfad für Mainserver-Einträge läuft über `deleteSvaMainserverSettings(...)`, damit der tatsächlich gespeicherte Datensatz entfernt wird
- lokale Overrides in `apps/public-waste-calendar-web/public-waste-config.local.json` werden per `.gitignore` aus dem Arbeitsbaum gehalten
- die zugehörige Plan-/Spec-Doku für das Mainserver-Delete-Verhalten liegt unter `docs/superpowers/`

## Warum

Auf der Waste-Scheduling-Seite wirkte die Zeilenauswahl defekt, obwohl die Checkboxen grundsätzlich vorhanden waren. Die eigentliche Ursache war ein UI-Reset in `StudioDataTable`: schon harmlose Parent-Rerender haben die Row-Selection geleert. Zusätzlich brauchten die Waste-Stammdaten besseres Logging, weil Fehlerpfade im Read-Handler die Diagnose unnötig erschwert haben.

Parallel dazu war das Löschen von Mainserver-Interfaces inkonsistent: die Liste zeigte den Datensatz, die Anwendung verhinderte aber die Löschaktion oder leitete sie in den generischen Delete-Pfad, der dedizierte Mainserver-Einträge bewusst ablehnt.

## Auswirkungen

- Ausweichtermine lassen sich wieder einzeln und mehrfach markieren
- Sammellöschen funktioniert für globale und tourbezogene Ausweichtermine, nicht aber für nicht löschbare Feiertagsregeln
- Waste-Stammdaten-Fehler lassen sich im Runtime-Log präziser unterscheiden
- Mainserver-Interfaces können aus der Interfaces-Ansicht jetzt konsistent gelöscht werden
- lokale Test-/Dev-Konfigurationen für den Public-Waste-Client landen nicht versehentlich im PR

## Root Cause

`StudioDataTable` hat `rowSelection` an jede Änderung der `data`-Referenz gebunden. Die Scheduling-Seite erzeugt bei Rerendern leicht neue Arrays mit identischem Inhalt. Dadurch wurde die Auswahl sofort wieder verworfen.

Für Mainserver-Einträge fehlte außerdem ein dedizierter Delete-Fluss. Die UI behandelte den Datensatz nicht wie andere löschbare Einträge, und die generische Server-Löschfunktion schützt absichtlich vor dem Entfernen des Mainserver-Backends über den falschen Pfad.

## Validierung

- `pnpm nx run auth-runtime:test:unit --testFiles=src/waste-management/core/read-handlers.test.ts`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run studio-ui-react:test:unit --testFiles=src/studio-primitives.test.tsx`
- `pnpm nx run studio-ui-react:test:types`
- `pnpm nx run plugin-waste-management:test:unit --testFiles=tests/waste-management.page.test.tsx`
- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/settings.test.ts`
- `pnpm nx run sva-studio-react:test:unit --testFiles=src/lib/interfaces-api.test.ts --testFiles=src/routes/interfaces/-interfaces-page.test.tsx`
- `pnpm nx run sva-studio-react:test:types`
