### PR TITLE
[codex] Use localeCompare for table scope sorting

### DIFF
--- a/packages/studio-ui-react/src/studio-data-table.tsx
+++ b/packages/studio-ui-react/src/studio-data-table.tsx
@@ -87,7 +87,18 @@ const SortIcon = ({ direction }: { direction: false | 'asc' | 'desc' }) => {
   return <ArrowUpDown className="h-4 w-4" aria-hidden="true" />;
 };
 
-export const compareAlphabetically = (left: string, right: string): number => left.localeCompare(right, 'de');
+const compareByCodeUnit = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+};
+
+export const compareAlphabetically = (left: string, right: string) =>
+  left.localeCompare(right, 'de') || compareByCodeUnit(left, right);
 
 const renderSelectionHeader = <TData,>(
   table: ReturnType<typeof useReactTable<TData>>,

--- a/packages/studio-ui-react/src/studio-data-table.tsx
+++ b/packages/studio-ui-react/src/studio-data-table.tsx
@@ -87,7 +87,7 @@ const SortIcon = ({ direction }: { direction: false | 'asc' | 'desc' }) => {
   return <ArrowUpDown className="h-4 w-4" aria-hidden="true" />;
 };
 
-export const compareAlphabetically = (left: string, right: string) => left.localeCompare(right);
+export const compareAlphabetically = (left: string, right: string): number => left.localeCompare(right, 'de');
 
 const renderSelectionHeader = <TData,>(
   table: ReturnType<typeof useReactTable<TData>>,

--- a/packages/studio-ui-react/src/studio-data-table.tsx
+++ b/packages/studio-ui-react/src/studio-data-table.tsx
@@ -87,6 +87,8 @@ const SortIcon = ({ direction }: { direction: false | 'asc' | 'desc' }) => {
   return <ArrowUpDown className="h-4 w-4" aria-hidden="true" />;
 };
 
+export const compareAlphabetically = (left: string, right: string) => left.localeCompare(right);
+
 const renderSelectionHeader = <TData,>(
   table: ReturnType<typeof useReactTable<TData>>,
   ariaLabel: string,
@@ -173,14 +175,14 @@ export function StudioDataTable<TData>({
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const [isCompact, setIsCompact] = React.useState(false);
   const selectionScopeKey = React.useMemo(
-    () => [...data].map((row) => getRowId(row)).sort().join('\u0000'),
+    () => [...data].map((row) => getRowId(row)).sort(compareAlphabetically).join('\u0000'),
     [data, getRowId]
   );
   const selectableScopeKey = React.useMemo(
     () =>
       [...data]
         .map((row) => `${getRowId(row)}:${canSelectRow ? (canSelectRow(row) ? '1' : '0') : '1'}`)
-        .sort()
+        .sort(compareAlphabetically)
         .join('\u0000'),
     [canSelectRow, data, getRowId]
   );

--- a/packages/studio-ui-react/src/studio-primitives.test.tsx
+++ b/packages/studio-ui-react/src/studio-primitives.test.tsx
@@ -47,6 +47,7 @@ import {
   StudioTechnicalStatusPanel,
   Textarea,
 } from './index.js';
+import { compareAlphabetically } from './studio-data-table.js';
 
 const tableLabels: StudioDataTableLabels = {
   selectionColumn: 'Auswahl',
@@ -662,6 +663,27 @@ describe('studio-ui-react primitives', () => {
 
     expect(screen.queryByLabelText('News a auswählen')).toBeNull();
     expect(screen.getAllByText('a')).toHaveLength(2);
+  });
+
+  it('sorts strings with localeCompare for deterministic alphabetical comparisons', () => {
+    const localeCompareSpy = vi
+      .spyOn(String.prototype, 'localeCompare')
+      .mockImplementation(function mockLocaleCompare(this: string, other: string) {
+        if (this === 'b' && other === 'a') {
+          return -1;
+        }
+        if (this === 'a' && other === 'b') {
+          return 1;
+        }
+        return 0;
+      });
+
+    try {
+      expect(['a', 'b'].sort(compareAlphabetically)).toEqual(['b', 'a']);
+      expect(localeCompareSpy).toHaveBeenCalled();
+    } finally {
+      localeCompareSpy.mockRestore();
+    }
   });
 
   it('keeps a bulk action enabled without selection when disabled is explicitly false', () => {

--- a/packages/studio-ui-react/src/studio-primitives.test.tsx
+++ b/packages/studio-ui-react/src/studio-primitives.test.tsx
@@ -665,22 +665,21 @@ describe('studio-ui-react primitives', () => {
     expect(screen.getAllByText('a')).toHaveLength(2);
   });
 
-  it('sorts strings with localeCompare for deterministic alphabetical comparisons', () => {
+  it('sorts strings with a fixed locale and a deterministic tie-breaker', () => {
     const localeCompareSpy = vi
       .spyOn(String.prototype, 'localeCompare')
-      .mockImplementation(function mockLocaleCompare(this: string, other: string) {
-        if (this === 'b' && other === 'a') {
-          return -1;
-        }
-        if (this === 'a' && other === 'b') {
-          return 1;
-        }
+      .mockImplementation(function mockLocaleCompare(
+        this: string,
+        _other: string,
+        _locales?: string | readonly string[],
+        _options?: Intl.CollatorOptions
+      ) {
         return 0;
       });
 
     try {
-      expect(['a', 'b'].sort(compareAlphabetically)).toEqual(['b', 'a']);
-      expect(localeCompareSpy).toHaveBeenCalled();
+      expect(compareAlphabetically('a', 'b')).toBeLessThan(0);
+      expect(localeCompareSpy).toHaveBeenCalledWith('b', 'de');
     } finally {
       localeCompareSpy.mockRestore();
     }


### PR DESCRIPTION
## Was wurde geändert?
- expliziten String-Comparator auf Basis von `String.localeCompare` für die Scope-Sortierung in `StudioDataTable` eingeführt
- beide betroffenen `Array.sort()`-Aufrufe auf den neuen Comparator umgestellt
- Regressionstest ergänzt, der nachweist, dass die alphabetische Sortierung über `localeCompare` läuft

## Warum wurde es geändert?
Die bisherigen Sortierungen verließen sich auf das Default-Verhalten von `Array.sort()`. Das ist typabhängig und für alphabetische String-Sortierung nicht explizit genug.

## Auswirkung
Die Scope-Keys für Auswahl- und Selektionslogik werden jetzt absichtlich und reproduzierbar alphabetisch verglichen. Das adressiert die gemeldeten Reliability- und Intentionality-Befunde.

## Root Cause
Es fehlte ein expliziter String-Comparator; dadurch hing das Verhalten vom impliziten Default-Sortierpfad ab.

## Verifikation
- `pnpm nx run studio-ui-react:test:unit --testFiles=src/studio-primitives.test.tsx --skipNxCache`
- `pnpm nx run studio-ui-react:test:types`
