### PR TITLE
[codex] Deduplicate media field options

### DIFF
--- a/packages/plugin-sdk/src/content-ui-utils.test.ts
+++ b/packages/plugin-sdk/src/content-ui-utils.test.ts
@@ -91,6 +91,7 @@ describe('content-ui-utils', () => {
     expect(
       toHostMediaFieldOptions([
         { id: 'asset-1', metadata: { title: 'Titelbild' } },
+        { id: 'asset-1', metadata: { title: 'Titelbild Duplikat' } },
         { id: 'asset-2' },
       ])
     ).toEqual([

--- a/packages/plugin-sdk/src/content-ui-utils.ts
+++ b/packages/plugin-sdk/src/content-ui-utils.ts
@@ -180,11 +180,20 @@ export const fromDatetimeLocalValue = (value: string, referenceValue?: string): 
   return '';
 };
 
-export const toHostMediaFieldOptions = (assets: readonly HostMediaAssetListItem[]): readonly HostMediaFieldOption[] =>
-  assets.map((asset) => ({
-    assetId: asset.id,
-    label: String(asset.metadata?.title ?? asset.id),
-  }));
+export const toHostMediaFieldOptions = (assets: readonly HostMediaAssetListItem[]): readonly HostMediaFieldOption[] => {
+  const seenAssetIds = new Set<string>();
+
+  return assets.flatMap((asset) => {
+    if (seenAssetIds.has(asset.id)) {
+      return [];
+    }
+    seenAssetIds.add(asset.id);
+    return [{
+      assetId: asset.id,
+      label: String(asset.metadata?.title ?? asset.id),
+    }];
+  });
+};
 
 export const findHostMediaReferenceAssetId = (
   references: readonly HostMediaReferenceSelection[],

--- a/packages/studio-ui-react/src/media-reference-field.test.tsx
+++ b/packages/studio-ui-react/src/media-reference-field.test.tsx
@@ -55,7 +55,7 @@ describe('MediaReferenceField', () => {
 
   it('does not emit duplicate key warnings when multiple options share the same asset id', () => {
     const onChange = vi.fn();
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     render(
       <MediaReferenceField

--- a/packages/studio-ui-react/src/media-reference-field.test.tsx
+++ b/packages/studio-ui-react/src/media-reference-field.test.tsx
@@ -52,33 +52,4 @@ describe('MediaReferenceField', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Auswahl entfernen' }));
     expect(onChange).toHaveBeenCalledWith(null);
   });
-
-  it('does not emit duplicate key warnings when multiple options share the same asset id', () => {
-    const onChange = vi.fn();
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-
-    render(
-      <MediaReferenceField
-        id="duplicate-media"
-        label="Doppelte Medien"
-        value={null}
-        options={[
-          { assetId: 'asset-1', label: 'Titelbild' },
-          { assetId: 'asset-1', label: 'Titelbild Kopie' },
-        ]}
-        onChange={onChange}
-        placeholder="Medium auswählen"
-      />
-    );
-
-    expect(screen.getByRole('option', { name: 'Titelbild' })).toBeTruthy();
-    expect(screen.getByRole('option', { name: 'Titelbild Kopie' })).toBeTruthy();
-    expect(
-      consoleErrorSpy.mock.calls.some(([message]) =>
-        typeof message === 'string' && message.includes('Each child in a list should have a unique "key" prop')
-      )
-    ).toBe(false);
-
-    consoleErrorSpy.mockRestore();
-  });
 });

--- a/packages/studio-ui-react/src/media-reference-field.test.tsx
+++ b/packages/studio-ui-react/src/media-reference-field.test.tsx
@@ -52,4 +52,33 @@ describe('MediaReferenceField', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Auswahl entfernen' }));
     expect(onChange).toHaveBeenCalledWith(null);
   });
+
+  it('does not emit duplicate key warnings when multiple options share the same asset id', () => {
+    const onChange = vi.fn();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <MediaReferenceField
+        id="duplicate-media"
+        label="Doppelte Medien"
+        value={null}
+        options={[
+          { assetId: 'asset-1', label: 'Titelbild' },
+          { assetId: 'asset-1', label: 'Titelbild Kopie' },
+        ]}
+        onChange={onChange}
+        placeholder="Medium auswählen"
+      />
+    );
+
+    expect(screen.getByRole('option', { name: 'Titelbild' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Titelbild Kopie' })).toBeTruthy();
+    expect(
+      consoleErrorSpy.mock.calls.some(([message]) =>
+        typeof message === 'string' && message.includes('Each child in a list should have a unique "key" prop')
+      )
+    ).toBe(false);
+
+    consoleErrorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Was wurde geändert?
- `toHostMediaFieldOptions(...)` dedupliziert Host-Media-Assets jetzt nach `asset.id`
- Regressionstest für doppelte Media-Assets im `plugin-sdk` ergänzt
- UI-nahen Test für `MediaReferenceField` ergänzt, damit der React-Key-Warnpfad abgesichert bleibt

## Warum?
Im lokalen Browser trat ein React-Warnhinweis auf: `Each child in a list should have a unique "key" prop` im Renderpfad von `select` aus `MediaReferenceField`.

Die Ursache war, dass doppelte Media-Assets ungefiltert bis in die Select-Optionen durchgereicht wurden. Dadurch konnten mehrere Optionen mit derselben `assetId` entstehen.

## Auswirkung
- keine funktionale Änderung für eindeutige Media-Listen
- doppelte Asset-Einträge erzeugen keinen unnötigen Select-Duplikatpfad mehr
- der Warnhinweis in der Browser-Console sollte damit entfallen

## Verifikation
- `NX_SKIP_NX_CACHE=true pnpm nx run plugin-sdk:test:unit --testFiles=packages/plugin-sdk/src/content-ui-utils.test.ts`
- `NX_SKIP_NX_CACHE=true pnpm nx run studio-ui-react:test:unit --testFiles=packages/studio-ui-react/src/media-reference-field.test.tsx`