### PR TITLE
fix: sync injected workspace packages before waste build

### DIFF
--- a/apps/public-waste-calendar-web/package.json
+++ b/apps/public-waste-calendar-web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3002",
-    "build": "rm -rf dist && vite build --outDir dist/client && pnpm exec tsc -p tsconfig.server.json",
+    "build": "bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/sync-injected-workspace-packages.ts . && rm -rf dist && vite build --outDir dist/client && pnpm exec tsc -p tsconfig.server.json",
     "preview": "vite preview",
     "start": "node dist/server/server/main.js",
     "test": "vitest run --passWithNoTests",

--- a/apps/public-waste-calendar-web/project.json
+++ b/apps/public-waste-calendar-web/project.json
@@ -16,7 +16,13 @@
       "executor": "nx:run-commands",
       "dependsOn": ["^build"],
       "cache": true,
-      "inputs": ["production", "^production", "frontendTooling"],
+      "inputs": [
+        "production",
+        "^production",
+        "frontendTooling",
+        "{workspaceRoot}/scripts/ci/sync-injected-workspace-packages.ts",
+        "{workspaceRoot}/scripts/ci/run-workspace-node.sh"
+      ],
       "outputs": ["{projectRoot}/dist"],
       "options": {
         "cwd": "apps/public-waste-calendar-web",

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -320,3 +320,23 @@ test('injected workspace sync copies dist into pnpm store package copies', () =>
     rmSync(tempRoot, { force: true, recursive: true });
   }
 });
+
+test('public waste build syncs injected workspace packages before vite resolves server imports', () => {
+  const publicWastePackageJson = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'apps/public-waste-calendar-web/package.json'),
+    'utf8'
+  );
+  const publicWasteProjectJson = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'apps/public-waste-calendar-web/project.json'),
+    'utf8'
+  );
+
+  assert.match(
+    publicWastePackageJson,
+    /sync-injected-workspace-packages\.ts \. && rm -rf dist && vite build --outDir dist\/client && pnpm exec tsc -p tsconfig\.server\.json/
+  );
+  assert.match(
+    publicWasteProjectJson,
+    /"dependsOn": \["\^build"\][\s\S]*"inputs": \[[\s\S]*sync-injected-workspace-packages\.ts[\s\S]*run-workspace-node\.sh[\s\S]*\]/
+  );
+});


### PR DESCRIPTION
## Ziel
Der Public-Waste-Release soll in frischen CI-Umgebungen wieder stabil bauen.

## Ursache
 haengt zur Vite-Config-Zeit an injizierten Workspace-Paketen aus . Nach den Dependency-Builds lagen die frischen -Artefakte nur im Workspace-Paket, nicht aber in den injizierten Kopien, wodurch  im Release-Workflow nicht aufgeloest werden konnte.

## Aenderung
- synchronisiert vor dem App-Build die injizierten Workspace-Pakete via 
- nimmt die Sync-Skripte in die Nx-Build-Inputs des Apps auf
- ergaenzt einen Guard-Test fuer den Public-Waste-Buildpfad

## Verifikation
- 
> nx run data:"test:unit"  [existing outputs match the cache, left as is]

> node packages/data/scripts/run-node-tests.mjs

▶ createDataClient.get
  [32m✔ validates payload with zod schema [90m(25.502291ms)[39m[39m
  [32m✔ throws when schema validation fails [90m(0.689709ms)[39m[39m
[32m✔ createDataClient.get [90m(26.698ms)[39m[39m
▶ iam seed statements
  [32m✔ builds permission upsert with structured fields and scope json [90m(1.297667ms)[39m[39m
  [32m✔ builds role upsert with ON CONFLICT update [90m(0.094875ms)[39m[39m
  [32m✔ builds group upsert with role_bundle defaults [90m(0.074ms)[39m[39m
  [32m✔ builds geo unit upsert with hierarchy path fields [90m(0.098166ms)[39m[39m
  [32m✔ allows explicit managedBy and external role mapping in role upserts [90m(0.05725ms)[39m[39m
  [32m✔ builds account-role assignment as idempotent insert [90m(0.057792ms)[39m[39m
  [32m✔ builds group-role assignment as idempotent insert [90m(0.062416ms)[39m[39m
  [32m✔ builds account-group assignment with origin and validity fields [90m(0.071084ms)[39m[39m
  [32m✔ builds account upsert with keycloak subject and instance conflict target [90m(0.072333ms)[39m[39m
  [32m✔ builds organization upsert with hierarchy and policy fields [90m(0.122541ms)[39m[39m
  [32m✔ builds account-organization assignment with default context and visibility fields [90m(0.065417ms)[39m[39m
[32m✔ iam seed statements [90m(2.683958ms)[39m[39m
▶ iam seed repository
  [32m✔ delegates to SQL executor [90m(0.199958ms)[39m[39m
  [32m✔ normalizes uuid array parameters before delegating organization statements to the executor [90m(0.101875ms)[39m[39m
[32m✔ iam seed repository [90m(0.407083ms)[39m[39m
▶ iam seed sql contracts
  [32m✔ keeps protected instance identity fields in 0001 additive for existing environments [90m(6.97825ms)[39m[39m
  [32m✔ seeds de-musterhausen with the local-keycloak reference identity by default [90m(0.433625ms)[39m[39m
  [32m✔ keeps 0002 non-destructive for an already provisioned instance identity [90m(6.232625ms)[39m[39m
  [32m✔ does not keep a tenant-side instance_registry_admin persona in 0001 anymore [90m(0.74475ms)[39m[39m
  [32m✔ expects the deletion-rules seed to create tenant defaults [90m(2.703292ms)[39m[39m
[32m✔ iam seed sql contracts [90m(18.633166ms)[39m[39m
▶ iam seed plan
  [32m✔ contains exactly one tenant bootstrap persona [90m(0.592708ms)[39m[39m
  [32m✔ keeps the canonical permission catalog in sync with the seed integration expectations [90m(0.119709ms)[39m[39m
  [32m✔ uses unique role slugs and keycloak subjects [90m(0.067458ms)[39m[39m
  [32m✔ defines role levels within range [90m(0.076291ms)[39m[39m
  [32m✔ resolves persona by stable key [90m(0.838083ms)[39m[39m
  [32m✔ does not expose a tenant-side instance_registry_admin persona anymore [90m(0.243208ms)[39m[39m
  [32m✔ keeps instance.registry.manage out of tenant bootstrap personas [90m(0.276041ms)[39m[39m
  [32m✔ contains hierarchical organizations for context-switch scenarios [90m(0.07475ms)[39m[39m
  [32m✔ derives stable resource types from permission keys [90m(0.126334ms)[39m[39m
  [32m✔ throws for unknown persona keys [90m(0.109416ms)[39m[39m
[32m✔ iam seed plan [90m(3.360042ms)[39m[39m
▶ instance registry repository boundary
  [32m✔ re-exports the leading repository factory from @sva/data-repositories [90m(0.465583ms)[39m[39m
  [32m✔ keeps the local repository types aligned with @sva/data-repositories [90m(0.055333ms)[39m[39m
[32m✔ instance registry repository boundary [90m(0.986ms)[39m[39m
▶ instance integration statements
  [32m✔ builds select statements for an instance scoped provider [90m(1.4375ms)[39m[39m
  [32m✔ builds upsert statements with verification metadata [90m(0.12175ms)[39m[39m
[32m✔ instance integration statements [90m(2.277ms)[39m[39m
▶ instance integration repository
  [32m✔ maps rows from the SQL executor [90m(0.166542ms)[39m[39m
  [32m✔ delegates upserts to the SQL executor [90m(0.112292ms)[39m[39m
[32m✔ instance integration repository [90m(0.3585ms)[39m[39m
▶ createCachedInstanceIntegrationLoader
  [32m✔ reuses cached records within the TTL window [90m(0.252333ms)[39m[39m
  [32m✔ does not cache null records [90m(0.089833ms)[39m[39m
  [32m✔ deduplicates in-flight loads for the same cache key [90m(3.249083ms)[39m[39m
[32m✔ createCachedInstanceIntegrationLoader [90m(3.724083ms)[39m[39m
[32m✔ geo hierarchy migration validates only paths affected by the new edge [90m(1.121ms)[39m[39m
[32m✔ bootstrap script validates usernames and uses identifier-safe grants [90m(0.3175ms)[39m[39m
[32m✔ migration script supports profile-specific postgres targets [90m(0.303083ms)[39m[39m
[32m✔ destructive integration scripts isolate themselves from the default local development database [90m(0.740083ms)[39m[39m
[32m✔ self-service permission change migration keeps admin inserts and rollback fail-closed [90m(2.150875ms)[39m[39m
[32m✔ sidebar application permission migration adds navigation permissions for existing roles [90m(1.030375ms)[39m[39m
[32m✔ sidebar application permission cache invalidation migration notifies affected instances [90m(0.434583ms)[39m[39m
[32m✔ platform tenant role split migration neutralizes tenant-side root role artifacts additively [90m(2.128542ms)[39m[39m
[32m✔ permission gate backfill migration seeds the new permission model for tenant governance paths [90m(3.267709ms)[39m[39m
[32m✔ experimental shell permission migration backfills the additive ui gate for existing roles [90m(0.485167ms)[39m[39m
[32m✔ legacy standard role grant cleanup migration removes historical seed grants from deprecated tenant defaults [90m(2.020083ms)[39m[39m
[32m✔ runtime artifact verification runs workspace node helper via bash [90m(2.642459ms)[39m[39m
[32m✔ runtime artifact checks avoid stale images and dev JSX false positives [90m(5.623083ms)[39m[39m
[32m✔ portable docker runtime guard only fails when a JSX dev runtime match is present [90m(37.604917ms)[39m[39m
[32m✔ injected workspace sync copies dist into pnpm store package copies [90m(1278.128708ms)[39m[39m
[32m✔ public waste build syncs injected workspace packages before vite resolves server imports [90m(0.430542ms)[39m[39m
[34mℹ tests 55[39m
[34mℹ suites 9[39m
[34mℹ pass 55[39m
[34mℹ fail 0[39m
[34mℹ cancelled 0[39m
[34mℹ skipped 0[39m
[34mℹ todo 0[39m
[34mℹ duration_ms 1680.471375[39m



 NX   Successfully ran target test:unit for project data

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.
- 
 NX   Running target build for project public-waste-calendar-web and 4 tasks it depends on:



> nx run core:build

> rm -rf packages/core/dist packages/core/tsconfig.lib.tsbuildinfo && tsc -p packages/core/tsconfig.lib.json


> nx run monitoring-client:build

> rm -rf packages/monitoring-client/dist && tsc -p packages/monitoring-client/tsconfig.build.json


> nx run server-runtime:build

> rm -rf packages/server-runtime/dist packages/server-runtime/tsconfig.lib.tsbuildinfo && tsc -p packages/server-runtime/tsconfig.lib.json


> nx run data-repositories:build

> rm -rf packages/data-repositories/dist packages/data-repositories/tsconfig.lib.tsbuildinfo && tsc -p packages/data-repositories/tsconfig.lib.json


> nx run public-waste-calendar-web:build

> pnpm run build

{
  "consumerDir": "/Users/wilimzig/Documents/Projects/SVA/sva-studio/apps/public-waste-calendar-web",
  "updatedCopyCount": 4,
  "updatedPackages": [
    {
      "name": "@sva/core",
      "skipped": false,
      "updatedCopies": 1
    },
    {
      "name": "@sva/data-repositories",
      "skipped": false,
      "updatedCopies": 1
    },
    {
      "name": "@sva/monitoring-client",
      "skipped": false,
      "updatedCopies": 1
    },
    {
      "name": "@sva/server-runtime",
      "skipped": false,
      "updatedCopies": 1
    }
  ],
  "workspaceRoot": "/Users/wilimzig/Documents/Projects/SVA/sva-studio"
}
[36mvite v8.0.14 [32mbuilding client environment for production...[36m[39m
[2Ktransforming...[32m✓[39m 6180 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/client/[0m[32mindex.html                 [39m[2m[1m  0.41 kB[0m[0m[2m │ gzip:   0.28 kB[0m
[2mdist/client/[0m[2massets/[0m[35mindex-Cn8vkoM2.css  [39m[2m[1m 10.54 kB[0m[0m[2m │ gzip:   2.64 kB[0m
[2mdist/client/[0m[2massets/[0m[36mindex-DLREPIS6.js   [39m[2m[1m422.63 kB[0m[0m[2m │ gzip: 125.99 kB[0m

[32m✓ built in 1.72s[39m



 NX   Successfully ran target build for project public-waste-calendar-web and 4 tasks it depends on
- 
 NX   Running target test:unit for 2 projects:

- public-waste-calendar-web
- data



> nx run data:"test:unit"  [existing outputs match the cache, left as is]

> node packages/data/scripts/run-node-tests.mjs

▶ createDataClient.get
  [32m✔ validates payload with zod schema [90m(25.502291ms)[39m[39m
  [32m✔ throws when schema validation fails [90m(0.689709ms)[39m[39m
[32m✔ createDataClient.get [90m(26.698ms)[39m[39m
▶ iam seed statements
  [32m✔ builds permission upsert with structured fields and scope json [90m(1.297667ms)[39m[39m
  [32m✔ builds role upsert with ON CONFLICT update [90m(0.094875ms)[39m[39m
  [32m✔ builds group upsert with role_bundle defaults [90m(0.074ms)[39m[39m
  [32m✔ builds geo unit upsert with hierarchy path fields [90m(0.098166ms)[39m[39m
  [32m✔ allows explicit managedBy and external role mapping in role upserts [90m(0.05725ms)[39m[39m
  [32m✔ builds account-role assignment as idempotent insert [90m(0.057792ms)[39m[39m
  [32m✔ builds group-role assignment as idempotent insert [90m(0.062416ms)[39m[39m
  [32m✔ builds account-group assignment with origin and validity fields [90m(0.071084ms)[39m[39m
  [32m✔ builds account upsert with keycloak subject and instance conflict target [90m(0.072333ms)[39m[39m
  [32m✔ builds organization upsert with hierarchy and policy fields [90m(0.122541ms)[39m[39m
  [32m✔ builds account-organization assignment with default context and visibility fields [90m(0.065417ms)[39m[39m
[32m✔ iam seed statements [90m(2.683958ms)[39m[39m
▶ iam seed repository
  [32m✔ delegates to SQL executor [90m(0.199958ms)[39m[39m
  [32m✔ normalizes uuid array parameters before delegating organization statements to the executor [90m(0.101875ms)[39m[39m
[32m✔ iam seed repository [90m(0.407083ms)[39m[39m
▶ iam seed sql contracts
  [32m✔ keeps protected instance identity fields in 0001 additive for existing environments [90m(6.97825ms)[39m[39m
  [32m✔ seeds de-musterhausen with the local-keycloak reference identity by default [90m(0.433625ms)[39m[39m
  [32m✔ keeps 0002 non-destructive for an already provisioned instance identity [90m(6.232625ms)[39m[39m
  [32m✔ does not keep a tenant-side instance_registry_admin persona in 0001 anymore [90m(0.74475ms)[39m[39m
  [32m✔ expects the deletion-rules seed to create tenant defaults [90m(2.703292ms)[39m[39m
[32m✔ iam seed sql contracts [90m(18.633166ms)[39m[39m
▶ iam seed plan
  [32m✔ contains exactly one tenant bootstrap persona [90m(0.592708ms)[39m[39m
  [32m✔ keeps the canonical permission catalog in sync with the seed integration expectations [90m(0.119709ms)[39m[39m
  [32m✔ uses unique role slugs and keycloak subjects [90m(0.067458ms)[39m[39m
  [32m✔ defines role levels within range [90m(0.076291ms)[39m[39m
  [32m✔ resolves persona by stable key [90m(0.838083ms)[39m[39m
  [32m✔ does not expose a tenant-side instance_registry_admin persona anymore [90m(0.243208ms)[39m[39m
  [32m✔ keeps instance.registry.manage out of tenant bootstrap personas [90m(0.276041ms)[39m[39m
  [32m✔ contains hierarchical organizations for context-switch scenarios [90m(0.07475ms)[39m[39m
  [32m✔ derives stable resource types from permission keys [90m(0.126334ms)[39m[39m
  [32m✔ throws for unknown persona keys [90m(0.109416ms)[39m[39m
[32m✔ iam seed plan [90m(3.360042ms)[39m[39m
▶ instance registry repository boundary
  [32m✔ re-exports the leading repository factory from @sva/data-repositories [90m(0.465583ms)[39m[39m
  [32m✔ keeps the local repository types aligned with @sva/data-repositories [90m(0.055333ms)[39m[39m
[32m✔ instance registry repository boundary [90m(0.986ms)[39m[39m
▶ instance integration statements
  [32m✔ builds select statements for an instance scoped provider [90m(1.4375ms)[39m[39m
  [32m✔ builds upsert statements with verification metadata [90m(0.12175ms)[39m[39m
[32m✔ instance integration statements [90m(2.277ms)[39m[39m
▶ instance integration repository
  [32m✔ maps rows from the SQL executor [90m(0.166542ms)[39m[39m
  [32m✔ delegates upserts to the SQL executor [90m(0.112292ms)[39m[39m
[32m✔ instance integration repository [90m(0.3585ms)[39m[39m
▶ createCachedInstanceIntegrationLoader
  [32m✔ reuses cached records within the TTL window [90m(0.252333ms)[39m[39m
  [32m✔ does not cache null records [90m(0.089833ms)[39m[39m
  [32m✔ deduplicates in-flight loads for the same cache key [90m(3.249083ms)[39m[39m
[32m✔ createCachedInstanceIntegrationLoader [90m(3.724083ms)[39m[39m
[32m✔ geo hierarchy migration validates only paths affected by the new edge [90m(1.121ms)[39m[39m
[32m✔ bootstrap script validates usernames and uses identifier-safe grants [90m(0.3175ms)[39m[39m
[32m✔ migration script supports profile-specific postgres targets [90m(0.303083ms)[39m[39m
[32m✔ destructive integration scripts isolate themselves from the default local development database [90m(0.740083ms)[39m[39m
[32m✔ self-service permission change migration keeps admin inserts and rollback fail-closed [90m(2.150875ms)[39m[39m
[32m✔ sidebar application permission migration adds navigation permissions for existing roles [90m(1.030375ms)[39m[39m
[32m✔ sidebar application permission cache invalidation migration notifies affected instances [90m(0.434583ms)[39m[39m
[32m✔ platform tenant role split migration neutralizes tenant-side root role artifacts additively [90m(2.128542ms)[39m[39m
[32m✔ permission gate backfill migration seeds the new permission model for tenant governance paths [90m(3.267709ms)[39m[39m
[32m✔ experimental shell permission migration backfills the additive ui gate for existing roles [90m(0.485167ms)[39m[39m
[32m✔ legacy standard role grant cleanup migration removes historical seed grants from deprecated tenant defaults [90m(2.020083ms)[39m[39m
[32m✔ runtime artifact verification runs workspace node helper via bash [90m(2.642459ms)[39m[39m
[32m✔ runtime artifact checks avoid stale images and dev JSX false positives [90m(5.623083ms)[39m[39m
[32m✔ portable docker runtime guard only fails when a JSX dev runtime match is present [90m(37.604917ms)[39m[39m
[32m✔ injected workspace sync copies dist into pnpm store package copies [90m(1278.128708ms)[39m[39m
[32m✔ public waste build syncs injected workspace packages before vite resolves server imports [90m(0.430542ms)[39m[39m
[34mℹ tests 55[39m
[34mℹ suites 9[39m
[34mℹ pass 55[39m
[34mℹ fail 0[39m
[34mℹ cancelled 0[39m
[34mℹ skipped 0[39m
[34mℹ todo 0[39m
[34mℹ duration_ms 1680.471375[39m

> nx run public-waste-calendar-web:"test:unit"  [existing outputs match the cache, left as is]

> node -e "console.log('public-waste-calendar-web unit tests disabled in CI gate')"

public-waste-calendar-web unit tests disabled in CI gate



 NX   Successfully ran target test:unit for 2 projects

Nx read the output from the cache instead of running the command for 2 out of 2 tasks.