### PR TITLE
[codex] Fix waste mainserver sync and fraction export

### DIFF
--- a/apps/sva-studio-react/e2e/waste-management-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/waste-management-plugin.spec.ts
@@ -617,6 +617,7 @@ test.describe('waste management plugin', () => {
     await expect(page.getByRole('button', { name: 'Fraktion anlegen' })).toBeVisible();
     await page.getByRole('button', { name: 'Fraktion anlegen' }).click();
     await page.locator('#waste-fraction-name').fill('Papier');
+    await page.locator('#waste-fraction-pdf-short-label').fill('PPK');
     await page.locator('#waste-fraction-color-text').fill('#00aaee');
     await page.locator('#waste-fraction-container-size').fill('240l');
     await page.locator('#waste-fraction-description').fill('Papierfraktion für den E2E-Pfad.');
@@ -629,6 +630,7 @@ test.describe('waste management plugin', () => {
     expect(harness.requests.createdFractions).toHaveLength(1);
     expect(harness.requests.createdFractions[0]).toMatchObject({
       name: 'Papier',
+      pdfShortLabel: 'PPK',
       color: '#00aaee',
       containerSize: '240l',
     });
@@ -721,6 +723,7 @@ test.describe('waste management plugin', () => {
     ).toBeVisible();
     await page.getByRole('button', { name: 'Fraktion anlegen' }).click();
     await page.locator('#waste-fraction-name').fill('Papier Plus');
+    await page.locator('#waste-fraction-pdf-short-label').fill('PP');
     await page.locator('#waste-fraction-color-text').fill('#123456');
     await page.locator('#waste-fraction-create-form').getByRole('button', { name: 'Abfallart speichern' }).click();
     await expect(page.getByText('Für das Speichern von Waste-Fraktionen fehlt die Berechtigung.').first()).toBeVisible();

--- a/apps/sva-studio-react/src/lib/plugin-operation-runtime.server.test.ts
+++ b/apps/sva-studio-react/src/lib/plugin-operation-runtime.server.test.ts
@@ -17,6 +17,7 @@ const createPluginJobExecutionHandlersMock = vi.fn(() => ({
   'waste-management.initialize-data-source': vi.fn(),
   'waste-management.reset-data': vi.fn(),
   'waste-management.seed-data': vi.fn(),
+  'waste-management.sync-waste-types': vi.fn(),
 }));
 
 vi.mock('../../../../packages/plugin-waste-management/src/server.ts', () => ({
@@ -43,6 +44,7 @@ const declaredWasteJobTypeIds = [
   'waste-management.initialize-data-source',
   'waste-management.reset-data',
   'waste-management.seed-data',
+  'waste-management.sync-waste-types',
 ] as const;
 
 const mockWasteBrowserPluginModule = (moduleExports: Record<string, unknown>): void => {
@@ -98,6 +100,7 @@ describe('plugin operation runtime registration', () => {
       'waste-management.initialize-data-source',
       'waste-management.reset-data',
       'waste-management.seed-data',
+      'waste-management.sync-waste-types',
     ]);
     expect(registerPluginOperationExecutionHandlersMock).toHaveBeenCalledWith(handlers);
   }, 30000);
@@ -199,6 +202,7 @@ describe('plugin operation runtime registration', () => {
       'waste-management.initialize-data-source',
       'waste-management.reset-data',
       'waste-management.seed-data',
+      'waste-management.sync-waste-types',
     ]);
   });
 

--- a/apps/sva-studio-react/src/lib/waste-management-operations.schema.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.schema.ts
@@ -21,6 +21,15 @@ ORDER BY table_name ASC;
   };
 };
 
+const wasteFractionShortLabelBackfillExpression =
+  "COALESCE(NULLIF(UPPER(LEFT(REGEXP_REPLACE(name, '[^[:alnum:]]+', '', 'g'), 3)), ''), UPPER(LEFT(REPLACE(id::text, '-', ''), 3)))";
+
+export const buildWasteFractionShortLabelBackfillStatement = (tableReference: string): string => `
+UPDATE ${tableReference}
+SET pdf_short_label = ${wasteFractionShortLabelBackfillExpression}
+WHERE pdf_short_label IS NULL OR BTRIM(pdf_short_label) = '';
+`.trim();
+
 export const applySchemaStatements = (schemaName: string): readonly string[] => {
   const schema = quoteIdentifier(schemaName);
   return [
@@ -34,6 +43,8 @@ export const applySchemaStatements = (schemaName: string): readonly string[] => 
     `CREATE TABLE IF NOT EXISTS ${schema}.waste_collection_locations (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), city_id UUID NOT NULL REFERENCES ${schema}.waste_cities(id) ON DELETE CASCADE, region_id UUID REFERENCES ${schema}.waste_regions(id) ON DELETE SET NULL, street_id UUID REFERENCES ${schema}.waste_streets(id) ON DELETE SET NULL, house_number_id UUID REFERENCES ${schema}.waste_house_numbers(id) ON DELETE SET NULL, active BOOLEAN NOT NULL DEFAULT TRUE, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW());`,
     `CREATE TABLE IF NOT EXISTS ${schema}.waste_fractions (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), name TEXT NOT NULL, pdf_short_label TEXT, label_translations JSONB, container_size TEXT, color TEXT NOT NULL DEFAULT '#808080', description TEXT, active BOOLEAN NOT NULL DEFAULT TRUE, reminder_count TEXT NOT NULL DEFAULT 'none' CHECK (reminder_count IN ('none', 'once', 'twice')), first_reminder_max_lead_days INTEGER CHECK (first_reminder_max_lead_days BETWEEN 1 AND 14), second_reminder_max_lead_days INTEGER CHECK (second_reminder_max_lead_days BETWEEN 1 AND 14), reminder_channel_push_enabled BOOLEAN NOT NULL DEFAULT FALSE, reminder_channel_email_enabled BOOLEAN NOT NULL DEFAULT FALSE, reminder_channel_calendar_enabled BOOLEAN NOT NULL DEFAULT FALSE, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW());`,
     `ALTER TABLE ${schema}.waste_fractions ADD COLUMN IF NOT EXISTS pdf_short_label TEXT;`,
+    buildWasteFractionShortLabelBackfillStatement(`${schema}.waste_fractions`),
+    `ALTER TABLE ${schema}.waste_fractions ALTER COLUMN pdf_short_label SET NOT NULL;`,
     `ALTER TABLE ${schema}.waste_fractions ADD COLUMN IF NOT EXISTS reminder_count TEXT NOT NULL DEFAULT 'none';`,
     `ALTER TABLE ${schema}.waste_fractions ADD COLUMN IF NOT EXISTS first_reminder_max_lead_days INTEGER;`,
     `ALTER TABLE ${schema}.waste_fractions ADD COLUMN IF NOT EXISTS second_reminder_max_lead_days INTEGER;`,

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
@@ -221,11 +221,17 @@ describe('waste management operations runtime', () => {
     const runtime = createWasteManagementOperationRuntime();
 
     expect(runtime.syncWasteTypes).toEqual(expect.any(Function));
-    await expect(
-      runtime.syncWasteTypes('instance-1', {
-        operation: 'sync-waste-types',
-      })
-    ).rejects.toThrow('waste_mainserver_sync_not_implemented');
+    const syncPromise = runtime.syncWasteTypes('instance-1', {
+      operation: 'sync-waste-types',
+    });
+
+    await expect(syncPromise).rejects.toThrow('waste_mainserver_sync_not_implemented');
+    await expect(syncPromise).rejects.toMatchObject({
+      cause: {
+        category: 'permanent',
+        code: 'waste_mainserver_sync_not_implemented',
+      },
+    });
   });
 
   it('resolves interface-based waste secrets with the shared default revealSecret path', async () => {

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
@@ -10,6 +10,8 @@ import { createWasteManagementOperationRuntime } from './waste-management-operat
 import { applySchemaStatements } from './waste-management-operations.schema.js';
 import { resolveRuntimeDataSource } from './waste-management-operations.shared.js';
 
+const createOrUpdateSvaMainserverStaticContentMock = vi.hoisted(() => vi.fn());
+
 const createInterfaceRecord = (schemaName = 'wm'): ExternalInterfaceRecord => ({
   id: 'iface-1',
   instanceId: 'instance-1',
@@ -48,6 +50,8 @@ describe('waste management operations runtime', () => {
     vi.resetModules();
     vi.doUnmock('@sva/server-runtime');
     vi.doUnmock('@sva/data-repositories');
+    vi.doUnmock('@sva/sva-mainserver/server');
+    createOrUpdateSvaMainserverStaticContentMock.mockReset();
   });
 
   it('applies schema migrations against the resolved waste schema', async () => {
@@ -217,20 +221,87 @@ describe('waste management operations runtime', () => {
     });
   });
 
-  it('provides a fail-fast syncWasteTypes runtime method', async () => {
-    const runtime = createWasteManagementOperationRuntime();
-
-    expect(runtime.syncWasteTypes).toEqual(expect.any(Function));
-    const syncPromise = runtime.syncWasteTypes('instance-1', {
-      operation: 'sync-waste-types',
+  it('syncs wasteTypes static content to the mainserver', async () => {
+    vi.doMock('@sva/sva-mainserver/server', () => ({
+      createOrUpdateSvaMainserverStaticContent: createOrUpdateSvaMainserverStaticContentMock,
+    }));
+    createOrUpdateSvaMainserverStaticContentMock.mockResolvedValue({
+      id: 'static-1',
     });
 
-    await expect(syncPromise).rejects.toThrow('waste_mainserver_sync_not_implemented');
-    await expect(syncPromise).rejects.toMatchObject({
-      cause: {
-        category: 'permanent',
-        code: 'waste_mainserver_sync_not_implemented',
-      },
+    const repository = createRepositoryMock({
+      listWasteFractions: vi.fn(async () => [
+        {
+          id: 'fraction-bio',
+          name: 'Biotonne auf Abruf',
+          pdfShortLabel: 'BIO',
+          translations: { de: 'Biotonne auf Abruf' },
+          containerSize: undefined,
+          color: '#8B4513',
+          description: 'Nur auf Abruf',
+          active: true,
+          reminderCount: 'none',
+          reminderChannelPushEnabled: false,
+          reminderChannelEmailEnabled: false,
+          reminderChannelCalendarEnabled: false,
+          createdAt: '',
+          updatedAt: '',
+        },
+      ]),
+    });
+    const runtime = await createRuntimeWithRepositoryMock(repository);
+
+    const result = await runtime.syncWasteTypes('instance-1', {
+      operation: 'sync-waste-types',
+      keycloakSubject: 'user-1',
+      activeOrganizationId: 'org-1',
+    });
+
+    expect(createOrUpdateSvaMainserverStaticContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'instance-1',
+        keycloakSubject: 'user-1',
+        activeOrganizationId: 'org-1',
+        staticContent: expect.objectContaining({
+          name: 'wasteTypes',
+          dataType: 'JSON',
+          version: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          content: JSON.stringify(
+            {
+              BIO: {
+                label: 'Biotonne auf Abruf',
+                color: '#8B4513',
+                selected_color: '#8B4513',
+                id: 'fraction-bio',
+                short_label: 'BIO',
+                active: true,
+                description: 'Nur auf Abruf',
+                container_size: null,
+                translations: { de: 'Biotonne auf Abruf' },
+                reminders: {
+                  reminder_count: 'none',
+                  first_reminder_max_lead_days: null,
+                  second_reminder_max_lead_days: null,
+                  channels: {
+                    push: false,
+                    email: false,
+                    calendar: false,
+                  },
+                },
+              },
+            },
+            null,
+            2
+          ),
+        }),
+      })
+    );
+    expect(result.details).toMatchObject({
+      operation: 'sync-waste-types',
+      mode: 'executed',
+      staticContentName: 'wasteTypes',
+      fractionCount: 1,
+      staticContentId: 'static-1',
     });
   });
 
@@ -299,9 +370,13 @@ describe('waste management operations runtime', () => {
 
   it('reads import workbooks from inline base64 data urls', async () => {
     const repository = createRepositoryMock();
-    vi.doMock('@sva/data-repositories', () => ({
-      createWasteMasterDataRepository: vi.fn(() => repository),
-    }));
+    vi.doMock('@sva/data-repositories', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@sva/data-repositories')>();
+      return {
+        ...actual,
+        createWasteMasterDataRepository: vi.fn(() => repository),
+      };
+    });
 
     const { createWasteManagementOperationRuntime: createRuntime } = await import('./waste-management-operations.server.js');
     const runtime = createRuntime({
@@ -885,9 +960,13 @@ const createRuntimeWithRepositoryMock = async (
   repository: ReturnType<typeof createRepositoryMock>,
   workbookBytes: Uint8Array = createToursWorkbookBytes()
 ) => {
-  vi.doMock('@sva/data-repositories', () => ({
-    createWasteMasterDataRepository: vi.fn(() => repository),
-  }));
+  vi.doMock('@sva/data-repositories', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@sva/data-repositories')>();
+    return {
+      ...actual,
+      createWasteMasterDataRepository: vi.fn(() => repository),
+    };
+  });
 
   const { createWasteManagementOperationRuntime: createRuntime } = await import('./waste-management-operations.server.js');
   return createRuntime({

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
@@ -217,6 +217,17 @@ describe('waste management operations runtime', () => {
     });
   });
 
+  it('provides a fail-fast syncWasteTypes runtime method', async () => {
+    const runtime = createWasteManagementOperationRuntime();
+
+    expect(runtime.syncWasteTypes).toEqual(expect.any(Function));
+    await expect(
+      runtime.syncWasteTypes('instance-1', {
+        operation: 'sync-waste-types',
+      })
+    ).rejects.toThrow('waste_mainserver_sync_not_implemented');
+  });
+
   it('resolves interface-based waste secrets with the shared default revealSecret path', async () => {
     const secretConfigCiphertext = protectField(
       JSON.stringify({

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
@@ -7,7 +7,10 @@ import * as XLSX from 'xlsx';
 import type { SqlClient, WasteOperationSqlPool } from './waste-management-operations.types.js';
 
 import { createWasteManagementOperationRuntime } from './waste-management-operations.server.js';
-import { applySchemaStatements } from './waste-management-operations.schema.js';
+import {
+  applySchemaStatements,
+  buildWasteFractionShortLabelBackfillStatement,
+} from './waste-management-operations.schema.js';
 import { resolveRuntimeDataSource } from './waste-management-operations.shared.js';
 
 const createOrUpdateSvaMainserverStaticContentMock = vi.hoisted(() => vi.fn());
@@ -93,6 +96,8 @@ describe('waste management operations runtime', () => {
     const statements = applySchemaStatements('wm').join('\n');
     expect(statements).toContain('pdf_short_label TEXT');
     expect(statements).toContain('ALTER TABLE "wm".waste_fractions ADD COLUMN IF NOT EXISTS pdf_short_label TEXT');
+    expect(statements).toContain(buildWasteFractionShortLabelBackfillStatement('"wm".waste_fractions'));
+    expect(statements).toContain('ALTER TABLE "wm".waste_fractions ALTER COLUMN pdf_short_label SET NOT NULL');
     expect(statements).toContain('waste_custom_recurrence_presets');
     expect(statements).toContain('waste_holiday_rules');
     expect(statements).toContain('holiday_date DATE NOT NULL');
@@ -229,6 +234,7 @@ describe('waste management operations runtime', () => {
       id: 'static-1',
     });
 
+    const query = vi.fn(async () => ({ rowCount: 0, rows: [] }));
     const repository = createRepositoryMock({
       listWasteFractions: vi.fn(async () => [
         {
@@ -249,7 +255,7 @@ describe('waste management operations runtime', () => {
         },
       ]),
     });
-    const runtime = await createRuntimeWithRepositoryMock(repository);
+    const runtime = await createRuntimeWithRepositoryMock(repository, createToursWorkbookBytes(), query);
 
     const result = await runtime.syncWasteTypes('instance-1', {
       operation: 'sync-waste-types',
@@ -262,10 +268,8 @@ describe('waste management operations runtime', () => {
         instanceId: 'instance-1',
         keycloakSubject: 'user-1',
         activeOrganizationId: 'org-1',
-        staticContent: expect.objectContaining({
+        staticContent: {
           name: 'wasteTypes',
-          dataType: 'JSON',
-          version: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
           content: JSON.stringify(
             {
               BIO: {
@@ -293,9 +297,11 @@ describe('waste management operations runtime', () => {
             null,
             2
           ),
-        }),
+        },
       })
     );
+    expect(query).toHaveBeenCalledWith('SET search_path TO "wm", public;');
+    expect(query).toHaveBeenCalledWith(buildWasteFractionShortLabelBackfillStatement('waste_fractions'));
     expect(result.details).toMatchObject({
       operation: 'sync-waste-types',
       mode: 'executed',
@@ -958,7 +964,8 @@ const createRepositoryMockBase = () => ({
 
 const createRuntimeWithRepositoryMock = async (
   repository: ReturnType<typeof createRepositoryMock>,
-  workbookBytes: Uint8Array = createToursWorkbookBytes()
+  workbookBytes: Uint8Array = createToursWorkbookBytes(),
+  query: SqlClient['query'] = vi.fn(async () => ({ rowCount: 0, rows: [] }))
 ) => {
   vi.doMock('@sva/data-repositories', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@sva/data-repositories')>();
@@ -972,7 +979,7 @@ const createRuntimeWithRepositoryMock = async (
   return createRuntime({
     loadDefaultInterfaceRecord: vi.fn(async () => createInterfaceRecord()),
     revealSecret: vi.fn(revealSupabaseSecretConfig),
-    createPool: vi.fn(() => createPoolMock(createSqlClientMock(vi.fn(async () => ({ rowCount: 0, rows: [] }))))),
+    createPool: vi.fn(() => createPoolMock(createSqlClientMock(query))),
     readBinarySource: vi.fn(async () => workbookBytes),
   });
 };

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
@@ -35,95 +35,84 @@ const resolveBoundWasteSchemaName = (configuredSchemaName: string, requestedSche
   return configuredSchemaName;
 };
 
-export const createWasteManagementOperationRuntime = (
-  deps: WasteOperationRuntimeDeps = {}
-): WasteManagementOperationRuntime => ({
-  async initializeDataSource(instanceId, input) {
-    const startedAt = Date.now();
-    const dataSource = await resolveRuntimeDataSource(deps, instanceId);
+const createInitializeDataSourceOperation = (
+  deps: WasteOperationRuntimeDeps
+): WasteManagementOperationRuntime['initializeDataSource'] => async (instanceId, input) => {
+  const startedAt = Date.now();
+  const dataSource = await resolveRuntimeDataSource(deps, instanceId);
+  const schemaName = resolveBoundWasteSchemaName(dataSource.schemaName, input.targetSchema);
+  const connectionCheck = await runWasteConnectionCheck({
+    dataSource,
+    probe: async (resolved) => {
+      const pool = (deps.createPool ?? defaultCreatePool)(resolved.databaseUrl);
+      try {
+        const client = await pool.connect();
+        client.release();
+      } finally {
+        await pool.end();
+      }
+    },
+    now: deps.now,
+  });
+  const schemaInspection = await withWasteClient(deps, instanceId, async ({ client, dataSource: resolved }) =>
+    inspectWasteSchema(client, resolveBoundWasteSchemaName(resolved.schemaName, schemaName))
+  );
+  return buildOperationSummary(startedAt, {
+    operation: 'initialize-data-source',
+    mode: 'executed',
+    connectionCheck,
+    schemaInspection,
+  });
+};
+
+const createApplyMigrationsOperation = (
+  deps: WasteOperationRuntimeDeps
+): WasteManagementOperationRuntime['applyMigrations'] => async (instanceId, input) => {
+  const startedAt = Date.now();
+  const details = await withWasteClient(deps, instanceId, async ({ client, dataSource }) => {
     const schemaName = resolveBoundWasteSchemaName(dataSource.schemaName, input.targetSchema);
-    const connectionCheck = await runWasteConnectionCheck({
-      dataSource,
-      probe: async (resolved) => {
-        const pool = (deps.createPool ?? defaultCreatePool)(resolved.databaseUrl);
-        try {
-          const client = await pool.connect();
-          client.release();
-        } finally {
-          await pool.end();
-        }
-      },
-      now: deps.now,
-    });
-    const schemaInspection = await withWasteClient(deps, instanceId, async ({ client, dataSource: resolved }) =>
-      inspectWasteSchema(client, resolveBoundWasteSchemaName(resolved.schemaName, schemaName))
-    );
-    return buildOperationSummary(startedAt, {
-      operation: 'initialize-data-source',
+    const statements = applySchemaStatements(schemaName);
+    for (const statement of statements) {
+      await client.query(statement);
+    }
+    return {
+      operation: 'apply-migrations',
       mode: 'executed',
-      connectionCheck,
-      schemaInspection,
-    });
-  },
+      requestedByVersion: normalizeOptionalText(input.requestedByVersion),
+      schemaInspection: await inspectWasteSchema(client, schemaName),
+      appliedStatementCount: statements.length,
+    };
+  });
+  return buildOperationSummary(startedAt, details);
+};
 
-  async applyMigrations(instanceId, input) {
-    const startedAt = Date.now();
-    const details = await withWasteClient(deps, instanceId, async ({ client, dataSource }) => {
-      const schemaName = resolveBoundWasteSchemaName(dataSource.schemaName, input.targetSchema);
-      const statements = applySchemaStatements(schemaName);
-      for (const statement of statements) {
-        await client.query(statement);
-      }
-      return {
-        operation: 'apply-migrations',
-        mode: 'executed',
-        requestedByVersion: normalizeOptionalText(input.requestedByVersion),
-        schemaInspection: await inspectWasteSchema(client, schemaName),
-        appliedStatementCount: statements.length,
-      };
-    });
-    return buildOperationSummary(startedAt, details);
-  },
-
-  async importData(instanceId, input, progressReporter) {
-    const startedAt = Date.now();
-    const parsedLocationTourPickupDates =
-      input.importProfileId === wasteManagementOperationsContract.importProfileIds.locationTourPickupDates
-        ? await parseLocationTourPickupDateImport(deps, {
-            sourceFormat: input.sourceFormat,
-            blobRef: input.blobRef,
-            delimiterOverride: input.delimiterOverride,
-          })
-        : undefined;
-    const rows =
-      input.importProfileId === wasteManagementOperationsContract.importProfileIds.locationTourPickupDates
-        ? []
-        : await parseImportRows(deps, {
-            profileId: input.importProfileId,
-            sourceFormat: input.sourceFormat,
-            blobRef: input.blobRef,
-          });
-    const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
-      const catalogEntry = getWasteManagementImportCatalogEntry(input.importProfileId);
-      if (!catalogEntry) {
-        throw new Error(`unknown_import_profile:${input.importProfileId}`);
-      }
-      if (parsedLocationTourPickupDates) {
-        const preview = await previewLocationTourPickupDateImport(repository, parsedLocationTourPickupDates);
-        if (input.dryRun) {
-          return {
-            operation: 'import-data',
-            mode: 'executed',
-            importProfileId: input.importProfileId,
-            sourceFormat: input.sourceFormat,
-            dryRun: true,
-            rowCount: preview.validRowCount,
-            skippedRows: preview.invalidRowCount,
-            errorCount: preview.errors.length,
-            preview,
-          };
-        }
-      }
+const createImportDataOperation = (
+  deps: WasteOperationRuntimeDeps
+): WasteManagementOperationRuntime['importData'] => async (instanceId, input, progressReporter) => {
+  const startedAt = Date.now();
+  const parsedLocationTourPickupDates =
+    input.importProfileId === wasteManagementOperationsContract.importProfileIds.locationTourPickupDates
+      ? await parseLocationTourPickupDateImport(deps, {
+          sourceFormat: input.sourceFormat,
+          blobRef: input.blobRef,
+          delimiterOverride: input.delimiterOverride,
+        })
+      : undefined;
+  const rows =
+    input.importProfileId === wasteManagementOperationsContract.importProfileIds.locationTourPickupDates
+      ? []
+      : await parseImportRows(deps, {
+          profileId: input.importProfileId,
+          sourceFormat: input.sourceFormat,
+          blobRef: input.blobRef,
+        });
+  const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
+    const catalogEntry = getWasteManagementImportCatalogEntry(input.importProfileId);
+    if (!catalogEntry) {
+      throw new Error(`unknown_import_profile:${input.importProfileId}`);
+    }
+    if (parsedLocationTourPickupDates) {
+      const preview = await previewLocationTourPickupDateImport(repository, parsedLocationTourPickupDates);
       if (input.dryRun) {
         return {
           operation: 'import-data',
@@ -131,108 +120,138 @@ export const createWasteManagementOperationRuntime = (
           importProfileId: input.importProfileId,
           sourceFormat: input.sourceFormat,
           dryRun: true,
-          rowCount: rows.length,
+          rowCount: preview.validRowCount,
+          skippedRows: preview.invalidRowCount,
+          errorCount: preview.errors.length,
+          preview,
         };
       }
+    }
+    if (input.dryRun) {
       return {
         operation: 'import-data',
         mode: 'executed',
         importProfileId: input.importProfileId,
         sourceFormat: input.sourceFormat,
-        dryRun: false,
-        ...(await executeImport(repository, {
-          profileId: input.importProfileId,
-          rows,
-          parsedLocationTourPickupDates,
-          reportProgress: progressReporter?.reportProgress,
-        })),
+        dryRun: true,
+        rowCount: rows.length,
       };
-    });
-    return buildOperationSummary(startedAt, details);
-  },
+    }
+    return {
+      operation: 'import-data',
+      mode: 'executed',
+      importProfileId: input.importProfileId,
+      sourceFormat: input.sourceFormat,
+      dryRun: false,
+      ...(await executeImport(repository, {
+        profileId: input.importProfileId,
+        rows,
+        parsedLocationTourPickupDates,
+        reportProgress: progressReporter?.reportProgress,
+      })),
+    };
+  });
+  return buildOperationSummary(startedAt, details);
+};
 
-  async seedData(instanceId, input) {
-    const startedAt = Date.now();
-    const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
-      if (input.seedKey !== 'baseline') {
-        throw new Error(`unsupported_seed_key:${input.seedKey}`);
-      }
-      await seedWasteBaseline(repository);
-      return {
-        operation: 'seed-data',
-        mode: 'executed',
-        seedKey: input.seedKey,
-        seededEntityCount: Object.keys(baselineIds).length,
-      };
-    });
-    return buildOperationSummary(startedAt, details);
-  },
+const createSeedDataOperation = (
+  deps: WasteOperationRuntimeDeps
+): WasteManagementOperationRuntime['seedData'] => async (instanceId, input) => {
+  const startedAt = Date.now();
+  const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
+    if (input.seedKey !== 'baseline') {
+      throw new Error(`unsupported_seed_key:${input.seedKey}`);
+    }
+    await seedWasteBaseline(repository);
+    return {
+      operation: 'seed-data',
+      mode: 'executed',
+      seedKey: input.seedKey,
+      seededEntityCount: Object.keys(baselineIds).length,
+    };
+  });
+  return buildOperationSummary(startedAt, details);
+};
 
-  async syncWasteTypes(instanceId, input) {
-    const startedAt = Date.now();
-    const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
-      const fractions = await repository.listWasteFractions();
-      const artifact = await buildWasteTypesStaticContent(fractions);
-      const writeResult = await createOrUpdateSvaMainserverStaticContent({
-        instanceId,
-        keycloakSubject: normalizeOptionalText(input.keycloakSubject) ?? 'plugin-operation-runtime',
-        activeOrganizationId: normalizeOptionalText(input.activeOrganizationId),
-        staticContent: {
-          name: artifact.name,
-          content: artifact.content,
-          dataType: artifact.dataType,
-          version: artifact.version,
-        },
-      });
-
-      return {
-        operation: 'sync-waste-types',
-        mode: 'executed',
-        staticContentName: artifact.name,
+const createSyncWasteTypesOperation = (
+  deps: WasteOperationRuntimeDeps
+): WasteManagementOperationRuntime['syncWasteTypes'] => async (instanceId, input) => {
+  const startedAt = Date.now();
+  const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
+    const fractions = await repository.listWasteFractions();
+    const artifact = await buildWasteTypesStaticContent(fractions);
+    const writeResult = await createOrUpdateSvaMainserverStaticContent({
+      instanceId,
+      keycloakSubject: normalizeOptionalText(input.keycloakSubject) ?? 'plugin-operation-runtime',
+      activeOrganizationId: normalizeOptionalText(input.activeOrganizationId),
+      staticContent: {
+        name: artifact.name,
+        content: artifact.content,
+        dataType: artifact.dataType,
         version: artifact.version,
-        fractionCount: artifact.fractionCount,
-        staticContentId: writeResult.id,
-      };
+      },
     });
 
-    return buildOperationSummary(startedAt, details);
-  },
+    return {
+      operation: 'sync-waste-types',
+      mode: 'executed',
+      staticContentName: artifact.name,
+      version: artifact.version,
+      fractionCount: artifact.fractionCount,
+      staticContentId: writeResult.id,
+    };
+  });
 
-  async resetData(instanceId, input) {
-    const startedAt = Date.now();
-    const normalizedConfirmationToken = input.confirmationToken.trim();
-    if (normalizedConfirmationToken.length === 0) {
-      throw new Error('missing_reset_confirmation_token');
+  return buildOperationSummary(startedAt, details);
+};
+
+const createResetDataOperation = (
+  deps: WasteOperationRuntimeDeps
+): WasteManagementOperationRuntime['resetData'] => async (instanceId, input) => {
+  const startedAt = Date.now();
+  const normalizedConfirmationToken = input.confirmationToken.trim();
+  if (normalizedConfirmationToken.length === 0) {
+    throw new Error('missing_reset_confirmation_token');
+  }
+  if (normalizedConfirmationToken !== wasteManagementOperationsContract.resetConfirmationToken) {
+    throw new Error('invalid_reset_confirmation_token');
+  }
+  const details = await withWasteClient(deps, instanceId, async ({ client }) => {
+    const tableOrder = [
+      'waste_location_tour_pickup_dates',
+      'waste_location_tour_links',
+      'waste_tour_date_shifts',
+      'waste_global_date_shifts',
+      'waste_collection_locations',
+      'waste_house_numbers',
+      'waste_streets',
+      'waste_tours',
+      'waste_fractions',
+      'waste_cities',
+      'waste_regions',
+    ] as const;
+    const deletedRows: Record<string, number> = {};
+    for (const tableName of tableOrder) {
+      const result = await client.query(`DELETE FROM ${tableName};`);
+      deletedRows[tableName] = result.rowCount ?? 0;
     }
-    if (normalizedConfirmationToken !== wasteManagementOperationsContract.resetConfirmationToken) {
-      throw new Error('invalid_reset_confirmation_token');
-    }
-    const details = await withWasteClient(deps, instanceId, async ({ client }) => {
-      const tableOrder = [
-        'waste_location_tour_pickup_dates',
-        'waste_location_tour_links',
-        'waste_tour_date_shifts',
-        'waste_global_date_shifts',
-        'waste_collection_locations',
-        'waste_house_numbers',
-        'waste_streets',
-        'waste_tours',
-        'waste_fractions',
-        'waste_cities',
-        'waste_regions',
-      ] as const;
-      const deletedRows: Record<string, number> = {};
-      for (const tableName of tableOrder) {
-        const result = await client.query(`DELETE FROM ${tableName};`);
-        deletedRows[tableName] = result.rowCount ?? 0;
-      }
-      return {
-        operation: 'reset-data',
-        mode: 'executed',
-        confirmationTokenLength: normalizedConfirmationToken.length,
-        deletedRows,
-      };
-    });
-    return buildOperationSummary(startedAt, details);
-  },
+    return {
+      operation: 'reset-data',
+      mode: 'executed',
+      confirmationTokenLength: normalizedConfirmationToken.length,
+      deletedRows,
+    };
+  });
+  return buildOperationSummary(startedAt, details);
+};
+
+export const createWasteManagementOperationRuntime = (
+  deps: WasteOperationRuntimeDeps = {}
+): WasteManagementOperationRuntime => ({
+  initializeDataSource: createInitializeDataSourceOperation(deps),
+  applyMigrations: createApplyMigrationsOperation(deps),
+  importData: createImportDataOperation(deps),
+  seedData: createSeedDataOperation(deps),
+  syncWasteTypes: createSyncWasteTypesOperation(deps),
+  resetData: createResetDataOperation(deps),
 });

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
@@ -167,6 +167,10 @@ export const createWasteManagementOperationRuntime = (
     return buildOperationSummary(startedAt, details);
   },
 
+  async syncWasteTypes(_instanceId, _input) {
+    throw new Error('waste_mainserver_sync_not_implemented');
+  },
+
   async resetData(instanceId, input) {
     const startedAt = Date.now();
     const normalizedConfirmationToken = input.confirmationToken.trim();

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
@@ -168,7 +168,12 @@ export const createWasteManagementOperationRuntime = (
   },
 
   async syncWasteTypes(_instanceId, _input) {
-    throw new Error('waste_mainserver_sync_not_implemented');
+    throw new Error('waste_mainserver_sync_not_implemented', {
+      cause: {
+        category: 'permanent',
+        code: 'waste_mainserver_sync_not_implemented',
+      },
+    });
   },
 
   async resetData(instanceId, input) {

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
@@ -9,7 +9,11 @@ import {
   previewLocationTourPickupDateImport,
 } from './waste-management-operations.import.js';
 import { baselineIds, seedWasteBaseline } from './waste-management-operations.seed.js';
-import { applySchemaStatements, inspectWasteSchema } from './waste-management-operations.schema.js';
+import {
+  applySchemaStatements,
+  buildWasteFractionShortLabelBackfillStatement,
+  inspectWasteSchema,
+} from './waste-management-operations.schema.js';
 import {
   buildOperationSummary,
   defaultCreatePool,
@@ -177,7 +181,8 @@ const createSyncWasteTypesOperation = (
   deps: WasteOperationRuntimeDeps
 ): WasteManagementOperationRuntime['syncWasteTypes'] => async (instanceId, input) => {
   const startedAt = Date.now();
-  const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
+  const details = await withWasteClient(deps, instanceId, async ({ client, repository }) => {
+    await client.query(buildWasteFractionShortLabelBackfillStatement('waste_fractions'));
     const fractions = await repository.listWasteFractions();
     const artifact = await buildWasteTypesStaticContent(fractions);
     const writeResult = await createOrUpdateSvaMainserverStaticContent({
@@ -187,8 +192,6 @@ const createSyncWasteTypesOperation = (
       staticContent: {
         name: artifact.name,
         content: artifact.content,
-        dataType: artifact.dataType,
-        version: artifact.version,
       },
     });
 

--- a/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.server.ts
@@ -1,5 +1,6 @@
-import { getWasteManagementImportCatalogEntry, wasteManagementOperationsContract } from '@sva/core';
+import { buildWasteTypesStaticContent, getWasteManagementImportCatalogEntry, wasteManagementOperationsContract } from '@sva/core';
 import { runWasteConnectionCheck } from '@sva/server-runtime';
+import { createOrUpdateSvaMainserverStaticContent } from '@sva/sva-mainserver/server';
 
 import {
   executeImport,
@@ -167,13 +168,34 @@ export const createWasteManagementOperationRuntime = (
     return buildOperationSummary(startedAt, details);
   },
 
-  async syncWasteTypes(_instanceId, _input) {
-    throw new Error('waste_mainserver_sync_not_implemented', {
-      cause: {
-        category: 'permanent',
-        code: 'waste_mainserver_sync_not_implemented',
-      },
+  async syncWasteTypes(instanceId, input) {
+    const startedAt = Date.now();
+    const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
+      const fractions = await repository.listWasteFractions();
+      const artifact = await buildWasteTypesStaticContent(fractions);
+      const writeResult = await createOrUpdateSvaMainserverStaticContent({
+        instanceId,
+        keycloakSubject: normalizeOptionalText(input.keycloakSubject) ?? 'plugin-operation-runtime',
+        activeOrganizationId: normalizeOptionalText(input.activeOrganizationId),
+        staticContent: {
+          name: artifact.name,
+          content: artifact.content,
+          dataType: artifact.dataType,
+          version: artifact.version,
+        },
+      });
+
+      return {
+        operation: 'sync-waste-types',
+        mode: 'executed',
+        staticContentName: artifact.name,
+        version: artifact.version,
+        fractionCount: artifact.fractionCount,
+        staticContentId: writeResult.id,
+      };
     });
+
+    return buildOperationSummary(startedAt, details);
   },
 
   async resetData(instanceId, input) {

--- a/apps/sva-studio-react/src/lib/waste-management-operations.types.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.types.ts
@@ -5,6 +5,7 @@ import type {
   WasteManagementInitializeJobInput,
   WasteManagementResetJobInput,
   WasteManagementSeedJobInput,
+  WasteManagementSyncWasteTypesJobInput,
 } from '@sva/core';
 import type { loadDefaultExternalInterfaceRecord, listExternalInterfaceRecords } from '@sva/data-repositories/server';
 
@@ -48,5 +49,6 @@ export type WasteManagementOperationRuntime = {
     progressReporter?: WasteImportProgressReporter
   ) => Promise<OperationSummary>;
   seedData: (instanceId: string, input: WasteManagementSeedJobInput) => Promise<OperationSummary>;
+  syncWasteTypes: (instanceId: string, input: WasteManagementSyncWasteTypesJobInput) => Promise<OperationSummary>;
   resetData: (instanceId: string, input: WasteManagementResetJobInput) => Promise<OperationSummary>;
 };

--- a/apps/sva-studio-react/src/server.test.ts
+++ b/apps/sva-studio-react/src/server.test.ts
@@ -190,6 +190,38 @@ describe('server transport', () => {
     await expect(response.text()).resolves.toBe('plain');
   });
 
+  it('refreshes plugin operation handlers on subsequent development requests without restarting the worker', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const startFetch = vi.fn().mockResolvedValue(new Response('plain', { status: 200 }));
+    ensurePluginOperationWorkerStartedMock.mockResolvedValue(undefined);
+    dispatchMainserverNewsRequestMock.mockResolvedValue(null);
+    dispatchMainserverEventsRequestMock.mockResolvedValue(null);
+    dispatchMainserverPoiRequestMock.mockResolvedValue(null);
+    dispatchAuthRouteRequestMock.mockResolvedValue(null);
+    createStartHandlerMock.mockReturnValue(startFetch);
+    withRequestContextMock.mockImplementation(async (_input, callback) => callback());
+    getWorkspaceContextMock.mockReturnValue({ requestId: 'req-refresh' });
+    createSdkLoggerMock.mockReturnValue({ info: vi.fn() });
+    createServerFunctionRequestDiagnosticsMock.mockReturnValue({
+      isServerFnRequest: false,
+      requestId: 'req-refresh',
+    });
+
+    const mod = await import('./server');
+
+    await mod.default.fetch(new Request('http://localhost:3000/admin/users'));
+    await Promise.resolve();
+    const registrationCountAfterFirstRequest = registerStudioPluginOperationHandlersMock.mock.calls.length;
+    await mod.default.fetch(new Request('http://localhost:3000/admin/users?page=2'));
+    await Promise.resolve();
+
+    expect(registrationCountAfterFirstRequest).toBeGreaterThanOrEqual(1);
+    expect(registerStudioPluginOperationHandlersMock.mock.calls.length).toBeGreaterThan(registrationCountAfterFirstRequest);
+    expect(ensurePluginOperationWorkerStartedMock).toHaveBeenCalledTimes(1);
+    expect(startFetch).toHaveBeenCalledTimes(2);
+  });
+
   it('logs routed server-function requests in development', async () => {
     vi.stubEnv('NODE_ENV', 'development');
 

--- a/apps/sva-studio-react/src/server.ts
+++ b/apps/sva-studio-react/src/server.ts
@@ -12,6 +12,7 @@ import {
 
 const startFetch = createStartHandler(defaultStreamHandler);
 const diagnosticsEnabled = (process.env.NODE_ENV ?? 'development') === 'development';
+const devRuntimeRefreshEnabled = diagnosticsEnabled;
 const serverFnBase = normalizeServerFnBase(process.env.TSS_SERVER_FN_BASE);
 const studioJobWorkerEnabled = process.env.SVA_PLUGIN_OPERATION_WORKER_ENABLED !== 'false';
 
@@ -80,6 +81,10 @@ const getEnsureStudioJobWorkerStarted = async () => {
 };
 
 const getRegisterStudioPluginOperationHandlers = async () => {
+  if (devRuntimeRefreshEnabled) {
+    return (await import('./lib/plugin-operation-runtime.server')).registerStudioPluginOperationHandlers;
+  }
+
   registerStudioPluginOperationHandlersPromise ??= import('./lib/plugin-operation-runtime.server').then(
     (mod) => mod.registerStudioPluginOperationHandlers
   );
@@ -108,6 +113,19 @@ const getDispatchMainserverPoiRequest = async () => {
 };
 
 const ensurePluginOperationHandlersRegistered = async (): Promise<void> => {
+  if (devRuntimeRefreshEnabled) {
+    pluginOperationHandlerRegistrationPromise ??= (async () => {
+      const registerPluginOperationHandlers = await getRegisterStudioPluginOperationHandlers();
+      await registerPluginOperationHandlers();
+    })().finally(() => {
+      pluginOperationHandlerRegistrationPromise = null;
+      registerStudioPluginOperationHandlersPromise = null;
+    });
+
+    await pluginOperationHandlerRegistrationPromise;
+    return;
+  }
+
   pluginOperationHandlerRegistrationPromise ??= (async () => {
     const registerPluginOperationHandlers = await getRegisterStudioPluginOperationHandlers();
     await registerPluginOperationHandlers();
@@ -120,12 +138,23 @@ const ensurePluginOperationHandlersRegistered = async (): Promise<void> => {
   await pluginOperationHandlerRegistrationPromise;
 };
 
+const logPluginWorkerBootstrapFailure = async (error: unknown): Promise<void> => {
+  (await getLogger('server-entry-transport')).info('Plugin worker bootstrap failed', {
+    operation: 'plugin_operation_worker_bootstrap',
+    error: error instanceof Error ? error.message : String(error),
+  });
+};
+
 const startPluginOperationWorkerInBackground = (): void => {
   if (!studioJobWorkerEnabled) {
     return;
   }
 
   if (pluginOperationWorkerBootstrapPromise) {
+    if (devRuntimeRefreshEnabled) {
+      void ensurePluginOperationHandlersRegistered().catch((error) => logPluginWorkerBootstrapFailure(error));
+    }
+
     return;
   }
 
@@ -136,10 +165,7 @@ const startPluginOperationWorkerInBackground = (): void => {
       await startWorker();
     } catch (error) {
       pluginOperationWorkerBootstrapPromise = null;
-      (await getLogger('server-entry-transport')).info('Plugin worker bootstrap failed', {
-        operation: 'plugin_operation_worker_bootstrap',
-        error: error instanceof Error ? error.message : String(error),
-      });
+      await logPluginWorkerBootstrapFailure(error);
     }
   })();
 };

--- a/apps/sva-studio-react/vitest.shared.ts
+++ b/apps/sva-studio-react/vitest.shared.ts
@@ -38,6 +38,9 @@ export const sharedVitestConfig = defineConfig({
       '@sva/iam-governance/legal-text-sanitize-html': fileURLToPath(
         new URL('../../packages/iam-governance/src/legal-text-sanitize-html.ts', import.meta.url)
       ),
+      '@sva/iam-governance/dsr-export-payload': fileURLToPath(
+        new URL('../../packages/iam-governance/src/dsr-export-payload.ts', import.meta.url)
+      ),
       '@sva/sva-mainserver/server': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.server.ts', import.meta.url)),
       '@sva/sva-mainserver': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.ts', import.meta.url)),
       '@sva/instance-registry': fileURLToPath(new URL('../../packages/instance-registry/src/index.ts', import.meta.url)),

--- a/apps/sva-studio-react/vitest.shared.ts
+++ b/apps/sva-studio-react/vitest.shared.ts
@@ -44,6 +44,7 @@ export const sharedVitestConfig = defineConfig({
       '@sva/sva-mainserver/server': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.server.ts', import.meta.url)),
       '@sva/sva-mainserver': fileURLToPath(new URL('../../packages/sva-mainserver/src/index.ts', import.meta.url)),
       '@sva/instance-registry': fileURLToPath(new URL('../../packages/instance-registry/src/index.ts', import.meta.url)),
+      '@sva/media': fileURLToPath(new URL('../../packages/media/src/index.ts', import.meta.url)),
       '@sva/plugin-waste-management': fileURLToPath(
         new URL('../../packages/plugin-waste-management/src/index.ts', import.meta.url)
       ),

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -31,6 +31,7 @@ Abhängigkeiten des aktuellen Systems.
    - generische Route-Registry Utilities (`mergeRouteFactories`, `buildRouteTree`)
    - kanonisches Inhaltsmodell für `Content`, Statusmodell und JSON-Payload-Validierung
    - generische Plattformverträge für Studio-Jobs wie Jobstatus, Jobdetail, Jobstart, Jobquelle (`plugin|host`) und Importphasen
+   - baut framework-agnostisch das `wasteTypes`-Static-Content-Artefakt aus aktiven Fraktionen, inklusive stabiler Key-Normalisierung und inhaltsbasiertem Versionshash
 3. Routing (`packages/routing`)
    - zentrale Route-Factories (client + server)
    - einzige Source of Truth für Auth-Handler-Mapping, Runtime-Guard und JSON-Error-Boundary
@@ -71,6 +72,7 @@ Abhängigkeiten des aktuellen Systems.
   - dedizierte Integrationsschicht für OAuth2, GraphQL-Transport, Fehlerabbildung und Fachadapter
   - trennt client-sichere Typen von serverseitigen Delegations- und Diagnostikfunktionen
   - exportiert die kanonischen serverseitigen Host-Verträge für Mainserver-News, -Events, -POI und die Schnittstellenverwaltung; `apps/sva-studio-react` hält dafür nur dünne Request- und TanStack-Adapter
+  - kapselt zusätzlich den getypten Schreibpfad für Mainserver-Static-Content wie `wasteTypes` über `createOrUpdateStaticContent`, ohne Browser- oder Plugin-Code direkt an GraphQL zu koppeln
   - liest seine instanzbezogene Endpunktkonfiguration nicht mehr aus einer Mainserver-Spezialtabelle, sondern aus der zentralen External-Interface-Registry
   - hält `src/server/service.ts` bewusst als schlanke Fassade; Credentials, Token, GraphQL-Transport, Sichtbarkeits-Pagination, Mapper und ressourcenspezifische Operationen liegen in getrennten internen Modulen unter `src/server/service-internals/`
 11. Plugin News (`packages/plugin-news`)
@@ -84,6 +86,7 @@ Abhängigkeiten des aktuellen Systems.
    - konsumiert ausschließlich hostgeführte Endpunkte unter `/api/v1/waste-management/*`
    - hält bewusst nur fachliche UI-, Dialog-, Bulk- und lokale View-Model-Logik; keine direkte Datenbank-, Supabase- oder `Newcms`-Runtime-Kopplung
    - nutzt `@sva/plugin-sdk` für Route, Navigation, Audit-, Import- und Job-Verträge sowie `@sva/studio-ui-react` für generische Confirm-, Status- und Job-UI
+   - stößt nach erfolgreichen Fraktionsmutationen asynchron den dedizierten Job `waste-management.sync-waste-types` an und degradiert reine Mainserver-Sync-Fehler bewusst zu einem Retry-Hinweis im Fraktionskontext
    - zeigt für den laufenden CSV-Spezialimport eine fachnahe Live-Fortschrittskarte an, leitet Prozent und Zeilenstand aber weiterhin ausschließlich aus dem generischen Host-Jobvertrag ab
 13. Instanz-Registry (`packages/instance-registry`)
    - Host-Klassifikation, Vertrags- und Run-Modell fuer Registry, Preflight, Plan und Provisioning-Protokoll
@@ -106,6 +109,7 @@ Abhängigkeiten des aktuellen Systems.
    - eine interne Worker-Anbindung wie Graphile Worker bleibt hinter diesem Hostpfad austauschbar und ist kein Teil öffentlicher Plugin- oder Self-Service-Verträge
 15. Waste-Host-Fassade (`packages/auth-runtime`, `packages/server-runtime`, `packages/data-repositories`)
    - `@sva/auth-runtime` publiziert die hostgeführte Waste-Fassade für Settings, Historie, CRUD, Bulk-Flows und technische Tool-Starts
+   - derselbe Hostpfad startet auch den dedizierten Job `waste-management.sync-waste-types`; die eigentliche Mainserver-Schreiboperation bleibt dahinter in der Studio-Runtime und `@sva/sva-mainserver`
    - `@sva/server-runtime` löst die aktive instanzbezogene Waste-Datenquelle serverseitig auf und kapselt Secret-Nutzung sowie Connection-Checks
    - `@sva/data-repositories` hält sowohl die zentrale Governance-Persistenz der Waste-Datenquelle im Studio-Postgres als auch die hostseitigen Repositories gegen die instanzbezogene `waste_*`-Tabellenfamilie
    - `@sva/data` bleibt dabei ausdrücklich ohne neue primäre Waste-SQL- oder Orchestrierungs-Ownership

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -63,14 +63,17 @@ Fehlerpfad:
 5. Für Settings, Ausgabe-Stamminhalte, Seed, Reset, Migrations- und Importpfade löst `@sva/server-runtime` die aktive Waste-Datenquelle der Instanz auf und verwendet dabei serverseitig geschützte Secrets.
 6. Zentrale Governance-Daten wie Waste-Datenquelle, letzter Connection-Check und Auditspur liegen im Studio-Postgres; die fachlichen Waste-Daten liegen in der instanzbezogenen Waste-Fachdatenbank.
 7. Mutationen gegen Fraktionen, Orte, Abholorte, Touren, Ausweichtermine und Bulk-Zuordnungen laufen immer über dieselbe Host-Fassade und erzeugen zentrale Audit-Events.
-8. Der Tab `Ausgabe` pflegt nur statische PDF-Inhalte wie Branding und Kontaktblock; operative PDF-Erzeugung gehört nicht mehr zum Studio-Laufzeitpfad.
-9. Technische Operationen wie Import, Migration, Seed und Reset starten als generische Plugin-Jobs über den gemeinsamen Host-Jobpfad; das Plugin zeigt nur die fachnahe Bedienhülle und Statusprojektion.
-10. Der Waste-CSV-Spezialimport veröffentlicht während des Commit-Pfads blockweise Fortschritt für gültige Zeilen, inklusive fachlicher Phasen `Vorbereitung`, `Importlauf` und `Abschluss`; die Plugin-UI pollt diesen aktiven Fall enger als die generische Historienansicht.
+8. Erfolgreiche Fraktionsmutationen starten zusätzlich asynchron den dedizierten Job `waste-management.sync-waste-types`.
+9. Die Studio-Runtime lädt dafür die aktiven Fraktionen, baut in `@sva/core` das `wasteTypes`-JSON mit stabilen Kürzel-/Fallback-Keys und schreibt es über `@sva/sva-mainserver` per `createOrUpdateStaticContent` auf den Mainserver.
+10. Der Tab `Ausgabe` pflegt nur statische PDF-Inhalte wie Branding und Kontaktblock; operative PDF-Erzeugung gehört nicht mehr zum Studio-Laufzeitpfad.
+11. Technische Operationen wie Import, Migration, Seed, Reset und `sync-waste-types` starten als generische Plugin-Jobs über den gemeinsamen Host-Jobpfad; das Plugin zeigt nur die fachnahe Bedienhülle und Statusprojektion.
+12. Der Waste-CSV-Spezialimport veröffentlicht während des Commit-Pfads blockweise Fortschritt für gültige Zeilen, inklusive fachlicher Phasen `Vorbereitung`, `Importlauf` und `Abschluss`; die Plugin-UI pollt diesen aktiven Fall enger als die generische Historienansicht.
 
 Fehlerpfad:
 
 - Fehlt die Modulfreigabe oder die spezifische `waste-management.*`-Berechtigung, blockiert der Host fail-closed vor der Mutation oder dem Jobstart.
 - Fehlt oder driftet die Waste-Datenquelle einer Instanz, antwortet die Fassade mit technischem Fehlervertrag; Secrets werden nie im Plugin oder Browser aufgelöst.
+- Scheitert nach einer erfolgreichen Fraktionsmutation nur der Mainserver-Sync, bleibt die lokale Änderung bestehen; die UI zeigt stattdessen einen Warning-Hinweis mit Retry über denselben technischen Startpfad.
 - Ein `Newcms`-ähnlicher Direktzugriff auf Supabase-Funktionen, direkte DB-Connections oder mitportierte Runtime-Hooks ist kein zulässiger Alternativpfad.
 
 ### Öffentlicher Abfallkalender: Auswahl, Restore und Detailansicht

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -64,7 +64,7 @@ Fehlerpfad:
 6. Zentrale Governance-Daten wie Waste-Datenquelle, letzter Connection-Check und Auditspur liegen im Studio-Postgres; die fachlichen Waste-Daten liegen in der instanzbezogenen Waste-Fachdatenbank.
 7. Mutationen gegen Fraktionen, Orte, Abholorte, Touren, Ausweichtermine und Bulk-Zuordnungen laufen immer über dieselbe Host-Fassade und erzeugen zentrale Audit-Events.
 8. Erfolgreiche Fraktionsmutationen starten zusätzlich asynchron den dedizierten Job `waste-management.sync-waste-types`.
-9. Die Studio-Runtime lädt dafür die aktiven Fraktionen, baut in `@sva/core` das `wasteTypes`-JSON mit stabilen Kürzel-/Fallback-Keys und schreibt es über `@sva/sva-mainserver` per `createOrUpdateStaticContent` auf den Mainserver.
+9. Die Studio-Runtime lädt dafür die aktiven Fraktionen, baut in `@sva/core` das `wasteTypes`-JSON mit stabilen PDF-Kürzel-Keys und schreibt es über `@sva/sva-mainserver` per `createOrUpdateStaticContent` auf den Mainserver.
 10. Der Tab `Ausgabe` pflegt nur statische PDF-Inhalte wie Branding und Kontaktblock; operative PDF-Erzeugung gehört nicht mehr zum Studio-Laufzeitpfad.
 11. Technische Operationen wie Import, Migration, Seed, Reset und `sync-waste-types` starten als generische Plugin-Jobs über den gemeinsamen Host-Jobpfad; das Plugin zeigt nur die fachnahe Bedienhülle und Statusprojektion.
 12. Der Waste-CSV-Spezialimport veröffentlicht während des Commit-Pfads blockweise Fortschritt für gültige Zeilen, inklusive fachlicher Phasen `Vorbereitung`, `Importlauf` und `Abschluss`; die Plugin-UI pollt diesen aktiven Fall enger als die generische Historienansicht.

--- a/docs/development/studio-db-schema.md
+++ b/docs/development/studio-db-schema.md
@@ -233,7 +233,7 @@ Kernidee:
 
 Für den aktuellen Waste-PDF-Export-Shift ist wichtig:
 
-- Das optionale Fraktionskürzel `waste_fractions.pdf_short_label` gehört zur externen Waste-Fachdatenbank, nicht zur zentralen Studio-DB.
+- Das verpflichtende Fraktionskürzel `waste_fractions.pdf_short_label` gehört zur externen Waste-Fachdatenbank, nicht zur zentralen Studio-DB; Legacy-Daten werden im runtime-nahen Waste-Migrationspfad deterministisch aus Fraktionsname oder ID backfilled.
 - Die zugehörige Schemaquelle liegt aktuell im runtime-nahen Waste-Migrationspfad unter `apps/sva-studio-react/src/lib/waste-management-operations.schema.ts`.
 - PDF-bezogene Stamminhalte wie `calendarWebUrl`, `pdfBrandingAssetUrl` und `pdfContactBlock` liegen dagegen weiterhin in der zentralen Studio-DB als Teil von `iam.instance_external_interfaces.public_config`.
 

--- a/docs/superpowers/plans/2026-06-09-news-editor-redaktionelle-vereinfachung.md
+++ b/docs/superpowers/plans/2026-06-09-news-editor-redaktionelle-vereinfachung.md
@@ -1,0 +1,1062 @@
+# News Editor Redaktionelle Vereinfachung Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die News-Bearbeitung wird auf einen redaktionell vereinfachten, card-basierten Editor mit globalem Speichern, echtem Entwurfsmodus über `changeVisibility` und einer draft-fähigen Studio-Liste umgestellt.
+
+**Architecture:** Der lokale SVA-Mainserver-Adapter bekommt einen getrennten Visibility-Pfad für News sowie einen Studio-Lesemodus, der unsichtbare Datensätze einschließen kann. Das News-Plugin kapselt die neue redaktionelle Form in einem eigenen Editor-Mapping, speichert immer den Gesamtzustand und leitet Veröffentlichung, Push und Sichtbarkeit aus genau einem Save-Plan ab.
+
+**Tech Stack:** TypeScript strict mode, React, TanStack Router, React Hook Form, Zod, Vitest, Nx, bestehende `@sva/plugin-sdk`-CRUD-Clients, bestehende SVA-Mainserver-GraphQL-Integration
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/plugin-news/src/news.detail-card.tsx`
+- `packages/plugin-news/src/news.editor-model.ts`
+- `packages/plugin-news/tests/news.detail-page.test.tsx`
+- `packages/plugin-news/tests/news.editor-model.test.ts`
+- `packages/sva-mainserver/src/generated/news-visibility.ts`
+- `packages/sva-mainserver/src/server/service-internals/news-visibility-operations.ts`
+
+**Delete:**
+- `packages/plugin-news/src/news.detail-release-tab.tsx`
+
+**Modify:**
+- `apps/sva-studio-react/e2e/news-plugin.spec.ts`
+- `apps/sva-studio-react/src/routing/app-route-bindings.test.tsx`
+- `apps/sva-studio-react/src/routing/app-route-bindings.tsx`
+- `docs/architecture/05-building-block-view.md`
+- `docs/architecture/06-runtime-view.md`
+- `packages/plugin-news/src/index.ts`
+- `packages/plugin-news/src/news.api.ts`
+- `packages/plugin-news/src/news.detail-basis-tab.tsx`
+- `packages/plugin-news/src/news.detail-content-tab.tsx`
+- `packages/plugin-news/src/news.detail-form.ts`
+- `packages/plugin-news/src/news.detail-history-tab.tsx`
+- `packages/plugin-news/src/news.detail-page.tsx`
+- `packages/plugin-news/src/news.detail-settings-tab.tsx`
+- `packages/plugin-news/src/news.detail-tabs.tsx`
+- `packages/plugin-news/src/news.pages.tsx`
+- `packages/plugin-news/src/news.types.ts`
+- `packages/plugin-news/src/plugin.translations.ts`
+- `packages/plugin-news/tests/news.api.test.ts`
+- `packages/plugin-news/tests/news.detail-form.test.ts`
+- `packages/plugin-news/tests/news.detail-history-tab.test.tsx`
+- `packages/plugin-news/tests/news.pages.test.tsx`
+- `packages/plugin-news/tests/plugin.translations.test.ts`
+- `packages/sva-mainserver/src/index.server.ts`
+- `packages/sva-mainserver/src/server/news-route.test.ts`
+- `packages/sva-mainserver/src/server/news-route.ts`
+- `packages/sva-mainserver/src/server/service-internals/news-mappers.ts`
+- `packages/sva-mainserver/src/server/service-internals/news-operations.ts`
+- `packages/sva-mainserver/src/server/service.test.ts`
+- `packages/sva-mainserver/src/server/service.ts`
+- `packages/sva-mainserver/src/types.ts`
+
+## Constraints And Decisions
+
+- Drafts bleiben ein normaler News-Datensatz mit technischem `publishedAt`; der redaktionelle Zustand `Entwurf` wird ausschließlich über `visible=false` modelliert.
+- Für Visibility wird im Studio ein eigener HTTP-Pfad über die lokale News-Route eingeführt: `PATCH /api/v1/mainserver/news/:id/visibility`.
+- Der GraphQL-Record-Typ ist fest auf `NewsItem` verdrahtet; der Client darf diesen Wert nicht frei senden.
+- Bestehende Legacy-Felder außerhalb der vereinfachten Oberfläche bleiben bei Updates erhalten und werden aus dem geladenen Datensatz zurückgespiegelt.
+- Die Studio-Liste lädt Drafts explizit mit; öffentliche oder sichtbarkeitsorientierte Listen filtern unsichtbare News weiterhin heraus.
+
+### Task 1: Add News Visibility Mutation Support To The Local Mainserver Adapter
+
+**Files:**
+- Create: `packages/sva-mainserver/src/generated/news-visibility.ts`
+- Create: `packages/sva-mainserver/src/server/service-internals/news-visibility-operations.ts`
+- Modify: `packages/sva-mainserver/src/types.ts`
+- Modify: `packages/sva-mainserver/src/server/service.ts`
+- Modify: `packages/sva-mainserver/src/server/news-route.ts`
+- Modify: `packages/sva-mainserver/src/server/service-internals/news-operations.ts`
+- Modify: `packages/sva-mainserver/src/index.server.ts`
+- Test: `packages/sva-mainserver/src/server/service.test.ts`
+- Test: `packages/sva-mainserver/src/server/news-route.test.ts`
+
+- [ ] **Step 1: Write the failing adapter and route tests**
+
+```ts
+// packages/sva-mainserver/src/server/service.test.ts
+it('keeps invisible upstream news in studio mode', async () => {
+  const service = createSvaMainserverService({ fetchImpl: fetchMock as typeof fetch });
+
+  await expect(
+    service.listNews({
+      instanceId: 'instance-1',
+      keycloakSubject: 'user-1',
+      page: 1,
+      pageSize: 25,
+      includeInvisible: true,
+    })
+  ).resolves.toMatchObject({
+    data: expect.arrayContaining([
+      expect.objectContaining({ id: 'news-visible', visible: true }),
+      expect.objectContaining({ id: 'news-draft', visible: false }),
+    ]),
+  });
+});
+
+it('calls changeVisibility with recordType NewsItem', async () => {
+  const service = createSvaMainserverService({ fetchImpl: fetchMock as typeof fetch });
+
+  await service.changeNewsVisibility({
+    instanceId: 'instance-1',
+    keycloakSubject: 'user-1',
+    newsId: 'news-1',
+    visible: false,
+  });
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({
+      method: 'POST',
+      body: expect.stringContaining('"recordType":"NewsItem"'),
+    })
+  );
+});
+
+// packages/sva-mainserver/src/server/news-route.test.ts
+it('handles PATCH /api/v1/mainserver/news/:id/visibility', async () => {
+  const request = new Request('https://studio.test/api/v1/mainserver/news/news-1/visibility', {
+    method: 'PATCH',
+    body: JSON.stringify({ visible: false }),
+    headers: { 'content-type': 'application/json' },
+  });
+
+  await dispatchSvaMainserverNewsRequest(request);
+
+  expect(changeSvaMainserverNewsVisibility).toHaveBeenCalledWith(
+    expect.objectContaining({ newsId: 'news-1', visible: false })
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused adapter tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts --testFiles=src/server/news-route.test.ts
+```
+
+Expected:
+
+```text
+FAIL  packages/sva-mainserver/src/server/service.test.ts > keeps invisible upstream news in studio mode
+FAIL  packages/sva-mainserver/src/server/service.test.ts > calls changeVisibility with recordType NewsItem
+FAIL  packages/sva-mainserver/src/server/news-route.test.ts > handles PATCH /api/v1/mainserver/news/:id/visibility
+```
+
+- [ ] **Step 3: Add the GraphQL visibility document, service contract, and studio list flag**
+
+```ts
+// packages/sva-mainserver/src/types.ts
+export type SvaMainserverListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly includeInvisible?: boolean;
+};
+
+// packages/sva-mainserver/src/generated/news-visibility.ts
+export const svaMainserverChangeNewsVisibilityDocument = /* GraphQL */ `
+  mutation SvaMainserverChangeNewsVisibility($id: ID!, $recordType: String!, $visible: Boolean!) {
+    changeVisibility(id: $id, recordType: $recordType, visible: $visible) {
+      statusCode
+      success
+      message
+    }
+  }
+`;
+
+// packages/sva-mainserver/src/server/service-internals/news-visibility-operations.ts
+export const createNewsVisibilityOperations = (executeGraphqlWithConfig: GraphqlExecutor) => ({
+  changeNewsVisibilityWithConfig: async (
+    input: SvaMainserverConnectionInput & { readonly newsId: string; readonly visible: boolean },
+    config: SvaMainserverInstanceConfig
+  ) =>
+    executeGraphqlWithConfig(
+      {
+        ...input,
+        document: svaMainserverChangeNewsVisibilityDocument,
+        operationName: 'SvaMainserverChangeNewsVisibility',
+        variables: { id: input.newsId, recordType: 'NewsItem', visible: input.visible },
+      },
+      config
+    ),
+});
+
+// packages/sva-mainserver/src/server/service-internals/news-operations.ts
+const includeInvisible = input.includeInvisible === true;
+
+return listVisibleRecordsWithConfig({
+  input,
+  config,
+  loadPage,
+  isVisible: includeInvisible ? () => true : (item) => item.visible !== false,
+});
+```
+
+- [ ] **Step 4: Wire the new service method and HTTP route**
+
+```ts
+// packages/sva-mainserver/src/server/service.ts
+const newsVisibilityOperations = createNewsVisibilityOperations(executeGraphqlWithConfig);
+
+const changeNewsVisibility = async (
+  input: SvaMainserverConnectionInput & { readonly newsId: string; readonly visible: boolean }
+) => {
+  const config = await loadValidatedInstanceConfig(input, 'load_instance_config');
+  await newsVisibilityOperations.changeNewsVisibilityWithConfig(input, config);
+};
+
+export const changeSvaMainserverNewsVisibility = (
+  input: SvaMainserverConnectionInput & { readonly newsId: string; readonly visible: boolean }
+) => getDefaultService().changeNewsVisibility(input);
+
+// packages/sva-mainserver/src/server/news-route.ts
+type RouteMatch =
+  | { readonly kind: 'collection' }
+  | { readonly kind: 'categories' }
+  | { readonly kind: 'item'; readonly newsId: string }
+  | { readonly kind: 'itemVisibility'; readonly newsId: string };
+
+if (pathname.endsWith('/visibility') && pathname.startsWith(NEWS_ITEM_PATH_PREFIX)) {
+  return { kind: 'itemVisibility', newsId: decodeURIComponent(pathname.slice(NEWS_ITEM_PATH_PREFIX.length, -'/visibility'.length)) };
+}
+
+const includeInvisible = new URL(request.url).searchParams.get('includeInvisible') === 'true';
+
+return listSvaMainserverNews({ ...actor, ...parseMainserverListQuery(request), includeInvisible });
+```
+
+- [ ] **Step 5: Re-run the adapter slice and the runtime/type checks**
+
+Run:
+
+```bash
+pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts --testFiles=src/server/news-route.test.ts
+pnpm nx run sva-mainserver:test:types
+pnpm nx run sva-mainserver:check:runtime
+```
+
+Expected:
+
+```text
+PASS  packages/sva-mainserver/src/server/service.test.ts
+PASS  packages/sva-mainserver/src/server/news-route.test.ts
+PASS  sva-mainserver:test:types
+PASS  sva-mainserver:check:runtime
+```
+
+- [ ] **Step 6: Commit the adapter foundation**
+
+```bash
+git add packages/sva-mainserver/src/types.ts packages/sva-mainserver/src/generated/news-visibility.ts packages/sva-mainserver/src/server/service-internals/news-visibility-operations.ts packages/sva-mainserver/src/server/service-internals/news-operations.ts packages/sva-mainserver/src/server/service.ts packages/sva-mainserver/src/server/news-route.ts packages/sva-mainserver/src/server/service.test.ts packages/sva-mainserver/src/server/news-route.test.ts packages/sva-mainserver/src/index.server.ts
+git commit -m "feat: add news visibility support to mainserver adapter"
+```
+
+### Task 2: Introduce The Simplified Editorial Form Model
+
+**Files:**
+- Create: `packages/plugin-news/src/news.editor-model.ts`
+- Create: `packages/plugin-news/tests/news.editor-model.test.ts`
+- Modify: `packages/plugin-news/src/news.types.ts`
+- Modify: `packages/plugin-news/src/news.detail-form.ts`
+- Modify: `packages/plugin-news/tests/news.detail-form.test.ts`
+
+- [ ] **Step 1: Write the failing editor-model and form tests**
+
+```ts
+// packages/plugin-news/tests/news.editor-model.test.ts
+it('falls back to the first content block headline when the explicit title is empty', () => {
+  expect(
+    createNewsEditorFormValues({
+      ...newsItemFixture,
+      title: '',
+      contentBlocks: [{ title: 'Block Headline', intro: 'Teaser', body: '<p>Body</p>', mediaContents: [] }],
+    }).title
+  ).toBe('Block Headline');
+});
+
+it('derives draft, scheduled, and published from visible and publishedAt', () => {
+  expect(deriveNewsEditorialStatus({ visible: false, publishedAt: '2026-06-09T09:00:00.000Z' }, '2026-06-09T10:00:00.000Z')).toBe('draft');
+  expect(deriveNewsEditorialStatus({ visible: true, publishedAt: '2026-06-09T11:00:00.000Z' }, '2026-06-09T10:00:00.000Z')).toBe('scheduled');
+  expect(deriveNewsEditorialStatus({ visible: true, publishedAt: '2026-06-09T09:00:00.000Z' }, '2026-06-09T10:00:00.000Z')).toBe('published');
+});
+
+it('preserves hidden legacy fields on update payloads', () => {
+  const payload = buildNewsSavePayload(editorValuesFixture, newsItemFixture, '2026-06-09T10:00:00.000Z').mutation;
+  expect(payload).toMatchObject({
+    externalId: 'legacy-external-id',
+    newsType: 'legacy-news-type',
+    charactersToBeShown: 240,
+    fullVersion: true,
+    showPublishDate: false,
+    pointOfInterestId: 'poi-7',
+  });
+});
+
+// packages/plugin-news/tests/news.detail-form.test.ts
+it('requires a schedule date only for scheduled publication mode', async () => {
+  await expect(newsDetailFormSchema.parseAsync({
+    ...createDefaultNewsDetailFormValues(),
+    title: 'News title',
+    author: 'Redaktion',
+    contentTeaser: 'Teaser',
+    contentBody: '<p>Body</p>',
+    publicationMode: 'scheduled',
+    scheduledPublicationAt: '',
+  })).rejects.toThrow();
+});
+```
+
+- [ ] **Step 2: Run the focused editor-model tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.editor-model.test.ts --testFiles=tests/news.detail-form.test.ts
+```
+
+Expected:
+
+```text
+FAIL  packages/plugin-news/tests/news.editor-model.test.ts > falls back to the first content block headline when the explicit title is empty
+FAIL  packages/plugin-news/tests/news.editor-model.test.ts > derives draft, scheduled, and published from visible and publishedAt
+FAIL  packages/plugin-news/tests/news.detail-form.test.ts > requires a schedule date only for scheduled publication mode
+```
+
+- [ ] **Step 3: Define the editorial types and payload builder**
+
+```ts
+// packages/plugin-news/src/news.types.ts
+export type NewsPublicationMode = 'draft' | 'immediate' | 'scheduled';
+export type NewsEditorialStatus = 'draft' | 'scheduled' | 'published';
+
+export type NewsDetailFormValues = {
+  title: string;
+  author: string;
+  categories: string[];
+  contentTeaser: string;
+  contentBody: string;
+  contentMedia: NewsMediaContentFormValue[];
+  sourceUrl: string;
+  sourceUrlDescription: string;
+  pushNotificationEnabled: boolean;
+  publicationMode: NewsPublicationMode;
+  scheduledPublicationAt: string;
+};
+
+export type NewsSavePlan = {
+  readonly mutation: NewsFormInput;
+  readonly visible: boolean;
+  readonly editorialStatus: NewsEditorialStatus;
+};
+
+// packages/plugin-news/src/news.editor-model.ts
+export const deriveNewsEditorialStatus = (
+  input: Pick<NewsContentItem, 'visible' | 'publishedAt'>,
+  nowIso: string
+): NewsEditorialStatus => {
+  if (input.visible === false) {
+    return 'draft';
+  }
+  return new Date(input.publishedAt).getTime() > new Date(nowIso).getTime() ? 'scheduled' : 'published';
+};
+
+export const createNewsEditorFormValues = (item: NewsContentItem): NewsDetailFormValues => {
+  const firstBlock = item.contentBlocks?.[0];
+  const editorialStatus = deriveNewsEditorialStatus(item, new Date().toISOString());
+  return {
+    title: item.title.trim().length > 0 ? item.title : firstBlock?.title ?? '',
+    author: item.author,
+    categories: item.categories?.map((category) => category.name) ?? [],
+    contentTeaser: firstBlock?.intro ?? item.payload.teaser ?? '',
+    contentBody: firstBlock?.body ?? item.payload.body ?? '',
+    contentMedia:
+      firstBlock?.mediaContents?.map((media) => ({
+        captionText: media.captionText ?? '',
+        copyright: media.copyright ?? '',
+        contentType: media.contentType ?? 'image',
+        height: media.height !== undefined ? String(media.height) : '',
+        width: media.width !== undefined ? String(media.width) : '',
+        sourceUrl: {
+          url: media.sourceUrl?.url ?? '',
+          description: media.sourceUrl?.description ?? '',
+        },
+      })) ?? [],
+    sourceUrl: item.sourceUrl?.url ?? '',
+    sourceUrlDescription: item.sourceUrl?.description ?? '',
+    pushNotificationEnabled: false,
+    publicationMode: editorialStatus === 'draft' ? 'draft' : editorialStatus === 'scheduled' ? 'scheduled' : 'immediate',
+    scheduledPublicationAt: editorialStatus === 'scheduled' ? item.publishedAt : '',
+  };
+};
+
+export const buildNewsSavePayload = (
+  values: NewsDetailFormValues,
+  existingItem: NewsContentItem | null,
+  nowIso: string
+): NewsSavePlan => {
+  const publishedAt =
+    values.publicationMode === 'scheduled'
+      ? values.scheduledPublicationAt
+      : nowIso;
+  const visible = values.publicationMode !== 'draft';
+
+  return {
+    visible,
+    editorialStatus: deriveNewsEditorialStatus({ visible, publishedAt }, nowIso),
+    mutation: {
+      externalId: existingItem?.externalId,
+      fullVersion: existingItem?.fullVersion,
+      charactersToBeShown:
+        existingItem?.charactersToBeShown !== undefined ? Number(existingItem.charactersToBeShown) : undefined,
+      newsType: existingItem?.newsType,
+      showPublishDate: existingItem?.showPublishDate,
+      pointOfInterestId: existingItem?.pointOfInterestId,
+      title: values.title,
+      author: values.author,
+      categories: values.categories.map((name) => ({ name })),
+      publishedAt: values.publicationMode === 'draft' ? nowIso : publishedAt,
+      publicationDate: values.publicationMode === 'draft' ? nowIso : publishedAt,
+      sourceUrl: {
+        url: values.sourceUrl,
+        description: values.sourceUrlDescription,
+      },
+      contentBlocks: [
+        {
+          title: values.title,
+          intro: values.contentTeaser,
+          body: values.contentBody,
+          mediaContents: values.contentMedia,
+        },
+      ],
+      ...(existingItem?.pushNotificationsSentAt ? {} : { pushNotification: values.pushNotificationEnabled }),
+    },
+  };
+};
+```
+
+- [ ] **Step 4: Replace the old form schema with the simplified redactional one**
+
+```ts
+// packages/plugin-news/src/news.detail-form.ts
+export const newsDetailFormSchema = z.object({
+  title: z.string().trim().min(1, 'title'),
+  author: z.string().trim().min(1, 'author'),
+  categories: z.array(z.string().trim().min(1, 'categories')),
+  contentTeaser: z.string(),
+  contentBody: z.string().trim().min(1, 'contentBody'),
+  contentMedia: z.array(mediaContentSchema),
+  sourceUrl: z.string(),
+  sourceUrlDescription: z.string(),
+  pushNotificationEnabled: z.boolean(),
+  publicationMode: z.enum(['draft', 'immediate', 'scheduled']),
+  scheduledPublicationAt: z.string(),
+}).superRefine((values, ctx) => {
+  if (values.sourceUrl.length > 0 && isHttpsUrl(values.sourceUrl) === false) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['sourceUrl'], message: 'sourceUrl' });
+  }
+
+  if (values.publicationMode === 'scheduled' && isValidDateString(values.scheduledPublicationAt) === false) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['scheduledPublicationAt'], message: 'scheduledPublicationAt' });
+  }
+
+  if (getVisibleTextLength(values.contentBody) === 0) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['contentBody'], message: 'contentBody' });
+  }
+});
+
+export const createDefaultNewsDetailFormValues = (author = ''): NewsDetailFormValues => ({
+  title: '',
+  author,
+  categories: [],
+  contentTeaser: '',
+  contentBody: '',
+  contentMedia: [],
+  sourceUrl: '',
+  sourceUrlDescription: '',
+  pushNotificationEnabled: false,
+  publicationMode: 'draft',
+  scheduledPublicationAt: '',
+});
+```
+
+- [ ] **Step 5: Re-run the plugin-news unit and type checks**
+
+Run:
+
+```bash
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.editor-model.test.ts --testFiles=tests/news.detail-form.test.ts
+pnpm nx run plugin-news:test:types
+```
+
+Expected:
+
+```text
+PASS  packages/plugin-news/tests/news.editor-model.test.ts
+PASS  packages/plugin-news/tests/news.detail-form.test.ts
+PASS  plugin-news:test:types
+```
+
+- [ ] **Step 6: Commit the editor model slice**
+
+```bash
+git add packages/plugin-news/src/news.types.ts packages/plugin-news/src/news.editor-model.ts packages/plugin-news/src/news.detail-form.ts packages/plugin-news/tests/news.editor-model.test.ts packages/plugin-news/tests/news.detail-form.test.ts
+git commit -m "feat: add simplified news editor model"
+```
+
+### Task 3: Wire Author Context And One Global Save Flow
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/routing/app-route-bindings.tsx`
+- Modify: `apps/sva-studio-react/src/routing/app-route-bindings.test.tsx`
+- Modify: `packages/plugin-news/src/news.api.ts`
+- Modify: `packages/plugin-news/src/news.detail-page.tsx`
+- Modify: `packages/plugin-news/src/news.types.ts`
+- Modify: `packages/plugin-news/src/index.ts`
+- Modify: `packages/plugin-news/tests/news.api.test.ts`
+- Create: `packages/plugin-news/tests/news.detail-page.test.tsx`
+
+- [ ] **Step 1: Write the failing author-context and save-flow tests**
+
+```ts
+// apps/sva-studio-react/src/routing/app-route-bindings.test.tsx
+it('offers organization or personal author choice when contentAuthorPolicy is org_or_personal', async () => {
+  render(<NewsCreateRoutePage />);
+
+  await expect(screen.findByLabelText('Autor')).resolves.toHaveValue('Organisation Musterstadt');
+  expect(screen.getAllByRole('option').map((option) => option.textContent)).toEqual([
+    'Organisation Musterstadt',
+    'Max Mustermann',
+  ]);
+});
+
+// packages/plugin-news/tests/news.api.test.ts
+it('creates a draft with a second visibility request', async () => {
+  await saveNewsEditorItem({ values: { ...editorValuesFixture, publicationMode: 'draft' } });
+
+  expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/v1/mainserver/news', expect.objectContaining({ method: 'POST' }));
+  expect(fetchMock).toHaveBeenNthCalledWith(
+    2,
+    '/api/v1/mainserver/news/news-1/visibility',
+    expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ visible: false }) })
+  );
+});
+
+// packages/plugin-news/tests/news.detail-page.test.tsx
+it('renders exactly one save button in the page header', () => {
+  render(<NewsDetailPage mode="create" initialAuthor="Redaktion" />);
+  expect(screen.getAllByRole('button', { name: 'Speichern' })).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run the focused route, API, and page tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routing/app-route-bindings.test.tsx
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.api.test.ts --testFiles=tests/news.detail-page.test.tsx
+```
+
+Expected:
+
+```text
+FAIL  apps/sva-studio-react/src/routing/app-route-bindings.test.tsx > offers organization or personal author choice when contentAuthorPolicy is org_or_personal
+FAIL  packages/plugin-news/tests/news.api.test.ts > creates a draft with a second visibility request
+FAIL  packages/plugin-news/tests/news.detail-page.test.tsx > renders exactly one save button in the page header
+```
+
+- [ ] **Step 3: Replace the single initial-author string with an author control model**
+
+```ts
+// packages/plugin-news/src/news.types.ts
+export type NewsAuthorControl =
+  | { readonly kind: 'fixed'; readonly value: string }
+  | {
+      readonly kind: 'selectable';
+      readonly value: string;
+      readonly options: readonly { readonly value: string; readonly label: string }[];
+    };
+
+// apps/sva-studio-react/src/routing/app-route-bindings.tsx
+const resolveNewsAuthorControl = (input: {
+  readonly organizations: readonly IamOrganizationContextOption[];
+  readonly organizationDetails: ReadonlyMap<string, IamOrganizationDetail>;
+  readonly userDisplayName?: string;
+}): NewsAuthorControl => {
+  const activeOrganization = input.organizations.find((organization) => organization.isActive);
+  const userDisplayName = input.userDisplayName?.trim() || 'Benutzer';
+  const policy = activeOrganization
+    ? input.organizationDetails.get(activeOrganization.organizationId)?.contentAuthorPolicy
+    : undefined;
+
+  if (policy === 'org_only' && activeOrganization?.displayName.trim()) {
+    return { kind: 'fixed', value: activeOrganization.displayName.trim() };
+  }
+
+  if (policy === 'org_or_personal' && activeOrganization?.displayName.trim()) {
+    return {
+      kind: 'selectable',
+      value: activeOrganization.displayName.trim(),
+      options: [
+        { value: activeOrganization.displayName.trim(), label: activeOrganization.displayName.trim() },
+        { value: userDisplayName, label: userDisplayName },
+      ],
+    };
+  }
+
+  return { kind: 'fixed', value: userDisplayName };
+};
+
+return <NewsCreatePage authorControl={authorControl} />;
+```
+
+- [ ] **Step 4: Implement the single save orchestration in the page and API client**
+
+```ts
+// packages/plugin-news/src/news.api.ts
+export const setNewsVisibility = async (contentId: string, visible: boolean): Promise<void> => {
+  await requestMainserverJson<{ readonly status: string }, NewsApiError>({
+    url: `/api/v1/mainserver/news/${encodeURIComponent(contentId)}/visibility`,
+    method: 'PATCH',
+    body: JSON.stringify({ visible }),
+    headers: createMainserverJsonRequestHeaders(),
+    errorFactory: (code, message) => new NewsApiError(code, message),
+  });
+};
+
+export const saveNewsEditorItem = async (input: {
+  readonly contentId?: string;
+  readonly values: NewsDetailFormValues;
+  readonly existingItem?: NewsContentItem | null;
+  readonly now?: () => string;
+}): Promise<NewsContentItem> => {
+  const nowIso = input.now?.() ?? new Date().toISOString();
+  const plan = buildNewsSavePayload(input.values, input.existingItem ?? null, nowIso);
+  const saved = input.contentId
+    ? await updateNews(input.contentId, plan.mutation)
+    : await createNews(plan.mutation);
+
+  await setNewsVisibility(saved.id, plan.visible);
+  return getNews(saved.id);
+};
+
+// packages/plugin-news/src/news.detail-page.tsx
+const onSubmit = form.handleSubmit(async (values) => {
+  const saved = await saveNewsEditorItem({ contentId, values, existingItem: item ?? null });
+  navigateToSavedItem(saved.id);
+});
+
+<StudioOverviewPageTemplate
+  title={pageTitle}
+  primaryAction={<Button type="submit" form={formId}>{pt('actions.save')}</Button>}
+>
+```
+
+- [ ] **Step 5: Re-run the author/save slice and type checks**
+
+Run:
+
+```bash
+pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routing/app-route-bindings.test.tsx
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.api.test.ts --testFiles=tests/news.detail-page.test.tsx
+pnpm nx run plugin-news:test:types
+pnpm nx run sva-studio-react:test:types
+```
+
+Expected:
+
+```text
+PASS  apps/sva-studio-react/src/routing/app-route-bindings.test.tsx
+PASS  packages/plugin-news/tests/news.api.test.ts
+PASS  packages/plugin-news/tests/news.detail-page.test.tsx
+PASS  plugin-news:test:types
+PASS  sva-studio-react:test:types
+```
+
+- [ ] **Step 6: Commit the author/save orchestration**
+
+```bash
+git add apps/sva-studio-react/src/routing/app-route-bindings.tsx apps/sva-studio-react/src/routing/app-route-bindings.test.tsx packages/plugin-news/src/news.api.ts packages/plugin-news/src/news.detail-page.tsx packages/plugin-news/src/news.types.ts packages/plugin-news/src/index.ts packages/plugin-news/tests/news.api.test.ts packages/plugin-news/tests/news.detail-page.test.tsx
+git commit -m "feat: wire global save flow for news editor"
+```
+
+### Task 4: Rebuild The Tabs Into Card-Based Editorial Panels
+
+**Files:**
+- Create: `packages/plugin-news/src/news.detail-card.tsx`
+- Modify: `packages/plugin-news/src/news.detail-basis-tab.tsx`
+- Modify: `packages/plugin-news/src/news.detail-content-tab.tsx`
+- Modify: `packages/plugin-news/src/news.detail-history-tab.tsx`
+- Modify: `packages/plugin-news/src/news.detail-settings-tab.tsx`
+- Modify: `packages/plugin-news/src/news.detail-tabs.tsx`
+- Modify: `packages/plugin-news/src/plugin.translations.ts`
+- Modify: `packages/plugin-news/tests/news.detail-history-tab.test.tsx`
+- Modify: `packages/plugin-news/tests/plugin.translations.test.ts`
+- Delete: `packages/plugin-news/src/news.detail-release-tab.tsx`
+- Test: `packages/plugin-news/tests/news.detail-page.test.tsx`
+
+- [ ] **Step 1: Write the failing UI-structure and translation tests**
+
+```ts
+// packages/plugin-news/tests/news.detail-page.test.tsx
+it('renders the tabs basis, content, settings, and history only', () => {
+  render(<NewsDetailPage mode="edit" item={newsItemFixture} authorControl={{ kind: 'fixed', value: 'Redaktion' }} />);
+  expect(screen.queryByRole('tab', { name: 'Veröffentlichung' })).not.toBeInTheDocument();
+  expect(screen.getByRole('tab', { name: 'Basis' })).toBeInTheDocument();
+  expect(screen.getByRole('tab', { name: 'Inhalte' })).toBeInTheDocument();
+  expect(screen.getByRole('tab', { name: 'Einstellungen' })).toBeInTheDocument();
+  expect(screen.getByRole('tab', { name: 'Historie' })).toBeInTheDocument();
+});
+
+it('shows the publication mode radios and only reveals the schedule field when scheduled is selected', async () => {
+  render(<NewsDetailPage mode="create" authorControl={{ kind: 'fixed', value: 'Redaktion' }} />);
+  await user.click(screen.getByRole('tab', { name: 'Einstellungen' }));
+  expect(screen.getByLabelText('Entwurfsmodus')).toBeChecked();
+  expect(screen.queryByLabelText('Veröffentlichungszeitpunkt')).not.toBeInTheDocument();
+});
+
+// packages/plugin-news/tests/news.detail-history-tab.test.tsx
+it('shows a history empty state when there are no entries', () => {
+  render(<NewsDetailHistoryTab entries={[]} />);
+  expect(screen.getByText('Noch keine Historie vorhanden.')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the focused component and translation tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.detail-page.test.tsx --testFiles=tests/news.detail-history-tab.test.tsx --testFiles=tests/plugin.translations.test.ts
+```
+
+Expected:
+
+```text
+FAIL  packages/plugin-news/tests/news.detail-page.test.tsx > renders the tabs basis, content, settings, and history only
+FAIL  packages/plugin-news/tests/news.detail-page.test.tsx > shows the publication mode radios and only reveals the schedule field when scheduled is selected
+FAIL  packages/plugin-news/tests/news.detail-history-tab.test.tsx > shows a history empty state when there are no entries
+```
+
+- [ ] **Step 3: Add the reusable card shell and rebuild the tabs around editorial tasks**
+
+```tsx
+// packages/plugin-news/src/news.detail-card.tsx
+export const NewsDetailCard = ({
+  title,
+  description,
+  children,
+}: {
+  readonly title: string;
+  readonly description?: string;
+  readonly children: React.ReactNode;
+}) => (
+  <section className="rounded-2xl border border-border/60 bg-white p-6 shadow-sm">
+    <header className="mb-4 space-y-1">
+      <h2 className="text-base font-semibold text-foreground">{title}</h2>
+      {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+    </header>
+    <div className="space-y-4">{children}</div>
+  </section>
+);
+
+// packages/plugin-news/src/news.detail-tabs.tsx
+export type NewsDetailTabId = 'basis' | 'content' | 'settings' | 'history';
+
+export const NEWS_DETAIL_TABS: readonly NewsDetailTabId[] = ['basis', 'content', 'settings', 'history'];
+
+// packages/plugin-news/src/news.detail-settings-tab.tsx
+<NewsDetailCard title={pt('cards.push.title')} description={pt('cards.push.description')}>
+  {item?.pushNotificationsSentAt ? (
+    <p>{formatDate(item.pushNotificationsSentAt) ?? '--.--.-- --:--'}</p>
+  ) : (
+    <SwitchField name="pushNotificationEnabled" label={pt('fields.pushNotificationEnabled')} />
+  )}
+</NewsDetailCard>
+
+<NewsDetailCard title={pt('cards.publication.title')} description={pt('cards.publication.description')}>
+  <RadioGroupField name="publicationMode" options={[
+    { value: 'draft', label: pt('publicationModes.draft') },
+    { value: 'immediate', label: pt('publicationModes.immediate') },
+    { value: 'scheduled', label: pt('publicationModes.scheduled') },
+  ]} />
+  {watchPublicationMode === 'scheduled' ? (
+    <DateTimeField name="scheduledPublicationAt" label={pt('fields.scheduledPublicationAt')} />
+  ) : null}
+</NewsDetailCard>
+```
+
+- [ ] **Step 4: Update the Basis-, Inhalte-, and Historie-tabs plus the translations**
+
+```tsx
+// packages/plugin-news/src/news.detail-basis-tab.tsx
+<NewsDetailCard title={pt('cards.titleCategories.title')} description={pt('cards.titleCategories.description')}>
+  <InputField name="title" label={pt('fields.title')} />
+  <CategoryRepeaterField name="categories" addLabel={pt('actions.addCategory')} />
+</NewsDetailCard>
+
+<NewsDetailCard title={pt('cards.authorMeta.title')} description={pt('cards.authorMeta.description')}>
+  {authorControl.kind === 'selectable' ? (
+    <SelectField name="author" label={pt('fields.author')} options={authorControl.options} />
+  ) : (
+    <ReadOnlyField label={pt('fields.author')} value={authorControl.value} />
+  )}
+  <MetadataGrid values={{
+    createdAt: item?.createdAt ?? '--.--.-- --:--',
+    publishedAt: item?.publishedAt ?? '--.--.-- --:--',
+    updatedAt: item?.updatedAt ?? '--.--.-- --:--',
+  }} />
+</NewsDetailCard>
+
+// packages/plugin-news/src/news.detail-content-tab.tsx
+<NewsDetailCard title={pt('cards.content.title')} description={pt('cards.content.description')}>
+  <ReadOnlyField label={pt('fields.headline')} value={form.watch('title')} />
+  <TextareaField name="contentTeaser" label={pt('fields.contentTeaser')} />
+  <RichTextEditorField name="contentBody" label={pt('fields.contentBody')} />
+</NewsDetailCard>
+
+<NewsDetailCard title={pt('cards.media.title')} description={pt('cards.media.description')}>
+  <MediaRepeaterField name="contentMedia" />
+</NewsDetailCard>
+
+<NewsDetailCard title={pt('cards.history.title')} description={pt('cards.history.description')}>
+  <StudioDataTable
+    columns={historyColumns}
+    data={entries}
+    emptyState={<StudioEmptyState>{pt('history.empty')}</StudioEmptyState>}
+  />
+</NewsDetailCard>
+```
+
+- [ ] **Step 5: Re-run the UI slice, translations, and i18n check**
+
+Run:
+
+```bash
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.detail-page.test.tsx --testFiles=tests/news.detail-history-tab.test.tsx --testFiles=tests/plugin.translations.test.ts
+pnpm nx run sva-studio-react:check:i18n
+pnpm nx run plugin-news:test:types
+```
+
+Expected:
+
+```text
+PASS  packages/plugin-news/tests/news.detail-page.test.tsx
+PASS  packages/plugin-news/tests/news.detail-history-tab.test.tsx
+PASS  packages/plugin-news/tests/plugin.translations.test.ts
+PASS  sva-studio-react:check:i18n
+PASS  plugin-news:test:types
+```
+
+- [ ] **Step 6: Commit the UI rebuild**
+
+```bash
+git add packages/plugin-news/src/news.detail-card.tsx packages/plugin-news/src/news.detail-basis-tab.tsx packages/plugin-news/src/news.detail-content-tab.tsx packages/plugin-news/src/news.detail-history-tab.tsx packages/plugin-news/src/news.detail-settings-tab.tsx packages/plugin-news/src/news.detail-tabs.tsx packages/plugin-news/src/plugin.translations.ts packages/plugin-news/tests/news.detail-page.test.tsx packages/plugin-news/tests/news.detail-history-tab.test.tsx packages/plugin-news/tests/plugin.translations.test.ts
+git rm packages/plugin-news/src/news.detail-release-tab.tsx
+git commit -m "feat: rebuild news editor tabs as editorial cards"
+```
+
+### Task 5: Update The Studio List, Filters, E2E Flow, And Architecture Docs
+
+**Files:**
+- Modify: `packages/plugin-news/src/news.api.ts`
+- Modify: `packages/plugin-news/src/news.pages.tsx`
+- Modify: `packages/plugin-news/src/news.types.ts`
+- Modify: `packages/plugin-news/tests/news.pages.test.tsx`
+- Modify: `packages/sva-mainserver/src/types.ts`
+- Modify: `packages/sva-mainserver/src/server/news-route.ts`
+- Modify: `packages/sva-mainserver/src/server/service-internals/news-operations.ts`
+- Modify: `packages/sva-mainserver/src/server/service.test.ts`
+- Modify: `apps/sva-studio-react/e2e/news-plugin.spec.ts`
+- Modify: `docs/architecture/05-building-block-view.md`
+- Modify: `docs/architecture/06-runtime-view.md`
+
+- [ ] **Step 1: Write the failing list-page, adapter-filter, and E2E tests**
+
+```ts
+// packages/plugin-news/tests/news.pages.test.tsx
+it('loads the studio list with drafts included and shows the editorial status badge', async () => {
+  render(<NewsListPage />);
+  await waitFor(() =>
+    expect(listNews).toHaveBeenCalledWith({
+      page: 1,
+      pageSize: 25,
+      includeInvisible: true,
+      visibilityFilter: 'all',
+      editorialStatusFilter: 'all',
+    })
+  );
+  expect(screen.getByText('Entwurf')).toBeInTheDocument();
+});
+
+it('toggles visibility directly from the list row', async () => {
+  render(<NewsListPage />);
+  await user.click(await screen.findByRole('switch', { name: 'Sichtbar' }));
+  expect(setNewsVisibility).toHaveBeenCalledWith('news-1', false);
+});
+
+// packages/sva-mainserver/src/server/service.test.ts
+it('filters studio news by editorial status after including invisible items', async () => {
+  await expect(
+    service.listNews({
+      instanceId: 'instance-1',
+      keycloakSubject: 'user-1',
+      page: 1,
+      pageSize: 25,
+      includeInvisible: true,
+      visibilityFilter: 'all',
+      editorialStatusFilter: 'draft',
+    })
+  ).resolves.toMatchObject({
+    data: [expect.objectContaining({ id: 'news-draft', visible: false })],
+  });
+});
+```
+
+```ts
+// apps/sva-studio-react/e2e/news-plugin.spec.ts
+test('draft, publish, schedule, and push-once flow', async ({ page }) => {
+  await page.goto('/admin/news/new');
+  await page.getByLabel('Titel').fill('Wichtige Nachricht');
+  await page.getByLabel('Teaser').fill('Kurzfassung');
+  await page.getByRole('tab', { name: 'Einstellungen' }).click();
+  await page.getByLabel('Entwurfsmodus').check();
+  await page.getByRole('button', { name: 'Speichern' }).click();
+  await expect(page.getByText('Entwurf')).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run the focused list and adapter tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.pages.test.tsx
+pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts --testFiles=src/server/news-route.test.ts
+```
+
+Expected:
+
+```text
+FAIL  packages/plugin-news/tests/news.pages.test.tsx > loads the studio list with drafts included and shows the editorial status badge
+FAIL  packages/plugin-news/tests/news.pages.test.tsx > toggles visibility directly from the list row
+FAIL  packages/sva-mainserver/src/server/service.test.ts > filters studio news by editorial status after including invisible items
+```
+
+- [ ] **Step 3: Add studio list filters and direct visibility toggles**
+
+```ts
+// packages/plugin-news/src/news.types.ts
+export type NewsListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly includeInvisible?: boolean;
+  readonly visibilityFilter?: 'all' | 'visible' | 'hidden';
+  readonly editorialStatusFilter?: 'all' | 'draft' | 'scheduled' | 'published';
+};
+
+// packages/sva-mainserver/src/types.ts
+export type SvaMainserverListQuery = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly includeInvisible?: boolean;
+  readonly visibilityFilter?: 'all' | 'visible' | 'hidden';
+  readonly editorialStatusFilter?: 'all' | 'draft' | 'scheduled' | 'published';
+};
+
+// packages/sva-mainserver/src/server/service-internals/news-operations.ts
+const filteredItems = mappedItems.filter((item) => {
+  const matchesVisibility =
+    input.visibilityFilter === 'hidden' ? item.visible === false :
+    input.visibilityFilter === 'visible' ? item.visible !== false :
+    true;
+
+  const status = deriveEditorialStatusForList(item, new Date().toISOString());
+  const matchesStatus = input.editorialStatusFilter && input.editorialStatusFilter !== 'all'
+    ? status === input.editorialStatusFilter
+    : true;
+
+  return matchesVisibility && matchesStatus;
+});
+```
+
+- [ ] **Step 4: Rebuild the News list UI, E2E journey, and arc42 notes**
+
+```tsx
+// packages/plugin-news/src/news.pages.tsx
+const query: NewsListQuery = {
+  page,
+  pageSize,
+  includeInvisible: true,
+  visibilityFilter,
+  editorialStatusFilter,
+};
+
+<Select value={visibilityFilter} onValueChange={setVisibilityFilter}>
+  <SelectItem value="all">{pt('filters.visibility.all')}</SelectItem>
+  <SelectItem value="visible">{pt('filters.visibility.visible')}</SelectItem>
+  <SelectItem value="hidden">{pt('filters.visibility.hidden')}</SelectItem>
+</Select>
+
+<Badge variant={status === 'draft' ? 'secondary' : status === 'scheduled' ? 'outline' : 'default'}>
+  {pt(`statuses.${status}`)}
+</Badge>
+
+<Switch
+  checked={item.visible !== false}
+  aria-label={pt('fields.visible')}
+  onCheckedChange={(checked) => void handleVisibilityChange(item.id, checked)}
+/>
+```
+
+```md
+<!-- docs/architecture/05-building-block-view.md -->
+- Das News-Plugin besitzt nun ein eigenes redaktionelles Editor-Mapping (`news.editor-model.ts`), das UI-Felder auf `contentBlocks[0]`, Veröffentlichungsmodus und Visibility-Schritt abbildet.
+
+<!-- docs/architecture/06-runtime-view.md -->
+- Speichern einer News läuft in zwei technischen Schritten: erst `createNews`/`updateNews`, danach `changeVisibility(recordType: "NewsItem")`.
+- Die Studio-Newsliste nutzt den Mainserver-Lesepfad mit `includeInvisible=true`, um Entwürfe im Backoffice sichtbar zu halten.
+```
+
+- [ ] **Step 5: Run the relevant verification path including E2E**
+
+Run:
+
+```bash
+pnpm nx run plugin-news:test:unit --testFiles=tests/news.pages.test.tsx --testFiles=tests/news.api.test.ts --testFiles=tests/news.detail-page.test.tsx
+pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts --testFiles=src/server/news-route.test.ts
+pnpm nx run plugin-news:test:types
+pnpm nx run sva-mainserver:test:types
+pnpm nx run sva-mainserver:check:runtime
+pnpm nx run sva-studio-react:test:types
+pnpm nx run sva-studio-react:test:e2e
+```
+
+Expected:
+
+```text
+PASS  packages/plugin-news/tests/news.pages.test.tsx
+PASS  packages/plugin-news/tests/news.api.test.ts
+PASS  packages/plugin-news/tests/news.detail-page.test.tsx
+PASS  packages/sva-mainserver/src/server/service.test.ts
+PASS  packages/sva-mainserver/src/server/news-route.test.ts
+PASS  plugin-news:test:types
+PASS  sva-mainserver:test:types
+PASS  sva-mainserver:check:runtime
+PASS  sva-studio-react:test:types
+PASS  sva-studio-react:test:e2e
+```
+
+- [ ] **Step 6: Commit the list, E2E, and documentation slice**
+
+```bash
+git add packages/plugin-news/src/news.api.ts packages/plugin-news/src/news.pages.tsx packages/plugin-news/src/news.types.ts packages/plugin-news/tests/news.pages.test.tsx packages/sva-mainserver/src/types.ts packages/sva-mainserver/src/server/news-route.ts packages/sva-mainserver/src/server/service-internals/news-operations.ts packages/sva-mainserver/src/server/service.test.ts apps/sva-studio-react/e2e/news-plugin.spec.ts docs/architecture/05-building-block-view.md docs/architecture/06-runtime-view.md
+git commit -m "feat: support draft-aware studio news list"
+```

--- a/docs/superpowers/plans/2026-06-09-waste-mainserver-sync-job.md
+++ b/docs/superpowers/plans/2026-06-09-waste-mainserver-sync-job.md
@@ -1,0 +1,871 @@
+# Waste Mainserver Sync Job Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Nach jeder Fraktionsänderung wird das vollständige `wasteTypes`-JSON als dedizierter Waste-Job auf den Mainserver synchronisiert; bei Sync-Fehlern bleibt der lokale Save erfolgreich und im Fraktionskontext erscheint ein Retry.
+
+**Architecture:** Die Exportlogik bleibt framework-agnostisch in `@sva/core`, die Mainserver-Schreiboperation kommt als schlanke dedizierte SVA-Mainserver-Operation hinzu, und die konkrete Job-Runtime sitzt in `apps/sva-studio-react`. Das Waste-Plugin erweitert seinen bestehenden Job-/API-/UI-Pfad um genau einen neuen Jobtyp `waste-management.sync-waste-types` und verwendet für Retry denselben technischen Startpfad.
+
+**Tech Stack:** TypeScript strict mode, Nx, Vitest, React, TanStack Router, Zod, bestehende Plugin-Operations-Infrastruktur, bestehende SVA-Mainserver OAuth-/GraphQL-Integration
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/core/src/waste-management-static-content.ts`
+- `packages/core/src/waste-management-static-content.test.ts`
+- `packages/sva-mainserver/src/generated/static-content.ts`
+- `packages/sva-mainserver/src/server/service-internals/static-content-operations.ts`
+
+**Modify:**
+- `packages/core/src/waste-management-operations-contract.ts`
+- `packages/core/src/waste-management-operations-contract.test.ts`
+- `packages/core/src/index.ts`
+- `packages/plugin-sdk/src/public-api.ts`
+- `packages/plugin-sdk/src/index.ts`
+- `packages/plugin-waste-management/src/plugin-operations.ts`
+- `packages/plugin-waste-management/src/server.ts`
+- `packages/plugin-waste-management/src/waste-management.api.operations.ts`
+- `packages/plugin-waste-management/src/waste-management.api.types.operations-inputs.ts`
+- `packages/plugin-waste-management/src/waste-management.page.support.tsx`
+- `packages/plugin-waste-management/src/waste-management.master-data.state.ts`
+- `packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts`
+- `packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.ts`
+- `packages/plugin-waste-management/src/waste-management.master-data.controller.ts`
+- `packages/plugin-waste-management/src/waste-management.master-data-panel.tsx`
+- `packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts`
+- `packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts`
+- `packages/plugin-waste-management/tests/plugin-operations.test.ts`
+- `packages/plugin-waste-management/tests/server.test.ts`
+- `packages/plugin-waste-management/tests/waste-management.api.test.ts`
+- `packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts`
+- `packages/plugin-waste-management/tests/waste-management.page.test.tsx`
+- `packages/auth-runtime/src/waste-management/core/schemas.ts`
+- `packages/auth-runtime/src/waste-management/core/operations.ts`
+- `packages/auth-runtime/src/waste-management/core/operations.test.ts`
+- `packages/auth-runtime/src/routes.ts`
+- `packages/sva-mainserver/src/types.ts`
+- `packages/sva-mainserver/src/server/service.ts`
+- `packages/sva-mainserver/src/index.server.ts`
+- `packages/sva-mainserver/src/server/service.test.ts`
+- `apps/sva-studio-react/src/lib/waste-management-operations.types.ts`
+- `apps/sva-studio-react/src/lib/waste-management-operations.server.ts`
+- `apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts`
+- `docs/architecture/05-building-block-view.md`
+- `docs/architecture/06-runtime-view.md`
+
+## Constraints And Decisions
+
+- `createOrUpdateStaticContent` ist laut lokalem Mainserver-Snapshot bereits vorhanden; ein vorgelagerter Schema-/Contract-Change ist nicht Teil dieses Plans.
+- Der Snapshot enthält **keinen** lesbaren Query-Pfad für `StaticContent`/`AppUserContent`; bestehende `icon`-Werte können deshalb nicht vor dem Überschreiben konserviert werden.
+- Konsequenz für diese Iteration: Das generierte `wasteTypes`-Artefakt exportiert nur Felder, die aus dem bestehenden Fraktionsmodell ableitbar sind. `icon` bleibt bewusst außen vor, bis es eine eigene Quelle im Studio oder einen lesbaren Mainserver-Query-Pfad gibt.
+- Für den manuellen Retry wird **keine** neue IAM-Permission eingeführt; der technische Startpfad verwendet wie die übrigen Waste-Admin-Operationen `waste-management.settings.manage`.
+
+### Task 1: Add The Dedicated Waste Sync Job Contract And Start Endpoint
+
+**Files:**
+- Modify: `packages/core/src/waste-management-operations-contract.ts`
+- Modify: `packages/core/src/waste-management-operations-contract.test.ts`
+- Modify: `packages/core/src/index.ts`
+- Modify: `packages/plugin-sdk/src/public-api.ts`
+- Modify: `packages/plugin-sdk/src/index.ts`
+- Modify: `packages/plugin-waste-management/src/plugin-operations.ts`
+- Modify: `packages/plugin-waste-management/src/server.ts`
+- Modify: `packages/plugin-waste-management/src/waste-management.api.operations.ts`
+- Modify: `packages/plugin-waste-management/src/waste-management.api.types.operations-inputs.ts`
+- Modify: `packages/plugin-waste-management/tests/plugin-operations.test.ts`
+- Modify: `packages/plugin-waste-management/tests/server.test.ts`
+- Modify: `packages/plugin-waste-management/tests/waste-management.api.test.ts`
+- Modify: `packages/auth-runtime/src/waste-management/core/schemas.ts`
+- Modify: `packages/auth-runtime/src/waste-management/core/operations.ts`
+- Modify: `packages/auth-runtime/src/waste-management/core/operations.test.ts`
+- Modify: `packages/auth-runtime/src/routes.ts`
+
+- [ ] **Step 1: Write failing contract and API tests**
+
+```ts
+// packages/core/src/waste-management-operations-contract.test.ts
+expect(wasteManagementOperationsContract.jobTypeIds).toMatchObject({
+  syncWasteTypes: 'waste-management.sync-waste-types',
+});
+
+// packages/plugin-waste-management/tests/plugin-operations.test.ts
+expect(createWasteManagementPluginJobTypes()).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({
+      jobTypeId: 'waste-management.sync-waste-types',
+      queue: 'plugin-operations',
+    }),
+  ])
+);
+
+// packages/plugin-waste-management/tests/waste-management.api.test.ts
+await startWasteManagementSyncWasteTypes();
+expect(fetchMock).toHaveBeenCalledWith(
+  '/api/v1/waste-management/tools/sync-waste-types',
+  expect.objectContaining({ method: 'POST' })
+);
+
+// packages/auth-runtime/src/waste-management/core/operations.test.ts
+expect(startPluginOperationJob).toHaveBeenCalledWith(
+  expect.objectContaining({
+    data: expect.objectContaining({
+      jobTypeId: 'waste-management.sync-waste-types',
+      input: { operation: 'sync-waste-types' },
+    }),
+  })
+);
+```
+
+- [ ] **Step 2: Run the focused tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run core:test:unit --testFiles=src/waste-management-operations-contract.test.ts
+pnpm nx run plugin-waste-management:test:unit --testFiles=tests/plugin-operations.test.ts --testFiles=tests/server.test.ts --testFiles=tests/waste-management.api.test.ts
+pnpm nx run auth-runtime:test:unit --testFiles=src/waste-management/core/operations.test.ts
+```
+
+Expected:
+
+```text
+FAIL  ...syncWasteTypes...
+FAIL  ...startWasteManagementSyncWasteTypes is not a function...
+FAIL  .../tools/sync-waste-types route missing...
+```
+
+- [ ] **Step 3: Extend the shared Waste job contract and re-exports**
+
+```ts
+// packages/core/src/waste-management-operations-contract.ts
+const wasteManagementJobTypeIds = {
+  initializeDataSource: 'waste-management.initialize-data-source',
+  applyMigrations: 'waste-management.apply-migrations',
+  importData: 'waste-management.import-data',
+  seedData: 'waste-management.seed-data',
+  resetData: 'waste-management.reset-data',
+  syncWasteTypes: 'waste-management.sync-waste-types',
+} as const;
+
+export type WasteManagementSyncWasteTypesJobInput = {
+  readonly operation: 'sync-waste-types';
+};
+
+export type WasteManagementJobInput =
+  | WasteManagementInitializeJobInput
+  | WasteManagementApplyMigrationsJobInput
+  | WasteManagementImportJobInput
+  | WasteManagementSeedJobInput
+  | WasteManagementResetJobInput
+  | WasteManagementSyncWasteTypesJobInput;
+```
+
+```ts
+// packages/core/src/index.ts
+export type {
+  WasteManagementSyncWasteTypesJobInput,
+} from './waste-management-operations-contract.js';
+```
+
+- [ ] **Step 4: Add the new job metadata, handler mapping, client API, and host route**
+
+```ts
+// packages/plugin-waste-management/src/plugin-operations.ts
+{
+  jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+  queue: wasteManagementOperationsContract.queueName,
+  displayName: 'Waste-Typen mit Mainserver synchronisieren',
+  progress: {
+    phaseKeys: ['waste-management.sync-waste-types', 'waste-management.completed'],
+    stepKeys: ['build-static-content', 'push-static-content'],
+  },
+  result: {
+    summaryKeys: ['durationMs'],
+    detailKeys: ['staticContentName', 'version', 'fractionCount'],
+  },
+  errors: {
+    detailKeys: ['failed-step'],
+  },
+}
+```
+
+```ts
+// packages/plugin-waste-management/src/waste-management.api.operations.ts
+export const startWasteManagementSyncWasteTypes = async () =>
+  requestWasteManagementJob('/api/v1/waste-management/tools/sync-waste-types', {});
+```
+
+```ts
+// packages/auth-runtime/src/waste-management/core/operations.ts
+startWasteManagementSyncWasteTypesInternal: async (request, ctx, deps = {}) =>
+  startToolJob(request, ctx, deps, {
+    requiredPermission: 'waste-management.settings.manage',
+    endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
+    schema: z.object({}),
+    jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+    auditActionId: 'waste-management.sync-waste-types.started',
+    toPayload: () => ({ operation: 'sync-waste-types' }),
+  }),
+```
+
+```ts
+// packages/auth-runtime/src/routes.ts
+| '/api/v1/waste-management/tools/sync-waste-types'
+```
+
+- [ ] **Step 5: Re-run the same focused tests and make them pass**
+
+Run:
+
+```bash
+pnpm nx run core:test:unit --testFiles=src/waste-management-operations-contract.test.ts
+pnpm nx run plugin-waste-management:test:unit --testFiles=tests/plugin-operations.test.ts --testFiles=tests/server.test.ts --testFiles=tests/waste-management.api.test.ts
+pnpm nx run auth-runtime:test:unit --testFiles=src/waste-management/core/operations.test.ts
+```
+
+Expected:
+
+```text
+PASS  packages/core/src/waste-management-operations-contract.test.ts
+PASS  packages/plugin-waste-management/tests/plugin-operations.test.ts
+PASS  packages/plugin-waste-management/tests/waste-management.api.test.ts
+PASS  packages/auth-runtime/src/waste-management/core/operations.test.ts
+```
+
+- [ ] **Step 6: Commit the contract slice**
+
+```bash
+git add packages/core packages/plugin-sdk packages/plugin-waste-management packages/auth-runtime
+git commit -m "feat: add waste mainserver sync job contract"
+```
+
+### Task 2: Add A Typed SVA Mainserver Static Content Write Operation
+
+**Files:**
+- Create: `packages/sva-mainserver/src/generated/static-content.ts`
+- Create: `packages/sva-mainserver/src/server/service-internals/static-content-operations.ts`
+- Modify: `packages/sva-mainserver/src/types.ts`
+- Modify: `packages/sva-mainserver/src/server/service.ts`
+- Modify: `packages/sva-mainserver/src/index.server.ts`
+- Modify: `packages/sva-mainserver/src/server/service.test.ts`
+
+- [ ] **Step 1: Write the failing service test**
+
+```ts
+// packages/sva-mainserver/src/server/service.test.ts
+await expect(
+  service.createOrUpdateStaticContent({
+    instanceId: baseConfig.instanceId,
+    keycloakSubject: 'subject-1',
+    staticContent: {
+      name: 'wasteTypes',
+      content: '{"bio":{"label":"Biotonne"}}',
+      dataType: 'JSON',
+      version: 'sha256:abc',
+    },
+  })
+).resolves.toEqual({ id: '77' });
+
+expect(fetchImpl).toHaveBeenLastCalledWith(
+  baseConfig.graphqlBaseUrl,
+  expect.objectContaining({
+    method: 'POST',
+    body: expect.stringContaining('createOrUpdateStaticContent'),
+  })
+);
+```
+
+- [ ] **Step 2: Run the SVA Mainserver unit test and confirm it fails**
+
+Run:
+
+```bash
+pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts
+```
+
+Expected:
+
+```text
+FAIL  ...createOrUpdateStaticContent is not a function...
+```
+
+- [ ] **Step 3: Add generated document/types and the dedicated internal operation**
+
+```ts
+// packages/sva-mainserver/src/generated/static-content.ts
+export type SvaMainserverCreateOrUpdateStaticContentMutation = {
+  readonly createOrUpdateStaticContent?: {
+    readonly id?: string | number | null;
+  } | null;
+};
+
+export const svaMainserverCreateOrUpdateStaticContentDocument = `
+mutation SvaMainserverCreateOrUpdateStaticContent(
+  $name: String!,
+  $content: String!,
+  $dataType: String!,
+  $version: String!
+) {
+  createOrUpdateStaticContent(
+    name: $name
+    content: $content
+    dataType: $dataType
+    version: $version
+  ) {
+    id
+  }
+}
+`;
+```
+
+```ts
+// packages/sva-mainserver/src/server/service-internals/static-content-operations.ts
+export const createStaticContentOperations = (executeGraphqlWithConfig: GraphqlExecutor) => ({
+  writeStaticContentWithConfig: async (input, config): Promise<{ readonly id: string }> => {
+    const response = await executeGraphqlWithConfig<SvaMainserverCreateOrUpdateStaticContentMutation>(
+      {
+        ...input,
+        document: svaMainserverCreateOrUpdateStaticContentDocument,
+        operationName: 'SvaMainserverCreateOrUpdateStaticContent',
+        variables: input.staticContent,
+      },
+      config
+    );
+
+    const id = response.createOrUpdateStaticContent?.id;
+    if (id === null || id === undefined) {
+      throw toSvaMainserverError({
+        code: 'invalid_response',
+        message: 'SVA-Mainserver konnte den Static-Content-Eintrag nicht schreiben.',
+        statusCode: 502,
+      });
+    }
+
+    return { id: String(id) };
+  },
+});
+```
+
+- [ ] **Step 4: Wire the public service surface**
+
+```ts
+// packages/sva-mainserver/src/types.ts
+export type SvaMainserverStaticContentInput = {
+  readonly name: string;
+  readonly content: string;
+  readonly dataType: 'JSON';
+  readonly version: string;
+};
+```
+
+```ts
+// packages/sva-mainserver/src/server/service.ts
+const staticContentOperations = createStaticContentOperations(executeGraphqlWithConfig);
+
+const createOrUpdateStaticContent = async (
+  input: SvaMainserverConnectionInput & { readonly staticContent: SvaMainserverStaticContentInput }
+) => {
+  const config = await loadValidatedInstanceConfig(input, 'load_instance_config');
+  return staticContentOperations.writeStaticContentWithConfig(input, config);
+};
+
+return {
+  createOrUpdateStaticContent,
+  createEvent,
+  createNews,
+  createPoi,
+  deleteEvent,
+  deleteNews,
+  deletePoi,
+  getConnectionStatus,
+  getEvent,
+  getMutationRootTypename,
+  getNews,
+  getPoi,
+  getQueryRootTypename,
+  listCategories,
+  listEvents,
+  listNews,
+  listPoi,
+  updateEvent,
+  updateNews,
+  updatePoi,
+};
+
+export const createOrUpdateSvaMainserverStaticContent = (
+  input: SvaMainserverConnectionInput & { readonly staticContent: SvaMainserverStaticContentInput }
+) => getDefaultService().createOrUpdateStaticContent(input);
+```
+
+- [ ] **Step 5: Re-run the service test and make it pass**
+
+Run:
+
+```bash
+pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts
+```
+
+Expected:
+
+```text
+PASS  packages/sva-mainserver/src/server/service.test.ts
+```
+
+- [ ] **Step 6: Commit the SVA Mainserver integration slice**
+
+```bash
+git add packages/sva-mainserver
+git commit -m "feat: add mainserver static content write operation"
+```
+
+### Task 3: Build The `wasteTypes` Export And Execute The Sync Job Runtime
+
+**Files:**
+- Create: `packages/core/src/waste-management-static-content.ts`
+- Create: `packages/core/src/waste-management-static-content.test.ts`
+- Modify: `packages/core/src/index.ts`
+- Modify: `packages/plugin-waste-management/src/server.ts`
+- Modify: `packages/plugin-waste-management/tests/server.test.ts`
+- Modify: `apps/sva-studio-react/src/lib/waste-management-operations.types.ts`
+- Modify: `apps/sva-studio-react/src/lib/waste-management-operations.server.ts`
+- Modify: `apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts`
+
+- [ ] **Step 1: Write the failing export-builder and runtime tests**
+
+```ts
+// packages/core/src/waste-management-static-content.test.ts
+expect(
+  buildWasteTypesStaticContent([
+    {
+      id: 'fraction-bio',
+      name: 'Biotonne auf Abruf',
+      pdfShortLabel: 'BIO',
+      color: '#8B4513',
+      description: 'Nur auf Abruf',
+      containerSize: undefined,
+      translations: { de: 'Biotonne auf Abruf' },
+      active: true,
+      reminderCount: 'none',
+      reminderChannelPushEnabled: false,
+      reminderChannelEmailEnabled: false,
+      reminderChannelCalendarEnabled: false,
+    },
+  ])
+).toEqual({
+  name: 'wasteTypes',
+  version: expect.stringMatching(/^sha256:/),
+  content: expect.stringContaining('"bio"'),
+});
+
+// apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
+expect(createOrUpdateSvaMainserverStaticContentMock).toHaveBeenCalledWith(
+  expect.objectContaining({
+    staticContent: expect.objectContaining({
+      name: 'wasteTypes',
+      dataType: 'JSON',
+    }),
+  })
+);
+```
+
+- [ ] **Step 2: Run the focused export/runtime tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run core:test:unit --testFiles=src/waste-management-static-content.test.ts
+pnpm nx run plugin-waste-management:test:unit --testFiles=tests/server.test.ts
+pnpm nx run sva-studio-react:test:unit --testFiles=src/lib/waste-management-operations.server.test.ts
+```
+
+Expected:
+
+```text
+FAIL  ...buildWasteTypesStaticContent is not defined...
+FAIL  ...syncWasteTypes handler missing...
+FAIL  ...createOrUpdateSvaMainserverStaticContent not called...
+```
+
+- [ ] **Step 3: Implement the pure export builder in `@sva/core`**
+
+```ts
+// packages/core/src/waste-management-static-content.ts
+import { createHash } from 'node:crypto';
+import type { WasteFractionRecord } from './waste-management-master-data.js';
+
+const normalizeWasteTypeKey = (value: string): string =>
+  value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+
+export const buildWasteTypesStaticContent = (fractions: readonly WasteFractionRecord[]) => {
+  const payload = Object.fromEntries(
+    fractions
+      .filter((fraction) => fraction.active)
+      .map((fraction) => {
+        const key = normalizeWasteTypeKey(fraction.pdfShortLabel ?? fraction.id);
+        return [
+          key,
+          {
+            label: fraction.name,
+            color: fraction.color,
+            selected_color: fraction.color,
+            id: fraction.id,
+            short_label: fraction.pdfShortLabel ?? null,
+            active: fraction.active,
+            description: fraction.description ?? null,
+            container_size: fraction.containerSize ?? null,
+            translations: fraction.translations ?? {},
+          },
+        ];
+      })
+  );
+
+  const content = JSON.stringify(payload, null, 2);
+  const version = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+  return {
+    name: 'wasteTypes' as const,
+    dataType: 'JSON' as const,
+    version,
+    content,
+    fractionCount: Object.keys(payload).length,
+  };
+};
+```
+
+- [ ] **Step 4: Add the runtime method and plugin job execution branch**
+
+```ts
+// apps/sva-studio-react/src/lib/waste-management-operations.types.ts
+export type WasteManagementOperationRuntime = {
+  initializeDataSource: (instanceId: string, input: WasteManagementInitializeJobInput) => Promise<OperationSummary>;
+  applyMigrations: (instanceId: string, input: WasteManagementApplyMigrationsJobInput) => Promise<OperationSummary>;
+  importData: (
+    instanceId: string,
+    input: WasteManagementImportJobInput,
+    progressReporter?: WasteImportProgressReporter
+  ) => Promise<OperationSummary>;
+  seedData: (instanceId: string, input: WasteManagementSeedJobInput) => Promise<OperationSummary>;
+  resetData: (instanceId: string, input: WasteManagementResetJobInput) => Promise<OperationSummary>;
+  syncWasteTypes: (instanceId: string, input: WasteManagementSyncWasteTypesJobInput) => Promise<OperationSummary>;
+};
+```
+
+```ts
+// apps/sva-studio-react/src/lib/waste-management-operations.server.ts
+async syncWasteTypes(instanceId, _input) {
+  const startedAt = Date.now();
+  const details = await withWasteClient(deps, instanceId, async ({ repository }) => {
+    const fractions = await repository.listWasteFractions();
+    const artifact = buildWasteTypesStaticContent(fractions);
+    const writeResult = await createOrUpdateSvaMainserverStaticContent({
+      instanceId,
+      keycloakSubject: 'plugin-operation-runtime',
+      staticContent: {
+        name: artifact.name,
+        content: artifact.content,
+        dataType: artifact.dataType,
+        version: artifact.version,
+      },
+    });
+
+    return {
+      operation: 'sync-waste-types',
+      mode: 'executed',
+      staticContentName: artifact.name,
+      version: artifact.version,
+      fractionCount: artifact.fractionCount,
+      staticContentId: writeResult.id,
+    };
+  });
+
+  return buildOperationSummary(startedAt, details);
+}
+```
+
+```ts
+// packages/plugin-waste-management/src/server.ts
+[wasteManagementOperationsContract.jobTypeIds.syncWasteTypes]:
+  createOperationHandler<WasteManagementSyncWasteTypesJobInput>({
+    jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+    expectedOperation: 'sync-waste-types',
+    phaseKey: 'waste-management.sync-waste-types',
+    execute: (runtimeArg, instanceId, payload) => runtimeArg.syncWasteTypes(instanceId, payload),
+  })(runtime),
+```
+
+- [ ] **Step 5: Re-run the focused tests and make them pass**
+
+Run:
+
+```bash
+pnpm nx run core:test:unit --testFiles=src/waste-management-static-content.test.ts
+pnpm nx run plugin-waste-management:test:unit --testFiles=tests/server.test.ts
+pnpm nx run sva-studio-react:test:unit --testFiles=src/lib/waste-management-operations.server.test.ts
+```
+
+Expected:
+
+```text
+PASS  packages/core/src/waste-management-static-content.test.ts
+PASS  packages/plugin-waste-management/tests/server.test.ts
+PASS  apps/sva-studio-react/src/lib/waste-management-operations.server.test.ts
+```
+
+- [ ] **Step 6: Commit the export/runtime slice**
+
+```bash
+git add packages/core packages/plugin-waste-management apps/sva-studio-react
+git commit -m "feat: sync waste types to mainserver"
+```
+
+### Task 4: Trigger Sync After Fraction Changes And Surface Retry In The Fractions Context
+
+**Files:**
+- Modify: `packages/plugin-waste-management/src/waste-management.page.support.tsx`
+- Modify: `packages/plugin-waste-management/src/waste-management.master-data.state.ts`
+- Modify: `packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts`
+- Modify: `packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.ts`
+- Modify: `packages/plugin-waste-management/src/waste-management.master-data.controller.ts`
+- Modify: `packages/plugin-waste-management/src/waste-management.master-data-panel.tsx`
+- Modify: `packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts`
+- Modify: `packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts`
+- Modify: `packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts`
+- Modify: `packages/plugin-waste-management/tests/waste-management.page.test.tsx`
+
+- [ ] **Step 1: Write failing UI/submission tests**
+
+```ts
+// packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
+expect(startWasteManagementSyncWasteTypesMock).toHaveBeenCalledTimes(1);
+expect(ctx.state.setMessage).toHaveBeenCalledWith({
+  kind: 'warning',
+  text: 'masterData.fractions.messages.syncWarning',
+  retryAction: 'sync-waste-types',
+});
+
+// packages/plugin-waste-management/tests/waste-management.page.test.tsx
+expect(screen.getByRole('button', { name: /erneut synchronisieren/i })).toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run the fractions/UI tests and confirm they fail**
+
+Run:
+
+```bash
+pnpm nx run plugin-waste-management:test:unit --testFiles=tests/waste-management.master-data.fraction-submissions.test.ts --testFiles=tests/waste-management.page.test.tsx
+```
+
+Expected:
+
+```text
+FAIL  ...warning...
+FAIL  ...retryAction...
+FAIL  ...Erneut synchronisieren button missing...
+```
+
+- [ ] **Step 3: Extend the message model with a single dedicated retry action**
+
+```ts
+// packages/plugin-waste-management/src/waste-management.page.support.tsx
+export type StatusMessage = {
+  readonly kind: 'success' | 'error' | 'warning';
+  readonly text: string;
+  readonly retryAction?: 'sync-waste-types';
+};
+```
+
+```tsx
+// packages/plugin-waste-management/src/waste-management.page.support.tsx
+export const StatusNotice = ({
+  message,
+  onRetry,
+}: {
+  readonly message: StatusMessage | null;
+  readonly onRetry?: (action: StatusMessage['retryAction']) => void;
+}) =>
+  message ? (
+    <Alert>
+      <AlertTitle>
+        {message.kind === 'success'
+          ? pt('common.statusSuccessTitle')
+          : message.kind === 'warning'
+            ? pt('common.statusWarningTitle')
+            : pt('common.statusErrorTitle')}
+      </AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>{message.text}</p>
+        {message.retryAction ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onRetry?.(message.retryAction)}
+          >
+            {pt('masterData.fractions.actions.retrySync')}
+          </Button>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  ) : null;
+```
+
+- [ ] **Step 4: Start the sync job after successful fraction mutations and downgrade sync failures to warnings**
+
+```ts
+// packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts
+const startFractionSyncWithWarning = async (ctx: FractionRegionSubmissionHelperContext) => {
+  try {
+    await startWasteManagementSyncWasteTypes();
+  } catch {
+    ctx.state.setMessage({
+      kind: 'warning',
+      text: ctx.pt('masterData.fractions.messages.syncWarning'),
+      retryAction: 'sync-waste-types',
+    });
+  }
+};
+```
+
+```ts
+// in createSubmitFractionHandler / createDeleteFractionHandler / createDeleteFractionsHandler / createSetFractionActiveHandler
+await ctx.loadOverview(true);
+applySuccess(
+  () => ctx.state.setDialogOpen(false),
+  ctx.state.setMessage,
+  mode === 'create'
+    ? ctx.pt('masterData.fractions.messages.createSuccess')
+    : ctx.pt('masterData.fractions.messages.updateSuccess'),
+  () => ctx.state.setLastOutcome(mode === 'create' ? 'fraction-create-success' : 'fraction-update-success')
+);
+await startFractionSyncWithWarning(ctx);
+```
+
+```ts
+// packages/plugin-waste-management/src/waste-management.master-data.controller.ts
+const retrySyncWasteTypes = async () => {
+  state.setMessage(null);
+  try {
+    await startWasteManagementSyncWasteTypes();
+    state.setMessage({ kind: 'success', text: pt('masterData.fractions.messages.syncRetryStarted') });
+  } catch {
+    state.setMessage({
+      kind: 'warning',
+      text: pt('masterData.fractions.messages.syncWarning'),
+      retryAction: 'sync-waste-types',
+    });
+  }
+};
+```
+
+- [ ] **Step 5: Wire the retry button in the panel and add translations**
+
+```tsx
+// packages/plugin-waste-management/src/waste-management.master-data-panel.tsx
+<StatusNotice
+  message={controller.message}
+  onRetry={(action) => {
+    if (action === 'sync-waste-types') {
+      void controller.retrySyncWasteTypes();
+    }
+  }}
+/>;
+```
+
+```ts
+// packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts
+syncWarning: 'Die Fraktion wurde gespeichert, aber wasteTypes konnte nicht mit dem Mainserver synchronisiert werden.',
+syncRetryStarted: 'Die Synchronisation von wasteTypes wurde erneut gestartet.',
+retrySync: 'Erneut synchronisieren',
+```
+
+- [ ] **Step 6: Re-run the fractions/UI tests and make them pass**
+
+Run:
+
+```bash
+pnpm nx run plugin-waste-management:test:unit --testFiles=tests/waste-management.master-data.fraction-submissions.test.ts --testFiles=tests/waste-management.page.test.tsx
+```
+
+Expected:
+
+```text
+PASS  packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
+PASS  packages/plugin-waste-management/tests/waste-management.page.test.tsx
+```
+
+- [ ] **Step 7: Commit the trigger/retry slice**
+
+```bash
+git add packages/plugin-waste-management
+git commit -m "feat: retry failed waste mainserver sync from fractions"
+```
+
+### Task 5: Final Verification And Documentation
+
+**Files:**
+- Modify: `docs/architecture/05-building-block-view.md`
+- Modify: `docs/architecture/06-runtime-view.md`
+
+- [ ] **Step 1: Document the new building block and runtime flow**
+
+```md
+<!-- docs/architecture/05-building-block-view.md -->
+- `@sva/core` enthält die framework-agnostische Erzeugung des `wasteTypes`-Static-Content-Artefakts.
+- `@sva/sva-mainserver` kapselt die dedizierte GraphQL-Mutation `createOrUpdateStaticContent`.
+- `apps/sva-studio-react` stellt die konkrete Waste-Job-Runtime bereit und führt den Mainserver-Sync aus.
+```
+
+```md
+<!-- docs/architecture/06-runtime-view.md -->
+1. Fraktion lokal in Waste speichern
+2. Fraktionsübersicht neu laden
+3. Plugin-Operation `waste-management.sync-waste-types` enqueuen
+4. Runtime lädt aktive Fraktionen, erzeugt `wasteTypes`, berechnet `sha256`-Version
+5. Runtime schreibt `createOrUpdateStaticContent(name: "wasteTypes", ...)` auf den Mainserver
+6. Bei Enqueue-Fehler zeigt das Studio eine Warnung mit Retry im Fraktionskontext
+```
+
+- [ ] **Step 2: Run the smallest real multi-package verification path**
+
+Run:
+
+```bash
+pnpm nx run core:test:unit --testFiles=src/waste-management-operations-contract.test.ts --testFiles=src/waste-management-static-content.test.ts
+pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts
+pnpm nx run auth-runtime:test:unit --testFiles=src/waste-management/core/operations.test.ts
+pnpm nx run plugin-waste-management:test:unit --testFiles=tests/plugin-operations.test.ts --testFiles=tests/server.test.ts --testFiles=tests/waste-management.api.test.ts --testFiles=tests/waste-management.master-data.fraction-submissions.test.ts --testFiles=tests/waste-management.page.test.tsx
+pnpm nx run sva-studio-react:test:unit --testFiles=src/lib/waste-management-operations.server.test.ts --testFiles=src/lib/plugin-operation-runtime.server.test.ts
+pnpm check:server-runtime
+pnpm nx affected --target=test:types --base=origin/main
+```
+
+Expected:
+
+```text
+PASS  all targeted Vitest runs
+PASS  check:server-runtime
+PASS  affected type checks
+```
+
+- [ ] **Step 3: Create the final integration commit**
+
+```bash
+git add packages apps docs/architecture
+git commit -m "feat: sync waste types to mainserver after fraction changes"
+```
+
+- [ ] **Step 4: Sanity-check the working tree**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+```text
+No unexpected modified files outside the planned scope.
+```

--- a/docs/superpowers/plans/2026-06-09-waste-mainserver-sync-job.md
+++ b/docs/superpowers/plans/2026-06-09-waste-mainserver-sync-job.md
@@ -60,7 +60,7 @@
 - `createOrUpdateStaticContent` ist laut lokalem Mainserver-Snapshot bereits vorhanden; ein vorgelagerter Schema-/Contract-Change ist nicht Teil dieses Plans.
 - Der Snapshot enthält **keinen** lesbaren Query-Pfad für `StaticContent`/`AppUserContent`; bestehende `icon`-Werte können deshalb nicht vor dem Überschreiben konserviert werden.
 - Konsequenz für diese Iteration: Das generierte `wasteTypes`-Artefakt exportiert nur Felder, die aus dem bestehenden Fraktionsmodell ableitbar sind. `icon` bleibt bewusst außen vor, bis es eine eigene Quelle im Studio oder einen lesbaren Mainserver-Query-Pfad gibt.
-- Für den manuellen Retry wird **keine** neue IAM-Permission eingeführt; der technische Startpfad verwendet wie die übrigen Waste-Admin-Operationen `waste-management.settings.manage`.
+- Für den manuellen Retry wird **keine** neue IAM-Permission eingeführt; der technische Startpfad verwendet wie die Fraktionspflege `waste-management.master-data.manage`.
 
 ### Task 1: Add The Dedicated Waste Sync Job Contract And Start Endpoint
 
@@ -112,7 +112,11 @@ expect(startPluginOperationJob).toHaveBeenCalledWith(
   expect.objectContaining({
     data: expect.objectContaining({
       jobTypeId: 'waste-management.sync-waste-types',
-      input: { operation: 'sync-waste-types' },
+      input: {
+        operation: 'sync-waste-types',
+        keycloakSubject: actor.user.id,
+        activeOrganizationId: actor.activeOrganizationId,
+      },
     }),
   })
 );
@@ -201,12 +205,16 @@ export const startWasteManagementSyncWasteTypes = async () =>
 // packages/auth-runtime/src/waste-management/core/operations.ts
 startWasteManagementSyncWasteTypesInternal: async (request, ctx, deps = {}) =>
   startToolJob(request, ctx, deps, {
-    requiredPermission: 'waste-management.settings.manage',
+    requiredPermission: 'waste-management.master-data.manage',
     endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
-    schema: z.object({}),
+    schema: startSyncWasteTypesSchema,
     jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
     auditActionId: 'waste-management.sync-waste-types.started',
-    toPayload: () => ({ operation: 'sync-waste-types' }),
+    toPayload: () => ({
+      operation: 'sync-waste-types',
+      keycloakSubject: ctx.user.id,
+      activeOrganizationId: ctx.activeOrganizationId,
+    }),
   }),
 ```
 

--- a/docs/superpowers/specs/2026-06-09-categories-page-design.md
+++ b/docs/superpowers/specs/2026-06-09-categories-page-design.md
@@ -1,0 +1,245 @@
+# Kategorien-Seite Tabellenansicht Design
+
+## Kontext
+
+Im Studio existiert bereits ein Menüpunkt `Kategorien` in der Sidebar, die Zielroute `/categories` rendert aktuell aber nur eine Placeholder-Seite. Gleichzeitig liefert die bestehende Mainserver-Integration bereits Kategorien als hierarchisches Modell mit Metadaten wie `id`, `name`, `position`, `tagList`, `updatedAt` und `children`.
+
+Diese Kategorien sind kein rein news-spezifisches Konzept, sondern ein fachlich breiteres Mainserver-Modell. Für die erste Ausbaustufe der Kategorien-Seite soll deshalb keine vollständige Kategorienverwaltung gebaut werden, sondern eine belastbare Übersicht, die die vorhandenen Daten sichtbar macht und spätere Schreibpfade vorbereitet.
+
+## Ziele
+
+- Die Route `/categories` zeigt eine echte Kategorienseite statt des bisherigen Placeholders.
+- Die Seite verwendet das bestehende Studio-Tabellenmuster und wirkt wie eine reguläre Admin-Listenansicht.
+- Die Mainserver-Kategorien werden flach und lesbar in einer Tabelle dargestellt.
+- Die Tabelle zeigt die von der Redaktion gewünschten Kerndaten: `Name`, `ID`, `Hierarchie`, `Position`, `Tags` und `Updated At`.
+- Zeilenaktionen `Bearbeiten`, `Neue Unterkategorie` und `Löschen` sind bereits sichtbar, aber bewusst deaktiviert.
+- Die Lösung bleibt auf eine kleine read-only-Variante begrenzt und dupliziert keine news-spezifische Kategorienlogik.
+
+## Nicht-Ziele
+
+- Keine echten Mainserver-Schreiboperationen für Kategorien.
+- Kein Edit-Dialog, keine Detailseite und kein Create-Flow in dieser Ausbaustufe.
+- Keine Baumansicht, kein Expand/Collapse und keine verschachtelte Tabellenstruktur.
+- Keine neue Kategorienpersistenz im Studio.
+- Keine fachliche Umdeutung oder Normalisierung der Mainserver-Tags über eine reine Anzeigeaufbereitung hinaus.
+
+## Bestehender Stand
+
+- Die Sidebar enthält bereits einen Menüpunkt `Kategorien`, der auf `/categories` verweist.
+- Die Route `/categories` ist derzeit nur als `PlaceholderPage` verdrahtet.
+- Das Studio besitzt mit Seiten wie der Schnittstellenansicht bereits ein etabliertes Muster für tabellarische Verwaltungsseiten auf Basis von `StudioDataTable`.
+- Die Mainserver-Fassade bietet bereits einen Read-Pfad `GET /api/v1/mainserver/categories`.
+- Dieser Read-Pfad liefert Kategorien hierarchisch; die heutige News-Bearbeitung reduziert diese Struktur später auf eine vereinfachte Namensliste.
+
+## Bewertete Ansätze
+
+### Ansatz A: Kleine Read-only-Tabelle mit deaktivierten Aktionen
+
+Die Placeholder-Seite wird durch eine flache Tabellenansicht ersetzt. Die Aktionen sind sichtbar, aber nicht aktiv.
+
+Vorteile:
+- minimaler Scope
+- konsistente Studio-UX
+- schafft sofort Orientierung über die vorhandenen Kategorien
+- bereitet spätere Schreibaktionen ohne Architekturbruch vor
+
+Nachteile:
+- keine echte Bearbeitung im ersten Schritt
+- Hierarchie bleibt eine Anzeigeableitung statt interaktiver Struktur
+
+### Ansatz B: Tabelle mit bereits vorbereiteten Zielrouten für Edit/Create/Delete
+
+Zusätzlich zur Tabelle würden schon Zielrouten oder Dialoghüllen für künftige Bearbeitungsflows angelegt, auch wenn diese noch Placeholder bleiben.
+
+Vorteile:
+- spätere Ausbaupfade hätten bereits stabile Navigationsziele
+
+Nachteile:
+- zusätzlicher Routing- und UI-Ballast ohne unmittelbaren Nutzwert
+- erhöht den Scope der kleinen Variante unnötig
+
+### Ansatz C: Master-Detail-Ansicht mit Tabelle plus seitlichem Detailpanel
+
+Die Seite würde links eine Liste und rechts eine lesende Detaildarstellung der selektierten Kategorie zeigen.
+
+Vorteile:
+- mehr Metadaten ohne zusätzliche Navigation sichtbar
+
+Nachteile:
+- deutlich höhere UI-Komplexität
+- für die erste Iteration zu groß
+- erzeugt schon eine Interaktionslogik, die für den aktuellen Mehrwert nicht nötig ist
+
+## Entscheidung
+
+Es wird Ansatz A umgesetzt: eine kleine read-only-Kategorienseite mit flacher Tabelle und deaktivierten Zeilenaktionen.
+
+Diese Entscheidung passt am besten zum gewünschten Scope. Sie ersetzt den Placeholder durch eine fachlich nützliche Verwaltungsansicht, nutzt vorhandene Tabellenmuster des Studios und lässt sich später ohne Bruch zu echten Schreibpfaden ausbauen.
+
+## Zielbild
+
+### 1. Seitenaufbau
+
+- Die Route `/categories` rendert eine echte Kategorienlisten-Seite.
+- Die Seite folgt dem bestehenden Studio-Muster für Admin-Tabellen.
+- Im Kopfbereich stehen:
+  - Seitentitel
+  - kurze Beschreibung der Seite
+  - ein kleiner Hinweis, dass Bearbeiten, Unterkategorien und Löschen vorbereitet, aber noch nicht verfügbar sind
+- Hauptinhalt ist eine flache Tabelle mit genau einer Zeile pro angezeigter Kategorie.
+
+### 2. Tabellenspalten
+
+Die Tabelle enthält in der ersten Ausbaustufe folgende Spalten:
+
+- `Name`
+- `ID`
+- `Hierarchie`
+- `Position`
+- `Tags`
+- `Aktualisiert`
+- `Aktionen`
+
+Leitlinien pro Spalte:
+
+- `Name`: Anzeigename der Kategorie.
+- `ID`: technische Mainserver-ID.
+- `Hierarchie`: lesbarer Pfad- oder Parent-Kontext der Kategorie in flacher Form.
+- `Position`: numerischer Positionswert, sofern vorhanden.
+- `Tags`: Anzeigedarstellung auf Basis von `tagList`.
+- `Aktualisiert`: letzter bekannter Änderungszeitpunkt.
+- `Aktionen`: sichtbare, deaktivierte Steuerflächen für spätere CRUD-Fälle.
+
+### 3. Hierarchie-Darstellung
+
+Die Mainserver-Kategorien bleiben fachlich hierarchisch, die Seite zeigt sie aber bewusst flach an.
+
+Regeln:
+
+- Jede Kategorie erscheint als eigene Tabellenzeile.
+- Die Tabelle verwendet keine eingerückte Baumansicht.
+- Die Spalte `Hierarchie` zeigt den abgeleiteten Parent-/Pfadkontext, damit Unterkategorien trotz flacher Darstellung verständlich bleiben.
+- Die Reihenfolge soll stabil und lesbar sein; Eltern und Kinder dürfen zusammenhängend erscheinen, ohne dass dafür ein Tree-Widget gebaut wird.
+
+### 4. Datenfluss und View-Modell
+
+Die Seite verwendet den bestehenden Mainserver-Kategorien-Read-Pfad als Quelle der Wahrheit.
+
+Architekturprinzipien:
+
+- Das Mainserver-Modell bleibt hierarchisch und unverändert.
+- Die Kategorien-Seite führt eine gezielte Flattening-Transformation nur für die Anzeige ein.
+- Es wird kein news-spezifisches Kategorienmodell wiederverwendet, das Kategorien auf reine Namen reduziert.
+- Für die Tabelle wird ein eigenes flaches View-Modell eingeführt.
+
+Das flache Zeilenmodell enthält mindestens:
+
+- `id`
+- `name`
+- `hierarchyLabel`
+- `position`
+- `tagsDisplay`
+- `updatedAt`
+- `actionTargetId`
+
+Optional interne Hilfsfelder wie `depth`, `sortKey` oder `parentId` sind erlaubt, gehören aber nicht zwingend zur UI-Oberfläche.
+
+### 5. Tags-Darstellung
+
+Die Mainserver-Kategorie liefert `tagList` aktuell als String-Wert.
+
+Für die kleine Variante gilt:
+
+- `tagList` wird als Anzeigeinformation behandelt, nicht als bereits voll standardisierte Tag-Domain.
+- Die Seite normalisiert nur oberflächlich für die Darstellung, zum Beispiel durch `trim`.
+- Es wird keine fachliche Semantik wie Bearbeitbarkeit, Validierung oder feste Tag-Arrays eingeführt.
+- Wenn `tagList` fehlt oder leer ist, wird ein klarer Leerwert angezeigt.
+
+Damit bleibt der erste Schritt konservativ und vermeidet falsche Annahmen über das genaue Upstream-Tagformat.
+
+### 6. Aktionen
+
+Jede Tabellenzeile zeigt drei vorbereitete Aktionen:
+
+- `Bearbeiten`
+- `Neue Unterkategorie`
+- `Löschen`
+
+Für diese erste Ausbaustufe gilt:
+
+- Alle drei Aktionen sind sichtbar.
+- Alle drei Aktionen sind deaktiviert.
+- Sie dürfen nicht wie kaputte Links oder aktive Controls wirken.
+- Die Oberfläche macht klar, dass diese Funktionen vorgesehen, aber noch nicht verfügbar sind.
+- Jede Aktion bleibt bereits an die Kategorie-ID der Zeile gebunden, damit spätere Schreibpfade darauf aufbauen können.
+
+Eine zusätzliche `Details`-Aktion wird nicht vorgesehen, weil sie in dieser Ausbaustufe keinen klaren Mehrwert gegenüber dem späteren Bearbeitungsfluss bietet.
+
+### 7. Lade-, Fehler- und Leerzustände
+
+Die Seite braucht vollständige Zustände analog zu anderen Studio-Listen:
+
+- Ladezustand:
+  - bestehender Pending-/Skeleton-Stil der Tabellenroute
+- Fehlerzustand:
+  - klar lesbare Fehlermeldung innerhalb der Seite
+  - optional mit `Erneut laden`, falls das bestehende Muster das unterstützt
+- Leerzustand:
+  - explizite Meldung, dass aktuell keine Kategorien aus dem Mainserver geliefert wurden
+
+Die Seite darf im Fehlerfall nicht auf den alten Placeholder zurückfallen.
+
+## Architektur und Bausteine
+
+### App-Route
+
+- Die bestehende Route `/categories` wird von der Placeholder-Verdrahtung auf eine echte Kategorienseiten-Komponente umgestellt.
+
+### Datenzugriff
+
+- Die Seite nutzt die bestehende Mainserver-Kategorien-Fassade.
+- Falls dafür ein neuer app-seitiger Fetch-Helper sinnvoll ist, wird dieser generisch auf Kategorien ausgerichtet und nicht im News-Plugin verankert.
+
+### Mapping
+
+- Eine kleine, klar abgegrenzte Flattening-Funktion transformiert die hierarchischen Mainserver-Kategorien in Tabellenzeilen.
+- Diese Funktion kapselt Parent-/Pfadableitung, Tags-Anzeige und Sortierreihenfolge.
+
+### UI
+
+- Die Renderlogik folgt dem vorhandenen `StudioDataTable`-Muster.
+- Tabellenlabels, Caption, Empty-State und Aria-Beschriftung werden explizit lokalisiert.
+
+## Teststrategie
+
+Die erste Ausbaustufe benötigt gezielte Tests auf Routen-, Mapping- und UI-Ebene.
+
+Mindestens abzudecken:
+
+- `/categories` rendert keine Placeholder-Seite mehr.
+- Die Route zeigt eine echte Kategorien-Tabelle.
+- Hierarchische Mainserver-Daten werden korrekt in flache Tabellenzeilen transformiert.
+- Die Spalte `Hierarchie` bildet Parent-/Pfadkontext nachvollziehbar ab.
+- `tagList` wird als `Tags`-Anzeige robust gerendert.
+- Fehlende `position`, `tagList` oder `updatedAt` führen zu stabilen Leerwerten statt zu kaputtem Rendering.
+- Fehlerzustand wird sichtbar gerendert.
+- Leerzustand wird sichtbar gerendert.
+- Die Aktionen `Bearbeiten`, `Neue Unterkategorie` und `Löschen` sind sichtbar und deaktiviert.
+
+## Offene Anschlussfähigkeit
+
+Die kleine Variante soll spätere Ausbaustufen erleichtern, ohne sie vorwegzunehmen.
+
+Dafür werden bewusst vorbereitet:
+
+- stabile Kategorie-IDs pro Zeile
+- eine saubere Trennung zwischen Mainserver-Modell und Tabellen-View-Modell
+- eine dedizierte Aktionsspalte
+- ein Seitenlayout, das später um echte Schreibaktionen erweitert werden kann
+
+Nicht vorbereitet werden in dieser Iteration:
+
+- echte Edit-Routen
+- Create-/Delete-Mutationen
+- Detailseiten
+- Bulk-Aktionen

--- a/docs/superpowers/specs/2026-06-09-news-editor-redaktionelle-vereinfachung-design.md
+++ b/docs/superpowers/specs/2026-06-09-news-editor-redaktionelle-vereinfachung-design.md
@@ -1,0 +1,368 @@
+# News-Editor Redaktionelle Vereinfachung Design
+
+## Kontext
+
+Die Bearbeitungsansicht des News-Plugins ist aktuell technisch nah an der Mainserver-/GraphQL-Struktur aufgebaut. Innerhalb der Tabpanels stehen viele Felder in einer flachen Formularfläche. Für Redakteure ist die Oberfläche dadurch schwerer zu scannen und stärker vom technischen Datenmodell geprägt als vom redaktionellen Arbeitsablauf.
+
+Gleichzeitig existiert im Studio bereits ein klareres Workspace-Muster, etwa im Waste-Management: eine äußere Panel-Fläche pro Tab und darin fachlich getrennte weiße Arbeitskarten. Dieses Muster soll auf die News-Bearbeitung übertragen werden.
+
+Zusätzlich soll die Oberfläche redaktionell vereinfacht werden:
+
+- nur noch ein globales `Speichern`
+- weniger technische Felder
+- klarere Gruppierung nach Arbeitsaufgaben
+- ein echter Entwurfsmodus auf Basis von `visible=false`
+
+## Ziele
+
+- Die News-Detailansicht arbeitet innerhalb jedes Tabpanels mit klar getrennten weißen Cards.
+- Die Oberfläche orientiert sich an redaktionellen Aufgaben statt an der 1:1-Abbildung des GraphQL-Modells.
+- `Speichern` sichert immer den gesamten Formularzustand über alle Tabs.
+- Entwürfe werden mit `visible=false` gespeichert und bleiben in der Studio-Newsliste sichtbar.
+- Die vereinfachte Oberfläche mappt weiterhin auf das bestehende News-Modell, insbesondere auf den ersten `contentBlock`.
+- Push-Benachrichtigungen bleiben pro News maximal einmal auslösbar.
+
+## Nicht-Ziele
+
+- Kein vollständiger Neuaufbau des News-Datenmodells im Mainserver.
+- Keine Einführung eines zweiten, separaten Draft-Speichers neben dem Mainserver.
+- Keine Galerieauswahl für Medien in diesem Change.
+- Kein Ausbau der öffentlichen App-Darstellung von News.
+- Kein 1:1-Nachbau aller historischen oder technischen Mainserver-Felder in der neuen Studio-Oberfläche.
+
+## Bestehender Stand
+
+- Die News-Detailansicht besitzt bereits Tabs für `Basis`, `Inhalte`, `Veröffentlichung`, `Einstellungen` und `Historie`.
+- Das Formular speichert heute tabweise Teilmutationen.
+- Die Oberfläche verwendet aktuell Felder wie `keywords`, `externalId`, `newsType`, `charactersToBeShown`, `fullVersion`, `pointOfInterestId`, `teaserImageAssetId` und `headerImageAssetId`.
+- Die Mainserver-News-Typen sind lokal auf `status: 'published'` und ein Pflichtfeld `publishedAt` zugeschnitten.
+- Das Upstream-Newsmodell liefert `visible`, die aktuelle Studio-/Mainserver-Route behandelt dieses Feld im Write-Pfad aber als readonly.
+- Die Studio-Newsliste liest aktuell denselben News-Pfad, der unsichtbare News herausfiltert.
+- Die Historie existiert bereits über `fetchIamContentHistory`, wird aber im Detailtab als Timeline-ähnliche Liste dargestellt.
+
+## Bewertete Ansätze
+
+### Ansatz A: Reine UI-Politur ohne fachliche Änderungen
+
+Die Tabpanels würden nur optisch in Cards gegliedert, die bestehende tabweise Speicherlogik und das bestehende Formularmodell blieben weitgehend erhalten.
+
+Vorteile:
+- geringerer Eingriff
+- wenig Risiko in Adapter und Tests
+
+Nachteile:
+- löst die redaktionelle Vereinfachung nur oberflächlich
+- Entwurfsmodus bleibt unecht
+- technische Felder und tabweise Saves bleiben bestehen
+
+### Ansatz B: Redaktionelle UI-Vereinfachung mit Adapter-Mapping und `visible=false` als Entwurf
+
+Die Oberfläche wird fachlich neu geschnitten, speichert aber weiterhin in die bestehende News-Struktur. `visible=false` dient als Entwurfsmodus. Studio-Liste und Mainserver-Adapter werden dafür gezielt erweitert.
+
+Vorteile:
+- klarer redaktioneller Workflow
+- vorhandenes Upstream-Feld `visible` wird sinnvoll genutzt
+- keine unnötige Parallelpersistenz
+- UI und Studio-Liste bilden Entwürfe konsistent ab
+
+Nachteile:
+- ist kein reiner UI-Fix mehr
+- erfordert gezielte Änderungen in Route, Adapter, Typen und Liste
+
+### Ansatz C: Neuer separater Draft-Mechanismus außerhalb des News-Pfads
+
+Entwürfe würden in einer eigenen lokalen oder Studio-spezifischen Persistenz verwaltet und erst bei Veröffentlichung in den Mainserver geschrieben.
+
+Vorteile:
+- maximale Studio-Kontrolle über Entwürfe
+
+Nachteile:
+- deutlich größerer Architektur-Change
+- doppeltes Datenmodell
+- unnötige Komplexität für das aktuelle Ziel
+
+## Entscheidung
+
+Es wird Ansatz B umgesetzt: redaktionelle UI-Vereinfachung mit gezieltem Adapter-Mapping und `visible=false` als Entwurfsmodus.
+
+Diese Entscheidung hält den Change inhaltlich auf den News-Editor fokussiert, löst aber den Entwurfsmodus fachlich korrekt statt nur kosmetisch. Das vorhandene Upstream-Feld `visible` wird bewusst als redaktioneller Veröffentlichungszustand genutzt. Dafür werden der News-Write-Pfad und die Studio-Newsliste erweitert, ohne einen zweiten Persistenzpfad einzuführen.
+
+## Zielbild
+
+### 1. Grundstruktur der Seite
+
+- Die bestehende Tab-Hülle bleibt erhalten.
+- Jedes Tabpanel besitzt weiterhin eine äußere Workspace-Fläche mit Titel, Beschreibung und rechts platziertem globalem `Speichern`-Button.
+- Innerhalb des Panels werden die Inhalte in weiße Cards gegliedert.
+- Der Save-Button speichert immer das gesamte Formular, unabhängig davon, in welchem Tab er ausgelöst wird.
+- Dirty-Indikatoren können pro Tab sichtbar bleiben, blockieren den Tabwechsel aber nicht mehr tabweise.
+
+### 2. Tabs und Cards
+
+#### Tab `Basis`
+
+Card `Titel & Kategorien`
+
+- Das Feld `Titel` bleibt das primäre redaktionelle Titelfeld.
+- Wenn ein News-Datensatz keinen expliziten Titel besitzt, wird der Titel beim Laden initial aus der Headline des ersten `contentBlock` vorbelegt.
+- Danach ist der Titel ein eigenständiges, editierbares Feld.
+- Kategorien werden als wiederholbare Auswahlzeilen modelliert.
+- Die verfügbaren Kategorien werden aus der bestehenden Kategorien-Query geladen.
+- Ein Add-Button fügt jeweils eine weitere Kategorien-Auswahl hinzu.
+- Beim Speichern werden Kategorien dedupliziert und leere Einträge entfernt.
+
+Card `Autor & Metadaten`
+
+- Der Autor wird aus Benutzer- und Organisationskontext vorbelegt.
+- Bei `org_only` ist das Feld gesperrt und zeigt die aktive Organisation als Autor.
+- Bei `org_or_personal` wird zwischen zulässigen Autorquellen gewählt: aktive Organisation oder aktueller Benutzer.
+- Wenn keine aktive Organisation vorhanden ist, bleibt nur der Benutzer als Autorquelle.
+- Im Edit-Modus zeigt die Card zusätzlich:
+  - `Erstellt`
+  - `Veröffentlicht`
+  - `Zuletzt geändert`
+- Fehlende Zeitwerte werden als `--.--.-- --:--` angezeigt.
+- `keywords` entfallen vollständig aus der Oberfläche.
+
+#### Tab `Inhalte`
+
+Card `Textinhalt`
+
+- `Headline` wird hier als read-only Spiegel des ersten `contentBlock.title` angezeigt.
+- `Teaser` wird als einfaches Textfeld geführt und auf `contentBlocks[0].intro` gemappt.
+- `Inhalt` wird als Rich-Text-Feld geführt und auf `contentBlocks[0].body` gemappt.
+- Für den Rich-Text wird der vorhandene Studio-Rich-Text-Editor wiederverwendet.
+
+Card `Medien`
+
+- Alle in Studio bearbeitbaren Medien liegen ausschließlich im ersten `contentBlock.mediaContents`.
+- `teaserImageAssetId` und `headerImageAssetId` werden nicht mehr angezeigt und nicht mehr aktiv bearbeitet.
+- Die Card zeigt eine vereinfachte Liste der zugeordneten Medien mit Hinzufügen und Entfernen.
+- Upload/Drag-and-Drop wird im UI-Pfad vorbereitet; die spätere Galerieauswahl bleibt explizit außerhalb dieses Changes.
+
+Card `Quelle`
+
+- Die Card enthält nur:
+  - Link
+  - Linktext
+- Diese Felder werden auf `sourceUrl.url` und `sourceUrl.description` gemappt.
+- Ein separater Öffnungsmodus wird nicht eingeführt.
+
+#### Tab `Einstellungen`
+
+Card `Push-Benachrichtigungen`
+
+- Solange noch keine Push-Benachrichtigung versendet wurde, ist ein Schalter sichtbar.
+- Aktiviert der Nutzer diesen Schalter und speichert eine veröffentlichte News, wird Push wie bisher einmalig ausgelöst.
+- Sobald `pushNotificationsSentAt` gesetzt ist, wird kein erneuter Schalter mehr angeboten.
+- Stattdessen zeigt die Card nur noch den Versandzeitpunkt.
+- Ein erneutes Speichern einer bereits gepushten News löst keinen zweiten Versand aus.
+
+Card `Veröffentlichung`
+
+- Die Card bietet drei redaktionelle Modi:
+  - `Entwurf`
+  - `Sofort veröffentlichen`
+  - `Zeitgesteuert`
+- `Entwurf` speichert mit `visible=false`.
+- `Sofort veröffentlichen` speichert mit `visible=true` und `publishedAt=jetzt`.
+- `Zeitgesteuert` speichert mit `visible=true` und einem frei wählbaren Veröffentlichungszeitpunkt.
+- Der gewählte Zeitpunkt darf in der Vergangenheit oder Zukunft liegen.
+- Bei bereits gespeicherten News zeigt die Card zusätzlich das tatsächliche Veröffentlichungsdatum des Datensatzes.
+
+#### Tab `Historie`
+
+- Die Historie wird als Tabelle statt als Karten-/Timeline-Liste dargestellt.
+- Vorgesehene Spalten:
+  - Zeitpunkt
+  - Aktion
+  - Akteur
+  - Zusammenfassung
+- Wenn keine Historie vorhanden ist, erscheint ein klarer Leerzustand.
+
+## Datenmodell und Mapping
+
+### 1. Vereinfachtes Editor-Formmodell
+
+Die neue Oberfläche arbeitet mit einem redaktionellen Formularmodell, das nicht 1:1 dem Mainserver-Input entspricht.
+
+Relevante UI-Felder:
+
+- `title`
+- `authorMode`
+- `author`
+- `categories[]`
+- `contentHeadline`
+- `contentTeaser`
+- `contentBody`
+- `contentMedia[]`
+- `sourceUrl`
+- `sourceUrlDescription`
+- `pushNotificationEnabled`
+- `publicationMode`
+- `scheduledPublicationAt`
+
+### 2. Mapping auf die bestehende News-Struktur
+
+- `title` bleibt das explizite Titelfeld der News.
+- `contentHeadline` wird auf `contentBlocks[0].title` gemappt.
+- `contentTeaser` wird auf `contentBlocks[0].intro` gemappt.
+- `contentBody` wird auf `contentBlocks[0].body` gemappt.
+- `contentMedia[]` wird auf `contentBlocks[0].mediaContents` gemappt.
+- `sourceUrl` und `sourceUrlDescription` werden auf `sourceUrl` gemappt.
+- Kategorien werden auf `categories` gemappt.
+
+Wenn beim Laden keine `contentBlocks` vorhanden sind, wird weiterhin ein erster Block erzeugt. Die vereinfachte Oberfläche arbeitet immer gegen diesen ersten Block.
+
+### 3. Legacy-Felder außerhalb des vereinfachten UI-Scope
+
+Folgende Felder werden in der neuen Oberfläche nicht mehr aktiv angeboten:
+
+- `keywords`
+- `externalId`
+- `newsType`
+- `charactersToBeShown`
+- `fullVersion`
+- `pointOfInterestId`
+- `showPublishDate`
+- `teaserImageAssetId`
+- `headerImageAssetId`
+
+Regel:
+
+- Beim Editieren bestehender News bleiben vorhandene Werte dieser Felder erhalten.
+- Die globale Save-Logik darf sie nicht versehentlich löschen.
+- Neue Records senden diese Felder nicht, solange es keine dedizierte UI dafür gibt.
+
+## Veröffentlichungslogik
+
+### 1. Redaktionelle Statusableitung
+
+Der für Studio sichtbare Status wird aus `visible` und `publishedAt` abgeleitet:
+
+- `visible=false` => `Entwurf`
+- `visible=true` und `publishedAt` in der Zukunft => `Geplant`
+- `visible=true` und `publishedAt` in der Vergangenheit oder Gegenwart => `Veröffentlicht`
+
+Ein separater Mainserver-Status für Drafts wird nicht eingeführt.
+
+### 2. Persistenzregeln
+
+Der Change erweitert den lokalen News-Vertrag gezielt:
+
+- `visible` wird im News-Write-Pfad schreibbar.
+- `publishedAt` wird für Entwürfe optional.
+- `publishedAt` bleibt für sichtbare News verpflichtend.
+
+Konkrete Regeln:
+
+- `Entwurf`
+  - `visible=false`
+  - `publishedAt` wird nicht gesetzt
+  - `publicationDate` wird nicht gesetzt
+- `Sofort veröffentlichen`
+  - `visible=true`
+  - `publishedAt=jetzt`
+  - `publicationDate` folgt demselben Zeitpunkt
+- `Zeitgesteuert`
+  - `visible=true`
+  - `publishedAt=<gewählter Zeitpunkt>`
+  - `publicationDate=<gewählter Zeitpunkt>`
+
+Die lokale Mainserver-Route und die Typen werden so erweitert, dass diese Regeln explizit zulässig sind. Ein implizites „Tricksen“ mit künstlichen Draft-Zeitpunkten findet nicht statt.
+
+## Studio-Liste
+
+Die normale Studio-Newsliste muss Entwürfe weiterhin anzeigen.
+
+Dafür wird der Studio-Lesepfad vom öffentlichen Sichtbarkeitsfilter getrennt:
+
+- öffentliche bzw. sichtbarkeitsorientierte Listen blenden `visible=false` weiterhin aus
+- die Studio-Newsliste fordert News inklusive unsichtbarer Datensätze an
+
+Technisch wird dafür ein expliziter Studio-Lesepfad benötigt, zum Beispiel über einen dedizierten Parameter oder eine getrennte interne Listenoperation. Wichtig ist nicht die konkrete URL-Form, sondern die klare Semantik: authentifizierte Studio-Listen dürfen Drafts sehen, öffentliche Pfade nicht.
+
+In der Liste wird ein verständlicher redaktioneller Status angezeigt:
+
+- `Entwurf`
+- `Geplant`
+- `Veröffentlicht`
+
+## Historie
+
+- Die bestehende IAM-History bleibt die Datenquelle.
+- Es wird keine zweite, News-spezifische Historienpersistenz eingeführt.
+- Die Darstellung wechselt auf eine Tabelle.
+- Die vorhandenen zusammenfassenden Texte und geänderten Felder werden weiterverwendet, aber tabellarisch gerahmt.
+
+## Architektur und Bausteine
+
+### Plugin-News UI
+
+- baut die Tab-Inhalte in Card-Sektionen um
+- ersetzt tabweise Save-Buttons durch globale Save-Actions in der Panel-Header-Zone
+- führt das vereinfachte Formularmodell ein
+- verwendet den bestehenden Rich-Text-Editor
+
+### Plugin-News Mapping
+
+- liest und schreibt `contentBlocks[0]` als primäres Redaktionsmodell
+- kapselt die Ableitung zwischen `publicationMode`, `visible`, `publishedAt` und `publicationDate`
+- erhält nicht sichtbare Legacy-Felder bei Updates
+
+### SVA-Mainserver Route und Operations
+
+- erweitert den lokalen News-Write-Vertrag um `visible`
+- erlaubt Draft-Speicherung ohne `publishedAt`
+- reicht `visible` an den GraphQL-Mutationspfad weiter
+- passt den lokalen generierten/gemappten News-Contract so an, dass Drafts nicht bereits vor dem UI-Pfad scheitern
+
+### Studio-Newsliste
+
+- lädt Drafts mit
+- zeigt redaktionellen Status statt nur technischer Felder
+
+## Fehlerbehandlung
+
+- Ungültige oder fehlende Veröffentlichungszeitpunkte blockieren `Sofort veröffentlichen` und `Zeitgesteuert`, nicht aber `Entwurf`.
+- Ist kein zulässiger Autor konfigurierbar, wird ein klarer Fehler in der Autoren-Card gezeigt.
+- Fehler in Kategorien-, Historien- oder Medien-Nebenpfaden bleiben lokal an der jeweiligen Card sichtbar.
+- Ein Save-Fehler betrifft weiterhin das Gesamtformular und wird zentral als Formularzusammenfassung ausgegeben.
+
+## Tests
+
+### Unit- und Komponententests
+
+- Mapping zwischen vereinfachtem Formular und `contentBlocks[0]`
+- Statusableitung aus `visible` und `publishedAt`
+- Autorenlogik für `org_only` und `org_or_personal`
+- Push-Einmaligkeit
+- Card-Struktur und Leerzustände
+- Tabellenansicht der Historie
+
+### Adapter- und Routentests
+
+- Draft-Save mit `visible=false` ohne `publishedAt`
+- sofortige Veröffentlichung mit `visible=true` und aktuellem Zeitpunkt
+- zeitgesteuerte Veröffentlichung mit vergangenem und zukünftigem Zeitpunkt
+- Studio-Liste inklusive unsichtbarer News
+
+### E2E
+
+- News als Entwurf anlegen und in der Studio-Liste wiederfinden
+- Entwurf öffnen und veröffentlichen
+- News zeitgesteuert speichern
+- bereits gepushte News ohne erneuten Push speichern
+
+## Auswirkungen und Risiken
+
+- Der Change berührt nicht nur das Plugin, sondern auch den lokalen Mainserver-Adapter und den Studio-Listenpfad.
+- Die Einführung von `visible` im Write-Pfad muss mit dem realen Upstream-GraphQL-Vertrag synchron gehalten werden.
+- Die globale Save-Logik darf versteckte Legacy-Felder bei Updates nicht verlieren.
+- Der vereinfachte Fokus auf `contentBlocks[0]` ist bewusst redaktionell sinnvoll, setzt aber voraus, dass zusätzliche Content-Blöcke nicht parallel in derselben UI gepflegt werden sollen.
+
+## Umsetzungshinweise
+
+- Bestehende Tab- und Panel-Patterns aus dem Waste-Management sollen wiederverwendet werden.
+- Für den Rich-Text-Einsatz soll der bestehende Host-Editor genutzt werden, nicht ein zweiter Editor-Stack.
+- Vor jeder Implementierung müssen die kleinsten relevanten Nx-Testpfade und die betroffenen Type-Checks grün gehalten werden.

--- a/docs/superpowers/specs/2026-06-09-news-editor-redaktionelle-vereinfachung-design.md
+++ b/docs/superpowers/specs/2026-06-09-news-editor-redaktionelle-vereinfachung-design.md
@@ -11,14 +11,14 @@ Zusätzlich soll die Oberfläche redaktionell vereinfacht werden:
 - nur noch ein globales `Speichern`
 - weniger technische Felder
 - klarere Gruppierung nach Arbeitsaufgaben
-- ein echter Entwurfsmodus auf Basis von `visible=false`
+- ein echter Entwurfsmodus auf Basis der separaten Visibility-Mutation
 
 ## Ziele
 
 - Die News-Detailansicht arbeitet innerhalb jedes Tabpanels mit klar getrennten weißen Cards.
 - Die Oberfläche orientiert sich an redaktionellen Aufgaben statt an der 1:1-Abbildung des GraphQL-Modells.
 - `Speichern` sichert immer den gesamten Formularzustand über alle Tabs.
-- Entwürfe werden mit `visible=false` gespeichert und bleiben in der Studio-Newsliste sichtbar.
+- Entwürfe werden über die separate Visibility-Mutation auf unsichtbar gesetzt und bleiben in der Studio-Newsliste sichtbar.
 - Die vereinfachte Oberfläche mappt weiterhin auf das bestehende News-Modell, insbesondere auf den ersten `contentBlock`.
 - Push-Benachrichtigungen bleiben pro News maximal einmal auslösbar.
 
@@ -36,7 +36,9 @@ Zusätzlich soll die Oberfläche redaktionell vereinfacht werden:
 - Das Formular speichert heute tabweise Teilmutationen.
 - Die Oberfläche verwendet aktuell Felder wie `keywords`, `externalId`, `newsType`, `charactersToBeShown`, `fullVersion`, `pointOfInterestId`, `teaserImageAssetId` und `headerImageAssetId`.
 - Die Mainserver-News-Typen sind lokal auf `status: 'published'` und ein Pflichtfeld `publishedAt` zugeschnitten.
-- Das Upstream-Newsmodell liefert `visible`, die aktuelle Studio-/Mainserver-Route behandelt dieses Feld im Write-Pfad aber als readonly.
+- Das Upstream-Newsmodell liefert `visible`.
+- Die echte GraphQL-API verwendet für Sichtbarkeit eine separate Mutation `changeVisibility(id, recordType, visible)`.
+- Der aktuelle lokale Studio-/Mainserver-Adapter bildet diese Visibility-Mutation für News noch nicht ab.
 - Die Studio-Newsliste liest aktuell denselben News-Pfad, der unsichtbare News herausfiltert.
 - Die Historie existiert bereits über `fetchIamContentHistory`, wird aber im Detailtab als Timeline-ähnliche Liste dargestellt.
 
@@ -55,13 +57,13 @@ Nachteile:
 - Entwurfsmodus bleibt unecht
 - technische Felder und tabweise Saves bleiben bestehen
 
-### Ansatz B: Redaktionelle UI-Vereinfachung mit Adapter-Mapping und `visible=false` als Entwurf
+### Ansatz B: Redaktionelle UI-Vereinfachung mit Adapter-Mapping und separater Visibility-Steuerung für Entwürfe
 
-Die Oberfläche wird fachlich neu geschnitten, speichert aber weiterhin in die bestehende News-Struktur. `visible=false` dient als Entwurfsmodus. Studio-Liste und Mainserver-Adapter werden dafür gezielt erweitert.
+Die Oberfläche wird fachlich neu geschnitten, speichert aber weiterhin in die bestehende News-Struktur. Der Entwurfsmodus wird über die separate Mutation `changeVisibility(..., visible: false)` hergestellt. Studio-Liste und Mainserver-Adapter werden dafür gezielt erweitert.
 
 Vorteile:
 - klarer redaktioneller Workflow
-- vorhandenes Upstream-Feld `visible` wird sinnvoll genutzt
+- vorhandene Upstream-Sichtbarkeitslogik wird sinnvoll genutzt
 - keine unnötige Parallelpersistenz
 - UI und Studio-Liste bilden Entwürfe konsistent ab
 
@@ -83,9 +85,9 @@ Nachteile:
 
 ## Entscheidung
 
-Es wird Ansatz B umgesetzt: redaktionelle UI-Vereinfachung mit gezieltem Adapter-Mapping und `visible=false` als Entwurfsmodus.
+Es wird Ansatz B umgesetzt: redaktionelle UI-Vereinfachung mit gezieltem Adapter-Mapping und separater Visibility-Steuerung als Entwurfsmodus.
 
-Diese Entscheidung hält den Change inhaltlich auf den News-Editor fokussiert, löst aber den Entwurfsmodus fachlich korrekt statt nur kosmetisch. Das vorhandene Upstream-Feld `visible` wird bewusst als redaktioneller Veröffentlichungszustand genutzt. Dafür werden der News-Write-Pfad und die Studio-Newsliste erweitert, ohne einen zweiten Persistenzpfad einzuführen.
+Diese Entscheidung hält den Change inhaltlich auf den News-Editor fokussiert, löst aber den Entwurfsmodus fachlich korrekt statt nur kosmetisch. Die vorhandene Upstream-Sichtbarkeitslogik wird bewusst als redaktioneller Veröffentlichungszustand genutzt. Dafür werden der News-Write-Pfad, eine dedizierte Visibility-Operation und die Studio-Newsliste erweitert, ohne einen zweiten Persistenzpfad einzuführen.
 
 ## Zielbild
 
@@ -164,9 +166,9 @@ Card `Veröffentlichung`
   - `Entwurf`
   - `Sofort veröffentlichen`
   - `Zeitgesteuert`
-- `Entwurf` speichert mit `visible=false`.
-- `Sofort veröffentlichen` speichert mit `visible=true` und `publishedAt=jetzt`.
-- `Zeitgesteuert` speichert mit `visible=true` und einem frei wählbaren Veröffentlichungszeitpunkt.
+- `Entwurf` speichert News-Inhalt und setzt die Sichtbarkeit anschließend über `changeVisibility(..., false)` auf unsichtbar.
+- `Sofort veröffentlichen` speichert News-Inhalt und stellt die Sichtbarkeit anschließend über `changeVisibility(..., true)` sicher.
+- `Zeitgesteuert` speichert News-Inhalt mit einem frei wählbaren Veröffentlichungszeitpunkt und stellt die Sichtbarkeit anschließend über `changeVisibility(..., true)` sicher.
 - Der gewählte Zeitpunkt darf in der Vergangenheit oder Zukunft liegen.
 - Bei bereits gespeicherten News zeigt die Card zusätzlich das tatsächliche Veröffentlichungsdatum des Datensatzes.
 
@@ -238,38 +240,45 @@ Regel:
 
 ### 1. Redaktionelle Statusableitung
 
-Der für Studio sichtbare Status wird aus `visible` und `publishedAt` abgeleitet:
+Der für Studio sichtbare Status wird aus Sichtbarkeit und `publishedAt` abgeleitet:
 
-- `visible=false` => `Entwurf`
-- `visible=true` und `publishedAt` in der Zukunft => `Geplant`
-- `visible=true` und `publishedAt` in der Vergangenheit oder Gegenwart => `Veröffentlicht`
+- unsichtbar => `Entwurf`
+- sichtbar und `publishedAt` in der Zukunft => `Geplant`
+- sichtbar und `publishedAt` in der Vergangenheit oder Gegenwart => `Veröffentlicht`
 
 Ein separater Mainserver-Status für Drafts wird nicht eingeführt.
 
 ### 2. Persistenzregeln
 
-Der Change erweitert den lokalen News-Vertrag gezielt:
+Der Change erweitert den lokalen Studio-Adapter gezielt:
 
-- `visible` wird im News-Write-Pfad schreibbar.
-- `publishedAt` wird für Entwürfe optional.
-- `publishedAt` bleibt für sichtbare News verpflichtend.
+- die normale News-Mutation bleibt für Inhaltsfelder zuständig
+- die separate Mutation `changeVisibility(id, recordType, visible)` wird als neue Operation ergänzt
+- für News wird dabei `recordType: 'NewsItem'` verwendet
+- der Sichtbarkeitswechsel gilt beim Anlegen und Bearbeiten gleichermaßen
+- `publishedAt` bleibt Bestandteil der normalen News-Mutation
 
 Konkrete Regeln:
 
 - `Entwurf`
-  - `visible=false`
-  - `publishedAt` wird nicht gesetzt
-  - `publicationDate` wird nicht gesetzt
+  - News-Inhalt wird zuerst über `createNews/updateNews` gespeichert
+  - danach wird `changeVisibility(..., false)` ausgeführt
+  - `publishedAt` bleibt als technischer Zeitwert gesetzt
+  - bei neuen Entwürfen wird dafür standardmäßig der Save-Zeitpunkt verwendet
 - `Sofort veröffentlichen`
-  - `visible=true`
-  - `publishedAt=jetzt`
+  - `createNews/updateNews` setzt `publishedAt=jetzt`
+  - danach wird `changeVisibility(..., true)` ausgeführt
   - `publicationDate` folgt demselben Zeitpunkt
 - `Zeitgesteuert`
-  - `visible=true`
-  - `publishedAt=<gewählter Zeitpunkt>`
+  - `createNews/updateNews` setzt `publishedAt=<gewählter Zeitpunkt>`
+  - danach wird `changeVisibility(..., true)` ausgeführt
   - `publicationDate=<gewählter Zeitpunkt>`
 
-Die lokale Mainserver-Route und die Typen werden so erweitert, dass diese Regeln explizit zulässig sind. Ein implizites „Tricksen“ mit künstlichen Draft-Zeitpunkten findet nicht statt.
+Wichtig:
+
+- Der Sichtbarkeitswechsel ist immer ein zweiter technischer Schritt nach der Inhaltsmutation.
+- Das gilt sowohl beim erstmaligen Anlegen als auch bei späteren Wechseln `Entwurf <-> sichtbar`.
+- Der redaktionelle Status `Entwurf` wird im Studio aus der Unsichtbarkeit abgeleitet, nicht aus einem leeren `publishedAt`.
 
 ## Studio-Liste
 
@@ -307,15 +316,18 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 ### Plugin-News Mapping
 
 - liest und schreibt `contentBlocks[0]` als primäres Redaktionsmodell
-- kapselt die Ableitung zwischen `publicationMode`, `visible`, `publishedAt` und `publicationDate`
+- kapselt die Ableitung zwischen `publicationMode`, Sichtbarkeit, `publishedAt` und `publicationDate`
 - erhält nicht sichtbare Legacy-Felder bei Updates
 
 ### SVA-Mainserver Route und Operations
 
-- erweitert den lokalen News-Write-Vertrag um `visible`
-- erlaubt Draft-Speicherung ohne `publishedAt`
-- reicht `visible` an den GraphQL-Mutationspfad weiter
-- passt den lokalen generierten/gemappten News-Contract so an, dass Drafts nicht bereits vor dem UI-Pfad scheitern
+- ergänzt eine dedizierte News-Visibility-Operation für `changeVisibility(id, recordType, visible)`
+- verwendet dafür den Record-Typ `NewsItem`
+- orchestriert beim Speichern zwei Schritte:
+  - `createNews/updateNews`
+  - danach optional `changeVisibility`
+- hält den normalen News-Mutationsvertrag frei von direktem `visible`-Schreiben
+- passt den lokalen Adapter so an, dass Studio-Status und Visibility-Wechsel konsistent zusammenarbeiten
 
 ### Studio-Newsliste
 
@@ -342,7 +354,7 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 
 ### Adapter- und Routentests
 
-- Draft-Save mit `visible=false` ohne `publishedAt`
+- Draft-Save mit nachgelagertem `changeVisibility(..., false)`
 - sofortige Veröffentlichung mit `visible=true` und aktuellem Zeitpunkt
 - zeitgesteuerte Veröffentlichung mit vergangenem und zukünftigem Zeitpunkt
 - Studio-Liste inklusive unsichtbarer News
@@ -357,8 +369,9 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 ## Auswirkungen und Risiken
 
 - Der Change berührt nicht nur das Plugin, sondern auch den lokalen Mainserver-Adapter und den Studio-Listenpfad.
-- Die Einführung von `visible` im Write-Pfad muss mit dem realen Upstream-GraphQL-Vertrag synchron gehalten werden.
+- Die neue lokale Visibility-Operation muss mit dem realen Upstream-GraphQL-Vertrag synchron gehalten werden.
 - Die globale Save-Logik darf versteckte Legacy-Felder bei Updates nicht verlieren.
+- Der zweite technische Schritt `changeVisibility` braucht ein sauberes Fehlerverhalten, damit klar ist, ob der Inhalts-Save erfolgreich war, aber der Sichtbarkeitswechsel nicht.
 - Der vereinfachte Fokus auf `contentBlocks[0]` ist bewusst redaktionell sinnvoll, setzt aber voraus, dass zusätzliche Content-Blöcke nicht parallel in derselben UI gepflegt werden sollen.
 
 ## Umsetzungshinweise

--- a/docs/superpowers/specs/2026-06-09-news-editor-redaktionelle-vereinfachung-design.md
+++ b/docs/superpowers/specs/2026-06-09-news-editor-redaktionelle-vereinfachung-design.md
@@ -19,6 +19,7 @@ Zusätzlich soll die Oberfläche redaktionell vereinfacht werden:
 - Die Oberfläche orientiert sich an redaktionellen Aufgaben statt an der 1:1-Abbildung des GraphQL-Modells.
 - `Speichern` sichert immer den gesamten Formularzustand über alle Tabs.
 - Entwürfe werden über die separate Visibility-Mutation auf unsichtbar gesetzt und bleiben in der Studio-Newsliste sichtbar.
+- In der Studio-Inhaltsliste bleibt für Redakteure jeder Inhalt sichtbar; Sichtbarkeit wird dort zusätzlich direkt über einen Schieberegler steuerbar.
 - Die vereinfachte Oberfläche mappt weiterhin auf das bestehende News-Modell, insbesondere auf den ersten `contentBlock`.
 - Push-Benachrichtigungen bleiben pro News maximal einmal auslösbar.
 
@@ -94,9 +95,11 @@ Diese Entscheidung hält den Change inhaltlich auf den News-Editor fokussiert, l
 ### 1. Grundstruktur der Seite
 
 - Die bestehende Tab-Hülle bleibt erhalten.
-- Jedes Tabpanel besitzt weiterhin eine äußere Workspace-Fläche mit Titel, Beschreibung und rechts platziertem globalem `Speichern`-Button.
+- Die Seite erhält eine globale Save-Action oben rechts außerhalb der Tabs.
+- Diese Save-Action ist als Gesamtspeichern erkennbar und unabhängig vom aktiven Tab.
+- Jedes Tabpanel besitzt weiterhin eine äußere Workspace-Fläche mit Titel und Beschreibung.
 - Innerhalb des Panels werden die Inhalte in weiße Cards gegliedert.
-- Der Save-Button speichert immer das gesamte Formular, unabhängig davon, in welchem Tab er ausgelöst wird.
+- Der Save-Button speichert immer das gesamte Formular über alle Tabs.
 - Dirty-Indikatoren können pro Tab sichtbar bleiben, blockieren den Tabwechsel aber nicht mehr tabweise.
 
 ### 2. Tabs und Cards
@@ -116,8 +119,9 @@ Card `Titel & Kategorien`
 Card `Autor & Metadaten`
 
 - Der Autor wird aus Benutzer- und Organisationskontext vorbelegt.
-- Bei `org_only` ist das Feld gesperrt und zeigt die aktive Organisation als Autor.
-- Bei `org_or_personal` wird zwischen zulässigen Autorquellen gewählt: aktive Organisation oder aktueller Benutzer.
+- Das Feld wird nie als Freitext dargestellt.
+- Bei `org_only` ist der Autor fest gesetzt und als nicht editierbarer Wert sichtbar.
+- Bei `org_or_personal` wird zwischen zulässigen Autorquellen über ein Dropdown gewählt: aktive Organisation oder aktueller Benutzer.
 - Wenn keine aktive Organisation vorhanden ist, bleibt nur der Benutzer als Autorquelle.
 - Im Edit-Modus zeigt die Card zusätzlich:
   - `Erstellt`
@@ -130,7 +134,9 @@ Card `Autor & Metadaten`
 
 Card `Textinhalt`
 
-- `Headline` wird hier als read-only Spiegel des ersten `contentBlock.title` angezeigt.
+- Redaktionell wird der Titel im Tab `Basis` erstellt und bearbeitet.
+- Technisch wird dieser Titel weiterhin in `contentBlocks[0].title` geschrieben.
+- `Headline` wird im Tab `Inhalte` nur noch als read-only Information angezeigt.
 - `Teaser` wird als einfaches Textfeld geführt und auf `contentBlocks[0].intro` gemappt.
 - `Inhalt` wird als Rich-Text-Feld geführt und auf `contentBlocks[0].body` gemappt.
 - Für den Rich-Text wird der vorhandene Studio-Rich-Text-Editor wiederverwendet.
@@ -139,7 +145,9 @@ Card `Medien`
 
 - Alle in Studio bearbeitbaren Medien liegen ausschließlich im ersten `contentBlock.mediaContents`.
 - `teaserImageAssetId` und `headerImageAssetId` werden nicht mehr angezeigt und nicht mehr aktiv bearbeitet.
-- Die Card zeigt eine vereinfachte Liste der zugeordneten Medien mit Hinzufügen und Entfernen.
+- Die Card zeigt ein vereinfachtes Medienfeld mit einer zugehörigen Liste der angehängten Dateien.
+- Dieses Feld darf mehrere Dateien enthalten.
+- Die Vereinfachung ist fachlich vertretbar, weil die angebundene App ebenfalls nur diese angehängten Medien nutzt.
 - Upload/Drag-and-Drop wird im UI-Pfad vorbereitet; die spätere Galerieauswahl bleibt explizit außerhalb dieses Changes.
 
 Card `Quelle`
@@ -194,7 +202,6 @@ Relevante UI-Felder:
 - `authorMode`
 - `author`
 - `categories[]`
-- `contentHeadline`
 - `contentTeaser`
 - `contentBody`
 - `contentMedia[]`
@@ -207,7 +214,7 @@ Relevante UI-Felder:
 ### 2. Mapping auf die bestehende News-Struktur
 
 - `title` bleibt das explizite Titelfeld der News.
-- `contentHeadline` wird auf `contentBlocks[0].title` gemappt.
+- `title` wird zusätzlich auf `contentBlocks[0].title` gespiegelt.
 - `contentTeaser` wird auf `contentBlocks[0].intro` gemappt.
 - `contentBody` wird auf `contentBlocks[0].body` gemappt.
 - `contentMedia[]` wird auf `contentBlocks[0].mediaContents` gemappt.
@@ -288,6 +295,7 @@ Dafür wird der Studio-Lesepfad vom öffentlichen Sichtbarkeitsfilter getrennt:
 
 - öffentliche bzw. sichtbarkeitsorientierte Listen blenden `visible=false` weiterhin aus
 - die Studio-Newsliste fordert News inklusive unsichtbarer Datensätze an
+- für Redakteure bleiben damit alle News sichtbar, weil sie sonst den Veröffentlichungszustand nicht ändern könnten
 
 Technisch wird dafür ein expliziter Studio-Lesepfad benötigt, zum Beispiel über einen dedizierten Parameter oder eine getrennte interne Listenoperation. Wichtig ist nicht die konkrete URL-Form, sondern die klare Semantik: authentifizierte Studio-Listen dürfen Drafts sehen, öffentliche Pfade nicht.
 
@@ -296,6 +304,21 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 - `Entwurf`
 - `Geplant`
 - `Veröffentlicht`
+
+Zusätzlich erhält die Studio-Inhaltsliste eine eigene Sichtbarkeitsinteraktion:
+
+- pro Zeile gibt es einen Schieberegler für `sichtbar` / `nicht sichtbar`
+- der Schieberegler arbeitet gegen dieselbe Visibility-Operation wie der Editor
+- die Zeile bleibt auch nach dem Umschalten sichtbar und wechselt nur ihren redaktionellen Status
+- dieses Listenmuster ist so geschnitten, dass es später auch für andere Content-Typen nutzbar ist
+
+Zusätzlich gibt es ein passendes Filterkriterium:
+
+- `Alle`
+- `Sichtbar`
+- `Nicht sichtbar`
+
+Der Sichtbarkeitsfilter ergänzt den bestehenden redaktionellen Statusfilter, ersetzt ihn aber nicht.
 
 ## Historie
 
@@ -309,7 +332,7 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 ### Plugin-News UI
 
 - baut die Tab-Inhalte in Card-Sektionen um
-- ersetzt tabweise Save-Buttons durch globale Save-Actions in der Panel-Header-Zone
+- ersetzt tabweise Save-Buttons durch eine globale Save-Action im Seitenkopf oberhalb der Tabs
 - führt das vereinfachte Formularmodell ein
 - verwendet den bestehenden Rich-Text-Editor
 
@@ -333,6 +356,8 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 
 - lädt Drafts mit
 - zeigt redaktionellen Status statt nur technischer Felder
+- bietet einen Schieberegler pro Zeile für den Visibility-Wechsel
+- ergänzt ein Filterkriterium für `sichtbar` / `nicht sichtbar`
 
 ## Fehlerbehandlung
 
@@ -340,6 +365,7 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 - Ist kein zulässiger Autor konfigurierbar, wird ein klarer Fehler in der Autoren-Card gezeigt.
 - Fehler in Kategorien-, Historien- oder Medien-Nebenpfaden bleiben lokal an der jeweiligen Card sichtbar.
 - Ein Save-Fehler betrifft weiterhin das Gesamtformular und wird zentral als Formularzusammenfassung ausgegeben.
+- Schlägt ein Visibility-Wechsel direkt in der Liste fehl, bleibt die Zeile sichtbar und zeigt den Fehler kontextnah am Schieberegler.
 
 ## Tests
 
@@ -351,6 +377,7 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 - Push-Einmaligkeit
 - Card-Struktur und Leerzustände
 - Tabellenansicht der Historie
+- Titelbearbeitung in `Basis` bei gleichzeitigem Schreiben nach `contentBlocks[0].title`
 
 ### Adapter- und Routentests
 
@@ -358,6 +385,8 @@ In der Liste wird ein verständlicher redaktioneller Status angezeigt:
 - sofortige Veröffentlichung mit `visible=true` und aktuellem Zeitpunkt
 - zeitgesteuerte Veröffentlichung mit vergangenem und zukünftigem Zeitpunkt
 - Studio-Liste inklusive unsichtbarer News
+- Sichtbarkeitswechsel per Listenschieberegler
+- Sichtbarkeitsfilter `Alle` / `Sichtbar` / `Nicht sichtbar`
 
 ### E2E
 

--- a/docs/superpowers/specs/2026-06-09-waste-mainserver-sync-job-design.md
+++ b/docs/superpowers/specs/2026-06-09-waste-mainserver-sync-job-design.md
@@ -1,0 +1,274 @@
+# Waste-Mainserver-Sync-Job Design
+
+## Kontext
+
+Im Waste-Management-Plugin sollen Fraktionsänderungen nicht nur lokal im Studio gespeichert werden, sondern zusätzlich ein für die App relevantes JSON-Artefakt `wasteTypes` auf den hinterlegten Mainserver schreiben. Dieses JSON soll aus dem bestehenden Fraktionsbestand generiert werden und weiterhin abwärtskompatibel bleiben, indem bestehende Basiseigenschaften erhalten und um zusätzliche Felder ergänzt werden.
+
+Die Synchronisation darf lokale Fraktionsänderungen nicht blockieren. Ein Fehler beim Mainserver-Update soll deshalb den Fraktionsspeicherpfad nicht rückabwickeln. Gleichzeitig muss es einen nachvollziehbaren und erneut ausführbaren technischen Pfad für die Synchronisation geben.
+
+## Ziele
+
+- Fraktionsänderungen triggern immer eine Synchronisation des vollständigen `wasteTypes`-Artefakts.
+- Die Synchronisation ist vom CRUD-Pfad entkoppelt und läuft als eigener Waste-Job.
+- Ein fehlgeschlagener Mainserver-Sync macht lokale Fraktionsänderungen nicht rückgängig.
+- Nutzer können den Sync gezielt erneut anstoßen.
+- Die Lösung bleibt auf den konkreten Fall `wasteTypes` fokussiert und generalisiert nicht vorzeitig.
+
+## Nicht-Ziele
+
+- Kein generischer plattformweiter Static-Content-Sync für beliebige Plugins.
+- Kein Ausbau des internen Fraktionsfachmodells.
+- Keine Delta-Synchronisation einzelner Fraktionen; exportiert wird immer der vollständige Zielzustand.
+- Kein transaktionales Zwei-Phasen-Commit zwischen Waste-Datenbank und Mainserver.
+
+## Bestehender Stand
+
+- Fraktionen werden heute direkt über die Waste-Master-Data-Submissions gespeichert.
+- Das Waste-Plugin verfügt bereits über eine bestehende Job-/History-Infrastruktur in den Datentools.
+- Die Mainserver-Integration besitzt bereits OAuth-, GraphQL- und Fehlerbehandlungsbausteine.
+- Das App-JSON soll auf dem bestehenden Kürzel als Key basieren; das zugrunde liegende Fraktionsmodell bleibt unverändert.
+
+## Bewertete Ansätze
+
+### Ansatz A: Direkter Mainserver-Sync im Fraktions-Save
+
+Nach erfolgreichem Fraktionsspeichern würde direkt die Mainserver-Mutation ausgeführt.
+
+Vorteile:
+- wenig zusätzliche Infrastruktur
+- unmittelbare Rückmeldung im Save-Flow
+
+Nachteile:
+- stärkere Kopplung zwischen CRUD und externer Systemintegration
+- Retry müsste im UI separat nachgebildet werden
+- schlechtere technische Nachvollziehbarkeit in bestehender Job-History
+
+### Ansatz B: Dedizierter Waste-Job `waste-management.sync-waste-types`
+
+Nach jeder relevanten Fraktionsänderung wird ein spezifischer Job eingeplant, der das vollständige `wasteTypes`-JSON erzeugt und auf den Mainserver schreibt.
+
+Vorteile:
+- entkoppelt den lokalen Speicherpfad vom externen Sync
+- nutzt vorhandene Waste-Job-Infrastruktur
+- natürlicher Retry-Pfad über denselben Jobtyp
+- gute Sichtbarkeit über History/Job-Details
+
+Nachteile:
+- zusätzlicher technischer Pfad im Plugin
+- Erfolg des lokalen Speicherns und Erfolg des externen Syncs fallen zeitlich auseinander
+
+### Ansatz C: Generischer Static-Content-Sync-Job
+
+Ein allgemeiner Jobtyp würde beliebige Mainserver-Static-Contents synchronisieren.
+
+Vorteile:
+- perspektivisch wiederverwendbar
+
+Nachteile:
+- aktuell unnötige Vorab-Generaliserung
+- mehr Abstraktion ohne konkreten zweiten Anwendungsfall
+
+## Entscheidung
+
+Es wird Ansatz B umgesetzt: ein dedizierter Jobtyp `waste-management.sync-waste-types`.
+
+Diese Entscheidung hält den Scope bewusst eng. Sie erfüllt die Anforderungen an Entkopplung, Retry und Nachvollziehbarkeit, ohne einen generischen Exportbaukasten einzuführen, dessen zukünftige Anforderungen noch nicht belastbar bekannt sind.
+
+## Zielbild
+
+### 1. Trigger
+
+Der Job wird immer nach erfolgreicher lokaler Fraktionsänderung angestoßen:
+
+- Anlegen einer Fraktion
+- Bearbeiten einer Fraktion
+- Löschen einer Fraktion
+- Statuswechsel aktiv/inaktiv
+
+Der Trigger erfolgt erst nach erfolgreicher lokaler Mutation. Ein Trigger- oder Mainserver-Fehler blockiert den Abschluss der lokalen Mutation nicht.
+
+### 2. Job-Semantik
+
+Der Job arbeitet immer mit einem vollständigen Snapshot des aktuellen Fraktionsbestands.
+
+Ablauf:
+
+1. aktuellen Fraktionsbestand laden
+2. Exportmodell `wasteTypes` daraus vollständig neu generieren
+3. `version` deterministisch aus dem JSON-Inhalt ableiten
+4. Mainserver-Mutation `createOrUpdateStaticContent` ausführen
+5. strukturiertes Job-Ergebnis und technische Details zurückgeben
+
+Wichtig:
+
+- Es werden keine partiellen Deltas einzelner Fraktionen synchronisiert.
+- Wiederholtes Ausführen desselben Jobs bleibt fachlich idempotent, weil immer der vollständige Zielzustand geschrieben wird.
+
+### 3. Exportmodell `wasteTypes`
+
+Das bestehende App-JSON bleibt in seiner Grundstruktur erhalten: eine Map mit Kürzeln als Keys.
+
+Beispielhaft:
+
+```json
+{
+  "bio": {
+    "label": "Biotonne auf Abruf",
+    "color": "#8B4513",
+    "selected_color": "#8B4513",
+    "icon": "https://fileserver.smart-village.app/foobar.png",
+    "id": "fraction-bio",
+    "short_label": "BIO",
+    "active": true,
+    "description": "Nur auf Abruf",
+    "container_size": null,
+    "translations": {
+      "de": "Biotonne auf Abruf"
+    }
+  }
+}
+```
+
+Leitlinien:
+
+- JSON-Key basiert auf dem vorhandenen Kürzel und wird für den Export normalisiert.
+- Das interne Fraktionsmodell wird dafür nicht erweitert.
+- Bestehende Pflichtfelder bleiben erhalten.
+- Zusätzliche Felder werden nur ergänzend exportiert.
+
+### 4. Versionierung
+
+Die Mainserver-Mutation verwendet eine inhaltsbasierte `version`.
+
+Empfehlung:
+
+- Hash des serialisierten JSON-Inhalts
+
+Begründung:
+
+- identischer Inhalt ergibt identische Version
+- Retries bleiben stabil
+- unnötige Versionssprünge durch reine Zeitstempel entfallen
+
+### 5. Mainserver-Aufruf
+
+Die Jobausführung schreibt das Exportartefakt mit folgender Mutation:
+
+```graphql
+mutation {
+  createOrUpdateStaticContent(
+    name: "wasteTypes"
+    content: "{...}"
+    dataType: "JSON"
+    version: "x"
+  ) {
+    id
+  }
+}
+```
+
+Die Mainserver-Kommunikation nutzt die bestehende OAuth-/GraphQL-Infrastruktur der SVA-Mainserver-Integration. Für `wasteTypes` wird ein schlanker dedizierter Operationspfad ergänzt, statt die News-/Events-/POI-Routen zu missbrauchen.
+
+## Architektur und Bausteine
+
+### Waste-Plugin
+
+- ergänzt einen neuen Jobtyp `waste-management.sync-waste-types`
+- startet diesen Job nach jeder erfolgreichen Fraktionsmutation
+- bietet im Fraktionskontext einen manuellen Retry-Button
+
+### Job-Handler
+
+- lädt den aktuellen Fraktionsbestand
+- mappt die Exportstruktur
+- berechnet die Inhaltsversion
+- ruft den Mainserver-Write-Pfad auf
+- liefert ein technisches Ergebnis für History und UI
+
+### Mainserver-Integration
+
+- ergänzt eine fokussierte Operation zum Schreiben von `StaticContent`
+- nutzt vorhandene Auth-, Config- und GraphQL-Bausteine
+- kapselt Mainserver-spezifische Fehlercodes sauber
+
+## UI-Verhalten
+
+### Erfolgsfall
+
+- lokale Fraktionsänderung bleibt wie bisher erfolgreich
+- Job wird gestartet
+- UI darf darauf hinweisen, dass die Mainserver-Synchronisation eingeplant wurde
+
+### Fehlerfall beim Jobstart oder Joblauf
+
+- lokale Fraktionsänderung bleibt bestehen
+- Nutzer erhalten eine Warnung, dass `wasteTypes` nicht synchronisiert werden konnte
+- im Fraktionsbereich steht ein Button `Erneut versuchen` zur Verfügung
+- der Button startet denselben Jobtyp erneut
+
+### Sichtbarkeit
+
+- der Sync-Lauf erscheint zusätzlich in den Waste-Datentools bzw. der technischen History
+- der Fraktionsbereich zeigt den Retry-Pfad dort an, wo die Nutzer die fachliche Änderung gerade vorgenommen haben
+
+## Fehlerbehandlung
+
+Fehlerklassen:
+
+- Mainserver-Konfiguration fehlt oder ist ungültig
+- Credentials fehlen
+- Tokenabruf schlägt fehl
+- GraphQL-Aufruf schlägt fehl
+- Mainserver liefert fachlichen Fehler oder ungültige Antwort
+- Exportgenerierung schlägt an Kürzelkonflikten oder ungültigen Daten fehl
+
+Fehlergrundsätze:
+
+- lokale Mutation bleibt erfolgreich, wenn der nachgelagerte Sync fehlschlägt
+- technische Fehler werden im Job protokolliert und in der History sichtbar gemacht
+- UI bekommt eine verständliche Warnmeldung plus Retry-Pfad
+
+## Datenkonsistenz
+
+Da der Job immer den vollständigen aktuellen Fraktionsbestand exportiert, wird die Zielrepräsentation bei jedem erfolgreichen Lauf vollständig überschrieben. Dadurch bleiben `delete` und `Statuswechsel` konsistent, ohne dass ältere Artefakte manuell bereinigt werden müssen.
+
+## Teststrategie
+
+### Unit-Tests
+
+- Export-Mapping von Fraktionen zu `wasteTypes`
+- Kürzelnormalisierung und Konflikterkennung
+- deterministische Versionsbildung
+- Job-Handler-Ergebnisse für Erfolg und Fehler
+
+### Integrationsnahe Tests
+
+- Jobtyp-Registrierung und Handler-Verdrahtung
+- Mainserver-Operation mit gemocktem GraphQL-Client
+- Trigger nach `create`, `update`, `delete` und `Statuswechsel`
+
+### UI-Tests
+
+- Fraktionsänderung bleibt erfolgreich trotz fehlgeschlagenem Sync
+- Warnmeldung und Retry-Button werden angezeigt
+- Retry stößt den Job erneut an
+
+### History-/Operations-Tests
+
+- neuer Jobtyp erscheint korrekt in Waste-Datentools
+- Status und technische Details werden erwartbar angezeigt
+
+## Risiken und Trade-offs
+
+- Nutzer sehen unter Umständen kurzzeitig einen lokal aktuelleren Stand als im Mainserver-Artefakt.
+  - Mitigation: klarer Retry-Pfad und technische History
+
+- Mehrere schnelle Fraktionsänderungen können mehrere Jobs erzeugen.
+  - Mitigation: vollständiger Snapshot pro Job hält das Endergebnis fachlich korrekt
+
+- Kürzelkonflikte werden jetzt exportkritisch.
+  - Mitigation: Konflikte fail-closed behandeln und im Job klar ausweisen
+
+## Offene Umsetzungsleitlinie
+
+Die Lösung bleibt absichtlich konkret auf `wasteTypes` fokussiert. Falls später weitere Mainserver-Artefakte aus Waste synchronisiert werden sollen, kann aus dem dedizierten Jobtyp ein allgemeineres Muster abgeleitet werden. Diese Generalisierung ist jedoch nicht Teil dieses Designs.

--- a/docs/superpowers/specs/2026-06-09-waste-mainserver-sync-job-design.md
+++ b/docs/superpowers/specs/2026-06-09-waste-mainserver-sync-job-design.md
@@ -112,7 +112,7 @@ Beispielhaft:
 
 ```json
 {
-  "bio": {
+  "BIO": {
     "label": "Biotonne auf Abruf",
     "color": "#8B4513",
     "selected_color": "#8B4513",
@@ -122,6 +122,16 @@ Beispielhaft:
     "active": true,
     "description": "Nur auf Abruf",
     "container_size": null,
+    "reminders": {
+      "reminder_count": "none",
+      "first_reminder_max_lead_days": null,
+      "second_reminder_max_lead_days": null,
+      "channels": {
+        "push": false,
+        "email": false,
+        "calendar": false
+      }
+    },
     "translations": {
       "de": "Biotonne auf Abruf"
     }
@@ -131,36 +141,42 @@ Beispielhaft:
 
 Leitlinien:
 
-- JSON-Key basiert auf dem vorhandenen Kürzel und wird für den Export normalisiert.
+- JSON-Key basiert direkt auf dem gepflegten Kürzel und wird kanonisch in Großbuchstaben exportiert.
 - Das interne Fraktionsmodell wird dafür nicht erweitert.
 - Bestehende Pflichtfelder bleiben erhalten.
-- Zusätzliche Felder werden nur ergänzend exportiert.
+- Das vorhandene Erinnerungsmodell wird ergänzend als strukturierter Block `reminders` exportiert.
+- Die Kanalfreigaben gelten auf Fraktionsebene und werden daher gemeinsam unter `reminders.channels` ausgegeben.
 
 ### 4. Versionierung
 
-Die Mainserver-Mutation verwendet eine inhaltsbasierte `version`.
-
-Empfehlung:
-
-- Hash des serialisierten JSON-Inhalts
+Die Mainserver-Mutation schreibt `version` bewusst als leeren String.
 
 Begründung:
 
-- identischer Inhalt ergibt identische Version
-- Retries bleiben stabil
-- unnötige Versionssprünge durch reine Zeitstempel entfallen
+- Das Mainserver-Schema erwartet für diesen Anwendungsfall kein fachliches Versionskonzept.
+- Der zwischen Studio und Mainserver abgestimmte Write-Pfad arbeitet mit leerem `version`-Feld.
+- Retries bleiben damit kompatibel zum aktuell erwarteten Mainserver-Verhalten.
 
 ### 5. Mainserver-Aufruf
 
-Die Jobausführung schreibt das Exportartefakt mit folgender Mutation:
+Die Jobausführung liest zuerst die vorhandene Datei-ID und schreibt das Exportartefakt anschließend mit dieser ID erneut:
 
 ```graphql
+query {
+  publicJsonFile(
+    name: "wastetypes"
+  ) {
+    id
+  }
+}
+
 mutation {
   createOrUpdateStaticContent(
-    name: "wasteTypes"
+    name: "wastetypes"
+    id: "1707"
     content: "{...}"
-    dataType: "JSON"
-    version: "x"
+    dataType: "json"
+    version: ""
   ) {
     id
   }

--- a/packages/auth-runtime/src/plugin-operations/job-error-mapper.test.ts
+++ b/packages/auth-runtime/src/plugin-operations/job-error-mapper.test.ts
@@ -57,4 +57,24 @@ describe('job error mapper', () => {
       message: 'fatal',
     });
   });
+
+  it('treats explicitly permanent plugin causes as permanent before the final attempt', () => {
+    const error = new Error('waste_mainserver_sync_not_implemented') as Error & { cause?: unknown };
+    error.cause = {
+      category: 'permanent',
+      code: 'waste_mainserver_sync_not_implemented',
+    };
+
+    expect(createExecutionErrorPayload(baseJob, error, false)).toEqual({
+      code: 'plugin_operation_execution_failed',
+      category: 'permanent',
+      message: 'waste_mainserver_sync_not_implemented',
+      details: {
+        plugin: {
+          category: 'permanent',
+          code: 'waste_mainserver_sync_not_implemented',
+        },
+      },
+    });
+  });
 });

--- a/packages/auth-runtime/src/plugin-operations/job-error-mapper.ts
+++ b/packages/auth-runtime/src/plugin-operations/job-error-mapper.ts
@@ -7,6 +7,9 @@ const readPluginErrorCause = (error: Error): Record<string, unknown> | undefined
     : undefined;
 };
 
+const hasPermanentPluginCause = (error: Error): boolean =>
+  readPluginErrorCause(error)?.category === 'permanent';
+
 export const createMissingHandlerPayload = (
   job: Pick<StudioJobRecord, 'source' | 'jobTypeId' | 'pluginId'>
 ): StudioJobError => ({
@@ -27,7 +30,7 @@ export const createExecutionErrorPayload = (
   finalFailure: boolean
 ): StudioJobError => ({
   code: job.source === 'plugin' ? 'plugin_operation_execution_failed' : 'studio_job_execution_failed',
-  category: finalFailure ? 'permanent' : 'retryable',
+  category: error instanceof Error && hasPermanentPluginCause(error) ? 'permanent' : finalFailure ? 'permanent' : 'retryable',
   message: error instanceof Error ? error.message : String(error),
   details:
     error instanceof Error

--- a/packages/auth-runtime/src/plugin-operations/job-lifecycle-orchestrator.ts
+++ b/packages/auth-runtime/src/plugin-operations/job-lifecycle-orchestrator.ts
@@ -173,14 +173,15 @@ export const createJobLifecycleOrchestrator = (deps: OrchestratorDeps) => ({
         return;
       }
 
-      const finalFailure = attempts >= maxAttempts;
+      const errorPayload = createExecutionErrorPayload(job, error, attempts >= maxAttempts);
+      const finalFailure = errorPayload.category === 'permanent';
       await stateWriter.markRetriedOrFailed({
         job,
         attempts,
         startedAt,
         workerId,
         progress: getLatestProgress(),
-        errorPayload: createExecutionErrorPayload(job, error, finalFailure),
+        errorPayload,
         finalFailure,
       });
       if (!finalFailure) {

--- a/packages/auth-runtime/src/plugin-operations/job-lifecycle-orchestrator.ts
+++ b/packages/auth-runtime/src/plugin-operations/job-lifecycle-orchestrator.ts
@@ -91,6 +91,21 @@ const createHandlerContext = async (
   };
 };
 
+const createOrchestratorStateWriter = (
+  deps: Pick<OrchestratorDeps, 'now'>,
+  repository: RepositoryPort,
+  eventWriter: ReturnType<typeof createJobEventWriter>
+) =>
+  createJobStateWriter({
+    updateJobState: repository.updateJobState,
+    appendStartedEvent: eventWriter.appendStartedEvent,
+    appendSucceededEvent: eventWriter.appendSucceededEvent,
+    appendRetriedEvent: eventWriter.appendRetriedEvent,
+    appendFailedEvent: eventWriter.appendFailedEvent,
+    appendCancelledEvent: eventWriter.appendCancelledEvent,
+    now: deps.now,
+  });
+
 export const createJobLifecycleOrchestrator = (deps: OrchestratorDeps) => ({
   run: async ({ instanceId, jobId, attempts, maxAttempts }: RunInput): Promise<void> => {
     const repository = await deps.loadRepository(instanceId);
@@ -117,15 +132,7 @@ export const createJobLifecycleOrchestrator = (deps: OrchestratorDeps) => ({
       attempts,
       workerId
     );
-    const stateWriter = createJobStateWriter({
-      updateJobState: repository.updateJobState,
-      appendStartedEvent: eventWriter.appendStartedEvent,
-      appendSucceededEvent: eventWriter.appendSucceededEvent,
-      appendRetriedEvent: eventWriter.appendRetriedEvent,
-      appendFailedEvent: eventWriter.appendFailedEvent,
-      appendCancelledEvent: eventWriter.appendCancelledEvent,
-      now: deps.now,
-    });
+    const stateWriter = createOrchestratorStateWriter(deps, repository, eventWriter);
 
     try {
       await stateWriter.markRunning({

--- a/packages/auth-runtime/src/plugin-operations/runner.test.ts
+++ b/packages/auth-runtime/src/plugin-operations/runner.test.ts
@@ -276,6 +276,58 @@ describe('plugin operation runner task list', () => {
     );
   });
 
+  it('marks a job as failed immediately for explicitly permanent execution errors', async () => {
+    const updateJobState = vi.fn(async () => null);
+    const appendJobEvent = vi.fn(async () => null);
+    repositoryState.withStudioJobRepository.mockImplementation(async (_instanceId, work) =>
+      work({
+        getJobById: vi.fn(async () => baseJob),
+        updateJobState,
+        appendJobEvent,
+      })
+    );
+
+    const handler = vi.fn(async () => {
+      throw new Error('waste_mainserver_sync_not_implemented', {
+        cause: {
+          category: 'permanent',
+          code: 'waste_mainserver_sync_not_implemented',
+        },
+      });
+    });
+
+    const taskList = createPluginOperationTaskList(
+      () => new Map([['news.import-articles', { handler, queueName: 'plugin-operations' }]])
+    );
+
+    await expect(
+      taskList[studioJobTaskIdentifier]?.(
+        { instanceId: 'tenant-a', jobId: 'job-1' },
+        {
+          job: { attempts: 1, max_attempts: 5 },
+        } as never
+      )
+    ).resolves.toBeUndefined();
+
+    expect(updateJobState).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        jobId: 'job-1',
+        status: 'failed',
+        errorPayload: expect.objectContaining({
+          code: 'plugin_operation_execution_failed',
+          category: 'permanent',
+          details: {
+            plugin: {
+              category: 'permanent',
+              code: 'waste_mainserver_sync_not_implemented',
+            },
+          },
+        }),
+      })
+    );
+  });
+
   it('marks a job as cancelled when the handler cooperatively aborts', async () => {
     const updateJobState = vi.fn(async () => null);
     const appendJobEvent = vi.fn(async () => null);

--- a/packages/auth-runtime/src/routes.ts
+++ b/packages/auth-runtime/src/routes.ts
@@ -116,6 +116,7 @@ export type AuthRoutePath =
   | '/api/v1/waste-management/tools/imports/preview'
   | '/api/v1/waste-management/tools/migrations'
   | '/api/v1/waste-management/tools/seed'
+  | '/api/v1/waste-management/tools/sync-waste-types'
   | '/api/v1/waste-management/tools/reset'
   | '/api/v1/plugin-operations/jobs'
   | '/api/v1/plugin-operations/jobs/$jobId'
@@ -238,6 +239,7 @@ export const authRoutePaths = [
   '/api/v1/waste-management/tools/imports/preview',
   '/api/v1/waste-management/tools/migrations',
   '/api/v1/waste-management/tools/seed',
+  '/api/v1/waste-management/tools/sync-waste-types',
   '/api/v1/waste-management/tools/reset',
   '/api/v1/plugin-operations/jobs',
   '/api/v1/plugin-operations/jobs/$jobId',

--- a/packages/auth-runtime/src/waste-management/core.test.ts
+++ b/packages/auth-runtime/src/waste-management/core.test.ts
@@ -583,6 +583,7 @@ describe('waste-management auth runtime handlers', () => {
     const savedFraction: WasteFractionRecord = {
       id: 'fraction-new',
       name: 'Papier',
+      pdfShortLabel: 'PAP',
       translations: { de: 'Papier', en: 'Paper' },
       containerSize: '120L',
       color: '#123456',
@@ -614,6 +615,7 @@ describe('waste-management auth runtime handlers', () => {
         body: JSON.stringify({
           id: 'fraction-new',
           name: 'Papier',
+          pdfShortLabel: 'PAP',
           translations: { de: 'Papier', en: 'Paper' },
           containerSize: '120L',
           color: '#123456',
@@ -643,6 +645,7 @@ describe('waste-management auth runtime handlers', () => {
     expect(saveWasteFraction).toHaveBeenCalledWith('tenant-a', {
       id: 'fraction-new',
       name: 'Papier',
+      pdfShortLabel: 'PAP',
       translations: { de: 'Papier', en: 'Paper' },
       containerSize: '120L',
       color: '#123456',
@@ -679,6 +682,7 @@ describe('waste-management auth runtime handlers', () => {
     const existingFraction: WasteFractionRecord = {
       id: 'fraction-1',
       name: 'Restmüll',
+      pdfShortLabel: 'RES',
       color: '#111111',
       active: true,
       reminderCount: 'once',
@@ -692,6 +696,7 @@ describe('waste-management auth runtime handlers', () => {
     const updatedFraction: WasteFractionRecord = {
       ...existingFraction,
       name: 'Restmüll Plus',
+      pdfShortLabel: 'RPL',
       reminderCount: 'none',
       firstReminderMaxLeadDays: undefined,
       secondReminderMaxLeadDays: undefined,
@@ -717,6 +722,7 @@ describe('waste-management auth runtime handlers', () => {
         },
         body: JSON.stringify({
           name: 'Restmüll Plus',
+          pdfShortLabel: 'RPL',
           translations: { de: 'Restmüll Plus', en: 'Residual waste plus' },
           color: '#111111',
           active: true,
@@ -743,6 +749,7 @@ describe('waste-management auth runtime handlers', () => {
     expect(saveWasteFraction).toHaveBeenCalledWith('tenant-a', {
       id: 'fraction-1',
       name: 'Restmüll Plus',
+      pdfShortLabel: 'RPL',
       translations: { de: 'Restmüll Plus', en: 'Residual waste plus' },
       containerSize: undefined,
       color: '#111111',

--- a/packages/auth-runtime/src/waste-management/core.test.ts
+++ b/packages/auth-runtime/src/waste-management/core.test.ts
@@ -601,7 +601,13 @@ describe('waste-management auth runtime handlers', () => {
 
     const saveWasteFraction = vi.fn(async () => undefined);
     const loadWasteFractionById = vi.fn(async () => savedFraction);
-
+    const startPluginOperationJob = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { id: 'job-fraction-create' } }), {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
     const emitAuditEvent = vi.fn(async () => undefined);
 
     const response = await createWasteManagementFractionInternal(
@@ -615,7 +621,7 @@ describe('waste-management auth runtime handlers', () => {
         body: JSON.stringify({
           id: 'fraction-new',
           name: 'Papier',
-          pdfShortLabel: 'PAP',
+          pdfShortLabel: 'pap',
           translations: { de: 'Papier', en: 'Paper' },
           containerSize: '120L',
           color: '#123456',
@@ -633,8 +639,10 @@ describe('waste-management auth runtime handlers', () => {
       {
         getRequestId: () => 'req-test',
         emitAuditEvent,
+        resolveActorInfo: vi.fn(async () => resolvedActorInfo),
         saveWasteFraction,
         loadWasteFractionById,
+        startPluginOperationJob,
         resolvePermissions: vi.fn(async () => ({
           ok: true as const,
           permissions: allowPermission('waste-management.master-data.manage'),
@@ -659,6 +667,21 @@ describe('waste-management auth runtime handlers', () => {
       reminderChannelCalendarEnabled: true,
     });
     expect(loadWasteFractionById).toHaveBeenCalledWith('tenant-a', 'fraction-new');
+    expect(startPluginOperationJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'tenant-a',
+        actorAccountId: 'account-1',
+        endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
+        data: expect.objectContaining({
+          jobTypeId: 'waste-management.sync-waste-types',
+          input: {
+            operation: 'sync-waste-types',
+            keycloakSubject: 'user-1',
+            activeOrganizationId: undefined,
+          },
+        }),
+      })
+    );
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual({
       data: savedFraction,
@@ -711,6 +734,13 @@ describe('waste-management auth runtime handlers', () => {
       .mockResolvedValueOnce(existingFraction)
       .mockResolvedValueOnce(updatedFraction);
     const saveWasteFraction = vi.fn(async () => undefined);
+    const startPluginOperationJob = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { id: 'job-fraction-update' } }), {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
 
     const response = await updateWasteManagementFractionInternal(
       new Request('https://studio.test/api/v1/waste-management/fractions/fraction-1', {
@@ -722,7 +752,7 @@ describe('waste-management auth runtime handlers', () => {
         },
         body: JSON.stringify({
           name: 'Restmüll Plus',
-          pdfShortLabel: 'RPL',
+          pdfShortLabel: 'rpl',
           translations: { de: 'Restmüll Plus', en: 'Residual waste plus' },
           color: '#111111',
           active: true,
@@ -737,8 +767,10 @@ describe('waste-management auth runtime handlers', () => {
       actor,
       {
         getRequestId: () => 'req-test',
+        resolveActorInfo: vi.fn(async () => resolvedActorInfo),
         saveWasteFraction,
         loadWasteFractionById,
+        startPluginOperationJob,
         resolvePermissions: vi.fn(async () => ({
           ok: true as const,
           permissions: allowPermission('waste-management.master-data.manage'),
@@ -762,6 +794,21 @@ describe('waste-management auth runtime handlers', () => {
       reminderChannelEmailEnabled: false,
       reminderChannelCalendarEnabled: false,
     });
+    expect(startPluginOperationJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: 'tenant-a',
+        actorAccountId: 'account-1',
+        endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
+        data: expect.objectContaining({
+          jobTypeId: 'waste-management.sync-waste-types',
+          input: {
+            operation: 'sync-waste-types',
+            keycloakSubject: 'user-1',
+            activeOrganizationId: undefined,
+          },
+        }),
+      })
+    );
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       data: updatedFraction,

--- a/packages/auth-runtime/src/waste-management/core.test.ts
+++ b/packages/auth-runtime/src/waste-management/core.test.ts
@@ -601,6 +601,15 @@ describe('waste-management auth runtime handlers', () => {
 
     const saveWasteFraction = vi.fn(async () => undefined);
     const loadWasteFractionById = vi.fn(async () => savedFraction);
+    const loadMasterDataFractionsOverview = vi.fn(async (): Promise<WasteManagementMasterDataOverview> => ({
+      fractions: [],
+      regions: [],
+      cities: [],
+      streets: [],
+      houseNumbers: [],
+      collectionLocations: [],
+      locationTourLinks: [],
+    }));
     const startPluginOperationJob = vi.fn(
       async () =>
         new Response(JSON.stringify({ data: { id: 'job-fraction-create' } }), {
@@ -640,6 +649,7 @@ describe('waste-management auth runtime handlers', () => {
         getRequestId: () => 'req-test',
         emitAuditEvent,
         resolveActorInfo: vi.fn(async () => resolvedActorInfo),
+        loadMasterDataFractionsOverview,
         saveWasteFraction,
         loadWasteFractionById,
         startPluginOperationJob,
@@ -685,6 +695,8 @@ describe('waste-management auth runtime handlers', () => {
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual({
       data: savedFraction,
+      syncStatus: 'queued',
+      syncJob: { id: 'job-fraction-create' },
       requestId: 'req-test',
     });
     expect(emitAuditEvent).toHaveBeenCalledWith(
@@ -734,6 +746,15 @@ describe('waste-management auth runtime handlers', () => {
       .mockResolvedValueOnce(existingFraction)
       .mockResolvedValueOnce(updatedFraction);
     const saveWasteFraction = vi.fn(async () => undefined);
+    const loadMasterDataFractionsOverview = vi.fn(async (): Promise<WasteManagementMasterDataOverview> => ({
+      fractions: [],
+      regions: [],
+      cities: [],
+      streets: [],
+      houseNumbers: [],
+      collectionLocations: [],
+      locationTourLinks: [],
+    }));
     const startPluginOperationJob = vi.fn(
       async () =>
         new Response(JSON.stringify({ data: { id: 'job-fraction-update' } }), {
@@ -768,6 +789,7 @@ describe('waste-management auth runtime handlers', () => {
       {
         getRequestId: () => 'req-test',
         resolveActorInfo: vi.fn(async () => resolvedActorInfo),
+        loadMasterDataFractionsOverview,
         saveWasteFraction,
         loadWasteFractionById,
         startPluginOperationJob,
@@ -812,6 +834,8 @@ describe('waste-management auth runtime handlers', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       data: updatedFraction,
+      syncStatus: 'queued',
+      syncJob: { id: 'job-fraction-update' },
       requestId: 'req-test',
     });
   });

--- a/packages/auth-runtime/src/waste-management/core/fractions-support.ts
+++ b/packages/auth-runtime/src/waste-management/core/fractions-support.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ApiItemResponse, StudioJobRecord, WasteFractionRecord } from '@sva/core';
+import { wasteManagementOperationsContract } from '@sva/core';
+
+import type { AuthenticatedRequestContext } from '../../middleware.js';
+import { resolveActorInfo } from '../../iam-account-management/shared.js';
+import { asApiItem, createApiError } from '../../shared/request-helpers.js';
+import { startPluginOperationJobFromFacade } from './operations-support.js';
+import type { WasteManagementHandlerDeps } from './types.js';
+import { getRequestId, requireDeps } from './utils.js';
+
+type WasteFractionSyncStatus = 'queued' | 'failed';
+
+type WasteFractionSyncMetadata = Readonly<{
+  syncStatus?: WasteFractionSyncStatus;
+  syncJob?: StudioJobRecord;
+}>;
+
+type WasteFractionMutationApiResponse<T> = ApiItemResponse<T> & WasteFractionSyncMetadata;
+
+export const normalizeWasteFractionShortLabel = (value: string): string => value.trim().toUpperCase();
+
+export const withWasteFractionSyncMetadata = async <T>(
+  response: Response,
+  syncMetadata: WasteFractionSyncMetadata
+): Promise<Response> => {
+  const payload = (await response.json()) as ApiItemResponse<T>;
+
+  return new Response(
+    JSON.stringify({
+      ...payload,
+      ...(syncMetadata.syncStatus ? { syncStatus: syncMetadata.syncStatus } : {}),
+      ...(syncMetadata.syncJob ? { syncJob: syncMetadata.syncJob } : {}),
+    } satisfies WasteFractionMutationApiResponse<T>),
+    {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+};
+
+export const createWasteFractionMutationResponse = <T>(
+  status: number,
+  data: T,
+  requestId: string | undefined,
+  syncMetadata: WasteFractionSyncMetadata
+): Response =>
+  new Response(
+    JSON.stringify({
+      ...asApiItem(data, requestId),
+      ...(syncMetadata.syncStatus ? { syncStatus: syncMetadata.syncStatus } : {}),
+      ...(syncMetadata.syncJob ? { syncJob: syncMetadata.syncJob } : {}),
+    } satisfies WasteFractionMutationApiResponse<T>),
+    {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+
+const findConflictingActiveFraction = async (
+  deps: WasteManagementHandlerDeps,
+  instanceId: string,
+  shortLabel: string,
+  currentFractionId?: string
+): Promise<WasteFractionRecord | null> => {
+  const overview = await requireDeps(deps.loadMasterDataFractionsOverview, 'loadMasterDataFractionsOverview')(instanceId);
+
+  return (
+    overview.fractions.find((fraction) => {
+      if (!fraction.active || fraction.id === currentFractionId) {
+        return false;
+      }
+
+      return normalizeWasteFractionShortLabel(fraction.pdfShortLabel ?? '') === shortLabel;
+    }) ?? null
+  );
+};
+
+export const validateUniqueActiveWasteFractionShortLabel = async (
+  deps: WasteManagementHandlerDeps,
+  instanceId: string,
+  shortLabel: string,
+  active: boolean,
+  requestId?: string,
+  currentFractionId?: string
+): Promise<Response | null> => {
+  if (!active) {
+    return null;
+  }
+
+  const conflictingFraction = await findConflictingActiveFraction(deps, instanceId, shortLabel, currentFractionId);
+  if (!conflictingFraction) {
+    return null;
+  }
+
+  return createApiError(
+    409,
+    'conflict',
+    `Das PDF-Kürzel "${shortLabel}" wird bereits von der aktiven Waste-Fraktion "${conflictingFraction.name}" verwendet.`,
+    requestId
+  );
+};
+
+export const enqueueWasteTypesSyncAfterFractionMutation = async (
+  request: Request,
+  ctx: AuthenticatedRequestContext,
+  deps: WasteManagementHandlerDeps,
+  instanceId: string
+): Promise<WasteFractionSyncMetadata> => {
+  const actorResolution = await (deps.resolveActorInfo ??
+    ((scopedRequest: Request, scopedCtx: AuthenticatedRequestContext) =>
+      resolveActorInfo(scopedRequest, scopedCtx, { requireActorMembership: true })))(request, ctx);
+  if ('error' in actorResolution || !actorResolution.actor.actorAccountId) {
+    return { syncStatus: 'failed' };
+  }
+
+  const response = await (deps.startPluginOperationJob ?? startPluginOperationJobFromFacade)({
+    instanceId: actorResolution.actor.instanceId,
+    actorAccountId: actorResolution.actor.actorAccountId,
+    endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
+    idempotencyKey: `waste-sync:${instanceId}:${randomUUID()}`,
+    requestId: actorResolution.actor.requestId ?? getRequestId(deps),
+    scheduledAt: new Date().toISOString(),
+    data: {
+      pluginId: wasteManagementOperationsContract.pluginId,
+      jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+      input: {
+        operation: 'sync-waste-types',
+        keycloakSubject: ctx.user.id,
+        activeOrganizationId: ctx.activeOrganizationId,
+      },
+    },
+  });
+
+  if (!response.ok) {
+    return { syncStatus: 'failed' };
+  }
+
+  try {
+    const payload = (await response.json()) as ApiItemResponse<StudioJobRecord>;
+    if (!payload.data?.id) {
+      return { syncStatus: 'failed' };
+    }
+
+    return {
+      syncStatus: 'queued',
+      syncJob: payload.data,
+    };
+  } catch {
+    return { syncStatus: 'failed' };
+  }
+};
+
+export const normalizeWasteFractionReminderConfig = (input: {
+  readonly reminderCount: 'none' | 'once' | 'twice';
+  readonly firstReminderMaxLeadDays?: number;
+  readonly secondReminderMaxLeadDays?: number;
+  readonly reminderChannelPushEnabled: boolean;
+  readonly reminderChannelEmailEnabled: boolean;
+  readonly reminderChannelCalendarEnabled: boolean;
+}) => {
+  if (input.reminderCount === 'none') {
+    return {
+      reminderCount: 'none' as const,
+      firstReminderMaxLeadDays: undefined,
+      secondReminderMaxLeadDays: undefined,
+      reminderChannelPushEnabled: false,
+      reminderChannelEmailEnabled: false,
+      reminderChannelCalendarEnabled: false,
+    };
+  }
+
+  if (input.reminderCount === 'once') {
+    return {
+      reminderCount: 'once' as const,
+      firstReminderMaxLeadDays: input.firstReminderMaxLeadDays,
+      secondReminderMaxLeadDays: undefined,
+      reminderChannelPushEnabled: input.reminderChannelPushEnabled,
+      reminderChannelEmailEnabled: input.reminderChannelEmailEnabled,
+      reminderChannelCalendarEnabled: input.reminderChannelCalendarEnabled,
+    };
+  }
+
+  return {
+    reminderCount: 'twice' as const,
+    firstReminderMaxLeadDays: input.firstReminderMaxLeadDays,
+    secondReminderMaxLeadDays: input.secondReminderMaxLeadDays,
+    reminderChannelPushEnabled: input.reminderChannelPushEnabled,
+    reminderChannelEmailEnabled: input.reminderChannelEmailEnabled,
+    reminderChannelCalendarEnabled: input.reminderChannelCalendarEnabled,
+  };
+};

--- a/packages/auth-runtime/src/waste-management/core/fractions.ts
+++ b/packages/auth-runtime/src/waste-management/core/fractions.ts
@@ -1,200 +1,24 @@
-import { randomUUID } from 'node:crypto';
-
-import type { ApiItemResponse, StudioJobRecord, WasteFractionRecord } from '@sva/core';
-import { wasteManagementOperationsContract } from '@sva/core';
+import type { WasteFractionRecord } from '@sva/core';
 
 import type { AuthenticatedRequestContext } from '../../middleware.js';
-import { resolveActorInfo } from '../../iam-account-management/shared.js';
 import { validateCsrf } from '../../shared/request-security.js';
-import { asApiItem, createApiError, parseRequestBody, readPathSegment } from '../../shared/request-helpers.js';
+import { createApiError, parseRequestBody, readPathSegment } from '../../shared/request-helpers.js';
 import { authorizeWasteManagementAction, emitWasteAuditEvent } from './auth.js';
+import {
+  createWasteFractionMutationResponse,
+  enqueueWasteTypesSyncAfterFractionMutation,
+  normalizeWasteFractionReminderConfig,
+  normalizeWasteFractionShortLabel,
+  validateUniqueActiveWasteFractionShortLabel,
+  withWasteFractionSyncMetadata,
+} from './fractions-support.js';
 import { runWasteCreateMutation, runWasteUpdateMutation } from './mutation-helpers.js';
-import { startPluginOperationJobFromFacade } from './operations-support.js';
 import { wasteManagementMasterDataSchemas } from './schemas.js';
 import { updateWasteVisibleStatus } from './settings-shared.js';
 import type { WasteManagementHandlerDeps } from './types.js';
 import { getRequestId, normalizeOptionalString, requireActorInstanceId, requireDeps } from './utils.js';
 
 const { createWasteFractionSchema, updateWasteFractionSchema } = wasteManagementMasterDataSchemas;
-const normalizeWasteFractionShortLabel = (value: string): string => value.trim().toUpperCase();
-type WasteFractionSyncStatus = 'queued' | 'failed';
-type WasteFractionSyncMetadata = Readonly<{
-  syncStatus?: WasteFractionSyncStatus;
-  syncJob?: StudioJobRecord;
-}>;
-
-type WasteFractionMutationApiResponse<T> = ApiItemResponse<T> & WasteFractionSyncMetadata;
-
-const withWasteFractionSyncMetadata = async <T>(
-  response: Response,
-  syncMetadata: WasteFractionSyncMetadata
-): Promise<Response> => {
-  const payload = (await response.json()) as ApiItemResponse<T>;
-
-  return new Response(
-    JSON.stringify({
-      ...payload,
-      ...(syncMetadata.syncStatus ? { syncStatus: syncMetadata.syncStatus } : {}),
-      ...(syncMetadata.syncJob ? { syncJob: syncMetadata.syncJob } : {}),
-    } satisfies WasteFractionMutationApiResponse<T>),
-    {
-      status: response.status,
-      headers: { 'Content-Type': 'application/json' },
-    }
-  );
-};
-
-const createWasteFractionMutationResponse = <T>(
-  status: number,
-  data: T,
-  requestId: string | undefined,
-  syncMetadata: WasteFractionSyncMetadata
-): Response =>
-  new Response(
-    JSON.stringify({
-      ...asApiItem(data, requestId),
-      ...(syncMetadata.syncStatus ? { syncStatus: syncMetadata.syncStatus } : {}),
-      ...(syncMetadata.syncJob ? { syncJob: syncMetadata.syncJob } : {}),
-    } satisfies WasteFractionMutationApiResponse<T>),
-    {
-      status,
-      headers: { 'Content-Type': 'application/json' },
-    }
-  );
-
-const findConflictingActiveFraction = async (
-  deps: WasteManagementHandlerDeps,
-  instanceId: string,
-  shortLabel: string,
-  currentFractionId?: string
-): Promise<WasteFractionRecord | null> => {
-  const overview = await requireDeps(deps.loadMasterDataFractionsOverview, 'loadMasterDataFractionsOverview')(instanceId);
-
-  return (
-    overview.fractions.find((fraction) => {
-      if (!fraction.active || fraction.id === currentFractionId) {
-        return false;
-      }
-
-      return normalizeWasteFractionShortLabel(fraction.pdfShortLabel ?? '') === shortLabel;
-    }) ?? null
-  );
-};
-
-const validateUniqueActiveWasteFractionShortLabel = async (
-  deps: WasteManagementHandlerDeps,
-  instanceId: string,
-  shortLabel: string,
-  active: boolean,
-  requestId?: string,
-  currentFractionId?: string
-): Promise<Response | null> => {
-  if (!active) {
-    return null;
-  }
-
-  const conflictingFraction = await findConflictingActiveFraction(deps, instanceId, shortLabel, currentFractionId);
-  if (!conflictingFraction) {
-    return null;
-  }
-
-  return createApiError(
-    409,
-    'conflict',
-    `Das PDF-Kürzel "${shortLabel}" wird bereits von der aktiven Waste-Fraktion "${conflictingFraction.name}" verwendet.`,
-    requestId
-  );
-};
-
-const enqueueWasteTypesSyncAfterFractionMutation = async (
-  request: Request,
-  ctx: AuthenticatedRequestContext,
-  deps: WasteManagementHandlerDeps,
-  instanceId: string
-): Promise<WasteFractionSyncMetadata> => {
-  const actorResolution = await (deps.resolveActorInfo ??
-    ((scopedRequest: Request, scopedCtx: AuthenticatedRequestContext) =>
-      resolveActorInfo(scopedRequest, scopedCtx, { requireActorMembership: true })))(request, ctx);
-  if ('error' in actorResolution || !actorResolution.actor.actorAccountId) {
-    return { syncStatus: 'failed' };
-  }
-
-  const response = await (deps.startPluginOperationJob ?? startPluginOperationJobFromFacade)({
-    instanceId: actorResolution.actor.instanceId,
-    actorAccountId: actorResolution.actor.actorAccountId,
-    endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
-    idempotencyKey: `waste-sync:${instanceId}:${randomUUID()}`,
-    requestId: actorResolution.actor.requestId ?? getRequestId(deps),
-    scheduledAt: new Date().toISOString(),
-    data: {
-      pluginId: wasteManagementOperationsContract.pluginId,
-      jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
-      input: {
-        operation: 'sync-waste-types',
-        keycloakSubject: ctx.user.id,
-        activeOrganizationId: ctx.activeOrganizationId,
-      },
-    },
-  });
-
-  if (!response.ok) {
-    return { syncStatus: 'failed' };
-  }
-
-  try {
-    const payload = (await response.json()) as ApiItemResponse<StudioJobRecord>;
-    if (!payload.data?.id) {
-      return { syncStatus: 'failed' };
-    }
-
-    return {
-      syncStatus: 'queued',
-      syncJob: payload.data,
-    };
-  } catch {
-    return { syncStatus: 'failed' };
-  }
-};
-
-const normalizeWasteFractionReminderConfig = (input: {
-  readonly reminderCount: 'none' | 'once' | 'twice';
-  readonly firstReminderMaxLeadDays?: number;
-  readonly secondReminderMaxLeadDays?: number;
-  readonly reminderChannelPushEnabled: boolean;
-  readonly reminderChannelEmailEnabled: boolean;
-  readonly reminderChannelCalendarEnabled: boolean;
-}) => {
-  if (input.reminderCount === 'none') {
-    return {
-      reminderCount: 'none' as const,
-      firstReminderMaxLeadDays: undefined,
-      secondReminderMaxLeadDays: undefined,
-      reminderChannelPushEnabled: false,
-      reminderChannelEmailEnabled: false,
-      reminderChannelCalendarEnabled: false,
-    };
-  }
-
-  if (input.reminderCount === 'once') {
-    return {
-      reminderCount: 'once' as const,
-      firstReminderMaxLeadDays: input.firstReminderMaxLeadDays,
-      secondReminderMaxLeadDays: undefined,
-      reminderChannelPushEnabled: input.reminderChannelPushEnabled,
-      reminderChannelEmailEnabled: input.reminderChannelEmailEnabled,
-      reminderChannelCalendarEnabled: input.reminderChannelCalendarEnabled,
-    };
-  }
-
-  return {
-    reminderCount: 'twice' as const,
-    firstReminderMaxLeadDays: input.firstReminderMaxLeadDays,
-    secondReminderMaxLeadDays: input.secondReminderMaxLeadDays,
-    reminderChannelPushEnabled: input.reminderChannelPushEnabled,
-    reminderChannelEmailEnabled: input.reminderChannelEmailEnabled,
-    reminderChannelCalendarEnabled: input.reminderChannelCalendarEnabled,
-  };
-};
 
 export const wasteManagementFractionHandlers = {
   createWasteManagementFractionInternal: async (

--- a/packages/auth-runtime/src/waste-management/core/fractions.ts
+++ b/packages/auth-runtime/src/waste-management/core/fractions.ts
@@ -1,14 +1,53 @@
+import { randomUUID } from 'node:crypto';
+
+import { wasteManagementOperationsContract } from '@sva/core';
+
 import type { AuthenticatedRequestContext } from '../../middleware.js';
+import { resolveActorInfo } from '../../iam-account-management/shared.js';
 import { validateCsrf } from '../../shared/request-security.js';
 import { asApiItem, createApiError, parseRequestBody, readPathSegment } from '../../shared/request-helpers.js';
 import { authorizeWasteManagementAction, emitWasteAuditEvent } from './auth.js';
 import { runWasteCreateMutation, runWasteUpdateMutation } from './mutation-helpers.js';
+import { startPluginOperationJobFromFacade } from './operations-support.js';
 import { wasteManagementMasterDataSchemas } from './schemas.js';
 import { updateWasteVisibleStatus } from './settings-shared.js';
 import type { WasteManagementHandlerDeps } from './types.js';
 import { getRequestId, normalizeOptionalString, requireActorInstanceId, requireDeps } from './utils.js';
 
 const { createWasteFractionSchema, updateWasteFractionSchema } = wasteManagementMasterDataSchemas;
+const normalizeWasteFractionShortLabel = (value: string): string => value.trim().toUpperCase();
+
+const enqueueWasteTypesSyncAfterFractionMutation = async (
+  request: Request,
+  ctx: AuthenticatedRequestContext,
+  deps: WasteManagementHandlerDeps,
+  instanceId: string
+): Promise<void> => {
+  const actorResolution = await (deps.resolveActorInfo ??
+    ((scopedRequest: Request, scopedCtx: AuthenticatedRequestContext) =>
+      resolveActorInfo(scopedRequest, scopedCtx, { requireActorMembership: true })))(request, ctx);
+  if ('error' in actorResolution || !actorResolution.actor.actorAccountId) {
+    return;
+  }
+
+  await (deps.startPluginOperationJob ?? startPluginOperationJobFromFacade)({
+    instanceId: actorResolution.actor.instanceId,
+    actorAccountId: actorResolution.actor.actorAccountId,
+    endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
+    idempotencyKey: `waste-sync:${instanceId}:${randomUUID()}`,
+    requestId: actorResolution.actor.requestId ?? getRequestId(deps),
+    scheduledAt: new Date().toISOString(),
+    data: {
+      pluginId: wasteManagementOperationsContract.pluginId,
+      jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+      input: {
+        operation: 'sync-waste-types',
+        keycloakSubject: ctx.user.id,
+        activeOrganizationId: ctx.activeOrganizationId,
+      },
+    },
+  });
+};
 
 const normalizeWasteFractionReminderConfig = (input: {
   readonly reminderCount: 'none' | 'once' | 'twice';
@@ -78,7 +117,7 @@ export const wasteManagementFractionHandlers = {
     }
     const reminderConfig = normalizeWasteFractionReminderConfig(parsed.data);
 
-    return runWasteCreateMutation({
+    const response = await runWasteCreateMutation({
       deps,
       ctx,
       instanceId,
@@ -96,7 +135,7 @@ export const wasteManagementFractionHandlers = {
         requireDeps(deps.saveWasteFraction, 'saveWasteFraction')(instanceId, {
           id: parsed.data.id,
           name: parsed.data.name.trim(),
-          pdfShortLabel: parsed.data.pdfShortLabel.trim(),
+          pdfShortLabel: normalizeWasteFractionShortLabel(parsed.data.pdfShortLabel),
           translations: parsed.data.translations,
           containerSize: normalizeOptionalString(parsed.data.containerSize),
           color: parsed.data.color,
@@ -111,6 +150,12 @@ export const wasteManagementFractionHandlers = {
         }),
       loadSaved: () => requireDeps(deps.loadWasteFractionById, 'loadWasteFractionById')(instanceId, parsed.data.id),
     });
+
+    if (response.status < 400) {
+      await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
+    }
+
+    return response;
   },
   updateWasteManagementFractionInternal: async (
     request: Request,
@@ -146,7 +191,7 @@ export const wasteManagementFractionHandlers = {
 
     const loadWasteFraction = requireDeps(deps.loadWasteFractionById, 'loadWasteFractionById');
 
-    return runWasteUpdateMutation({
+    const response = await runWasteUpdateMutation({
       deps,
       ctx,
       instanceId,
@@ -166,7 +211,7 @@ export const wasteManagementFractionHandlers = {
         requireDeps(deps.saveWasteFraction, 'saveWasteFraction')(instanceId, {
           id: fractionId,
           name: parsed.data.name.trim(),
-          pdfShortLabel: parsed.data.pdfShortLabel.trim(),
+          pdfShortLabel: normalizeWasteFractionShortLabel(parsed.data.pdfShortLabel),
           translations: parsed.data.translations,
           containerSize: normalizeOptionalString(parsed.data.containerSize),
           color: parsed.data.color,
@@ -181,6 +226,12 @@ export const wasteManagementFractionHandlers = {
         }),
       loadSaved: () => loadWasteFraction(instanceId, fractionId),
     });
+
+    if (response.status < 400) {
+      await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
+    }
+
+    return response;
   },
   deleteWasteManagementFractionInternal: async (
     request: Request,
@@ -227,6 +278,7 @@ export const wasteManagementFractionHandlers = {
       });
 
       await updateWasteVisibleStatus(deps, instanceId, 'success');
+      await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
       return new Response(JSON.stringify(asApiItem({ id: fractionId }, requestId)), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },

--- a/packages/auth-runtime/src/waste-management/core/fractions.ts
+++ b/packages/auth-runtime/src/waste-management/core/fractions.ts
@@ -96,6 +96,7 @@ export const wasteManagementFractionHandlers = {
         requireDeps(deps.saveWasteFraction, 'saveWasteFraction')(instanceId, {
           id: parsed.data.id,
           name: parsed.data.name.trim(),
+          pdfShortLabel: parsed.data.pdfShortLabel.trim(),
           translations: parsed.data.translations,
           containerSize: normalizeOptionalString(parsed.data.containerSize),
           color: parsed.data.color,
@@ -165,6 +166,7 @@ export const wasteManagementFractionHandlers = {
         requireDeps(deps.saveWasteFraction, 'saveWasteFraction')(instanceId, {
           id: fractionId,
           name: parsed.data.name.trim(),
+          pdfShortLabel: parsed.data.pdfShortLabel.trim(),
           translations: parsed.data.translations,
           containerSize: normalizeOptionalString(parsed.data.containerSize),
           color: parsed.data.color,

--- a/packages/auth-runtime/src/waste-management/core/fractions.ts
+++ b/packages/auth-runtime/src/waste-management/core/fractions.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
+import type { ApiItemResponse, StudioJobRecord, WasteFractionRecord } from '@sva/core';
 import { wasteManagementOperationsContract } from '@sva/core';
 
 import type { AuthenticatedRequestContext } from '../../middleware.js';
@@ -16,21 +17,109 @@ import { getRequestId, normalizeOptionalString, requireActorInstanceId, requireD
 
 const { createWasteFractionSchema, updateWasteFractionSchema } = wasteManagementMasterDataSchemas;
 const normalizeWasteFractionShortLabel = (value: string): string => value.trim().toUpperCase();
+type WasteFractionSyncStatus = 'queued' | 'failed';
+type WasteFractionSyncMetadata = Readonly<{
+  syncStatus?: WasteFractionSyncStatus;
+  syncJob?: StudioJobRecord;
+}>;
+
+type WasteFractionMutationApiResponse<T> = ApiItemResponse<T> & WasteFractionSyncMetadata;
+
+const withWasteFractionSyncMetadata = async <T>(
+  response: Response,
+  syncMetadata: WasteFractionSyncMetadata
+): Promise<Response> => {
+  const payload = (await response.json()) as ApiItemResponse<T>;
+
+  return new Response(
+    JSON.stringify({
+      ...payload,
+      ...(syncMetadata.syncStatus ? { syncStatus: syncMetadata.syncStatus } : {}),
+      ...(syncMetadata.syncJob ? { syncJob: syncMetadata.syncJob } : {}),
+    } satisfies WasteFractionMutationApiResponse<T>),
+    {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+};
+
+const createWasteFractionMutationResponse = <T>(
+  status: number,
+  data: T,
+  requestId: string | undefined,
+  syncMetadata: WasteFractionSyncMetadata
+): Response =>
+  new Response(
+    JSON.stringify({
+      ...asApiItem(data, requestId),
+      ...(syncMetadata.syncStatus ? { syncStatus: syncMetadata.syncStatus } : {}),
+      ...(syncMetadata.syncJob ? { syncJob: syncMetadata.syncJob } : {}),
+    } satisfies WasteFractionMutationApiResponse<T>),
+    {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+
+const findConflictingActiveFraction = async (
+  deps: WasteManagementHandlerDeps,
+  instanceId: string,
+  shortLabel: string,
+  currentFractionId?: string
+): Promise<WasteFractionRecord | null> => {
+  const overview = await requireDeps(deps.loadMasterDataFractionsOverview, 'loadMasterDataFractionsOverview')(instanceId);
+
+  return (
+    overview.fractions.find((fraction) => {
+      if (!fraction.active || fraction.id === currentFractionId) {
+        return false;
+      }
+
+      return normalizeWasteFractionShortLabel(fraction.pdfShortLabel ?? '') === shortLabel;
+    }) ?? null
+  );
+};
+
+const validateUniqueActiveWasteFractionShortLabel = async (
+  deps: WasteManagementHandlerDeps,
+  instanceId: string,
+  shortLabel: string,
+  active: boolean,
+  requestId?: string,
+  currentFractionId?: string
+): Promise<Response | null> => {
+  if (!active) {
+    return null;
+  }
+
+  const conflictingFraction = await findConflictingActiveFraction(deps, instanceId, shortLabel, currentFractionId);
+  if (!conflictingFraction) {
+    return null;
+  }
+
+  return createApiError(
+    409,
+    'conflict',
+    `Das PDF-Kürzel "${shortLabel}" wird bereits von der aktiven Waste-Fraktion "${conflictingFraction.name}" verwendet.`,
+    requestId
+  );
+};
 
 const enqueueWasteTypesSyncAfterFractionMutation = async (
   request: Request,
   ctx: AuthenticatedRequestContext,
   deps: WasteManagementHandlerDeps,
   instanceId: string
-): Promise<void> => {
+): Promise<WasteFractionSyncMetadata> => {
   const actorResolution = await (deps.resolveActorInfo ??
     ((scopedRequest: Request, scopedCtx: AuthenticatedRequestContext) =>
       resolveActorInfo(scopedRequest, scopedCtx, { requireActorMembership: true })))(request, ctx);
   if ('error' in actorResolution || !actorResolution.actor.actorAccountId) {
-    return;
+    return { syncStatus: 'failed' };
   }
 
-  await (deps.startPluginOperationJob ?? startPluginOperationJobFromFacade)({
+  const response = await (deps.startPluginOperationJob ?? startPluginOperationJobFromFacade)({
     instanceId: actorResolution.actor.instanceId,
     actorAccountId: actorResolution.actor.actorAccountId,
     endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
@@ -47,6 +136,24 @@ const enqueueWasteTypesSyncAfterFractionMutation = async (
       },
     },
   });
+
+  if (!response.ok) {
+    return { syncStatus: 'failed' };
+  }
+
+  try {
+    const payload = (await response.json()) as ApiItemResponse<StudioJobRecord>;
+    if (!payload.data?.id) {
+      return { syncStatus: 'failed' };
+    }
+
+    return {
+      syncStatus: 'queued',
+      syncJob: payload.data,
+    };
+  } catch {
+    return { syncStatus: 'failed' };
+  }
 };
 
 const normalizeWasteFractionReminderConfig = (input: {
@@ -115,6 +222,17 @@ export const wasteManagementFractionHandlers = {
     if (!parsed.ok) {
       return createApiError(400, 'invalid_request', parsed.message, requestId);
     }
+    const normalizedShortLabel = normalizeWasteFractionShortLabel(parsed.data.pdfShortLabel);
+    const duplicateShortLabelError = await validateUniqueActiveWasteFractionShortLabel(
+      deps,
+      instanceId,
+      normalizedShortLabel,
+      parsed.data.active,
+      requestId
+    );
+    if (duplicateShortLabelError) {
+      return duplicateShortLabelError;
+    }
     const reminderConfig = normalizeWasteFractionReminderConfig(parsed.data);
 
     const response = await runWasteCreateMutation({
@@ -135,7 +253,7 @@ export const wasteManagementFractionHandlers = {
         requireDeps(deps.saveWasteFraction, 'saveWasteFraction')(instanceId, {
           id: parsed.data.id,
           name: parsed.data.name.trim(),
-          pdfShortLabel: normalizeWasteFractionShortLabel(parsed.data.pdfShortLabel),
+          pdfShortLabel: normalizedShortLabel,
           translations: parsed.data.translations,
           containerSize: normalizeOptionalString(parsed.data.containerSize),
           color: parsed.data.color,
@@ -151,11 +269,12 @@ export const wasteManagementFractionHandlers = {
       loadSaved: () => requireDeps(deps.loadWasteFractionById, 'loadWasteFractionById')(instanceId, parsed.data.id),
     });
 
-    if (response.status < 400) {
-      await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
+    if (response.status >= 400) {
+      return response;
     }
 
-    return response;
+    const syncMetadata = await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
+    return await withWasteFractionSyncMetadata<WasteFractionRecord>(response, syncMetadata);
   },
   updateWasteManagementFractionInternal: async (
     request: Request,
@@ -187,9 +306,25 @@ export const wasteManagementFractionHandlers = {
     if (!parsed.ok) {
       return createApiError(400, 'invalid_request', parsed.message, requestId);
     }
+    const normalizedShortLabel = normalizeWasteFractionShortLabel(parsed.data.pdfShortLabel);
     const reminderConfig = normalizeWasteFractionReminderConfig(parsed.data);
 
     const loadWasteFraction = requireDeps(deps.loadWasteFractionById, 'loadWasteFractionById');
+    const existing = await loadWasteFraction(instanceId, fractionId);
+    if (!existing) {
+      return createApiError(404, 'not_found', 'Die Waste-Fraktion wurde nicht gefunden.', requestId);
+    }
+    const duplicateShortLabelError = await validateUniqueActiveWasteFractionShortLabel(
+      deps,
+      instanceId,
+      normalizedShortLabel,
+      parsed.data.active,
+      requestId,
+      fractionId
+    );
+    if (duplicateShortLabelError) {
+      return duplicateShortLabelError;
+    }
 
     const response = await runWasteUpdateMutation({
       deps,
@@ -206,12 +341,12 @@ export const wasteManagementFractionHandlers = {
         verificationFailed: 'Die Waste-Fraktion konnte nicht verifiziert werden.',
         persistenceFailed: 'Die Waste-Fraktion konnte nicht gespeichert werden.',
       },
-      loadExisting: () => loadWasteFraction(instanceId, fractionId),
+      loadExisting: async () => existing,
       save: () =>
         requireDeps(deps.saveWasteFraction, 'saveWasteFraction')(instanceId, {
           id: fractionId,
           name: parsed.data.name.trim(),
-          pdfShortLabel: normalizeWasteFractionShortLabel(parsed.data.pdfShortLabel),
+          pdfShortLabel: normalizedShortLabel,
           translations: parsed.data.translations,
           containerSize: normalizeOptionalString(parsed.data.containerSize),
           color: parsed.data.color,
@@ -227,11 +362,12 @@ export const wasteManagementFractionHandlers = {
       loadSaved: () => loadWasteFraction(instanceId, fractionId),
     });
 
-    if (response.status < 400) {
-      await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
+    if (response.status >= 400) {
+      return response;
     }
 
-    return response;
+    const syncMetadata = await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
+    return await withWasteFractionSyncMetadata<WasteFractionRecord>(response, syncMetadata);
   },
   deleteWasteManagementFractionInternal: async (
     request: Request,
@@ -278,11 +414,8 @@ export const wasteManagementFractionHandlers = {
       });
 
       await updateWasteVisibleStatus(deps, instanceId, 'success');
-      await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
-      return new Response(JSON.stringify(asApiItem({ id: fractionId }, requestId)), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      const syncMetadata = await enqueueWasteTypesSyncAfterFractionMutation(request, ctx, deps, instanceId);
+      return createWasteFractionMutationResponse(200, { id: fractionId }, requestId, syncMetadata);
     } catch (error) {
       if (error instanceof Error && error.message.startsWith('missing_dependency:')) {
         throw error;

--- a/packages/auth-runtime/src/waste-management/core/master-data-branches.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/master-data-branches.test.ts
@@ -72,6 +72,7 @@ describe('waste-management master-data branch handlers', () => {
           body: JSON.stringify({
             id: 'fraction-invalid-reminder',
             name: 'Papier',
+            pdfShortLabel: 'PAP',
             color: '#123456',
             active: true,
             reminderCount: 'many',
@@ -404,6 +405,7 @@ describe('waste-management master-data branch handlers', () => {
           headers: createHeaders(),
           body: JSON.stringify({
             name: 'Rest',
+            pdfShortLabel: 'RES',
             translations: { de: 'Restmüll' },
             color: '#111111',
             active: true,
@@ -630,6 +632,7 @@ describe('waste-management master-data branch handlers', () => {
           body: JSON.stringify({
             id: 'fraction-new',
             name: 'Rest',
+            pdfShortLabel: 'RES',
             translations: { de: 'Restmüll' },
             color: '#111111',
             active: true,
@@ -773,6 +776,7 @@ describe('waste-management master-data branch handlers', () => {
           body: JSON.stringify({
             id: 'fraction-verify',
             name: 'Papier',
+            pdfShortLabel: 'PAP',
             translations: { de: 'Papier' },
             color: '#123456',
             active: true,
@@ -988,6 +992,7 @@ describe('waste-management master-data branch handlers', () => {
           headers: createHeaders(),
           body: JSON.stringify({
             name: 'Papier',
+            pdfShortLabel: 'PAP',
             translations: { de: 'Papier' },
             color: '#123456',
             active: true,
@@ -1299,6 +1304,7 @@ describe('waste-management master-data branch handlers', () => {
           headers: createHeaders(),
           body: JSON.stringify({
             name: 'Papier',
+            pdfShortLabel: 'PAP',
             translations: { de: 'Papier' },
             color: '#123456',
             active: true,
@@ -1614,6 +1620,7 @@ describe('waste-management master-data branch handlers', () => {
         body: JSON.stringify({
           id: 'fraction-1',
           name: 'Restmüll',
+          pdfShortLabel: 'RES',
           color: '#111111',
           active: true,
           reminderCount: 'none',

--- a/packages/auth-runtime/src/waste-management/core/master-data-branches.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/master-data-branches.test.ts
@@ -62,6 +62,15 @@ const createDeps = (action = 'waste-management.master-data.manage') => ({
       },
     ],
   })),
+  loadMasterDataFractionsOverview: vi.fn(async () => ({
+    fractions: [],
+    regions: [],
+    cities: [],
+    streets: [],
+    houseNumbers: [],
+    collectionLocations: [],
+    locationTourLinks: [],
+  })),
 });
 
 describe('waste-management master-data branch handlers', () => {
@@ -257,6 +266,108 @@ describe('waste-management master-data branch handlers', () => {
       },
       requestId: 'req-test',
     });
+  });
+
+  it('rejects duplicate active PDF short labels before saving waste fractions', async () => {
+    const duplicateOverview = {
+      fractions: [
+        {
+          id: 'fraction-existing',
+          name: 'Biotonne',
+          pdfShortLabel: 'BIO',
+          color: '#228833',
+          active: true,
+          createdAt: '2026-05-09T10:00:00.000Z',
+          updatedAt: '2026-05-09T10:00:00.000Z',
+        },
+      ],
+      regions: [],
+      cities: [],
+      streets: [],
+      houseNumbers: [],
+      collectionLocations: [],
+      locationTourLinks: [],
+    };
+
+    const saveWasteFraction = vi.fn(async () => undefined);
+
+    const createResponse = await wasteManagementFractionHandlers.createWasteManagementFractionInternal(
+      new Request('https://studio.test/api/v1/waste-management/fractions', {
+        method: 'POST',
+        headers: createHeaders(),
+        body: JSON.stringify({
+          id: 'fraction-new',
+          name: 'Biomüll extra',
+          pdfShortLabel: 'bio',
+          color: '#22aa55',
+          active: true,
+          reminderCount: 'none',
+          reminderChannelPushEnabled: false,
+          reminderChannelEmailEnabled: false,
+          reminderChannelCalendarEnabled: false,
+        }),
+      }),
+      actor,
+      {
+        ...createDeps(),
+        saveWasteFraction,
+        loadWasteFractionById: vi.fn(async () => null),
+        loadMasterDataFractionsOverview: vi.fn(async () => duplicateOverview),
+      }
+    );
+
+    expect(createResponse.status).toBe(409);
+    await expect(createResponse.json()).resolves.toMatchObject({
+      error: {
+        code: 'conflict',
+        message: expect.stringContaining('BIO'),
+      },
+      requestId: 'req-test',
+    });
+    expect(saveWasteFraction).not.toHaveBeenCalled();
+
+    const updateSaveWasteFraction = vi.fn(async () => undefined);
+    const updateResponse = await wasteManagementFractionHandlers.updateWasteManagementFractionInternal(
+      new Request('https://studio.test/api/v1/waste-management/fractions/fraction-update', {
+        method: 'PUT',
+        headers: createHeaders(),
+        body: JSON.stringify({
+          name: 'Biomüll extra',
+          pdfShortLabel: 'bio',
+          color: '#22aa55',
+          active: true,
+          reminderCount: 'none',
+          reminderChannelPushEnabled: false,
+          reminderChannelEmailEnabled: false,
+          reminderChannelCalendarEnabled: false,
+        }),
+      }),
+      actor,
+      {
+        ...createDeps(),
+        saveWasteFraction: updateSaveWasteFraction,
+        loadWasteFractionById: vi.fn(async () => ({
+          id: 'fraction-update',
+          name: 'Papier',
+          pdfShortLabel: 'PAP',
+          color: '#123456',
+          active: true,
+          createdAt: '2026-05-09T10:00:00.000Z',
+          updatedAt: '2026-05-09T10:00:00.000Z',
+        })),
+        loadMasterDataFractionsOverview: vi.fn(async () => duplicateOverview),
+      }
+    );
+
+    expect(updateResponse.status).toBe(409);
+    await expect(updateResponse.json()).resolves.toMatchObject({
+      error: {
+        code: 'conflict',
+        message: expect.stringContaining('BIO'),
+      },
+      requestId: 'req-test',
+    });
+    expect(updateSaveWasteFraction).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/auth-runtime/src/waste-management/core/master-data-branches.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/master-data-branches.test.ts
@@ -37,6 +37,21 @@ const createDeps = (action = 'waste-management.master-data.manage') => ({
     activeOrganizationId: 'org-1',
   })),
   emitAuditEvent: vi.fn(async () => undefined),
+  resolveActorInfo: vi.fn(async () => ({
+    actor: {
+      instanceId: 'tenant-a',
+      actorAccountId: 'account-1',
+      requestId: 'req-test',
+      traceId: 'trace-test',
+    },
+  })),
+  startPluginOperationJob: vi.fn(
+    async () =>
+      new Response(JSON.stringify({ data: { id: 'job-1' } }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      })
+  ),
   resolvePermissions: vi.fn(async () => ({
     ok: true as const,
     permissions: [
@@ -1649,6 +1664,7 @@ describe('waste-management master-data branch handlers', () => {
       deps
     );
     expect(deleteSucceeded.status).toBe(200);
+    expect(deps.startPluginOperationJob).toHaveBeenCalledTimes(1);
 
     const deleteConflict = await wasteManagementFractionHandlers.deleteWasteManagementFractionInternal(
       new Request('https://studio.test/api/v1/waste-management/fractions/fraction-1', {
@@ -1679,6 +1695,7 @@ describe('waste-management master-data branch handlers', () => {
         code: 'database_unavailable',
       },
     });
+    expect(deps.startPluginOperationJob).toHaveBeenCalledTimes(1);
   });
 
   it('covers tour delete success, not-found, conflict, and fallback errors', async () => {

--- a/packages/auth-runtime/src/waste-management/core/operations.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/operations.test.ts
@@ -19,6 +19,7 @@ const mockedGetWasteManagementImportCatalogEntry = vi.mocked(getWasteManagementI
 
 const actor: AuthenticatedRequestContext = {
   sessionId: 'session-1',
+  activeOrganizationId: 'org-1',
   user: {
     id: 'user-1',
     instanceId: 'tenant-a',
@@ -333,6 +334,8 @@ describe('waste-management operation handlers', () => {
           jobTypeId: 'waste-management.sync-waste-types',
           input: {
             operation: 'sync-waste-types',
+            keycloakSubject: 'user-1',
+            activeOrganizationId: 'org-1',
           },
         }),
       })

--- a/packages/auth-runtime/src/waste-management/core/operations.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/operations.test.ts
@@ -304,6 +304,42 @@ describe('waste-management operation handlers', () => {
     expect(response.status).toBe(202);
   });
 
+  it('creates a dedicated waste-type sync job payload', async () => {
+    const startPluginOperationJob = vi.fn(async () => new Response(JSON.stringify({ data: { id: 'job-2' } }), { status: 202 }));
+
+    const response = await wasteManagementOperationHandlers.startWasteManagementSyncWasteTypesInternal(
+      createToolRequest('https://studio.test/api/v1/waste-management/tools/sync-waste-types', {}),
+      actor,
+      {
+        ...createDeps(),
+        resolvePermissions: vi.fn(async () => ({
+          ok: true as const,
+          permissions: [
+            {
+              action: 'waste-management.settings.manage',
+              resourceType: 'waste-management',
+              effect: 'allow' as const,
+            },
+          ],
+        })),
+        startPluginOperationJob,
+      }
+    );
+
+    expect(startPluginOperationJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
+        data: expect.objectContaining({
+          jobTypeId: 'waste-management.sync-waste-types',
+          input: {
+            operation: 'sync-waste-types',
+          },
+        }),
+      })
+    );
+    expect(response.status).toBe(202);
+  });
+
   it('rejects tool starts when the actor membership cannot be resolved to an IAM account', async () => {
     const startPluginOperationJob = vi.fn();
 

--- a/packages/auth-runtime/src/waste-management/core/operations.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/operations.test.ts
@@ -150,6 +150,21 @@ describe('waste-management operation handlers', () => {
       expectedCode: 'forbidden',
     },
     {
+      label: 'sync-waste-types returns forbidden when the master-data permission is missing',
+      handler: wasteManagementOperationHandlers.startWasteManagementSyncWasteTypesInternal,
+      request: () => createToolRequest('https://studio.test/api/v1/waste-management/tools/sync-waste-types', {}),
+      deps: () => ({
+        ...createDeps(),
+        resolvePermissions: vi.fn(async () => ({
+          ok: true as const,
+          permissions: [],
+        })),
+      }),
+      actor,
+      expectedStatus: 403,
+      expectedCode: 'forbidden',
+    },
+    {
       label: 'reset rejects a missing actor instance id',
       handler: wasteManagementOperationHandlers.startWasteManagementResetInternal,
       request: () =>
@@ -317,7 +332,7 @@ describe('waste-management operation handlers', () => {
           ok: true as const,
           permissions: [
             {
-              action: 'waste-management.settings.manage',
+              action: 'waste-management.master-data.manage',
               resourceType: 'waste-management',
               effect: 'allow' as const,
             },

--- a/packages/auth-runtime/src/waste-management/core/operations.ts
+++ b/packages/auth-runtime/src/waste-management/core/operations.ts
@@ -352,6 +352,8 @@ export const wasteManagementOperationHandlers = {
       auditActionId: 'waste-management.sync-waste-types.started',
       toPayload: () => ({
         operation: 'sync-waste-types',
+        keycloakSubject: ctx.user.id,
+        activeOrganizationId: ctx.activeOrganizationId,
       }),
     }),
   startWasteManagementResetInternal: async (

--- a/packages/auth-runtime/src/waste-management/core/operations.ts
+++ b/packages/auth-runtime/src/waste-management/core/operations.ts
@@ -19,6 +19,7 @@ const {
   startMigrationsSchema,
   startResetSchema,
   startSeedSchema,
+  startSyncWasteTypesSchema,
 } =
   wasteManagementOperationSchemas;
 
@@ -336,6 +337,21 @@ export const wasteManagementOperationHandlers = {
       toPayload: () => ({
         operation: 'seed-data',
         seedKey: 'baseline',
+      }),
+    }),
+  startWasteManagementSyncWasteTypesInternal: async (
+    request: Request,
+    ctx: AuthenticatedRequestContext,
+    deps: WasteManagementHandlerDeps = {}
+  ): Promise<Response> =>
+    startToolJob(request, ctx, deps, {
+      requiredPermission: 'waste-management.settings.manage',
+      endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
+      schema: startSyncWasteTypesSchema,
+      jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+      auditActionId: 'waste-management.sync-waste-types.started',
+      toPayload: () => ({
+        operation: 'sync-waste-types',
       }),
     }),
   startWasteManagementResetInternal: async (

--- a/packages/auth-runtime/src/waste-management/core/operations.ts
+++ b/packages/auth-runtime/src/waste-management/core/operations.ts
@@ -345,7 +345,7 @@ export const wasteManagementOperationHandlers = {
     deps: WasteManagementHandlerDeps = {}
   ): Promise<Response> =>
     startToolJob(request, ctx, deps, {
-      requiredPermission: 'waste-management.settings.manage',
+      requiredPermission: 'waste-management.master-data.manage',
       endpoint: 'POST:/api/v1/waste-management/tools/sync-waste-types',
       schema: startSyncWasteTypesSchema,
       jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,

--- a/packages/auth-runtime/src/waste-management/core/schemas.ts
+++ b/packages/auth-runtime/src/waste-management/core/schemas.ts
@@ -235,6 +235,8 @@ const startSeedSchema = z.object({
   seedKey: z.literal('baseline').default('baseline'),
 });
 
+const startSyncWasteTypesSchema = z.object({});
+
 const startResetSchema = z.object({
   confirmationToken: z.string().trim().refine(
     (value) => value === wasteManagementOperationsContract.resetConfirmationToken,
@@ -283,5 +285,6 @@ export const wasteManagementOperationSchemas = {
   startImportSchema,
   previewLocationTourPickupDateImportSchema,
   startSeedSchema,
+  startSyncWasteTypesSchema,
   startResetSchema,
 } as const;

--- a/packages/auth-runtime/src/waste-management/core/schemas.ts
+++ b/packages/auth-runtime/src/waste-management/core/schemas.ts
@@ -33,7 +33,7 @@ const withWasteFractionReminderValidation = <TSchema extends z.ZodObject>(schema
 const wasteFractionSchemaBase = z.object({
   id: z.string().trim().min(1),
   name: z.string().trim().min(1),
-  pdfShortLabel: z.string().trim().min(1).max(12).optional(),
+  pdfShortLabel: z.string().trim().min(1).max(12),
   translations: z.record(z.string().trim().min(1), z.string().trim().min(1)).optional(),
   containerSize: z.string().trim().min(1).optional(),
   color: z.string().trim().regex(/^#[0-9a-fA-F]{6}$/, 'Ungültiger Hex-Farbwert.'),

--- a/packages/auth-runtime/src/waste-management/core/types.ts
+++ b/packages/auth-runtime/src/waste-management/core/types.ts
@@ -45,6 +45,19 @@ export type SaveWasteCustomRecurrencePresetsInput = {
   readonly deletedPresetFallbacks: Readonly<Record<string, WasteCustomRecurrencePresetFallback>>;
 };
 
+type ResolveWasteActorInfoResult =
+  | {
+      readonly actor: {
+        readonly instanceId: string;
+        readonly requestId?: string;
+        readonly traceId?: string;
+        readonly actorAccountId?: string;
+      };
+    }
+  | {
+      readonly error: Response;
+    };
+
 export type WasteManagementHandlerDeps = {
   readonly getRequestId?: () => string | undefined;
   readonly getSessionById?: (sessionId: string) => Promise<Session | undefined>;
@@ -75,19 +88,7 @@ export type WasteManagementHandlerDeps = {
   readonly resolveActorInfo?: (
     request: Request,
     ctx: AuthenticatedRequestContext
-  ) => Promise<
-    | {
-        readonly actor: {
-          readonly instanceId: string;
-          readonly requestId?: string;
-          readonly traceId?: string;
-          readonly actorAccountId?: string;
-        };
-      }
-    | {
-        readonly error: Response;
-      }
-  >;
+  ) => Promise<ResolveWasteActorInfoResult>;
   readonly startPluginOperationJob?: (input: {
     readonly instanceId: string;
     readonly actorAccountId: string;

--- a/packages/auth-runtime/src/waste-management/server-loaders.test.ts
+++ b/packages/auth-runtime/src/waste-management/server-loaders.test.ts
@@ -38,7 +38,7 @@ const instanceDbQueryMock = vi.hoisted(() =>
         request_id: 'req-1',
         latest_event_message: 'done',
         error_code: null,
-        total_count: 3,
+        total_count: 4,
       },
       {
         id: 'job-2',
@@ -50,7 +50,7 @@ const instanceDbQueryMock = vi.hoisted(() =>
         latest_event_message: 'failed',
         error_code: 'import_failed',
         error_message: 'Import request failed loudly',
-        total_count: 3,
+        total_count: 4,
       },
       {
         id: 'job-3',
@@ -62,7 +62,19 @@ const instanceDbQueryMock = vi.hoisted(() =>
         latest_event_message: 'cancelled',
         error_code: 'cancelled',
         error_message: null,
-        total_count: 3,
+        total_count: 4,
+      },
+      {
+        id: 'job-4',
+        job_type_id: 'waste-management.sync-waste-types',
+        status: 'succeeded',
+        finished_at: '2026-05-09T09:00:00.000Z',
+        updated_at: '2026-05-09T09:00:00.000Z',
+        request_id: 'req-4',
+        latest_event_message: 'synced',
+        error_code: null,
+        error_message: null,
+        total_count: 4,
       },
     ],
   }))
@@ -113,27 +125,37 @@ const listJobsMock = vi.hoisted(() => vi.fn(async () => ({
       errorPayload: { code: 'cancelled' },
     },
     {
-      id: 'job-4',
+      id: 'job-5',
       jobTypeId: 'other-job',
       status: 'succeeded',
       finishedAt: '2026-05-09T07:00:00.000Z',
       updatedAt: '2026-05-09T07:00:00.000Z',
-      requestId: 'req-4',
+      requestId: 'req-5',
       latestEvent: { message: 'ignored' },
       errorPayload: undefined,
     },
     {
-      id: 'job-5',
+      id: 'job-6',
       jobTypeId: 'waste-management.reset-data',
       status: 'running',
       finishedAt: null,
       updatedAt: '2026-05-09T06:00:00.000Z',
-      requestId: 'req-5',
+      requestId: 'req-6',
       latestEvent: { message: 'running' },
       errorPayload: undefined,
     },
+    {
+      id: 'job-4',
+      jobTypeId: 'waste-management.sync-waste-types',
+      status: 'failed',
+      finishedAt: '2026-05-09T09:00:00.000Z',
+      updatedAt: '2026-05-09T09:00:00.000Z',
+      requestId: 'req-4',
+      latestEvent: { message: 'sync failed' },
+      errorPayload: { code: 'sync_failed' },
+    },
   ],
-  total: 5,
+  total: 6,
 })));
 
 const revealFieldMock = vi.hoisted(() => vi.fn(() => 'revealed-secret'));
@@ -300,8 +322,10 @@ describe('waste-management server loaders', () => {
       ['tenant-a', expect.any(Array), '%fraction%', 10]
     );
     expect(historyOverview.audit.total).toBe(1);
-    expect(historyOverview.technical.total).toBe(4);
-    expect(historyOverview.technical.items).toEqual([
+    expect(historyOverview.technical.total).toBe(5);
+    expect(historyOverview.technical.items).toHaveLength(5);
+    expect(historyOverview.technical.items).toEqual(
+      expect.arrayContaining([
       expect.objectContaining({ id: 'job:job-1:succeeded', eventType: 'migration.succeeded' }),
       expect.objectContaining({
         id: 'job:job-2:failed',
@@ -310,8 +334,14 @@ describe('waste-management server loaders', () => {
         message: 'failed',
       }),
       expect.objectContaining({ id: 'job:job-3:cancelled', eventType: 'seed.failed' }),
+      expect.objectContaining({
+        id: 'job:job-4:succeeded',
+        eventType: 'sync.succeeded',
+        message: 'synced',
+      }),
       expect.objectContaining({ id: 'technical-audit-1' }),
-    ]);
+      ])
+    );
     expect(PoolMock).toHaveBeenCalledTimes(1);
     expect(poolFactoryInstances.at(0)?.end).not.toHaveBeenCalled();
     expect(poolFactoryInstances.at(0)?.query).toHaveBeenCalledWith('SET search_path TO "wm", public;');

--- a/packages/auth-runtime/src/waste-management/server-loaders.test.ts
+++ b/packages/auth-runtime/src/waste-management/server-loaders.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const expectedTechnicalHistoryJobTypeIds = [
+  'waste-management.initialize-data-source',
+  'waste-management.apply-migrations',
+  'waste-management.import-data',
+  'waste-management.seed-data',
+  'waste-management.reset-data',
+  'waste-management.sync-waste-types',
+] as const;
+
 const resolveWasteDataSourceMock = vi.hoisted(() => vi.fn(async () => ({
   instanceId: 'tenant-a',
   schemaName: 'wm',
@@ -881,15 +890,15 @@ describe('waste-management server loaders', () => {
 
     expect(instanceDbQueryMock).toHaveBeenCalledWith(
       expect.stringContaining("COALESCE(j.request_id, '') ILIKE $3"),
-      ['tenant-a', expect.any(Array), '%req-2%', 10]
+      ['tenant-a', expectedTechnicalHistoryJobTypeIds, '%req-2%', 10]
     );
     expect(instanceDbQueryMock).toHaveBeenCalledWith(
       expect.stringContaining("COALESCE(j.error_payload ->> 'message', '') ILIKE $3"),
-      ['tenant-a', expect.any(Array), '%req-2%', 10]
+      ['tenant-a', expectedTechnicalHistoryJobTypeIds, '%req-2%', 10]
     );
     expect(instanceDbQueryMock).toHaveBeenCalledWith(
       expect.stringContaining("COALESCE(j.error_payload ->> 'code', '') ILIKE $3"),
-      ['tenant-a', expect.any(Array), '%req-2%', 10]
+      ['tenant-a', expectedTechnicalHistoryJobTypeIds, '%req-2%', 10]
     );
   });
 
@@ -986,7 +995,7 @@ describe('waste-management server loaders', () => {
     );
     expect(instanceDbQueryMock).toHaveBeenCalledWith(
       expect.stringContaining('FROM iam.studio_jobs j'),
-      ['tenant-a', expect.any(Array), 4]
+      ['tenant-a', expectedTechnicalHistoryJobTypeIds, 4]
     );
   });
 });

--- a/packages/auth-runtime/src/waste-management/server-loaders.ts
+++ b/packages/auth-runtime/src/waste-management/server-loaders.ts
@@ -510,6 +510,9 @@ const mapJobTypeIdToTechnicalEventType = (
   if (jobTypeId === 'waste-management.reset-data') {
     return status === 'succeeded' ? 'reset.succeeded' : 'reset.failed';
   }
+  if (jobTypeId === 'waste-management.sync-waste-types') {
+    return status === 'succeeded' ? 'sync.succeeded' : 'sync.failed';
+  }
   return null;
 };
 

--- a/packages/auth-runtime/src/waste-management/server-loaders.ts
+++ b/packages/auth-runtime/src/waste-management/server-loaders.ts
@@ -656,6 +656,7 @@ const loadWasteHistoryOverview = async (query: {
       'waste-management.import-data',
       'waste-management.seed-data',
       'waste-management.reset-data',
+      'waste-management.sync-waste-types',
     ] as const;
     const buildJobHistoryWhereClause = (): {
       readonly clause: string;

--- a/packages/auth-runtime/src/waste-management/server.test.ts
+++ b/packages/auth-runtime/src/waste-management/server.test.ts
@@ -235,6 +235,7 @@ describe('wasteManagementHandlers', () => {
         internal: coreHandlerMocks.createWasteManagementFractionInternal,
         deps: {
           ...sharedWasteManagementDepsMock,
+          loadMasterDataFractionsOverview: loaderMocks.loadMasterDataFractionsOverview,
           saveWasteFraction: saverMocks.saveWasteFraction,
           loadWasteFractionById: loaderMocks.loadWasteFractionById,
         },
@@ -244,6 +245,7 @@ describe('wasteManagementHandlers', () => {
         internal: coreHandlerMocks.updateWasteManagementFractionInternal,
         deps: {
           ...sharedWasteManagementDepsMock,
+          loadMasterDataFractionsOverview: loaderMocks.loadMasterDataFractionsOverview,
           saveWasteFraction: saverMocks.saveWasteFraction,
           loadWasteFractionById: loaderMocks.loadWasteFractionById,
         },

--- a/packages/auth-runtime/src/waste-management/server.test.ts
+++ b/packages/auth-runtime/src/waste-management/server.test.ts
@@ -48,6 +48,7 @@ const coreHandlerMocks = vi.hoisted(() => ({
   startWasteManagementMigrationsInternal: vi.fn(async () => new Response('start-migrations')),
   startWasteManagementResetInternal: vi.fn(async () => new Response('start-reset')),
   startWasteManagementSeedInternal: vi.fn(async () => new Response('start-seed')),
+  startWasteManagementSyncWasteTypesInternal: vi.fn(async () => new Response('start-sync-waste-types')),
   updateWasteManagementCityInternal: vi.fn(async () => new Response('update-city')),
   updateWasteManagementCollectionLocationInternal: vi.fn(async () => new Response('update-location')),
   updateWasteManagementFractionInternal: vi.fn(async () => new Response('update-fraction')),
@@ -508,6 +509,10 @@ describe('wasteManagementHandlers', () => {
       {
         handlerKey: 'startSeed',
         internal: coreHandlerMocks.startWasteManagementSeedInternal,
+      },
+      {
+        handlerKey: 'startSyncWasteTypes',
+        internal: coreHandlerMocks.startWasteManagementSyncWasteTypesInternal,
       },
       {
         handlerKey: 'startReset',

--- a/packages/auth-runtime/src/waste-management/server.ts
+++ b/packages/auth-runtime/src/waste-management/server.ts
@@ -37,6 +37,7 @@ const {
   startWasteManagementMigrationsInternal,
   startWasteManagementResetInternal,
   startWasteManagementSeedInternal,
+  startWasteManagementSyncWasteTypesInternal,
   updateWasteManagementCityInternal,
   updateWasteManagementCollectionLocationInternal,
   updateWasteManagementFractionInternal,
@@ -403,6 +404,10 @@ export const wasteManagementHandlers = {
   startSeed: (request: Request): Promise<Response> =>
     withAuthenticatedWasteManagementHandler(request, (nextRequest, ctx) =>
       startWasteManagementSeedInternal(nextRequest, ctx)
+    ),
+  startSyncWasteTypes: (request: Request): Promise<Response> =>
+    withAuthenticatedWasteManagementHandler(request, (nextRequest, ctx) =>
+      startWasteManagementSyncWasteTypesInternal(nextRequest, ctx)
     ),
   startReset: (request: Request): Promise<Response> =>
     withAuthenticatedWasteManagementHandler(request, (nextRequest, ctx) =>

--- a/packages/auth-runtime/src/waste-management/server.ts
+++ b/packages/auth-runtime/src/waste-management/server.ts
@@ -158,6 +158,7 @@ export const wasteManagementHandlers = {
     withAuthenticatedWasteManagementHandler(request, (nextRequest, ctx) =>
       createWasteManagementFractionInternal(nextRequest, ctx, {
         ...sharedWasteManagementDeps,
+        loadMasterDataFractionsOverview,
         saveWasteFraction,
         loadWasteFractionById,
       })
@@ -174,6 +175,7 @@ export const wasteManagementHandlers = {
     withAuthenticatedWasteManagementHandler(request, (nextRequest, ctx) =>
       updateWasteManagementFractionInternal(nextRequest, ctx, {
         ...sharedWasteManagementDeps,
+        loadMasterDataFractionsOverview,
         saveWasteFraction,
         loadWasteFractionById,
       })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,6 +190,8 @@ export { buildWasteCalendarPdfDocument, renderWasteCalendarPdf } from './waste-m
 export type {
   WasteCalendarPdfBrandingImage, WasteCalendarPdfDocument, WasteOutputPickupEntry, WasteOutputFraction,
 } from './waste-management-output.types.js';
+export { buildWasteTypesStaticContent } from './waste-management-static-content.js';
+export type { WasteTypeStaticContentEntry, WasteTypesStaticContentArtifact } from './waste-management-static-content.js';
 export * from './routing/registry.js';
 export * from './iam/index.js';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,6 +139,7 @@ export type {
   WasteManagementJobTypeId,
   WasteManagementResetJobInput,
   WasteManagementSeedJobInput,
+  WasteManagementSyncWasteTypesJobInput,
 } from './waste-management-operations-contract.js';
 export type {
   WasteDateShiftReasonType,

--- a/packages/core/src/waste-management-audit.ts
+++ b/packages/core/src/waste-management-audit.ts
@@ -46,7 +46,10 @@ export type WasteManagementTechnicalHistoryRecord = {
     | 'seed.failed'
     | 'reset.started'
     | 'reset.succeeded'
-    | 'reset.failed';
+    | 'reset.failed'
+    | 'sync.started'
+    | 'sync.succeeded'
+    | 'sync.failed';
   readonly outcome: WasteManagementTechnicalHistoryOutcome;
   readonly occurredAt: string;
   readonly source: 'audit' | 'job';

--- a/packages/core/src/waste-management-contract.test.ts
+++ b/packages/core/src/waste-management-contract.test.ts
@@ -35,8 +35,11 @@ describe('waste-management-contract', () => {
       'reset.started',
       'reset.succeeded',
       'reset.failed',
+      'sync.started',
+      'sync.succeeded',
+      'sync.failed',
     ]);
-    expect(wasteManagementDataSourceContract.isTechnicalEventType('seed.failed')).toBe(true);
+    expect(wasteManagementDataSourceContract.isTechnicalEventType('sync.failed')).toBe(true);
     expect(wasteManagementDataSourceContract.isTechnicalEventType('connection-check.pending')).toBe(false);
   });
 });

--- a/packages/core/src/waste-management-contract.ts
+++ b/packages/core/src/waste-management-contract.ts
@@ -21,6 +21,9 @@ const wasteManagementTechnicalEventTypes = [
   'reset.started',
   'reset.succeeded',
   'reset.failed',
+  'sync.started',
+  'sync.succeeded',
+  'sync.failed',
 ] as const;
 
 export type WasteManagementDataSourceProvider = (typeof wasteManagementDataSourceProviders)[number];

--- a/packages/core/src/waste-management-operations-contract.test.ts
+++ b/packages/core/src/waste-management-operations-contract.test.ts
@@ -12,6 +12,7 @@ describe('waste-management-operations-contract', () => {
       importData: 'waste-management.import-data',
       seedData: 'waste-management.seed-data',
       resetData: 'waste-management.reset-data',
+      syncWasteTypes: 'waste-management.sync-waste-types',
     });
     expect(wasteManagementOperationsContract.isJobTypeId('waste-management.import-data')).toBe(true);
     expect(wasteManagementOperationsContract.isJobTypeId('waste-management.unknown')).toBe(false);

--- a/packages/core/src/waste-management-operations-contract.ts
+++ b/packages/core/src/waste-management-operations-contract.ts
@@ -62,6 +62,8 @@ export type WasteManagementResetJobInput = {
 
 export type WasteManagementSyncWasteTypesJobInput = {
   readonly operation: 'sync-waste-types';
+  readonly keycloakSubject?: string;
+  readonly activeOrganizationId?: string;
 };
 
 export type WasteManagementJobInput =

--- a/packages/core/src/waste-management-operations-contract.ts
+++ b/packages/core/src/waste-management-operations-contract.ts
@@ -4,6 +4,7 @@ const wasteManagementJobTypeIds = {
   importData: 'waste-management.import-data',
   seedData: 'waste-management.seed-data',
   resetData: 'waste-management.reset-data',
+  syncWasteTypes: 'waste-management.sync-waste-types',
 } as const;
 
 const wasteManagementResetConfirmationToken = 'RESET' as const;
@@ -59,12 +60,17 @@ export type WasteManagementResetJobInput = {
   readonly confirmationToken: string;
 };
 
+export type WasteManagementSyncWasteTypesJobInput = {
+  readonly operation: 'sync-waste-types';
+};
+
 export type WasteManagementJobInput =
   | WasteManagementInitializeJobInput
   | WasteManagementApplyMigrationsJobInput
   | WasteManagementImportJobInput
   | WasteManagementSeedJobInput
-  | WasteManagementResetJobInput;
+  | WasteManagementResetJobInput
+  | WasteManagementSyncWasteTypesJobInput;
 
 export const wasteManagementOperationsContract = {
   pluginId: 'waste-management',

--- a/packages/core/src/waste-management-static-content.test.ts
+++ b/packages/core/src/waste-management-static-content.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WasteFractionRecord } from './waste-management-master-data.js';
+import { buildWasteTypesStaticContent } from './waste-management-static-content.js';
+
+const createFraction = (overrides: Partial<WasteFractionRecord> = {}): WasteFractionRecord => ({
+  id: 'fraction-bio',
+  name: 'Biotonne auf Abruf',
+  pdfShortLabel: 'BIO',
+  color: '#8B4513',
+  description: 'Nur auf Abruf',
+  translations: { de: 'Biotonne auf Abruf' },
+  active: true,
+  reminderCount: 'none',
+  firstReminderMaxLeadDays: undefined,
+  secondReminderMaxLeadDays: undefined,
+  reminderChannelPushEnabled: false,
+  reminderChannelEmailEnabled: false,
+  reminderChannelCalendarEnabled: false,
+  createdAt: '2026-06-09T10:00:00.000Z',
+  updatedAt: '2026-06-09T10:00:00.000Z',
+  ...overrides,
+});
+
+describe('buildWasteTypesStaticContent', () => {
+  it('builds a deterministic wasteTypes artifact from active fractions', async () => {
+    const artifact = await buildWasteTypesStaticContent([
+      createFraction(),
+      createFraction({
+        id: 'fraction-paper',
+        name: 'Papiertonne 240 l',
+        pdfShortLabel: 'PPK',
+        color: '#1E90FF',
+        description: undefined,
+        containerSize: '240 l',
+        translations: { de: 'Papiertonne 240 l', en: 'Paper bin 240 l' },
+        reminderCount: 'twice',
+        firstReminderMaxLeadDays: 7,
+        secondReminderMaxLeadDays: 2,
+        reminderChannelPushEnabled: true,
+        reminderChannelEmailEnabled: false,
+        reminderChannelCalendarEnabled: true,
+      }),
+      createFraction({
+        id: 'fraction-inactive',
+        name: 'Inaktiv',
+        pdfShortLabel: 'OFF',
+        active: false,
+      }),
+    ]);
+
+    expect(artifact).toMatchObject({
+      name: 'wasteTypes',
+      dataType: 'JSON',
+      version: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      fractionCount: 2,
+    });
+    expect(JSON.parse(artifact.content)).toEqual({
+      BIO: {
+        label: 'Biotonne auf Abruf',
+        color: '#8B4513',
+        selected_color: '#8B4513',
+        id: 'fraction-bio',
+        short_label: 'BIO',
+        active: true,
+        description: 'Nur auf Abruf',
+        container_size: null,
+        translations: { de: 'Biotonne auf Abruf' },
+        reminders: {
+          reminder_count: 'none',
+          first_reminder_max_lead_days: null,
+          second_reminder_max_lead_days: null,
+          channels: {
+            push: false,
+            email: false,
+            calendar: false,
+          },
+        },
+      },
+      PPK: {
+        label: 'Papiertonne 240 l',
+        color: '#1E90FF',
+        selected_color: '#1E90FF',
+        id: 'fraction-paper',
+        short_label: 'PPK',
+        active: true,
+        description: null,
+        container_size: '240 l',
+        translations: { de: 'Papiertonne 240 l', en: 'Paper bin 240 l' },
+        reminders: {
+          reminder_count: 'twice',
+          first_reminder_max_lead_days: 7,
+          second_reminder_max_lead_days: 2,
+          channels: {
+            push: true,
+            email: false,
+            calendar: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('rejects fractions without a short label', async () => {
+    await expect(buildWasteTypesStaticContent([createFraction({ pdfShortLabel: undefined })])).rejects.toThrow(
+      'missing_waste_type_short_label:fraction-bio'
+    );
+  });
+
+  it('rejects duplicate normalized waste type keys', async () => {
+    await expect(
+      buildWasteTypesStaticContent([
+        createFraction({ id: 'fraction-1', pdfShortLabel: 'BIO' }),
+        createFraction({ id: 'fraction-2', pdfShortLabel: 'bio' }),
+      ])
+    ).rejects.toThrow('duplicate_waste_type_key:BIO');
+  });
+});

--- a/packages/core/src/waste-management-static-content.test.ts
+++ b/packages/core/src/waste-management-static-content.test.ts
@@ -115,4 +115,13 @@ describe('buildWasteTypesStaticContent', () => {
       ])
     ).rejects.toThrow('duplicate_waste_type_key:BIO');
   });
+
+  it('sorts waste type keys deterministically without relying on runtime locale', async () => {
+    const artifact = await buildWasteTypesStaticContent([
+      createFraction({ id: 'fraction-umlaut', pdfShortLabel: 'ÄB' }),
+      createFraction({ id: 'fraction-ascii', pdfShortLabel: 'ZA' }),
+    ]);
+
+    expect(Object.keys(JSON.parse(artifact.content) as Record<string, unknown>)).toEqual(['ZA', 'ÄB']);
+  });
 });

--- a/packages/core/src/waste-management-static-content.ts
+++ b/packages/core/src/waste-management-static-content.ts
@@ -31,6 +31,13 @@ export type WasteTypesStaticContentArtifact = {
 };
 
 const normalizeWasteTypeKey = (value: string): string => value.trim().toUpperCase();
+const compareWasteTypeKeys = (leftKey: string, rightKey: string): number => {
+  if (leftKey === rightKey) {
+    return 0;
+  }
+
+  return leftKey < rightKey ? -1 : 1;
+};
 
 const toWasteTypeEntry = (fraction: WasteFractionRecord, shortLabel: string): WasteTypeStaticContentEntry => ({
   label: fraction.name,
@@ -80,7 +87,7 @@ export const buildWasteTypesStaticContent = async (
       }
       return [key, toWasteTypeEntry(fraction, key)] as const;
     })
-    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+    .sort(([leftKey], [rightKey]) => compareWasteTypeKeys(leftKey, rightKey));
 
   const payload: Record<string, WasteTypeStaticContentEntry> = {};
   for (const [key, entry] of entries) {

--- a/packages/core/src/waste-management-static-content.ts
+++ b/packages/core/src/waste-management-static-content.ts
@@ -1,0 +1,102 @@
+import type { WasteFractionRecord, WasteLocalizedTextRecord } from './waste-management-master-data.js';
+
+export type WasteTypeStaticContentEntry = {
+  readonly label: string;
+  readonly color: string;
+  readonly selected_color: string;
+  readonly id: string;
+  readonly short_label: string;
+  readonly active: boolean;
+  readonly description: string | null;
+  readonly container_size: string | null;
+  readonly translations: WasteLocalizedTextRecord;
+  readonly reminders: {
+    readonly reminder_count: WasteFractionRecord['reminderCount'];
+    readonly first_reminder_max_lead_days: number | null;
+    readonly second_reminder_max_lead_days: number | null;
+    readonly channels: {
+      readonly push: boolean;
+      readonly email: boolean;
+      readonly calendar: boolean;
+    };
+  };
+};
+
+export type WasteTypesStaticContentArtifact = {
+  readonly name: 'wasteTypes';
+  readonly dataType: 'JSON';
+  readonly version: `sha256:${string}`;
+  readonly content: string;
+  readonly fractionCount: number;
+};
+
+const normalizeWasteTypeKey = (value: string): string => value.trim().toUpperCase();
+
+const toWasteTypeEntry = (fraction: WasteFractionRecord, shortLabel: string): WasteTypeStaticContentEntry => ({
+  label: fraction.name,
+  color: fraction.color,
+  selected_color: fraction.color,
+  id: fraction.id,
+  short_label: shortLabel,
+  active: fraction.active,
+  description: fraction.description ?? null,
+  container_size: fraction.containerSize ?? null,
+  translations: fraction.translations ?? {},
+  reminders: {
+    reminder_count: fraction.reminderCount,
+    first_reminder_max_lead_days: fraction.firstReminderMaxLeadDays ?? null,
+    second_reminder_max_lead_days: fraction.secondReminderMaxLeadDays ?? null,
+    channels: {
+      push: fraction.reminderChannelPushEnabled,
+      email: fraction.reminderChannelEmailEnabled,
+      calendar: fraction.reminderChannelCalendarEnabled,
+    },
+  },
+});
+
+const hashContent = async (value: string): Promise<`sha256:${string}`> => {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error('crypto_subtle_unavailable');
+  }
+
+  const buffer = await subtle.digest('SHA-256', new TextEncoder().encode(value));
+  const hash = Array.from(new Uint8Array(buffer), (byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `sha256:${hash}`;
+};
+
+export const buildWasteTypesStaticContent = async (
+  fractions: readonly WasteFractionRecord[]
+): Promise<WasteTypesStaticContentArtifact> => {
+  const entries = fractions
+    .filter((fraction) => fraction.active)
+    .map((fraction) => {
+      if (!fraction.pdfShortLabel?.trim()) {
+        throw new Error(`missing_waste_type_short_label:${fraction.id}`);
+      }
+      const key = normalizeWasteTypeKey(fraction.pdfShortLabel);
+      if (key.length === 0) {
+        throw new Error(`invalid_waste_type_key:${fraction.id}`);
+      }
+      return [key, toWasteTypeEntry(fraction, key)] as const;
+    })
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+
+  const payload: Record<string, WasteTypeStaticContentEntry> = {};
+  for (const [key, entry] of entries) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      throw new Error(`duplicate_waste_type_key:${key}`);
+    }
+    payload[key] = entry;
+  }
+
+  const content = JSON.stringify(payload, null, 2);
+
+  return {
+    name: 'wasteTypes',
+    dataType: 'JSON',
+    version: await hashContent(content),
+    content,
+    fractionCount: entries.length,
+  };
+};

--- a/packages/iam-governance/src/waste-audit-read-models.test.ts
+++ b/packages/iam-governance/src/waste-audit-read-models.test.ts
@@ -105,7 +105,7 @@ describe('iam-governance/waste-audit-read-models', () => {
   it('maps the technical waste audit subset into the technical history shape', async () => {
     const client = buildClient(
       {
-        rowCount: 2,
+        rowCount: 3,
         rows: [
           {
             id: 'log-2',
@@ -134,11 +134,24 @@ describe('iam-governance/waste-audit-read-models', () => {
               result: 'success',
             },
           },
+          {
+            id: 'log-0',
+            event_type: 'plugin_action_authorized',
+            created_at: '2026-05-09T11:55:00.000Z',
+            account_id: 'account-0',
+            request_id: 'req-0',
+            trace_id: 'trace-0',
+            payload: {
+              action_id: 'waste-management.sync-waste-types.started',
+              action_namespace: 'waste-management',
+              result: 'success',
+            },
+          },
         ],
       },
       {
         rowCount: 1,
-        rows: [{ total: 2 }],
+        rows: [{ total: 3 }],
       }
     );
 
@@ -148,7 +161,7 @@ describe('iam-governance/waste-audit-read-models', () => {
       pageSize: 20,
     });
 
-    expect(result.total).toBe(2);
+    expect(result.total).toBe(3);
     expect(result.items).toEqual([
       expect.objectContaining({
         id: 'log-2',
@@ -159,6 +172,11 @@ describe('iam-governance/waste-audit-read-models', () => {
       expect.objectContaining({
         id: 'log-1',
         eventType: 'import.started',
+        outcome: 'started',
+      }),
+      expect.objectContaining({
+        id: 'log-0',
+        eventType: 'sync.started',
         outcome: 'started',
       }),
     ]);

--- a/packages/iam-governance/src/waste-audit-read-models.ts
+++ b/packages/iam-governance/src/waste-audit-read-models.ts
@@ -48,6 +48,7 @@ const technicalActionMap = {
   'waste-management.import.started': 'import.started',
   'waste-management.seed.started': 'seed.started',
   'waste-management.reset.started': 'reset.started',
+  'waste-management.sync-waste-types.started': 'sync.started',
 } as const satisfies Readonly<Record<string, WasteManagementTechnicalHistoryRecord['eventType']>>;
 
 const hasTechnicalAction = (actionId: string): actionId is keyof typeof technicalActionMap =>

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -138,6 +138,7 @@ export type {
   WasteManagementMasterDataOverview,
   WasteManagementResetJobInput,
   WasteManagementSeedJobInput,
+  WasteManagementSyncWasteTypesJobInput,
   WasteManagementSettingsInterfaceOption,
   WasteManagementSettingsRecord,
   WasteRegionRecord,

--- a/packages/plugin-sdk/src/public-api.ts
+++ b/packages/plugin-sdk/src/public-api.ts
@@ -40,6 +40,7 @@ export type {
   WasteManagementMasterDataOverview,
   WasteManagementResetJobInput,
   WasteManagementSeedJobInput,
+  WasteManagementSyncWasteTypesJobInput,
   WasteManagementSettingsInterfaceOption,
   WasteManagementSettingsRecord,
   WasteRegionRecord,

--- a/packages/plugin-waste-management/src/plugin-operations.ts
+++ b/packages/plugin-waste-management/src/plugin-operations.ts
@@ -103,6 +103,22 @@ const wasteManagementPluginJobTypes = [
       detailKeys: ['failed-step', 'failed-table'],
     },
   },
+  {
+    jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+    queue: wasteManagementOperationsContract.queueName,
+    displayName: 'Waste-Typen mit Mainserver synchronisieren',
+    progress: {
+      phaseKeys: ['waste-management.sync-waste-types', 'waste-management.completed'],
+      stepKeys: ['build-static-content', 'push-static-content'],
+    },
+    result: {
+      summaryKeys: ['durationMs'],
+      detailKeys: ['staticContentName', 'version', 'fractionCount'],
+    },
+    errors: {
+      detailKeys: ['failed-step'],
+    },
+  },
 ] satisfies readonly PluginJobTypeDefinition[];
 
 const wasteManagementPluginImportProfiles = [

--- a/packages/plugin-waste-management/src/plugin.translations.de.audit.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.de.audit.ts
@@ -29,6 +29,7 @@ export const wasteManagementPluginTranslationsDEAudit = {
     "importStarted": "Waste-Import gestartet",
     "seedStarted": "Waste-Seed gestartet",
     "resetStarted": "Waste-Reset gestartet",
+    "syncWasteTypesStarted": "Waste-Typen-Synchronisierung gestartet",
     "dataSourceInitialized": "Waste-Datenquelle initialisiert"
   }
 } as const;

--- a/packages/plugin-waste-management/src/plugin.translations.de.common.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.de.common.ts
@@ -5,6 +5,7 @@ export const wasteManagementPluginTranslationsDECommon = {
     "active": "Aktiv",
     "inactive": "Inaktiv",
     "statusSuccessTitle": "OK",
+    "statusWarningTitle": "Warnung",
     "statusErrorTitle": "Fehler"
   }
 } as const;

--- a/packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts
@@ -34,6 +34,7 @@ export const wasteManagementPluginTranslationsDEMasterDataFractions = {
     create: 'Fraktion speichern',
     save: 'Änderungen speichern',
     saving: 'Speichert…',
+    retrySync: 'Erneut synchronisieren',
   },
   fields: {
     name: 'Name',
@@ -85,8 +86,7 @@ export const wasteManagementPluginTranslationsDEMasterDataFractions = {
       description: 'Beschreiben Sie die Abfallart kurz und verständlich. Maximal 300 Zeichen.',
       translationDe: 'Optional: deutsche Bezeichnung für mehrsprachige Ausgaben.',
       translationEn: 'Optional: englische Bezeichnung für mehrsprachige Ausgaben.',
-      pdfShortLabel:
-        'Optional: Kürzel für die PDF-Legende. Wenn nichts gepflegt ist, wird später ein Kürzel aus der Bezeichnung abgeleitet.',
+      pdfShortLabel: 'Pflichtfeld: Kürzel für die PDF-Legende. Dieses Kürzel wird direkt für Ausgabe und Legende verwendet.',
       containerSize: 'Optional: Tragen Sie eine Behältergröße nur ein, wenn diese Abfallart in mehreren Größen geführt wird, zum Beispiel 120 l oder 240 l.',
       color: 'Diese Farbe wird später zur Wiedererkennung im Kalender und in Tabellen verwendet.',
       active: 'Nur aktive Abfallarten stehen für die weitere Planung zur Verfügung.',
@@ -105,6 +105,7 @@ export const wasteManagementPluginTranslationsDEMasterDataFractions = {
     },
     validation: {
       nameRequired: 'Bitte geben Sie einen Namen ein.',
+      pdfShortLabelRequired: 'Bitte geben Sie ein PDF-Kürzel ein.',
       colorRequired: 'Bitte geben Sie eine gültige Farbe im Hex-Format an.',
     },
     meta: {
@@ -170,5 +171,8 @@ export const wasteManagementPluginTranslationsDEMasterDataFractions = {
     deleteError: 'Die Waste-Fraktion konnte nicht gelöscht werden.',
     deleteForbidden: 'Für das Löschen von Waste-Fraktionen fehlt die Berechtigung.',
     deleteConflict: 'Die Waste-Fraktion kann wegen bestehender Zuordnungen nicht gelöscht werden.',
+    syncWarning:
+      'Die Fraktionsänderung wurde gespeichert, aber wasteTypes konnte nicht mit dem Mainserver synchronisiert werden.',
+    syncRetryStarted: 'Die Synchronisation von wasteTypes wurde erneut gestartet.',
   },
 } as const;

--- a/packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts
@@ -168,6 +168,7 @@ export const wasteManagementPluginTranslationsDEMasterDataFractions = {
     deletePartialSuccess: '{{count}} von {{total}} Waste-Fraktionen wurden gelöscht.',
     saveError: 'Die Waste-Fraktion konnte nicht gespeichert werden.',
     saveForbidden: 'Für das Speichern von Waste-Fraktionen fehlt die Berechtigung.',
+    saveConflict: 'Das PDF-Kürzel wird bereits von einer anderen aktiven Waste-Fraktion verwendet.',
     deleteError: 'Die Waste-Fraktion konnte nicht gelöscht werden.',
     deleteForbidden: 'Für das Löschen von Waste-Fraktionen fehlt die Berechtigung.',
     deleteConflict: 'Die Waste-Fraktion kann wegen bestehender Zuordnungen nicht gelöscht werden.',

--- a/packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.de.masterData.fractions.ts
@@ -8,6 +8,7 @@ export const wasteManagementPluginTranslationsDEMasterDataFractions = {
     caption: 'Tabelle der Waste-Abfallfraktionen mit Status, Metadaten und Aktionen.',
     name: 'Fraktion',
     nameWithContainerSize: 'Name (Gefäßgröße)',
+    shortLabel: 'Kürzel',
     selection: 'Auswahl',
     status: 'Status',
     color: 'Farbe',

--- a/packages/plugin-waste-management/src/plugin.translations.en.audit.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.en.audit.ts
@@ -29,6 +29,7 @@ export const wasteManagementPluginTranslationsENAudit = {
     importStarted: 'Started waste import',
     seedStarted: 'Started waste seed',
     resetStarted: 'Started waste reset',
+    syncWasteTypesStarted: 'Started waste type sync',
     dataSourceInitialized: 'Initialized waste data source',
   },
 } as const;

--- a/packages/plugin-waste-management/src/plugin.translations.en.common.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.en.common.ts
@@ -5,6 +5,7 @@ export const wasteManagementPluginTranslationsENCommon = {
     "active": "Active",
     "inactive": "Inactive",
     "statusSuccessTitle": "OK",
+    "statusWarningTitle": "Warning",
     "statusErrorTitle": "Error"
   }
 } as const;

--- a/packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts
@@ -168,6 +168,7 @@ export const wasteManagementPluginTranslationsENMasterDataFractions = {
     deletePartialSuccess: '{{count}} of {{total}} waste fractions were deleted.',
     saveError: 'The waste fraction could not be saved.',
     saveForbidden: 'Missing permission to save waste fractions.',
+    saveConflict: 'The PDF short label is already used by another active waste fraction.',
     deleteError: 'The waste fraction could not be deleted.',
     deleteForbidden: 'Missing permission to delete waste fractions.',
     deleteConflict: 'The waste fraction cannot be deleted because assignments still exist.',

--- a/packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts
@@ -8,6 +8,7 @@ export const wasteManagementPluginTranslationsENMasterDataFractions = {
     caption: 'Table of waste fractions with status, metadata, and actions.',
     name: 'Fraction',
     nameWithContainerSize: 'Name (Container size)',
+    shortLabel: 'Short label',
     selection: 'Selection',
     status: 'Status',
     color: 'Color',

--- a/packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.en.masterData.fractions.ts
@@ -34,6 +34,7 @@ export const wasteManagementPluginTranslationsENMasterDataFractions = {
     create: 'Save fraction',
     save: 'Save changes',
     saving: 'Saving…',
+    retrySync: 'Retry sync',
   },
   fields: {
     name: 'Name',
@@ -85,8 +86,7 @@ export const wasteManagementPluginTranslationsENMasterDataFractions = {
       description: 'Describe the waste type briefly and clearly. Maximum 300 characters.',
       translationDe: 'Optional: German label for multilingual output.',
       translationEn: 'Optional: English label for multilingual output.',
-      pdfShortLabel:
-        'Optional: Short label for the PDF legend. If omitted, a short code will later be derived from the fraction label.',
+      pdfShortLabel: 'Required: Short label for the PDF legend. This short label is used directly in PDF output and legends.',
       containerSize: 'Optional: Only enter a container size if this waste type exists in multiple sizes, for example 120 l or 240 l.',
       color: 'This color will later help users recognize the waste type in calendars and tables.',
       active: 'Only active waste types are available for further planning.',
@@ -105,6 +105,7 @@ export const wasteManagementPluginTranslationsENMasterDataFractions = {
     },
     validation: {
       nameRequired: 'Please enter a name.',
+      pdfShortLabelRequired: 'Please enter a PDF short label.',
       colorRequired: 'Please enter a valid hex color.',
     },
     meta: {
@@ -170,5 +171,8 @@ export const wasteManagementPluginTranslationsENMasterDataFractions = {
     deleteError: 'The waste fraction could not be deleted.',
     deleteForbidden: 'Missing permission to delete waste fractions.',
     deleteConflict: 'The waste fraction cannot be deleted because assignments still exist.',
+    syncWarning:
+      'The fraction change was saved, but wasteTypes could not be synchronized with the mainserver.',
+    syncRetryStarted: 'The wasteTypes synchronization was started again.',
   },
 } as const;

--- a/packages/plugin-waste-management/src/plugin.translations.shared.master-data.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.shared.master-data.ts
@@ -66,6 +66,7 @@ type MasterDataFractionsCreateViewCopy = Readonly<{
     description: string;
     translationDe: string;
     translationEn: string;
+    pdfShortLabel: string;
     containerSize: string;
     color: string;
     active: string;
@@ -76,6 +77,7 @@ type MasterDataFractionsCreateViewCopy = Readonly<{
   }>;
   validation: Readonly<{
     nameRequired: string;
+    pdfShortLabelRequired: string;
     colorRequired: string;
   }>;
   meta: Readonly<{

--- a/packages/plugin-waste-management/src/plugin.translations.shared.master-data.ts
+++ b/packages/plugin-waste-management/src/plugin.translations.shared.master-data.ts
@@ -46,7 +46,15 @@ type MasterDataFractionsCopy = Readonly<{
   dialog: CrudDialogCopy;
   deleteDialog: Readonly<Record<string, string>>;
   statusDialog: Readonly<Record<string, string>>;
-  messages: Readonly<CrudMessagesCopy & { deleteSuccess: string; deleteError: string; deleteForbidden: string; deleteConflict: string }>;
+  messages: Readonly<
+    CrudMessagesCopy & {
+      saveConflict: string;
+      deleteSuccess: string;
+      deleteError: string;
+      deleteForbidden: string;
+      deleteConflict: string;
+    }
+  >;
 }>;
 
 type MasterDataFractionsCreateViewCopy = Readonly<{

--- a/packages/plugin-waste-management/src/plugin.tsx
+++ b/packages/plugin-waste-management/src/plugin.tsx
@@ -148,6 +148,10 @@ export const wasteManagementAuditEventDefinitions = definePluginAuditEvents('was
     titleKey: 'wasteManagement.audit.resetStarted',
   },
   {
+    eventType: 'waste-management.sync-waste-types.started',
+    titleKey: 'wasteManagement.audit.syncWasteTypesStarted',
+  },
+  {
     eventType: 'waste-management.datasource.reconfigured',
     titleKey: 'wasteManagement.audit.dataSourceInitialized',
   },

--- a/packages/plugin-waste-management/src/server.ts
+++ b/packages/plugin-waste-management/src/server.ts
@@ -8,6 +8,7 @@ import {
   type WasteManagementJobInput,
   type WasteManagementResetJobInput,
   type WasteManagementSeedJobInput,
+  type WasteManagementSyncWasteTypesJobInput,
 } from '@sva/plugin-sdk';
 
 import { createWasteManagementPluginJobTypes } from './plugin-operations.js';
@@ -144,6 +145,13 @@ export type WasteManagementOperationRuntime = {
   readonly resetData: (
     instanceId: string,
     payload: WasteManagementResetJobInput
+  ) => Promise<{
+    readonly durationMs: number;
+    readonly details: Record<string, unknown>;
+  }>;
+  readonly syncWasteTypes: (
+    instanceId: string,
+    payload: WasteManagementSyncWasteTypesJobInput
   ) => Promise<{
     readonly durationMs: number;
     readonly details: Record<string, unknown>;
@@ -319,6 +327,13 @@ export const createWasteManagementPluginOperationExecutionHandlers = (
       expectedOperation: 'reset-data',
       phaseKey: 'waste-management.reset',
       execute: (runtimeArg, instanceId, payload) => runtimeArg.resetData(instanceId, payload),
+    })(runtime),
+  [wasteManagementOperationsContract.jobTypeIds.syncWasteTypes]:
+    createOperationHandler<WasteManagementSyncWasteTypesJobInput>({
+      jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+      expectedOperation: 'sync-waste-types',
+      phaseKey: 'waste-management.sync-waste-types',
+      execute: (runtimeArg, instanceId, payload) => runtimeArg.syncWasteTypes(instanceId, payload),
     })(runtime),
 });
 

--- a/packages/plugin-waste-management/src/waste-management.api.master-data-addresses.ts
+++ b/packages/plugin-waste-management/src/waste-management.api.master-data-addresses.ts
@@ -1,4 +1,5 @@
 import type {
+  StudioJobResponse,
   WasteCityRecord,
   WasteCollectionLocationRecord,
   WasteFractionRecord,
@@ -21,20 +22,35 @@ import type {
   UpdateWasteManagementRegionInput,
   UpdateWasteManagementStreetInput,
 } from './waste-management.api.types.js';
-import { requestWasteManagementMutation } from './waste-management.api.shared.js';
+import {
+  requestWasteManagementMutation,
+  requestWasteManagementMutationResponse,
+} from './waste-management.api.shared.js';
+
+type WasteFractionSyncStatus = 'queued' | 'failed';
+
+export type WasteFractionMutationResponse<T> = Readonly<{
+  data: T;
+  requestId?: string;
+  syncStatus?: WasteFractionSyncStatus;
+  syncJob?: StudioJobResponse['data'];
+}>;
 
 export const createWasteManagementFraction = async (
   input: CreateWasteManagementFractionInput
-): Promise<WasteFractionRecord> => requestWasteManagementMutation('/api/v1/waste-management/fractions', input);
+): Promise<WasteFractionMutationResponse<WasteFractionRecord>> =>
+  requestWasteManagementMutationResponse('/api/v1/waste-management/fractions', input);
 
 export const updateWasteManagementFraction = async (
   fractionId: string,
   input: UpdateWasteManagementFractionInput
-): Promise<WasteFractionRecord> =>
-  requestWasteManagementMutation(`/api/v1/waste-management/fractions/${encodeURIComponent(fractionId)}`, input, 'PUT');
+): Promise<WasteFractionMutationResponse<WasteFractionRecord>> =>
+  requestWasteManagementMutationResponse(`/api/v1/waste-management/fractions/${encodeURIComponent(fractionId)}`, input, 'PUT');
 
-export const deleteWasteManagementFraction = async (fractionId: string): Promise<{ readonly id: string }> =>
-  requestWasteManagementMutation(`/api/v1/waste-management/fractions/${encodeURIComponent(fractionId)}`, undefined, 'DELETE');
+export const deleteWasteManagementFraction = async (
+  fractionId: string
+): Promise<WasteFractionMutationResponse<{ readonly id: string }>> =>
+  requestWasteManagementMutationResponse(`/api/v1/waste-management/fractions/${encodeURIComponent(fractionId)}`, undefined, 'DELETE');
 
 export const createWasteManagementRegion = async (
   input: CreateWasteManagementRegionInput

--- a/packages/plugin-waste-management/src/waste-management.api.operations.ts
+++ b/packages/plugin-waste-management/src/waste-management.api.operations.ts
@@ -110,6 +110,9 @@ export const startWasteManagementSeed = async (input: StartWasteManagementSeedIn
     seedKey: input.seedKey ?? 'baseline',
   });
 
+export const startWasteManagementSyncWasteTypes = async () =>
+  requestWasteManagementJob('/api/v1/waste-management/tools/sync-waste-types', {});
+
 export const startWasteManagementReset = async (input: StartWasteManagementResetInput) =>
   requestWasteManagementJob('/api/v1/waste-management/tools/reset', input);
 

--- a/packages/plugin-waste-management/src/waste-management.api.shared.ts
+++ b/packages/plugin-waste-management/src/waste-management.api.shared.ts
@@ -15,15 +15,21 @@ const createWasteManagementApiError = (code: string, message: string) => new Was
 
 const createIdempotencyKey = () => crypto.randomUUID();
 
-export const requestWasteManagementItem = async <T>(input: {
+export const requestWasteManagementResponse = async <T>(input: {
   readonly url: string;
   readonly init?: RequestInit;
-}): Promise<T> => {
-  const response = await requestMainserverJson<ApiItemResponse<T>, WasteManagementApiError>({
+}): Promise<T> =>
+  await requestMainserverJson<T, WasteManagementApiError>({
     url: input.url,
     init: input.init,
     errorFactory: createWasteManagementApiError,
   });
+
+export const requestWasteManagementItem = async <T>(input: {
+  readonly url: string;
+  readonly init?: RequestInit;
+}): Promise<T> => {
+  const response = await requestWasteManagementResponse<ApiItemResponse<T>>(input);
 
   return response.data;
 };
@@ -43,6 +49,20 @@ export const requestWasteManagementMutation = <T>(
   method = 'POST'
 ) =>
   requestWasteManagementItem<T>({
+    url,
+    init: {
+      method,
+      headers: createMainserverJsonRequestHeaders(),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    },
+  });
+
+export const requestWasteManagementMutationResponse = <T>(
+  url: string,
+  body?: Readonly<Record<string, unknown>>,
+  method = 'POST'
+) =>
+  requestWasteManagementResponse<T>({
     url,
     init: {
       method,

--- a/packages/plugin-waste-management/src/waste-management.api.types.master-data-inputs.fractions.ts
+++ b/packages/plugin-waste-management/src/waste-management.api.types.master-data-inputs.fractions.ts
@@ -3,7 +3,7 @@ import type { WasteFractionReminderCount, WasteLocalizedTextRecord } from '@sva/
 export type CreateWasteManagementFractionInput = Readonly<{
   id: string;
   name: string;
-  pdfShortLabel?: string;
+  pdfShortLabel: string;
   translations?: WasteLocalizedTextRecord;
   containerSize?: string;
   color: string;
@@ -19,7 +19,7 @@ export type CreateWasteManagementFractionInput = Readonly<{
 
 export type UpdateWasteManagementFractionInput = Readonly<{
   name: string;
-  pdfShortLabel?: string;
+  pdfShortLabel: string;
   translations?: WasteLocalizedTextRecord;
   containerSize?: string;
   color: string;

--- a/packages/plugin-waste-management/src/waste-management.api.types.operations-inputs.ts
+++ b/packages/plugin-waste-management/src/waste-management.api.types.operations-inputs.ts
@@ -137,6 +137,8 @@ export type StartWasteManagementSeedInput = Readonly<{
   seedKey?: 'baseline';
 }>;
 
+export type StartWasteManagementSyncWasteTypesInput = Readonly<Record<never, never>>;
+
 export type StartWasteManagementResetInput = Readonly<{
   confirmationToken: string;
 }>;

--- a/packages/plugin-waste-management/src/waste-management.master-data-entity-dialogs.shared.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-entity-dialogs.shared.tsx
@@ -16,12 +16,14 @@ import type {
   UseFormReset,
 } from 'react-hook-form';
 
+import type { StatusMessage } from './waste-management.page.support.js';
+
 export type BaseProps<TForm> = {
   readonly open: boolean;
   readonly mode: 'create' | 'edit';
   readonly form: TForm;
   readonly saving: boolean;
-  readonly message: { readonly kind: 'success' | 'error'; readonly text: string } | null;
+  readonly message: StatusMessage | null;
   readonly onOpenChange: (open: boolean) => void;
   readonly onChange: (patch: Partial<TForm>) => void;
   readonly onBeforeSubmit?: () => void;

--- a/packages/plugin-waste-management/src/waste-management.master-data-fraction-create-content.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-fraction-create-content.tsx
@@ -33,7 +33,7 @@ export const WasteMasterDataFractionCreateContent = ({
   const pt = usePluginTranslation('wasteManagement');
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const errors = useMemo(() => validateFractionForm(form, pt), [form, pt]);
-  const hasErrors = Boolean(errors.name || errors.color);
+  const hasErrors = Boolean(errors.name || errors.pdfShortLabel || errors.color);
   const title = mode === 'create' ? pt('masterData.fractions.createView.title') : pt('masterData.fractions.dialog.editTitle');
   const description =
     mode === 'create'

--- a/packages/plugin-waste-management/src/waste-management.master-data-fraction-create.parts.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-fraction-create.parts.tsx
@@ -64,6 +64,89 @@ export const FractionFormActions = ({
   </div>
 );
 
+const FractionDescriptionHint = ({
+  count,
+  pt,
+}: {
+  readonly count: number;
+  readonly pt: ReturnType<typeof usePluginTranslation>;
+}) => (
+  <span className="flex items-center justify-between gap-3">
+    <span>{pt('masterData.fractions.createView.fieldHints.description')}</span>
+    <span className="shrink-0">{pt('masterData.fractions.createView.meta.descriptionCounter', { count })}</span>
+  </span>
+);
+
+const FractionBasicsFields = ({
+  form,
+  submitAttempted,
+  errors,
+  onChange,
+  pt,
+}: {
+  readonly form: FractionFormState;
+  readonly submitAttempted: boolean;
+  readonly errors: FractionFormErrors;
+  readonly onChange: (patch: Partial<FractionFormState>) => void;
+  readonly pt: ReturnType<typeof usePluginTranslation>;
+}) => (
+  <StudioFieldGroup>
+    <StudioField
+      id="waste-fraction-name"
+      label={pt('masterData.fractions.fields.name')}
+      description={pt('masterData.fractions.createView.fieldHints.name')}
+      error={submitAttempted ? errors.name : undefined}
+      required
+    >
+      <Input
+        id="waste-fraction-name"
+        value={form.name}
+        aria-invalid={submitAttempted && errors.name ? 'true' : undefined}
+        onChange={(event) => onChange({ name: event.target.value })}
+      />
+    </StudioField>
+    <StudioField
+      id="waste-fraction-description"
+      label={pt('masterData.fractions.fields.description')}
+      description={<FractionDescriptionHint count={form.description.length} pt={pt} />}
+    >
+      <Textarea
+        id="waste-fraction-description"
+        value={form.description}
+        rows={4}
+        maxLength={300}
+        onChange={(event) => onChange({ description: event.target.value })}
+      />
+    </StudioField>
+    <StudioField
+      id="waste-fraction-pdf-short-label"
+      label={pt('masterData.fractions.fields.pdfShortLabel')}
+      description={pt('masterData.fractions.createView.fieldHints.pdfShortLabel')}
+      error={submitAttempted ? errors.pdfShortLabel : undefined}
+      required
+    >
+      <Input
+        id="waste-fraction-pdf-short-label"
+        value={form.pdfShortLabel}
+        maxLength={12}
+        aria-invalid={submitAttempted && errors.pdfShortLabel ? 'true' : undefined}
+        onChange={(event) => onChange({ pdfShortLabel: event.target.value })}
+      />
+    </StudioField>
+    <StudioField
+      id="waste-fraction-container-size"
+      label={pt('masterData.fractions.fields.containerSize')}
+      description={pt('masterData.fractions.createView.fieldHints.containerSize')}
+    >
+      <Input
+        id="waste-fraction-container-size"
+        value={form.containerSize}
+        onChange={(event) => onChange({ containerSize: event.target.value })}
+      />
+    </StudioField>
+  </StudioFieldGroup>
+);
+
 export const FractionBasicsSection = ({
   form,
   submitAttempted,
@@ -76,73 +159,13 @@ export const FractionBasicsSection = ({
   readonly onChange: (patch: Partial<FractionFormState>) => void;
 }) => {
   const pt = usePluginTranslation('wasteManagement');
-  const descriptionLength = form.description.length;
 
   return (
     <FractionSection
       title={pt('masterData.fractions.createView.sections.basics')}
       description={pt('masterData.fractions.createView.sections.basicsHint')}
     >
-      <StudioFieldGroup>
-        <StudioField
-          id="waste-fraction-name"
-          label={pt('masterData.fractions.fields.name')}
-          description={pt('masterData.fractions.createView.fieldHints.name')}
-          error={submitAttempted ? errors.name : undefined}
-          required
-        >
-          <Input
-            id="waste-fraction-name"
-            value={form.name}
-            aria-invalid={submitAttempted && errors.name ? 'true' : undefined}
-            onChange={(event) => onChange({ name: event.target.value })}
-          />
-        </StudioField>
-        <StudioField
-          id="waste-fraction-description"
-          label={pt('masterData.fractions.fields.description')}
-          description={
-            <span className="flex items-center justify-between gap-3">
-              <span>{pt('masterData.fractions.createView.fieldHints.description')}</span>
-              <span className="shrink-0">{pt('masterData.fractions.createView.meta.descriptionCounter', { count: descriptionLength })}</span>
-            </span>
-          }
-        >
-          <Textarea
-            id="waste-fraction-description"
-            value={form.description}
-            rows={4}
-            maxLength={300}
-            onChange={(event) => onChange({ description: event.target.value })}
-          />
-        </StudioField>
-        <StudioField
-          id="waste-fraction-pdf-short-label"
-          label={pt('masterData.fractions.fields.pdfShortLabel')}
-          description={pt('masterData.fractions.createView.fieldHints.pdfShortLabel')}
-          error={submitAttempted ? errors.pdfShortLabel : undefined}
-          required
-        >
-          <Input
-            id="waste-fraction-pdf-short-label"
-            value={form.pdfShortLabel}
-            maxLength={12}
-            aria-invalid={submitAttempted && errors.pdfShortLabel ? 'true' : undefined}
-            onChange={(event) => onChange({ pdfShortLabel: event.target.value })}
-          />
-        </StudioField>
-        <StudioField
-          id="waste-fraction-container-size"
-          label={pt('masterData.fractions.fields.containerSize')}
-          description={pt('masterData.fractions.createView.fieldHints.containerSize')}
-        >
-          <Input
-            id="waste-fraction-container-size"
-            value={form.containerSize}
-            onChange={(event) => onChange({ containerSize: event.target.value })}
-          />
-        </StudioField>
-      </StudioFieldGroup>
+      <FractionBasicsFields form={form} submitAttempted={submitAttempted} errors={errors} onChange={onChange} pt={pt} />
     </FractionSection>
   );
 };

--- a/packages/plugin-waste-management/src/waste-management.master-data-fraction-create.parts.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-fraction-create.parts.tsx
@@ -7,6 +7,7 @@ import type { FractionFormState } from './waste-management.master-data.forms.js'
 
 export type FractionFormErrors = {
   readonly name?: string;
+  readonly pdfShortLabel?: string;
   readonly color?: string;
 };
 
@@ -18,6 +19,9 @@ export const validateFractionForm = (
   pt: ReturnType<typeof usePluginTranslation>
 ): FractionFormErrors => ({
   name: form.name.trim() ? undefined : pt('masterData.fractions.createView.validation.nameRequired'),
+  pdfShortLabel: form.pdfShortLabel.trim()
+    ? undefined
+    : pt('masterData.fractions.createView.validation.pdfShortLabelRequired'),
   color: isHexColor(form.color) ? undefined : pt('masterData.fractions.createView.validation.colorRequired'),
 });
 
@@ -116,11 +120,14 @@ export const FractionBasicsSection = ({
           id="waste-fraction-pdf-short-label"
           label={pt('masterData.fractions.fields.pdfShortLabel')}
           description={pt('masterData.fractions.createView.fieldHints.pdfShortLabel')}
+          error={submitAttempted ? errors.pdfShortLabel : undefined}
+          required
         >
           <Input
             id="waste-fraction-pdf-short-label"
             value={form.pdfShortLabel}
             maxLength={12}
+            aria-invalid={submitAttempted && errors.pdfShortLabel ? 'true' : undefined}
             onChange={(event) => onChange({ pdfShortLabel: event.target.value })}
           />
         </StudioField>

--- a/packages/plugin-waste-management/src/waste-management.master-data-fraction-dialog.fields.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-fraction-dialog.fields.tsx
@@ -1,0 +1,165 @@
+import { usePluginTranslation } from '@sva/plugin-sdk';
+import {
+  Input,
+  StudioField,
+  StudioFieldGroup,
+  StudioFormSummaryErrors,
+  getStudioFormFieldProps,
+} from '@sva/studio-ui-react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { WasteManagementFormSwitch } from './waste-management.form-switch.js';
+import type { FractionFormState } from './waste-management.master-data.forms.js';
+import { collectSummaryErrors, type BaseProps } from './waste-management.master-data-entity-dialogs.shared.js';
+
+const FractionDialogTextFields = ({
+  clearErrors,
+  nameField,
+  onChange,
+  pdfShortLabel,
+  pdfShortLabelField,
+  pt,
+  register,
+  translations,
+}: {
+  readonly clearErrors: ReturnType<typeof useForm<FractionFormState>>['clearErrors'];
+  readonly nameField: ReturnType<typeof getStudioFormFieldProps>;
+  readonly onChange: BaseProps<FractionFormState>['onChange'];
+  readonly pdfShortLabel: FractionFormState['pdfShortLabel'];
+  readonly pdfShortLabelField: ReturnType<typeof getStudioFormFieldProps>;
+  readonly pt: ReturnType<typeof usePluginTranslation>;
+  readonly register: ReturnType<typeof useForm<FractionFormState>>['register'];
+  readonly translations: FractionFormState['translations'];
+}) => (
+  <StudioFieldGroup>
+    <StudioField {...nameField} label={pt('masterData.fractions.fields.name')}>
+      <Input
+        {...nameField.controlProps}
+        {...register('name', {
+          required: pt('masterData.fractions.fields.name'),
+          onChange: (event) => {
+            clearErrors('name');
+            onChange({ name: event.target.value });
+          },
+        })}
+      />
+    </StudioField>
+    <StudioField {...pdfShortLabelField} label={pt('masterData.fractions.fields.pdfShortLabel')}>
+      <Input
+        {...pdfShortLabelField.controlProps}
+        value={pdfShortLabel}
+        maxLength={12}
+        {...register('pdfShortLabel', {
+          required: pt('masterData.fractions.fields.pdfShortLabel'),
+          onChange: (event) => {
+            clearErrors('pdfShortLabel');
+            onChange({ pdfShortLabel: event.target.value });
+          },
+        })}
+      />
+    </StudioField>
+    <StudioField id="waste-fraction-name-de" label={pt('masterData.fractions.fields.translationDe')}>
+      <Input
+        id="waste-fraction-name-de"
+        {...register('translations.de' as const, {
+          onChange: (event) => onChange({ translations: { ...translations, de: event.target.value } }),
+        })}
+      />
+    </StudioField>
+    <StudioField id="waste-fraction-name-en" label={pt('masterData.fractions.fields.translationEn')}>
+      <Input
+        id="waste-fraction-name-en"
+        {...register('translations.en' as const, {
+          onChange: (event) => onChange({ translations: { ...translations, en: event.target.value } }),
+        })}
+      />
+    </StudioField>
+    <StudioField id="waste-fraction-color" label={pt('masterData.fractions.fields.color')}>
+      <Input id="waste-fraction-color" {...register('color', { onChange: (event) => onChange({ color: event.target.value }) })} />
+    </StudioField>
+    <StudioField id="waste-fraction-container-size" label={pt('masterData.fractions.fields.containerSize')}>
+      <Input id="waste-fraction-container-size" {...register('containerSize', { onChange: (event) => onChange({ containerSize: event.target.value }) })} />
+    </StudioField>
+    <StudioField id="waste-fraction-description" label={pt('masterData.fractions.fields.description')}>
+      <Input id="waste-fraction-description" {...register('description', { onChange: (event) => onChange({ description: event.target.value }) })} />
+    </StudioField>
+  </StudioFieldGroup>
+);
+
+const FractionDialogActiveField = ({
+  active,
+  control,
+  onChange,
+  pt,
+}: {
+  readonly active: boolean;
+  readonly control: ReturnType<typeof useForm<FractionFormState>>['control'];
+  readonly onChange: BaseProps<FractionFormState>['onChange'];
+  readonly pt: ReturnType<typeof usePluginTranslation>;
+}) => (
+  <div className="flex items-center gap-3">
+    <Controller
+      name="active"
+      control={control}
+      render={({ field }) => (
+        <WasteManagementFormSwitch
+          checked={field.value}
+          ariaLabel={pt('masterData.fractions.fields.active')}
+          onChange={(nextActive) => {
+            field.onChange(nextActive);
+            onChange({ active: nextActive });
+          }}
+        />
+      )}
+    />
+    <span className="text-sm text-muted-foreground">{active ? pt('common.active') : pt('common.inactive')}</span>
+  </div>
+);
+
+export const FractionDialogFields = ({
+  active,
+  clearErrors,
+  control,
+  errors,
+  onChange,
+  pdfShortLabel,
+  pt,
+  register,
+  translations,
+}: {
+  readonly active: boolean;
+  readonly clearErrors: ReturnType<typeof useForm<FractionFormState>>['clearErrors'];
+  readonly control: ReturnType<typeof useForm<FractionFormState>>['control'];
+  readonly errors: ReturnType<typeof useForm<FractionFormState>>['formState']['errors'];
+  readonly onChange: BaseProps<FractionFormState>['onChange'];
+  readonly pdfShortLabel: FractionFormState['pdfShortLabel'];
+  readonly pt: ReturnType<typeof usePluginTranslation>;
+  readonly register: ReturnType<typeof useForm<FractionFormState>>['register'];
+  readonly translations: FractionFormState['translations'];
+}) => {
+  const nameField = getStudioFormFieldProps({
+    id: 'waste-fraction-name',
+    error: errors.name,
+  });
+  const pdfShortLabelField = getStudioFormFieldProps({
+    id: 'waste-fraction-pdf-short-label',
+    error: errors.pdfShortLabel,
+  });
+
+  return (
+    <>
+      <StudioFormSummaryErrors errors={collectSummaryErrors([nameField, pdfShortLabelField])} />
+      <FractionDialogTextFields
+        clearErrors={clearErrors}
+        nameField={nameField}
+        onChange={onChange}
+        pdfShortLabel={pdfShortLabel}
+        pdfShortLabelField={pdfShortLabelField}
+        pt={pt}
+        register={register}
+        translations={translations}
+      />
+      <FractionDialogActiveField active={active} control={control} onChange={onChange} pt={pt} />
+    </>
+  );
+};

--- a/packages/plugin-waste-management/src/waste-management.master-data-fraction-dialog.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-fraction-dialog.tsx
@@ -29,6 +29,7 @@ const FractionDialogFields = ({
   control,
   errors,
   onChange,
+  pdfShortLabel,
   pt,
   register,
   translations,
@@ -38,6 +39,7 @@ const FractionDialogFields = ({
   readonly control: ReturnType<typeof useForm<FractionFormState>>['control'];
   readonly errors: ReturnType<typeof useForm<FractionFormState>>['formState']['errors'];
   readonly onChange: BaseProps<FractionFormState>['onChange'];
+  readonly pdfShortLabel: FractionFormState['pdfShortLabel'];
   readonly pt: ReturnType<typeof usePluginTranslation>;
   readonly register: ReturnType<typeof useForm<FractionFormState>>['register'];
   readonly translations: FractionFormState['translations'];
@@ -46,11 +48,24 @@ const FractionDialogFields = ({
     id: 'waste-fraction-name',
     error: errors.name,
   });
+  const pdfShortLabelField = getStudioFormFieldProps({
+    id: 'waste-fraction-pdf-short-label',
+    error: errors.pdfShortLabel,
+  });
 
   return (
     <>
-      <StudioFormSummaryErrors errors={collectSummaryErrors([nameField])} />
-      <FractionDialogTextFields clearErrors={clearErrors} nameField={nameField} onChange={onChange} pt={pt} register={register} translations={translations} />
+      <StudioFormSummaryErrors errors={collectSummaryErrors([nameField, pdfShortLabelField])} />
+      <FractionDialogTextFields
+        clearErrors={clearErrors}
+        nameField={nameField}
+        onChange={onChange}
+        pdfShortLabel={pdfShortLabel}
+        pdfShortLabelField={pdfShortLabelField}
+        pt={pt}
+        register={register}
+        translations={translations}
+      />
       <FractionDialogActiveField active={active} control={control} onChange={onChange} pt={pt} />
     </>
   );
@@ -60,6 +75,8 @@ const FractionDialogTextFields = ({
   clearErrors,
   nameField,
   onChange,
+  pdfShortLabel,
+  pdfShortLabelField,
   pt,
   register,
   translations,
@@ -67,6 +84,8 @@ const FractionDialogTextFields = ({
   readonly clearErrors: ReturnType<typeof useForm<FractionFormState>>['clearErrors'];
   readonly nameField: ReturnType<typeof getStudioFormFieldProps>;
   readonly onChange: BaseProps<FractionFormState>['onChange'];
+  readonly pdfShortLabel: FractionFormState['pdfShortLabel'];
+  readonly pdfShortLabelField: ReturnType<typeof getStudioFormFieldProps>;
   readonly pt: ReturnType<typeof usePluginTranslation>;
   readonly register: ReturnType<typeof useForm<FractionFormState>>['register'];
   readonly translations: FractionFormState['translations'];
@@ -80,6 +99,20 @@ const FractionDialogTextFields = ({
           onChange: (event) => {
             clearErrors('name');
             onChange({ name: event.target.value });
+          },
+        })}
+      />
+    </StudioField>
+    <StudioField {...pdfShortLabelField} label={pt('masterData.fractions.fields.pdfShortLabel')}>
+      <Input
+        {...pdfShortLabelField.controlProps}
+        value={pdfShortLabel}
+        maxLength={12}
+        {...register('pdfShortLabel', {
+          required: pt('masterData.fractions.fields.pdfShortLabel'),
+          onChange: (event) => {
+            clearErrors('pdfShortLabel');
+            onChange({ pdfShortLabel: event.target.value });
           },
         })}
       />
@@ -217,6 +250,7 @@ const FractionDialogForm = ({
             control={control}
             errors={errors}
             onChange={onChange}
+            pdfShortLabel={watch('pdfShortLabel')}
             pt={pt}
             register={register}
             translations={watch('translations')}

--- a/packages/plugin-waste-management/src/waste-management.master-data-fraction-dialog.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-fraction-dialog.tsx
@@ -2,178 +2,19 @@ import { usePluginTranslation } from '@sva/plugin-sdk';
 import {
   Dialog,
   DialogContent,
-  Input,
-  StudioField,
-  StudioFieldGroup,
-  StudioFormSummaryErrors,
-  getStudioFormFieldProps,
 } from '@sva/studio-ui-react';
-import React from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 
-import { WasteManagementFormSwitch } from './waste-management.form-switch.js';
 import type { FractionFormState } from './waste-management.master-data.forms.js';
 import {
-  collectSummaryErrors,
   createSubmitHandler,
   MasterDataDialogActions,
   MasterDataDialogHeader,
   type BaseProps,
   useResetOnFormContextChange,
 } from './waste-management.master-data-entity-dialogs.shared.js';
+import { FractionDialogFields } from './waste-management.master-data-fraction-dialog.fields.js';
 import { StatusNotice } from './waste-management.page.support.js';
-
-const FractionDialogFields = ({
-  active,
-  clearErrors,
-  control,
-  errors,
-  onChange,
-  pdfShortLabel,
-  pt,
-  register,
-  translations,
-}: {
-  readonly active: boolean;
-  readonly clearErrors: ReturnType<typeof useForm<FractionFormState>>['clearErrors'];
-  readonly control: ReturnType<typeof useForm<FractionFormState>>['control'];
-  readonly errors: ReturnType<typeof useForm<FractionFormState>>['formState']['errors'];
-  readonly onChange: BaseProps<FractionFormState>['onChange'];
-  readonly pdfShortLabel: FractionFormState['pdfShortLabel'];
-  readonly pt: ReturnType<typeof usePluginTranslation>;
-  readonly register: ReturnType<typeof useForm<FractionFormState>>['register'];
-  readonly translations: FractionFormState['translations'];
-}) => {
-  const nameField = getStudioFormFieldProps({
-    id: 'waste-fraction-name',
-    error: errors.name,
-  });
-  const pdfShortLabelField = getStudioFormFieldProps({
-    id: 'waste-fraction-pdf-short-label',
-    error: errors.pdfShortLabel,
-  });
-
-  return (
-    <>
-      <StudioFormSummaryErrors errors={collectSummaryErrors([nameField, pdfShortLabelField])} />
-      <FractionDialogTextFields
-        clearErrors={clearErrors}
-        nameField={nameField}
-        onChange={onChange}
-        pdfShortLabel={pdfShortLabel}
-        pdfShortLabelField={pdfShortLabelField}
-        pt={pt}
-        register={register}
-        translations={translations}
-      />
-      <FractionDialogActiveField active={active} control={control} onChange={onChange} pt={pt} />
-    </>
-  );
-};
-
-const FractionDialogTextFields = ({
-  clearErrors,
-  nameField,
-  onChange,
-  pdfShortLabel,
-  pdfShortLabelField,
-  pt,
-  register,
-  translations,
-}: {
-  readonly clearErrors: ReturnType<typeof useForm<FractionFormState>>['clearErrors'];
-  readonly nameField: ReturnType<typeof getStudioFormFieldProps>;
-  readonly onChange: BaseProps<FractionFormState>['onChange'];
-  readonly pdfShortLabel: FractionFormState['pdfShortLabel'];
-  readonly pdfShortLabelField: ReturnType<typeof getStudioFormFieldProps>;
-  readonly pt: ReturnType<typeof usePluginTranslation>;
-  readonly register: ReturnType<typeof useForm<FractionFormState>>['register'];
-  readonly translations: FractionFormState['translations'];
-}) => (
-  <StudioFieldGroup>
-    <StudioField {...nameField} label={pt('masterData.fractions.fields.name')}>
-      <Input
-        {...nameField.controlProps}
-        {...register('name', {
-          required: pt('masterData.fractions.fields.name'),
-          onChange: (event) => {
-            clearErrors('name');
-            onChange({ name: event.target.value });
-          },
-        })}
-      />
-    </StudioField>
-    <StudioField {...pdfShortLabelField} label={pt('masterData.fractions.fields.pdfShortLabel')}>
-      <Input
-        {...pdfShortLabelField.controlProps}
-        value={pdfShortLabel}
-        maxLength={12}
-        {...register('pdfShortLabel', {
-          required: pt('masterData.fractions.fields.pdfShortLabel'),
-          onChange: (event) => {
-            clearErrors('pdfShortLabel');
-            onChange({ pdfShortLabel: event.target.value });
-          },
-        })}
-      />
-    </StudioField>
-    <StudioField id="waste-fraction-name-de" label={pt('masterData.fractions.fields.translationDe')}>
-      <Input
-        id="waste-fraction-name-de"
-        {...register('translations.de' as const, {
-          onChange: (event) => onChange({ translations: { ...translations, de: event.target.value } }),
-        })}
-      />
-    </StudioField>
-    <StudioField id="waste-fraction-name-en" label={pt('masterData.fractions.fields.translationEn')}>
-      <Input
-        id="waste-fraction-name-en"
-        {...register('translations.en' as const, {
-          onChange: (event) => onChange({ translations: { ...translations, en: event.target.value } }),
-        })}
-      />
-    </StudioField>
-    <StudioField id="waste-fraction-color" label={pt('masterData.fractions.fields.color')}>
-      <Input id="waste-fraction-color" {...register('color', { onChange: (event) => onChange({ color: event.target.value }) })} />
-    </StudioField>
-    <StudioField id="waste-fraction-container-size" label={pt('masterData.fractions.fields.containerSize')}>
-      <Input id="waste-fraction-container-size" {...register('containerSize', { onChange: (event) => onChange({ containerSize: event.target.value }) })} />
-    </StudioField>
-    <StudioField id="waste-fraction-description" label={pt('masterData.fractions.fields.description')}>
-      <Input id="waste-fraction-description" {...register('description', { onChange: (event) => onChange({ description: event.target.value }) })} />
-    </StudioField>
-  </StudioFieldGroup>
-);
-
-const FractionDialogActiveField = ({
-  active,
-  control,
-  onChange,
-  pt,
-}: {
-  readonly active: boolean;
-  readonly control: ReturnType<typeof useForm<FractionFormState>>['control'];
-  readonly onChange: BaseProps<FractionFormState>['onChange'];
-  readonly pt: ReturnType<typeof usePluginTranslation>;
-}) => (
-  <div className="flex items-center gap-3">
-    <Controller
-      name="active"
-      control={control}
-      render={({ field }) => (
-        <WasteManagementFormSwitch
-          checked={field.value}
-          ariaLabel={pt('masterData.fractions.fields.active')}
-          onChange={(nextActive) => {
-            field.onChange(nextActive);
-            onChange({ active: nextActive });
-          }}
-        />
-      )}
-    />
-    <span className="text-sm text-muted-foreground">{active ? pt('common.active') : pt('common.inactive')}</span>
-  </div>
-);
 
 export const FractionDialog = ({ open, mode, form, saving, message, onOpenChange, onChange, onBeforeSubmit, onSubmit }: BaseProps<FractionFormState>) => {
   const pt = usePluginTranslation('wasteManagement');

--- a/packages/plugin-waste-management/src/waste-management.master-data-fractions-content.columns.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-fractions-content.columns.tsx
@@ -11,6 +11,14 @@ const createFractionIdentityColumn = (pt: ReturnType<typeof usePluginTranslation
   cell: (fraction) => <p className="font-medium">{fraction.containerSize ? `${fraction.name} (${fraction.containerSize})` : fraction.name}</p>,
 });
 
+const createFractionShortLabelColumn = (pt: ReturnType<typeof usePluginTranslation>): StudioColumnDef<WasteFractionRecord> => ({
+  id: 'pdfShortLabel',
+  header: pt('masterData.fractions.table.shortLabel'),
+  mobileLabel: pt('masterData.fractions.table.shortLabel'),
+  cell: (fraction) =>
+    fraction.pdfShortLabel ? <span className="font-mono text-sm uppercase">{fraction.pdfShortLabel}</span> : null,
+});
+
 const createFractionColorColumn = (pt: ReturnType<typeof usePluginTranslation>): StudioColumnDef<WasteFractionRecord> => ({
   id: 'color',
   header: pt('masterData.fractions.table.color'),
@@ -100,6 +108,7 @@ export const useFractionColumns = ({
   const pt = usePluginTranslation('wasteManagement');
   return [
     createFractionIdentityColumn(pt),
+    createFractionShortLabelColumn(pt),
     createFractionColorColumn(pt),
     createFractionDescriptionColumn(pt),
     createFractionStatusColumn({ pt, saving, onToggleFractionStatus }),

--- a/packages/plugin-waste-management/src/waste-management.master-data-panel.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-panel.tsx
@@ -5,8 +5,32 @@ import { useWasteMasterDataController } from './waste-management.master-data.con
 import { WasteMasterDataDialogs } from './waste-management.master-data-dialogs.js';
 import { WasteMasterDataPanelEmptyState } from './waste-management.master-data-panel.empty-state.js';
 import { WasteMasterDataTabContent } from './waste-management.master-data-tab-content.js';
-import { StatusNotice } from './waste-management.page.support.js';
+import { StatusNotice, type StatusMessage } from './waste-management.page.support.js';
 import type { WasteManagementSearchParams } from './search-params.js';
+
+const hasAnyMasterData = (
+  overview: ReturnType<typeof useWasteMasterDataController>['overview']
+): boolean =>
+  Boolean(
+    overview &&
+      (
+        overview.fractions.length > 0 ||
+        overview.regions.length > 0 ||
+        overview.cities.length > 0 ||
+        overview.streets.length > 0 ||
+        overview.houseNumbers.length > 0 ||
+        overview.collectionLocations.length > 0
+      )
+  );
+
+const retrySyncWasteTypes = async (
+  controller: ReturnType<typeof useWasteMasterDataController>,
+  action: NonNullable<StatusMessage['retryAction']>
+) => {
+  if (action === 'sync-waste-types') {
+    await controller.retrySyncWasteTypes();
+  }
+};
 
 export const WasteMasterDataPanel = ({
   search,
@@ -29,30 +53,13 @@ export const WasteMasterDataPanel = ({
   const dialogs = <WasteMasterDataDialogs controller={controller} />;
   const showFractionFormView = tab === 'fractions' && search.fractionsView !== 'list';
   const showLocationFormView = tab === 'locations' && search.locationsView !== 'list';
-  const hasAnyMasterData = Boolean(
-    controller.overview &&
-      (
-        controller.overview.fractions.length > 0 ||
-        controller.overview.regions.length > 0 ||
-        controller.overview.cities.length > 0 ||
-        controller.overview.streets.length > 0 ||
-        controller.overview.houseNumbers.length > 0 ||
-        controller.overview.collectionLocations.length > 0
-      )
-  );
+  const showEmptyState = !showFractionFormView && !showLocationFormView && !hasAnyMasterData(controller.overview);
 
-  if (!showFractionFormView && !showLocationFormView && !hasAnyMasterData) {
+  if (showEmptyState) {
     return (
       <>
         <div className="space-y-4">
-          <StatusNotice
-            message={controller.message}
-            onRetry={(action) => {
-              if (action === 'sync-waste-types') {
-                void controller.retrySyncWasteTypes();
-              }
-            }}
-          />
+          <StatusNotice message={controller.message} onRetry={(action) => void retrySyncWasteTypes(controller, action)} />
         </div>
         <WasteMasterDataPanelEmptyState controller={controller} search={search} />
         {dialogs}
@@ -63,14 +70,7 @@ export const WasteMasterDataPanel = ({
   return (
     <>
       <div className="space-y-4">
-        <StatusNotice
-          message={controller.message}
-          onRetry={(action) => {
-            if (action === 'sync-waste-types') {
-              void controller.retrySyncWasteTypes();
-            }
-          }}
-        />
+        <StatusNotice message={controller.message} onRetry={(action) => void retrySyncWasteTypes(controller, action)} />
         <WasteMasterDataTabContent controller={controller} search={search} tab={tab} />
       </div>
       {dialogs}

--- a/packages/plugin-waste-management/src/waste-management.master-data-panel.tsx
+++ b/packages/plugin-waste-management/src/waste-management.master-data-panel.tsx
@@ -44,6 +44,16 @@ export const WasteMasterDataPanel = ({
   if (!showFractionFormView && !showLocationFormView && !hasAnyMasterData) {
     return (
       <>
+        <div className="space-y-4">
+          <StatusNotice
+            message={controller.message}
+            onRetry={(action) => {
+              if (action === 'sync-waste-types') {
+                void controller.retrySyncWasteTypes();
+              }
+            }}
+          />
+        </div>
         <WasteMasterDataPanelEmptyState controller={controller} search={search} />
         {dialogs}
       </>
@@ -53,7 +63,14 @@ export const WasteMasterDataPanel = ({
   return (
     <>
       <div className="space-y-4">
-        <StatusNotice message={controller.message} />
+        <StatusNotice
+          message={controller.message}
+          onRetry={(action) => {
+            if (action === 'sync-waste-types') {
+              void controller.retrySyncWasteTypes();
+            }
+          }}
+        />
         <WasteMasterDataTabContent controller={controller} search={search} tab={tab} />
       </div>
       {dialogs}

--- a/packages/plugin-waste-management/src/waste-management.master-data.controller.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.controller.ts
@@ -6,10 +6,13 @@ import {
 import { startWasteManagementSyncWasteTypes } from './waste-management.api.js';
 import { useWasteMasterDataDataLoading } from './waste-management.master-data.loaders.js';
 import { createWasteMasterDataSubmitHandlers } from './waste-management.master-data.submissions.js';
+import { useWasteTrackedJob } from './waste-management.tools.job-state.js';
 import type { WasteManagementSearchParams } from './search-params.js';
 import { useWasteMasterDataState } from './waste-management.master-data.state.js';
 
 type Translate = (key: string, variables?: Readonly<Record<string, string | number>>) => string;
+
+const noopRefreshTechnicalHistory = async () => undefined;
 
 export const useWasteMasterDataController = (pt: Translate, search: WasteManagementSearchParams) => {
   const state = useWasteMasterDataState();
@@ -25,15 +28,33 @@ export const useWasteMasterDataController = (pt: Translate, search: WasteManagem
     selectedCollectionLocationIds: derivedState.selectedCollectionLocations.map((location) => location.id),
   });
   const resetActions = createWasteMasterDataResetActions(state);
+
+  useWasteTrackedJob({
+    lastJob: state.trackedSyncWasteTypesJob,
+    refreshTechnicalHistory: noopRefreshTechnicalHistory,
+    setLastJob: state.setTrackedSyncWasteTypesJob,
+    onTerminalJob: async (job) => {
+      if (job.status === 'failed' || job.status === 'cancelled') {
+        state.setMessage({
+          kind: 'warning',
+          text: pt('masterData.fractions.messages.syncWarning'),
+          retryAction: 'sync-waste-types',
+        });
+      }
+    },
+  });
+
   const retrySyncWasteTypes = async () => {
     state.setMessage(null);
     try {
-      await startWasteManagementSyncWasteTypes();
+      const job = await startWasteManagementSyncWasteTypes();
+      state.setTrackedSyncWasteTypesJob(job ?? null);
       state.setMessage({
         kind: 'success',
         text: pt('masterData.fractions.messages.syncRetryStarted'),
       });
     } catch {
+      state.setTrackedSyncWasteTypesJob(null);
       state.setMessage({
         kind: 'warning',
         text: pt('masterData.fractions.messages.syncWarning'),

--- a/packages/plugin-waste-management/src/waste-management.master-data.controller.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.controller.ts
@@ -3,6 +3,7 @@ import {
   createWasteMasterDataDerivedState,
   createWasteMasterDataResetActions,
 } from './waste-management.master-data.derived.js';
+import { startWasteManagementSyncWasteTypes } from './waste-management.api.js';
 import { useWasteMasterDataDataLoading } from './waste-management.master-data.loaders.js';
 import { createWasteMasterDataSubmitHandlers } from './waste-management.master-data.submissions.js';
 import type { WasteManagementSearchParams } from './search-params.js';
@@ -24,6 +25,22 @@ export const useWasteMasterDataController = (pt: Translate, search: WasteManagem
     selectedCollectionLocationIds: derivedState.selectedCollectionLocations.map((location) => location.id),
   });
   const resetActions = createWasteMasterDataResetActions(state);
+  const retrySyncWasteTypes = async () => {
+    state.setMessage(null);
+    try {
+      await startWasteManagementSyncWasteTypes();
+      state.setMessage({
+        kind: 'success',
+        text: pt('masterData.fractions.messages.syncRetryStarted'),
+      });
+    } catch {
+      state.setMessage({
+        kind: 'warning',
+        text: pt('masterData.fractions.messages.syncWarning'),
+        retryAction: 'sync-waste-types',
+      });
+    }
+  };
 
   return {
     ...state,
@@ -33,5 +50,6 @@ export const useWasteMasterDataController = (pt: Translate, search: WasteManagem
     ...submitHandlers,
     ...resetActions,
     reloadOverview: loadOverview,
+    retrySyncWasteTypes,
   };
 };

--- a/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
@@ -177,7 +177,7 @@ export const wasteMasterDataInputMappers = {
   toCreateFractionInput: (form: FractionFormState): CreateWasteManagementFractionInput => ({
     id: form.id,
     name: form.name.trim(),
-    pdfShortLabel: compactOptionalString(form.pdfShortLabel),
+    pdfShortLabel: form.pdfShortLabel.trim(),
     translations: normalizeLocalizedTextRecord(form.translations),
     containerSize: compactOptionalString(form.containerSize),
     color: form.color.trim(),
@@ -187,7 +187,7 @@ export const wasteMasterDataInputMappers = {
   }),
   toUpdateFractionInput: (form: FractionFormState): UpdateWasteManagementFractionInput => ({
     name: form.name.trim(),
-    pdfShortLabel: compactOptionalString(form.pdfShortLabel),
+    pdfShortLabel: form.pdfShortLabel.trim(),
     translations: normalizeLocalizedTextRecord(form.translations),
     containerSize: compactOptionalString(form.containerSize),
     color: form.color.trim(),

--- a/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.forms.ts
@@ -59,6 +59,7 @@ export type CollectionLocationFormState = {
 
 export type LocationTourLinkBulkFormState = { readonly tourId: string; readonly startDate: string; readonly endDate: string };
 const defaultFractionReminderLeadDays = 1;
+const normalizeFractionShortLabel = (value: string): string => value.trim().toUpperCase();
 
 export const wasteMasterDataFormDefaults = {
   createFraction: (): FractionFormState => ({
@@ -177,7 +178,7 @@ export const wasteMasterDataInputMappers = {
   toCreateFractionInput: (form: FractionFormState): CreateWasteManagementFractionInput => ({
     id: form.id,
     name: form.name.trim(),
-    pdfShortLabel: form.pdfShortLabel.trim(),
+    pdfShortLabel: normalizeFractionShortLabel(form.pdfShortLabel),
     translations: normalizeLocalizedTextRecord(form.translations),
     containerSize: compactOptionalString(form.containerSize),
     color: form.color.trim(),
@@ -187,7 +188,7 @@ export const wasteMasterDataInputMappers = {
   }),
   toUpdateFractionInput: (form: FractionFormState): UpdateWasteManagementFractionInput => ({
     name: form.name.trim(),
-    pdfShortLabel: form.pdfShortLabel.trim(),
+    pdfShortLabel: normalizeFractionShortLabel(form.pdfShortLabel),
     translations: normalizeLocalizedTextRecord(form.translations),
     containerSize: compactOptionalString(form.containerSize),
     color: form.color.trim(),

--- a/packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts
@@ -4,7 +4,7 @@ import {
   createWasteManagementFraction,
   createWasteManagementRegion,
   deleteWasteManagementFraction,
-  startWasteManagementSyncWasteTypes,
+  type WasteFractionMutationResponse,
   updateWasteManagementFraction,
   updateWasteManagementRegion,
 } from './waste-management.api.js';
@@ -40,7 +40,9 @@ const setFractionSaveErrorMessage = (ctx: FractionRegionSubmissionHelperContext,
     text:
       code === 'forbidden'
         ? ctx.pt('masterData.fractions.messages.saveForbidden')
-        : ctx.pt('masterData.fractions.messages.saveError'),
+        : code === 'conflict'
+          ? ctx.pt('masterData.fractions.messages.saveConflict')
+          : ctx.pt('masterData.fractions.messages.saveError'),
   });
 };
 
@@ -55,20 +57,22 @@ const setRegionSaveErrorMessage = (ctx: FractionRegionSubmissionHelperContext, e
   });
 };
 
-const startFractionSyncWithWarning = async (ctx: FractionRegionSubmissionHelperContext) => {
-  try {
-    const job = await startWasteManagementSyncWasteTypes();
-    ctx.state.setTrackedSyncWasteTypesJob(job ?? null);
+const applyFractionSyncResult = <T>(
+  ctx: FractionRegionSubmissionHelperContext,
+  response: WasteFractionMutationResponse<T>
+) => {
+  if (response.syncStatus === 'queued' && response.syncJob) {
+    ctx.state.setTrackedSyncWasteTypesJob(response.syncJob);
     return true;
-  } catch {
-    ctx.state.setTrackedSyncWasteTypesJob(null);
-    ctx.state.setMessage({
-      kind: 'warning',
-      text: ctx.pt('masterData.fractions.messages.syncWarning'),
-      retryAction: 'sync-waste-types',
-    });
-    return false;
   }
+
+  ctx.state.setTrackedSyncWasteTypesJob(null);
+  ctx.state.setMessage({
+    kind: 'warning',
+    text: ctx.pt('masterData.fractions.messages.syncWarning'),
+    retryAction: 'sync-waste-types',
+  });
+  return false;
 };
 
 export const createSubmitFractionHandler =
@@ -79,16 +83,16 @@ export const createSubmitFractionHandler =
     ctx.state.setMessage(null);
     ctx.state.setLastOutcome(null);
     try {
-      if (mode === 'create') {
-        await createWasteManagementFraction(wasteMasterDataInputMappers.toCreateFractionInput(ctx.state.fractionForm));
-      } else {
-        await updateWasteManagementFraction(
-          ctx.state.fractionForm.id,
-          wasteMasterDataInputMappers.toUpdateFractionInput(ctx.state.fractionForm)
-        );
-      }
+      const response =
+        mode === 'create'
+          ? await createWasteManagementFraction(wasteMasterDataInputMappers.toCreateFractionInput(ctx.state.fractionForm))
+          : await updateWasteManagementFraction(
+              ctx.state.fractionForm.id,
+              wasteMasterDataInputMappers.toUpdateFractionInput(ctx.state.fractionForm)
+            );
+
       await ctx.loadOverview(true);
-      const syncStarted = await startFractionSyncWithWarning(ctx);
+      const syncStarted = applyFractionSyncResult(ctx, response);
       applySuccess(
         () => ctx.state.setDialogOpen(false),
         ctx.state.setMessage,
@@ -110,9 +114,9 @@ export const createDeleteFractionHandler = (ctx: FractionRegionSubmissionHelperC
   ctx.state.setMessage(null);
   ctx.state.setLastOutcome(null);
   try {
-    await deleteWasteManagementFraction(fractionId);
+    const response = await deleteWasteManagementFraction(fractionId);
     await ctx.loadOverview(true);
-    const syncStarted = await startFractionSyncWithWarning(ctx);
+    const syncStarted = applyFractionSyncResult(ctx, response);
     if (syncStarted) {
       ctx.state.setMessage({ kind: 'success', text: ctx.pt('masterData.fractions.messages.deleteSuccess') });
     }
@@ -130,20 +134,24 @@ export const createDeleteFractionsHandler = (ctx: FractionRegionSubmissionHelper
   ctx.state.setLastOutcome(null);
   try {
     const results = await Promise.allSettled(fractionIds.map((fractionId) => deleteWasteManagementFraction(fractionId)));
-    const deletedCount = results.filter((result) => result.status === 'fulfilled').length;
+    const fulfilledResults = results.filter(
+      (result): result is PromiseFulfilledResult<WasteFractionMutationResponse<{ readonly id: string }>> =>
+        result.status === 'fulfilled'
+    );
+    const deletedCount = fulfilledResults.length;
     const failedResults = results.filter((result) => result.status === 'rejected');
     if (deletedCount > 0) {
       await ctx.loadOverview(true);
     }
     if (failedResults.length === 0) {
-      const syncStarted = await startFractionSyncWithWarning(ctx);
+      const syncStarted = applyFractionSyncResult(ctx, fulfilledResults[0].value);
       if (syncStarted) {
         ctx.state.setMessage({ kind: 'success', text: ctx.pt('masterData.fractions.messages.deleteSuccess') });
       }
       return;
     }
     if (deletedCount > 0) {
-      const syncStarted = await startFractionSyncWithWarning(ctx);
+      const syncStarted = applyFractionSyncResult(ctx, fulfilledResults[0].value);
       if (syncStarted) {
         ctx.state.setMessage({
           kind: 'success',
@@ -166,7 +174,7 @@ export const createSetFractionActiveHandler = (ctx: FractionRegionSubmissionHelp
   ctx.state.setMessage(null);
   ctx.state.setLastOutcome(null);
   try {
-    await updateWasteManagementFraction(
+    const response = await updateWasteManagementFraction(
       fraction.id,
       wasteMasterDataInputMappers.toUpdateFractionInput({
         ...wasteMasterDataFormMappers.fractionToForm(fraction),
@@ -174,7 +182,7 @@ export const createSetFractionActiveHandler = (ctx: FractionRegionSubmissionHelp
       })
     );
     await ctx.loadOverview(true);
-    await startFractionSyncWithWarning(ctx);
+    applyFractionSyncResult(ctx, response);
   } catch (error) {
     setFractionSaveErrorMessage(ctx, error);
   } finally {

--- a/packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts
@@ -57,9 +57,11 @@ const setRegionSaveErrorMessage = (ctx: FractionRegionSubmissionHelperContext, e
 
 const startFractionSyncWithWarning = async (ctx: FractionRegionSubmissionHelperContext) => {
   try {
-    await startWasteManagementSyncWasteTypes();
+    const job = await startWasteManagementSyncWasteTypes();
+    ctx.state.setTrackedSyncWasteTypesJob(job ?? null);
     return true;
   } catch {
+    ctx.state.setTrackedSyncWasteTypesJob(null);
     ctx.state.setMessage({
       kind: 'warning',
       text: ctx.pt('masterData.fractions.messages.syncWarning'),

--- a/packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.fraction-region-submissions.helpers.ts
@@ -4,6 +4,7 @@ import {
   createWasteManagementFraction,
   createWasteManagementRegion,
   deleteWasteManagementFraction,
+  startWasteManagementSyncWasteTypes,
   updateWasteManagementFraction,
   updateWasteManagementRegion,
 } from './waste-management.api.js';
@@ -54,6 +55,20 @@ const setRegionSaveErrorMessage = (ctx: FractionRegionSubmissionHelperContext, e
   });
 };
 
+const startFractionSyncWithWarning = async (ctx: FractionRegionSubmissionHelperContext) => {
+  try {
+    await startWasteManagementSyncWasteTypes();
+    return true;
+  } catch {
+    ctx.state.setMessage({
+      kind: 'warning',
+      text: ctx.pt('masterData.fractions.messages.syncWarning'),
+      retryAction: 'sync-waste-types',
+    });
+    return false;
+  }
+};
+
 export const createSubmitFractionHandler =
   (ctx: FractionRegionSubmissionHelperContext) =>
   async (event: React.FormEvent<HTMLFormElement>, mode = ctx.state.dialogMode) => {
@@ -71,13 +86,15 @@ export const createSubmitFractionHandler =
         );
       }
       await ctx.loadOverview(true);
+      const syncStarted = await startFractionSyncWithWarning(ctx);
       applySuccess(
         () => ctx.state.setDialogOpen(false),
         ctx.state.setMessage,
         mode === 'create'
           ? ctx.pt('masterData.fractions.messages.createSuccess')
           : ctx.pt('masterData.fractions.messages.updateSuccess'),
-        () => ctx.state.setLastOutcome(mode === 'create' ? 'fraction-create-success' : 'fraction-update-success')
+        () => ctx.state.setLastOutcome(mode === 'create' ? 'fraction-create-success' : 'fraction-update-success'),
+        syncStarted
       );
     } catch (error) {
       setFractionSaveErrorMessage(ctx, error);
@@ -93,7 +110,10 @@ export const createDeleteFractionHandler = (ctx: FractionRegionSubmissionHelperC
   try {
     await deleteWasteManagementFraction(fractionId);
     await ctx.loadOverview(true);
-    ctx.state.setMessage({ kind: 'success', text: ctx.pt('masterData.fractions.messages.deleteSuccess') });
+    const syncStarted = await startFractionSyncWithWarning(ctx);
+    if (syncStarted) {
+      ctx.state.setMessage({ kind: 'success', text: ctx.pt('masterData.fractions.messages.deleteSuccess') });
+    }
   } catch (error) {
     setDeleteErrorMessage(ctx, error);
   } finally {
@@ -114,14 +134,20 @@ export const createDeleteFractionsHandler = (ctx: FractionRegionSubmissionHelper
       await ctx.loadOverview(true);
     }
     if (failedResults.length === 0) {
-      ctx.state.setMessage({ kind: 'success', text: ctx.pt('masterData.fractions.messages.deleteSuccess') });
+      const syncStarted = await startFractionSyncWithWarning(ctx);
+      if (syncStarted) {
+        ctx.state.setMessage({ kind: 'success', text: ctx.pt('masterData.fractions.messages.deleteSuccess') });
+      }
       return;
     }
     if (deletedCount > 0) {
-      ctx.state.setMessage({
-        kind: 'success',
-        text: ctx.pt('masterData.fractions.messages.deletePartialSuccess', { count: deletedCount, total: fractionIds.length }),
-      });
+      const syncStarted = await startFractionSyncWithWarning(ctx);
+      if (syncStarted) {
+        ctx.state.setMessage({
+          kind: 'success',
+          text: ctx.pt('masterData.fractions.messages.deletePartialSuccess', { count: deletedCount, total: fractionIds.length }),
+        });
+      }
       return;
     }
     setDeleteErrorMessage(ctx, failedResults[0]?.reason);
@@ -146,6 +172,7 @@ export const createSetFractionActiveHandler = (ctx: FractionRegionSubmissionHelp
       })
     );
     await ctx.loadOverview(true);
+    await startFractionSyncWithWarning(ctx);
   } catch (error) {
     setFractionSaveErrorMessage(ctx, error);
   } finally {

--- a/packages/plugin-waste-management/src/waste-management.master-data.state.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.state.ts
@@ -1,3 +1,4 @@
+import type { StudioJobResponse } from '@sva/plugin-sdk';
 import { type StatusMessage } from './waste-management.page.support.js';
 import { startTransition, useState } from 'react';
 import type { WasteManagementMasterDataOverview } from './waste-management.api.js';
@@ -9,6 +10,7 @@ export const useWasteMasterDataState = () => {
   const [overview, setOverview] = useState<WasteManagementMasterDataOverview | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<StatusMessage | null>(null);
+  const [trackedSyncWasteTypesJob, setTrackedSyncWasteTypesJob] = useState<StudioJobResponse['data'] | null>(null);
   const [lastOutcome, setLastOutcome] = useState<
     'fraction-create-success' | 'fraction-update-success' | 'location-create-success' | 'location-update-success' | null
   >(null);
@@ -21,6 +23,7 @@ export const useWasteMasterDataState = () => {
     overview,
     error,
     message,
+    trackedSyncWasteTypesJob,
     lastOutcome,
     saving,
     ...entityState,
@@ -29,6 +32,7 @@ export const useWasteMasterDataState = () => {
     setOverview,
     setError,
     setMessage,
+    setTrackedSyncWasteTypesJob,
     setLastOutcome,
     setSaving,
   };

--- a/packages/plugin-waste-management/src/waste-management.master-data.state.ts
+++ b/packages/plugin-waste-management/src/waste-management.master-data.state.ts
@@ -40,11 +40,14 @@ export const applySuccess = (
   closeDialog: () => void,
   setMessage: (message: StatusMessage | null) => void,
   text: string,
-  onSuccess?: () => void
+  onSuccess?: () => void,
+  showMessage = true
 ) => {
   startTransition(() => {
     closeDialog();
     onSuccess?.();
-    setMessage({ kind: 'success', text });
+    if (showMessage) {
+      setMessage({ kind: 'success', text });
+    }
   });
 };

--- a/packages/plugin-waste-management/src/waste-management.page.support.tsx
+++ b/packages/plugin-waste-management/src/waste-management.page.support.tsx
@@ -14,6 +14,7 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
+  Button,
   Input,
   StudioConfirmDialog,
   StudioField,
@@ -24,8 +25,9 @@ import * as XLSX from 'xlsx';
 import { WasteManagementApiError } from './waste-management.api.js';
 
 export type StatusMessage = {
-  readonly kind: 'success' | 'error';
+  readonly kind: 'success' | 'error' | 'warning';
   readonly text: string;
+  readonly retryAction?: 'sync-waste-types';
 };
 
 export type TechnicalStatusTone = 'neutral' | 'success' | 'warning' | 'error';
@@ -150,13 +152,33 @@ export const readFileAsDataUrl = async (file: File): Promise<string> =>
     reader.readAsDataURL(file);
   });
 
-export const StatusNotice = ({ message }: { readonly message: StatusMessage | null }) => {
+export const StatusNotice = ({
+  message,
+  onRetry,
+}: {
+  readonly message: StatusMessage | null;
+  readonly onRetry?: (action: NonNullable<StatusMessage['retryAction']>) => void;
+}) => {
   const pt = usePluginTranslation('wasteManagement');
+  const retryAction = message?.retryAction;
 
   return message ? (
     <Alert>
-      <AlertTitle>{message.kind === 'success' ? pt('common.statusSuccessTitle') : pt('common.statusErrorTitle')}</AlertTitle>
-      <AlertDescription>{message.text}</AlertDescription>
+      <AlertTitle>
+        {message.kind === 'success'
+          ? pt('common.statusSuccessTitle')
+          : message.kind === 'warning'
+            ? pt('common.statusWarningTitle')
+            : pt('common.statusErrorTitle')}
+      </AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>{message.text}</p>
+        {retryAction && onRetry ? (
+          <Button type="button" variant="outline" size="sm" onClick={() => onRetry(retryAction)}>
+            {pt('masterData.fractions.actions.retrySync')}
+          </Button>
+        ) : null}
+      </AlertDescription>
     </Alert>
   ) : null;
 };

--- a/packages/plugin-waste-management/src/waste-management.tools.job-state.ts
+++ b/packages/plugin-waste-management/src/waste-management.tools.job-state.ts
@@ -11,10 +11,12 @@ const terminalStatuses = new Set(['succeeded', 'failed', 'cancelled']);
 export const useWasteTrackedJob = ({
   lastJob,
   refreshTechnicalHistory,
+  onTerminalJob,
   setLastJob,
 }: {
   readonly lastJob: StudioJobResponse['data'] | null;
   readonly refreshTechnicalHistory: () => Promise<void>;
+  readonly onTerminalJob?: (job: StudioJobResponse['data']) => void | Promise<void>;
   readonly setLastJob: (job: StudioJobResponse['data'] | null) => void;
 }) => {
   const latestRequestIdRef = useRef(0);
@@ -45,6 +47,9 @@ export const useWasteTrackedJob = ({
         }
         setLastJob(detail);
         await refreshTechnicalHistory();
+        if (terminalStatuses.has(detail.status)) {
+          await onTerminalJob?.(detail);
+        }
       } catch {
         if (controller.signal.aborted || isDisposed || requestId !== latestRequestIdRef.current) {
           return;
@@ -62,5 +67,5 @@ export const useWasteTrackedJob = ({
       activeController?.abort();
       window.clearInterval(intervalId);
     };
-  }, [lastJob?.id, lastJob?.status, refreshTechnicalHistory, setLastJob]);
+  }, [lastJob?.id, lastJob?.status, onTerminalJob, refreshTechnicalHistory, setLastJob]);
 };

--- a/packages/plugin-waste-management/src/waste-management.tools.job-state.ts
+++ b/packages/plugin-waste-management/src/waste-management.tools.job-state.ts
@@ -20,6 +20,11 @@ export const useWasteTrackedJob = ({
   readonly setLastJob: (job: StudioJobResponse['data'] | null) => void;
 }) => {
   const latestRequestIdRef = useRef(0);
+  const latestOnTerminalJobRef = useRef(onTerminalJob);
+
+  useEffect(() => {
+    latestOnTerminalJobRef.current = onTerminalJob;
+  }, [onTerminalJob]);
 
   useEffect(() => {
     if (!lastJob?.id || terminalStatuses.has(lastJob.status)) {
@@ -48,7 +53,7 @@ export const useWasteTrackedJob = ({
         setLastJob(detail);
         await refreshTechnicalHistory();
         if (terminalStatuses.has(detail.status)) {
-          await onTerminalJob?.(detail);
+          await latestOnTerminalJobRef.current?.(detail);
         }
       } catch {
         if (controller.signal.aborted || isDisposed || requestId !== latestRequestIdRef.current) {
@@ -67,5 +72,5 @@ export const useWasteTrackedJob = ({
       activeController?.abort();
       window.clearInterval(intervalId);
     };
-  }, [lastJob?.id, lastJob?.status, onTerminalJob, refreshTechnicalHistory, setLastJob]);
+  }, [lastJob?.id, lastJob?.status, refreshTechnicalHistory, setLastJob]);
 };

--- a/packages/plugin-waste-management/tests/plugin-operations.test.ts
+++ b/packages/plugin-waste-management/tests/plugin-operations.test.ts
@@ -25,6 +25,10 @@ describe('waste management plugin operations', () => {
       expect.objectContaining({
         jobTypeId: 'waste-management.reset-data',
       }),
+      expect.objectContaining({
+        jobTypeId: 'waste-management.sync-waste-types',
+        queue: 'plugin-operations',
+      }),
     ]);
   });
 

--- a/packages/plugin-waste-management/tests/plugin.test.ts
+++ b/packages/plugin-waste-management/tests/plugin.test.ts
@@ -161,6 +161,10 @@ describe('pluginWasteManagement contract', () => {
       { eventType: 'waste-management.seed.started', titleKey: 'wasteManagement.audit.seedStarted' },
       { eventType: 'waste-management.reset.started', titleKey: 'wasteManagement.audit.resetStarted' },
       {
+        eventType: 'waste-management.sync-waste-types.started',
+        titleKey: 'wasteManagement.audit.syncWasteTypesStarted',
+      },
+      {
         eventType: 'waste-management.datasource.reconfigured',
         titleKey: 'wasteManagement.audit.dataSourceInitialized',
       },

--- a/packages/plugin-waste-management/tests/plugin.test.ts
+++ b/packages/plugin-waste-management/tests/plugin.test.ts
@@ -82,6 +82,7 @@ describe('pluginWasteManagement contract', () => {
       'waste-management.import-data',
       'waste-management.seed-data',
       'waste-management.reset-data',
+      'waste-management.sync-waste-types',
     ]);
   });
 

--- a/packages/plugin-waste-management/tests/server.test.ts
+++ b/packages/plugin-waste-management/tests/server.test.ts
@@ -181,6 +181,11 @@ describe('waste management plugin server handlers', () => {
         inputPayload: { operation: 'reset-data' },
         expectedDetailKeys: ['confirmationTokenLength', 'deletedRows'],
       },
+      {
+        jobTypeId: wasteManagementOperationsContract.jobTypeIds.syncWasteTypes,
+        inputPayload: { operation: 'sync-waste-types' },
+        expectedDetailKeys: ['staticContentName', 'version', 'fractionCount'],
+      },
     ] as const;
 
     for (const scenario of scenarios) {
@@ -364,6 +369,15 @@ const createRuntime = (
       operation: 'reset-data',
       confirmationTokenLength: 5,
       deletedRows: { waste_regions: 1 },
+    },
+  })),
+  syncWasteTypes: vi.fn(async () => ({
+    durationMs: 1,
+    details: {
+      operation: 'sync-waste-types',
+      staticContentName: 'wasteTypes',
+      version: '2026.06.09',
+      fractionCount: 5,
     },
   })),
   ...overrides,

--- a/packages/plugin-waste-management/tests/waste-management.api.test.ts
+++ b/packages/plugin-waste-management/tests/waste-management.api.test.ts
@@ -27,6 +27,7 @@ import {
   startWasteManagementHolidaySync,
   startWasteManagementReset,
   startWasteManagementSeed,
+  startWasteManagementSyncWasteTypes,
   updateWasteManagementHolidayRule,
   updateWasteManagementFraction,
   updateWasteManagementCity,
@@ -1355,16 +1356,18 @@ describe('waste-management api client', () => {
     );
   });
 
-  it('starts initialize, migration, seed and reset jobs with idempotency keys', async () => {
+  it('starts initialize, migration, seed, waste-type sync and reset jobs with idempotency keys', async () => {
     fetchMock
       .mockResolvedValueOnce(createJobResponse('waste-management.initialize-data-source'))
       .mockResolvedValueOnce(createJobResponse('waste-management.apply-migrations'))
       .mockResolvedValueOnce(createJobResponse('waste-management.seed-data'))
+      .mockResolvedValueOnce(createJobResponse('waste-management.sync-waste-types'))
       .mockResolvedValueOnce(createJobResponse('waste-management.reset-data'));
 
     await startWasteManagementInitialize({ targetSchema: 'wm' });
     await startWasteManagementMigrations({ targetSchema: 'wm', requestedByVersion: '2026.05.0' });
     await startWasteManagementSeed();
+    await startWasteManagementSyncWasteTypes();
     await startWasteManagementReset({ confirmationToken: 'RESET' });
 
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -1393,6 +1396,14 @@ describe('waste-management api client', () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       4,
+      '/api/v1/waste-management/tools/sync-waste-types',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
       '/api/v1/waste-management/tools/reset',
       expect.objectContaining({
         method: 'POST',

--- a/packages/plugin-waste-management/tests/waste-management.api.test.ts
+++ b/packages/plugin-waste-management/tests/waste-management.api.test.ts
@@ -344,10 +344,35 @@ describe('waste-management api client', () => {
             data: {
               id: 'fraction-3',
               name: 'Papier',
+              pdfShortLabel: 'PPK',
               color: '#123456',
               active: true,
+              translations: { de: 'Papier', en: 'Paper' },
+              description: null,
+              containerSize: null,
+              reminderCount: 'none',
+              reminderChannelPushEnabled: false,
+              reminderChannelEmailEnabled: false,
+              reminderChannelCalendarEnabled: false,
               createdAt: '2026-05-09T10:00:00.000Z',
               updatedAt: '2026-05-09T10:00:00.000Z',
+            },
+            syncStatus: 'queued',
+            syncJob: {
+              id: 'job-1',
+              instanceId: 'tenant-a',
+              pluginId: 'waste-management',
+              jobTypeId: 'waste-management.sync-waste-types',
+              queueName: 'plugin-operations',
+              status: 'queued',
+              inputPayload: { operation: 'sync-waste-types' },
+              attempts: 0,
+              maxAttempts: 5,
+              idempotencyKey: 'idem-1',
+              scheduledAt: '2026-05-09T10:00:00.000Z',
+              createdAt: '2026-05-09T10:00:00.000Z',
+              updatedAt: '2026-05-09T10:00:00.000Z',
+              history: [],
             },
           }),
           { status: 201, headers: { 'Content-Type': 'application/json' } }
@@ -359,28 +384,67 @@ describe('waste-management api client', () => {
             data: {
               id: 'fraction-3',
               name: 'Papier Plus',
+              pdfShortLabel: 'PPK+',
               color: '#123456',
               active: true,
+              translations: { de: 'Papier Plus', en: 'Paper Plus' },
+              description: null,
+              containerSize: null,
+              reminderCount: 'once',
+              firstReminderMaxLeadDays: 2,
+              reminderChannelPushEnabled: true,
+              reminderChannelEmailEnabled: false,
+              reminderChannelCalendarEnabled: false,
               createdAt: '2026-05-09T10:00:00.000Z',
               updatedAt: '2026-05-09T12:00:00.000Z',
             },
+            syncStatus: 'queued',
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } }
         )
       );
 
-    await createWasteManagementFraction({
-      id: 'fraction-3',
-      name: 'Papier',
-      translations: { de: 'Papier', en: 'Paper' },
-      color: '#123456',
-      active: true,
+    await expect(
+      createWasteManagementFraction({
+        id: 'fraction-3',
+        name: 'Papier',
+        pdfShortLabel: 'PPK',
+        translations: { de: 'Papier', en: 'Paper' },
+        color: '#123456',
+        active: true,
+        reminderCount: 'none',
+        reminderChannelPushEnabled: false,
+        reminderChannelEmailEnabled: false,
+        reminderChannelCalendarEnabled: false,
+      })
+    ).resolves.toMatchObject({
+      data: expect.objectContaining({
+        id: 'fraction-3',
+        name: 'Papier',
+        pdfShortLabel: 'PPK',
+      }),
+      syncStatus: 'queued',
     });
-    await updateWasteManagementFraction('fraction-3', {
-      name: 'Papier Plus',
-      translations: { de: 'Papier Plus', en: 'Paper Plus' },
-      color: '#123456',
-      active: true,
+    await expect(
+      updateWasteManagementFraction('fraction-3', {
+        name: 'Papier Plus',
+        pdfShortLabel: 'PPK+',
+        translations: { de: 'Papier Plus', en: 'Paper Plus' },
+        color: '#123456',
+        active: true,
+        reminderCount: 'once',
+        firstReminderMaxLeadDays: 2,
+        reminderChannelPushEnabled: true,
+        reminderChannelEmailEnabled: false,
+        reminderChannelCalendarEnabled: false,
+      })
+    ).resolves.toMatchObject({
+      data: expect.objectContaining({
+        id: 'fraction-3',
+        name: 'Papier Plus',
+        pdfShortLabel: 'PPK+',
+      }),
+      syncStatus: 'queued',
     });
 
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -391,9 +455,14 @@ describe('waste-management api client', () => {
         body: JSON.stringify({
           id: 'fraction-3',
           name: 'Papier',
+          pdfShortLabel: 'PPK',
           translations: { de: 'Papier', en: 'Paper' },
           color: '#123456',
           active: true,
+          reminderCount: 'none',
+          reminderChannelPushEnabled: false,
+          reminderChannelEmailEnabled: false,
+          reminderChannelCalendarEnabled: false,
         }),
       })
     );
@@ -404,9 +473,15 @@ describe('waste-management api client', () => {
         method: 'PUT',
         body: JSON.stringify({
           name: 'Papier Plus',
+          pdfShortLabel: 'PPK+',
           translations: { de: 'Papier Plus', en: 'Paper Plus' },
           color: '#123456',
           active: true,
+          reminderCount: 'once',
+          firstReminderMaxLeadDays: 2,
+          reminderChannelPushEnabled: true,
+          reminderChannelEmailEnabled: false,
+          reminderChannelCalendarEnabled: false,
         }),
       })
     );

--- a/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
@@ -648,12 +648,19 @@ describe('waste management helper modules', () => {
   });
 
   it('covers fraction and region submission handlers for success and forbidden error branches', async () => {
-    const createWasteManagementFractionMock = vi.fn();
-    const updateWasteManagementFractionMock = vi.fn();
+    const createWasteManagementFractionMock = vi.fn(async () => ({
+      data: { id: 'fraction-1' },
+      syncStatus: 'queued',
+      syncJob: { id: 'job-sync-1', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
+    }));
+    const updateWasteManagementFractionMock = vi.fn(async () => ({
+      data: { id: 'fraction-1' },
+      syncStatus: 'queued',
+      syncJob: { id: 'job-sync-2', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
+    }));
     const deleteWasteManagementFractionMock = vi.fn();
     const createWasteManagementRegionMock = vi.fn();
     const updateWasteManagementRegionMock = vi.fn();
-    const startWasteManagementSyncWasteTypesMock = vi.fn(async () => undefined);
     const applySuccessSpy = vi.fn((close, setMessage, text: string, _onSuccess?: () => void, showMessage = true) => {
       close();
       if (showMessage) {
@@ -669,7 +676,6 @@ describe('waste management helper modules', () => {
         updateWasteManagementFraction: updateWasteManagementFractionMock,
         deleteWasteManagementFraction: deleteWasteManagementFractionMock,
         createWasteManagementRegion: createWasteManagementRegionMock,
-        startWasteManagementSyncWasteTypes: startWasteManagementSyncWasteTypesMock,
         updateWasteManagementRegion: updateWasteManagementRegionMock,
       };
     });
@@ -750,7 +756,7 @@ describe('waste management helper modules', () => {
     });
 
     state.regionDialogMode = 'edit';
-    updateWasteManagementRegionMock.mockResolvedValueOnce(undefined);
+    updateWasteManagementRegionMock.mockResolvedValueOnce({ id: 'region-1', name: 'Nord' });
     await handlers.onSubmitRegion(createEvent);
     expect(updateWasteManagementRegionMock).toHaveBeenCalledWith(
       'region-1',

--- a/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
@@ -300,7 +300,7 @@ describe('waste management helper modules', () => {
       wasteMasterDataInputMappers.toCreateFractionInput({
         id: 'fraction-1',
         name: ' Rest ',
-        pdfShortLabel: ' RST ',
+        pdfShortLabel: ' rst ',
         translations: {
           de: ' Restmüll ',
           en: ' ',
@@ -372,7 +372,7 @@ describe('waste management helper modules', () => {
       wasteMasterDataInputMappers.toUpdateFractionInput({
         id: 'fraction-3',
         name: ' Papier ',
-        pdfShortLabel: ' PPK ',
+        pdfShortLabel: ' ppk ',
         translations: {},
         containerSize: '',
         color: '#2255aa',
@@ -688,6 +688,7 @@ describe('waste management helper modules', () => {
 
     const setSaving = vi.fn();
     const setMessage = vi.fn();
+    const setTrackedSyncWasteTypesJob = vi.fn();
     const setLastOutcome = vi.fn();
     const setDialogOpen = vi.fn();
     const setRegionDialogOpen = vi.fn();
@@ -699,6 +700,7 @@ describe('waste management helper modules', () => {
       regionForm: { id: 'region-1', name: 'Nord' },
       setSaving,
       setMessage,
+      setTrackedSyncWasteTypesJob,
       setLastOutcome,
       setDialogOpen,
       setRegionDialogOpen,

--- a/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.helpers.test.tsx
@@ -327,8 +327,6 @@ describe('waste management helper modules', () => {
       description: 'Beschreibung',
       active: true,
       reminderCount: 'none',
-      firstReminderMaxLeadDays: undefined,
-      secondReminderMaxLeadDays: undefined,
       reminderChannelPushEnabled: false,
       reminderChannelEmailEnabled: false,
       reminderChannelCalendarEnabled: false,
@@ -367,6 +365,34 @@ describe('waste management helper modules', () => {
       secondReminderMaxLeadDays: 1,
       reminderChannelPushEnabled: false,
       reminderChannelEmailEnabled: true,
+      reminderChannelCalendarEnabled: false,
+    });
+
+    expect(
+      wasteMasterDataInputMappers.toUpdateFractionInput({
+        id: 'fraction-3',
+        name: ' Papier ',
+        pdfShortLabel: ' PPK ',
+        translations: {},
+        containerSize: '',
+        color: '#2255aa',
+        description: '',
+        active: true,
+        reminderCount: 'none',
+        firstReminderMaxLeadDays: 1,
+        secondReminderMaxLeadDays: 1,
+        reminderChannelPushEnabled: false,
+        reminderChannelEmailEnabled: false,
+        reminderChannelCalendarEnabled: false,
+      })
+    ).toEqual({
+      name: 'Papier',
+      pdfShortLabel: 'PPK',
+      color: '#2255aa',
+      active: true,
+      reminderCount: 'none',
+      reminderChannelPushEnabled: false,
+      reminderChannelEmailEnabled: false,
       reminderChannelCalendarEnabled: false,
     });
 
@@ -627,9 +653,12 @@ describe('waste management helper modules', () => {
     const deleteWasteManagementFractionMock = vi.fn();
     const createWasteManagementRegionMock = vi.fn();
     const updateWasteManagementRegionMock = vi.fn();
-    const applySuccessSpy = vi.fn((close, setMessage, text: string) => {
+    const startWasteManagementSyncWasteTypesMock = vi.fn(async () => undefined);
+    const applySuccessSpy = vi.fn((close, setMessage, text: string, _onSuccess?: () => void, showMessage = true) => {
       close();
-      setMessage({ kind: 'success', text });
+      if (showMessage) {
+        setMessage({ kind: 'success', text });
+      }
     });
 
     vi.doMock('../src/waste-management.api.js', async (importOriginal) => {
@@ -640,6 +669,7 @@ describe('waste management helper modules', () => {
         updateWasteManagementFraction: updateWasteManagementFractionMock,
         deleteWasteManagementFraction: deleteWasteManagementFractionMock,
         createWasteManagementRegion: createWasteManagementRegionMock,
+        startWasteManagementSyncWasteTypes: startWasteManagementSyncWasteTypesMock,
         updateWasteManagementRegion: updateWasteManagementRegionMock,
       };
     });
@@ -688,7 +718,8 @@ describe('waste management helper modules', () => {
       expect.any(Function),
       setMessage,
       'masterData.fractions.messages.createSuccess',
-      expect.any(Function)
+      expect.any(Function),
+      true
     );
     expect(setDialogOpen).toHaveBeenCalledWith(false);
 

--- a/packages/plugin-waste-management/tests/waste-management.master-data-entity-dialogs.components.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.master-data-entity-dialogs.components.test.tsx
@@ -90,6 +90,7 @@ describe('waste-management.master-data-entity-dialogs components', () => {
         mode="create"
         form={{
           name: 'Restmüll',
+          pdfShortLabel: 'RES',
           translations: { de: 'Rest', en: '' },
           color: '#111111',
           containerSize: '120L',
@@ -118,12 +119,18 @@ describe('waste-management.master-data-entity-dialogs components', () => {
     fireEvent.change(screen.getByLabelText('masterData.fractions.fields.translationEn'), {
       target: { value: 'Residual waste' },
     });
+    fireEvent.change(screen.getByLabelText('masterData.fractions.fields.pdfShortLabel'), {
+      target: { value: 'RSD' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'masterData.fractions.actions.cancel' }));
     const submitButton = screen.getByRole('button', { name: 'masterData.fractions.actions.create' });
     fireEvent.click(submitButton);
 
     expect(onChange).toHaveBeenCalledWith({
       translations: { de: 'Rest', en: 'Residual waste' },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      pdfShortLabel: 'RSD',
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
@@ -289,6 +296,7 @@ describe('waste-management.master-data-entity-dialogs components', () => {
         mode="create"
         form={{
           name: '',
+          pdfShortLabel: '',
           translations: { de: '', en: '' },
           color: '',
           containerSize: '',
@@ -312,6 +320,7 @@ describe('waste-management.master-data-entity-dialogs components', () => {
     fireEvent.click(screen.getByRole('button', { name: 'masterData.fractions.actions.create' }));
     expect(await screen.findByRole('alert')).toBeTruthy();
     expect(screen.getByRole('alert').textContent).toContain('masterData.fractions.fields.name');
+    expect(screen.getByRole('alert').textContent).toContain('masterData.fractions.fields.pdfShortLabel');
 
     rerender(
       <CityDialog

--- a/packages/plugin-waste-management/tests/waste-management.master-data-fraction-create-content.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.master-data-fraction-create-content.test.tsx
@@ -67,6 +67,7 @@ describe('WasteMasterDataFractionCreateContent', () => {
         form={{
           id: 'fraction-1',
           name: 'Biotonne',
+          pdfShortLabel: 'BIO',
           translations: {},
           containerSize: '',
           color: '#16A34A',
@@ -117,6 +118,7 @@ describe('WasteMasterDataFractionCreateContent', () => {
         form={{
           id: 'fraction-1',
           name: 'Biotonne',
+          pdfShortLabel: 'BIO',
           translations: {},
           containerSize: '',
           color: '#16A34A',

--- a/packages/plugin-waste-management/tests/waste-management.master-data-fractions-content.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.master-data-fractions-content.test.tsx
@@ -110,6 +110,7 @@ describe('WasteMasterDataFractionsContent', () => {
     const fraction = {
       id: 'fraction-1',
       name: 'Biotonne',
+      pdfShortLabel: 'BIO',
       description: 'Baseline-Fraktion für Seed-Daten',
       color: '#16A34A',
       containerSize: '120l',
@@ -144,22 +145,30 @@ describe('WasteMasterDataFractionsContent', () => {
     expect(tableProps.sorting).toEqual([{ id: 'nameWithContainerSize', desc: false }]);
     expect((tableProps.columns as Array<{ id: string; sortable?: boolean }>).map((column) => column.id)).toEqual([
       'nameWithContainerSize',
+      'pdfShortLabel',
       'color',
       'description',
       'status',
     ]);
-    expect((tableProps.columns as Array<{ id: string; sortable?: boolean }>).every((column) => column.sortable === true)).toBe(true);
+    expect((tableProps.columns as Array<{ id: string; sortable?: boolean }>).map((column) => column.sortable ?? false)).toEqual([
+      true,
+      false,
+      true,
+      true,
+      true,
+    ]);
 
     fireEvent.click(screen.getByRole('button', { name: 'sort-color' }));
     const updatedTableProps = dataTableMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect(updatedTableProps.sorting).toEqual([{ id: 'color', desc: true }]);
     expect(onFractionsSortChange).toHaveBeenCalledWith('color', 'desc');
 
-    const [nameColumn, colorColumn, descriptionColumn, statusColumn] = tableProps.columns as Array<{
+    const [nameColumn, pdfShortLabelColumn, colorColumn, descriptionColumn, statusColumn] = tableProps.columns as Array<{
       id: string;
       cell: (row: typeof fraction) => React.ReactNode;
     }>;
     expect(nameColumn.cell(fraction)).toBeTruthy();
+    expect(pdfShortLabelColumn.cell(fraction)).toBeTruthy();
     expect(colorColumn.cell(fraction)).toBeTruthy();
     expect(descriptionColumn.cell(fraction)).toBeTruthy();
     expect(statusColumn.cell(fraction)).toBeTruthy();
@@ -211,6 +220,7 @@ describe('WasteMasterDataFractionsContent', () => {
       {
         id: 'fraction-1',
         name: 'Biotonne',
+        pdfShortLabel: 'BIO',
         description: 'Bio',
         color: '#16A34A',
         containerSize: '240l',
@@ -219,6 +229,7 @@ describe('WasteMasterDataFractionsContent', () => {
       {
         id: 'fraction-2',
         name: 'Papier',
+        pdfShortLabel: undefined,
         description: undefined,
         color: '#2563EB',
         containerSize: undefined,
@@ -258,10 +269,12 @@ describe('WasteMasterDataFractionsContent', () => {
     expect((tableProps.data as Array<{ id: string }>).map((fraction) => fraction.id)).toEqual(['fraction-2', 'fraction-1']);
     expect(screen.queryByRole('button', { name: 'masterData.fractions.filters.reset' })).toBeNull();
 
-    const [, , , statusColumn] = tableProps.columns as Array<{
+    const [, pdfShortLabelColumn, , , statusColumn] = tableProps.columns as Array<{
       id: string;
       cell: (row: (typeof fractions)[number]) => React.ReactNode;
     }>;
+    expect(pdfShortLabelColumn.cell(fractions[0]!)).toBeTruthy();
+    expect(pdfShortLabelColumn.cell(fractions[1]!)).toBeNull();
     const rowActions = tableProps.rowActions as (row: (typeof fractions)[number]) => React.ReactNode;
     render(
       <div>

--- a/packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
+++ b/packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
@@ -1,8 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const createWasteManagementFractionMock = vi.hoisted(() => vi.fn(async () => undefined));
-const startWasteManagementSyncWasteTypesMock = vi.hoisted(() => vi.fn(async () => undefined));
-const updateWasteManagementFractionMock = vi.hoisted(() => vi.fn(async () => undefined));
+const createWasteManagementFractionMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    data: { id: 'fraction-created' },
+    syncStatus: 'queued',
+    syncJob: { id: 'job-sync-1', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
+  }))
+);
+const updateWasteManagementFractionMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    data: { id: 'fraction-updated' },
+    syncStatus: 'queued',
+    syncJob: { id: 'job-sync-2', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
+  }))
+);
 
 import { createSubmitFractionHandler } from '../src/waste-management.master-data.fraction-region-submissions.helpers.js';
 
@@ -11,17 +22,24 @@ vi.mock('../src/waste-management.api.js', async (importOriginal) => {
   return {
     ...actual,
     createWasteManagementFraction: createWasteManagementFractionMock,
-    startWasteManagementSyncWasteTypes: startWasteManagementSyncWasteTypesMock,
     updateWasteManagementFraction: updateWasteManagementFractionMock,
   };
 });
 
 describe('createSubmitFractionHandler', () => {
   beforeEach(() => {
-    createWasteManagementFractionMock.mockClear();
-    startWasteManagementSyncWasteTypesMock.mockReset();
-    startWasteManagementSyncWasteTypesMock.mockImplementation(async () => undefined);
-    updateWasteManagementFractionMock.mockClear();
+    createWasteManagementFractionMock.mockReset();
+    createWasteManagementFractionMock.mockImplementation(async () => ({
+      data: { id: 'fraction-created' },
+      syncStatus: 'queued',
+      syncJob: { id: 'job-sync-1', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
+    }));
+    updateWasteManagementFractionMock.mockReset();
+    updateWasteManagementFractionMock.mockImplementation(async () => ({
+      data: { id: 'fraction-updated' },
+      syncStatus: 'queued',
+      syncJob: { id: 'job-sync-2', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
+    }));
   });
 
   it('submits edit views through the update path even if dialogMode still says create', async () => {
@@ -81,12 +99,18 @@ describe('createSubmitFractionHandler', () => {
     expect(createWasteManagementFractionMock).not.toHaveBeenCalled();
     expect(ctx.loadOverview).toHaveBeenCalledWith(true);
     expect(ctx.state.setLastOutcome).toHaveBeenCalledWith('fraction-update-success');
-    expect(startWasteManagementSyncWasteTypesMock).toHaveBeenCalledTimes(1);
-    expect(ctx.state.setTrackedSyncWasteTypesJob).toHaveBeenCalledWith(null);
+    expect(ctx.state.setTrackedSyncWasteTypesJob).toHaveBeenCalledWith({
+      id: 'job-sync-2',
+      jobTypeId: 'waste-management.sync-waste-types',
+      status: 'queued',
+    });
   });
 
-  it('downgrades sync start failures to a retryable warning after a successful create', async () => {
-    startWasteManagementSyncWasteTypesMock.mockRejectedValueOnce(new Error('sync_failed'));
+  it('downgrades sync enqueue failures to a retryable warning after a successful create', async () => {
+    createWasteManagementFractionMock.mockResolvedValueOnce({
+      data: { id: 'fraction-created' },
+      syncStatus: 'failed',
+    });
     const ctx = {
       state: {
         dialogMode: 'create',
@@ -125,7 +149,6 @@ describe('createSubmitFractionHandler', () => {
     await createSubmitFractionHandler(ctx)(event, 'create');
 
     expect(createWasteManagementFractionMock).toHaveBeenCalledTimes(1);
-    expect(startWasteManagementSyncWasteTypesMock).toHaveBeenCalledTimes(1);
     expect(ctx.state.setTrackedSyncWasteTypesJob).toHaveBeenCalledWith(null);
     expect(ctx.state.setMessage).toHaveBeenCalledWith({
       kind: 'warning',

--- a/packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
+++ b/packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createWasteManagementFractionMock = vi.hoisted(() => vi.fn(async () => undefined));
+const startWasteManagementSyncWasteTypesMock = vi.hoisted(() => vi.fn(async () => undefined));
 const updateWasteManagementFractionMock = vi.hoisted(() => vi.fn(async () => undefined));
 
 import { createSubmitFractionHandler } from '../src/waste-management.master-data.fraction-region-submissions.helpers.js';
@@ -10,11 +11,19 @@ vi.mock('../src/waste-management.api.js', async (importOriginal) => {
   return {
     ...actual,
     createWasteManagementFraction: createWasteManagementFractionMock,
+    startWasteManagementSyncWasteTypes: startWasteManagementSyncWasteTypesMock,
     updateWasteManagementFraction: updateWasteManagementFractionMock,
   };
 });
 
 describe('createSubmitFractionHandler', () => {
+  beforeEach(() => {
+    createWasteManagementFractionMock.mockClear();
+    startWasteManagementSyncWasteTypesMock.mockReset();
+    startWasteManagementSyncWasteTypesMock.mockImplementation(async () => undefined);
+    updateWasteManagementFractionMock.mockClear();
+  });
+
   it('submits edit views through the update path even if dialogMode still says create', async () => {
     const ctx = {
       state: {
@@ -22,7 +31,7 @@ describe('createSubmitFractionHandler', () => {
         fractionForm: {
           id: 'fraction-1',
           name: 'Restmüll',
-          pdfShortLabel: '',
+          pdfShortLabel: 'RES',
           translations: {},
           containerSize: '120L',
           color: '#111111',
@@ -56,6 +65,7 @@ describe('createSubmitFractionHandler', () => {
       'fraction-1',
       expect.objectContaining({
         name: 'Restmüll',
+        pdfShortLabel: 'RES',
         containerSize: '120L',
         color: '#111111',
         active: true,
@@ -70,5 +80,53 @@ describe('createSubmitFractionHandler', () => {
     expect(createWasteManagementFractionMock).not.toHaveBeenCalled();
     expect(ctx.loadOverview).toHaveBeenCalledWith(true);
     expect(ctx.state.setLastOutcome).toHaveBeenCalledWith('fraction-update-success');
+    expect(startWasteManagementSyncWasteTypesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('downgrades sync start failures to a retryable warning after a successful create', async () => {
+    startWasteManagementSyncWasteTypesMock.mockRejectedValueOnce(new Error('sync_failed'));
+    const ctx = {
+      state: {
+        dialogMode: 'create',
+        fractionForm: {
+          id: 'fraction-2',
+          name: 'Bio',
+          pdfShortLabel: 'BIO',
+          translations: {},
+          containerSize: '',
+          color: '#228833',
+          description: '',
+          active: true,
+          reminderCount: 'none',
+          firstReminderMaxLeadDays: undefined,
+          secondReminderMaxLeadDays: undefined,
+          reminderChannelPushEnabled: false,
+          reminderChannelEmailEnabled: false,
+          reminderChannelCalendarEnabled: false,
+        },
+        setSaving: vi.fn(),
+        setMessage: vi.fn(),
+        setLastOutcome: vi.fn(),
+        setDialogOpen: vi.fn(),
+      },
+      pt: (key: string) => key,
+      loadOverview: vi.fn(async () => undefined),
+    } as never;
+
+    const form = document.createElement('form');
+    const event = {
+      preventDefault: vi.fn(),
+      currentTarget: form,
+    } as unknown as React.FormEvent<HTMLFormElement>;
+
+    await createSubmitFractionHandler(ctx)(event, 'create');
+
+    expect(createWasteManagementFractionMock).toHaveBeenCalledTimes(1);
+    expect(startWasteManagementSyncWasteTypesMock).toHaveBeenCalledTimes(1);
+    expect(ctx.state.setMessage).toHaveBeenCalledWith({
+      kind: 'warning',
+      text: 'masterData.fractions.messages.syncWarning',
+      retryAction: 'sync-waste-types',
+    });
   });
 });

--- a/packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
+++ b/packages/plugin-waste-management/tests/waste-management.master-data.fraction-submissions.test.ts
@@ -46,6 +46,7 @@ describe('createSubmitFractionHandler', () => {
         },
         setSaving: vi.fn(),
         setMessage: vi.fn(),
+        setTrackedSyncWasteTypesJob: vi.fn(),
         setLastOutcome: vi.fn(),
         setDialogOpen: vi.fn(),
       },
@@ -81,6 +82,7 @@ describe('createSubmitFractionHandler', () => {
     expect(ctx.loadOverview).toHaveBeenCalledWith(true);
     expect(ctx.state.setLastOutcome).toHaveBeenCalledWith('fraction-update-success');
     expect(startWasteManagementSyncWasteTypesMock).toHaveBeenCalledTimes(1);
+    expect(ctx.state.setTrackedSyncWasteTypesJob).toHaveBeenCalledWith(null);
   });
 
   it('downgrades sync start failures to a retryable warning after a successful create', async () => {
@@ -106,6 +108,7 @@ describe('createSubmitFractionHandler', () => {
         },
         setSaving: vi.fn(),
         setMessage: vi.fn(),
+        setTrackedSyncWasteTypesJob: vi.fn(),
         setLastOutcome: vi.fn(),
         setDialogOpen: vi.fn(),
       },
@@ -123,6 +126,7 @@ describe('createSubmitFractionHandler', () => {
 
     expect(createWasteManagementFractionMock).toHaveBeenCalledTimes(1);
     expect(startWasteManagementSyncWasteTypesMock).toHaveBeenCalledTimes(1);
+    expect(ctx.state.setTrackedSyncWasteTypesJob).toHaveBeenCalledWith(null);
     expect(ctx.state.setMessage).toHaveBeenCalledWith({
       kind: 'warning',
       text: 'masterData.fractions.messages.syncWarning',

--- a/packages/plugin-waste-management/tests/waste-management.page.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.page.test.tsx
@@ -165,6 +165,23 @@ const wasteManagementApiMocks = vi.hoisted(() => ({
     audit: { items: [], total: 0 },
     technical: { items: [], total: 0 },
   })),
+  getWasteManagementJobDetail: vi.fn(async () => ({
+    id: 'job-sync-1',
+    instanceId: 'tenant-a',
+    pluginId: 'waste-management',
+    jobTypeId: 'waste-management.sync-waste-types',
+    queueName: 'plugin-operations',
+    status: 'succeeded',
+    inputPayload: { operation: 'sync-waste-types' },
+    attempts: 1,
+    maxAttempts: 5,
+    idempotencyKey: 'idem-sync-1',
+    scheduledAt: '2026-05-10T10:00:00.000Z',
+    createdAt: '2026-05-10T10:00:00.000Z',
+    updatedAt: '2026-05-10T10:00:05.000Z',
+    finishedAt: '2026-05-10T10:00:05.000Z',
+    history: [],
+  })),
   getWasteManagementImportCatalog: vi.fn(() => [
     {
       profileId: 'waste-management.geografie-abholorte',
@@ -357,6 +374,24 @@ describe('WasteManagementPage', () => {
     wasteManagementApiMocks.getWasteManagementHistoryOverview.mockImplementation(async () => ({
       audit: { items: [], total: 0 },
       technical: { items: [], total: 0 },
+    }));
+    wasteManagementApiMocks.getWasteManagementJobDetail.mockReset();
+    wasteManagementApiMocks.getWasteManagementJobDetail.mockImplementation(async () => ({
+      id: 'job-sync-1',
+      instanceId: 'tenant-a',
+      pluginId: 'waste-management',
+      jobTypeId: 'waste-management.sync-waste-types',
+      queueName: 'plugin-operations',
+      status: 'succeeded',
+      inputPayload: { operation: 'sync-waste-types' },
+      attempts: 1,
+      maxAttempts: 5,
+      idempotencyKey: 'idem-sync-1',
+      scheduledAt: '2026-05-10T10:00:00.000Z',
+      createdAt: '2026-05-10T10:00:00.000Z',
+      updatedAt: '2026-05-10T10:00:05.000Z',
+      finishedAt: '2026-05-10T10:00:05.000Z',
+      history: [],
     }));
     wasteManagementApiMocks.getWasteManagementImportCatalog.mockReset();
     wasteManagementApiMocks.getWasteManagementImportCatalog.mockImplementation(() => [
@@ -1324,6 +1359,96 @@ describe('WasteManagementPage', () => {
 
     await waitFor(() => {
       expect(wasteManagementApiMocks.startWasteManagementSyncWasteTypes).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'wasteManagement.masterData.fractions.actions.retrySync' })
+    ).toBeTruthy();
+  });
+
+  it('shows a retry action when the queued wasteTypes sync later fails in the worker', async () => {
+    searchMock.mockImplementation(() => ({
+      tab: 'fractions',
+      masterDataTab: 'fractions',
+      fractionsView: 'create',
+      q: '',
+      page: 1,
+      pageSize: 25,
+      status: 'all',
+      shiftContext: 'all',
+    }));
+    wasteManagementApiMocks.getWasteManagementMasterDataOverview
+      .mockResolvedValueOnce({
+        fractions: [],
+        regions: [],
+        cities: [],
+        streets: [],
+        houseNumbers: [],
+        collectionLocations: [],
+        locationTourLinks: [],
+      })
+      .mockResolvedValue({
+        fractions: [
+          {
+            id: 'fraction-3',
+            name: 'Papier',
+            color: '#123456',
+            active: true,
+            createdAt: '2026-05-09T10:00:00.000Z',
+            updatedAt: '2026-05-09T10:00:00.000Z',
+          },
+        ],
+        regions: [],
+        cities: [],
+        streets: [],
+        houseNumbers: [],
+        collectionLocations: [],
+        locationTourLinks: [],
+      });
+    wasteManagementApiMocks.startWasteManagementSyncWasteTypes.mockResolvedValueOnce({
+      id: 'job-sync-late-failure',
+      jobTypeId: 'waste-management.sync-waste-types',
+      status: 'queued',
+    });
+    wasteManagementApiMocks.getWasteManagementJobDetail.mockResolvedValueOnce({
+      id: 'job-sync-late-failure',
+      instanceId: 'tenant-a',
+      pluginId: 'waste-management',
+      jobTypeId: 'waste-management.sync-waste-types',
+      queueName: 'plugin-operations',
+      status: 'failed',
+      inputPayload: { operation: 'sync-waste-types' },
+      attempts: 1,
+      maxAttempts: 5,
+      idempotencyKey: 'idem-sync-late-failure',
+      scheduledAt: '2026-05-10T10:00:00.000Z',
+      createdAt: '2026-05-10T10:00:00.000Z',
+      updatedAt: '2026-05-10T10:00:05.000Z',
+      finishedAt: '2026-05-10T10:00:05.000Z',
+      history: [],
+    });
+
+    render(<WasteManagementPage />);
+
+    await waitFor(() => {
+      expect(wasteManagementApiMocks.getWasteManagementMasterDataOverview).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByLabelText('wasteManagement.masterData.fractions.fields.name'), {
+      target: { value: 'Papier' },
+    });
+    fireEvent.change(screen.getByLabelText('wasteManagement.masterData.fractions.fields.pdfShortLabel'), {
+      target: { value: 'PAP' },
+    });
+    fireEvent.change(document.getElementById('waste-fraction-color-text') as HTMLInputElement, {
+      target: { value: '#123456' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'wasteManagement.masterData.fractions.createView.actions.savePrimary' })[0]!);
+
+    await waitFor(() => {
+      expect(wasteManagementApiMocks.getWasteManagementJobDetail).toHaveBeenCalledWith('job-sync-late-failure', {
+        signal: expect.any(AbortSignal),
+      });
     });
 
     expect(

--- a/packages/plugin-waste-management/tests/waste-management.page.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.page.test.tsx
@@ -222,6 +222,11 @@ const wasteManagementApiMocks = vi.hoisted(() => ({
     jobTypeId: 'waste-management.seed-data',
     status: 'pending',
   })),
+  startWasteManagementSyncWasteTypes: vi.fn(async () => ({
+    id: 'job-sync-1',
+    jobTypeId: 'waste-management.sync-waste-types',
+    status: 'pending',
+  })),
   startWasteManagementReset: vi.fn(async () => ({
     id: 'job-3',
     jobTypeId: 'waste-management.reset-data',
@@ -1238,21 +1243,92 @@ describe('WasteManagementPage', () => {
     fireEvent.change(screen.getByLabelText('wasteManagement.masterData.fractions.fields.description'), {
       target: { value: 'Blaue Tonne' },
     });
+    fireEvent.change(screen.getByLabelText('wasteManagement.masterData.fractions.fields.pdfShortLabel'), {
+      target: { value: 'PAP' },
+    });
     fireEvent.change(document.getElementById('waste-fraction-color-text') as HTMLInputElement, {
       target: { value: '#123456' },
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'wasteManagement.masterData.fractions.createView.actions.savePrimary' })[0]!);
 
     await waitFor(() => {
-      expect(wasteManagementApiMocks.createWasteManagementFraction).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'Papier',
-          description: 'Blaue Tonne',
-          color: '#123456',
-          active: true,
-        })
+        expect(wasteManagementApiMocks.createWasteManagementFraction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'Papier',
+            description: 'Blaue Tonne',
+            pdfShortLabel: 'PAP',
+            color: '#123456',
+            active: true,
+          })
       );
     });
+  });
+
+  it('shows a retry action when the follow-up wasteTypes sync cannot be started', async () => {
+    searchMock.mockImplementation(() => ({
+      tab: 'fractions',
+      masterDataTab: 'fractions',
+      fractionsView: 'create',
+      q: '',
+      page: 1,
+      pageSize: 25,
+      status: 'all',
+      shiftContext: 'all',
+    }));
+    wasteManagementApiMocks.getWasteManagementMasterDataOverview
+      .mockResolvedValueOnce({
+        fractions: [],
+        regions: [],
+        cities: [],
+        streets: [],
+        houseNumbers: [],
+        collectionLocations: [],
+        locationTourLinks: [],
+      })
+      .mockResolvedValueOnce({
+        fractions: [
+          {
+            id: 'fraction-3',
+            name: 'Papier',
+            color: '#123456',
+            active: true,
+            createdAt: '2026-05-09T10:00:00.000Z',
+            updatedAt: '2026-05-09T10:00:00.000Z',
+          },
+        ],
+        regions: [],
+        cities: [],
+        streets: [],
+        houseNumbers: [],
+        collectionLocations: [],
+        locationTourLinks: [],
+      });
+    wasteManagementApiMocks.startWasteManagementSyncWasteTypes.mockRejectedValueOnce(new Error('sync_failed'));
+
+    render(<WasteManagementPage />);
+
+    await waitFor(() => {
+      expect(wasteManagementApiMocks.getWasteManagementMasterDataOverview).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByLabelText('wasteManagement.masterData.fractions.fields.name'), {
+      target: { value: 'Papier' },
+    });
+    fireEvent.change(screen.getByLabelText('wasteManagement.masterData.fractions.fields.pdfShortLabel'), {
+      target: { value: 'PAP' },
+    });
+    fireEvent.change(document.getElementById('waste-fraction-color-text') as HTMLInputElement, {
+      target: { value: '#123456' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'wasteManagement.masterData.fractions.createView.actions.savePrimary' })[0]!);
+
+    await waitFor(() => {
+      expect(wasteManagementApiMocks.startWasteManagementSyncWasteTypes).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'wasteManagement.masterData.fractions.actions.retrySync' })
+    ).toBeTruthy();
   });
 
   it('creates a waste region from the master-data dialog', async () => {

--- a/packages/plugin-waste-management/tests/waste-management.page.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.page.test.tsx
@@ -88,12 +88,16 @@ const wasteManagementApiMocks = vi.hoisted(() => ({
     ],
   })),
   createWasteManagementFraction: vi.fn(async () => ({
-    id: 'fraction-3',
-    name: 'Papier',
-    color: '#123456',
-    active: true,
-    createdAt: '2026-05-09T10:00:00.000Z',
-    updatedAt: '2026-05-09T10:00:00.000Z',
+    data: {
+      id: 'fraction-3',
+      name: 'Papier',
+      color: '#123456',
+      active: true,
+      createdAt: '2026-05-09T10:00:00.000Z',
+      updatedAt: '2026-05-09T10:00:00.000Z',
+    },
+    syncStatus: 'queued',
+    syncJob: { id: 'job-sync-1', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
   })),
   createWasteManagementHouseNumber: vi.fn(async () => ({
     id: 'house-3',
@@ -250,12 +254,16 @@ const wasteManagementApiMocks = vi.hoisted(() => ({
     status: 'pending',
   })),
   updateWasteManagementFraction: vi.fn(async () => ({
-    id: 'fraction-1',
-    name: 'Restmüll Plus',
-    color: '#111111',
-    active: true,
-    createdAt: '2026-05-09T10:00:00.000Z',
-    updatedAt: '2026-05-09T12:00:00.000Z',
+    data: {
+      id: 'fraction-1',
+      name: 'Restmüll Plus',
+      color: '#111111',
+      active: true,
+      createdAt: '2026-05-09T10:00:00.000Z',
+      updatedAt: '2026-05-09T12:00:00.000Z',
+    },
+    syncStatus: 'queued',
+    syncJob: { id: 'job-sync-1', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
   })),
   updateWasteManagementCity: vi.fn(async () => ({
     id: 'city-1',
@@ -437,12 +445,16 @@ describe('WasteManagementPage', () => {
     wasteManagementApiMocks.updateWasteManagementSettings.mockImplementation(async () => null);
     wasteManagementApiMocks.createWasteManagementFraction.mockReset();
     wasteManagementApiMocks.createWasteManagementFraction.mockImplementation(async () => ({
-      id: 'fraction-3',
-      name: 'Papier',
-      color: '#123456',
-      active: true,
-      createdAt: '2026-05-09T10:00:00.000Z',
-      updatedAt: '2026-05-09T10:00:00.000Z',
+      data: {
+        id: 'fraction-3',
+        name: 'Papier',
+        color: '#123456',
+        active: true,
+        createdAt: '2026-05-09T10:00:00.000Z',
+        updatedAt: '2026-05-09T10:00:00.000Z',
+      },
+      syncStatus: 'queued',
+      syncJob: { id: 'job-sync-1', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
     }));
     wasteManagementApiMocks.createWasteManagementCity.mockReset();
     wasteManagementApiMocks.createWasteManagementCity.mockImplementation(async () => ({
@@ -581,12 +593,16 @@ describe('WasteManagementPage', () => {
     }));
     wasteManagementApiMocks.updateWasteManagementFraction.mockReset();
     wasteManagementApiMocks.updateWasteManagementFraction.mockImplementation(async () => ({
-      id: 'fraction-1',
-      name: 'Restmüll Plus',
-      color: '#111111',
-      active: true,
-      createdAt: '2026-05-09T10:00:00.000Z',
-      updatedAt: '2026-05-09T12:00:00.000Z',
+      data: {
+        id: 'fraction-1',
+        name: 'Restmüll Plus',
+        color: '#111111',
+        active: true,
+        createdAt: '2026-05-09T10:00:00.000Z',
+        updatedAt: '2026-05-09T12:00:00.000Z',
+      },
+      syncStatus: 'queued',
+      syncJob: { id: 'job-sync-1', jobTypeId: 'waste-management.sync-waste-types', status: 'queued' },
     }));
     wasteManagementApiMocks.updateWasteManagementCity.mockReset();
     wasteManagementApiMocks.updateWasteManagementCity.mockImplementation(async () => ({
@@ -1338,7 +1354,17 @@ describe('WasteManagementPage', () => {
         collectionLocations: [],
         locationTourLinks: [],
       });
-    wasteManagementApiMocks.startWasteManagementSyncWasteTypes.mockRejectedValueOnce(new Error('sync_failed'));
+    wasteManagementApiMocks.createWasteManagementFraction.mockResolvedValueOnce({
+      data: {
+        id: 'fraction-3',
+        name: 'Papier',
+        color: '#123456',
+        active: true,
+        createdAt: '2026-05-09T10:00:00.000Z',
+        updatedAt: '2026-05-09T10:00:00.000Z',
+      },
+      syncStatus: 'failed',
+    });
 
     render(<WasteManagementPage />);
 
@@ -1357,13 +1383,7 @@ describe('WasteManagementPage', () => {
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'wasteManagement.masterData.fractions.createView.actions.savePrimary' })[0]!);
 
-    await waitFor(() => {
-      expect(wasteManagementApiMocks.startWasteManagementSyncWasteTypes).toHaveBeenCalledTimes(1);
-    });
-
-    expect(
-      screen.getByRole('button', { name: 'wasteManagement.masterData.fractions.actions.retrySync' })
-    ).toBeTruthy();
+    expect(await screen.findByRole('button', { name: 'wasteManagement.masterData.fractions.actions.retrySync' })).toBeTruthy();
   });
 
   it('shows a retry action when the queued wasteTypes sync later fails in the worker', async () => {
@@ -1405,6 +1425,17 @@ describe('WasteManagementPage', () => {
         collectionLocations: [],
         locationTourLinks: [],
       });
+    wasteManagementApiMocks.createWasteManagementFraction.mockResolvedValueOnce({
+      data: {
+        id: 'fraction-3',
+        name: 'Papier',
+        color: '#123456',
+        active: true,
+        createdAt: '2026-05-09T10:00:00.000Z',
+        updatedAt: '2026-05-09T10:00:00.000Z',
+      },
+      syncStatus: 'failed',
+    });
     wasteManagementApiMocks.startWasteManagementSyncWasteTypes.mockResolvedValueOnce({
       id: 'job-sync-late-failure',
       jobTypeId: 'waste-management.sync-waste-types',
@@ -1444,6 +1475,7 @@ describe('WasteManagementPage', () => {
       target: { value: '#123456' },
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'wasteManagement.masterData.fractions.createView.actions.savePrimary' })[0]!);
+    fireEvent.click(await screen.findByRole('button', { name: 'wasteManagement.masterData.fractions.actions.retrySync' }));
 
     await waitFor(() => {
       expect(wasteManagementApiMocks.getWasteManagementJobDetail).toHaveBeenCalledWith('job-sync-late-failure', {

--- a/packages/plugin-waste-management/tests/waste-management.tools.job-state.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.tools.job-state.test.tsx
@@ -246,4 +246,90 @@ describe('useWasteTrackedJob', () => {
     expect(setLastJob).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-4', status: 'failed' }));
     expect(onTerminalJob).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-4', status: 'failed' }));
   });
+
+  it('keeps polling stable when the terminal callback identity changes between renders', async () => {
+    const refreshTechnicalHistory = vi.fn(async () => undefined);
+    const setLastJob = vi.fn();
+    const firstOnTerminalJob = vi.fn();
+    const secondOnTerminalJob = vi.fn();
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+
+    getWasteManagementJobDetailMock
+      .mockResolvedValueOnce({
+        id: 'job-5',
+        instanceId: 'tenant-a',
+        pluginId: 'waste-management',
+        jobTypeId: 'waste-management.sync-waste-types',
+        queueName: 'plugin-operations',
+        status: 'running',
+        inputPayload: { operation: 'sync-waste-types' },
+        attempts: 1,
+        maxAttempts: 5,
+        idempotencyKey: 'idem-5',
+        scheduledAt: '2026-05-10T10:00:00.000Z',
+        createdAt: '2026-05-10T10:00:00.000Z',
+        updatedAt: '2026-05-10T10:00:05.000Z',
+        history: [],
+      })
+      .mockResolvedValueOnce({
+        id: 'job-5',
+        instanceId: 'tenant-a',
+        pluginId: 'waste-management',
+        jobTypeId: 'waste-management.sync-waste-types',
+        queueName: 'plugin-operations',
+        status: 'failed',
+        inputPayload: { operation: 'sync-waste-types' },
+        attempts: 1,
+        maxAttempts: 5,
+        idempotencyKey: 'idem-5',
+        scheduledAt: '2026-05-10T10:00:00.000Z',
+        createdAt: '2026-05-10T10:00:00.000Z',
+        updatedAt: '2026-05-10T10:00:10.000Z',
+        finishedAt: '2026-05-10T10:00:10.000Z',
+        history: [],
+      });
+
+    const { rerender } = renderHook(
+      ({ onTerminalJob }) =>
+        useWasteTrackedJob({
+          lastJob: {
+            id: 'job-5',
+            jobTypeId: 'waste-management.sync-waste-types',
+            status: 'queued',
+          } as never,
+          refreshTechnicalHistory,
+          onTerminalJob,
+          setLastJob,
+        }),
+      {
+        initialProps: {
+          onTerminalJob: firstOnTerminalJob,
+        },
+      }
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+    rerender({
+      onTerminalJob: secondOnTerminalJob,
+    });
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    expect(firstOnTerminalJob).not.toHaveBeenCalled();
+    expect(secondOnTerminalJob).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-5', status: 'failed' }));
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/plugin-waste-management/tests/waste-management.tools.job-state.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.tools.job-state.test.tsx
@@ -202,4 +202,48 @@ describe('useWasteTrackedJob', () => {
     expect(setLastJob).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'job-3', status: 'running' }));
     expect(refreshTechnicalHistory).toHaveBeenCalledTimes(1);
   });
+
+  it('invokes the optional terminal callback when a tracked job fails', async () => {
+    const refreshTechnicalHistory = vi.fn(async () => undefined);
+    const setLastJob = vi.fn();
+    const onTerminalJob = vi.fn();
+
+    getWasteManagementJobDetailMock.mockResolvedValue({
+      id: 'job-4',
+      instanceId: 'tenant-a',
+      pluginId: 'waste-management',
+      jobTypeId: 'waste-management.sync-waste-types',
+      queueName: 'plugin-operations',
+      status: 'failed',
+      inputPayload: { operation: 'sync-waste-types' },
+      attempts: 1,
+      maxAttempts: 5,
+      idempotencyKey: 'idem-4',
+      scheduledAt: '2026-05-10T10:00:00.000Z',
+      createdAt: '2026-05-10T10:00:00.000Z',
+      updatedAt: '2026-05-10T10:00:05.000Z',
+      finishedAt: '2026-05-10T10:00:05.000Z',
+      history: [],
+    });
+
+    renderHook(() =>
+      useWasteTrackedJob({
+        lastJob: {
+          id: 'job-4',
+          jobTypeId: 'waste-management.sync-waste-types',
+          status: 'queued',
+        } as never,
+        refreshTechnicalHistory,
+        onTerminalJob,
+        setLastJob,
+      })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(setLastJob).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-4', status: 'failed' }));
+    expect(onTerminalJob).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-4', status: 'failed' }));
+  });
 });

--- a/packages/routing/src/auth.routes.server.handlers.ts
+++ b/packages/routing/src/auth.routes.server.handlers.ts
@@ -184,6 +184,9 @@ export const governanceAuthHandlerMap = {
   '/api/v1/waste-management/tools/seed': {
     POST: routeHandler(authRuntimeRoutes.wasteManagementHandlers.startSeed),
   },
+  '/api/v1/waste-management/tools/sync-waste-types': {
+    POST: routeHandler(authRuntimeRoutes.wasteManagementHandlers.startSyncWasteTypes),
+  },
   '/api/v1/waste-management/tools/reset': {
     POST: routeHandler(authRuntimeRoutes.wasteManagementHandlers.startReset),
   },

--- a/packages/routing/src/auth.routes.server.test.ts
+++ b/packages/routing/src/auth.routes.server.test.ts
@@ -176,6 +176,7 @@ const authServerMocks = vi.hoisted(() => {
       startImport: vi.fn(async () => response('startWasteManagementImportHandler')),
       previewLocationTourPickupDateImport: vi.fn(async () => response('previewLocationTourPickupDateImportHandler')),
       startSeed: vi.fn(async () => response('startWasteManagementSeedHandler')),
+      startSyncWasteTypes: vi.fn(async () => response('startWasteManagementSyncWasteTypesHandler')),
       startReset: vi.fn(async () => response('startWasteManagementResetHandler')),
     },
     listContentsHandler: vi.fn(async () => response('listContentsHandler')),
@@ -477,6 +478,7 @@ describe('auth.routes.server', () => {
     const importHandlers = resolveAuthHandlers('/api/v1/waste-management/tools/imports');
     const importPreviewHandlers = resolveAuthHandlers('/api/v1/waste-management/tools/imports/preview');
     const seedHandlers = resolveAuthHandlers('/api/v1/waste-management/tools/seed');
+    const syncWasteTypesHandlers = resolveAuthHandlers('/api/v1/waste-management/tools/sync-waste-types');
     const resetHandlers = resolveAuthHandlers('/api/v1/waste-management/tools/reset');
 
     expect(masterDataHandlers?.GET).toBeDefined();
@@ -507,6 +509,7 @@ describe('auth.routes.server', () => {
     expect(migrationsHandlers?.POST).toBeDefined();
     expect(importHandlers?.POST).toBeDefined();
     expect(seedHandlers?.POST).toBeDefined();
+    expect(syncWasteTypesHandlers?.POST).toBeDefined();
     expect(resetHandlers?.POST).toBeDefined();
 
     await masterDataHandlers.GET?.({
@@ -625,6 +628,9 @@ describe('auth.routes.server', () => {
     await seedHandlers.POST?.({
       request: new Request('http://localhost/api/v1/waste-management/tools/seed', { method: 'POST' }),
     });
+    await syncWasteTypesHandlers.POST?.({
+      request: new Request('http://localhost/api/v1/waste-management/tools/sync-waste-types', { method: 'POST' }),
+    });
     await resetHandlers.POST?.({
       request: new Request('http://localhost/api/v1/waste-management/tools/reset', { method: 'POST' }),
     });
@@ -663,6 +669,7 @@ describe('auth.routes.server', () => {
     expect(authServerMocks.wasteManagementHandlers.startImport).toHaveBeenCalled();
     expect(authServerMocks.wasteManagementHandlers.previewLocationTourPickupDateImport).toHaveBeenCalled();
     expect(authServerMocks.wasteManagementHandlers.startSeed).toHaveBeenCalled();
+    expect(authServerMocks.wasteManagementHandlers.startSyncWasteTypes).toHaveBeenCalled();
     expect(authServerMocks.wasteManagementHandlers.startReset).toHaveBeenCalled();
   });
 

--- a/packages/sva-mainserver/src/generated/static-content.ts
+++ b/packages/sva-mainserver/src/generated/static-content.ts
@@ -1,0 +1,64 @@
+// Generated from the checked-in SVA Mainserver schema snapshot.
+// The waste sync only needs the mutation id response for static content writes.
+
+export type SvaMainserverPublicJsonFileQuery = {
+  readonly publicJsonFile?: {
+    readonly id?: string | number | null;
+  } | null;
+};
+
+export type SvaMainserverCreateOrUpdateStaticContentMutation = {
+  readonly createOrUpdateStaticContent?: {
+    readonly id?: string | number | null;
+  } | null;
+};
+
+export const svaMainserverPublicJsonFileDocument = `
+query SvaMainserverPublicJsonFile(
+  $name: String!
+) {
+  publicJsonFile(
+    name: $name
+  ) {
+    id
+  }
+}
+`;
+
+export const svaMainserverCreateOrUpdateStaticContentDocument = `
+mutation SvaMainserverCreateOrUpdateStaticContent(
+  $name: String!
+  $content: String!
+  $dataType: String!
+  $version: String!
+) {
+  createOrUpdateStaticContent(
+    name: $name
+    content: $content
+    dataType: $dataType
+    version: $version
+  ) {
+    id
+  }
+}
+`;
+
+export const svaMainserverCreateOrUpdateStaticContentWithIdDocument = `
+mutation SvaMainserverCreateOrUpdateStaticContentWithId(
+  $name: String!
+  $id: ID!
+  $content: String!
+  $dataType: String!
+  $version: String!
+) {
+  createOrUpdateStaticContent(
+    name: $name
+    id: $id
+    content: $content
+    dataType: $dataType
+    version: $version
+  ) {
+    id
+  }
+}
+`;

--- a/packages/sva-mainserver/src/server/service-internals/shared.ts
+++ b/packages/sva-mainserver/src/server/service-internals/shared.ts
@@ -171,9 +171,15 @@ export const parseGraphqlPayload = <TResult>(payload: unknown): TResult => {
 
   const result = payloadResult.data as GraphqlResponse<TResult>;
   if (result.errors && result.errors.length > 0) {
+    const errorMessages = result.errors
+      .map((error) => error.message?.trim())
+      .filter((message): message is string => Boolean(message));
     throw toSvaMainserverError({
       code: 'graphql_error',
-      message: `GraphQL-Antwort des SVA-Mainservers enthielt ${result.errors.length} Fehler.`,
+      message:
+        errorMessages.length > 0
+          ? `GraphQL-Antwort des SVA-Mainservers enthielt ${result.errors.length} Fehler: ${errorMessages.join(' | ')}`
+          : `GraphQL-Antwort des SVA-Mainservers enthielt ${result.errors.length} Fehler.`,
       statusCode: 502,
     });
   }

--- a/packages/sva-mainserver/src/server/service-internals/static-content-operations.ts
+++ b/packages/sva-mainserver/src/server/service-internals/static-content-operations.ts
@@ -1,0 +1,68 @@
+import type {
+  SvaMainserverConnectionInput,
+  SvaMainserverInstanceConfig,
+  SvaMainserverStaticContentInput,
+} from '../../types.js';
+import {
+  svaMainserverPublicJsonFileDocument,
+  type SvaMainserverPublicJsonFileQuery,
+  svaMainserverCreateOrUpdateStaticContentDocument,
+  svaMainserverCreateOrUpdateStaticContentWithIdDocument,
+  type SvaMainserverCreateOrUpdateStaticContentMutation,
+} from '../../generated/static-content.js';
+
+import { toSvaMainserverError, type GraphqlExecutor } from './shared.js';
+
+export const createStaticContentOperations = (executeGraphqlWithConfig: GraphqlExecutor) => ({
+  writeStaticContentWithConfig: async (
+    input: SvaMainserverConnectionInput & { readonly staticContent: SvaMainserverStaticContentInput },
+    config: SvaMainserverInstanceConfig
+  ): Promise<{ readonly id: string }> => {
+    const normalizedName = input.staticContent.name.trim().toLowerCase();
+    const existingFile = await executeGraphqlWithConfig<SvaMainserverPublicJsonFileQuery>(
+      {
+        ...input,
+        document: svaMainserverPublicJsonFileDocument,
+        operationName: 'SvaMainserverPublicJsonFile',
+        variables: {
+          name: normalizedName,
+        },
+      },
+      config
+    );
+    const existingId = existingFile.publicJsonFile?.id;
+
+    const response = await executeGraphqlWithConfig<SvaMainserverCreateOrUpdateStaticContentMutation>(
+      {
+        ...input,
+        document:
+          existingId === null || existingId === undefined
+            ? svaMainserverCreateOrUpdateStaticContentDocument
+            : svaMainserverCreateOrUpdateStaticContentWithIdDocument,
+        operationName:
+          existingId === null || existingId === undefined
+            ? 'SvaMainserverCreateOrUpdateStaticContent'
+            : 'SvaMainserverCreateOrUpdateStaticContentWithId',
+        variables: {
+          ...input.staticContent,
+          name: normalizedName,
+          ...(existingId === null || existingId === undefined ? {} : { id: String(existingId) }),
+          dataType: 'json',
+          version: '',
+        },
+      },
+      config
+    );
+
+    const id = response.createOrUpdateStaticContent?.id;
+    if (id === null || id === undefined) {
+      throw toSvaMainserverError({
+        code: 'invalid_response',
+        message: 'SVA-Mainserver konnte den Static-Content-Eintrag nicht schreiben.',
+        statusCode: 502,
+      });
+    }
+
+    return { id: String(id) };
+  },
+});

--- a/packages/sva-mainserver/src/server/service-internals/static-content-operations.ts
+++ b/packages/sva-mainserver/src/server/service-internals/static-content-operations.ts
@@ -31,6 +31,21 @@ export const createStaticContentOperations = (executeGraphqlWithConfig: GraphqlE
       config
     );
     const existingId = existingFile.publicJsonFile?.id;
+    const variables =
+      existingId === null || existingId === undefined
+        ? {
+            name: normalizedName,
+            content: input.staticContent.content,
+            dataType: 'json' as const,
+            version: '',
+          }
+        : {
+            id: String(existingId),
+            name: normalizedName,
+            content: input.staticContent.content,
+            dataType: 'json' as const,
+            version: '',
+          };
 
     const response = await executeGraphqlWithConfig<SvaMainserverCreateOrUpdateStaticContentMutation>(
       {
@@ -43,13 +58,7 @@ export const createStaticContentOperations = (executeGraphqlWithConfig: GraphqlE
           existingId === null || existingId === undefined
             ? 'SvaMainserverCreateOrUpdateStaticContent'
             : 'SvaMainserverCreateOrUpdateStaticContentWithId',
-        variables: {
-          ...input.staticContent,
-          name: normalizedName,
-          ...(existingId === null || existingId === undefined ? {} : { id: String(existingId) }),
-          dataType: 'json',
-          version: '',
-        },
+        variables,
       },
       config
     );

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -61,6 +61,7 @@ vi.mock('@sva/server-runtime', async (importOriginal) => {
 });
 
 import {
+  createOrUpdateSvaMainserverStaticContent,
   createSvaMainserverEvent,
   createSvaMainserverNews,
   createSvaMainserverPoi,
@@ -349,6 +350,85 @@ describe('createSvaMainserverService', () => {
       id: 'news-1',
     });
     await expect(deleteSvaMainserverNews({ ...connection, newsId: 'news-1' })).resolves.toEqual({ id: 'news-1' });
+  });
+
+  it('creates or updates static content with typed GraphQL variables', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { publicJsonFile: { id: '1707' } } }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { createOrUpdateStaticContent: { id: 77 } } }));
+
+    const service = createSvaMainserverService({
+      loadInstanceConfig: async () => baseConfig,
+      readCredentials: async () => ({ apiKey: 'key-1', apiSecret: 'secret-1' }),
+      fetchImpl,
+    });
+
+    await expect(
+      service.createOrUpdateStaticContent({
+        instanceId: baseConfig.instanceId,
+        keycloakSubject: 'subject-1',
+        staticContent: {
+          name: 'wasteTypes',
+          content: '{"bio":{"label":"Biotonne"}}',
+          dataType: 'JSON',
+          version: 'sha256:abc',
+        },
+      })
+    ).resolves.toEqual({ id: '77' });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      baseConfig.graphqlBaseUrl,
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringMatching(/publicJsonFile/),
+      })
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      baseConfig.graphqlBaseUrl,
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+    const thirdCallBody = String(fetchImpl.mock.calls[2]?.[1]?.body ?? '');
+    expect(thirdCallBody).toContain('createOrUpdateStaticContent');
+    expect(thirdCallBody).toContain('"name":"wastetypes"');
+    expect(thirdCallBody).toContain('"id":"1707"');
+    expect(thirdCallBody).toContain('"dataType":"json"');
+    expect(thirdCallBody).toContain('"version":""');
+  });
+
+  it('routes the default static content helper through the default service', async () => {
+    state.loadSvaMainserverInstanceConfig.mockResolvedValue(baseConfig);
+    state.readEffectiveSvaMainserverCredentialsWithStatus.mockResolvedValue({
+      status: 'ok',
+      source: 'user',
+      credentials: { apiKey: 'key-1', apiSecret: 'secret-1' },
+    });
+
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { publicJsonFile: { id: '1707' } } }))
+      .mockResolvedValueOnce(createJsonResponse(200, { data: { createOrUpdateStaticContent: { id: 'static-1' } } }));
+
+    vi.stubGlobal('fetch', fetchImpl);
+
+    await expect(
+      createOrUpdateSvaMainserverStaticContent({
+        instanceId: baseConfig.instanceId,
+        keycloakSubject: 'subject-1',
+        staticContent: {
+          name: 'wasteTypes',
+          content: '{"bio":{"label":"Biotonne"}}',
+          dataType: 'JSON',
+          version: 'sha256:def',
+        },
+      })
+    ).resolves.toEqual({ id: 'static-1' });
   });
 
   it('lists, reads, writes and deletes events and POI with typed GraphQL variables', async () => {
@@ -1161,6 +1241,7 @@ describe('createSvaMainserverService', () => {
     ).resolves.toMatchObject({
       status: 'error',
       errorCode: 'graphql_error',
+      errorMessage: expect.stringContaining('boom'),
     });
   });
 
@@ -1388,6 +1469,7 @@ describe('createSvaMainserverService', () => {
     await expect(statusPromise).resolves.toMatchObject({
       status: 'error',
       errorCode: 'graphql_error',
+      errorMessage: expect.stringContaining('boom'),
     });
   });
 });

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -372,8 +372,6 @@ describe('createSvaMainserverService', () => {
         staticContent: {
           name: 'wasteTypes',
           content: '{"bio":{"label":"Biotonne"}}',
-          dataType: 'JSON',
-          version: 'sha256:abc',
         },
       })
     ).resolves.toEqual({ id: '77' });
@@ -424,8 +422,6 @@ describe('createSvaMainserverService', () => {
         staticContent: {
           name: 'wasteTypes',
           content: '{"bio":{"label":"Biotonne"}}',
-          dataType: 'JSON',
-          version: 'sha256:def',
         },
       })
     ).resolves.toEqual({ id: 'static-1' });

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -397,6 +397,7 @@ describe('createSvaMainserverService', () => {
     expect(thirdCallBody).toContain('"id":"1707"');
     expect(thirdCallBody).toContain('"dataType":"json"');
     expect(thirdCallBody).toContain('"version":""');
+    expect(thirdCallBody).not.toContain('"dataType":"JSON"');
   });
 
   it('routes the default static content helper through the default service', async () => {

--- a/packages/sva-mainserver/src/server/service.ts
+++ b/packages/sva-mainserver/src/server/service.ts
@@ -19,6 +19,7 @@ import type {
   SvaMainserverListQuery,
   SvaMainserverNewsInput,
   SvaMainserverPoiInput,
+  SvaMainserverStaticContentInput,
 } from '../types.js';
 import { loadSvaMainserverInstanceConfig } from './config-store.js';
 import { createAccessTokenProvider } from './service-internals/access-token-provider.js';
@@ -29,6 +30,7 @@ import { mapCategory } from './service-internals/mappers-shared.js';
 import { createNewsOperations } from './service-internals/news-operations.js';
 import { buildLogContext, logger, withObservedHop } from './service-internals/observability.js';
 import { createPoiOperations } from './service-internals/poi-operations.js';
+import { createStaticContentOperations } from './service-internals/static-content-operations.js';
 import {
   DEFAULT_CACHE_MAX_SIZE,
   DEFAULT_CREDENTIAL_CACHE_TTL_MS,
@@ -116,6 +118,7 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
   const newsOperations = createNewsOperations(executeGraphqlWithConfig);
   const eventOperations = createEventOperations(executeGraphqlWithConfig);
   const poiOperations = createPoiOperations(executeGraphqlWithConfig);
+  const staticContentOperations = createStaticContentOperations(executeGraphqlWithConfig);
 
   const getQueryRootTypenameWithConfig = async (
     input: SvaMainserverConnectionInput,
@@ -253,6 +256,13 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
     return poiOperations.destroyPoiWithConfig(input, config);
   };
 
+  const createOrUpdateStaticContent = async (
+    input: SvaMainserverConnectionInput & { readonly staticContent: SvaMainserverStaticContentInput }
+  ) => {
+    const config = await loadValidatedInstanceConfig(input, 'load_instance_config');
+    return staticContentOperations.writeStaticContentWithConfig(input, config);
+  };
+
   const getConnectionStatus = async (
     input: SvaMainserverConnectionInput
   ): Promise<SvaMainserverConnectionStatus> => {
@@ -306,6 +316,7 @@ export const createSvaMainserverService = (options: SvaMainserverServiceOptions 
   };
 
   return {
+    createOrUpdateStaticContent,
     createEvent,
     createNews,
     createPoi,
@@ -401,3 +412,7 @@ export const updateSvaMainserverPoi = (
 
 export const deleteSvaMainserverPoi = (input: SvaMainserverConnectionInput & { readonly poiId: string }) =>
   getDefaultService().deletePoi(input);
+
+export const createOrUpdateSvaMainserverStaticContent = (
+  input: SvaMainserverConnectionInput & { readonly staticContent: SvaMainserverStaticContentInput }
+) => getDefaultService().createOrUpdateStaticContent(input);

--- a/packages/sva-mainserver/src/types.ts
+++ b/packages/sva-mainserver/src/types.ts
@@ -43,6 +43,13 @@ export type SvaMainserverConnectionInput = {
   readonly activeOrganizationId?: string;
 };
 
+export type SvaMainserverStaticContentInput = {
+  readonly name: string;
+  readonly content: string;
+  readonly dataType: 'JSON';
+  readonly version: string;
+};
+
 export type SvaMainserverListQuery = {
   readonly page: number;
   readonly pageSize: number;

--- a/packages/sva-mainserver/src/types.ts
+++ b/packages/sva-mainserver/src/types.ts
@@ -46,8 +46,6 @@ export type SvaMainserverConnectionInput = {
 export type SvaMainserverStaticContentInput = {
   readonly name: string;
   readonly content: string;
-  readonly dataType?: 'JSON' | 'json';
-  readonly version?: string;
 };
 
 export type SvaMainserverListQuery = {

--- a/packages/sva-mainserver/src/types.ts
+++ b/packages/sva-mainserver/src/types.ts
@@ -46,8 +46,8 @@ export type SvaMainserverConnectionInput = {
 export type SvaMainserverStaticContentInput = {
   readonly name: string;
   readonly content: string;
-  readonly dataType: 'JSON';
-  readonly version: string;
+  readonly dataType?: 'JSON' | 'json';
+  readonly version?: string;
 };
 
 export type SvaMainserverListQuery = {


### PR DESCRIPTION
## Was sich ändert

- Fraktionen exportieren `wasteTypes` jetzt mit dem PDF-Kürzel als stabilem JSON-Key und `short_label`-Wert.
- Das PDF-Kürzel ist im Studio sofort verpflichtend, wird zuverlässig gespeichert und in der Fraktionen-Liste als eigene Spalte angezeigt.
- Der Mainserver-Sync lädt zuerst die `publicJsonFile`-ID für `wastetypes` und schreibt danach per `createOrUpdateStaticContent` mit `dataType: "json"` und leerer `version`.
- Das exportierte JSON enthält zusätzlich die Erinnerungs-Konfiguration pro Fraktion.
- Nach erfolgreichem Speichern einer Fraktion wird der Sync-Job gestartet; falls das Starten scheitert, zeigt die UI eine retrybare Warnung mit erneutem Versuch an.
- Für die lokale Entwicklung werden Plugin-Operation-Handler nach Server-Änderungen in Development erneut registriert, damit der Worker nicht mit veraltetem Stand weiterläuft.

## Warum

- Die App braucht künftig ein aus dem Studio generiertes, mainserver-kompatibles `wasteTypes`-JSON.
- Dafür mussten PDF-Kürzel fachlich führend werden und der Sync robuster auf das tatsächliche Mainserver-GraphQL-Verhalten angepasst werden.

## Verifikation

- `pnpm nx run core:test:unit --testFiles=src/waste-management-static-content.test.ts`
- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts`
- `pnpm nx run plugin-waste-management:test:types`
- `pnpm nx run auth-runtime:test:unit`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run sva-studio-react:test:unit:server --testFiles=src/lib/waste-management-operations.server.test.ts --testFiles=src/server.test.ts`
- `pnpm nx run plugin-waste-management:test:unit`
- `git diff --check`
