### PR TITLE
refactor(waste): export sync-mainserver job input type

### DIFF
--- a/apps/sva-studio-react/src/lib/waste-management-operations.types.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-operations.types.ts
@@ -3,17 +3,12 @@ import type {
   WasteManagementApplyMigrationsJobInput,
   WasteManagementImportJobInput,
   WasteManagementInitializeJobInput,
-  WasteManagementJobInput,
   WasteManagementResetJobInput,
   WasteManagementSeedJobInput,
+  WasteManagementSyncMainserverJobInput,
   WasteManagementSyncWasteTypesJobInput,
 } from '@sva/core';
 import type { loadDefaultExternalInterfaceRecord, listExternalInterfaceRecords } from '@sva/data-repositories/server';
-
-type WasteManagementSyncMainserverJobInput = Extract<
-  WasteManagementJobInput,
-  { readonly operation: 'sync-mainserver' }
->;
 
 export type SqlClient = {
   query: <TRow = Record<string, unknown>>(text: string, values?: readonly unknown[]) => Promise<{

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,10 +138,10 @@ export type {
   WasteManagementJobInput,
   WasteManagementJobTypeId,
   WasteManagementResetJobInput,
-  WasteManagementSyncMainserverJobInput,
   WasteManagementSeedJobInput,
   WasteManagementSyncWasteTypesJobInput,
 } from './waste-management-operations-contract.js';
+export type { WasteManagementSyncMainserverJobInput } from './waste-management-sync-mainserver-job-input.js';
 export type {
   WasteDateShiftReasonType,
   WasteCollectionLocationListFilter,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,6 +138,7 @@ export type {
   WasteManagementJobInput,
   WasteManagementJobTypeId,
   WasteManagementResetJobInput,
+  WasteManagementSyncMainserverJobInput,
   WasteManagementSeedJobInput,
   WasteManagementSyncWasteTypesJobInput,
 } from './waste-management-operations-contract.js';

--- a/packages/core/src/waste-management-operations-contract.ts
+++ b/packages/core/src/waste-management-operations-contract.ts
@@ -61,6 +61,12 @@ export type WasteManagementResetJobInput = {
   readonly confirmationToken: string;
 };
 
+export type WasteManagementSyncMainserverJobInput = {
+  readonly operation: 'sync-mainserver';
+  readonly keycloakSubject?: string;
+  readonly activeOrganizationId?: string;
+};
+
 export type WasteManagementSyncWasteTypesJobInput = {
   readonly operation: 'sync-waste-types';
   readonly keycloakSubject?: string;
@@ -73,11 +79,7 @@ export type WasteManagementJobInput =
   | WasteManagementImportJobInput
   | WasteManagementSeedJobInput
   | WasteManagementResetJobInput
-  | {
-      readonly operation: 'sync-mainserver';
-      readonly keycloakSubject?: string;
-      readonly activeOrganizationId?: string;
-    }
+  | WasteManagementSyncMainserverJobInput
   | WasteManagementSyncWasteTypesJobInput;
 
 export const wasteManagementOperationsContract = {

--- a/packages/core/src/waste-management-operations-contract.ts
+++ b/packages/core/src/waste-management-operations-contract.ts
@@ -1,3 +1,5 @@
+import type { WasteManagementSyncMainserverJobInput } from './waste-management-sync-mainserver-job-input.js';
+
 const wasteManagementJobTypeIds = {
   initializeDataSource: 'waste-management.initialize-data-source',
   applyMigrations: 'waste-management.apply-migrations',
@@ -59,12 +61,6 @@ export type WasteManagementSeedJobInput = {
 export type WasteManagementResetJobInput = {
   readonly operation: 'reset-data';
   readonly confirmationToken: string;
-};
-
-export type WasteManagementSyncMainserverJobInput = {
-  readonly operation: 'sync-mainserver';
-  readonly keycloakSubject?: string;
-  readonly activeOrganizationId?: string;
 };
 
 export type WasteManagementSyncWasteTypesJobInput = {

--- a/packages/core/src/waste-management-sync-mainserver-job-input.ts
+++ b/packages/core/src/waste-management-sync-mainserver-job-input.ts
@@ -1,0 +1,5 @@
+export type WasteManagementSyncMainserverJobInput = {
+  readonly operation: 'sync-mainserver';
+  readonly keycloakSubject?: string;
+  readonly activeOrganizationId?: string;
+};

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -138,6 +138,7 @@ export type {
   WasteManagementMasterDataOverview,
   WasteManagementResetJobInput,
   WasteManagementSeedJobInput,
+  WasteManagementSyncMainserverJobInput,
   WasteManagementSyncWasteTypesJobInput,
   WasteManagementSettingsInterfaceOption,
   WasteManagementSettingsRecord,

--- a/packages/plugin-sdk/src/public-api.ts
+++ b/packages/plugin-sdk/src/public-api.ts
@@ -40,6 +40,7 @@ export type {
   WasteManagementMasterDataOverview,
   WasteManagementResetJobInput,
   WasteManagementSeedJobInput,
+  WasteManagementSyncMainserverJobInput,
   WasteManagementSyncWasteTypesJobInput,
   WasteManagementSettingsInterfaceOption,
   WasteManagementSettingsRecord,

--- a/packages/plugin-waste-management/src/server.ts
+++ b/packages/plugin-waste-management/src/server.ts
@@ -8,6 +8,7 @@ import {
   type WasteManagementJobInput,
   type WasteManagementResetJobInput,
   type WasteManagementSeedJobInput,
+  type WasteManagementSyncMainserverJobInput,
   type WasteManagementSyncWasteTypesJobInput,
 } from '@sva/plugin-sdk';
 
@@ -29,10 +30,6 @@ const createProgress = (input: {
 });
 
 type WasteManagementJobProgress = ReturnType<typeof createProgress>;
-type WasteManagementSyncMainserverJobInput = Extract<
-  WasteManagementJobInput,
-  { readonly operation: 'sync-mainserver' }
->;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;


### PR DESCRIPTION
## Ziel
Den `sync-mainserver`-Jobinput als benannten Vertragstyp zentral exportieren, statt ihn an mehreren Stellen per `Extract<>` lokal abzuleiten.

## Änderungen
- `WasteManagementSyncMainserverJobInput` in `@sva/core` als eigenen Typ exportiert
- Re-Exports in `@sva/core` und `@sva/plugin-sdk` ergänzt
- lokale `Extract<>`-Ableitungen in Studio- und Plugin-Code entfernt

## Verifikation
- `pnpm nx affected --target=test:types --base=origin/main`