### PR TITLE
[codex] Stabilize SonarCloud scan action

### DIFF
--- a/.github/workflows/runtime-gates.yml
+++ b/.github/workflows/runtime-gates.yml
@@ -145,9 +145,19 @@ jobs:
           fi
           git rev-parse --is-shallow-repository
 
+      - name: Setup Java for SonarCloud
+        if: always() && github.event_name != 'pull_request' && env.SONAR_TOKEN != ''
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - name: SonarCloud Scan
         if: always() && github.event_name != 'pull_request' && env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@v7
+        with:
+          args: >
+            -Dsonar.scanner.skipJreProvisioning=true
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 


### PR DESCRIPTION
## Was wurde geändert?
- `Runtime Gates` richtet vor dem SonarCloud-Scan explizit Java 17 per `actions/setup-java@v5` ein.
- Der SonarScanner läuft mit `-Dsonar.scanner.skipJreProvisioning=true`, damit kein JRE-Download zur Laufzeit mehr nötig ist.

## Warum?
- Der GitHub-Action-Run für `SonarSource/sonarqube-scan-action@v7` ist auf `main` wiederholt vor der eigentlichen Analyse fehlgeschlagen.
- Root Cause war der neue JRE-Provisioning-Pfad des Scanners: der Abruf von `https://api.sonarcloud.io/analysis/jres` endete mit `403 Forbidden`.

## Auswirkung
- Der SonarCloud-Scan verwendet die auf dem Runner vorbereitete Java-Laufzeit statt der automatischen Provisionierung.
- Die Änderung ist auf den CI-Workflow begrenzt und ändert keine Laufzeitlogik der Anwendung.

## Validierung
- `pnpm nx affected --target=test:unit --base=origin/main`
