### PR TITLE
fix: unblock public waste web release build

### DIFF
--- a/.github/workflows/public-waste-web-release.yml
+++ b/.github/workflows/public-waste-web-release.yml
@@ -56,7 +56,9 @@ jobs:
           pnpm exec tsc -p tsconfig.scripts.json --noEmit
 
       - name: Build public waste app
-        run: pnpm nx run public-waste-calendar-web:build
+        run: |
+          pnpm nx run core:build --skip-nx-cache
+          pnpm nx run public-waste-calendar-web:build --skip-nx-cache
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -8,7 +8,7 @@
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/dist"],
       "options": {
-        "command": "tsc -p packages/core/tsconfig.lib.json"
+        "command": "rm -rf packages/core/dist packages/core/tsconfig.lib.tsbuildinfo && tsc -p packages/core/tsconfig.lib.json"
       }
     },
     "check:runtime": {


### PR DESCRIPTION
## Summary
- clean the core build output and tsbuildinfo before compiling
- build @sva/core explicitly in the public waste release workflow before the app build

## Verification
- pnpm nx run core:build --skip-nx-cache
- pnpm nx run public-waste-calendar-web:build --skip-nx-cache
- pnpm exec vitest run scripts/ops/public-waste/portainer-release.test.ts
- pnpm exec tsc -p tsconfig.scripts.json --noEmit

## Context
- release tag waste-web-v0.1.2 failed in GitHub Actions because public-waste-calendar-web could not resolve @sva/core from a fresh checkout
