### PR TITLE
refactor: reduce sonar top complexity hotspots

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -14,6 +14,11 @@ args = [
   "--no-usage-statistics",
 ]
 
+[mcp_servers.sonarcloud]
+url = "https://api.sonarcloud.io/mcp"
+bearer_token_env_var = "SONARCLOUD_TOKEN"
+http_headers = { "SONARQUBE_ORG" = "smart-village-app" }
+
 [features]
 multi_agent = true
 

--- a/apps/sva-studio-react/src/components/DevelopmentLogConsole.tsx
+++ b/apps/sva-studio-react/src/components/DevelopmentLogConsole.tsx
@@ -34,6 +34,24 @@ const isVisibleForSource = (filter: LogSourceFilter, source: DevelopmentLogRecor
   return filter === 'all' ? true : source === filter;
 };
 
+const stringifyPrimitiveContext = (context: Exclude<unknown, object>): string => {
+  return `${context}`;
+};
+
+const stringifyObjectContext = (context: object): string => {
+  const stringifier = context.toString;
+
+  if (typeof stringifier === 'function' && stringifier !== Object.prototype.toString) {
+    try {
+      return stringifier.call(context);
+    } catch {
+      return Object.prototype.toString.call(context);
+    }
+  }
+
+  return Object.prototype.toString.call(context);
+};
+
 const stringifyContext = (context: unknown): string | null => {
   if (!context) {
     return null;
@@ -43,19 +61,10 @@ const stringifyContext = (context: unknown): string | null => {
     return JSON.stringify(context, null, 2);
   } catch {
     if (typeof context === 'object') {
-      const stringifier = context.toString;
-      if (typeof stringifier === 'function' && stringifier !== Object.prototype.toString) {
-        try {
-          return String(context);
-        } catch {
-          return Object.prototype.toString.call(context);
-        }
-      }
-
-      return Object.prototype.toString.call(context);
+      return stringifyObjectContext(context);
     }
 
-    return String(context);
+    return stringifyPrimitiveContext(context);
   }
 };
 

--- a/apps/sva-studio-react/src/components/ErrorFallback.tsx
+++ b/apps/sva-studio-react/src/components/ErrorFallback.tsx
@@ -25,7 +25,7 @@ export default function ErrorFallback({ error, reset }: Readonly<ErrorComponentP
       VITE_ENABLE_ERROR_DEBUG_DETAILS?: string;
     };
   };
-  const browserWindow = typeof globalThis.window !== 'undefined' ? globalThis.window : undefined;
+  const browserWindow = globalThis.window;
   const isLocalDebugHost =
     browserWindow?.location.hostname === 'localhost' || browserWindow?.location.hostname === '127.0.0.1';
   const debugDetailsEnabled = metaEnv.env?.VITE_ENABLE_ERROR_DEBUG_DETAILS === 'true';

--- a/apps/sva-studio-react/src/components/Header.tsx
+++ b/apps/sva-studio-react/src/components/Header.tsx
@@ -41,6 +41,21 @@ type HeaderDropdownItem = Readonly<{
 const iconButtonClassName =
   'h-10 w-10 rounded-full border border-transparent bg-transparent px-0 text-muted-foreground shadow-none hover:border-border hover:bg-card hover:text-foreground';
 
+type HeaderAuthActionProps = Readonly<{
+  isHydrated: boolean;
+  isLoading: boolean;
+  isAuthLoading: boolean;
+  isAuthenticated: boolean;
+  isDevAuthAvailable?: boolean;
+  hideAnonymousLoginAction: boolean;
+  loginHref: string;
+  loginWithDevAuth?: () => Promise<unknown> | void;
+  logout: () => Promise<unknown> | void;
+  user: { readonly id: string } | null;
+  displayName: string;
+  initials: string;
+}>;
+
 const resolveUserDisplayName = (user: { readonly id: string }) => {
   const candidate = user as { readonly name?: string; readonly displayName?: string };
   return candidate.displayName?.trim() || candidate.name?.trim() || user.id;
@@ -53,6 +68,8 @@ const resolveUserInitials = (value: string) =>
     .slice(0, 2)
     .map((part) => part[0]?.toUpperCase() ?? '')
     .join('') || value.slice(0, 2).toUpperCase();
+
+const HeaderSectionDivider = () => <hr className="my-1 border-border" />;
 
 const HeaderDropdownMenu = ({
   trigger,
@@ -88,12 +105,12 @@ const HeaderDropdownMenu = ({
       }
     };
 
-    window.addEventListener('mousedown', handlePointerDown);
-    window.addEventListener('keydown', handleKeyDown);
+    globalThis.addEventListener('mousedown', handlePointerDown);
+    globalThis.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      window.removeEventListener('mousedown', handlePointerDown);
-      window.removeEventListener('keydown', handleKeyDown);
+      globalThis.removeEventListener('mousedown', handlePointerDown);
+      globalThis.removeEventListener('keydown', handleKeyDown);
     };
   }, [open]);
 
@@ -204,6 +221,126 @@ const HeaderPromptField = ({
   </div>
 );
 
+const HeaderAuthAction = ({
+  isHydrated,
+  isLoading,
+  isAuthLoading,
+  isAuthenticated,
+  isDevAuthAvailable = false,
+  hideAnonymousLoginAction,
+  loginHref,
+  loginWithDevAuth,
+  logout,
+  user,
+  displayName,
+  initials,
+}: HeaderAuthActionProps): React.ReactNode => {
+  if (!isHydrated || isLoading || isAuthLoading) {
+    return (
+      <>
+        <span role="status" aria-live="polite" className="sr-only">
+          {t('shell.header.authLoading')}
+        </span>
+        <span aria-hidden="true" className="h-9 w-28 animate-skeleton rounded-full" />
+      </>
+    );
+  }
+
+  if (!isAuthenticated) {
+    if (hideAnonymousLoginAction) {
+      return null;
+    }
+
+    if (isDevAuthAvailable) {
+      return (
+        <Button type="button" variant="secondary" onClick={() => void loginWithDevAuth?.()}>
+          {t('shell.header.login')}
+        </Button>
+      );
+    }
+
+    return (
+      <Button asChild variant="secondary">
+        <a href={loginHref}>{t('shell.header.login')}</a>
+      </Button>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  const logoutItem: HeaderDropdownItem = isDevAuthAvailable
+    ? {
+        id: 'logout',
+        label: t('shell.header.logout'),
+        onSelect: () => {
+          void logout();
+        },
+      }
+    : {
+        id: 'logout',
+        label: t('shell.header.logout'),
+        render: (
+          <form action="/auth/logout" method="post" onSubmit={() => clearClientLogoutState()}>
+            <input type="hidden" name="logoutIntent" value="user" />
+            <button
+              type="submit"
+              role="menuitem"
+              className="flex w-full items-start gap-3 rounded-md px-3 py-2 text-left hover:bg-accent hover:text-accent-foreground"
+            >
+              <span className="space-y-0.5">
+                <span className="block text-sm font-medium">{t('shell.header.logout')}</span>
+              </span>
+            </button>
+          </form>
+        ),
+      };
+
+  const accountMenuItems: readonly HeaderDropdownItem[] = [
+    { id: 'account', label: t('account.profile.title'), href: '/account' },
+    { id: 'password', label: t('shell.header.changePassword'), disabled: true },
+    { id: 'email', label: t('shell.header.changeEmail'), disabled: true },
+    {
+      id: 'divider-privacy',
+      render: <HeaderSectionDivider />,
+    },
+    { id: 'privacy', label: t('account.privacy.navLabel'), href: '/account/privacy' },
+    { id: 'rules', label: t('account.rules.navLabel'), href: '/account/rules' },
+    {
+      id: 'divider-session',
+      render: <HeaderSectionDivider />,
+    },
+    logoutItem,
+  ];
+
+  return (
+    <HeaderDropdownMenu
+      align="right"
+      menuLabel={t('shell.header.accountMenu')}
+      items={accountMenuItems}
+      trigger={({ open, toggle, menuId }) => (
+        <button
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={menuId}
+          className="flex items-center gap-3 rounded-full px-1 py-1 text-left hover:bg-accent/60"
+          onClick={toggle}
+        >
+          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-foreground text-sm font-semibold text-background">
+            {initials}
+          </span>
+          <span className="hidden min-w-0 sm:block">
+            <span className="block truncate text-sm font-medium text-foreground">{displayName}</span>
+          </span>
+          <ChevronDown aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+        </button>
+      )}
+    />
+  );
+};
+
 /**
  * Rendert die Kopfzeile mit globalen Aktionen.
  *
@@ -234,103 +371,6 @@ export default function Header({
   React.useEffect(() => {
     setIsHydrated(true);
   }, []);
-
-  let authAction: React.ReactNode = null;
-
-  if (!isHydrated || isLoading || isAuthLoading) {
-    authAction = (
-      <>
-        <span role="status" aria-live="polite" className="sr-only">
-          {t('shell.header.authLoading')}
-        </span>
-        <span aria-hidden="true" className="h-9 w-28 animate-skeleton rounded-full" />
-      </>
-    );
-  } else if (!isAuthenticated) {
-    authAction = hideAnonymousLoginAction
-      ? null
-      : isDevAuthAvailable
-        ? (
-            <Button type="button" variant="secondary" onClick={() => void loginWithDevAuth()}>
-              {t('shell.header.login')}
-            </Button>
-          )
-        : (
-            <Button asChild variant="secondary">
-              <a href={loginHref}>{t('shell.header.login')}</a>
-            </Button>
-          );
-  } else if (user) {
-    const logoutItem: HeaderDropdownItem = isDevAuthAvailable
-      ? {
-          id: 'logout',
-          label: t('shell.header.logout'),
-          onSelect: () => {
-            void logout();
-          },
-        }
-      : {
-          id: 'logout',
-          label: t('shell.header.logout'),
-          render: (
-            <form action="/auth/logout" method="post" onSubmit={() => clearClientLogoutState()}>
-              <input type="hidden" name="logoutIntent" value="user" />
-              <button
-                type="submit"
-                role="menuitem"
-                className="flex w-full items-start gap-3 rounded-md px-3 py-2 text-left hover:bg-accent hover:text-accent-foreground"
-              >
-                <span className="space-y-0.5">
-                  <span className="block text-sm font-medium">{t('shell.header.logout')}</span>
-                </span>
-              </button>
-            </form>
-          ),
-        };
-
-    const accountMenuItems: readonly HeaderDropdownItem[] = [
-      { id: 'account', label: t('account.profile.title'), href: '/account' },
-      { id: 'password', label: t('shell.header.changePassword'), disabled: true },
-      { id: 'email', label: t('shell.header.changeEmail'), disabled: true },
-      {
-        id: 'divider-privacy',
-        render: <div role="separator" className="my-1 border-t border-border" />,
-      },
-      { id: 'privacy', label: t('account.privacy.navLabel'), href: '/account/privacy' },
-      { id: 'rules', label: t('account.rules.navLabel'), href: '/account/rules' },
-      {
-        id: 'divider-session',
-        render: <div role="separator" className="my-1 border-t border-border" />,
-      },
-      logoutItem,
-    ];
-
-    authAction = (
-      <HeaderDropdownMenu
-        align="right"
-        menuLabel={t('shell.header.accountMenu')}
-        items={accountMenuItems}
-        trigger={({ open, toggle, menuId }) => (
-          <button
-            type="button"
-            aria-haspopup="menu"
-            aria-expanded={open}
-            aria-controls={menuId}
-            className="flex items-center gap-3 rounded-full px-1 py-1 text-left hover:bg-accent/60"
-            onClick={toggle}
-          >
-            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-foreground text-sm font-semibold text-background">
-              {initials}
-            </span>
-            <span className="hidden min-w-0 sm:block">
-              <span className="block truncate text-sm font-medium text-foreground">{displayName}</span>
-            </span>
-            <ChevronDown aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
-          </button>
-        )}
-      />
-    );
-  }
 
   const languageItems: readonly HeaderDropdownItem[] = [
     {
@@ -446,7 +486,20 @@ export default function Header({
           >
             {resolvedMode === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
           </Button>
-          {authAction}
+          <HeaderAuthAction
+            isHydrated={isHydrated}
+            isLoading={isLoading}
+            isAuthLoading={isAuthLoading}
+            isAuthenticated={isAuthenticated}
+            isDevAuthAvailable={isDevAuthAvailable}
+            hideAnonymousLoginAction={hideAnonymousLoginAction}
+            loginHref={loginHref}
+            loginWithDevAuth={loginWithDevAuth}
+            logout={logout}
+            user={user}
+            displayName={displayName}
+            initials={initials}
+          />
         </div>
       </div>
     </header>

--- a/apps/sva-studio-react/src/lib/waste-management-operations.import.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.import.ts
@@ -315,89 +315,97 @@ export const previewLocationTourPickupDateImport = async (
   };
 };
 
-export const executeImport = async (
+const executeLocationTourPickupDateImport = async (
   repository: WasteRepository,
   input: {
-    readonly profileId: WasteManagementImportProfileId;
-    readonly rows?: readonly GenericImportRow[];
-    readonly parsedLocationTourPickupDates?: WasteLocationTourPickupDateImportParseResult;
+    readonly parsedLocationTourPickupDates: WasteLocationTourPickupDateImportParseResult;
     readonly reportProgress?: (progress: StudioJobProgress) => Promise<void> | void;
   }
 ) => {
-  if (input.profileId === 'waste-management.ortsbezogene-tourtermine') {
-    if (!input.parsedLocationTourPickupDates) {
-      throw new Error('missing_location_tour_pickup_date_import');
+  if (input.parsedLocationTourPickupDates.issues.length > 0) {
+    throw new Error('location_tour_pickup_date_import_has_issues');
+  }
+
+  const planned = await planLocationTourPickupDateImport(repository, {
+    parsed: input.parsedLocationTourPickupDates,
+    persist: true,
+    reportProgress: input.reportProgress,
+  });
+
+  return {
+    rowCount: input.parsedLocationTourPickupDates.validRowCount,
+    createdFractions: planned.summary.fractions.created,
+    createdTours: planned.newTours.length,
+    createdLocations: planned.summary.locations.created,
+    createdAssignments: planned.summary.assignments.created,
+    skippedRows: input.parsedLocationTourPickupDates.invalidRowCount,
+    errorCount: input.parsedLocationTourPickupDates.issues.length,
+  };
+};
+
+const executeGeographyImport = async (
+  repository: WasteRepository,
+  rows: readonly GenericImportRow[],
+  counts: { rows: number; upserts: number }
+) => {
+  for (const row of rows) {
+    await repository.upsertWasteRegion({ id: row.region_id, name: row.region_name });
+    await repository.upsertWasteCity({ id: row.city_id, name: row.city_name, regionId: row.region_id });
+    counts.upserts += 2;
+    if (normalizeOptionalText(row.street_id) && normalizeOptionalText(row.street_name)) {
+      await repository.upsertWasteStreet({ id: row.street_id, name: row.street_name, cityId: row.city_id });
+      counts.upserts += 1;
     }
-    if (input.parsedLocationTourPickupDates.issues.length > 0) {
-      throw new Error('location_tour_pickup_date_import_has_issues');
+    if (
+      normalizeOptionalText(row.house_number_id) &&
+      normalizeOptionalText(row.house_number_value) &&
+      normalizeOptionalText(row.street_id)
+    ) {
+      await repository.upsertWasteHouseNumber({ id: row.house_number_id, number: row.house_number_value, streetId: row.street_id });
+      counts.upserts += 1;
     }
-    const planned = await planLocationTourPickupDateImport(repository, {
-      parsed: input.parsedLocationTourPickupDates,
-      persist: true,
-      reportProgress: input.reportProgress,
+    await repository.upsertWasteCollectionLocation({
+      id: row.location_id,
+      regionId: normalizeOptionalText(row.region_id),
+      cityId: row.city_id,
+      streetId: normalizeOptionalText(row.street_id),
+      houseNumberId: normalizeOptionalText(row.house_number_id),
+      active: parseBoolean(row.active, 'active'),
     });
-    return {
-      rowCount: input.parsedLocationTourPickupDates.validRowCount,
-      createdFractions: planned.summary.fractions.created,
-      createdTours: planned.newTours.length,
-      createdLocations: planned.summary.locations.created,
-      createdAssignments: planned.summary.assignments.created,
-      skippedRows: input.parsedLocationTourPickupDates.invalidRowCount,
-      errorCount: input.parsedLocationTourPickupDates.issues.length,
-    };
+    counts.upserts += 1;
   }
 
-  const rows = input.rows ?? [];
-  const counts = { rows: rows.length, upserts: 0 };
+  return counts;
+};
 
-  if (input.profileId === 'waste-management.geografie-abholorte') {
-    for (const row of rows) {
-      await repository.upsertWasteRegion({ id: row.region_id, name: row.region_name });
-      await repository.upsertWasteCity({ id: row.city_id, name: row.city_name, regionId: row.region_id });
-      counts.upserts += 2;
-      if (normalizeOptionalText(row.street_id) && normalizeOptionalText(row.street_name)) {
-        await repository.upsertWasteStreet({ id: row.street_id, name: row.street_name, cityId: row.city_id });
-        counts.upserts += 1;
-      }
-      if (
-        normalizeOptionalText(row.house_number_id) &&
-        normalizeOptionalText(row.house_number_value) &&
-        normalizeOptionalText(row.street_id)
-      ) {
-        await repository.upsertWasteHouseNumber({ id: row.house_number_id, number: row.house_number_value, streetId: row.street_id });
-        counts.upserts += 1;
-      }
-      await repository.upsertWasteCollectionLocation({
-        id: row.location_id,
-        regionId: normalizeOptionalText(row.region_id),
-        cityId: row.city_id,
-        streetId: normalizeOptionalText(row.street_id),
-        houseNumberId: normalizeOptionalText(row.house_number_id),
-        active: parseBoolean(row.active, 'active'),
-      });
-      counts.upserts += 1;
-    }
-    return counts;
+const executeToursImport = async (
+  repository: WasteRepository,
+  rows: readonly GenericImportRow[],
+  counts: { rows: number; upserts: number }
+) => {
+  for (const row of rows) {
+    await repository.upsertWasteTour({
+      id: row.tour_id,
+      name: row.tour_name,
+      description: normalizeOptionalText(row.description),
+      wasteFractionIds: parseDelimitedStringArray(row.waste_fraction_ids),
+      recurrence: parseRecurrence(row.recurrence) ?? null,
+      firstDate: normalizeOptionalText(row.first_date),
+      endDate: normalizeOptionalText(row.end_date),
+      customDates: parseCustomDates(row.custom_dates),
+      active: parseBoolean(row.active, 'active'),
+    });
+    counts.upserts += 1;
   }
 
-  if (input.profileId === 'waste-management.touren') {
-    for (const row of rows) {
-      await repository.upsertWasteTour({
-        id: row.tour_id,
-        name: row.tour_name,
-        description: normalizeOptionalText(row.description),
-        wasteFractionIds: parseDelimitedStringArray(row.waste_fraction_ids),
-        recurrence: parseRecurrence(row.recurrence) ?? null,
-        firstDate: normalizeOptionalText(row.first_date),
-        endDate: normalizeOptionalText(row.end_date),
-        customDates: parseCustomDates(row.custom_dates),
-        active: parseBoolean(row.active, 'active'),
-      });
-      counts.upserts += 1;
-    }
-    return counts;
-  }
+  return counts;
+};
 
+const executeDateShiftImport = async (
+  repository: WasteRepository,
+  rows: readonly GenericImportRow[],
+  counts: { rows: number; upserts: number }
+) => {
   for (const row of rows) {
     const shiftContext = normalizeOptionalText(row.shift_context);
     if (shiftContext !== 'global' && shiftContext !== 'tour') {
@@ -434,4 +442,34 @@ export const executeImport = async (
   }
 
   return counts;
+};
+
+export const executeImport = async (
+  repository: WasteRepository,
+  input: {
+    readonly profileId: WasteManagementImportProfileId;
+    readonly rows?: readonly GenericImportRow[];
+    readonly parsedLocationTourPickupDates?: WasteLocationTourPickupDateImportParseResult;
+    readonly reportProgress?: (progress: StudioJobProgress) => Promise<void> | void;
+  }
+) => {
+  const rows = input.rows ?? [];
+  const counts = { rows: rows.length, upserts: 0 };
+
+  switch (input.profileId) {
+    case 'waste-management.ortsbezogene-tourtermine':
+      if (!input.parsedLocationTourPickupDates) {
+        throw new Error('missing_location_tour_pickup_date_import');
+      }
+      return executeLocationTourPickupDateImport(repository, {
+        parsedLocationTourPickupDates: input.parsedLocationTourPickupDates,
+        reportProgress: input.reportProgress,
+      });
+    case 'waste-management.geografie-abholorte':
+      return executeGeographyImport(repository, rows, counts);
+    case 'waste-management.touren':
+      return executeToursImport(repository, rows, counts);
+    case 'waste-management.ausweichtermine':
+      return executeDateShiftImport(repository, rows, counts);
+  }
 };

--- a/apps/sva-studio-react/src/providers/auth-provider.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.tsx
@@ -38,7 +38,10 @@ import {
   fetchWithRequestTimeout,
   type IamHttpError,
 } from '../lib/iam-api';
-import { fetchAuthMeSingleFlight } from '../lib/auth-me-singleflight';
+import {
+  type AuthMeResult,
+  fetchAuthMeSingleFlight,
+} from '../lib/auth-me-singleflight';
 
 type SessionUser = {
   id: string;
@@ -375,15 +378,8 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     [logAuthDebug, recordTrail]
   );
 
-  const loadUser = React.useCallback(
-    async (silent: boolean) => {
-      if (silent && inFlightSilentLoadRef.current) {
-        return inFlightSilentLoadRef.current;
-      }
-
-      const runLoadUser = async () => {
-      const authFlowId = startAuthFlow();
-      const firstAttempt = nextAuthAttempt();
+  const startLoadUserRequest = React.useCallback(
+    (silent: boolean, authFlowId: string, firstAttempt: number) => {
       if (!silent && isMountedRef.current) {
         setIsLoading(true);
       }
@@ -392,188 +388,250 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         setError(null);
       }
 
-      try {
-        logBrowserOperationStart(authLogger, 'auth_session_load_started', {
-          auth_flow_id: authFlowId,
-          attempt: firstAttempt,
-          operation: silent ? 'invalidate_permissions' : 'load_session',
-          silent,
-          pathname: globalThis.location?.pathname ?? null,
-        });
-        recordTrail('auth_session_load_started', {
-          attempt: firstAttempt,
-          authFlowId,
-          recoveryStep: silent ? 'invalidate_permissions' : 'load_session',
-          result: 'started',
-        });
-        let result = await fetchAuthMeSingleFlight(() =>
-          fetchWithRequestTimeout(AUTH_ME_ENDPOINT, undefined, { timeoutMs: 5_000 })
-        );
-        logAuthDebug('auth_session_load_response', {
-          silent,
-          status: result.status,
-          ok: result.ok,
-        });
-        if (result.ok) {
-          recordTrail('auth_me_succeeded', {
+      logBrowserOperationStart(authLogger, 'auth_session_load_started', {
+        auth_flow_id: authFlowId,
+        attempt: firstAttempt,
+        operation: silent ? 'invalidate_permissions' : 'load_session',
+        silent,
+        pathname: globalThis.location?.pathname ?? null,
+      });
+      recordTrail('auth_session_load_started', {
+        attempt: firstAttempt,
+        authFlowId,
+        recoveryStep: silent ? 'invalidate_permissions' : 'load_session',
+        result: 'started',
+      });
+    },
+    [recordTrail]
+  );
+
+  const fetchAuthMe = React.useCallback(
+    () =>
+      fetchAuthMeSingleFlight(() =>
+        fetchWithRequestTimeout(AUTH_ME_ENDPOINT, undefined, { timeoutMs: 5_000 })
+      ),
+    []
+  );
+
+  const commitUnauthenticatedSession = React.useCallback(
+    (silent: boolean, authFlowId: string, result: AuthMeResult) => {
+      const shouldClearConfirmedSnapshot = !silent || result.status === 401 || result.status === 403;
+      if (isMountedRef.current) {
+        if (shouldClearConfirmedSnapshot) {
+          setUser(null);
+          setSessionExpiresAt(null);
+        }
+        setHasResolvedSession(true);
+      }
+      authLogger.info('auth_session_unauthenticated', {
+        auth_flow_id: authFlowId,
+        attempt: authAttemptRef.current,
+        operation: silent ? 'invalidate_permissions' : 'load_session',
+        silent,
+        status: result.status,
+        request_id: result.error?.requestId,
+        reason_code: result.error?.safeDetails?.reason_code,
+      });
+    },
+    []
+  );
+
+  const commitAuthenticatedSession = React.useCallback(
+    (silent: boolean, authFlowId: string, result: AuthMeResult) => {
+      const payload = parseAuthUser(result.payload);
+      const expiresAt = parseSessionExpiresAt(result.payload);
+      if (isMountedRef.current) {
+        setUser(payload);
+        setSessionExpiresAt(expiresAt ?? null);
+        setHasResolvedSession(true);
+        setSessionRecoveryFailed(false);
+      }
+      if (payload) {
+        markKnownSession();
+      }
+      logBrowserOperationSuccess(authLogger, 'auth_session_authenticated', {
+        auth_flow_id: authFlowId,
+        attempt: authAttemptRef.current,
+        operation: silent ? 'invalidate_permissions' : 'load_session',
+        silent,
+        has_user: Boolean(payload),
+        roles_count: payload?.roles.length ?? 0,
+        instance_id: payload?.instanceId,
+        expires_at: expiresAt,
+      });
+    },
+    []
+  );
+
+  const commitLoadUserFailure = React.useCallback(
+    (silent: boolean, authFlowId: string, firstAttempt: number, cause: unknown) => {
+      const resolvedError = asIamError(cause);
+      recordTrail('auth_session_load_failed', {
+        attempt: authAttemptRef.current || firstAttempt,
+        authFlowId,
+        ...readAuthDiagnosticMeta(resolvedError),
+        recoveryStep: silent ? 'invalidate_permissions' : 'load_session',
+        result: 'failed',
+      });
+      if (isMountedRef.current) {
+        if (!silent) {
+          setUser(null);
+          setSessionExpiresAt(null);
+          setError(resolvedError);
+        }
+        setHasResolvedSession(true);
+        setIsRecoveringSession(false);
+      }
+      logBrowserOperationFailure(authLogger, 'auth_session_load_failed', resolvedError, {
+        auth_flow_id: authFlowId,
+        attempt: authAttemptRef.current || firstAttempt,
+        operation: silent ? 'invalidate_permissions' : 'load_session',
+        silent,
+      });
+    },
+    [recordTrail]
+  );
+
+  const handleUnauthorizedSession = React.useCallback(
+    async (input: {
+      silent: boolean;
+      authFlowId: string;
+      firstAttempt: number;
+      result: AuthMeResult;
+    }): Promise<AuthMeResult> => {
+      const { authFlowId, firstAttempt, silent } = input;
+      const devAuthSessionActive = hasActiveDevAuthSession();
+      const hadKnownSession = readHadKnownSession();
+      const responseMeta = readAuthDiagnosticMeta(input.result.error);
+      recordTrail('auth_me_401_received', {
+        attempt: firstAttempt,
+        authFlowId,
+        ...responseMeta,
+        recoveryStep: 'initial_auth_me',
+        result: 'failed',
+      });
+
+      if (!silent && isMountedRef.current) {
+        setUser(null);
+        setSessionExpiresAt(null);
+        setHasResolvedSession(true);
+        setIsLoading(false);
+      }
+
+      if (isMountedRef.current) {
+        setIsRecoveringSession(true);
+      }
+
+      const recovered = devAuthSessionActive
+        ? false
+        : await attemptSilentSessionRecovery({
             attempt: firstAttempt,
             authFlowId,
-            result: 'succeeded',
-            status: result.status,
           });
-        }
+      logAuthDebug('auth_silent_recovery_result', { recovered });
 
-        if (!result.ok && result.status === 401) {
-          const devAuthSessionActive = hasActiveDevAuthSession();
-          const hadKnownSession = readHadKnownSession();
-          const responseMeta = readAuthDiagnosticMeta(result.error);
-          recordTrail('auth_me_401_received', {
-            attempt: firstAttempt,
-            authFlowId,
-            ...responseMeta,
-            recoveryStep: 'initial_auth_me',
-            result: 'failed',
-          });
+      if (isMountedRef.current) {
+        setIsRecoveringSession(false);
+      }
 
-          if (!silent && isMountedRef.current) {
-            setUser(null);
-            setSessionExpiresAt(null);
-            setHasResolvedSession(true);
-            setIsLoading(false);
-          }
-
-          if (isMountedRef.current) {
-            setIsRecoveringSession(true);
-          }
-
-          const recovered = devAuthSessionActive
-            ? false
-            : await attemptSilentSessionRecovery({
-                attempt: firstAttempt,
-                authFlowId,
-              });
-          logAuthDebug('auth_silent_recovery_result', { recovered });
-
-          if (isMountedRef.current) {
-            setIsRecoveringSession(false);
-          }
-
-          if (!recovered && hadKnownSession && !silent && isMountedRef.current) {
-            setSessionRecoveryFailed(true);
-            redirectToSessionExpiredNotice({
-              attempt: firstAttempt,
-              authFlowId,
-              ...responseMeta,
-              reasonCode: responseMeta.reasonCode ?? 'silent_recovery_failed',
-              recoveryStep: 'session_expired_redirect',
-              result: 'failed',
-            });
-          }
-
-          if (recovered) {
-            const recoveryAttempt = nextAuthAttempt();
-            result = await fetchAuthMeSingleFlight(() =>
-              fetchWithRequestTimeout(AUTH_ME_ENDPOINT, undefined, { timeoutMs: 5_000 })
-            );
-            logAuthDebug('auth_session_load_response_after_recovery', {
-              status: result.status,
-              ok: result.ok,
-            });
-            recordTrail(result.ok ? 'auth_me_retry_succeeded' : 'auth_me_retry_failed', {
-              attempt: recoveryAttempt,
-              authFlowId,
-              ...readAuthDiagnosticMeta(result.error),
-              recoveryStep: 'post_silent_recovery_auth_me',
-              result: result.ok ? 'succeeded' : 'failed',
-              status: result.status,
-            });
-
-            if (!result.ok && result.status === 401 && hadKnownSession && !silent && isMountedRef.current) {
-              const retryResponseMeta = readAuthDiagnosticMeta(result.error);
-              setSessionRecoveryFailed(true);
-              redirectToSessionExpiredNotice({
-                attempt: recoveryAttempt,
-                authFlowId,
-                ...retryResponseMeta,
-                reasonCode: retryResponseMeta.reasonCode ?? 'session_expired',
-                recoveryStep: 'session_expired_redirect',
-                result: 'failed',
-              });
-            }
-          }
-        }
-
-        if (!result.ok) {
-          const shouldClearConfirmedSnapshot = !silent || result.status === 401 || result.status === 403;
-          if (isMountedRef.current) {
-            if (shouldClearConfirmedSnapshot) {
-              setUser(null);
-              setSessionExpiresAt(null);
-            }
-            setHasResolvedSession(true);
-          }
-          authLogger.info('auth_session_unauthenticated', {
-            auth_flow_id: authFlowId,
-            attempt: authAttemptRef.current,
-            operation: silent ? 'invalidate_permissions' : 'load_session',
-            silent,
-            status: result.status,
-            request_id: result.error?.requestId,
-            reason_code: result.error?.safeDetails?.reason_code,
-          });
-          return;
-        }
-
-        const payload = parseAuthUser(result.payload);
-        const expiresAt = parseSessionExpiresAt(result.payload);
-        if (isMountedRef.current) {
-          setUser(payload);
-          setSessionExpiresAt(expiresAt ?? null);
-          setHasResolvedSession(true);
-          setSessionRecoveryFailed(false);
-        }
-        if (payload) {
-          markKnownSession();
-        }
-        logBrowserOperationSuccess(authLogger, 'auth_session_authenticated', {
-          auth_flow_id: authFlowId,
-          attempt: authAttemptRef.current,
-          operation: silent ? 'invalidate_permissions' : 'load_session',
-          silent,
-          has_user: Boolean(payload),
-          roles_count: payload?.roles.length ?? 0,
-          instance_id: payload?.instanceId,
-          expires_at: expiresAt,
-        });
-      } catch (cause) {
-        const resolvedError = asIamError(cause);
-        recordTrail('auth_session_load_failed', {
-          attempt: authAttemptRef.current || firstAttempt,
+      if (!recovered && hadKnownSession && !silent && isMountedRef.current) {
+        setSessionRecoveryFailed(true);
+        redirectToSessionExpiredNotice({
+          attempt: firstAttempt,
           authFlowId,
-          ...readAuthDiagnosticMeta(resolvedError),
-          recoveryStep: silent ? 'invalidate_permissions' : 'load_session',
+          ...responseMeta,
+          reasonCode: responseMeta.reasonCode ?? 'silent_recovery_failed',
+          recoveryStep: 'session_expired_redirect',
           result: 'failed',
         });
-        if (isMountedRef.current) {
-          if (!silent) {
-            setUser(null);
-            setSessionExpiresAt(null);
-            setError(resolvedError);
-          }
-          setHasResolvedSession(true);
-          setIsRecoveringSession(false);
-        }
-        logBrowserOperationFailure(authLogger, 'auth_session_load_failed', resolvedError, {
-          auth_flow_id: authFlowId,
-          attempt: authAttemptRef.current || firstAttempt,
-          operation: silent ? 'invalidate_permissions' : 'load_session',
-          silent,
-        });
-      } finally {
-        if (!silent && isMountedRef.current) {
-          setIsLoading(false);
-        }
       }
+
+      if (!recovered) {
+        return input.result;
+      }
+
+      const recoveryAttempt = nextAuthAttempt();
+      const recoveryResult = await fetchAuthMe();
+      logAuthDebug('auth_session_load_response_after_recovery', {
+        status: recoveryResult.status,
+        ok: recoveryResult.ok,
+      });
+      recordTrail(recoveryResult.ok ? 'auth_me_retry_succeeded' : 'auth_me_retry_failed', {
+        attempt: recoveryAttempt,
+        authFlowId,
+        ...readAuthDiagnosticMeta(recoveryResult.error),
+        recoveryStep: 'post_silent_recovery_auth_me',
+        result: recoveryResult.ok ? 'succeeded' : 'failed',
+        status: recoveryResult.status,
+      });
+
+      if (!recoveryResult.ok && recoveryResult.status === 401 && hadKnownSession && !silent && isMountedRef.current) {
+        const retryResponseMeta = readAuthDiagnosticMeta(recoveryResult.error);
+        setSessionRecoveryFailed(true);
+        redirectToSessionExpiredNotice({
+          attempt: recoveryAttempt,
+          authFlowId,
+          ...retryResponseMeta,
+          reasonCode: retryResponseMeta.reasonCode ?? 'session_expired',
+          recoveryStep: 'session_expired_redirect',
+          result: 'failed',
+        });
+      }
+
+      return recoveryResult;
+    },
+    [attemptSilentSessionRecovery, fetchAuthMe, logAuthDebug, nextAuthAttempt, recordTrail]
+  );
+
+  const loadUser = React.useCallback(
+    async (silent: boolean) => {
+      if (silent && inFlightSilentLoadRef.current) {
+        return inFlightSilentLoadRef.current;
+      }
+
+      const runLoadUser = async () => {
+        const authFlowId = startAuthFlow();
+        const firstAttempt = nextAuthAttempt();
+        startLoadUserRequest(silent, authFlowId, firstAttempt);
+
+        try {
+          let result = await fetchAuthMe();
+          logAuthDebug('auth_session_load_response', {
+            silent,
+            status: result.status,
+            ok: result.ok,
+          });
+          if (result.ok) {
+            recordTrail('auth_me_succeeded', {
+              attempt: firstAttempt,
+              authFlowId,
+              result: 'succeeded',
+              status: result.status,
+            });
+          }
+
+          if (!result.ok && result.status === 401) {
+            result = await handleUnauthorizedSession({
+              authFlowId,
+              firstAttempt,
+              result,
+              silent,
+            });
+          }
+
+          if (!result.ok) {
+            commitUnauthenticatedSession(silent, authFlowId, result);
+            return;
+          }
+
+          commitAuthenticatedSession(silent, authFlowId, result);
+        } catch (cause) {
+          commitLoadUserFailure(silent, authFlowId, firstAttempt, cause);
+        } finally {
+          if (!silent && isMountedRef.current) {
+            setIsLoading(false);
+          }
+        }
       };
 
       const loadPromise = runLoadUser();
@@ -590,7 +648,18 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         }
       }
     },
-    [attemptSilentSessionRecovery, logAuthDebug, nextAuthAttempt, recordTrail, startAuthFlow]
+    [
+      commitAuthenticatedSession,
+      commitLoadUserFailure,
+      commitUnauthenticatedSession,
+      fetchAuthMe,
+      handleUnauthorizedSession,
+      logAuthDebug,
+      nextAuthAttempt,
+      recordTrail,
+      startAuthFlow,
+      startLoadUserRequest,
+    ]
   );
 
   React.useEffect(() => {

--- a/apps/sva-studio-react/src/routes/admin/-iam-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/-iam-page.tsx
@@ -240,70 +240,165 @@ const StatusBadge = ({ label, tone }: Readonly<{ label: string; tone: string }>)
   </Badge>
 );
 
-export function IamViewerPage({ activeTab }: IamViewerPageProps) {
+type DeletionRulesDraft = {
+  deactivateAfterDays: string;
+  pseudonymizeAfterDays: string;
+  deleteAfterDays: string;
+  defaultContentStrategy: IamDeletionContentStrategy;
+  allowContentPreferenceOverride: boolean;
+};
+
+type ActiveTabHelp = {
+  title: string;
+  description: string;
+  options: readonly string[];
+};
+
+const createDeletionRulesDraft = (rules: IamTenantDeletionRulesOverview): DeletionRulesDraft => ({
+  deactivateAfterDays: String(rules.deactivateAfterDays),
+  pseudonymizeAfterDays: String(rules.pseudonymizeAfterDays),
+  deleteAfterDays: String(rules.deleteAfterDays),
+  defaultContentStrategy: rules.defaultContentStrategy,
+  allowContentPreferenceOverride: rules.allowContentPreferenceOverride,
+});
+
+const getActiveTabHelp = (activeTab: IamCockpitTabKey): ActiveTabHelp => {
+  switch (activeTab) {
+    case 'rights':
+      return {
+        title: t('admin.iam.tabHelp.rights.title'),
+        description: t('admin.iam.tabHelp.rights.description'),
+        options: [
+          t('admin.iam.tabHelp.rights.options.first'),
+          t('admin.iam.tabHelp.rights.options.second'),
+          t('admin.iam.tabHelp.rights.options.third'),
+        ],
+      };
+    case 'governance':
+      return {
+        title: t('admin.iam.tabHelp.governance.title'),
+        description: t('admin.iam.tabHelp.governance.description'),
+        options: [
+          t('admin.iam.tabHelp.governance.options.first'),
+          t('admin.iam.tabHelp.governance.options.second'),
+          t('admin.iam.tabHelp.governance.options.third'),
+        ],
+      };
+    case 'dsr':
+      return {
+        title: t('admin.iam.tabHelp.dsr.title'),
+        description: t('admin.iam.tabHelp.dsr.description'),
+        options: [
+          t('admin.iam.tabHelp.dsr.options.first'),
+          t('admin.iam.tabHelp.dsr.options.second'),
+          t('admin.iam.tabHelp.dsr.options.third'),
+        ],
+      };
+    case 'deletion-rules':
+      return {
+        title: t('admin.iam.tabHelp.deletionRules.title'),
+        description: t('admin.iam.tabHelp.deletionRules.description'),
+        options: [
+          t('admin.iam.tabHelp.deletionRules.options.first'),
+          t('admin.iam.tabHelp.deletionRules.options.second'),
+          t('admin.iam.tabHelp.deletionRules.options.third'),
+        ],
+      };
+  }
+};
+
+const buildGovernanceColumns = (): readonly StudioColumnDef<IamGovernanceCaseListItem>[] => [
+  {
+    id: 'case',
+    header: t('admin.iam.governance.columns.case'),
+    cell: (item) => (
+      <div className="space-y-1">
+        <a className="font-semibold text-foreground underline-offset-4 hover:underline" href={`/admin/iam/governance/${item.id}`}>
+          {formatGovernanceTitle(item)}
+        </a>
+        <p className="text-xs text-muted-foreground">{item.summary}</p>
+      </div>
+    ),
+  },
+  {
+    id: 'status',
+    header: t('admin.iam.governance.columns.status'),
+    cell: (item) => <StatusBadge label={item.status} tone="border-secondary/40 bg-secondary/10 text-secondary" />,
+  },
+  {
+    id: 'actors',
+    header: t('admin.iam.governance.columns.actors'),
+    cell: (item) => formatGovernanceActors(item),
+  },
+  {
+    id: 'ticket',
+    header: t('admin.iam.governance.columns.ticket'),
+    cell: (item) => item.ticketId ?? '—',
+  },
+  {
+    id: 'createdAt',
+    header: t('admin.iam.governance.columns.createdAt'),
+    cell: (item) => formatDateTime(item.createdAt),
+    sortable: true,
+    sortValue: (item) => item.createdAt,
+  },
+  {
+    id: 'updatedAt',
+    header: t('admin.iam.governance.columns.updatedAt'),
+    cell: (item) => formatDateTime(item.updatedAt ?? item.resolvedAt),
+    sortable: true,
+    sortValue: (item) => item.updatedAt ?? item.resolvedAt ?? item.createdAt,
+  },
+];
+
+const buildDsrColumns = (): readonly StudioColumnDef<IamDsrCaseListItem>[] => [
+  {
+    id: 'case',
+    header: t('admin.iam.dsr.columns.case'),
+    cell: (item) => (
+      <div className="space-y-1">
+        <a className="font-semibold text-foreground underline-offset-4 hover:underline" href={`/admin/iam/dsr/${item.id}`}>
+          {item.title}
+        </a>
+        <p className="text-xs text-muted-foreground">{item.summary}</p>
+      </div>
+    ),
+  },
+  {
+    id: 'status',
+    header: t('admin.iam.dsr.columns.status'),
+    cell: (item) => <StatusBadge label={t(mapDsrStatusToTranslationKey(item))} tone={mapDsrStatusTone(item)} />,
+  },
+  {
+    id: 'people',
+    header: t('admin.iam.dsr.columns.people'),
+    cell: (item) => formatDsrPeople(item),
+  },
+  {
+    id: 'blocker',
+    header: t('admin.iam.dsr.columns.blocker'),
+    cell: (item) => item.blockedReason ?? '—',
+  },
+  {
+    id: 'createdAt',
+    header: t('admin.iam.dsr.columns.createdAt'),
+    cell: (item) => formatDateTime(item.createdAt),
+    sortable: true,
+    sortValue: (item) => item.createdAt,
+  },
+  {
+    id: 'completedAt',
+    header: t('admin.iam.dsr.columns.completedAt'),
+    cell: (item) => formatDateTime(item.completedAt),
+    sortable: true,
+    sortValue: (item) => item.completedAt ?? item.createdAt,
+  },
+];
+
+const useIamTabNavigation = (activeTab: IamCockpitTabKey, allowedTabs: readonly IamCockpitTabKey[]) => {
   const navigate = useNavigate();
-  const { user, isLoading: isLoadingUser, error: authError, invalidatePermissions } = useAuth();
   const tabButtonRefs = React.useRef<Partial<Record<IamCockpitTabKey, HTMLButtonElement | null>>>({});
   const shouldFocusActiveTabRef = React.useRef(false);
-
-  const [instanceId, setInstanceId] = React.useState('');
-  const [organizationId, setOrganizationId] = React.useState('');
-  const [actingAsUserId, setActingAsUserId] = React.useState('');
-  const [queryText, setQueryText] = React.useState('');
-  const [selectedOrganizationIds, setSelectedOrganizationIds] = React.useState<string[]>([]);
-
-  const [permissions, setPermissions] = React.useState<readonly EffectivePermission[]>([]);
-  const [permissionSubject, setPermissionSubject] = React.useState<IamPermissionsResponse['subject'] | null>(null);
-  const [isLoadingPermissions, setIsLoadingPermissions] = React.useState(false);
-  const [permissionsError, setPermissionsError] = React.useState<string | null>(null);
-
-  const [authorizeAction, setAuthorizeAction] = React.useState('content.read');
-  const [authorizeResourceType, setAuthorizeResourceType] = React.useState('content');
-  const [authorizeResourceId, setAuthorizeResourceId] = React.useState('');
-  const [authorizeOrganizationId, setAuthorizeOrganizationId] = React.useState('');
-  const [authorizeDecision, setAuthorizeDecision] = React.useState<AuthorizeDecisionViewModel | null>(null);
-  const [authorizeError, setAuthorizeError] = React.useState<string | null>(null);
-  const [isAuthorizing, setIsAuthorizing] = React.useState(false);
-
-  const [governanceItems, setGovernanceItems] = React.useState<readonly IamGovernanceCaseListItem[]>([]);
-  const [governanceError, setGovernanceError] = React.useState<string | null>(null);
-  const [governanceQuery, setGovernanceQuery] = React.useState<GovernanceCasesQuery>({
-    page: 1,
-    pageSize: 12,
-    search: '',
-  });
-  const [isLoadingGovernance, setIsLoadingGovernance] = React.useState(false);
-
-  const [dsrItems, setDsrItems] = React.useState<readonly IamDsrCaseListItem[]>([]);
-  const [dsrError, setDsrError] = React.useState<string | null>(null);
-  const [dsrQuery, setDsrQuery] = React.useState<DsrAdminCasesQuery>({
-    page: 1,
-    pageSize: 12,
-    search: '',
-  });
-  const [isLoadingDsr, setIsLoadingDsr] = React.useState(false);
-  const [deletionRules, setDeletionRules] = React.useState<IamTenantDeletionRulesOverview | null>(null);
-  const [deletionRulesDraft, setDeletionRulesDraft] = React.useState<{
-    deactivateAfterDays: string;
-    pseudonymizeAfterDays: string;
-    deleteAfterDays: string;
-    defaultContentStrategy: IamDeletionContentStrategy;
-    allowContentPreferenceOverride: boolean;
-  } | null>(null);
-  const [deletionRulesError, setDeletionRulesError] = React.useState<string | null>(null);
-  const [isLoadingDeletionRules, setIsLoadingDeletionRules] = React.useState(false);
-  const [isSavingDeletionRules, setIsSavingDeletionRules] = React.useState(false);
-
-  const cockpitEnabled = isIamCockpitEnabled();
-  const canAccessCockpit = hasIamCockpitAccessRole(user);
-  const canExportGovernanceCompliance = hasGovernanceComplianceExportRole(user);
-  const allowedTabs = React.useMemo(() => getAllowedIamCockpitTabs(user), [user]);
-  const studioDataTableLabels = React.useMemo(() => createStudioDataTableLabels(), []);
-  const governanceRequestQuery = React.useMemo(
-    () => ({ ...governanceQuery, search: governanceQuery.search?.trim() ?? '' }),
-    [governanceQuery]
-  );
-  const dsrRequestQuery = React.useMemo(() => ({ ...dsrQuery, search: dsrQuery.search?.trim() ?? '' }), [dsrQuery]);
 
   const navigateToTab = React.useCallback(
     (tab: IamCockpitTabKey, focusActiveTab = false) => {
@@ -314,19 +409,13 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
   );
 
   React.useEffect(() => {
-    setInstanceId(user?.instanceId ?? '');
-  }, [user?.instanceId]);
-
-  React.useEffect(() => {
-    if (allowedTabs.length === 0) {
+    if (allowedTabs.length === 0 || allowedTabs.includes(activeTab)) {
       return;
     }
-    if (!allowedTabs.includes(activeTab)) {
-      shouldFocusActiveTabRef.current = false;
-      Promise.resolve(
-        navigate({ to: '/admin/iam', search: { tab: getFirstAllowedTab(allowedTabs) }, replace: true })
-      ).catch(() => undefined);
-    }
+    shouldFocusActiveTabRef.current = false;
+    Promise.resolve(
+      navigate({ to: '/admin/iam', search: { tab: getFirstAllowedTab(allowedTabs) }, replace: true })
+    ).catch(() => undefined);
   }, [activeTab, allowedTabs, navigate]);
 
   React.useEffect(() => {
@@ -339,7 +428,65 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
     }
     shouldFocusActiveTabRef.current = false;
     activeButton.focus();
-  }, [activeTab, allowedTabs]);
+  }, [activeTab]);
+
+  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, tabIndex: number) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+      return;
+    }
+
+    event.preventDefault();
+    if (event.key === 'Home') {
+      navigateToTab(allowedTabs[0] ?? 'rights', true);
+      return;
+    }
+    if (event.key === 'End') {
+      navigateToTab(allowedTabs[allowedTabs.length - 1] ?? 'rights', true);
+      return;
+    }
+
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (tabIndex + direction + allowedTabs.length) % allowedTabs.length;
+    navigateToTab(allowedTabs[nextIndex] ?? 'rights', true);
+  };
+
+  return {
+    handleTabKeyDown,
+    navigateToTab,
+    tabButtonRefs,
+  };
+};
+
+const useRightsTabState = ({
+  activeTab,
+  allowedTabs,
+  canAccessCockpit,
+  cockpitEnabled,
+  instanceId,
+  invalidatePermissions,
+}: Readonly<{
+  activeTab: IamCockpitTabKey;
+  allowedTabs: readonly IamCockpitTabKey[];
+  canAccessCockpit: boolean;
+  cockpitEnabled: boolean;
+  instanceId: string;
+  invalidatePermissions: () => Promise<void>;
+}>) => {
+  const [organizationId, setOrganizationId] = React.useState('');
+  const [actingAsUserId, setActingAsUserId] = React.useState('');
+  const [queryText, setQueryText] = React.useState('');
+  const [selectedOrganizationIds, setSelectedOrganizationIds] = React.useState<string[]>([]);
+  const [permissions, setPermissions] = React.useState<readonly EffectivePermission[]>([]);
+  const [permissionSubject, setPermissionSubject] = React.useState<IamPermissionsResponse['subject'] | null>(null);
+  const [isLoadingPermissions, setIsLoadingPermissions] = React.useState(false);
+  const [permissionsError, setPermissionsError] = React.useState<string | null>(null);
+  const [authorizeAction, setAuthorizeAction] = React.useState('content.read');
+  const [authorizeResourceType, setAuthorizeResourceType] = React.useState('content');
+  const [authorizeResourceId, setAuthorizeResourceId] = React.useState('');
+  const [authorizeOrganizationId, setAuthorizeOrganizationId] = React.useState('');
+  const [authorizeDecision, setAuthorizeDecision] = React.useState<AuthorizeDecisionViewModel | null>(null);
+  const [authorizeError, setAuthorizeError] = React.useState<string | null>(null);
+  const [isAuthorizing, setIsAuthorizing] = React.useState(false);
 
   React.useEffect(() => {
     if (!cockpitEnabled || !canAccessCockpit || !instanceId || activeTab !== 'rights' || !allowedTabs.includes('rights')) {
@@ -429,7 +576,7 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
           setIsLoadingPermissions(false);
         }
       }
-    }, 300);
+    }, FILTER_REQUEST_DEBOUNCE_MS);
 
     return () => {
       active = false;
@@ -437,198 +584,6 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
       controller.abort();
     };
   }, [actingAsUserId, activeTab, allowedTabs, canAccessCockpit, cockpitEnabled, instanceId, invalidatePermissions, organizationId]);
-
-  React.useEffect(() => {
-    if (!cockpitEnabled || !canAccessCockpit || activeTab !== 'governance' || !allowedTabs.includes('governance')) {
-      return;
-    }
-
-    const controller = new AbortController();
-    const timer = window.setTimeout(() => {
-      logBrowserOperationStart(iamViewerLogger, 'iam_governance_load_started', {
-        operation: 'list_governance_cases',
-      });
-      setIsLoadingGovernance(true);
-      setGovernanceError(null);
-
-      listGovernanceCases(governanceRequestQuery, { signal: controller.signal })
-        .then((response) => {
-          if (controller.signal.aborted) {
-            return;
-          }
-          setGovernanceItems(response.data);
-          logBrowserOperationSuccess(
-            iamViewerLogger,
-            'iam_governance_load_succeeded',
-            {
-              operation: 'list_governance_cases',
-              item_count: response.data.length,
-            },
-            'debug'
-          );
-        })
-        .catch((error) => {
-          if (isAbortError(error) || controller.signal.aborted) {
-            logBrowserOperationAbort(iamViewerLogger, 'iam_governance_load_aborted', {
-              operation: 'list_governance_cases',
-            });
-            return;
-          }
-          setGovernanceItems([]);
-          setGovernanceError(error instanceof Error ? error.message : String(error));
-          logBrowserOperationFailure(iamViewerLogger, 'iam_governance_load_failed', error, {
-            operation: 'list_governance_cases',
-          });
-        })
-        .finally(() => {
-          if (!controller.signal.aborted) {
-            setIsLoadingGovernance(false);
-          }
-        });
-    }, FILTER_REQUEST_DEBOUNCE_MS);
-
-    return () => {
-      window.clearTimeout(timer);
-      controller.abort();
-    };
-  }, [activeTab, allowedTabs, canAccessCockpit, cockpitEnabled, governanceRequestQuery]);
-
-  React.useEffect(() => {
-    if (!cockpitEnabled || !canAccessCockpit || activeTab !== 'dsr' || !allowedTabs.includes('dsr')) {
-      return;
-    }
-
-    const controller = new AbortController();
-    const timer = window.setTimeout(() => {
-      logBrowserOperationStart(iamViewerLogger, 'iam_dsr_load_started', {
-        operation: 'list_admin_dsr_cases',
-      });
-      setIsLoadingDsr(true);
-      setDsrError(null);
-
-      listAdminDsrCases(dsrRequestQuery, { signal: controller.signal })
-        .then((response) => {
-          if (controller.signal.aborted) {
-            return;
-          }
-          setDsrItems(response.data);
-          logBrowserOperationSuccess(
-            iamViewerLogger,
-            'iam_dsr_load_succeeded',
-            {
-              operation: 'list_admin_dsr_cases',
-              item_count: response.data.length,
-            },
-            'debug'
-          );
-        })
-        .catch((error) => {
-          if (isAbortError(error) || controller.signal.aborted) {
-            logBrowserOperationAbort(iamViewerLogger, 'iam_dsr_load_aborted', {
-              operation: 'list_admin_dsr_cases',
-            });
-            return;
-          }
-          setDsrItems([]);
-          setDsrError(error instanceof Error ? error.message : String(error));
-          logBrowserOperationFailure(iamViewerLogger, 'iam_dsr_load_failed', error, {
-            operation: 'list_admin_dsr_cases',
-          });
-        })
-        .finally(() => {
-          if (!controller.signal.aborted) {
-            setIsLoadingDsr(false);
-          }
-        });
-    }, FILTER_REQUEST_DEBOUNCE_MS);
-
-    return () => {
-      window.clearTimeout(timer);
-      controller.abort();
-    };
-  }, [activeTab, allowedTabs, canAccessCockpit, cockpitEnabled, dsrRequestQuery]);
-
-  React.useEffect(() => {
-    if (!cockpitEnabled || !canAccessCockpit || activeTab !== 'deletion-rules' || !allowedTabs.includes('deletion-rules')) {
-      return;
-    }
-    if (!instanceId) {
-      setDeletionRules(null);
-      setDeletionRulesDraft(null);
-      setDeletionRulesError(t('admin.iam.deletionRules.messages.instanceMissing'));
-      return;
-    }
-
-    const controller = new AbortController();
-    setIsLoadingDeletionRules(true);
-    setDeletionRulesError(null);
-
-    getAdminDeletionRules(instanceId)
-      .then((response) => {
-        if (controller.signal.aborted) {
-          return;
-        }
-        setDeletionRules(response);
-        setDeletionRulesDraft({
-          deactivateAfterDays: String(response.deactivateAfterDays),
-          pseudonymizeAfterDays: String(response.pseudonymizeAfterDays),
-          deleteAfterDays: String(response.deleteAfterDays),
-          defaultContentStrategy: response.defaultContentStrategy,
-          allowContentPreferenceOverride: response.allowContentPreferenceOverride,
-        });
-      })
-      .catch((error) => {
-        if (isAbortError(error) || controller.signal.aborted) {
-          return;
-        }
-        setDeletionRules(null);
-        setDeletionRulesDraft(null);
-        setDeletionRulesError(error instanceof Error ? error.message : String(error));
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setIsLoadingDeletionRules(false);
-        }
-      });
-
-    return () => {
-      controller.abort();
-    };
-  }, [activeTab, allowedTabs, canAccessCockpit, cockpitEnabled, instanceId]);
-
-  const handleDeletionRulesSave = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!instanceId || !deletionRulesDraft) {
-      setDeletionRulesError(t('admin.iam.deletionRules.messages.instanceMissing'));
-      return;
-    }
-
-    setIsSavingDeletionRules(true);
-    setDeletionRulesError(null);
-
-    try {
-      const response = await saveAdminDeletionRules({
-        instanceId,
-        deactivateAfterDays: Number(deletionRulesDraft.deactivateAfterDays),
-        pseudonymizeAfterDays: Number(deletionRulesDraft.pseudonymizeAfterDays),
-        deleteAfterDays: Number(deletionRulesDraft.deleteAfterDays),
-        defaultContentStrategy: deletionRulesDraft.defaultContentStrategy,
-        allowContentPreferenceOverride: deletionRulesDraft.allowContentPreferenceOverride,
-      });
-      setDeletionRules(response);
-      setDeletionRulesDraft({
-        deactivateAfterDays: String(response.deactivateAfterDays),
-        pseudonymizeAfterDays: String(response.pseudonymizeAfterDays),
-        deleteAfterDays: String(response.deleteAfterDays),
-        defaultContentStrategy: response.defaultContentStrategy,
-        allowContentPreferenceOverride: response.allowContentPreferenceOverride,
-      });
-    } catch (error) {
-      setDeletionRulesError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setIsSavingDeletionRules(false);
-    }
-  };
 
   const filteredPermissions = React.useMemo(
     () =>
@@ -638,7 +593,6 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
       }),
     [permissions, queryText, selectedOrganizationIds]
   );
-
   const organizationOptions = React.useMemo(() => {
     const organizationIds = new Set<string>();
     for (const permission of permissions) {
@@ -650,54 +604,6 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
     () => buildSelectOptions([...organizationOptions, organizationId, authorizeOrganizationId]),
     [authorizeOrganizationId, organizationId, organizationOptions]
   );
-  const governanceStatusOptions = React.useMemo(
-    () => buildSelectOptions([...governanceItems.map((item) => item.status), governanceQuery.status]),
-    [governanceItems, governanceQuery.status]
-  );
-  const activeTabHelp = React.useMemo(() => {
-    switch (activeTab) {
-      case 'rights':
-        return {
-          title: t('admin.iam.tabHelp.rights.title'),
-          description: t('admin.iam.tabHelp.rights.description'),
-          options: [
-            t('admin.iam.tabHelp.rights.options.first'),
-            t('admin.iam.tabHelp.rights.options.second'),
-            t('admin.iam.tabHelp.rights.options.third'),
-          ],
-        };
-      case 'governance':
-        return {
-          title: t('admin.iam.tabHelp.governance.title'),
-          description: t('admin.iam.tabHelp.governance.description'),
-          options: [
-            t('admin.iam.tabHelp.governance.options.first'),
-            t('admin.iam.tabHelp.governance.options.second'),
-            t('admin.iam.tabHelp.governance.options.third'),
-          ],
-        };
-      case 'dsr':
-        return {
-          title: t('admin.iam.tabHelp.dsr.title'),
-          description: t('admin.iam.tabHelp.dsr.description'),
-          options: [
-            t('admin.iam.tabHelp.dsr.options.first'),
-            t('admin.iam.tabHelp.dsr.options.second'),
-            t('admin.iam.tabHelp.dsr.options.third'),
-          ],
-        };
-      case 'deletion-rules':
-        return {
-          title: t('admin.iam.tabHelp.deletionRules.title'),
-          description: t('admin.iam.tabHelp.deletionRules.description'),
-          options: [
-            t('admin.iam.tabHelp.deletionRules.options.first'),
-            t('admin.iam.tabHelp.deletionRules.options.second'),
-            t('admin.iam.tabHelp.deletionRules.options.third'),
-          ],
-        };
-    }
-  }, [activeTab]);
 
   const handleOrganizationFilterToggle = (organizationValue: string) => {
     setSelectedOrganizationIds((current) =>
@@ -782,113 +688,881 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
     }
   };
 
-  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, tabIndex: number) => {
-    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+  return {
+    actingAsUserId,
+    authorizeAction,
+    authorizeDecision,
+    authorizeError,
+    authorizeOrganizationId,
+    authorizeResourceId,
+    authorizeResourceType,
+    filteredPermissions,
+    handleAuthorizeSubmit,
+    handleOrganizationFilterToggle,
+    isAuthorizing,
+    isLoadingPermissions,
+    organizationId,
+    organizationOptions,
+    organizationSelectOptions,
+    permissionSubject,
+    permissionsError,
+    queryText,
+    selectedOrganizationIds,
+    setActingAsUserId,
+    setAuthorizeAction,
+    setAuthorizeOrganizationId,
+    setAuthorizeResourceId,
+    setAuthorizeResourceType,
+    setOrganizationId,
+    setQueryText,
+  };
+};
+
+const useGovernanceTabState = ({
+  activeTab,
+  allowedTabs,
+  canAccessCockpit,
+  cockpitEnabled,
+}: Readonly<{
+  activeTab: IamCockpitTabKey;
+  allowedTabs: readonly IamCockpitTabKey[];
+  canAccessCockpit: boolean;
+  cockpitEnabled: boolean;
+}>) => {
+  const [items, setItems] = React.useState<readonly IamGovernanceCaseListItem[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const [query, setQuery] = React.useState<GovernanceCasesQuery>({
+    page: 1,
+    pageSize: 12,
+    search: '',
+  });
+  const [isLoading, setIsLoading] = React.useState(false);
+  const requestQuery = React.useMemo(() => ({ ...query, search: query.search?.trim() ?? '' }), [query]);
+
+  React.useEffect(() => {
+    if (!cockpitEnabled || !canAccessCockpit || activeTab !== 'governance' || !allowedTabs.includes('governance')) {
       return;
     }
 
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      logBrowserOperationStart(iamViewerLogger, 'iam_governance_load_started', {
+        operation: 'list_governance_cases',
+      });
+      setIsLoading(true);
+      setError(null);
+
+      listGovernanceCases(requestQuery, { signal: controller.signal })
+        .then((response) => {
+          if (controller.signal.aborted) {
+            return;
+          }
+          setItems(response.data);
+          logBrowserOperationSuccess(
+            iamViewerLogger,
+            'iam_governance_load_succeeded',
+            {
+              operation: 'list_governance_cases',
+              item_count: response.data.length,
+            },
+            'debug'
+          );
+        })
+        .catch((nextError) => {
+          if (isAbortError(nextError) || controller.signal.aborted) {
+            logBrowserOperationAbort(iamViewerLogger, 'iam_governance_load_aborted', {
+              operation: 'list_governance_cases',
+            });
+            return;
+          }
+          setItems([]);
+          setError(nextError instanceof Error ? nextError.message : String(nextError));
+          logBrowserOperationFailure(iamViewerLogger, 'iam_governance_load_failed', nextError, {
+            operation: 'list_governance_cases',
+          });
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setIsLoading(false);
+          }
+        });
+    }, FILTER_REQUEST_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [activeTab, allowedTabs, canAccessCockpit, cockpitEnabled, requestQuery]);
+
+  const statusOptions = React.useMemo(
+    () => buildSelectOptions([...items.map((item) => item.status), query.status]),
+    [items, query.status]
+  );
+
+  return {
+    error,
+    isLoading,
+    items,
+    query,
+    setQuery,
+    statusOptions,
+  };
+};
+
+const useDsrTabState = ({
+  activeTab,
+  allowedTabs,
+  canAccessCockpit,
+  cockpitEnabled,
+}: Readonly<{
+  activeTab: IamCockpitTabKey;
+  allowedTabs: readonly IamCockpitTabKey[];
+  canAccessCockpit: boolean;
+  cockpitEnabled: boolean;
+}>) => {
+  const [items, setItems] = React.useState<readonly IamDsrCaseListItem[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const [query, setQuery] = React.useState<DsrAdminCasesQuery>({
+    page: 1,
+    pageSize: 12,
+    search: '',
+  });
+  const [isLoading, setIsLoading] = React.useState(false);
+  const requestQuery = React.useMemo(() => ({ ...query, search: query.search?.trim() ?? '' }), [query]);
+
+  React.useEffect(() => {
+    if (!cockpitEnabled || !canAccessCockpit || activeTab !== 'dsr' || !allowedTabs.includes('dsr')) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      logBrowserOperationStart(iamViewerLogger, 'iam_dsr_load_started', {
+        operation: 'list_admin_dsr_cases',
+      });
+      setIsLoading(true);
+      setError(null);
+
+      listAdminDsrCases(requestQuery, { signal: controller.signal })
+        .then((response) => {
+          if (controller.signal.aborted) {
+            return;
+          }
+          setItems(response.data);
+          logBrowserOperationSuccess(
+            iamViewerLogger,
+            'iam_dsr_load_succeeded',
+            {
+              operation: 'list_admin_dsr_cases',
+              item_count: response.data.length,
+            },
+            'debug'
+          );
+        })
+        .catch((nextError) => {
+          if (isAbortError(nextError) || controller.signal.aborted) {
+            logBrowserOperationAbort(iamViewerLogger, 'iam_dsr_load_aborted', {
+              operation: 'list_admin_dsr_cases',
+            });
+            return;
+          }
+          setItems([]);
+          setError(nextError instanceof Error ? nextError.message : String(nextError));
+          logBrowserOperationFailure(iamViewerLogger, 'iam_dsr_load_failed', nextError, {
+            operation: 'list_admin_dsr_cases',
+          });
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setIsLoading(false);
+          }
+        });
+    }, FILTER_REQUEST_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [activeTab, allowedTabs, canAccessCockpit, cockpitEnabled, requestQuery]);
+
+  return {
+    error,
+    isLoading,
+    items,
+    query,
+    setQuery,
+  };
+};
+
+const useDeletionRulesTabState = ({
+  activeTab,
+  allowedTabs,
+  canAccessCockpit,
+  cockpitEnabled,
+  instanceId,
+}: Readonly<{
+  activeTab: IamCockpitTabKey;
+  allowedTabs: readonly IamCockpitTabKey[];
+  canAccessCockpit: boolean;
+  cockpitEnabled: boolean;
+  instanceId: string;
+}>) => {
+  const [deletionRules, setDeletionRules] = React.useState<IamTenantDeletionRulesOverview | null>(null);
+  const [draft, setDraft] = React.useState<DeletionRulesDraft | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!cockpitEnabled || !canAccessCockpit || activeTab !== 'deletion-rules' || !allowedTabs.includes('deletion-rules')) {
+      return;
+    }
+    if (!instanceId) {
+      setDeletionRules(null);
+      setDraft(null);
+      setError(t('admin.iam.deletionRules.messages.instanceMissing'));
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
+
+    getAdminDeletionRules(instanceId)
+      .then((response) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setDeletionRules(response);
+        setDraft(createDeletionRulesDraft(response));
+      })
+      .catch((nextError) => {
+        if (isAbortError(nextError) || controller.signal.aborted) {
+          return;
+        }
+        setDeletionRules(null);
+        setDraft(null);
+        setError(nextError instanceof Error ? nextError.message : String(nextError));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [activeTab, allowedTabs, canAccessCockpit, cockpitEnabled, instanceId]);
+
+  const handleSave = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (event.key === 'Home') {
-      navigateToTab(allowedTabs[0] ?? 'rights', true);
-      return;
-    }
-    if (event.key === 'End') {
-      navigateToTab(allowedTabs[allowedTabs.length - 1] ?? 'rights', true);
+    if (!instanceId || !draft) {
+      setError(t('admin.iam.deletionRules.messages.instanceMissing'));
       return;
     }
 
-    const direction = event.key === 'ArrowRight' ? 1 : -1;
-    const nextIndex = (tabIndex + direction + allowedTabs.length) % allowedTabs.length;
-    navigateToTab(allowedTabs[nextIndex] ?? 'rights', true);
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const response = await saveAdminDeletionRules({
+        instanceId,
+        deactivateAfterDays: Number(draft.deactivateAfterDays),
+        pseudonymizeAfterDays: Number(draft.pseudonymizeAfterDays),
+        deleteAfterDays: Number(draft.deleteAfterDays),
+        defaultContentStrategy: draft.defaultContentStrategy,
+        allowContentPreferenceOverride: draft.allowContentPreferenceOverride,
+      });
+      setDeletionRules(response);
+      setDraft(createDeletionRulesDraft(response));
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : String(nextError));
+    } finally {
+      setIsSaving(false);
+    }
   };
 
-  const governanceColumns = React.useMemo<readonly StudioColumnDef<IamGovernanceCaseListItem>[]>(() => [
-    {
-      id: 'case',
-      header: t('admin.iam.governance.columns.case'),
-      cell: (item) => (
-        <div className="space-y-1">
-          <a className="font-semibold text-foreground underline-offset-4 hover:underline" href={`/admin/iam/governance/${item.id}`}>
-            {formatGovernanceTitle(item)}
-          </a>
-          <p className="text-xs text-muted-foreground">{item.summary}</p>
-        </div>
-      ),
-    },
-    {
-      id: 'status',
-      header: t('admin.iam.governance.columns.status'),
-      cell: (item) => <StatusBadge label={item.status} tone="border-secondary/40 bg-secondary/10 text-secondary" />,
-    },
-    {
-      id: 'actors',
-      header: t('admin.iam.governance.columns.actors'),
-      cell: (item) => formatGovernanceActors(item),
-    },
-    {
-      id: 'ticket',
-      header: t('admin.iam.governance.columns.ticket'),
-      cell: (item) => item.ticketId ?? '—',
-    },
-    {
-      id: 'createdAt',
-      header: t('admin.iam.governance.columns.createdAt'),
-      cell: (item) => formatDateTime(item.createdAt),
-      sortable: true,
-      sortValue: (item) => item.createdAt,
-    },
-    {
-      id: 'updatedAt',
-      header: t('admin.iam.governance.columns.updatedAt'),
-      cell: (item) => formatDateTime(item.updatedAt ?? item.resolvedAt),
-      sortable: true,
-      sortValue: (item) => item.updatedAt ?? item.resolvedAt ?? item.createdAt,
-    },
-  ], []);
+  return {
+    deletionRules,
+    draft,
+    error,
+    handleSave,
+    isLoading,
+    isSaving,
+    setDraft,
+  };
+};
 
-  const dsrColumns = React.useMemo<readonly StudioColumnDef<IamDsrCaseListItem>[]>(() => [
-    {
-      id: 'case',
-      header: t('admin.iam.dsr.columns.case'),
-      cell: (item) => (
+const ActiveTabHelpCard = ({ activeTab }: Readonly<{ activeTab: IamCockpitTabKey }>) => {
+  const activeTabHelp = React.useMemo(() => getActiveTabHelp(activeTab), [activeTab]);
+
+  return (
+    <Card className="border-border/80 bg-white p-4 shadow-sm">
+      <div className="space-y-2">
+        <p className="text-sm font-semibold text-foreground">{activeTabHelp.title}</p>
+        <p className="text-sm text-muted-foreground">{activeTabHelp.description}</p>
         <div className="space-y-1">
-          <a className="font-semibold text-foreground underline-offset-4 hover:underline" href={`/admin/iam/dsr/${item.id}`}>
-            {item.title}
-          </a>
-          <p className="text-xs text-muted-foreground">{item.summary}</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('admin.iam.tabHelp.optionsLabel')}
+          </p>
+          <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+            {activeTabHelp.options.map((option) => (
+              <li key={option}>{option}</li>
+            ))}
+          </ul>
         </div>
-      ),
-    },
-    {
-      id: 'status',
-      header: t('admin.iam.dsr.columns.status'),
-      cell: (item) => <StatusBadge label={t(mapDsrStatusToTranslationKey(item))} tone={mapDsrStatusTone(item)} />,
-    },
-    {
-      id: 'people',
-      header: t('admin.iam.dsr.columns.people'),
-      cell: (item) => formatDsrPeople(item),
-    },
-    {
-      id: 'blocker',
-      header: t('admin.iam.dsr.columns.blocker'),
-      cell: (item) => item.blockedReason ?? '—',
-    },
-    {
-      id: 'createdAt',
-      header: t('admin.iam.dsr.columns.createdAt'),
-      cell: (item) => formatDateTime(item.createdAt),
-      sortable: true,
-      sortValue: (item) => item.createdAt,
-    },
-    {
-      id: 'completedAt',
-      header: t('admin.iam.dsr.columns.completedAt'),
-      cell: (item) => formatDateTime(item.completedAt),
-      sortable: true,
-      sortValue: (item) => item.completedAt ?? item.createdAt,
-    },
-  ], []);
+      </div>
+    </Card>
+  );
+};
+
+const RightsTabPanel = ({
+  panelId,
+  labelledBy,
+  state,
+}: Readonly<{
+  panelId: string;
+  labelledBy: string;
+  state: ReturnType<typeof useRightsTabState>;
+}>) => (
+  <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="space-y-4">
+    <StudioFilterSurface className="grid gap-3 lg:grid-cols-4">
+      <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+        <Label htmlFor="iam-organization-filter">{t('admin.iam.rights.filters.organization')}</Label>
+        <Select
+          id="iam-organization-filter"
+          value={state.organizationId}
+          onChange={(event) => state.setOrganizationId(event.target.value)}
+        >
+          <option value="">{t('admin.iam.shared.all')}</option>
+          {state.organizationSelectOptions.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+        <Label htmlFor="iam-acting-as-filter">{t('admin.iam.rights.filters.actingAs')}</Label>
+        <Input
+          id="iam-acting-as-filter"
+          value={state.actingAsUserId}
+          onChange={(event) => state.setActingAsUserId(event.target.value)}
+        />
+      </div>
+      <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+        <Label htmlFor="iam-query-filter">{t('admin.iam.rights.filters.search')}</Label>
+        <Input id="iam-query-filter" value={state.queryText} onChange={(event) => state.setQueryText(event.target.value)} />
+      </div>
+      <StudioSummaryCard
+        eyebrow={t('admin.iam.rights.subject.title')}
+        value={state.permissionSubject ? state.permissionSubject.effectiveUserId : '—'}
+        valueClassName="text-lg"
+      >
+        <p className="text-xs text-muted-foreground">
+          {state.permissionSubject?.isImpersonating
+            ? t('admin.iam.rights.subject.impersonating', { actor: state.permissionSubject.actorUserId })
+            : t('admin.iam.rights.subject.self')}
+        </p>
+      </StudioSummaryCard>
+    </StudioFilterSurface>
+
+    {state.organizationOptions.length > 0 ? (
+      <div className="flex flex-wrap gap-2">
+        {state.organizationOptions.map((organizationValue) => (
+          <Button
+            key={organizationValue || 'no-organization'}
+            type="button"
+            className={`rounded-full text-xs ${
+              state.selectedOrganizationIds.includes(organizationValue)
+                ? 'border-primary bg-primary/10 text-primary'
+                : 'border-border text-muted-foreground'
+            }`}
+            onClick={() => state.handleOrganizationFilterToggle(organizationValue)}
+            size="sm"
+            variant="outline"
+          >
+            {organizationValue || t('admin.iam.rights.noOrganization')}
+          </Button>
+        ))}
+      </div>
+    ) : null}
+
+    {state.permissionsError ? (
+      <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+        <AlertDescription>{t('admin.iam.rights.messages.error', { value: state.permissionsError })}</AlertDescription>
+      </Alert>
+    ) : null}
+
+    <Card aria-busy={state.isLoadingPermissions} className="p-4">
+      <PermissionTable permissions={state.filteredPermissions} />
+    </Card>
+
+    <StudioFilterSurface>
+      <form onSubmit={state.handleAuthorizeSubmit} className="grid gap-3 lg:grid-cols-4">
+        <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+          <Label htmlFor="iam-authorize-action">{t('admin.iam.rights.authorize.action')}</Label>
+          <Input
+            id="iam-authorize-action"
+            value={state.authorizeAction}
+            onChange={(event) => state.setAuthorizeAction(event.target.value)}
+          />
+        </div>
+        <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+          <Label htmlFor="iam-authorize-resource-type">{t('admin.iam.rights.authorize.resourceType')}</Label>
+          <Input
+            id="iam-authorize-resource-type"
+            value={state.authorizeResourceType}
+            onChange={(event) => state.setAuthorizeResourceType(event.target.value)}
+          />
+        </div>
+        <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+          <Label htmlFor="iam-authorize-resource-id">{t('admin.iam.rights.authorize.resourceId')}</Label>
+          <Input
+            id="iam-authorize-resource-id"
+            value={state.authorizeResourceId}
+            onChange={(event) => state.setAuthorizeResourceId(event.target.value)}
+          />
+        </div>
+        <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+          <Label htmlFor="iam-authorize-organization-id">{t('admin.iam.rights.authorize.organizationId')}</Label>
+          <Select
+            id="iam-authorize-organization-id"
+            value={state.authorizeOrganizationId}
+            onChange={(event) => state.setAuthorizeOrganizationId(event.target.value)}
+          >
+            <option value="">{t('admin.iam.shared.all')}</option>
+            {state.organizationSelectOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="lg:col-span-4 flex items-center gap-3">
+          <Button type="submit" disabled={state.isAuthorizing}>
+            {state.isAuthorizing ? t('admin.iam.rights.authorize.running') : t('admin.iam.rights.authorize.run')}
+          </Button>
+          {state.authorizeError ? <p className="text-sm text-destructive">{state.authorizeError}</p> : null}
+        </div>
+        {state.authorizeDecision ? (
+          <Card className="lg:col-span-4 bg-background p-3 shadow-none">
+            <p className="font-semibold text-foreground">
+              {state.authorizeDecision.allowed
+                ? t('admin.iam.rights.authorize.allowed')
+                : t('admin.iam.rights.authorize.denied')}
+            </p>
+            <dl className="mt-3 grid gap-2 text-sm">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('admin.iam.rights.authorize.summary.action')}
+                </dt>
+                <dd className="text-foreground">{state.authorizeAction.trim() || '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('admin.iam.rights.authorize.summary.resource')}
+                </dt>
+                <dd className="text-foreground">
+                  {[state.authorizeResourceType.trim(), state.authorizeResourceId.trim()].filter(Boolean).join(' / ') || '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('admin.iam.rights.authorize.summary.organization')}
+                </dt>
+                <dd className="text-foreground">
+                  {state.authorizeOrganizationId.trim() || state.organizationId.trim() || '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('admin.iam.rights.authorize.summary.cause')}
+                </dt>
+                <dd className="text-foreground">
+                  {state.authorizeDecision.reasonCode ?? state.authorizeDecision.reason}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {t('admin.iam.rights.authorize.summary.origin')}
+                </dt>
+                <dd className="text-foreground">
+                  {state.authorizeDecision.provenance?.sourceKinds && state.authorizeDecision.provenance.sourceKinds.length > 0
+                    ? formatPermissionSourceKindLabels(state.authorizeDecision.provenance.sourceKinds)
+                    : state.authorizeDecision.matchedPermissions && state.authorizeDecision.matchedPermissions.length > 0
+                      ? formatPermissionSourceKindLabels(
+                          [...new Set(state.authorizeDecision.matchedPermissions.map((permission) => permission.source))] as readonly string[]
+                        )
+                      : '—'}
+                </dd>
+              </div>
+            </dl>
+            {state.authorizeDecision.diagnostics ? (
+              <p className="mt-2 text-xs text-muted-foreground">
+                {formatObjectEntries(state.authorizeDecision.diagnostics)}
+              </p>
+            ) : null}
+          </Card>
+        ) : null}
+      </form>
+    </StudioFilterSurface>
+  </div>
+);
+
+const GovernanceTabPanel = ({
+  canExportGovernanceCompliance,
+  instanceId,
+  panelId,
+  labelledBy,
+  state,
+  columns,
+  labels,
+}: Readonly<{
+  canExportGovernanceCompliance: boolean;
+  instanceId: string;
+  panelId: string;
+  labelledBy: string;
+  state: ReturnType<typeof useGovernanceTabState>;
+  columns: readonly StudioColumnDef<IamGovernanceCaseListItem>[];
+  labels: ReturnType<typeof createStudioDataTableLabels>;
+}>) => (
+  <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="space-y-4">
+    <StudioFilterSurface className="grid gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">{t('admin.iam.governance.messages.exportHint')}</p>
+        {instanceId && canExportGovernanceCompliance ? (
+          <Button asChild size="sm" variant="outline">
+            <a href={buildGovernanceComplianceExportPath({ instanceId })}>{t('admin.iam.governance.actions.exportCsv')}</a>
+          </Button>
+        ) : null}
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+          <Label htmlFor="iam-governance-search">{t('admin.iam.governance.filters.search')}</Label>
+          <Input
+            id="iam-governance-search"
+            value={state.query.search ?? ''}
+            onChange={(event) => state.setQuery((current) => ({ ...current, page: 1, search: event.target.value }))}
+          />
+        </div>
+        <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+          <Label htmlFor="iam-governance-type">{t('admin.iam.governance.filters.type')}</Label>
+          <Select
+            id="iam-governance-type"
+            value={state.query.type ?? ''}
+            onChange={(event) =>
+              state.setQuery((current) => ({
+                ...current,
+                page: 1,
+                type: (event.target.value || undefined) as GovernanceCasesQuery['type'],
+              }))
+            }
+          >
+            <option value="">{t('admin.iam.shared.all')}</option>
+            {governanceTypeOptions.map((option) => (
+              <option key={option} value={option}>
+                {t(mapGovernanceTypeToTranslationKey(option))}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+          <Label htmlFor="iam-governance-status">{t('admin.iam.governance.filters.status')}</Label>
+          <Select
+            id="iam-governance-status"
+            value={state.query.status ?? ''}
+            onChange={(event) =>
+              state.setQuery((current) => ({
+                ...current,
+                page: 1,
+                status: event.target.value || undefined,
+              }))
+            }
+          >
+            <option value="">{t('admin.iam.shared.all')}</option>
+            {state.statusOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+    </StudioFilterSurface>
+    {state.error ? (
+      <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+        <AlertDescription>{state.error}</AlertDescription>
+      </Alert>
+    ) : null}
+    <StudioDataTable
+      ariaLabel={t('admin.iam.governance.tableAriaLabel')}
+      labels={labels}
+      caption={t('admin.iam.governance.tableCaption')}
+      data={state.items}
+      columns={columns}
+      getRowId={(item) => item.id}
+      selectionMode="none"
+      isLoading={state.isLoading}
+      loadingState={t('admin.iam.governance.messages.loading')}
+      emptyState={<p className="text-sm text-muted-foreground">{t('admin.iam.governance.messages.empty')}</p>}
+    />
+  </div>
+);
+
+const DsrTabPanel = ({
+  panelId,
+  labelledBy,
+  state,
+  columns,
+  labels,
+}: Readonly<{
+  panelId: string;
+  labelledBy: string;
+  state: ReturnType<typeof useDsrTabState>;
+  columns: readonly StudioColumnDef<IamDsrCaseListItem>[];
+  labels: ReturnType<typeof createStudioDataTableLabels>;
+}>) => (
+  <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="space-y-4">
+    <StudioFilterSurface className="grid gap-3 md:grid-cols-3">
+      <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+        <Label htmlFor="iam-dsr-search">{t('admin.iam.dsr.filters.search')}</Label>
+        <Input
+          id="iam-dsr-search"
+          value={state.query.search ?? ''}
+          onChange={(event) => state.setQuery((current) => ({ ...current, page: 1, search: event.target.value }))}
+        />
+      </div>
+      <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+        <Label htmlFor="iam-dsr-type">{t('admin.iam.dsr.filters.type')}</Label>
+        <Select
+          id="iam-dsr-type"
+          value={state.query.type ?? ''}
+          onChange={(event) =>
+            state.setQuery((current) => ({
+              ...current,
+              page: 1,
+              type: (event.target.value || undefined) as DsrAdminCasesQuery['type'],
+            }))
+          }
+        >
+          <option value="">{t('admin.iam.shared.all')}</option>
+          {dsrTypeOptions.map((option) => (
+            <option key={option} value={option}>
+              {t(mapDsrTypeToTranslationKey(option))}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+        <Label htmlFor="iam-dsr-status">{t('admin.iam.dsr.filters.status')}</Label>
+        <Select
+          id="iam-dsr-status"
+          value={state.query.status ?? ''}
+          onChange={(event) =>
+            state.setQuery((current) => ({
+              ...current,
+              page: 1,
+              status: (event.target.value || undefined) as DsrAdminCasesQuery['status'],
+            }))
+          }
+        >
+          <option value="">{t('admin.iam.shared.all')}</option>
+          {dsrStatusOptions.map((option) => (
+            <option key={option} value={option}>
+              {t(mapDsrCanonicalStatusToTranslationKey(option))}
+            </option>
+          ))}
+        </Select>
+      </div>
+    </StudioFilterSurface>
+    {state.error ? (
+      <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+        <AlertDescription>{state.error}</AlertDescription>
+      </Alert>
+    ) : null}
+    <StudioDataTable
+      ariaLabel={t('admin.iam.dsr.tableAriaLabel')}
+      labels={labels}
+      caption={t('admin.iam.dsr.tableCaption')}
+      data={state.items}
+      columns={columns}
+      getRowId={(item) => item.id}
+      selectionMode="none"
+      isLoading={state.isLoading}
+      loadingState={t('admin.iam.dsr.messages.loading')}
+      emptyState={<p className="text-sm text-muted-foreground">{t('admin.iam.dsr.messages.empty')}</p>}
+    />
+  </div>
+);
+
+const DeletionRulesTabPanel = ({
+  panelId,
+  labelledBy,
+  state,
+}: Readonly<{
+  panelId: string;
+  labelledBy: string;
+  state: ReturnType<typeof useDeletionRulesTabState>;
+}>) => (
+  <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="space-y-4">
+    <Card>
+      <CardHeader className="p-4 pb-0">
+        <CardTitle>{t('admin.iam.deletionRules.title')}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 p-4 pt-0">
+        <p className="text-sm text-muted-foreground">{t('admin.iam.deletionRules.subtitle')}</p>
+
+        {state.error ? (
+          <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+            <AlertDescription>{state.error}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {state.isLoading || !state.draft ? (
+          <p className="text-sm text-muted-foreground">{t('admin.iam.deletionRules.messages.loading')}</p>
+        ) : (
+          <form className="grid gap-4 md:grid-cols-2" onSubmit={state.handleSave}>
+            <div className="grid gap-1">
+              <Label htmlFor="deletion-rules-deactivate">{t('admin.iam.deletionRules.fields.deactivateAfterDays')}</Label>
+              <Input
+                id="deletion-rules-deactivate"
+                inputMode="numeric"
+                value={state.draft.deactivateAfterDays}
+                onChange={(event) =>
+                  state.setDraft((current) => (current ? { ...current, deactivateAfterDays: event.target.value } : current))
+                }
+                disabled={!state.deletionRules?.canEdit || state.isSaving}
+              />
+            </div>
+            <div className="grid gap-1">
+              <Label htmlFor="deletion-rules-pseudonymize">{t('admin.iam.deletionRules.fields.pseudonymizeAfterDays')}</Label>
+              <Input
+                id="deletion-rules-pseudonymize"
+                inputMode="numeric"
+                value={state.draft.pseudonymizeAfterDays}
+                onChange={(event) =>
+                  state.setDraft((current) => (current ? { ...current, pseudonymizeAfterDays: event.target.value } : current))
+                }
+                disabled={!state.deletionRules?.canEdit || state.isSaving}
+              />
+            </div>
+            <div className="grid gap-1">
+              <Label htmlFor="deletion-rules-delete">{t('admin.iam.deletionRules.fields.deleteAfterDays')}</Label>
+              <Input
+                id="deletion-rules-delete"
+                inputMode="numeric"
+                value={state.draft.deleteAfterDays}
+                onChange={(event) =>
+                  state.setDraft((current) => (current ? { ...current, deleteAfterDays: event.target.value } : current))
+                }
+                disabled={!state.deletionRules?.canEdit || state.isSaving}
+              />
+            </div>
+            <div className="grid gap-1">
+              <Label htmlFor="deletion-rules-strategy">{t('admin.iam.deletionRules.fields.defaultContentStrategy')}</Label>
+              <Select
+                id="deletion-rules-strategy"
+                value={state.draft.defaultContentStrategy}
+                onChange={(event) =>
+                  state.setDraft((current) =>
+                    current
+                      ? {
+                          ...current,
+                          defaultContentStrategy: event.target.value as IamDeletionContentStrategy,
+                        }
+                      : current
+                  )
+                }
+                disabled={!state.deletionRules?.canEdit || state.isSaving}
+              >
+                {deletionContentStrategyOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {t(mapDeletionContentStrategyKey(option))}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className="md:col-span-2 flex items-start gap-3 rounded-lg border border-border p-3">
+              <Checkbox
+                id="deletion-rules-allow-override"
+                checked={state.draft.allowContentPreferenceOverride}
+                onChange={(event) => {
+                  const nextChecked = event.currentTarget.checked;
+                  state.setDraft((current) =>
+                    current
+                      ? {
+                          ...current,
+                          allowContentPreferenceOverride: nextChecked,
+                        }
+                      : current
+                  );
+                }}
+                disabled={!state.deletionRules?.canEdit || state.isSaving}
+              />
+              <div className="grid gap-1">
+                <Label htmlFor="deletion-rules-allow-override">
+                  {t('admin.iam.deletionRules.fields.allowContentPreferenceOverride')}
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  {t('admin.iam.deletionRules.fields.allowContentPreferenceOverrideHint')}
+                </p>
+              </div>
+            </div>
+            <div className="md:col-span-2 flex items-center gap-3">
+              <Button type="submit" disabled={!state.deletionRules?.canEdit || state.isSaving}>
+                {state.isSaving ? t('admin.iam.deletionRules.actions.saving') : t('admin.iam.deletionRules.actions.save')}
+              </Button>
+              {!state.deletionRules?.canEdit ? (
+                <p className="text-sm text-muted-foreground">{t('admin.iam.deletionRules.messages.readOnly')}</p>
+              ) : null}
+            </div>
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  </div>
+);
+
+export function IamViewerPage({ activeTab }: IamViewerPageProps) {
+  const { user, isLoading: isLoadingUser, error: authError, invalidatePermissions } = useAuth();
+  const instanceId = user?.instanceId ?? '';
+  const cockpitEnabled = isIamCockpitEnabled();
+  const canAccessCockpit = hasIamCockpitAccessRole(user);
+  const canExportGovernanceCompliance = hasGovernanceComplianceExportRole(user);
+  const allowedTabs = React.useMemo(() => getAllowedIamCockpitTabs(user), [user]);
+  const studioDataTableLabels = React.useMemo(() => createStudioDataTableLabels(), []);
+  const { handleTabKeyDown, navigateToTab, tabButtonRefs } = useIamTabNavigation(activeTab, allowedTabs);
+  const rightsTabState = useRightsTabState({
+    activeTab,
+    allowedTabs,
+    canAccessCockpit,
+    cockpitEnabled,
+    instanceId,
+    invalidatePermissions,
+  });
+  const governanceTabState = useGovernanceTabState({
+    activeTab,
+    allowedTabs,
+    canAccessCockpit,
+    cockpitEnabled,
+  });
+  const dsrTabState = useDsrTabState({
+    activeTab,
+    allowedTabs,
+    canAccessCockpit,
+    cockpitEnabled,
+  });
+  const deletionRulesTabState = useDeletionRulesTabState({
+    activeTab,
+    allowedTabs,
+    canAccessCockpit,
+    cockpitEnabled,
+    instanceId,
+  });
+  const governanceColumns = React.useMemo(buildGovernanceColumns, []);
+  const dsrColumns = React.useMemo(buildDsrColumns, []);
 
   if (isLoadingUser) {
     return <p className="text-sm text-muted-foreground">{t('admin.iam.messages.initializing')}</p>;
@@ -951,539 +1625,44 @@ export function IamViewerPage({ activeTab }: IamViewerPageProps) {
         })}
       </Card>
 
-      <Card className="border-border/80 bg-white p-4 shadow-sm">
-        <div className="space-y-2">
-          <p className="text-sm font-semibold text-foreground">{activeTabHelp.title}</p>
-          <p className="text-sm text-muted-foreground">{activeTabHelp.description}</p>
-          <div className="space-y-1">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {t('admin.iam.tabHelp.optionsLabel')}
-            </p>
-            <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
-              {activeTabHelp.options.map((option) => (
-                <li key={option}>{option}</li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </Card>
+      <ActiveTabHelpCard activeTab={activeTab} />
 
       {activeTab === 'rights' ? (
-        <div
-          id={getTabPanelId('rights')}
-          role="tabpanel"
-          aria-labelledby={getTabId('rights')}
-          className="space-y-4"
-        >
-          <StudioFilterSurface className="grid gap-3 lg:grid-cols-4">
-            <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-              <Label htmlFor="iam-organization-filter">{t('admin.iam.rights.filters.organization')}</Label>
-              <Select
-                id="iam-organization-filter"
-                value={organizationId}
-                onChange={(event) => setOrganizationId(event.target.value)}
-              >
-                <option value="">{t('admin.iam.shared.all')}</option>
-                {organizationSelectOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
-              </Select>
-            </div>
-            <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-              <Label htmlFor="iam-acting-as-filter">{t('admin.iam.rights.filters.actingAs')}</Label>
-              <Input
-                id="iam-acting-as-filter"
-                value={actingAsUserId}
-                onChange={(event) => setActingAsUserId(event.target.value)}
-              />
-            </div>
-            <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-              <Label htmlFor="iam-query-filter">{t('admin.iam.rights.filters.search')}</Label>
-              <Input
-                id="iam-query-filter"
-                value={queryText}
-                onChange={(event) => setQueryText(event.target.value)}
-              />
-            </div>
-            <StudioSummaryCard
-              eyebrow={t('admin.iam.rights.subject.title')}
-              value={permissionSubject ? permissionSubject.effectiveUserId : '—'}
-              valueClassName="text-lg"
-            >
-              <p className="text-xs text-muted-foreground">
-                {permissionSubject?.isImpersonating
-                  ? t('admin.iam.rights.subject.impersonating', { actor: permissionSubject.actorUserId })
-                  : t('admin.iam.rights.subject.self')}
-              </p>
-            </StudioSummaryCard>
-          </StudioFilterSurface>
-
-          {organizationOptions.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {organizationOptions.map((organizationValue) => (
-                <Button
-                  key={organizationValue || 'no-organization'}
-                  type="button"
-                  className={`rounded-full text-xs ${
-                    selectedOrganizationIds.includes(organizationValue)
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-border text-muted-foreground'
-                  }`}
-                  onClick={() => handleOrganizationFilterToggle(organizationValue)}
-                  size="sm"
-                  variant="outline"
-                >
-                  {organizationValue || t('admin.iam.rights.noOrganization')}
-                </Button>
-              ))}
-            </div>
-          ) : null}
-
-          {permissionsError ? (
-            <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-              <AlertDescription>{t('admin.iam.rights.messages.error', { value: permissionsError })}</AlertDescription>
-            </Alert>
-          ) : null}
-
-          <Card aria-busy={isLoadingPermissions} className="p-4">
-            <PermissionTable permissions={filteredPermissions} />
-          </Card>
-
-          <StudioFilterSurface>
-            <form onSubmit={handleAuthorizeSubmit} className="grid gap-3 lg:grid-cols-4">
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-authorize-action">{t('admin.iam.rights.authorize.action')}</Label>
-                <Input
-                  id="iam-authorize-action"
-                  value={authorizeAction}
-                  onChange={(event) => setAuthorizeAction(event.target.value)}
-                />
-              </div>
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-authorize-resource-type">
-                  {t('admin.iam.rights.authorize.resourceType')}
-                </Label>
-                <Input
-                  id="iam-authorize-resource-type"
-                  value={authorizeResourceType}
-                  onChange={(event) => setAuthorizeResourceType(event.target.value)}
-                />
-              </div>
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-authorize-resource-id">
-                  {t('admin.iam.rights.authorize.resourceId')}
-                </Label>
-                <Input
-                  id="iam-authorize-resource-id"
-                  value={authorizeResourceId}
-                  onChange={(event) => setAuthorizeResourceId(event.target.value)}
-                />
-              </div>
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-authorize-organization-id">
-                  {t('admin.iam.rights.authorize.organizationId')}
-                </Label>
-                <Select
-                  id="iam-authorize-organization-id"
-                  value={authorizeOrganizationId}
-                  onChange={(event) => setAuthorizeOrganizationId(event.target.value)}
-                >
-                  <option value="">{t('admin.iam.shared.all')}</option>
-                  {organizationSelectOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-              <div className="lg:col-span-4 flex items-center gap-3">
-                <Button type="submit" disabled={isAuthorizing}>
-                  {isAuthorizing
-                    ? t('admin.iam.rights.authorize.running')
-                    : t('admin.iam.rights.authorize.run')}
-                </Button>
-                {authorizeError ? <p className="text-sm text-destructive">{authorizeError}</p> : null}
-              </div>
-              {authorizeDecision ? (
-                <Card className="lg:col-span-4 bg-background p-3 shadow-none">
-                  <p className="font-semibold text-foreground">
-                    {authorizeDecision.allowed
-                      ? t('admin.iam.rights.authorize.allowed')
-                      : t('admin.iam.rights.authorize.denied')}
-                  </p>
-                  <dl className="mt-3 grid gap-2 text-sm">
-                    <div>
-                      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-                        {t('admin.iam.rights.authorize.summary.action')}
-                      </dt>
-                      <dd className="text-foreground">{authorizeAction.trim() || '—'}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-                        {t('admin.iam.rights.authorize.summary.resource')}
-                      </dt>
-                      <dd className="text-foreground">
-                        {[authorizeResourceType.trim(), authorizeResourceId.trim()]
-                          .filter(Boolean)
-                          .join(' / ') || '—'}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-                        {t('admin.iam.rights.authorize.summary.organization')}
-                      </dt>
-                      <dd className="text-foreground">
-                        {authorizeOrganizationId.trim() || organizationId.trim() || '—'}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-                        {t('admin.iam.rights.authorize.summary.cause')}
-                      </dt>
-                      <dd className="text-foreground">
-                        {authorizeDecision.reasonCode ?? authorizeDecision.reason}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-                        {t('admin.iam.rights.authorize.summary.origin')}
-                      </dt>
-                      <dd className="text-foreground">
-                        {authorizeDecision.provenance?.sourceKinds &&
-                        authorizeDecision.provenance.sourceKinds.length > 0
-                          ? formatPermissionSourceKindLabels(
-                              authorizeDecision.provenance.sourceKinds
-                            )
-                          : authorizeDecision.matchedPermissions &&
-                              authorizeDecision.matchedPermissions.length > 0
-                            ? formatPermissionSourceKindLabels(
-                                [
-                                  ...new Set(
-                                    authorizeDecision.matchedPermissions.map(
-                                      (permission) => permission.source
-                                    )
-                                  ),
-                                ] as readonly string[]
-                              )
-                            : '—'}
-                      </dd>
-                    </div>
-                  </dl>
-                  {authorizeDecision.diagnostics ? (
-                    <p className="mt-2 text-xs text-muted-foreground">
-                      {formatObjectEntries(authorizeDecision.diagnostics)}
-                    </p>
-                  ) : null}
-                </Card>
-              ) : null}
-            </form>
-          </StudioFilterSurface>
-        </div>
+        <RightsTabPanel
+          panelId={getTabPanelId('rights')}
+          labelledBy={getTabId('rights')}
+          state={rightsTabState}
+        />
       ) : null}
 
       {activeTab === 'governance' ? (
-        <div
-          id={getTabPanelId('governance')}
-          role="tabpanel"
-          aria-labelledby={getTabId('governance')}
-          className="space-y-4"
-        >
-          <StudioFilterSurface className="grid gap-3">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <p className="text-sm text-muted-foreground">{t('admin.iam.governance.messages.exportHint')}</p>
-              {instanceId && canExportGovernanceCompliance ? (
-                <Button asChild size="sm" variant="outline">
-                  <a href={buildGovernanceComplianceExportPath({ instanceId })}>
-                    {t('admin.iam.governance.actions.exportCsv')}
-                  </a>
-                </Button>
-              ) : null}
-            </div>
-            <div className="grid gap-3 md:grid-cols-3">
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-governance-search">{t('admin.iam.governance.filters.search')}</Label>
-                <Input
-                  id="iam-governance-search"
-                  value={governanceQuery.search ?? ''}
-                  onChange={(event) => setGovernanceQuery((current) => ({ ...current, page: 1, search: event.target.value }))}
-                />
-              </div>
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-governance-type">{t('admin.iam.governance.filters.type')}</Label>
-                <Select
-                  id="iam-governance-type"
-                  value={governanceQuery.type ?? ''}
-                  onChange={(event) =>
-                    setGovernanceQuery((current) => ({
-                      ...current,
-                      page: 1,
-                      type: (event.target.value || undefined) as GovernanceCasesQuery['type'],
-                    }))
-                  }
-                >
-                  <option value="">{t('admin.iam.shared.all')}</option>
-                  {governanceTypeOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {t(mapGovernanceTypeToTranslationKey(option))}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-governance-status">{t('admin.iam.governance.filters.status')}</Label>
-                <Select
-                  id="iam-governance-status"
-                  value={governanceQuery.status ?? ''}
-                  onChange={(event) =>
-                    setGovernanceQuery((current) => ({
-                      ...current,
-                      page: 1,
-                      status: event.target.value || undefined,
-                    }))
-                  }
-                >
-                  <option value="">{t('admin.iam.shared.all')}</option>
-                  {governanceStatusOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-            </div>
-          </StudioFilterSurface>
-          {governanceError ? (
-            <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-              <AlertDescription>{governanceError}</AlertDescription>
-            </Alert>
-          ) : null}
-          <StudioDataTable
-            ariaLabel={t('admin.iam.governance.tableAriaLabel')}
-            labels={studioDataTableLabels}
-            caption={t('admin.iam.governance.tableCaption')}
-            data={governanceItems}
-            columns={governanceColumns}
-            getRowId={(item) => item.id}
-            selectionMode="none"
-            isLoading={isLoadingGovernance}
-            loadingState={t('admin.iam.governance.messages.loading')}
-            emptyState={<p className="text-sm text-muted-foreground">{t('admin.iam.governance.messages.empty')}</p>}
-          />
-        </div>
+        <GovernanceTabPanel
+          canExportGovernanceCompliance={canExportGovernanceCompliance}
+          instanceId={instanceId}
+          panelId={getTabPanelId('governance')}
+          labelledBy={getTabId('governance')}
+          state={governanceTabState}
+          columns={governanceColumns}
+          labels={studioDataTableLabels}
+        />
       ) : null}
 
       {activeTab === 'dsr' ? (
-        <div
-          id={getTabPanelId('dsr')}
-          role="tabpanel"
-          aria-labelledby={getTabId('dsr')}
-          className="space-y-4"
-        >
-          <StudioFilterSurface className="grid gap-3 md:grid-cols-3">
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-dsr-search">{t('admin.iam.dsr.filters.search')}</Label>
-                <Input
-                  id="iam-dsr-search"
-                  value={dsrQuery.search ?? ''}
-                  onChange={(event) => setDsrQuery((current) => ({ ...current, page: 1, search: event.target.value }))}
-                />
-              </div>
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-dsr-type">{t('admin.iam.dsr.filters.type')}</Label>
-                <Select
-                  id="iam-dsr-type"
-                  value={dsrQuery.type ?? ''}
-                  onChange={(event) =>
-                    setDsrQuery((current) => ({
-                      ...current,
-                      page: 1,
-                      type: (event.target.value || undefined) as DsrAdminCasesQuery['type'],
-                    }))
-                  }
-                >
-                  <option value="">{t('admin.iam.shared.all')}</option>
-                  {dsrTypeOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {t(mapDsrTypeToTranslationKey(option))}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-              <div className="grid gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="iam-dsr-status">{t('admin.iam.dsr.filters.status')}</Label>
-                <Select
-                  id="iam-dsr-status"
-                  value={dsrQuery.status ?? ''}
-                  onChange={(event) =>
-                    setDsrQuery((current) => ({
-                      ...current,
-                      page: 1,
-                      status: (event.target.value || undefined) as DsrAdminCasesQuery['status'],
-                    }))
-                  }
-                >
-                  <option value="">{t('admin.iam.shared.all')}</option>
-                  {dsrStatusOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {t(mapDsrCanonicalStatusToTranslationKey(option))}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-          </StudioFilterSurface>
-          {dsrError ? (
-            <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-              <AlertDescription>{dsrError}</AlertDescription>
-            </Alert>
-          ) : null}
-          <StudioDataTable
-            ariaLabel={t('admin.iam.dsr.tableAriaLabel')}
-            labels={studioDataTableLabels}
-            caption={t('admin.iam.dsr.tableCaption')}
-            data={dsrItems}
-            columns={dsrColumns}
-            getRowId={(item) => item.id}
-            selectionMode="none"
-            isLoading={isLoadingDsr}
-            loadingState={t('admin.iam.dsr.messages.loading')}
-            emptyState={<p className="text-sm text-muted-foreground">{t('admin.iam.dsr.messages.empty')}</p>}
-          />
-        </div>
+        <DsrTabPanel
+          panelId={getTabPanelId('dsr')}
+          labelledBy={getTabId('dsr')}
+          state={dsrTabState}
+          columns={dsrColumns}
+          labels={studioDataTableLabels}
+        />
       ) : null}
 
       {activeTab === 'deletion-rules' ? (
-        <div
-          id={getTabPanelId('deletion-rules')}
-          role="tabpanel"
-          aria-labelledby={getTabId('deletion-rules')}
-          className="space-y-4"
-        >
-          <Card>
-            <CardHeader className="p-4 pb-0">
-              <CardTitle>{t('admin.iam.deletionRules.title')}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 p-4 pt-0">
-              <p className="text-sm text-muted-foreground">{t('admin.iam.deletionRules.subtitle')}</p>
-
-              {deletionRulesError ? (
-                <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-                  <AlertDescription>{deletionRulesError}</AlertDescription>
-                </Alert>
-              ) : null}
-
-              {isLoadingDeletionRules || !deletionRulesDraft ? (
-                <p className="text-sm text-muted-foreground">{t('admin.iam.deletionRules.messages.loading')}</p>
-              ) : (
-                <form className="grid gap-4 md:grid-cols-2" onSubmit={handleDeletionRulesSave}>
-                  <div className="grid gap-1">
-                    <Label htmlFor="deletion-rules-deactivate">{t('admin.iam.deletionRules.fields.deactivateAfterDays')}</Label>
-                    <Input
-                      id="deletion-rules-deactivate"
-                      inputMode="numeric"
-                      value={deletionRulesDraft.deactivateAfterDays}
-                      onChange={(event) =>
-                        setDeletionRulesDraft((current) =>
-                          current ? { ...current, deactivateAfterDays: event.target.value } : current
-                        )
-                      }
-                      disabled={!deletionRules?.canEdit || isSavingDeletionRules}
-                    />
-                  </div>
-                  <div className="grid gap-1">
-                    <Label htmlFor="deletion-rules-pseudonymize">{t('admin.iam.deletionRules.fields.pseudonymizeAfterDays')}</Label>
-                    <Input
-                      id="deletion-rules-pseudonymize"
-                      inputMode="numeric"
-                      value={deletionRulesDraft.pseudonymizeAfterDays}
-                      onChange={(event) =>
-                        setDeletionRulesDraft((current) =>
-                          current ? { ...current, pseudonymizeAfterDays: event.target.value } : current
-                        )
-                      }
-                      disabled={!deletionRules?.canEdit || isSavingDeletionRules}
-                    />
-                  </div>
-                  <div className="grid gap-1">
-                    <Label htmlFor="deletion-rules-delete">{t('admin.iam.deletionRules.fields.deleteAfterDays')}</Label>
-                    <Input
-                      id="deletion-rules-delete"
-                      inputMode="numeric"
-                      value={deletionRulesDraft.deleteAfterDays}
-                      onChange={(event) =>
-                        setDeletionRulesDraft((current) =>
-                          current ? { ...current, deleteAfterDays: event.target.value } : current
-                        )
-                      }
-                      disabled={!deletionRules?.canEdit || isSavingDeletionRules}
-                    />
-                  </div>
-                  <div className="grid gap-1">
-                    <Label htmlFor="deletion-rules-strategy">{t('admin.iam.deletionRules.fields.defaultContentStrategy')}</Label>
-                    <Select
-                      id="deletion-rules-strategy"
-                      value={deletionRulesDraft.defaultContentStrategy}
-                      onChange={(event) =>
-                        setDeletionRulesDraft((current) =>
-                          current
-                            ? {
-                                ...current,
-                                defaultContentStrategy: event.target.value as IamDeletionContentStrategy,
-                              }
-                            : current
-                        )
-                      }
-                      disabled={!deletionRules?.canEdit || isSavingDeletionRules}
-                    >
-                      {deletionContentStrategyOptions.map((option) => (
-                        <option key={option} value={option}>
-                          {t(mapDeletionContentStrategyKey(option))}
-                        </option>
-                      ))}
-                    </Select>
-                  </div>
-                  <div className="md:col-span-2 flex items-start gap-3 rounded-lg border border-border p-3">
-                    <Checkbox
-                      id="deletion-rules-allow-override"
-                      checked={deletionRulesDraft.allowContentPreferenceOverride}
-                      onChange={(event) => {
-                        const nextChecked = event.currentTarget.checked;
-                        setDeletionRulesDraft((current) =>
-                          current
-                            ? {
-                                ...current,
-                                allowContentPreferenceOverride: nextChecked,
-                              }
-                            : current
-                        );
-                      }}
-                      disabled={!deletionRules?.canEdit || isSavingDeletionRules}
-                    />
-                    <div className="grid gap-1">
-                      <Label htmlFor="deletion-rules-allow-override">
-                        {t('admin.iam.deletionRules.fields.allowContentPreferenceOverride')}
-                      </Label>
-                      <p className="text-sm text-muted-foreground">
-                        {t('admin.iam.deletionRules.fields.allowContentPreferenceOverrideHint')}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="md:col-span-2 flex items-center gap-3">
-                    <Button type="submit" disabled={!deletionRules?.canEdit || isSavingDeletionRules}>
-                      {isSavingDeletionRules
-                        ? t('admin.iam.deletionRules.actions.saving')
-                        : t('admin.iam.deletionRules.actions.save')}
-                    </Button>
-                    {!deletionRules?.canEdit ? (
-                      <p className="text-sm text-muted-foreground">{t('admin.iam.deletionRules.messages.readOnly')}</p>
-                    ) : null}
-                  </div>
-                </form>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+        <DeletionRulesTabPanel
+          panelId={getTabPanelId('deletion-rules')}
+          labelledBy={getTabId('deletion-rules')}
+          state={deletionRulesTabState}
+        />
       ) : null}
     </section>
   );

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
@@ -158,6 +158,151 @@ export const getOperationsEvidenceSourceLabel = (source: EvidenceSource): string
 const isFinalKeycloakStateSatisfied = (instance: IamInstanceDetail) =>
   Boolean(instance.keycloakStatus && areAllInstanceKeycloakRequirementsSatisfied(instance.keycloakStatus));
 
+const deriveOperationsModelStatus = (steps: OperationsStepModel[]): RealmOperationsModel['status'] => {
+  if (steps.some((step) => step.status === 'fehlgeschlagen')) {
+    return 'blocked';
+  }
+
+  if (steps.some((step) => step.status === 'läuft' || step.status === 'bereit')) {
+    return 'degraded';
+  }
+
+  if (steps.every((step) => step.status === 'erfolgreich')) {
+    return 'ready';
+  }
+
+  return 'unknown';
+};
+
+const buildWorkerPreflightStep = (
+  mode: 'new' | 'existing',
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+): OperationsStepModel => {
+  const blocked = preflight?.overallStatus === 'blocked';
+  const pending = !contractComplete;
+  const ready = Boolean(preflight);
+
+  return createOperationStep({
+    key: 'worker_preflight',
+    title: t(
+      mode === 'new'
+        ? NEW_REALM_STEP_TITLES.worker_preflight
+        : EXISTING_REALM_STEP_TITLES.worker_preflight
+    ),
+    status: pending
+      ? 'offen'
+      : blocked
+        ? 'fehlgeschlagen'
+        : ready
+          ? 'erfolgreich'
+          : 'bereit',
+    summary: pending
+      ? t(
+        mode === 'new'
+          ? 'admin.instances.operations.new.stepSummaries.workerPreflightPending'
+          : 'admin.instances.operations.existing.stepSummaries.workerPreflightPending'
+      )
+      : blocked
+        ? (
+          mode === 'new'
+            ? findPreflightCheck(preflight, 'realm_mode')?.summary
+              ?? t('admin.instances.operations.new.stepSummaries.workerPreflightFailed')
+            : t('admin.instances.operations.existing.stepSummaries.workerPreflightFailed')
+        )
+        : ready
+          ? t(
+            mode === 'new'
+              ? 'admin.instances.operations.new.stepSummaries.workerPreflightReady'
+              : 'admin.instances.operations.existing.stepSummaries.workerPreflightReady'
+          )
+          : t(
+            mode === 'new'
+              ? 'admin.instances.operations.new.stepSummaries.workerPreflightReadyToRun'
+              : 'admin.instances.operations.existing.stepSummaries.workerPreflightReadyToRun'
+          ),
+    evidenceSource: 'worker_preflight',
+    checkedAt: readPreflightTimestamp(preflight),
+    action: contractComplete && !preflight ? 'check_preflight' : undefined,
+  });
+};
+
+const buildNewRealmLeadSteps = (
+  instance: IamInstanceDetail,
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+  plan: IamInstanceDetail['keycloakPlan'],
+): OperationsStepModel[] => [
+  createOperationStep({
+    key: 'registry_contract',
+    title: t(NEW_REALM_STEP_TITLES.registry_contract),
+    status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
+    summary: contractComplete
+      ? t('admin.instances.operations.new.stepSummaries.registryContractReady')
+      : t('admin.instances.operations.new.stepSummaries.registryContractFailed'),
+    evidenceSource: 'registry_contract',
+    checkedAt: instance.updatedAt,
+    action: contractComplete ? undefined : 'focus_configuration',
+  }),
+  buildWorkerPreflightStep('new', contractComplete, preflight),
+  createOperationStep({
+    key: 'worker_plan',
+    title: t(NEW_REALM_STEP_TITLES.worker_plan),
+    status: !contractComplete || preflight?.overallStatus === 'blocked'
+      ? 'offen'
+      : plan?.overallStatus === 'blocked'
+        ? 'fehlgeschlagen'
+        : plan
+          ? 'erfolgreich'
+          : 'bereit',
+    summary: !contractComplete || preflight?.overallStatus === 'blocked'
+      ? t('admin.instances.operations.new.stepSummaries.workerPlanPending')
+      : plan?.overallStatus === 'blocked'
+        ? plan.driftSummary
+        : plan
+          ? t('admin.instances.operations.new.stepSummaries.workerPlanReady')
+          : t('admin.instances.operations.new.stepSummaries.workerPlanReadyToRun'),
+    evidenceSource: 'worker_plan',
+    checkedAt: plan?.generatedAt,
+    action: contractComplete && preflight && !plan ? 'plan_provisioning' : undefined,
+  }),
+];
+
+const buildNewRealmOperationsSummary = (
+  instance: IamInstanceDetail,
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+  runState: ReturnType<typeof readProvisioningRunState>,
+  realmModeBlocked: boolean,
+): string => {
+  if (!contractComplete) {
+    return t('admin.instances.operations.new.summary.contractIncomplete');
+  }
+
+  if (realmModeBlocked) {
+    return t('admin.instances.operations.new.summary.modeConflict');
+  }
+
+  if (preflight?.overallStatus === 'blocked') {
+    return t('admin.instances.operations.new.summary.preflightBlocked');
+  }
+
+  if (runState.failed) {
+    return t('admin.instances.operations.new.summary.runFailed');
+  }
+
+  return isFinalKeycloakStateSatisfied(instance)
+    ? t('admin.instances.operations.new.summary.bootstrapComplete')
+    : t('admin.instances.operations.new.summary.inProgress');
+};
+
+const buildNewRealmFollowUpActions = (
+  instance: IamInstanceDetail,
+): RealmOperationsModel['followUpActions'] =>
+  instance.status !== 'active' && isFinalKeycloakStateSatisfied(instance)
+    ? ['activate_instance']
+    : [];
+
 const buildNewRealmArtifactSteps = (instance: IamInstanceDetail): OperationsStepModel[] => {
   const latestRun = readLatestKeycloakRun(instance);
   const runState = readProvisioningRunState(latestRun);
@@ -321,101 +466,123 @@ export const buildNewRealmOperationsModel = (
   const latestRun = readLatestKeycloakRun(instance);
   const runState = readProvisioningRunState(latestRun);
   const realmModeBlocked = findPreflightCheck(preflight, 'realm_mode')?.status === 'blocked';
-
-  const steps: OperationsStepModel[] = [
-    createOperationStep({
-      key: 'registry_contract',
-      title: t(NEW_REALM_STEP_TITLES.registry_contract),
-      status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
-      summary: contractComplete
-        ? t('admin.instances.operations.new.stepSummaries.registryContractReady')
-        : t('admin.instances.operations.new.stepSummaries.registryContractFailed'),
-      evidenceSource: 'registry_contract',
-      checkedAt: instance.updatedAt,
-      action: contractComplete ? undefined : 'focus_configuration',
-    }),
-    createOperationStep({
-      key: 'worker_preflight',
-      title: t(NEW_REALM_STEP_TITLES.worker_preflight),
-      status: !contractComplete
-        ? 'offen'
-        : preflight?.overallStatus === 'blocked'
-          ? 'fehlgeschlagen'
-          : preflight
-            ? 'erfolgreich'
-            : 'bereit',
-      summary: !contractComplete
-        ? t('admin.instances.operations.new.stepSummaries.workerPreflightPending')
-        : preflight?.overallStatus === 'blocked'
-          ? findPreflightCheck(preflight, 'realm_mode')?.summary
-            ?? t('admin.instances.operations.new.stepSummaries.workerPreflightFailed')
-          : preflight
-            ? t('admin.instances.operations.new.stepSummaries.workerPreflightReady')
-            : t('admin.instances.operations.new.stepSummaries.workerPreflightReadyToRun'),
-      evidenceSource: 'worker_preflight',
-      checkedAt: readPreflightTimestamp(preflight),
-      action: contractComplete && !preflight ? 'check_preflight' : undefined,
-    }),
-    createOperationStep({
-      key: 'worker_plan',
-      title: t(NEW_REALM_STEP_TITLES.worker_plan),
-      status: !contractComplete || preflight?.overallStatus === 'blocked'
-        ? 'offen'
-        : plan?.overallStatus === 'blocked'
-          ? 'fehlgeschlagen'
-          : plan
-            ? 'erfolgreich'
-            : 'bereit',
-      summary: !contractComplete || preflight?.overallStatus === 'blocked'
-        ? t('admin.instances.operations.new.stepSummaries.workerPlanPending')
-        : plan?.overallStatus === 'blocked'
-          ? plan.driftSummary
-          : plan
-            ? t('admin.instances.operations.new.stepSummaries.workerPlanReady')
-            : t('admin.instances.operations.new.stepSummaries.workerPlanReadyToRun'),
-      evidenceSource: 'worker_plan',
-      checkedAt: plan?.generatedAt,
-      action: contractComplete && preflight && !plan ? 'plan_provisioning' : undefined,
-    }),
-  ];
+  const steps: OperationsStepModel[] = buildNewRealmLeadSteps(instance, contractComplete, preflight, plan);
 
   steps.push(...buildNewRealmArtifactSteps(instance));
 
-  const currentStatus =
-    steps.some((step) => step.status === 'fehlgeschlagen')
-      ? 'blocked'
-      : steps.some((step) => step.status === 'läuft' || step.status === 'bereit')
-        ? 'degraded'
-        : steps.every((step) => step.status === 'erfolgreich')
-          ? 'ready'
-          : 'unknown';
-
-  const summary = !contractComplete
-    ? t('admin.instances.operations.new.summary.contractIncomplete')
-    : realmModeBlocked
-      ? t('admin.instances.operations.new.summary.modeConflict')
-      : preflight?.overallStatus === 'blocked'
-        ? t('admin.instances.operations.new.summary.preflightBlocked')
-        : runState.failed
-          ? t('admin.instances.operations.new.summary.runFailed')
-          : isFinalKeycloakStateSatisfied(instance)
-            ? t('admin.instances.operations.new.summary.bootstrapComplete')
-            : t('admin.instances.operations.new.summary.inProgress');
-
   return {
     mode: 'new',
-    status: currentStatus,
-    summary,
+    status: deriveOperationsModelStatus(steps),
+    summary: buildNewRealmOperationsSummary(instance, contractComplete, preflight, runState, realmModeBlocked),
     steps,
-    followUpActions: instance.status !== 'active' && isFinalKeycloakStateSatisfied(instance)
-      ? ['activate_instance']
-      : [],
+    followUpActions: buildNewRealmFollowUpActions(instance),
     signals: {
       modeConflict: realmModeBlocked,
       hasDrift: false,
     },
   };
 };
+
+const buildExistingRealmAssessmentSteps = (
+  instance: IamInstanceDetail,
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+  latestRun: IamInstanceDetail['latestKeycloakProvisioningRun'],
+  hasDrift: boolean,
+): OperationsStepModel[] => [
+  createOperationStep({
+    key: 'registry_contract',
+    title: t(EXISTING_REALM_STEP_TITLES.registry_contract),
+    status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
+    summary: contractComplete
+      ? t('admin.instances.operations.existing.stepSummaries.registryContractReady')
+      : t('admin.instances.operations.existing.stepSummaries.registryContractFailed'),
+    evidenceSource: 'registry_contract',
+    checkedAt: instance.updatedAt,
+    action: contractComplete ? undefined : 'focus_configuration',
+  }),
+  buildWorkerPreflightStep('existing', contractComplete, preflight),
+  createOperationStep({
+    key: 'live_status',
+    title: t(EXISTING_REALM_STEP_TITLES.live_status),
+    status: instance.keycloakStatus
+      ? 'erfolgreich'
+      : preflight?.overallStatus === 'blocked'
+        ? 'offen'
+        : 'bereit',
+    summary: instance.keycloakStatus
+      ? t('admin.instances.operations.existing.stepSummaries.liveStatusReady')
+      : t('admin.instances.operations.existing.stepSummaries.liveStatusPending'),
+    evidenceSource: instance.keycloakStatus ? 'final_validation' : 'worker_preflight',
+    checkedAt: instance.updatedAt,
+    action: instance.keycloakStatus ? undefined : 'check_keycloak_status',
+  }),
+  createOperationStep({
+    key: 'drift_analysis',
+    title: t(EXISTING_REALM_STEP_TITLES.drift_analysis),
+    status: !instance.keycloakStatus
+      ? 'offen'
+      : hasDrift
+        ? 'fehlgeschlagen'
+        : 'erfolgreich',
+    summary: !instance.keycloakStatus
+      ? t('admin.instances.operations.existing.stepSummaries.driftAnalysisPending')
+      : hasDrift
+        ? t('admin.instances.operations.existing.stepSummaries.driftAnalysisFailed')
+        : t('admin.instances.operations.existing.stepSummaries.driftAnalysisReady'),
+    evidenceSource: instance.keycloakStatus ? 'final_validation' : 'history',
+    checkedAt: instance.updatedAt,
+  }),
+  createOperationStep({
+    key: 'contract_repair',
+    title: t(EXISTING_REALM_STEP_TITLES.contract_repair),
+    status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
+    summary: contractComplete
+      ? t('admin.instances.operations.existing.stepSummaries.contractRepairReady')
+      : t('admin.instances.operations.existing.stepSummaries.contractRepairFailed'),
+    evidenceSource: 'registry_contract',
+    checkedAt: instance.updatedAt,
+    action: contractComplete ? undefined : 'focus_configuration',
+  }),
+  createOperationStep({
+    key: 'reconcile',
+    title: t(EXISTING_REALM_STEP_TITLES.reconcile),
+    status: !instance.keycloakStatus
+      ? 'offen'
+      : latestRun?.overallStatus === 'failed'
+        ? 'fehlgeschlagen'
+        : hasDrift
+          ? 'bereit'
+          : 'erfolgreich',
+    summary: !instance.keycloakStatus
+      ? t('admin.instances.operations.existing.stepSummaries.reconcilePending')
+      : latestRun?.overallStatus === 'failed'
+        ? t('admin.instances.operations.existing.stepSummaries.reconcileFailed')
+        : hasDrift
+          ? t('admin.instances.operations.existing.stepSummaries.reconcileReadyToRun')
+          : t('admin.instances.operations.existing.stepSummaries.reconcileReady'),
+    evidenceSource: latestRun ? 'keycloak_run' : 'final_validation',
+    checkedAt: readRunTimestamp(latestRun) ?? instance.updatedAt,
+    requestId: latestRun?.requestId,
+    action: instance.keycloakStatus && hasDrift ? 'reconcileKeycloak' : undefined,
+  }),
+  createOperationStep({
+    key: 'result_validation',
+    title: t(EXISTING_REALM_STEP_TITLES.result_validation),
+    status: !instance.keycloakStatus
+      ? 'offen'
+      : hasDrift
+        ? 'fehlgeschlagen'
+        : 'erfolgreich',
+    summary: !instance.keycloakStatus
+      ? t('admin.instances.operations.existing.stepSummaries.resultValidationPending')
+      : hasDrift
+        ? t('admin.instances.operations.existing.stepSummaries.resultValidationFailed')
+        : t('admin.instances.operations.existing.stepSummaries.resultValidationReady'),
+    evidenceSource: 'final_validation',
+    checkedAt: instance.updatedAt,
+  }),
+];
 
 export const buildExistingRealmOperationsModel = (
   instance: IamInstanceDetail,
@@ -432,130 +599,11 @@ export const buildExistingRealmOperationsModel = (
   const preflight = instance.keycloakPreflight;
   const latestRun = readLatestKeycloakRun(instance);
   const hasDrift = Boolean(instance.keycloakStatus && !areAllInstanceKeycloakRequirementsSatisfied(instance.keycloakStatus));
-  const steps: OperationsStepModel[] = [
-    createOperationStep({
-      key: 'registry_contract',
-      title: t(EXISTING_REALM_STEP_TITLES.registry_contract),
-      status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
-      summary: contractComplete
-        ? t('admin.instances.operations.existing.stepSummaries.registryContractReady')
-        : t('admin.instances.operations.existing.stepSummaries.registryContractFailed'),
-      evidenceSource: 'registry_contract',
-      checkedAt: instance.updatedAt,
-      action: contractComplete ? undefined : 'focus_configuration',
-    }),
-    createOperationStep({
-      key: 'worker_preflight',
-      title: t(EXISTING_REALM_STEP_TITLES.worker_preflight),
-      status: !contractComplete
-        ? 'offen'
-        : preflight?.overallStatus === 'blocked'
-          ? 'fehlgeschlagen'
-          : preflight
-            ? 'erfolgreich'
-            : 'bereit',
-      summary: !contractComplete
-        ? t('admin.instances.operations.existing.stepSummaries.workerPreflightPending')
-        : preflight?.overallStatus === 'blocked'
-          ? t('admin.instances.operations.existing.stepSummaries.workerPreflightFailed')
-          : preflight
-            ? t('admin.instances.operations.existing.stepSummaries.workerPreflightReady')
-            : t('admin.instances.operations.existing.stepSummaries.workerPreflightReadyToRun'),
-      evidenceSource: 'worker_preflight',
-      checkedAt: readPreflightTimestamp(preflight),
-      action: contractComplete && !preflight ? 'check_preflight' : undefined,
-    }),
-    createOperationStep({
-      key: 'live_status',
-      title: t(EXISTING_REALM_STEP_TITLES.live_status),
-      status: instance.keycloakStatus
-        ? 'erfolgreich'
-        : preflight?.overallStatus === 'blocked'
-          ? 'offen'
-          : 'bereit',
-      summary: instance.keycloakStatus
-        ? t('admin.instances.operations.existing.stepSummaries.liveStatusReady')
-        : t('admin.instances.operations.existing.stepSummaries.liveStatusPending'),
-      evidenceSource: instance.keycloakStatus ? 'final_validation' : 'worker_preflight',
-      checkedAt: instance.updatedAt,
-      action: instance.keycloakStatus ? undefined : 'check_keycloak_status',
-    }),
-    createOperationStep({
-      key: 'drift_analysis',
-      title: t(EXISTING_REALM_STEP_TITLES.drift_analysis),
-      status: !instance.keycloakStatus
-        ? 'offen'
-        : hasDrift
-          ? 'fehlgeschlagen'
-          : 'erfolgreich',
-      summary: !instance.keycloakStatus
-        ? t('admin.instances.operations.existing.stepSummaries.driftAnalysisPending')
-        : hasDrift
-          ? t('admin.instances.operations.existing.stepSummaries.driftAnalysisFailed')
-          : t('admin.instances.operations.existing.stepSummaries.driftAnalysisReady'),
-      evidenceSource: instance.keycloakStatus ? 'final_validation' : 'history',
-      checkedAt: instance.updatedAt,
-    }),
-    createOperationStep({
-      key: 'contract_repair',
-      title: t(EXISTING_REALM_STEP_TITLES.contract_repair),
-      status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
-      summary: contractComplete
-        ? t('admin.instances.operations.existing.stepSummaries.contractRepairReady')
-        : t('admin.instances.operations.existing.stepSummaries.contractRepairFailed'),
-      evidenceSource: 'registry_contract',
-      checkedAt: instance.updatedAt,
-      action: contractComplete ? undefined : 'focus_configuration',
-    }),
-    createOperationStep({
-      key: 'reconcile',
-      title: t(EXISTING_REALM_STEP_TITLES.reconcile),
-      status: !instance.keycloakStatus
-        ? 'offen'
-        : latestRun?.overallStatus === 'failed'
-          ? 'fehlgeschlagen'
-          : hasDrift
-            ? 'bereit'
-            : 'erfolgreich',
-      summary: !instance.keycloakStatus
-        ? t('admin.instances.operations.existing.stepSummaries.reconcilePending')
-        : latestRun?.overallStatus === 'failed'
-          ? t('admin.instances.operations.existing.stepSummaries.reconcileFailed')
-          : hasDrift
-            ? t('admin.instances.operations.existing.stepSummaries.reconcileReadyToRun')
-            : t('admin.instances.operations.existing.stepSummaries.reconcileReady'),
-      evidenceSource: latestRun ? 'keycloak_run' : 'final_validation',
-      checkedAt: readRunTimestamp(latestRun) ?? instance.updatedAt,
-      requestId: latestRun?.requestId,
-      action: instance.keycloakStatus && hasDrift ? 'reconcileKeycloak' : undefined,
-    }),
-    createOperationStep({
-      key: 'result_validation',
-      title: t(EXISTING_REALM_STEP_TITLES.result_validation),
-      status: !instance.keycloakStatus
-        ? 'offen'
-        : hasDrift
-          ? 'fehlgeschlagen'
-          : 'erfolgreich',
-      summary: !instance.keycloakStatus
-        ? t('admin.instances.operations.existing.stepSummaries.resultValidationPending')
-        : hasDrift
-          ? t('admin.instances.operations.existing.stepSummaries.resultValidationFailed')
-          : t('admin.instances.operations.existing.stepSummaries.resultValidationReady'),
-      evidenceSource: 'final_validation',
-      checkedAt: instance.updatedAt,
-    }),
-  ];
+  const steps = buildExistingRealmAssessmentSteps(instance, contractComplete, preflight, latestRun, hasDrift);
 
   return {
     mode: 'existing',
-    status: steps.some((step) => step.status === 'fehlgeschlagen')
-      ? 'blocked'
-      : steps.some((step) => step.status === 'bereit' || step.status === 'läuft')
-        ? 'degraded'
-        : steps.every((step) => step.status === 'erfolgreich')
-          ? 'ready'
-          : 'unknown',
+    status: deriveOperationsModelStatus(steps),
     summary: hasDrift
       ? t('admin.instances.operations.existing.summary.driftDetected')
       : t('admin.instances.operations.existing.summary.reconcileReady'),

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
@@ -288,61 +288,21 @@ export const hasUserFormChanges = (baseline: UserFormValues, current: UserFormVa
   baseline.mainserverUserApplicationSecret !== current.mainserverUserApplicationSecret ||
   baseline.mainserverUserApplicationSecretSet !== current.mainserverUserApplicationSecretSet;
 
-export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage }: UserEditPageProps) => {
-  const userApi = useUser(userId);
-  const rolesApi = useRoles();
-  const groupsApi = useGroups();
-  const selectableRoles = React.useMemo(
-    () => rolesApi.roles.filter((role) => isTenantRoleVisible(role)),
-    [rolesApi.roles]
-  );
-  const selectableGroups = React.useMemo(
-    () => groupsApi.groups.filter((group) => group.isActive !== false),
-    [groupsApi.groups]
-  );
-
-  const [activeTab, setActiveTab] = React.useState<UserEditTabKey>('personal');
-  const [formValues, setFormValues] = React.useState<UserFormValues>(() => toFormValues(userApi.user));
-  const [isSaving, setIsSaving] = React.useState(false);
-  const [isSendingPasswordSetupEmail, setIsSendingPasswordSetupEmail] = React.useState(false);
-  const [saveSuccess, setSaveSuccess] = React.useState(false);
-  const [passwordSetupEmailSuccess, setPasswordSetupEmailSuccess] = React.useState(false);
-  const [timeline, setTimeline] = React.useState<Awaited<ReturnType<typeof getUserTimeline>>['data']>([]);
-  const [isLoadingTimeline, setIsLoadingTimeline] = React.useState(false);
-  const [timelineError, setTimelineError] = React.useState<string | null>(null);
-  const [hasLoadedTimeline, setHasLoadedTimeline] = React.useState(false);
-
-  const [unsavedDialogOpen, setUnsavedDialogOpen] = React.useState(false);
-  const [pendingTab, setPendingTab] = React.useState<UserEditTabKey | null>(null);
-
-  React.useEffect(() => {
-    if (!userApi.user) {
-      return;
-    }
-
-    setFormValues(toFormValues(userApi.user));
-  }, [userApi.user]);
-
-  React.useEffect(() => {
-    setTimeline([]);
-    setTimelineError(null);
-    setHasLoadedTimeline(false);
-  }, [userId]);
-
-  const baselineFormValues = React.useMemo(() => toFormValues(userApi.user), [userApi.user]);
+const useUserEditFormState = (user: ReturnType<typeof useUser>['user']) => {
+  const [formValues, setFormValues] = React.useState<UserFormValues>(() => toFormValues(user));
+  const baselineFormValues = React.useMemo(() => toFormValues(user), [user]);
   const hasUnsavedChanges = React.useMemo(
     () => hasUserFormChanges(baselineFormValues, formValues),
     [baselineFormValues, formValues]
   );
-  const effectivePermissionTrace = React.useMemo(
-    () => (userApi.user?.permissionTrace ?? []).filter((entry) => entry.isEffective),
-    [userApi.user?.permissionTrace]
-  );
-  const inactivePermissionTrace = React.useMemo(
-    () => (userApi.user?.permissionTrace ?? []).filter((entry) => !entry.isEffective),
-    [userApi.user?.permissionTrace]
-  );
-  const groupMembershipById = React.useMemo(() => buildGroupMembershipById(userApi.user?.groups), [userApi.user?.groups]);
+
+  React.useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    setFormValues(toFormValues(user));
+  }, [user]);
 
   React.useEffect(() => {
     if (!hasUnsavedChanges) {
@@ -359,6 +319,25 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
       window.removeEventListener('beforeunload', onBeforeUnload);
     };
   }, [hasUnsavedChanges]);
+
+  return {
+    formValues,
+    hasUnsavedChanges,
+    setFormValues,
+  };
+};
+
+const useUserTimelineState = (activeTab: UserEditTabKey, userId: string) => {
+  const [timeline, setTimeline] = React.useState<Awaited<ReturnType<typeof getUserTimeline>>['data']>([]);
+  const [isLoadingTimeline, setIsLoadingTimeline] = React.useState(false);
+  const [timelineError, setTimelineError] = React.useState<string | null>(null);
+  const [hasLoadedTimeline, setHasLoadedTimeline] = React.useState(false);
+
+  React.useEffect(() => {
+    setTimeline([]);
+    setTimelineError(null);
+    setHasLoadedTimeline(false);
+  }, [userId]);
 
   React.useEffect(() => {
     if (activeTab !== 'history' || hasLoadedTimeline) {
@@ -411,7 +390,21 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
     }
   }, [userId]);
 
-  const onTabIntent = (nextTab: UserEditTabKey) => {
+  return {
+    hasLoadedTimeline,
+    isLoadingTimeline,
+    reloadTimeline,
+    timeline,
+    timelineError,
+  };
+};
+
+const useUserEditTabState = (hasUnsavedChanges: boolean) => {
+  const [activeTab, setActiveTab] = React.useState<UserEditTabKey>('personal');
+  const [unsavedDialogOpen, setUnsavedDialogOpen] = React.useState(false);
+  const [pendingTab, setPendingTab] = React.useState<UserEditTabKey | null>(null);
+
+  const onTabIntent = React.useCallback((nextTab: UserEditTabKey) => {
     if (nextTab === activeTab) {
       return;
     }
@@ -423,9 +416,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
     }
 
     setActiveTab(nextTab);
-  };
+  }, [activeTab, hasUnsavedChanges]);
 
-  const onTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, tabIndex: number) => {
+  const onTabKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLButtonElement>, tabIndex: number) => {
     const key = event.key;
     if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(key)) {
       return;
@@ -445,9 +438,31 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
     const direction = key === 'ArrowRight' ? 1 : -1;
     const nextIndex = (tabIndex + direction + TABS.length) % TABS.length;
     onTabIntent(TABS[nextIndex].key);
-  };
+  }, [onTabIntent]);
 
-  const onSave = async (event: React.FormEvent<HTMLFormElement>) => {
+  return {
+    activeTab,
+    onTabIntent,
+    onTabKeyDown,
+    pendingTab,
+    setActiveTab,
+    setPendingTab,
+    setUnsavedDialogOpen,
+    unsavedDialogOpen,
+  };
+};
+
+const useUserSaveActions = (
+  userApi: ReturnType<typeof useUser>,
+  formValues: UserFormValues,
+  setFormValues: React.Dispatch<React.SetStateAction<UserFormValues>>,
+) => {
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [isSendingPasswordSetupEmail, setIsSendingPasswordSetupEmail] = React.useState(false);
+  const [saveSuccess, setSaveSuccess] = React.useState(false);
+  const [passwordSetupEmailSuccess, setPasswordSetupEmailSuccess] = React.useState(false);
+
+  const onSave = React.useCallback(async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsSaving(true);
     setSaveSuccess(false);
@@ -477,9 +492,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
     }
 
     setIsSaving(false);
-  };
+  }, [formValues, setFormValues, userApi]);
 
-  const onSendPasswordSetupEmail = async () => {
+  const onSendPasswordSetupEmail = React.useCallback(async () => {
     if (!userApi.resendPasswordSetupEmail || isSendingPasswordSetupEmail) {
       return;
     }
@@ -494,7 +509,67 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
     }
 
     setIsSendingPasswordSetupEmail(false);
+  }, [isSendingPasswordSetupEmail, userApi]);
+
+  return {
+    isSaving,
+    isSendingPasswordSetupEmail,
+    onSave,
+    onSendPasswordSetupEmail,
+    passwordSetupEmailSuccess,
+    saveSuccess,
+    setPasswordSetupEmailSuccess,
+    setSaveSuccess,
   };
+};
+
+export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage }: UserEditPageProps) => {
+  const userApi = useUser(userId);
+  const rolesApi = useRoles();
+  const groupsApi = useGroups();
+  const selectableRoles = React.useMemo(
+    () => rolesApi.roles.filter((role) => isTenantRoleVisible(role)),
+    [rolesApi.roles]
+  );
+  const selectableGroups = React.useMemo(
+    () => groupsApi.groups.filter((group) => group.isActive !== false),
+    [groupsApi.groups]
+  );
+
+  const { formValues, hasUnsavedChanges, setFormValues } = useUserEditFormState(userApi.user);
+  const {
+    activeTab,
+    onTabIntent,
+    onTabKeyDown,
+    pendingTab,
+    setActiveTab,
+    setPendingTab,
+    setUnsavedDialogOpen,
+    unsavedDialogOpen,
+  } = useUserEditTabState(hasUnsavedChanges);
+  const {
+    isLoadingTimeline,
+    reloadTimeline,
+    timeline,
+    timelineError,
+  } = useUserTimelineState(activeTab, userId);
+  const {
+    isSaving,
+    isSendingPasswordSetupEmail,
+    onSave,
+    onSendPasswordSetupEmail,
+    passwordSetupEmailSuccess,
+    saveSuccess,
+  } = useUserSaveActions(userApi, formValues, setFormValues);
+  const effectivePermissionTrace = React.useMemo(
+    () => (userApi.user?.permissionTrace ?? []).filter((entry) => entry.isEffective),
+    [userApi.user?.permissionTrace]
+  );
+  const inactivePermissionTrace = React.useMemo(
+    () => (userApi.user?.permissionTrace ?? []).filter((entry) => !entry.isEffective),
+    [userApi.user?.permissionTrace]
+  );
+  const groupMembershipById = React.useMemo(() => buildGroupMembershipById(userApi.user?.groups), [userApi.user?.groups]);
 
   if (userApi.isLoading) {
     return (

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -89,40 +89,44 @@ type StatusActionDialogState =
       userIds: string[];
     };
 
-export const UserListPage = () => {
-  const studioDataTableLabels = createStudioDataTableLabels();
-  const usersApi = useUsers();
+type UsersApiState = ReturnType<typeof useUsers>;
+type UserListUser = UsersApiState['users'][number];
+type SyncStatusState = 'idle' | 'pending' | 'success' | 'empty' | 'error';
 
-  const [statusActionDialog, setStatusActionDialog] = React.useState<StatusActionDialogState | null>(null);
-  const [syncStatus, setSyncStatus] = React.useState<'idle' | 'pending' | 'success' | 'empty' | 'error'>('idle');
+const executeStatusAction = async (
+  usersApi: UsersApiState,
+  action: StatusActionDialogState | null,
+): Promise<void> => {
+  if (!action) {
+    return;
+  }
+
+  if (action.action === 'activate') {
+    await usersApi.updateUser(action.userId, { status: 'active' });
+    return;
+  }
+
+  if (action.mode === 'single') {
+    await usersApi.deactivateUser(action.userId);
+    return;
+  }
+
+  await usersApi.bulkDeactivate(action.userIds);
+};
+
+const resolveSyncStatus = (report: IamUserImportSyncReport): Extract<SyncStatusState, 'success' | 'empty'> =>
+  report.importedCount === 0
+  && report.updatedCount === 0
+  && report.manualReviewCount === 0
+    ? 'empty'
+    : 'success';
+
+const useUserSyncState = (usersApi: UsersApiState) => {
+  const [syncStatus, setSyncStatus] = React.useState<SyncStatusState>('idle');
   const [syncResult, setSyncResult] = React.useState<IamUserImportSyncReport | null>(null);
   const [syncError, setSyncError] = React.useState<Parameters<typeof userErrorMessage>[0]>(null);
-  const { user } = useAuth();
-  const isPlatformScope = user !== null && !user.instanceId && hasPlatformInstanceAdminAccess(user);
-  const isAuthLoading = user === null;
 
-  const onConfirmStatusAction = async () => {
-    const action = statusActionDialog;
-    setStatusActionDialog(null);
-
-    if (!action) {
-      return;
-    }
-
-    if (action.action === 'activate') {
-      await usersApi.updateUser(action.userId, { status: 'active' });
-      return;
-    }
-
-    if (action.mode === 'single') {
-      await usersApi.deactivateUser(action.userId);
-      return;
-    }
-
-    await usersApi.bulkDeactivate(action.userIds);
-  };
-
-  const onSyncUsers = async () => {
+  const onSyncUsers = React.useCallback(async () => {
     setSyncStatus('pending');
     setSyncResult(null);
     setSyncError(null);
@@ -134,104 +138,408 @@ export const UserListPage = () => {
     }
 
     setSyncResult(result.report);
-    setSyncStatus(
-      result.report.importedCount === 0 &&
-        result.report.updatedCount === 0 &&
-        result.report.manualReviewCount === 0
-        ? 'empty'
-        : 'success'
-    );
+    setSyncStatus(resolveSyncStatus(result.report));
+  }, [usersApi]);
+
+  return {
+    syncStatus,
+    syncResult,
+    syncError,
+    onSyncUsers,
   };
+};
+
+const UserStatusCell = ({
+  user,
+  isAuthLoading,
+  isPlatformScope,
+  onStatusAction,
+}: {
+  user: UserListUser;
+  isAuthLoading: boolean;
+  isPlatformScope: boolean;
+  onStatusAction: React.Dispatch<React.SetStateAction<StatusActionDialogState | null>>;
+}) =>
+  isPlatformScope || isAuthLoading ? (
+    <Badge className={`rounded-full ${statusClassByValue[user.status]}`} variant="outline">
+      {t(statusTranslationKeyByValue[user.status])}
+    </Badge>
+  ) : (
+    <div className="flex items-center gap-2">
+      <Switch
+        checked={user.status !== 'inactive'}
+        disabled={user.editability === 'blocked' || user.editability === 'read_only'}
+        aria-label={t('admin.users.messages.statusSwitchLabel', {
+          name: user.displayName,
+        })}
+        onCheckedChange={(checked) =>
+          onStatusAction({
+            action: checked ? 'activate' : 'deactivate',
+            mode: 'single',
+            userId: user.id,
+          })
+        }
+      />
+      {user.status === 'pending' ? (
+        <Badge className={`rounded-full ${statusClassByValue[user.status]}`} variant="outline">
+          {t(statusTranslationKeyByValue[user.status])}
+        </Badge>
+      ) : null}
+    </div>
+  );
+
+const UserKeycloakCell = ({ user }: { user: UserListUser }) => {
+  const mappingStatus = user.mappingStatus ?? 'mapped';
+  const editability = user.editability ?? 'editable';
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        <Badge className="rounded-full" variant="outline">
+          {t(mappingStatusTranslationKey[mappingStatus])}
+        </Badge>
+        <Badge className={`rounded-full ${editabilityClassByValue[editability]}`} variant="outline">
+          {t(editabilityTranslationKey[editability])}
+        </Badge>
+      </div>
+      {renderDiagnosticCodes(user.diagnostics)}
+    </div>
+  );
+};
+
+const buildUserColumns = (
+  isAuthLoading: boolean,
+  isPlatformScope: boolean,
+  onStatusAction: React.Dispatch<React.SetStateAction<StatusActionDialogState | null>>,
+): readonly StudioColumnDef<UserListUser>[] => [
+  {
+    id: 'displayName',
+    header: t('admin.users.table.headerName'),
+    cell: (user) => user.displayName,
+    sortable: true,
+    sortValue: (user) => user.displayName.toLowerCase(),
+  },
+  {
+    id: 'email',
+    header: t('admin.users.table.headerEmail'),
+    cell: (user) => user.email ?? '-',
+    sortable: true,
+    sortValue: (user) => (user.email ?? '').toLowerCase(),
+  },
+  {
+    id: 'role',
+    header: t('admin.users.table.headerRole'),
+    cell: (user) => user.roles[0]?.roleName ?? '-',
+    sortable: true,
+    sortValue: (user) => (user.roles[0]?.roleName ?? '').toLowerCase(),
+  },
+  {
+    id: 'status',
+    header: t('admin.users.table.headerStatus'),
+    cell: (user) => (
+      <UserStatusCell
+        user={user}
+        isAuthLoading={isAuthLoading}
+        isPlatformScope={isPlatformScope}
+        onStatusAction={onStatusAction}
+      />
+    ),
+    sortable: true,
+    sortValue: (user) => user.status,
+  },
+  {
+    id: 'keycloak',
+    header: t('admin.users.table.headerKeycloak'),
+    cell: (user) => <UserKeycloakCell user={user} />,
+    sortable: true,
+    sortValue: (user) => `${user.mappingStatus ?? 'mapped'}:${user.editability ?? 'editable'}`,
+  },
+  {
+    id: 'lastLoginAt',
+    header: t('admin.users.table.headerLastLogin'),
+    cell: (user) => user.lastLoginAt ?? '-',
+    sortable: true,
+    sortValue: (user) => user.lastLoginAt ?? '',
+  },
+];
+
+const UserListToolbarStart = ({ usersApi }: { usersApi: UsersApiState }) => (
+  <>
+    <div className="flex flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+      <Label htmlFor="users-search">{t('admin.users.filters.searchLabel')}</Label>
+      <Input
+        id="users-search"
+        placeholder={t('admin.users.filters.searchPlaceholder')}
+        value={usersApi.filters.search}
+        onChange={(event) => usersApi.setSearch(event.target.value)}
+      />
+    </div>
+    <div className="flex flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+      <Label htmlFor="users-status">{t('admin.users.filters.statusLabel')}</Label>
+      <Select
+        id="users-status"
+        value={usersApi.filters.status}
+        onChange={(event) => usersApi.setStatus(event.target.value as 'active' | 'inactive' | 'pending' | 'all')}
+      >
+        <option value="all">{t('admin.users.filters.statusAll')}</option>
+        <option value="active">{t('admin.users.filters.statusActive')}</option>
+        <option value="inactive">{t('admin.users.filters.statusInactive')}</option>
+        <option value="pending">{t('admin.users.filters.statusPending')}</option>
+      </Select>
+    </div>
+  </>
+);
+
+const UserListToolbarEnd = ({
+  syncStatus,
+  total,
+  onSyncUsers,
+}: {
+  syncStatus: SyncStatusState;
+  total: number;
+  onSyncUsers: () => Promise<void>;
+}) => (
+  <>
+    <p role="status" className="text-xs text-muted-foreground">
+      {t('admin.users.messages.resultCount', { count: total })}
+    </p>
+    <Button
+      type="button"
+      variant="outline"
+      disabled={syncStatus === 'pending'}
+      onClick={() => void onSyncUsers()}
+    >
+      {syncStatus === 'pending' ? t('admin.users.actions.syncing') : t('admin.users.actions.syncKeycloak')}
+    </Button>
+  </>
+);
+
+const UserListSyncFeedback = ({
+  syncError,
+  syncResult,
+  syncStatus,
+  onRetry,
+}: {
+  syncError: Parameters<typeof userErrorMessage>[0];
+  syncResult: IamUserImportSyncReport | null;
+  syncStatus: SyncStatusState;
+  onRetry: () => Promise<void>;
+}) => {
+  if (syncStatus === 'pending') {
+    return (
+      <p role="status" aria-live="polite" className="text-xs text-muted-foreground">
+        {t('admin.users.messages.syncRunning')}
+      </p>
+    );
+  }
+
+  if (syncStatus === 'success' && syncResult) {
+    return (
+      <Alert className="border-secondary/40 bg-secondary/10 text-secondary" role="status">
+        <AlertDescription>
+          {t('admin.users.messages.syncResult', {
+            checkedCount: syncResult.checkedCount,
+            correctedCount: syncResult.correctedCount,
+            manualReviewCount: syncResult.manualReviewCount,
+            importedCount: syncResult.importedCount,
+            updatedCount: syncResult.updatedCount,
+            skippedCount: syncResult.skippedCount,
+          })}
+          <span className="block text-xs text-muted-foreground">
+            {t(syncOutcomeTranslationKey[syncResult.outcome])}
+          </span>
+          {syncResult.diagnostics ? (
+            <span className="block text-xs text-muted-foreground">
+              {t('admin.users.messages.syncDiagnostics', {
+                authRealm: syncResult.diagnostics.authRealm,
+                providerSource:
+                  syncResult.diagnostics.providerSource === 'instance'
+                    ? t('admin.users.messages.syncProviderSource.instance')
+                    : syncResult.diagnostics.providerSource === 'fallback_global'
+                      ? t('admin.users.messages.syncProviderSource.fallback_global')
+                      : syncResult.diagnostics.providerSource === 'platform'
+                        ? t('admin.users.messages.syncProviderSource.platform')
+                        : t('admin.users.messages.syncProviderSource.global'),
+                matchedWithoutInstanceAttributeCount: String(
+                  syncResult.diagnostics.matchedWithoutInstanceAttributeCount ?? 0
+                ),
+              })}
+            </span>
+          ) : null}
+          {syncResult.objects && syncResult.objects.length > 0 ? (
+            <span className="block text-xs text-muted-foreground">
+              {t('admin.users.messages.syncObjectDiagnostics', {
+                count: syncResult.objects.length,
+                codes: Array.from(
+                  new Set(
+                    syncResult.objects.flatMap((entry) =>
+                      entry.diagnostics.map((diagnostic) => diagnostic.code)
+                    )
+                  )
+                ).join(', '),
+              })}
+            </span>
+          ) : null}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (syncStatus === 'empty' && syncResult) {
+    return (
+      <Alert className="border-secondary/40 bg-secondary/10 text-secondary" role="status">
+        <AlertDescription>
+          {t('admin.users.messages.syncEmpty', {
+            skippedCount: syncResult.skippedCount,
+          })}
+          <span className="block text-xs text-muted-foreground">
+            {t(syncOutcomeTranslationKey[syncResult.outcome])}
+          </span>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (syncStatus === 'error' && syncError) {
+    return (
+      <Alert className="border-destructive/40 bg-destructive/10 text-destructive" role="alert">
+        <AlertDescription className="flex flex-col gap-3">
+          <span>{userErrorMessage(syncError)}</span>
+          <IamRuntimeDiagnosticDetails error={syncError} />
+          <div>
+            <Button type="button" size="sm" variant="outline" onClick={() => void onRetry()}>
+              {t('admin.users.actions.retry')}
+            </Button>
+          </div>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return null;
+};
+
+const UserListErrorAlert = ({
+  error,
+  onRetry,
+}: {
+  error: UsersApiState['error'];
+  onRetry: () => void;
+}) =>
+  error ? (
+    <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+      <AlertDescription className="flex flex-col gap-3">
+        <span>{userErrorMessage(error)}</span>
+        <IamRuntimeDiagnosticDetails error={error} />
+        <div>
+          <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+            {t('admin.users.actions.retry')}
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  ) : null;
+
+const UserListPaginationFooter = ({
+  page,
+  pageCount,
+  setPage,
+}: {
+  page: number;
+  pageCount: number;
+  setPage: (page: number) => void;
+}) => (
+  <footer className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+    <p key={page} className="animate-pagination-active" aria-live="polite">
+      {t('admin.users.pagination.pageLabel', { page, totalPages: pageCount })}
+    </p>
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={page <= 1}
+        onClick={() => setPage(page - 1)}
+      >
+        {t('admin.users.pagination.previous')}
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={page >= pageCount}
+        onClick={() => setPage(page + 1)}
+      >
+        {t('admin.users.pagination.next')}
+      </Button>
+    </div>
+  </footer>
+);
+
+const UserListRowActions = ({ user }: { user: UserListUser }) =>
+  user.editability === 'blocked' ? (
+    <Button
+      type="button"
+      size="icon"
+      variant="outline"
+      disabled
+      aria-label={t('admin.users.actions.edit')}
+      title={t('admin.users.actions.edit')}
+    >
+      <IconEdit aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  ) : (
+    <Button asChild type="button" size="icon" variant="outline">
+      <Link
+        to="/admin/users/$userId"
+        params={{ userId: user.id }}
+        aria-label={t('admin.users.actions.edit')}
+        title={t('admin.users.actions.edit')}
+      >
+        <IconEdit aria-hidden="true" className="h-4 w-4" />
+      </Link>
+    </Button>
+  );
+
+const getStatusActionDialogCopy = (statusActionDialog: StatusActionDialogState | null) => ({
+  title: t(
+    statusActionDialog?.action === 'activate'
+      ? 'admin.users.confirm.activateTitle'
+      : statusActionDialog?.mode === 'bulk'
+        ? 'admin.users.confirm.bulkTitle'
+        : 'admin.users.confirm.singleTitle'
+  ),
+  description: t(
+    statusActionDialog?.action === 'activate'
+      ? 'admin.users.confirm.activateDescription'
+      : statusActionDialog?.mode === 'bulk'
+        ? 'admin.users.confirm.bulkDescription'
+        : 'admin.users.confirm.singleDescription'
+  ),
+  confirmLabel: t(
+    statusActionDialog?.action === 'activate' ? 'admin.users.actions.activate' : 'admin.users.actions.deactivate'
+  ),
+});
+
+export const UserListPage = () => {
+  const studioDataTableLabels = createStudioDataTableLabels();
+  const usersApi = useUsers();
+
+  const [statusActionDialog, setStatusActionDialog] = React.useState<StatusActionDialogState | null>(null);
+  const { syncStatus, syncResult, syncError, onSyncUsers } = useUserSyncState(usersApi);
+  const { user } = useAuth();
+  const isPlatformScope = user !== null && !user.instanceId && hasPlatformInstanceAdminAccess(user);
+  const isAuthLoading = user === null;
+  const statusActionDialogCopy = getStatusActionDialogCopy(statusActionDialog);
+
+  const onConfirmStatusAction = React.useCallback(async () => {
+    const action = statusActionDialog;
+    setStatusActionDialog(null);
+    await executeStatusAction(usersApi, action);
+  }, [statusActionDialog, usersApi]);
 
   const pageCount = Math.max(1, Math.ceil(usersApi.total / usersApi.pageSize));
-  const userColumns = React.useMemo<readonly StudioColumnDef<(typeof usersApi.users)[number]>[]>(
-    () => [
-      {
-        id: 'displayName',
-        header: t('admin.users.table.headerName'),
-        cell: (user) => user.displayName,
-        sortable: true,
-        sortValue: (user) => user.displayName.toLowerCase(),
-      },
-      {
-        id: 'email',
-        header: t('admin.users.table.headerEmail'),
-        cell: (user) => user.email ?? '-',
-        sortable: true,
-        sortValue: (user) => (user.email ?? '').toLowerCase(),
-      },
-      {
-        id: 'role',
-        header: t('admin.users.table.headerRole'),
-        cell: (user) => user.roles[0]?.roleName ?? '-',
-        sortable: true,
-        sortValue: (user) => (user.roles[0]?.roleName ?? '').toLowerCase(),
-      },
-      {
-        id: 'status',
-        header: t('admin.users.table.headerStatus'),
-        cell: (user) =>
-          isPlatformScope || isAuthLoading ? (
-            <Badge className={`rounded-full ${statusClassByValue[user.status]}`} variant="outline">
-              {t(statusTranslationKeyByValue[user.status])}
-            </Badge>
-          ) : (
-            <div className="flex items-center gap-2">
-              <Switch
-                checked={user.status !== 'inactive'}
-                disabled={user.editability === 'blocked' || user.editability === 'read_only'}
-                aria-label={t('admin.users.messages.statusSwitchLabel', {
-                  name: user.displayName,
-                })}
-                onCheckedChange={(checked) =>
-                  setStatusActionDialog({
-                    action: checked ? 'activate' : 'deactivate',
-                    mode: 'single',
-                    userId: user.id,
-                  })
-                }
-              />
-              {user.status === 'pending' ? (
-                <Badge className={`rounded-full ${statusClassByValue[user.status]}`} variant="outline">
-                  {t(statusTranslationKeyByValue[user.status])}
-                </Badge>
-              ) : null}
-            </div>
-          ),
-        sortable: true,
-        sortValue: (user) => user.status,
-      },
-      {
-        id: 'keycloak',
-        header: t('admin.users.table.headerKeycloak'),
-        cell: (user) => {
-          const mappingStatus = user.mappingStatus ?? 'mapped';
-          const editability = user.editability ?? 'editable';
-          return (
-            <div className="space-y-2">
-              <div className="flex flex-wrap gap-2">
-                <Badge className="rounded-full" variant="outline">
-                  {t(mappingStatusTranslationKey[mappingStatus])}
-                </Badge>
-                <Badge className={`rounded-full ${editabilityClassByValue[editability]}`} variant="outline">
-                  {t(editabilityTranslationKey[editability])}
-                </Badge>
-              </div>
-              {renderDiagnosticCodes(user.diagnostics)}
-            </div>
-          );
-        },
-        sortable: true,
-        sortValue: (user) => `${user.mappingStatus ?? 'mapped'}:${user.editability ?? 'editable'}`,
-      },
-      {
-        id: 'lastLoginAt',
-        header: t('admin.users.table.headerLastLogin'),
-        cell: (user) => user.lastLoginAt ?? '-',
-        sortable: true,
-        sortValue: (user) => user.lastLoginAt ?? '',
-      },
-    ],
+  const userColumns = React.useMemo(
+    () => buildUserColumns(isAuthLoading, isPlatformScope, setStatusActionDialog),
     [isAuthLoading, isPlatformScope]
   );
 
@@ -284,219 +592,28 @@ export const UserListPage = () => {
                 ]
               : []
           }
-          toolbarStart={
-            <>
-              <div className="flex flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="users-search">{t('admin.users.filters.searchLabel')}</Label>
-                <Input
-                  id="users-search"
-                  placeholder={t('admin.users.filters.searchPlaceholder')}
-                  value={usersApi.filters.search}
-                  onChange={(event) => usersApi.setSearch(event.target.value)}
-                />
-              </div>
-              <div className="flex flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                <Label htmlFor="users-status">{t('admin.users.filters.statusLabel')}</Label>
-                <Select
-                  id="users-status"
-                  value={usersApi.filters.status}
-                  onChange={(event) => usersApi.setStatus(event.target.value as 'active' | 'inactive' | 'pending' | 'all')}
-                >
-                  <option value="all">{t('admin.users.filters.statusAll')}</option>
-                  <option value="active">{t('admin.users.filters.statusActive')}</option>
-                  <option value="inactive">{t('admin.users.filters.statusInactive')}</option>
-                  <option value="pending">{t('admin.users.filters.statusPending')}</option>
-                </Select>
-              </div>
-            </>
-          }
-          toolbarEnd={
-            <>
-              <p role="status" className="text-xs text-muted-foreground">
-                {t('admin.users.messages.resultCount', { count: usersApi.total })}
-              </p>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={syncStatus === 'pending'}
-                onClick={() => void onSyncUsers()}
-              >
-                {syncStatus === 'pending' ? t('admin.users.actions.syncing') : t('admin.users.actions.syncKeycloak')}
-              </Button>
-            </>
-          }
-          rowActions={isPlatformScope || isAuthLoading ? undefined : (user) => (
-            <>
-              {user.editability === 'blocked' ? (
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="outline"
-                  disabled
-                  aria-label={t('admin.users.actions.edit')}
-                  title={t('admin.users.actions.edit')}
-                >
-                  <IconEdit aria-hidden="true" className="h-4 w-4" />
-                </Button>
-              ) : (
-                <Button asChild type="button" size="icon" variant="outline">
-                  <Link
-                    to="/admin/users/$userId"
-                    params={{ userId: user.id }}
-                    aria-label={t('admin.users.actions.edit')}
-                    title={t('admin.users.actions.edit')}
-                  >
-                    <IconEdit aria-hidden="true" className="h-4 w-4" />
-                  </Link>
-                </Button>
-              )}
-            </>
-          )}
+          toolbarStart={<UserListToolbarStart usersApi={usersApi} />}
+          toolbarEnd={<UserListToolbarEnd syncStatus={syncStatus} total={usersApi.total} onSyncUsers={onSyncUsers} />}
+          rowActions={isPlatformScope || isAuthLoading ? undefined : (user) => <UserListRowActions user={user} />}
         />
       </StudioListPageTemplate>
 
-      {syncStatus === 'pending' ? (
-        <p role="status" aria-live="polite" className="text-xs text-muted-foreground">
-          {t('admin.users.messages.syncRunning')}
-        </p>
-      ) : null}
+      <UserListSyncFeedback
+        syncStatus={syncStatus}
+        syncResult={syncResult}
+        syncError={syncError}
+        onRetry={onSyncUsers}
+      />
 
-      {syncStatus === 'success' && syncResult ? (
-        <Alert className="border-secondary/40 bg-secondary/10 text-secondary" role="status">
-          <AlertDescription>
-            {t('admin.users.messages.syncResult', {
-              checkedCount: syncResult.checkedCount,
-              correctedCount: syncResult.correctedCount,
-              manualReviewCount: syncResult.manualReviewCount,
-              importedCount: syncResult.importedCount,
-              updatedCount: syncResult.updatedCount,
-              skippedCount: syncResult.skippedCount,
-            })}
-            <span className="block text-xs text-muted-foreground">
-              {t(syncOutcomeTranslationKey[syncResult.outcome])}
-            </span>
-            {syncResult.diagnostics ? (
-              <span className="block text-xs text-muted-foreground">
-                {t('admin.users.messages.syncDiagnostics', {
-                  authRealm: syncResult.diagnostics.authRealm,
-                  providerSource:
-                    syncResult.diagnostics.providerSource === 'instance'
-                      ? t('admin.users.messages.syncProviderSource.instance')
-                      : syncResult.diagnostics.providerSource === 'fallback_global'
-                        ? t('admin.users.messages.syncProviderSource.fallback_global')
-                        : syncResult.diagnostics.providerSource === 'platform'
-                          ? t('admin.users.messages.syncProviderSource.platform')
-                          : t('admin.users.messages.syncProviderSource.global'),
-                  matchedWithoutInstanceAttributeCount: String(
-                    syncResult.diagnostics.matchedWithoutInstanceAttributeCount ?? 0
-                  ),
-                })}
-              </span>
-            ) : null}
-            {syncResult.objects && syncResult.objects.length > 0 ? (
-              <span className="block text-xs text-muted-foreground">
-                {t('admin.users.messages.syncObjectDiagnostics', {
-                  count: syncResult.objects.length,
-                  codes: Array.from(
-                    new Set(
-                      syncResult.objects.flatMap((entry) =>
-                        entry.diagnostics.map((diagnostic) => diagnostic.code)
-                      )
-                    )
-                  ).join(', '),
-                })}
-              </span>
-            ) : null}
-          </AlertDescription>
-        </Alert>
-      ) : null}
+      <UserListErrorAlert error={usersApi.error} onRetry={() => void usersApi.refetch()} />
 
-      {syncStatus === 'empty' && syncResult ? (
-        <Alert className="border-secondary/40 bg-secondary/10 text-secondary" role="status">
-          <AlertDescription>
-            {t('admin.users.messages.syncEmpty', {
-              skippedCount: syncResult.skippedCount,
-            })}
-            <span className="block text-xs text-muted-foreground">
-              {t(syncOutcomeTranslationKey[syncResult.outcome])}
-            </span>
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {syncStatus === 'error' && syncError ? (
-        <Alert className="border-destructive/40 bg-destructive/10 text-destructive" role="alert">
-          <AlertDescription className="flex flex-col gap-3">
-            <span>{userErrorMessage(syncError)}</span>
-            <IamRuntimeDiagnosticDetails error={syncError} />
-            <div>
-              <Button type="button" size="sm" variant="outline" onClick={() => void onSyncUsers()}>
-                {t('admin.users.actions.retry')}
-              </Button>
-            </div>
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {usersApi.error ? (
-        <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-          <AlertDescription className="flex flex-col gap-3">
-            <span>{userErrorMessage(usersApi.error)}</span>
-            <IamRuntimeDiagnosticDetails error={usersApi.error} />
-            <div>
-              <Button type="button" size="sm" variant="outline" onClick={() => void usersApi.refetch()}>
-                {t('admin.users.actions.retry')}
-              </Button>
-            </div>
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      <footer className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
-        <p key={usersApi.page} className="animate-pagination-active" aria-live="polite">
-          {t('admin.users.pagination.pageLabel', { page: usersApi.page, totalPages: pageCount })}
-        </p>
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={usersApi.page <= 1}
-            onClick={() => usersApi.setPage(usersApi.page - 1)}
-          >
-            {t('admin.users.pagination.previous')}
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={usersApi.page >= pageCount}
-            onClick={() => usersApi.setPage(usersApi.page + 1)}
-          >
-            {t('admin.users.pagination.next')}
-          </Button>
-        </div>
-      </footer>
+      <UserListPaginationFooter page={usersApi.page} pageCount={pageCount} setPage={usersApi.setPage} />
 
       <ConfirmDialog
         open={Boolean(statusActionDialog)}
-        title={t(
-          statusActionDialog?.action === 'activate'
-            ? 'admin.users.confirm.activateTitle'
-            : statusActionDialog?.mode === 'bulk'
-              ? 'admin.users.confirm.bulkTitle'
-              : 'admin.users.confirm.singleTitle'
-        )}
-        description={t(
-          statusActionDialog?.action === 'activate'
-            ? 'admin.users.confirm.activateDescription'
-            : statusActionDialog?.mode === 'bulk'
-              ? 'admin.users.confirm.bulkDescription'
-              : 'admin.users.confirm.singleDescription'
-        )}
-        confirmLabel={t(
-          statusActionDialog?.action === 'activate' ? 'admin.users.actions.activate' : 'admin.users.actions.deactivate'
-        )}
+        title={statusActionDialogCopy.title}
+        description={statusActionDialogCopy.description}
+        confirmLabel={statusActionDialogCopy.confirmLabel}
         cancelLabel={t('account.actions.cancel')}
         onCancel={() => setStatusActionDialog(null)}
         onConfirm={() => void onConfirmStatusAction()}

--- a/packages/auth-runtime/src/effective-session-roles.ts
+++ b/packages/auth-runtime/src/effective-session-roles.ts
@@ -85,17 +85,18 @@ export const enrichSessionUserWithEffectiveRoles = async (
   user: SessionUser,
   deps: EffectiveSessionRoleDeps = defaultDeps
 ): Promise<SessionUser> => {
-  if (!user.instanceId) {
+  const instanceId = user.instanceId;
+  if (!instanceId) {
     return user;
   }
 
   try {
     const persistedRoleNames = await deps.withResolvedInstanceDb(
       deps.resolvePool,
-      user.instanceId,
+      instanceId,
       async (client) =>
         loadPersistedEffectiveRoleNames(client, {
-          instanceId: user.instanceId!,
+          instanceId,
           keycloakSubject: user.id,
         })
     );
@@ -115,9 +116,9 @@ export const enrichSessionUserWithEffectiveRoles = async (
   } catch (error) {
     logger.warn('Effective IAM role hydration failed for session user', {
       user_id: user.id,
-      instance_id: user.instanceId,
+      instance_id: instanceId,
       error: error instanceof Error ? error.message : String(error),
-      ...buildLogContext({ kind: 'instance', instanceId: user.instanceId }),
+      ...buildLogContext({ kind: 'instance', instanceId }),
     });
     return user;
   }

--- a/packages/auth-runtime/src/iam-account-management/platform-handlers.ts
+++ b/packages/auth-runtime/src/iam-account-management/platform-handlers.ts
@@ -167,134 +167,126 @@ const resolveRuntimeAuthDisplay = async (
   };
 };
 
+const createReadyDependencyStatus = <TDiagnostics extends Record<string, unknown>>(diagnostics: TDiagnostics) => ({
+  ready: true as const,
+  diagnostics,
+});
+
+const createFailedDependencyStatus = <TDiagnostics extends Record<string, unknown>>(
+  error: string,
+  diagnostics: TDiagnostics
+) => ({
+  ready: false as const,
+  error,
+  diagnostics,
+});
+
+const resolveReadyDatabaseStatus = async () => {
+  try {
+    const pool = resolvePool();
+    if (!pool) {
+      return createFailedDependencyStatus('IAM database not configured', {
+        dependency: 'database',
+        reason_code: 'database_not_configured',
+      });
+    }
+
+    let client;
+    try {
+      client = await pool.connect();
+    } catch (error) {
+      const bootstrapped = await bootstrapStudioAppDbUserIfNeeded(error);
+      if (!bootstrapped) {
+        throw error;
+      }
+      client = await pool.connect();
+    }
+
+    try {
+      await client.query('SELECT 1;');
+      const schemaGuard = await runCriticalIamSchemaGuard(client);
+      if (!schemaGuard.ok) {
+        return createFailedDependencyStatus(summarizeSchemaGuardFailures(schemaGuard) ?? 'critical_schema_drift', {
+          dependency: 'database',
+          reason_code: 'schema_drift',
+          schema_guard: schemaGuard,
+        });
+      }
+
+      return createReadyDependencyStatus({
+        dependency: 'database',
+        reason_code: 'ready',
+        schema_guard: schemaGuard,
+      });
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    return createFailedDependencyStatus(error instanceof Error ? error.message : String(error), {
+      dependency: 'database',
+      reason_code: 'database_connection_failed',
+    });
+  }
+};
+
+const resolveReadyRedisStatus = async () => {
+  try {
+    const redisReady = await isRedisAvailable();
+    if (redisReady) {
+      return createReadyDependencyStatus({
+        dependency: 'redis',
+        reason_code: 'ready',
+      });
+    }
+
+    return createFailedDependencyStatus(getLastRedisError() ?? 'Redis ping failed', {
+      dependency: 'redis',
+      reason_code: 'redis_ping_failed',
+    });
+  } catch (error) {
+    return createFailedDependencyStatus(error instanceof Error ? error.message : String(error), {
+      dependency: 'redis',
+      reason_code: 'redis_ping_failed',
+    });
+  }
+};
+
+const resolveReadyKeycloakStatus = async () => {
+  const idp = resolveIdentityProvider();
+  if (!idp) {
+    return createFailedDependencyStatus('Keycloak admin client not configured', {
+      dependency: 'keycloak',
+      reason_code: 'keycloak_admin_not_configured',
+    });
+  }
+
+  if (!isKeycloakIdentityProvider(idp.provider)) {
+    return createReadyDependencyStatus({
+      dependency: 'keycloak',
+      reason_code: 'ready',
+    });
+  }
+
+  try {
+    await trackKeycloakCall('readiness_list_roles', () => idp.provider.listRoles());
+    return createReadyDependencyStatus({
+      dependency: 'keycloak',
+      reason_code: 'ready',
+    });
+  } catch (error) {
+    return createFailedDependencyStatus(error instanceof Error ? error.message : String(error), {
+      dependency: 'keycloak',
+      reason_code: 'keycloak_dependency_failed',
+    });
+  }
+};
+
 export const readyInternal = async (request: Request): Promise<Response> => {
   const requestContext = getWorkspaceContext();
   const runtimeAuth = await resolveRuntimeAuthDisplay(request);
-  const dbStatus = await (async () => {
-    try {
-      const pool = resolvePool();
-      if (!pool) {
-        return { ready: false, error: 'IAM database not configured' };
-      }
-      let client;
-      try {
-        client = await pool.connect();
-      } catch (error) {
-        const bootstrapped = await bootstrapStudioAppDbUserIfNeeded(error);
-        if (!bootstrapped) {
-          throw error;
-        }
-        client = await pool.connect();
-      }
-      try {
-        await client.query('SELECT 1;');
-        const schemaGuard = await runCriticalIamSchemaGuard(client);
-        if (!schemaGuard.ok) {
-          return {
-            ready: false,
-            error: summarizeSchemaGuardFailures(schemaGuard) ?? 'critical_schema_drift',
-            diagnostics: {
-              dependency: 'database',
-              reason_code: 'schema_drift',
-              schema_guard: schemaGuard,
-            },
-          };
-        }
-        return {
-          ready: true as const,
-          diagnostics: {
-            dependency: 'database',
-            reason_code: 'ready',
-            schema_guard: schemaGuard,
-          },
-        };
-      } finally {
-        client.release();
-      }
-    } catch (error) {
-      return {
-        ready: false,
-        error: error instanceof Error ? error.message : String(error),
-        diagnostics: {
-          dependency: 'database',
-          reason_code: 'database_connection_failed',
-        },
-      };
-    }
-  })();
-
-  const redisStatus = await (async () => {
-    try {
-      const redisReady = await isRedisAvailable();
-      return redisReady
-        ? {
-            ready: true as const,
-            diagnostics: {
-              dependency: 'redis',
-              reason_code: 'ready',
-            },
-          }
-        : {
-            ready: false,
-            error: getLastRedisError() ?? 'Redis ping failed',
-            diagnostics: {
-              dependency: 'redis',
-              reason_code: 'redis_ping_failed',
-            },
-          };
-    } catch (error) {
-      return {
-        ready: false,
-        error: error instanceof Error ? error.message : String(error),
-        diagnostics: {
-          dependency: 'redis',
-          reason_code: 'redis_ping_failed',
-        },
-      };
-    }
-  })();
-
-  const keycloakStatus = await (async () => {
-    const idp = resolveIdentityProvider();
-    if (!idp) {
-      return {
-        ready: false,
-        error: 'Keycloak admin client not configured',
-        diagnostics: {
-          dependency: 'keycloak',
-          reason_code: 'keycloak_admin_not_configured',
-        },
-      };
-    }
-    if (isKeycloakIdentityProvider(idp.provider)) {
-      try {
-        await trackKeycloakCall('readiness_list_roles', () => idp.provider.listRoles());
-        return {
-          ready: true as const,
-          diagnostics: {
-            dependency: 'keycloak',
-            reason_code: 'ready',
-          },
-        };
-      } catch (error) {
-        return {
-          ready: false,
-          error: error instanceof Error ? error.message : String(error),
-          diagnostics: {
-            dependency: 'keycloak',
-            reason_code: 'keycloak_dependency_failed',
-          },
-        };
-      }
-    }
-    return {
-      ready: true as const,
-      diagnostics: {
-        dependency: 'keycloak',
-        reason_code: 'ready',
-      },
-    };
-  })();
+  const dbStatus = await resolveReadyDatabaseStatus();
+  const redisStatus = await resolveReadyRedisStatus();
+  const keycloakStatus = await resolveReadyKeycloakStatus();
 
   const authorizationCache = getPermissionCacheHealth();
   const allReady = dbStatus.ready && redisStatus.ready && keycloakStatus.ready;

--- a/packages/auth-runtime/src/iam-authorization/authorize-performance-benchmark.ts
+++ b/packages/auth-runtime/src/iam-authorization/authorize-performance-benchmark.ts
@@ -1,0 +1,303 @@
+import type {
+  AuthorizePerformanceRequest,
+  AuthorizePerformanceScenario,
+  AuthorizePerformanceScenarioResult,
+  AuthorizeResponse,
+} from '@sva/core';
+import { buildAuthorizePerformancePayload, summarizeAuthorizePerformanceDurations } from '@sva/core';
+
+import { authorizeHandler } from './authorize.js';
+import { invalidateRedisPermissionSnapshots } from './redis-permission-snapshot.server.js';
+import { permissionSnapshotCache } from './shared.js';
+
+export type BenchmarkActor = {
+  readonly id: string;
+  readonly instanceId: string;
+};
+
+export type BenchmarkInput = {
+  readonly actor: BenchmarkActor;
+  readonly request: AuthorizePerformanceRequest;
+  readonly requestHeaders: Headers;
+  readonly requestUrl: string;
+};
+
+type ScenarioExecutionInput = BenchmarkInput & {
+  readonly measuredRequests: number;
+  readonly runId: string;
+  readonly warmupRequests: number;
+};
+
+const scenarioThresholdMs = (scenario: AuthorizePerformanceScenario): number => {
+  switch (scenario) {
+    case 'cache-hit':
+      return 100;
+    case 'cache-miss':
+      return 300;
+    case 'recompute':
+      return 300;
+  }
+};
+
+const assertScenarioStatuses = (input: {
+  readonly observedStatuses: readonly string[];
+  readonly scenario: AuthorizePerformanceScenario;
+}): void => {
+  if (input.observedStatuses.length === 0) {
+    throw new Error(`scenario:${input.scenario}:empty`);
+  }
+
+  if (input.scenario === 'cache-hit' && input.observedStatuses.some((status) => status !== 'hit')) {
+    throw new Error(`scenario:${input.scenario}:unexpected_cache_status`);
+  }
+
+  if (input.scenario === 'cache-miss' && input.observedStatuses.some((status) => status !== 'miss')) {
+    throw new Error(`scenario:${input.scenario}:unexpected_cache_status`);
+  }
+
+  if (input.scenario === 'recompute' && input.observedStatuses.some((status) => status === 'hit')) {
+    throw new Error(`scenario:${input.scenario}:unexpected_cache_status`);
+  }
+};
+
+const cloneHeadersForAuthorize = (headers: Headers, body: string): Headers => {
+  const nextHeaders = new Headers();
+  const headerNames = ['cookie', 'authorization', 'x-requested-with', 'origin', 'referer', 'traceparent'];
+
+  for (const headerName of headerNames) {
+    const value = headers.get(headerName);
+    if (value) {
+      nextHeaders.set(headerName, value);
+    }
+  }
+
+  nextHeaders.set('content-type', 'application/json');
+  nextHeaders.set('content-length', String(body.length));
+  nextHeaders.set('x-requested-with', nextHeaders.get('x-requested-with') ?? 'XMLHttpRequest');
+  return nextHeaders;
+};
+
+const invokeAuthorize = async (input: {
+  readonly headers: Headers;
+  readonly payload: ReturnType<typeof buildAuthorizePerformancePayload>;
+  readonly requestUrl: string;
+}): Promise<{
+  readonly cacheStatus: string;
+  readonly durationMs: number;
+}> => {
+  const startedAt = performance.now();
+  const body = JSON.stringify(input.payload);
+  const response = await authorizeHandler(
+    new Request(new URL('/iam/authorize', input.requestUrl).toString(), {
+      method: 'POST',
+      headers: cloneHeadersForAuthorize(input.headers, body),
+      body,
+    })
+  );
+  const durationMs = performance.now() - startedAt;
+
+  if (!response.ok) {
+    throw new Error(`authorize_http_${response.status}`);
+  }
+
+  const json = (await response.json()) as Partial<AuthorizeResponse>;
+  if (typeof json.cacheStatus !== 'string') {
+    throw new Error('authorize_missing_cache_status');
+  }
+
+  return {
+    cacheStatus: json.cacheStatus,
+    durationMs,
+  };
+};
+
+const invalidateUserScope = async (actor: BenchmarkActor): Promise<void> => {
+  permissionSnapshotCache.invalidate({
+    instanceId: actor.instanceId,
+    keycloakSubject: actor.id,
+  });
+  await invalidateRedisPermissionSnapshots(actor.instanceId, actor.id);
+};
+
+const buildAuthorizePerformanceBasePayload = (input: BenchmarkInput) => ({
+  instanceId: input.actor.instanceId,
+  action: input.request.action,
+  resource: {
+    type: input.request.resourceType,
+    ...(input.request.resourceId ? { id: input.request.resourceId } : {}),
+    ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
+  },
+  context: {
+    ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
+  },
+});
+
+const buildScenarioStableWarmupPayload = (input: {
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+}) =>
+  input.scenario === 'cache-miss'
+    ? null
+    : buildAuthorizePerformancePayload({
+        basePayload: input.basePayload,
+        runId: input.runId,
+        sampleIndex: 0,
+        scenario: input.scenario,
+      });
+
+const buildScenarioWarmupPayload = (input: {
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly runId: string;
+  readonly sampleIndex: number;
+  readonly scenario: AuthorizePerformanceScenario;
+  readonly stableWarmupPayload: ReturnType<typeof buildAuthorizePerformancePayload> | null;
+}) => {
+  if (input.scenario !== 'cache-miss') {
+    return input.stableWarmupPayload;
+  }
+
+  return buildAuthorizePerformancePayload({
+    basePayload: input.basePayload,
+    runId: `${input.runId}-warmup`,
+    sampleIndex: input.sampleIndex,
+    scenario: input.scenario,
+  });
+};
+
+const maybeInvalidateScopeForScenario = async (
+  scenario: AuthorizePerformanceScenario,
+  actor: BenchmarkActor
+): Promise<void> => {
+  if (scenario === 'recompute') {
+    await invalidateUserScope(actor);
+  }
+};
+
+const runScenarioWarmup = async (input: {
+  readonly actor: BenchmarkActor;
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly headers: Headers;
+  readonly requestUrl: string;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+  readonly warmupRequests: number;
+}): Promise<void> => {
+  const stableWarmupPayload = buildScenarioStableWarmupPayload({
+    basePayload: input.basePayload,
+    runId: input.runId,
+    scenario: input.scenario,
+  });
+
+  for (let index = 0; index < input.warmupRequests; index += 1) {
+    await maybeInvalidateScopeForScenario(input.scenario, input.actor);
+    const warmupPayload = buildScenarioWarmupPayload({
+      basePayload: input.basePayload,
+      runId: input.runId,
+      sampleIndex: index,
+      scenario: input.scenario,
+      stableWarmupPayload,
+    });
+
+    if (!warmupPayload) {
+      throw new Error('warmup_payload_missing');
+    }
+
+    await invokeAuthorize({
+      headers: input.headers,
+      payload: warmupPayload,
+      requestUrl: input.requestUrl,
+    });
+  }
+};
+
+const runScenarioMeasurements = async (input: {
+  readonly actor: BenchmarkActor;
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly headers: Headers;
+  readonly measuredRequests: number;
+  readonly requestUrl: string;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+}): Promise<{
+  readonly observedStatuses: string[];
+  readonly samplesMs: number[];
+}> => {
+  const observedStatuses: string[] = [];
+  const samplesMs: number[] = [];
+
+  for (let sampleIndex = 0; sampleIndex < input.measuredRequests; sampleIndex += 1) {
+    await maybeInvalidateScopeForScenario(input.scenario, input.actor);
+    const payload = buildAuthorizePerformancePayload({
+      basePayload: input.basePayload,
+      runId: input.runId,
+      sampleIndex,
+      scenario: input.scenario,
+    });
+    const result = await invokeAuthorize({
+      headers: input.headers,
+      payload,
+      requestUrl: input.requestUrl,
+    });
+
+    samplesMs.push(result.durationMs);
+    observedStatuses.push(result.cacheStatus);
+  }
+
+  return { observedStatuses, samplesMs };
+};
+
+const runScenarioBenchmark = async (input: {
+  readonly actor: BenchmarkActor;
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly headers: Headers;
+  readonly measuredRequests: number;
+  readonly requestUrl: string;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+  readonly warmupRequests: number;
+}): Promise<AuthorizePerformanceScenarioResult> => {
+  await runScenarioWarmup(input);
+  const { observedStatuses, samplesMs } = await runScenarioMeasurements(input);
+
+  assertScenarioStatuses({
+    observedStatuses,
+    scenario: input.scenario,
+  });
+
+  const summary = summarizeAuthorizePerformanceDurations(samplesMs);
+  const evaluation = summary.p95Ms < scenarioThresholdMs(input.scenario) ? 'accepted' : 'rejected';
+
+  return {
+    scenario: input.scenario,
+    samplesMs,
+    summary,
+    evaluation,
+    evaluationLabel: evaluation === 'accepted' ? 'erfüllt' : 'nicht erfüllt',
+    observedCacheStatuses: observedStatuses,
+  };
+};
+
+export const runAuthorizePerformanceScenarios = async (
+  input: ScenarioExecutionInput
+): Promise<AuthorizePerformanceScenarioResult[]> => {
+  const basePayload = buildAuthorizePerformanceBasePayload(input);
+  const scenarios: AuthorizePerformanceScenarioResult[] = [];
+
+  for (const scenario of ['cache-hit', 'cache-miss', 'recompute'] as const) {
+    scenarios.push(
+      await runScenarioBenchmark({
+        actor: input.actor,
+        basePayload,
+        headers: input.requestHeaders,
+        measuredRequests: input.measuredRequests,
+        requestUrl: input.requestUrl,
+        runId: input.runId,
+        scenario,
+        warmupRequests: input.warmupRequests,
+      })
+    );
+  }
+
+  return scenarios;
+};

--- a/packages/auth-runtime/src/iam-authorization/authorize-performance.server.ts
+++ b/packages/auth-runtime/src/iam-authorization/authorize-performance.server.ts
@@ -3,33 +3,11 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type {
-  AuthorizePerformanceRequest,
   AuthorizePerformanceRunResult,
-  AuthorizePerformanceScenario,
-  AuthorizePerformanceScenarioResult,
-  AuthorizeResponse,
 } from '@sva/core';
-import {
-  buildAuthorizePerformancePayload,
-  renderAuthorizePerformanceMarkdownReport,
-  summarizeAuthorizePerformanceDurations,
-} from '@sva/core';
+import { renderAuthorizePerformanceMarkdownReport } from '@sva/core';
 
-import { authorizeHandler } from './authorize.js';
-import { invalidateRedisPermissionSnapshots } from './redis-permission-snapshot.server.js';
-import { permissionSnapshotCache } from './shared.js';
-
-type BenchmarkActor = {
-  readonly id: string;
-  readonly instanceId: string;
-};
-
-type BenchmarkInput = {
-  readonly actor: BenchmarkActor;
-  readonly request: AuthorizePerformanceRequest;
-  readonly requestHeaders: Headers;
-  readonly requestUrl: string;
-};
+import { runAuthorizePerformanceScenarios, type BenchmarkInput } from './authorize-performance-benchmark.js';
 
 const DEFAULT_MEASURED_REQUESTS = 12;
 const DEFAULT_WARMUP_REQUESTS = 2;
@@ -53,97 +31,6 @@ const sweepExpiredBenchmarks = (): void => {
       latestBenchmarkByActor.delete(actorKey);
     }
   }
-};
-
-const scenarioThresholdMs = (scenario: AuthorizePerformanceScenario): number => {
-  switch (scenario) {
-    case 'cache-hit':
-      return 100;
-    case 'cache-miss':
-      return 300;
-    case 'recompute':
-      return 300;
-  }
-};
-
-const assertScenarioStatuses = (input: {
-  readonly observedStatuses: readonly string[];
-  readonly scenario: AuthorizePerformanceScenario;
-}): void => {
-  if (input.observedStatuses.length === 0) {
-    throw new Error(`scenario:${input.scenario}:empty`);
-  }
-
-  if (input.scenario === 'cache-hit' && input.observedStatuses.some((status) => status !== 'hit')) {
-    throw new Error(`scenario:${input.scenario}:unexpected_cache_status`);
-  }
-
-  if (input.scenario === 'cache-miss' && input.observedStatuses.some((status) => status !== 'miss')) {
-    throw new Error(`scenario:${input.scenario}:unexpected_cache_status`);
-  }
-
-  if (input.scenario === 'recompute' && input.observedStatuses.some((status) => status === 'hit')) {
-    throw new Error(`scenario:${input.scenario}:unexpected_cache_status`);
-  }
-};
-
-const cloneHeadersForAuthorize = (headers: Headers, body: string): Headers => {
-  const nextHeaders = new Headers();
-  const headerNames = ['cookie', 'authorization', 'x-requested-with', 'origin', 'referer', 'traceparent'];
-
-  for (const headerName of headerNames) {
-    const value = headers.get(headerName);
-    if (value) {
-      nextHeaders.set(headerName, value);
-    }
-  }
-
-  nextHeaders.set('content-type', 'application/json');
-  nextHeaders.set('content-length', String(body.length));
-  nextHeaders.set('x-requested-with', nextHeaders.get('x-requested-with') ?? 'XMLHttpRequest');
-  return nextHeaders;
-};
-
-const invokeAuthorize = async (input: {
-  readonly headers: Headers;
-  readonly payload: ReturnType<typeof buildAuthorizePerformancePayload>;
-  readonly requestUrl: string;
-}): Promise<{
-  readonly cacheStatus: string;
-  readonly durationMs: number;
-}> => {
-  const startedAt = performance.now();
-  const body = JSON.stringify(input.payload);
-  const response = await authorizeHandler(
-    new Request(new URL('/iam/authorize', input.requestUrl).toString(), {
-      method: 'POST',
-      headers: cloneHeadersForAuthorize(input.headers, body),
-      body,
-    })
-  );
-  const durationMs = performance.now() - startedAt;
-
-  if (!response.ok) {
-    throw new Error(`authorize_http_${response.status}`);
-  }
-
-  const json = (await response.json()) as Partial<AuthorizeResponse>;
-  if (typeof json.cacheStatus !== 'string') {
-    throw new Error('authorize_missing_cache_status');
-  }
-
-  return {
-    cacheStatus: json.cacheStatus,
-    durationMs,
-  };
-};
-
-const invalidateUserScope = async (actor: BenchmarkActor): Promise<void> => {
-  permissionSnapshotCache.invalidate({
-    instanceId: actor.instanceId,
-    keycloakSubject: actor.id,
-  });
-  await invalidateRedisPermissionSnapshots(actor.instanceId, actor.id);
 };
 
 const createFilesystemSafeIsoTimestamp = (value: Date): string =>
@@ -178,162 +65,6 @@ export const readLatestAuthorizePerformanceBenchmark = (input: {
     return latestBenchmarkByActor.get(toActorKey(input))?.result ?? null;
   };
 
-const buildAuthorizePerformanceBasePayload = (input: BenchmarkInput) => ({
-  instanceId: input.actor.instanceId,
-  action: input.request.action,
-  resource: {
-    type: input.request.resourceType,
-    ...(input.request.resourceId ? { id: input.request.resourceId } : {}),
-    ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
-  },
-  context: {
-    ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
-  },
-});
-
-const buildScenarioStableWarmupPayload = (input: {
-  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
-  readonly runId: string;
-  readonly scenario: AuthorizePerformanceScenario;
-}) =>
-  input.scenario === 'cache-miss'
-    ? null
-    : buildAuthorizePerformancePayload({
-        basePayload: input.basePayload,
-        runId: input.runId,
-        sampleIndex: 0,
-        scenario: input.scenario,
-      });
-
-const buildScenarioWarmupPayload = (input: {
-  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
-  readonly runId: string;
-  readonly sampleIndex: number;
-  readonly scenario: AuthorizePerformanceScenario;
-  readonly stableWarmupPayload: ReturnType<typeof buildAuthorizePerformancePayload> | null;
-}) => {
-  if (input.scenario !== 'cache-miss') {
-    return input.stableWarmupPayload;
-  }
-
-  return buildAuthorizePerformancePayload({
-    basePayload: input.basePayload,
-    runId: `${input.runId}-warmup`,
-    sampleIndex: input.sampleIndex,
-    scenario: input.scenario,
-  });
-};
-
-const maybeInvalidateScopeForScenario = async (scenario: AuthorizePerformanceScenario, actor: BenchmarkActor): Promise<void> => {
-  if (scenario === 'recompute') {
-    await invalidateUserScope(actor);
-  }
-};
-
-const runScenarioWarmup = async (input: {
-  readonly actor: BenchmarkActor;
-  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
-  readonly headers: Headers;
-  readonly requestUrl: string;
-  readonly runId: string;
-  readonly scenario: AuthorizePerformanceScenario;
-  readonly warmupRequests: number;
-}): Promise<void> => {
-  const stableWarmupPayload = buildScenarioStableWarmupPayload({
-    basePayload: input.basePayload,
-    runId: input.runId,
-    scenario: input.scenario,
-  });
-
-  for (let index = 0; index < input.warmupRequests; index += 1) {
-    await maybeInvalidateScopeForScenario(input.scenario, input.actor);
-    const warmupPayload = buildScenarioWarmupPayload({
-      basePayload: input.basePayload,
-      runId: input.runId,
-      sampleIndex: index,
-      scenario: input.scenario,
-      stableWarmupPayload,
-    });
-
-    if (!warmupPayload) {
-      throw new Error('warmup_payload_missing');
-    }
-
-    await invokeAuthorize({
-      headers: input.headers,
-      payload: warmupPayload,
-      requestUrl: input.requestUrl,
-    });
-  }
-};
-
-const runScenarioMeasurements = async (input: {
-  readonly actor: BenchmarkActor;
-  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
-  readonly headers: Headers;
-  readonly measuredRequests: number;
-  readonly requestUrl: string;
-  readonly runId: string;
-  readonly scenario: AuthorizePerformanceScenario;
-}): Promise<{
-  readonly observedStatuses: string[];
-  readonly samplesMs: number[];
-}> => {
-  const observedStatuses: string[] = [];
-  const samplesMs: number[] = [];
-
-  for (let sampleIndex = 0; sampleIndex < input.measuredRequests; sampleIndex += 1) {
-    await maybeInvalidateScopeForScenario(input.scenario, input.actor);
-    const payload = buildAuthorizePerformancePayload({
-      basePayload: input.basePayload,
-      runId: input.runId,
-      sampleIndex,
-      scenario: input.scenario,
-    });
-    const result = await invokeAuthorize({
-      headers: input.headers,
-      payload,
-      requestUrl: input.requestUrl,
-    });
-
-    samplesMs.push(result.durationMs);
-    observedStatuses.push(result.cacheStatus);
-  }
-
-  return { observedStatuses, samplesMs };
-};
-
-const runScenarioBenchmark = async (input: {
-  readonly actor: BenchmarkActor;
-  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
-  readonly headers: Headers;
-  readonly measuredRequests: number;
-  readonly requestUrl: string;
-  readonly runId: string;
-  readonly scenario: AuthorizePerformanceScenario;
-  readonly warmupRequests: number;
-}): Promise<AuthorizePerformanceScenarioResult> => {
-  await runScenarioWarmup(input);
-  const { observedStatuses, samplesMs } = await runScenarioMeasurements(input);
-
-  assertScenarioStatuses({
-    observedStatuses,
-    scenario: input.scenario,
-  });
-
-  const summary = summarizeAuthorizePerformanceDurations(samplesMs);
-  const evaluation = summary.p95Ms < scenarioThresholdMs(input.scenario) ? 'accepted' : 'rejected';
-
-  return {
-    scenario: input.scenario,
-    samplesMs,
-    summary,
-    evaluation,
-    evaluationLabel: evaluation === 'accepted' ? 'erfüllt' : 'nicht erfüllt',
-    observedCacheStatuses: observedStatuses,
-  };
-};
-
 export const runAuthorizePerformanceBenchmark = async (
   input: BenchmarkInput
 ): Promise<AuthorizePerformanceRunResult> => {
@@ -341,23 +72,12 @@ export const runAuthorizePerformanceBenchmark = async (
   const measuredRequests = input.request.measuredRequests ?? DEFAULT_MEASURED_REQUESTS;
   const warmupRequests = input.request.warmupRequests ?? DEFAULT_WARMUP_REQUESTS;
   const runId = generatedAt.getTime().toString(36);
-  const basePayload = buildAuthorizePerformanceBasePayload(input);
-
-  const scenarios: AuthorizePerformanceScenarioResult[] = [];
-  for (const scenario of ['cache-hit', 'cache-miss', 'recompute'] as const) {
-    scenarios.push(
-      await runScenarioBenchmark({
-        actor: input.actor,
-        basePayload,
-        headers: input.requestHeaders,
-        measuredRequests,
-        requestUrl: input.requestUrl,
-        runId,
-        scenario,
-        warmupRequests,
-      })
-    );
-  }
+  const scenarios = await runAuthorizePerformanceScenarios({
+    ...input,
+    measuredRequests,
+    runId,
+    warmupRequests,
+  });
 
   const result: AuthorizePerformanceRunResult = {
     generatedAt: generatedAt.toISOString(),

--- a/packages/auth-runtime/src/iam-authorization/authorize-performance.server.ts
+++ b/packages/auth-runtime/src/iam-authorization/authorize-performance.server.ts
@@ -178,6 +178,162 @@ export const readLatestAuthorizePerformanceBenchmark = (input: {
     return latestBenchmarkByActor.get(toActorKey(input))?.result ?? null;
   };
 
+const buildAuthorizePerformanceBasePayload = (input: BenchmarkInput) => ({
+  instanceId: input.actor.instanceId,
+  action: input.request.action,
+  resource: {
+    type: input.request.resourceType,
+    ...(input.request.resourceId ? { id: input.request.resourceId } : {}),
+    ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
+  },
+  context: {
+    ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
+  },
+});
+
+const buildScenarioStableWarmupPayload = (input: {
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+}) =>
+  input.scenario === 'cache-miss'
+    ? null
+    : buildAuthorizePerformancePayload({
+        basePayload: input.basePayload,
+        runId: input.runId,
+        sampleIndex: 0,
+        scenario: input.scenario,
+      });
+
+const buildScenarioWarmupPayload = (input: {
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly runId: string;
+  readonly sampleIndex: number;
+  readonly scenario: AuthorizePerformanceScenario;
+  readonly stableWarmupPayload: ReturnType<typeof buildAuthorizePerformancePayload> | null;
+}) => {
+  if (input.scenario !== 'cache-miss') {
+    return input.stableWarmupPayload;
+  }
+
+  return buildAuthorizePerformancePayload({
+    basePayload: input.basePayload,
+    runId: `${input.runId}-warmup`,
+    sampleIndex: input.sampleIndex,
+    scenario: input.scenario,
+  });
+};
+
+const maybeInvalidateScopeForScenario = async (scenario: AuthorizePerformanceScenario, actor: BenchmarkActor): Promise<void> => {
+  if (scenario === 'recompute') {
+    await invalidateUserScope(actor);
+  }
+};
+
+const runScenarioWarmup = async (input: {
+  readonly actor: BenchmarkActor;
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly headers: Headers;
+  readonly requestUrl: string;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+  readonly warmupRequests: number;
+}): Promise<void> => {
+  const stableWarmupPayload = buildScenarioStableWarmupPayload({
+    basePayload: input.basePayload,
+    runId: input.runId,
+    scenario: input.scenario,
+  });
+
+  for (let index = 0; index < input.warmupRequests; index += 1) {
+    await maybeInvalidateScopeForScenario(input.scenario, input.actor);
+    const warmupPayload = buildScenarioWarmupPayload({
+      basePayload: input.basePayload,
+      runId: input.runId,
+      sampleIndex: index,
+      scenario: input.scenario,
+      stableWarmupPayload,
+    });
+
+    if (!warmupPayload) {
+      throw new Error('warmup_payload_missing');
+    }
+
+    await invokeAuthorize({
+      headers: input.headers,
+      payload: warmupPayload,
+      requestUrl: input.requestUrl,
+    });
+  }
+};
+
+const runScenarioMeasurements = async (input: {
+  readonly actor: BenchmarkActor;
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly headers: Headers;
+  readonly measuredRequests: number;
+  readonly requestUrl: string;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+}): Promise<{
+  readonly observedStatuses: string[];
+  readonly samplesMs: number[];
+}> => {
+  const observedStatuses: string[] = [];
+  const samplesMs: number[] = [];
+
+  for (let sampleIndex = 0; sampleIndex < input.measuredRequests; sampleIndex += 1) {
+    await maybeInvalidateScopeForScenario(input.scenario, input.actor);
+    const payload = buildAuthorizePerformancePayload({
+      basePayload: input.basePayload,
+      runId: input.runId,
+      sampleIndex,
+      scenario: input.scenario,
+    });
+    const result = await invokeAuthorize({
+      headers: input.headers,
+      payload,
+      requestUrl: input.requestUrl,
+    });
+
+    samplesMs.push(result.durationMs);
+    observedStatuses.push(result.cacheStatus);
+  }
+
+  return { observedStatuses, samplesMs };
+};
+
+const runScenarioBenchmark = async (input: {
+  readonly actor: BenchmarkActor;
+  readonly basePayload: ReturnType<typeof buildAuthorizePerformanceBasePayload>;
+  readonly headers: Headers;
+  readonly measuredRequests: number;
+  readonly requestUrl: string;
+  readonly runId: string;
+  readonly scenario: AuthorizePerformanceScenario;
+  readonly warmupRequests: number;
+}): Promise<AuthorizePerformanceScenarioResult> => {
+  await runScenarioWarmup(input);
+  const { observedStatuses, samplesMs } = await runScenarioMeasurements(input);
+
+  assertScenarioStatuses({
+    observedStatuses,
+    scenario: input.scenario,
+  });
+
+  const summary = summarizeAuthorizePerformanceDurations(samplesMs);
+  const evaluation = summary.p95Ms < scenarioThresholdMs(input.scenario) ? 'accepted' : 'rejected';
+
+  return {
+    scenario: input.scenario,
+    samplesMs,
+    summary,
+    evaluation,
+    evaluationLabel: evaluation === 'accepted' ? 'erfüllt' : 'nicht erfüllt',
+    observedCacheStatuses: observedStatuses,
+  };
+};
+
 export const runAuthorizePerformanceBenchmark = async (
   input: BenchmarkInput
 ): Promise<AuthorizePerformanceRunResult> => {
@@ -185,97 +341,22 @@ export const runAuthorizePerformanceBenchmark = async (
   const measuredRequests = input.request.measuredRequests ?? DEFAULT_MEASURED_REQUESTS;
   const warmupRequests = input.request.warmupRequests ?? DEFAULT_WARMUP_REQUESTS;
   const runId = generatedAt.getTime().toString(36);
-
-  const basePayload = {
-    instanceId: input.actor.instanceId,
-    action: input.request.action,
-    resource: {
-      type: input.request.resourceType,
-      ...(input.request.resourceId ? { id: input.request.resourceId } : {}),
-      ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
-    },
-    context: {
-      ...(input.request.organizationId ? { organizationId: input.request.organizationId } : {}),
-    },
-  };
+  const basePayload = buildAuthorizePerformanceBasePayload(input);
 
   const scenarios: AuthorizePerformanceScenarioResult[] = [];
   for (const scenario of ['cache-hit', 'cache-miss', 'recompute'] as const) {
-    const observedStatuses = [] as string[];
-
-    const stableWarmupPayload =
-      scenario === 'cache-miss'
-        ? null
-        : buildAuthorizePerformancePayload({
-            basePayload,
-            runId,
-            sampleIndex: 0,
-            scenario,
-          });
-
-    for (let index = 0; index < warmupRequests; index += 1) {
-      if (scenario === 'recompute') {
-        await invalidateUserScope(input.actor);
-      }
-
-      const warmupPayload =
-        scenario === 'cache-miss'
-          ? buildAuthorizePerformancePayload({
-              basePayload,
-              runId: `${runId}-warmup`,
-              sampleIndex: index,
-              scenario,
-            })
-          : stableWarmupPayload;
-
-      if (!warmupPayload) {
-        throw new Error('warmup_payload_missing');
-      }
-
-      await invokeAuthorize({
-        headers: input.requestHeaders,
-        payload: warmupPayload,
-        requestUrl: input.requestUrl,
-      });
-    }
-
-    const samplesMs = [] as number[];
-    for (let sampleIndex = 0; sampleIndex < measuredRequests; sampleIndex += 1) {
-      if (scenario === 'recompute') {
-        await invalidateUserScope(input.actor);
-      }
-
-      const payload = buildAuthorizePerformancePayload({
+    scenarios.push(
+      await runScenarioBenchmark({
+        actor: input.actor,
         basePayload,
-        runId,
-        sampleIndex,
-        scenario,
-      });
-      const result = await invokeAuthorize({
         headers: input.requestHeaders,
-        payload,
+        measuredRequests,
         requestUrl: input.requestUrl,
-      });
-      samplesMs.push(result.durationMs);
-      observedStatuses.push(result.cacheStatus);
-    }
-
-    assertScenarioStatuses({
-      observedStatuses,
-      scenario,
-    });
-
-    const summary = summarizeAuthorizePerformanceDurations(samplesMs);
-    const evaluation = summary.p95Ms < scenarioThresholdMs(scenario) ? 'accepted' : 'rejected';
-
-    scenarios.push({
-      scenario,
-      samplesMs,
-      summary,
-      evaluation,
-      evaluationLabel: evaluation === 'accepted' ? 'erfüllt' : 'nicht erfüllt',
-      observedCacheStatuses: observedStatuses,
-    });
+        runId,
+        scenario,
+        warmupRequests,
+      })
+    );
   }
 
   const result: AuthorizePerformanceRunResult = {

--- a/packages/auth-runtime/src/iam-authorization/shared.ts
+++ b/packages/auth-runtime/src/iam-authorization/shared.ts
@@ -124,81 +124,135 @@ const sortSourceKinds = (
 ): readonly NonNullable<PermissionRow['source_kind']>[] =>
   [...values].sort((left, right) => SOURCE_KIND_ORDER[left] - SOURCE_KIND_ORDER[right] || left.localeCompare(right));
 
+const buildPermissionBucketKey = (input: {
+  readonly action: string;
+  readonly resourceType: string;
+  readonly resourceId?: string;
+  readonly organizationId?: string | null;
+  readonly effect: IamPermissionEffect;
+  readonly scope?: Record<string, unknown>;
+}): string =>
+  JSON.stringify({
+    action: input.action,
+    resourceType: input.resourceType,
+    resourceId: input.resourceId,
+    organizationId: input.organizationId ?? '',
+    effect: input.effect,
+    scope: input.scope,
+  });
+
+const appendSortedUnique = (values: readonly string[] | undefined, nextValue: string | undefined): readonly string[] | undefined => {
+  if (!nextValue) {
+    return values;
+  }
+
+  return sortStrings(values?.includes(nextValue) ? values : [...(values ?? []), nextValue]);
+};
+
+const mergeSortedSourceKinds = (
+  values: readonly NonNullable<PermissionRow['source_kind']>[] | undefined,
+  nextValue: NonNullable<PermissionRow['source_kind']> | undefined
+): readonly NonNullable<PermissionRow['source_kind']>[] | undefined => {
+  if (!nextValue) {
+    return values;
+  }
+
+  return sortSourceKinds(Array.from(new Set([...(values ?? []), nextValue])));
+};
+
+const createEffectivePermission = (
+  row: PermissionRow,
+  normalized: {
+    readonly action: string;
+    readonly resourceType: string;
+    readonly resourceId?: string;
+    readonly effect: IamPermissionEffect;
+    readonly scope?: Record<string, unknown>;
+    readonly accountId?: string;
+    readonly groupId?: string;
+    readonly groupKey?: string;
+  }
+): EffectivePermission => ({
+  action: normalized.action,
+  resourceType: normalized.resourceType,
+  resourceId: normalized.resourceId,
+  organizationId: row.organization_id ?? undefined,
+  effect: normalized.effect,
+  scope: normalized.scope,
+  ...(normalized.accountId ? { sourceUserIds: [normalized.accountId] } : {}),
+  ...(row.role_id ? { sourceRoleIds: [row.role_id] } : {}),
+  ...(normalized.groupId ? { sourceGroupIds: [normalized.groupId] } : {}),
+  ...(normalized.groupKey ? { groupName: normalized.groupKey } : {}),
+  provenance: row.source_kind ? { sourceKinds: [row.source_kind] } : undefined,
+});
+
+const mergeEffectivePermission = (
+  existing: EffectivePermission,
+  row: PermissionRow,
+  normalized: {
+    readonly accountId?: string;
+    readonly groupId?: string;
+    readonly groupKey?: string;
+  }
+): EffectivePermission => {
+  const sourceUserIds = appendSortedUnique(existing.sourceUserIds, normalized.accountId);
+  const sourceRoleIds = appendSortedUnique(existing.sourceRoleIds, row.role_id ?? undefined);
+  const sourceGroupIds = appendSortedUnique(existing.sourceGroupIds, normalized.groupId);
+  const sourceKinds = mergeSortedSourceKinds(existing.provenance?.sourceKinds, row.source_kind ?? undefined);
+
+  return {
+    ...existing,
+    ...(sourceUserIds ? { sourceUserIds } : {}),
+    ...(sourceRoleIds ? { sourceRoleIds } : {}),
+    ...(sourceGroupIds ? { sourceGroupIds } : {}),
+    ...(normalized.groupKey ?? existing.groupName ? { groupName: normalized.groupKey ?? existing.groupName } : {}),
+    provenance: sourceKinds ? { ...(existing.provenance ?? {}), sourceKinds } : existing.provenance,
+  };
+};
+
+const finalizeEffectivePermission = (permission: EffectivePermission): EffectivePermission => ({
+  ...permission,
+  ...(permission.sourceUserIds ? { sourceUserIds: sortStrings(permission.sourceUserIds) } : {}),
+  ...(permission.sourceRoleIds ? { sourceRoleIds: sortStrings(permission.sourceRoleIds) } : {}),
+  ...(permission.sourceGroupIds ? { sourceGroupIds: sortStrings(permission.sourceGroupIds) } : {}),
+  provenance: permission.provenance?.sourceKinds
+    ? { ...permission.provenance, sourceKinds: sortSourceKinds(permission.provenance.sourceKinds) }
+    : permission.provenance,
+});
+
 export const toEffectivePermissions = (rows: readonly PermissionRow[]): EffectivePermission[] => {
   const buckets = new Map<string, EffectivePermission>();
 
   for (const row of rows) {
-    const action = row.action?.trim() || row.permission_key;
-    const resourceType = row.resource_type?.trim() || readResourceType(row.permission_key);
-    const resourceId = row.resource_id?.trim() || undefined;
-    const effect = row.effect ?? 'allow';
-    const scope = row.scope ?? undefined;
-    const accountId = row.account_id ?? undefined;
-    const groupId = row.group_id ?? undefined;
-    const groupKey = row.group_key ?? undefined;
-    const bucketKey = JSON.stringify({
-      action,
-      resourceType,
-      resourceId,
-      organizationId: row.organization_id ?? '',
-      effect,
-      scope,
+    const normalized = {
+      action: row.action?.trim() || row.permission_key,
+      resourceType: row.resource_type?.trim() || readResourceType(row.permission_key),
+      resourceId: row.resource_id?.trim() || undefined,
+      effect: row.effect ?? 'allow',
+      scope: row.scope ?? undefined,
+      accountId: row.account_id ?? undefined,
+      groupId: row.group_id ?? undefined,
+      groupKey: row.group_key ?? undefined,
+    };
+    const bucketKey = buildPermissionBucketKey({
+      action: normalized.action,
+      resourceType: normalized.resourceType,
+      resourceId: normalized.resourceId,
+      organizationId: row.organization_id,
+      effect: normalized.effect,
+      scope: normalized.scope,
     });
     const existing = buckets.get(bucketKey);
 
     if (!existing) {
-      buckets.set(bucketKey, {
-        action,
-        resourceType,
-        resourceId,
-        organizationId: row.organization_id ?? undefined,
-        effect,
-        scope,
-        ...(accountId ? { sourceUserIds: [accountId] } : {}),
-        ...(row.role_id ? { sourceRoleIds: [row.role_id] } : {}),
-        ...(groupId ? { sourceGroupIds: [groupId] } : {}),
-        ...(groupKey ? { groupName: groupKey } : {}),
-        provenance: row.source_kind ? { sourceKinds: [row.source_kind] } : undefined,
-      });
+      buckets.set(bucketKey, createEffectivePermission(row, normalized));
       continue;
     }
 
-    const sourceUserIds =
-      accountId && !(existing.sourceUserIds ?? []).includes(accountId)
-        ? [...(existing.sourceUserIds ?? []), accountId]
-        : existing.sourceUserIds;
-    const sourceRoleIds =
-      row.role_id && !(existing.sourceRoleIds ?? []).includes(row.role_id)
-        ? [...(existing.sourceRoleIds ?? []), row.role_id]
-        : existing.sourceRoleIds;
-    const sourceGroupIds =
-      groupId && !(existing.sourceGroupIds ?? []).includes(groupId)
-        ? [...(existing.sourceGroupIds ?? []), groupId]
-        : existing.sourceGroupIds;
-    const groupName = groupKey ?? existing.groupName;
-    const sourceKinds = row.source_kind
-      ? sortSourceKinds(Array.from(new Set([...(existing.provenance?.sourceKinds ?? []), row.source_kind])))
-      : existing.provenance?.sourceKinds;
-
-    buckets.set(bucketKey, {
-      ...existing,
-      ...(sourceUserIds ? { sourceUserIds: sortStrings(sourceUserIds) } : {}),
-      ...(sourceRoleIds ? { sourceRoleIds: sortStrings(sourceRoleIds) } : {}),
-      ...(sourceGroupIds ? { sourceGroupIds: sortStrings(sourceGroupIds) } : {}),
-      ...(groupName ? { groupName } : {}),
-      provenance: sourceKinds ? { ...(existing.provenance ?? {}), sourceKinds } : existing.provenance,
-    });
+    buckets.set(bucketKey, mergeEffectivePermission(existing, row, normalized));
   }
 
-  return [...buckets.values()].map((permission) => ({
-    ...permission,
-    ...(permission.sourceUserIds ? { sourceUserIds: sortStrings(permission.sourceUserIds) } : {}),
-    ...(permission.sourceRoleIds ? { sourceRoleIds: sortStrings(permission.sourceRoleIds) } : {}),
-    ...(permission.sourceGroupIds ? { sourceGroupIds: sortStrings(permission.sourceGroupIds) } : {}),
-    provenance: permission.provenance?.sourceKinds
-      ? { ...permission.provenance, sourceKinds: sortSourceKinds(permission.provenance.sourceKinds) }
-      : permission.provenance,
-  }));
+  return [...buckets.values()].map(finalizeEffectivePermission);
 };
 
 export const withInstanceScopedDb = async <T>(

--- a/packages/auth-runtime/src/instance-permission-authorization.ts
+++ b/packages/auth-runtime/src/instance-permission-authorization.ts
@@ -87,6 +87,13 @@ const buildDatabaseUnavailableResult = (): Extract<InstancePermissionAuthorizati
   message: 'Berechtigungen konnten nicht geprüft werden.',
 });
 
+const buildMissingInstanceResult = (): Extract<InstancePermissionAuthorizationResult, { ok: false }> => ({
+  ok: false,
+  status: 400,
+  error: 'missing_instance',
+  message: 'Kein Instanzkontext für diese Operation vorhanden.',
+});
+
 const resolveAuthorizationPermissions = async (input: {
   readonly ctx: AuthenticatedRequestContext;
   readonly action: string;
@@ -97,7 +104,11 @@ const resolveAuthorizationPermissions = async (input: {
   | Readonly<{ ok: true; permissions: readonly EffectivePermission[] }>
   | Readonly<{ ok: false; result: Extract<InstancePermissionAuthorizationResult, { ok: false }> }>
 > => {
-  const instanceId = input.ctx.user.instanceId!;
+  const instanceId = input.ctx.user.instanceId;
+  if (!instanceId) {
+    return { ok: false, result: buildMissingInstanceResult() };
+  }
+
   if (input.permissions) {
     return { ok: true, permissions: input.permissions };
   }
@@ -149,12 +160,7 @@ export const authorizeInstancePermissionForUser = async (input: {
 }): Promise<InstancePermissionAuthorizationResult> => {
   const instanceId = input.ctx.user.instanceId;
   if (!instanceId) {
-    return {
-      ok: false,
-      status: 400,
-      error: 'missing_instance',
-      message: 'Kein Instanzkontext für diese Operation vorhanden.',
-    };
+    return buildMissingInstanceResult();
   }
 
   const action = normalizeAuthorizationAction(input.action);


### PR DESCRIPTION
## Summary
- reduce the last Sonar top-complexity hotspot in the IAM cockpit by extracting tab controllers and tab panels
- split the remaining top Sonar complexity hotspots across auth-runtime, auth-provider, user admin, instance admin, and waste import flows into smaller helpers
- keep behavior unchanged while preserving the existing route, unit, and type coverage

## Validation
- pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/admin/-iam-page.test.tsx
- pnpm nx run sva-studio-react:test:types
- pnpm nx affected --target=test:unit --base=origin/main --outputStyle=static
- pnpm nx affected --target=test:types --base=origin/main --parallel=1