### PR TITLE
fix: harden public waste release prebuild chain

### DIFF
--- a/.github/workflows/public-waste-web-release.yml
+++ b/.github/workflows/public-waste-web-release.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build public waste app
         run: |
-          pnpm nx run core:build --skip-nx-cache
+          pnpm nx run data-repositories:build --skip-nx-cache
           pnpm nx run public-waste-calendar-web:build --skip-nx-cache
 
       - name: Setup Docker Buildx

--- a/.github/workflows/public-waste-web-release.yml
+++ b/.github/workflows/public-waste-web-release.yml
@@ -56,9 +56,7 @@ jobs:
           pnpm exec tsc -p tsconfig.scripts.json --noEmit
 
       - name: Build public waste app
-        run: |
-          pnpm nx run data-repositories:build --skip-nx-cache
-          pnpm nx run public-waste-calendar-web:build --skip-nx-cache
+        run: pnpm nx run public-waste-calendar-web:build --skip-nx-cache
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/apps/public-waste-calendar-web/project.json
+++ b/apps/public-waste-calendar-web/project.json
@@ -14,6 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
       "cache": true,
       "inputs": ["production", "^production", "frontendTooling"],
       "outputs": ["{projectRoot}/dist"],

--- a/packages/data-repositories/project.json
+++ b/packages/data-repositories/project.json
@@ -9,7 +9,7 @@
       "dependsOn": ["^build"],
       "outputs": ["{projectRoot}/dist"],
       "options": {
-        "command": "tsc -p packages/data-repositories/tsconfig.lib.json"
+        "command": "rm -rf packages/data-repositories/dist packages/data-repositories/tsconfig.lib.tsbuildinfo && tsc -p packages/data-repositories/tsconfig.lib.json"
       }
     },
     "check:runtime": {

--- a/packages/server-runtime/project.json
+++ b/packages/server-runtime/project.json
@@ -9,7 +9,7 @@
       "dependsOn": ["^build"],
       "outputs": ["{projectRoot}/dist"],
       "options": {
-        "command": "tsc -p packages/server-runtime/tsconfig.lib.json"
+        "command": "rm -rf packages/server-runtime/dist packages/server-runtime/tsconfig.lib.tsbuildinfo && tsc -p packages/server-runtime/tsconfig.lib.json"
       }
     },
     "check:runtime": {


### PR DESCRIPTION
## Summary
- prebuild  in the public waste release workflow before the app build
- clean  and  for  and  builds so fresh CI checkouts emit real artifacts

## Verification
- pnpm nx run data-repositories:build --skip-nx-cache
- pnpm nx run public-waste-calendar-web:build --skip-nx-cache
- pnpm exec vitest run scripts/ops/public-waste/portainer-release.test.ts
- pnpm exec tsc -p tsconfig.scripts.json --noEmit

## Context
- release tag waste-web-v0.1.3 still failed because Vite could not resolve  from a fresh checkout after fixing 
