### PR TITLE
fix: avoid bash dependency in waste docker build

### DIFF
--- a/apps/public-waste-calendar-web/package.json
+++ b/apps/public-waste-calendar-web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3002",
-    "build": "bash ../../scripts/ci/run-workspace-node.sh --import tsx ../../scripts/ci/sync-injected-workspace-packages.ts . && rm -rf dist && vite build --outDir dist/client && pnpm exec tsc -p tsconfig.server.json",
+    "build": "pnpm exec tsx ../../scripts/ci/sync-injected-workspace-packages.ts . && rm -rf dist && vite build --outDir dist/client && pnpm exec tsc -p tsconfig.server.json",
     "preview": "vite preview",
     "start": "node dist/server/server/main.js",
     "test": "vitest run --passWithNoTests",

--- a/apps/public-waste-calendar-web/project.json
+++ b/apps/public-waste-calendar-web/project.json
@@ -20,8 +20,7 @@
         "production",
         "^production",
         "frontendTooling",
-        "{workspaceRoot}/scripts/ci/sync-injected-workspace-packages.ts",
-        "{workspaceRoot}/scripts/ci/run-workspace-node.sh"
+        "{workspaceRoot}/scripts/ci/sync-injected-workspace-packages.ts"
       ],
       "outputs": ["{projectRoot}/dist"],
       "options": {

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -333,10 +333,10 @@ test('public waste build syncs injected workspace packages before vite resolves 
 
   assert.match(
     publicWastePackageJson,
-    /sync-injected-workspace-packages\.ts \. && rm -rf dist && vite build --outDir dist\/client && pnpm exec tsc -p tsconfig\.server\.json/
+    /pnpm exec tsx \.\.\/\.\.\/scripts\/ci\/sync-injected-workspace-packages\.ts \. && rm -rf dist && vite build --outDir dist\/client && pnpm exec tsc -p tsconfig\.server\.json/
   );
   assert.match(
     publicWasteProjectJson,
-    /"dependsOn": \["\^build"\][\s\S]*"inputs": \[[\s\S]*sync-injected-workspace-packages\.ts[\s\S]*run-workspace-node\.sh[\s\S]*\]/
+    /"dependsOn": \["\^build"\][\s\S]*"inputs": \[[\s\S]*sync-injected-workspace-packages\.ts[\s\S]*\]/
   );
 });


### PR DESCRIPTION
## Ziel
Der Public-Waste-Release soll auch im Docker-Build-Stage auf `node:24.15.0-alpine` stabil durchlaufen.

## Ursache
Nach dem ersten Fix war der App-Build in CI gruen, der Docker-Build scheiterte aber im Container mit `sh: bash: not found`, weil `public-waste-calendar-web` fuer den Sync-Schritt `bash` voraussetzte.

## Aenderung
- ersetzt den Sync-Aufruf im App-Build durch `pnpm exec tsx`, also ohne Bash-Abhaengigkeit
- reduziert die Nx-Build-Inputs auf das tatsaechlich verwendete Sync-Script
- aktualisiert den Guard-Test fuer den Public-Waste-Buildpfad

## Verifikation
- `pnpm nx run data:test:unit`
- `pnpm nx run public-waste-calendar-web:build --skip-nx-cache`
- `docker buildx build --platform linux/amd64 --progress=plain --provenance=false --sbom=false -f deploy/portainer/Dockerfile.public-waste -t public-waste-calendar-web:test --load .`
- `pnpm nx affected --target=test:unit --base=origin/main`
