### PR TITLE
[codex] Fix Sonar hotspots and coverage artifacts

### DIFF
--- a/packages/auth-runtime/src/iam-media/storage-s3.test.ts
+++ b/packages/auth-runtime/src/iam-media/storage-s3.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { GetObjectCommand, ListObjectsV2Command, type S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -487,5 +488,12 @@ describe('media storage s3 adapter', () => {
     vi.stubEnv('MEDIA_STORAGE_SECRET_ACCESS_KEY', '');
 
     expect(() => createConfiguredMediaStoragePort()).toThrow(MediaStorageUnavailableError);
+  });
+
+  it('avoids the slash-trimming regex patterns flagged by Sonar in the public base url builder', () => {
+    const source = fs.readFileSync(new URL('./storage-s3.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toContain('replace(/\\/+$/, \'\')');
+    expect(source).not.toContain('replace(/^\\/+|\\/+$/g, \'\')');
   });
 });

--- a/packages/auth-runtime/src/iam-media/storage-s3.ts
+++ b/packages/auth-runtime/src/iam-media/storage-s3.ts
@@ -53,6 +53,28 @@ const mimeTypeExtensions: Readonly<Record<string, string>> = {
 
 const resolveObjectExtension = (mimeType: string): string => mimeTypeExtensions[mimeType] ?? 'bin';
 
+const trimTrailingSlashes = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+};
+
+const trimSurroundingSlashes = (value: string): string => {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value.charCodeAt(start) === 47) {
+    start += 1;
+  }
+  while (end > start && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+};
+
 const resolveStoragePrefix = (instanceId: string, bucket: string): string =>
   bucket.trim() === instanceId.trim() ? '' : createMediaStorageInstancePrefix(instanceId);
 
@@ -67,7 +89,7 @@ const createPublicDeliveryUrl = (publicBaseUrl: string | undefined, storageKey: 
 };
 
 const createBucketPublicBaseUrl = (endpoint: string, bucket: string): string =>
-  `${endpoint.replace(/\/+$/, '')}/${bucket.replace(/^\/+|\/+$/g, '')}`;
+  `${trimTrailingSlashes(endpoint)}/${trimSurroundingSlashes(bucket)}`;
 
 const encodeStorageKeyForUrl = (storageKey: string): string =>
   storageKey

--- a/packages/auth-runtime/src/keycloak-account-action-support.test.ts
+++ b/packages/auth-runtime/src/keycloak-account-action-support.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const importModule = async () => import('./keycloak-account-action-support.js');
@@ -96,5 +98,11 @@ describe('keycloak account action support', () => {
     await expect(isUpdateEmailActionSupported('tenant-c')).resolves.toBe(true);
 
     expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('avoids the trailing-slash regex pattern flagged by Sonar in base-url normalization', async () => {
+    const source = fs.readFileSync(new URL('./keycloak-account-action-support.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toContain('replace(/\\/+$/u, \'\')');
   });
 });

--- a/packages/auth-runtime/src/keycloak-account-action-support.ts
+++ b/packages/auth-runtime/src/keycloak-account-action-support.ts
@@ -34,7 +34,13 @@ const requireEnv = (key: string): string => {
   return value;
 };
 
-const normalizeBaseUrl = (value: string): string => value.replace(/\/+$/u, '');
+const normalizeBaseUrl = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+};
 
 const encodePathSegment = (value: string): string => encodeURIComponent(value);
 

--- a/packages/auth-runtime/src/waste-management/core/schemas.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/schemas.test.ts
@@ -96,6 +96,69 @@ describe('waste-management schemas', () => {
     expect(invalidResult.success).toBe(false);
   });
 
+  it('rejects malformed email reminder addresses with doubled dots while accepting plus addressing', () => {
+    const basePayload = {
+      enabled: true,
+      publicSignupEnabled: true,
+      transportId: 'mail-1',
+      doiConfirmPath: '/confirm',
+      unsubscribePath: '/unsubscribe',
+      fromName: 'Waste Team',
+      fromEmail: 'waste+team@example.test',
+      replyToEmail: 'reply+mail@example.test',
+      privacyPolicyUrl: 'https://example.test/privacy',
+      imprintUrl: 'https://example.test/imprint',
+      consentLabel: 'Einverstanden',
+      consentVersion: 'v1',
+      doiSubjectTemplate: 'Bitte bestaetigen',
+      doiIntroText: 'Bitte bestaetigen Sie die Anmeldung.',
+      doiButtonLabel: 'Bestaetigen',
+      reminderSubjectTemplate: 'Erinnerung',
+      reminderIntroTemplate: 'Morgen wird abgeholt.',
+      unsubscribeLinkLabel: 'Abmelden',
+      unsubscribeSuccessHeadline: 'Abmeldung erfolgreich',
+      unsubscribeSuccessBody: 'Sie wurden erfolgreich abgemeldet.',
+      maxSubscriptionsPerEmailAndLocation: 3,
+      signupRateLimitPerIpPerHour: 10,
+      signupRateLimitPerEmailPerHour: 5,
+      doiTokenTtlHours: 48,
+      pendingSubscriptionTtlHours: 72,
+      materializationLookaheadDays: 7,
+    };
+
+    expect(
+      wasteManagementSettingsSchemas.updateWasteSettingsSchema.safeParse({
+        ...baseSettingsPayload,
+        emailReminderConfig: {
+          ...basePayload,
+          publicBaseUrl: 'https://example.test',
+        },
+      }).success
+    ).toBe(true);
+
+    expect(
+      wasteManagementSettingsSchemas.updateWasteSettingsSchema.safeParse({
+        ...baseSettingsPayload,
+        emailReminderConfig: {
+          ...basePayload,
+          publicBaseUrl: 'https://example.test',
+          fromEmail: 'waste..team@example.test',
+        },
+      }).success
+    ).toBe(false);
+
+    expect(
+      wasteManagementSettingsSchemas.updateWasteSettingsSchema.safeParse({
+        ...baseSettingsPayload,
+        emailReminderConfig: {
+          ...basePayload,
+          publicBaseUrl: 'https://example.test',
+          replyToEmail: 'reply@example..test',
+        },
+      }).success
+    ).toBe(false);
+  });
+
   it('rejects absolute success paths in email reminder settings', () => {
     const result = wasteManagementSettingsSchemas.updateWasteSettingsSchema.safeParse({
       ...baseSettingsPayload,

--- a/packages/auth-runtime/src/waste-management/core/schemas.ts
+++ b/packages/auth-runtime/src/waste-management/core/schemas.ts
@@ -1,4 +1,4 @@
-import { wasteManagementMasterDataContract, type WasteTourRecurrence } from '@sva/core';
+import { isPlausibleEmailAddress, wasteManagementMasterDataContract, type WasteTourRecurrence } from '@sva/core';
 import { z } from 'zod';
 
 const wasteFractionReminderCountSchema = z.enum(wasteManagementMasterDataContract.fractionReminderCounts);
@@ -165,7 +165,7 @@ const optionalWasteUrlSchema = z
 const optionalEmailSchema = z
   .string()
   .trim()
-  .refine((value) => value.length === 0 || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value), 'Ungültige E-Mail-Adresse.');
+  .refine((value) => value.length === 0 || isPlausibleEmailAddress(value), 'Ungültige E-Mail-Adresse.');
 const optionalRelativePathSchema = z
   .string()
   .trim()

--- a/packages/core/src/email-address.ts
+++ b/packages/core/src/email-address.ts
@@ -1,0 +1,70 @@
+const isWhitespaceCodePoint = (character: string): boolean => /\s/u.test(character);
+
+const isDomainLabelCharacter = (character: string): boolean => {
+  const codePoint = character.codePointAt(0);
+  if (codePoint === undefined) {
+    return false;
+  }
+
+  return (
+    (codePoint >= 48 && codePoint <= 57) ||
+    (codePoint >= 65 && codePoint <= 90) ||
+    (codePoint >= 97 && codePoint <= 122) ||
+    codePoint === 45
+  );
+};
+
+const hasWhitespace = (value: string): boolean => {
+  for (const character of value) {
+    if (isWhitespaceCodePoint(character)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const isValidDomainLabel = (label: string): boolean => {
+  if (label.length === 0 || label.startsWith('-') || label.endsWith('-')) {
+    return false;
+  }
+
+  for (const character of label) {
+    if (!isDomainLabelCharacter(character)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const isPlausibleEmailAddress = (value: string): boolean => {
+  if (value.length === 0 || hasWhitespace(value)) {
+    return false;
+  }
+
+  const atIndex = value.indexOf('@');
+  if (atIndex <= 0 || atIndex !== value.lastIndexOf('@') || atIndex === value.length - 1) {
+    return false;
+  }
+
+  const localPart = value.slice(0, atIndex);
+  const domainPart = value.slice(atIndex + 1);
+  if (
+    localPart.startsWith('.') ||
+    localPart.endsWith('.') ||
+    domainPart.startsWith('.') ||
+    domainPart.endsWith('.') ||
+    localPart.includes('..') ||
+    domainPart.includes('..')
+  ) {
+    return false;
+  }
+
+  const domainLabels = domainPart.split('.');
+  if (domainLabels.length < 2) {
+    return false;
+  }
+
+  return domainLabels.every(isValidDomainLabel);
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export const coreVersion = '0.0.1';
+export { isPlausibleEmailAddress } from './email-address.js';
 export {
   iamContentAccessReasonCodes,
   iamContentListSortDirections,

--- a/packages/core/src/waste-management-settings-public-config.test.ts
+++ b/packages/core/src/waste-management-settings-public-config.test.ts
@@ -349,6 +349,39 @@ describe('waste-management-settings-public-config', () => {
     expect(readWasteManagementEmailReminderConfig(next)).toEqual(createEmailReminderConfigInput());
   });
 
+  it('rejects malformed email reminder addresses with doubled dots while preserving valid plus addressing', () => {
+    expect(
+      readWasteManagementEmailReminderConfig({
+        emailReminderConfig: {
+          ...createEmailReminderConfigInput(),
+          fromEmail: 'abfall+service@example.org',
+          replyToEmail: 'reply+service@example.org',
+        },
+      })
+    ).toMatchObject({
+      fromEmail: 'abfall+service@example.org',
+      replyToEmail: 'reply+service@example.org',
+    });
+
+    expect(
+      readWasteManagementEmailReminderConfig({
+        emailReminderConfig: {
+          ...createEmailReminderConfigInput(),
+          fromEmail: 'abfall..service@example.org',
+        },
+      })
+    ).toBeUndefined();
+
+    expect(
+      readWasteManagementEmailReminderConfig({
+        emailReminderConfig: {
+          ...createEmailReminderConfigInput(),
+          replyToEmail: 'reply@example..org',
+        },
+      })
+    ).toBeUndefined();
+  });
+
   it('preserves the previous email reminder config when partial writes omit the field', () => {
     const current = buildWasteManagementPublicConfig(
       {},

--- a/packages/core/src/waste-management-settings-public-config.ts
+++ b/packages/core/src/waste-management-settings-public-config.ts
@@ -1,5 +1,6 @@
 import type { ExternalInterfaceRecord } from './external-interfaces-contract.js';
 import type { WasteHolidayStateCode } from './waste-management/master-data-contract.js';
+import { isPlausibleEmailAddress } from './email-address.js';
 import { wasteManagementMasterDataContract } from './waste-management-master-data.js';
 import { wasteManagementDataSourceContract, type WasteHolidaySyncStatus } from './waste-management-contract.js';
 
@@ -26,11 +27,9 @@ const readBoundedPositiveInteger = (value: unknown, maximum: number): number | u
 
 const readBoolean = (value: unknown): boolean | undefined => (typeof value === 'boolean' ? value : undefined);
 
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 const readEmail = (value: unknown): string | undefined => {
   const email = readTrimmedString(value);
-  return email && EMAIL_PATTERN.test(email) ? email : undefined;
+  return email && isPlausibleEmailAddress(email) ? email : undefined;
 };
 
 const normalizeUrlString = (url: URL): string => url.toString();

--- a/packages/mail-runtime/tests/vitest-config.test.ts
+++ b/packages/mail-runtime/tests/vitest-config.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import vitestConfig from '../vitest.config';
+
+describe('mail-runtime vitest coverage config', () => {
+  it('inherits the shared coverage reporters required by the CI gate', () => {
+    expect(vitestConfig.test?.coverage).toMatchObject({
+      provider: 'v8',
+      reporter: ['text-summary', 'json-summary', 'lcov'],
+      reportsDirectory: './coverage',
+    });
+  });
+});

--- a/packages/mail-runtime/vitest.config.ts
+++ b/packages/mail-runtime/vitest.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from 'vitest/config';
+import { sharedCoverageConfig } from '../../vitest.config';
 
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+    exclude: ['dist/**', 'coverage/**', 'node_modules/**'],
     environment: 'node',
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-    },
+    coverage: sharedCoverageConfig,
   },
 });


### PR DESCRIPTION
## Was geaendert wurde

- SonarCloud-Hotspots in `auth-runtime` und den Waste-Management-E-Mail-Validierungen beseitigt.
- Gemeinsame E-Mail-Validierung in `core` eingefuehrt und an den betroffenen Stellen verdrahtet.
- `mail-runtime` so angepasst, dass der Coverage-Lauf wieder `coverage-summary.json` erzeugt und durch einen Guard-Test abgesichert ist.

## Warum

- SonarCloud meldete mehrere offene `typescript:S5852`-Hotspots fuer Regexe mit moeglichem ReDoS-/Backtracking-Risiko.
- Der Coverage-Gate fuer `mail-runtime` schlug fehl, weil `json-summary` lokal ueberschrieben wurde und damit `coverage-summary.json` fehlte.

## Auswirkungen

- URL-/Slash-Normalisierung in `auth-runtime` laeuft jetzt ohne die beanstandeten Regexe.
- E-Mail-Adressen mit gueltigem Plus-Addressing bleiben erlaubt, fehlerhafte Adressen mit doppelten Punkten werden abgelehnt.
- `mail-runtime:test:coverage` produziert wieder die erwarteten Artefakte fuer das Coverage-Gate.

## Verifikation

- `pnpm nx run mail-runtime:test:unit`
- `pnpm nx run mail-runtime:test:coverage`
- `pnpm nx run core:test:unit --testFiles=src/waste-management-settings-public-config.test.ts`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/iam-media/storage-s3.test.ts --testFiles=src/waste-management/core/schemas.test.ts`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/keycloak-account-action-support.test.ts`
- `pnpm nx run core:test:types`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run core:check:runtime`
- `pnpm nx run auth-runtime:check:runtime`

## Root Cause

- Sonar-Hotspots entstanden durch kleine Normalisierungs-/Validierungsregexe an produktiven Eingabepfaden.
- Der Coverage-Reporter in `mail-runtime` wich von der gemeinsamen Vitest-Coverage-Konfiguration ab und unterdrueckte `json-summary`.
