### PR TITLE
[codex] Enrich public waste ICS output and lock reminder paths

### DIFF
--- a/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.ts
@@ -13,6 +13,7 @@ import {
 type PublicWasteLinkedFraction = {
   readonly id: string;
   readonly label: string;
+  readonly description?: string;
   readonly shortLabel?: string;
   readonly color?: string;
 };
@@ -310,6 +311,7 @@ export const calculatePublicWasteCalendarEntries = (
           date: shiftedDate,
           fractionId: fraction.id,
           fractionLabel: fraction.label,
+          ...(fraction.description ? { fractionDescription: fraction.description } : {}),
           ...(fraction.shortLabel ? { fractionShortLabel: fraction.shortLabel } : {}),
           ...(fraction.color ? { fractionColor: fraction.color } : {}),
           ...(linkedTour.tour.name.trim() ? { tourName: linkedTour.tour.name.trim() } : {}),

--- a/apps/public-waste-calendar-web/src/lib/public-waste-contract.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-contract.ts
@@ -39,6 +39,7 @@ export type PublicWasteCalendarEntry = {
   readonly date: string;
   readonly fractionId: string;
   readonly fractionLabel: string;
+  readonly fractionDescription?: string;
   readonly fractionShortLabel?: string;
   readonly fractionColor?: string;
   readonly tourName?: string;

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
@@ -219,9 +219,12 @@ describe('public waste endpoints', () => {
             date: '2026-05-19',
             fractionId: 'bio',
             fractionLabel: 'Bioabfall',
+            fractionDescription: 'Bioabfall aus Küche und Garten.',
+            tourDescription: 'Regelabfuhr für die Innenstadt.',
             note: 'Bitte Tonne ab 6 Uhr bereitstellen.',
           },
         ]),
+        loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
       },
       request: new Request(
         'https://example.invalid/public-waste/calendar.ics?regionId=11111111-1111-4111-8111-111111111111&cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&houseNumberId=44444444-4444-4444-8444-444444444444&calendarName=Musterstadt'
@@ -229,7 +232,70 @@ describe('public waste endpoints', () => {
     });
 
     expect(response.headers.get('content-type')).toContain('text/calendar');
-    await expect(response.text()).resolves.toContain('SUMMARY:Bioabfall');
+    const body = await response.text();
+    expect(body).toContain('DESCRIPTION:Abholort: Musterstadt\\, Hauptstraße 1');
+    expect(body).toContain(
+      'DESCRIPTION:Fraktion: Bioabfall aus Küche und Garten.\\nTour: Regelabfuhr für die Innenstadt.\\nHinweis: Bitte Tonne ab 6 Uhr bereitstellen.'
+    );
+  });
+
+  it('keeps the public default iCal as an all-fractions feed without calendar alarms', async () => {
+    const response = await handlePublicWasteIcalRequest({
+      repository: {
+        loadCalendarEntries: vi.fn().mockResolvedValue([
+          {
+            id: 'pickup-1',
+            date: '2026-05-19',
+            fractionId: 'bio',
+            fractionLabel: 'Bioabfall',
+            note: null,
+          },
+          {
+            id: 'pickup-2',
+            date: '2026-05-20',
+            fractionId: 'paper',
+            fractionLabel: 'Papier',
+            note: null,
+          },
+        ]),
+        loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
+      },
+      request: new Request(
+        'https://example.invalid/public-waste/calendar.ics?cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&calendarName=Musterstadt'
+      ),
+    });
+
+    const body = await response.text();
+    expect(body).toContain('SUMMARY:Bioabfall');
+    expect(body).toContain('SUMMARY:Papier');
+    expect(body).not.toContain('BEGIN:VALARM');
+  });
+
+  it('suppresses duplicate event description texts across fraction, tour and note parts', async () => {
+    const response = await handlePublicWasteIcalRequest({
+      repository: {
+        loadCalendarEntries: vi.fn().mockResolvedValue([
+          {
+            id: 'pickup-1',
+            date: '2026-05-19',
+            fractionId: 'bio',
+            fractionLabel: 'Bioabfall',
+            fractionDescription: 'Bereitstellung am Vorabend.',
+            tourDescription: 'Bereitstellung am Vorabend.',
+            note: 'Bereitstellung am Vorabend.',
+          },
+        ]),
+        loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
+      },
+      request: new Request(
+        'https://example.invalid/public-waste/calendar.ics?cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&calendarName=Musterstadt'
+      ),
+    });
+
+    const body = await response.text();
+    expect(body).toContain('DESCRIPTION:Fraktion: Bereitstellung am Vorabend.');
+    expect(body).not.toContain('\\nTour: Bereitstellung am Vorabend.');
+    expect(body).not.toContain('\\nHinweis: Bereitstellung am Vorabend.');
   });
 
   it('accepts the catch-all street sentinel for resolved calendar requests', async () => {

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
@@ -46,6 +46,36 @@ const readRequiredYear = (url: URL): number => {
 
 const normalizeDateForIcal = (value: string): string => value.replaceAll('-', '');
 
+const normalizeEventDescriptionPart = (value: string | undefined | null): string | null => {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+};
+
+const buildPublicWasteIcalEventDescription = (entry: {
+  readonly fractionDescription?: string;
+  readonly tourDescription?: string;
+  readonly note: string | null;
+}): string | undefined => {
+  const uniqueValues = new Set<string>();
+  const parts: string[] = [];
+  const candidates = [
+    ['Fraktion', normalizeEventDescriptionPart(entry.fractionDescription)] as const,
+    ['Tour', normalizeEventDescriptionPart(entry.tourDescription)] as const,
+    ['Hinweis', normalizeEventDescriptionPart(entry.note)] as const,
+  ];
+
+  for (const [label, value] of candidates) {
+    if (!value || uniqueValues.has(value)) {
+      continue;
+    }
+
+    uniqueValues.add(value);
+    parts.push(`${label}: ${value}`);
+  }
+
+  return parts.length > 0 ? parts.join('\n') : undefined;
+};
+
 const normalizePdfLocationLabel = (selectionSummary: string): string => {
   const parts = selectionSummary.split(',').map((part) => part.trim()).filter(Boolean);
   const city = parts[0] ?? '';
@@ -316,27 +346,35 @@ export const handlePublicWastePdfRequest = async (input: {
 };
 
 export const handlePublicWasteIcalRequest = async (input: {
-  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries'>;
+  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries' | 'loadSelectionSummary'>;
   readonly request: Request;
 }): Promise<Response> => {
   try {
     const url = new URL(input.request.url);
-    const calendar = await loadResolvedPublicWasteCalendar({
-      repository: input.repository,
-      input: {
-        selection: readPublicWasteResolvedSelection(url),
-        referenceDate: readPublicWasteReferenceDate(url),
-      },
-    });
+    const selection = readPublicWasteResolvedSelection(url);
+    const [calendar, selectionSummary] = await Promise.all([
+      loadResolvedPublicWasteCalendar({
+        repository: input.repository,
+        input: {
+          selection,
+          referenceDate: readPublicWasteReferenceDate(url),
+        },
+      }),
+      input.repository.loadSelectionSummary({ selection }),
+    ]);
 
     const body = renderPublicWasteIcal({
       calendarName: readPublicWasteCalendarName(url),
-      events: calendar.listEntries.map((entry) => ({
-        uid: `${entry.id}@public-waste-calendar`,
-        startDate: normalizeDateForIcal(entry.date),
-        summary: entry.fractionLabel,
-        ...(entry.note ? { description: entry.note } : {}),
-      })),
+      calendarDescription: `Abholort: ${selectionSummary}`,
+      events: calendar.listEntries.map((entry) => {
+        const description = buildPublicWasteIcalEventDescription(entry);
+        return {
+          uid: `${entry.id}@public-waste-calendar`,
+          startDate: normalizeDateForIcal(entry.date),
+          summary: entry.fractionLabel,
+          ...(description ? { description } : {}),
+        };
+      }),
     });
 
     return new Response(body, {

--- a/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.test.ts
@@ -27,4 +27,25 @@ describe('public waste iCal', () => {
     expect(ical).toContain('SUMMARY:Bioabfall');
     expect(ical).toContain('DTSTART;VALUE=DATE:20260519');
   });
+
+  it('normalizes carriage returns in calendar and event descriptions before escaping', () => {
+    const ical = renderPublicWasteIcal({
+      calendarName: 'Abfallkalender Musterstadt',
+      calendarDescription: 'Abholort:\r\nMusterstadt\rHauptstraße 1',
+      events: [
+        {
+          uid: 'pickup-1@example.invalid',
+          startDate: '20260519',
+          summary: 'Bioabfall',
+          description: 'Fraktion: Bioabfall\r\nTour: Innenstadt\rHinweis: Bereitstellen',
+        },
+      ],
+    });
+
+    expect(ical).toContain('DESCRIPTION:Abholort:\\nMusterstadt\\nHauptstraße 1');
+    expect(ical).toContain('X-WR-CALDESC:Abholort:\\nMusterstadt\\nHauptstraße 1');
+    expect(ical).toContain('DESCRIPTION:Fraktion: Bioabfall\\nTour: Innenstadt\\nHinweis: Bereitstellen');
+    expect(ical).not.toContain('\rHauptstraße 1');
+    expect(ical).not.toContain('\rTour: Innenstadt');
+  });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.test.ts
@@ -6,17 +6,24 @@ describe('public waste iCal', () => {
   it('renders a calendar feed for upcoming pickup entries', () => {
     const ical = renderPublicWasteIcal({
       calendarName: 'Abfallkalender Musterstadt',
+      calendarDescription: 'Abholort: Musterstadt, Hauptstraße 1',
       events: [
         {
           uid: 'pickup-1@example.invalid',
           startDate: '20260519',
           summary: 'Bioabfall',
-          description: 'Bitte Tonne ab 6 Uhr bereitstellen.',
+          description:
+            'Fraktion: Bioabfall aus Küche und Garten\nTour: Regelabfuhr für die Innenstadt\nHinweis: Bitte Tonne ab 6 Uhr bereitstellen.',
         },
       ],
     });
 
     expect(ical).toContain('BEGIN:VCALENDAR');
+    expect(ical).toContain('DESCRIPTION:Abholort: Musterstadt\\, Hauptstraße 1');
+    expect(ical).toContain('X-WR-CALDESC:Abholort: Musterstadt\\, Hauptstraße 1');
+    expect(ical).toContain(
+      'DESCRIPTION:Fraktion: Bioabfall aus Küche und Garten\\nTour: Regelabfuhr für die Innenstadt\\nHinweis: Bitte Tonne ab 6 Uhr bereitstellen.'
+    );
     expect(ical).toContain('SUMMARY:Bioabfall');
     expect(ical).toContain('DTSTART;VALUE=DATE:20260519');
   });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts
@@ -1,5 +1,6 @@
 export type PublicWasteIcalModel = {
   readonly calendarName: string;
+  readonly calendarDescription?: string;
   readonly events: readonly {
     readonly uid: string;
     readonly startDate: string;
@@ -17,6 +18,12 @@ export const renderPublicWasteIcal = (input: PublicWasteIcalModel): string =>
     'VERSION:2.0',
     'PRODID:-//SVA Studio//Public Waste Calendar//DE',
     `X-WR-CALNAME:${escapeIcalText(input.calendarName)}`,
+    ...(input.calendarDescription
+      ? [
+          `DESCRIPTION:${escapeIcalText(input.calendarDescription)}`,
+          `X-WR-CALDESC:${escapeIcalText(input.calendarDescription)}`,
+        ]
+      : []),
     ...input.events.flatMap((event) => [
       'BEGIN:VEVENT',
       `UID:${escapeIcalText(event.uid)}`,

--- a/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts
@@ -9,8 +9,10 @@ export type PublicWasteIcalModel = {
   }[];
 };
 
+const normalizeIcalText = (value: string): string => value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+
 const escapeIcalText = (value: string): string =>
-  value.replaceAll('\\', '\\\\').replaceAll('\n', '\\n').replaceAll(',', '\\,').replaceAll(';', '\\;');
+  normalizeIcalText(value).replaceAll('\\', '\\\\').replaceAll('\n', '\\n').replaceAll(',', '\\,').replaceAll(';', '\\;');
 
 export const renderPublicWasteIcal = (input: PublicWasteIcalModel): string =>
   [

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
@@ -192,6 +192,7 @@ describe('public waste repository', () => {
             tour_custom_dates: null,
             fraction_id: 'fraction-1',
             fraction_label: 'Restmuell',
+            fraction_description: 'Restabfall aus privaten Haushalten.',
             fraction_color: '#111111',
           },
         ],
@@ -216,6 +217,7 @@ describe('public waste repository', () => {
       })
     ).resolves.toContainEqual(
       expect.objectContaining({
+        fractionDescription: 'Restabfall aus privaten Haushalten.',
         tourName: 'Restmuell',
         tourDescription: 'Leerung fuer den Innenstadtbereich.',
       })

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
@@ -45,6 +45,7 @@ type CalendarEntryRow = {
   readonly tour_custom_dates: readonly { readonly date?: unknown; readonly description?: unknown }[] | null;
   readonly fraction_id: string;
   readonly fraction_label: string;
+  readonly fraction_description: string | null;
   readonly fraction_pdf_short_label: string | null;
   readonly fraction_color: string | null;
 };
@@ -73,6 +74,7 @@ type ImportedPickupDateRow = {
   readonly tour_description: string | null;
   readonly fraction_id: string | null;
   readonly fraction_label: string | null;
+  readonly fraction_description: string | null;
   readonly fraction_pdf_short_label: string | null;
   readonly fraction_color: string | null;
   readonly note: string | null;
@@ -387,6 +389,7 @@ export const createPublicWasteRepository = (input: {
             t.custom_dates AS tour_custom_dates,
             f.id AS fraction_id,
             f.name AS fraction_label,
+            f.description AS fraction_description,
             f.pdf_short_label AS fraction_pdf_short_label,
             f.color AS fraction_color
           FROM ${schemaName}.waste_collection_locations cl
@@ -453,6 +456,7 @@ export const createPublicWasteRepository = (input: {
               t.description AS tour_description,
               f.id AS fraction_id,
               f.name AS fraction_label,
+              f.description AS fraction_description,
               f.pdf_short_label AS fraction_pdf_short_label,
               f.color AS fraction_color,
               p.note AS note
@@ -529,6 +533,7 @@ export const createPublicWasteRepository = (input: {
                 readonly fractions: {
                   id: string;
                   label: string;
+                  description?: string;
                   shortLabel?: string;
                   color?: string;
                 }[];
@@ -541,6 +546,7 @@ export const createPublicWasteRepository = (input: {
             ? {
                 id: row.fraction_id,
                 label: row.fraction_label,
+                ...(row.fraction_description?.trim() ? { description: row.fraction_description.trim() } : {}),
                 ...(row.fraction_pdf_short_label ? { shortLabel: row.fraction_pdf_short_label } : {}),
                 ...(row.fraction_color ? { color: row.fraction_color } : {}),
               }
@@ -729,6 +735,7 @@ export const createPublicWasteRepository = (input: {
           date: shiftedDate,
           fractionId: row.fraction_id,
           fractionLabel: row.fraction_label,
+          ...(row.fraction_description?.trim() ? { fractionDescription: row.fraction_description.trim() } : {}),
           ...(row.fraction_pdf_short_label ? { fractionShortLabel: row.fraction_pdf_short_label } : {}),
           ...(row.fraction_color ? { fractionColor: row.fraction_color } : {}),
           ...(row.tour_name.trim() ? { tourName: row.tour_name.trim() } : {}),

--- a/docs/superpowers/plans/2026-06-16-public-waste-ical-event-descriptions.md
+++ b/docs/superpowers/plans/2026-06-16-public-waste-ical-event-descriptions.md
@@ -1,0 +1,46 @@
+# Public-Waste-iCal-Event-Descriptions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Der Public-Waste-iCal-Feed soll pro `VEVENT` eine gesammelte Beschreibung aus Fraktionsbeschreibung, Tourbeschreibung und Terminnotiz exportieren.
+
+**Architecture:** Die öffentliche Kalenderprojektion wird um eine optionale Fraktionsbeschreibung erweitert. Der iCal-Endpoint baut daraus einen stabil formatierten mehrzeiligen Beschreibungstext, während `SUMMARY` und kalenderweite Metadaten unverändert kurz bleiben.
+
+**Tech Stack:** TypeScript, Vitest, Nx, OpenSpec, serverseitiger Public-Waste-Endpoint
+
+---
+
+### Task 1: Öffentliche Kalenderprojektion erweitern
+
+**Files:**
+- Modify: `apps/public-waste-calendar-web/src/lib/public-waste-contract.ts`
+- Modify: `apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts`
+- Test: `apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts`
+
+- [ ] **Step 1: Write the failing repository test**
+- [ ] **Step 2: Run the repository test and verify it fails because the public entry lacks `fractionDescription`**
+- [ ] **Step 3: Extend the public calendar entry contract and repository mapping with optional `fractionDescription`**
+- [ ] **Step 4: Run the repository test and verify it passes**
+
+### Task 2: iCal event description builder ergänzen
+
+**Files:**
+- Modify: `apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts`
+- Modify: `apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts`
+- Test: `apps/public-waste-calendar-web/src/lib/public-waste-ical.server.test.ts`
+- Test: `apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts`
+
+- [ ] **Step 1: Write failing renderer and endpoint tests for collected event descriptions**
+- [ ] **Step 2: Run the tests and verify they fail on missing composed `VEVENT.DESCRIPTION` content**
+- [ ] **Step 3: Implement the minimal description composer with stable order and duplicate suppression**
+- [ ] **Step 4: Run the renderer and endpoint tests and verify they pass**
+
+### Task 3: Verifikation und Quality Gates
+
+**Files:**
+- Modify: `openspec/changes/update-public-waste-ical-event-descriptions/tasks.md`
+
+- [ ] **Step 1: Run targeted Public-Waste unit tests for repository, renderer and endpoint**
+- [ ] **Step 2: Run `pnpm nx run public-waste-calendar-web:test:types`**
+- [ ] **Step 3: Run the smallest relevant Nx affected gate for unit tests**
+- [ ] **Step 4: Mark the OpenSpec task checklist with completed items that are actually done**

--- a/docs/superpowers/specs/2026-06-16-public-waste-ical-event-descriptions-design.md
+++ b/docs/superpowers/specs/2026-06-16-public-waste-ical-event-descriptions-design.md
@@ -1,0 +1,36 @@
+# Design: Gesammelte Event-Beschreibungen im Public-Waste-iCal
+
+## Kontext
+Der Public-Waste-iCal-Feed exportiert pro Termin aktuell nur den Fraktionsnamen als `SUMMARY` und optional eine einzelne Notiz als `DESCRIPTION`. Fachliche Zusatzinformationen aus Fraktion und Tour bleiben damit in Kalender-Clients unsichtbar.
+
+## Zielbild
+Jedes `VEVENT` soll eine kompakte, aber vollständige `DESCRIPTION` erhalten, die alle verfügbaren Hinweise des Termins gesammelt ausgibt. Die kalenderweite Beschreibung mit dem Abholort bleibt zusätzlich auf `VCALENDAR`-Ebene bestehen.
+
+## Entscheidungen
+- Die Event-`SUMMARY` bleibt kurz und enthält weiterhin nur den Fraktionsnamen.
+- Die Event-`DESCRIPTION` sammelt verfügbare Inhalte in stabiler Reihenfolge:
+  1. Fraktionsbeschreibung
+  2. Tourbeschreibung
+  3. Terminnotiz
+- Leere Texte und inhaltsgleiche Wiederholungen werden unterdrückt.
+- Die Fraktionsbeschreibung wird in das öffentliche Kalenderdatenmodell aufgenommen, damit Repository, UI und Export auf denselben Fachdatensatz zugreifen.
+
+## Format
+Die `DESCRIPTION` wird mehrzeilig erzeugt. Beispiel:
+
+```text
+Fraktion: Bioabfall aus Küche und Garten
+Tour: Regelabfuhr für die Innenstadt
+Hinweis: Verschoben wegen Feiertag
+```
+
+## Abgrenzung
+- Kein Umbau der `SUMMARY`
+- Keine zusätzlichen proprietären iCal-Event-Felder
+- Keine Änderung der kalenderweiten Abholort-Beschreibung
+- Keine Personalisierung des öffentlichen Default-ICS; spätere private/personalisierte ICS-Links mit `VALARM`-Logik sind als Folgearbeit in GitHub-Issue `#557` vorgemerkt
+
+## Tests
+- iCal-Renderer prüft die zusammengesetzte `DESCRIPTION`
+- Endpoint-Test prüft den Exportpfad mit gesammelten Hinweisen
+- Repository-Test prüft die Projektion einer Fraktionsbeschreibung in öffentliche Kalendereinträge

--- a/openspec/changes/update-public-waste-ical-event-descriptions/proposal.md
+++ b/openspec/changes/update-public-waste-ical-event-descriptions/proposal.md
@@ -1,0 +1,17 @@
+# Change: Angereicherte Event-Beschreibungen im Public-Waste-iCal
+
+## Why
+Der öffentliche Abfallkalender liefert im iCal-Feed bislang pro Termin nur den Fraktionsnamen als Titel und optional eine einzelne Terminnotiz. Für Kalender-Clients fehlt damit die fachliche Kontextbeschreibung aus Fraktion, Tour und konkretem Abholhinweis direkt am jeweiligen Event.
+
+## What Changes
+- Der iCal-Feed der Capability `public-waste-calendar` ergänzt pro `VEVENT` eine gesammelte `DESCRIPTION`.
+- Die Event-Beschreibung fasst verfügbare Hinweise aus Fraktionsbeschreibung, Tourbeschreibung und terminbezogener Notiz in stabiler Reihenfolge zusammen.
+- Die App erweitert das öffentliche Kalenderdatenmodell um eine optionale Fraktionsbeschreibung, damit der iCal-Export dieselbe fachliche Quelle wie die UI nutzt.
+
+## Impact
+- Affected specs: `public-waste-calendar`
+- Affected code: `apps/public-waste-calendar-web/src/lib/public-waste-contract.ts`, `apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts`, `apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts`, `apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts`
+- Affected arc42 sections: keine
+
+## Follow-up
+- Personalisierte ICS-Links mit fraktions- und reminderbezogenen `VALARM`-Überlegungen werden bewusst nicht Teil dieses Changes und sind in GitHub-Issue `#557` festgehalten.

--- a/openspec/changes/update-public-waste-ical-event-descriptions/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/update-public-waste-ical-event-descriptions/specs/public-waste-calendar/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+### Requirement: Öffentliche App liefert PDF- und iCal-Aktionen konsistent zum Standort
+
+Das System SHALL globale PDF- und iCal-Aktionen aus demselben finalen Standortkontext ableiten wie die Kalenderansicht.
+
+#### Scenario: PDF-Aktion erzeugt das Dokument ad hoc
+
+- **WHEN** für einen vollständig aufgelösten Standort globale Aktionen angezeigt werden
+- **THEN** stellt die App eine PDF-Exportaktion für ein ausdrücklich gewähltes Jahr bereit
+- **AND** der Export wird serverseitig ad hoc erzeugt
+- **AND** die App ist selbst für die Auslieferung des PDFs verantwortlich
+- **AND** es werden keine stabilen, vorgenerierten PDF-URLs benötigt
+
+#### Scenario: iCal-Feed liefert alle verfügbaren künftigen Termine
+
+- **WHEN** ein Benutzer oder ein Kalender-Client den iCal-Link eines vollständig aufgelösten Standorts aufruft
+- **THEN** liefert die App einen serverseitig erzeugten iCal-Feed
+- **AND** der Feed enthält alle verfügbaren künftigen Termine dieses Standorts
+- **AND** der Feed ist konsistent zu den in der App sichtbaren Kalenderdaten
+- **AND** jedes `VEVENT` enthält eine gesammelte Beschreibung aus allen verfügbaren fachlichen Hinweisen des Termins
+
+#### Scenario: Event-Beschreibung bündelt fachliche Hinweise stabil
+
+- **WHEN** für einen Kalendereintrag Fraktionsbeschreibung, Tourbeschreibung und/oder Terminnotiz vorliegen
+- **THEN** fasst der iCal-Feed diese Inhalte in der `DESCRIPTION` des jeweiligen `VEVENT` zusammen
+- **AND** die Reihenfolge bleibt Fraktionsbeschreibung, dann Tourbeschreibung, dann Terminnotiz
+- **AND** nicht vorhandene oder inhaltsgleiche Textbausteine werden ausgelassen

--- a/openspec/changes/update-public-waste-ical-event-descriptions/tasks.md
+++ b/openspec/changes/update-public-waste-ical-event-descriptions/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementierung
+- [x] 1.1 OpenSpec-Delta für `public-waste-calendar` anlegen und validieren
+- [x] 1.2 Öffentliches Kalenderdatenmodell um optionale Fraktionsbeschreibung erweitern
+- [x] 1.3 Repository-Projektion und iCal-Endpoint so anpassen, dass `VEVENT.DESCRIPTION` gesammelte Hinweise enthält
+- [x] 1.4 Unit-Tests für iCal-Rendering, Endpoint und Repository-Mapping ergänzen bzw. anpassen
+- [x] 1.5 Relevante Public-Waste-Unit- und Type-Checks grün ausführen

--- a/packages/auth-runtime/src/waste-management/core/email-reminder-paths.ts
+++ b/packages/auth-runtime/src/waste-management/core/email-reminder-paths.ts
@@ -1,0 +1,25 @@
+import type { WasteManagementEmailReminderConfig } from '@sva/core';
+
+export const fixedWasteEmailReminderPaths = {
+  doiConfirmPath: '/email-reminders/confirm',
+  unsubscribePath: '/email-reminders/unsubscribe',
+  signupSuccessPath: '/email-reminders/pending',
+  activationSuccessPath: '/email-reminders/active',
+  unsubscribeSuccessPath: '/email-reminders/unsubscribed',
+  invalidTokenPath: '/email-reminders/token-invalid',
+} as const satisfies Pick<
+  WasteManagementEmailReminderConfig,
+  | 'doiConfirmPath'
+  | 'unsubscribePath'
+  | 'signupSuccessPath'
+  | 'activationSuccessPath'
+  | 'unsubscribeSuccessPath'
+  | 'invalidTokenPath'
+>;
+
+export const withFixedWasteEmailReminderPaths = (
+  config: WasteManagementEmailReminderConfig
+): WasteManagementEmailReminderConfig => ({
+  ...config,
+  ...fixedWasteEmailReminderPaths,
+});

--- a/packages/auth-runtime/src/waste-management/core/settings-write-support.test.ts
+++ b/packages/auth-runtime/src/waste-management/core/settings-write-support.test.ts
@@ -570,4 +570,56 @@ describe('waste-management settings write support', () => {
       }),
     });
   });
+
+  it('overrides internal email reminder paths with fixed system defaults before persisting', async () => {
+    const targetRecord = createInterfaceRecord();
+    const saved = createSettings();
+    const saveExternalInterfaceRecord = vi.fn(async () => undefined);
+
+    loadConfiguredWasteSettingsMock.mockResolvedValueOnce(createSettings()).mockResolvedValueOnce(saved);
+
+    const response = await updateWasteManagementSettingsAfterValidation({
+      deps: {
+        listInterfaceRecords: vi.fn(async () => [targetRecord]),
+        saveExternalInterfaceRecord,
+        loadWasteCustomRecurrencePresets: vi.fn(async () => []),
+        saveWasteCustomRecurrencePresets: vi.fn(async () => undefined),
+      },
+      ctx: actor,
+      instanceId: 'tenant-a',
+      requestId: 'req-1',
+      input: {
+        projectUrl: 'https://tenant.example',
+        schemaName: 'wm',
+        enabled: true,
+        emailReminderConfig: {
+          ...createEmailReminderConfig(),
+          doiConfirmPath: '/custom-confirm',
+          unsubscribePath: '/custom-unsubscribe',
+          signupSuccessPath: '/custom-pending',
+          activationSuccessPath: '/custom-active',
+          unsubscribeSuccessPath: '/custom-unsubscribed',
+          invalidTokenPath: '/custom-invalid',
+        },
+        customRecurrencePresets: [],
+        deletedPresetFallbacks: {},
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(saveExternalInterfaceRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicConfig: expect.objectContaining({
+          emailReminderConfig: expect.objectContaining({
+            doiConfirmPath: '/email-reminders/confirm',
+            unsubscribePath: '/email-reminders/unsubscribe',
+            signupSuccessPath: '/email-reminders/pending',
+            activationSuccessPath: '/email-reminders/active',
+            unsubscribeSuccessPath: '/email-reminders/unsubscribed',
+            invalidTokenPath: '/email-reminders/token-invalid',
+          }),
+        }),
+      })
+    );
+  });
 });

--- a/packages/auth-runtime/src/waste-management/core/settings-write-support.ts
+++ b/packages/auth-runtime/src/waste-management/core/settings-write-support.ts
@@ -14,6 +14,7 @@ import {
   persistWasteSettingsInterfaceSelection,
   resolveTargetInterfaceRecord,
 } from './settings-write-support.interface-selection.js';
+import { withFixedWasteEmailReminderPaths } from './email-reminder-paths.js';
 import { updateWasteVisibleStatus } from './settings-shared.js';
 import type { WasteManagementHandlerDeps } from './types.js';
 import { requireDeps } from './utils.js';
@@ -180,6 +181,9 @@ export const updateWasteManagementSettingsAfterValidation = async ({
     shouldRunHolidaySync && lastHolidaySyncStatus && lastHolidaySyncStatus !== 'failed'
       ? new Date().toISOString()
       : writeContext.current.lastSuccessfulHolidaySyncAt;
+  const normalizedEmailReminderConfig = input.emailReminderConfig
+    ? withFixedWasteEmailReminderPaths(input.emailReminderConfig)
+    : undefined;
 
   await persistWasteSettingsInterfaceSelection({
     deps,
@@ -188,7 +192,7 @@ export const updateWasteManagementSettingsAfterValidation = async ({
     calendarWebUrl: input.calendarWebUrl?.trim(),
     pdfBrandingAssetUrl: input.pdfBrandingAssetUrl?.trim(),
     pdfContactBlock: input.pdfContactBlock?.trim(),
-    emailReminderConfig: input.emailReminderConfig,
+    emailReminderConfig: normalizedEmailReminderConfig,
     holidayStateCode: input.holidayStateCode,
     lastHolidaySyncStatus,
     lastSuccessfulHolidaySyncAt,

--- a/packages/plugin-waste-management/src/waste-management.email-reminder-paths.ts
+++ b/packages/plugin-waste-management/src/waste-management.email-reminder-paths.ts
@@ -1,0 +1,25 @@
+import type { WasteManagementEmailReminderConfig } from '@sva/plugin-sdk';
+
+export const fixedWasteEmailReminderPaths = {
+  doiConfirmPath: '/email-reminders/confirm',
+  unsubscribePath: '/email-reminders/unsubscribe',
+  signupSuccessPath: '/email-reminders/pending',
+  activationSuccessPath: '/email-reminders/active',
+  unsubscribeSuccessPath: '/email-reminders/unsubscribed',
+  invalidTokenPath: '/email-reminders/token-invalid',
+} as const satisfies Pick<
+  WasteManagementEmailReminderConfig,
+  | 'doiConfirmPath'
+  | 'unsubscribePath'
+  | 'signupSuccessPath'
+  | 'activationSuccessPath'
+  | 'unsubscribeSuccessPath'
+  | 'invalidTokenPath'
+>;
+
+export const withFixedWasteEmailReminderPaths = (
+  config: WasteManagementEmailReminderConfig
+): WasteManagementEmailReminderConfig => ({
+  ...config,
+  ...fixedWasteEmailReminderPaths,
+});

--- a/packages/plugin-waste-management/src/waste-management.output-email-reminder-card.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-email-reminder-card.tsx
@@ -218,42 +218,6 @@ export const WasteEmailReminderConfigurationSection = ({
             value: value.publicBaseUrl,
             onChange: (next) => setValue('publicBaseUrl', next),
           })}
-          {textField({
-            id: 'waste-email-reminder-doi-confirm-path',
-            label: translate('output.emailReminder.fields.doiConfirmPath'),
-            value: value.doiConfirmPath,
-            onChange: (next) => setValue('doiConfirmPath', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-unsubscribe-path',
-            label: translate('output.emailReminder.fields.unsubscribePath'),
-            value: value.unsubscribePath,
-            onChange: (next) => setValue('unsubscribePath', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-signup-success-path',
-            label: translate('output.emailReminder.fields.signupSuccessPath'),
-            value: value.signupSuccessPath ?? '',
-            onChange: (next) => setValue('signupSuccessPath', next || undefined),
-          })}
-          {textField({
-            id: 'waste-email-reminder-activation-success-path',
-            label: translate('output.emailReminder.fields.activationSuccessPath'),
-            value: value.activationSuccessPath ?? '',
-            onChange: (next) => setValue('activationSuccessPath', next || undefined),
-          })}
-          {textField({
-            id: 'waste-email-reminder-unsubscribe-success-path',
-            label: translate('output.emailReminder.fields.unsubscribeSuccessPath'),
-            value: value.unsubscribeSuccessPath ?? '',
-            onChange: (next) => setValue('unsubscribeSuccessPath', next || undefined),
-          })}
-          {textField({
-            id: 'waste-email-reminder-invalid-token-path',
-            label: translate('output.emailReminder.fields.invalidTokenPath'),
-            value: value.invalidTokenPath ?? '',
-            onChange: (next) => setValue('invalidTokenPath', next || undefined),
-          })}
         </div>
 
         {sectionHeading({

--- a/packages/plugin-waste-management/src/waste-management.output-panel.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-panel.tsx
@@ -18,6 +18,7 @@ import {
 } from './waste-management.page.support.js';
 import { useWasteOutputPanelData } from './waste-management.output-panel.data.js';
 import { WasteEmailReminderConfigurationSection } from './waste-management.output-email-reminder-card.js';
+import { fixedWasteEmailReminderPaths, withFixedWasteEmailReminderPaths } from './waste-management.email-reminder-paths.js';
 import { WasteOutputConfigurationSection } from './waste-management.output-panel.parts.js';
 
 const buildDefaultEmailReminderConfig = ({
@@ -31,12 +32,7 @@ const buildDefaultEmailReminderConfig = ({
   publicSignupEnabled: false,
   transportId: transportOptions[0]?.id ?? '',
   publicBaseUrl: calendarWebUrl ?? 'https://demo.abfallkalender.example',
-  doiConfirmPath: '/email-reminders/confirm',
-  unsubscribePath: '/email-reminders/unsubscribe',
-  signupSuccessPath: '/email-reminders/pending',
-  activationSuccessPath: '/email-reminders/active',
-  unsubscribeSuccessPath: '/email-reminders/unsubscribed',
-  invalidTokenPath: '/email-reminders/token-invalid',
+  ...fixedWasteEmailReminderPaths,
   fromName: 'Abfallwirtschaft',
   fromEmail: 'abfall@example.org',
   replyToEmail: 'abfall@example.org',
@@ -120,7 +116,7 @@ export const WasteOutputPanel = () => {
         calendarWebUrl: settings?.calendarWebUrl,
         transportOptions: nextMailTransportOptions,
       });
-    setEmailReminderConfig(ensureTransportSelection(baseConfig, nextMailTransportOptions));
+    setEmailReminderConfig(withFixedWasteEmailReminderPaths(ensureTransportSelection(baseConfig, nextMailTransportOptions)));
   }, [
     settings?.availableInterfaces,
     settings?.calendarWebUrl,
@@ -202,7 +198,9 @@ export const WasteOutputPanel = () => {
         calendarWebUrl: settings.calendarWebUrl,
         pdfBrandingAssetUrl: compactOptionalString(brandingAssetUrl),
         pdfContactBlock: compactOptionalString(contactBlock),
-        emailReminderConfig: ensureTransportSelection(emailReminderConfig, nextMailTransportOptions),
+        emailReminderConfig: withFixedWasteEmailReminderPaths(
+          ensureTransportSelection(emailReminderConfig, nextMailTransportOptions)
+        ),
         holidayStateCode: settings.holidayStateCode,
         customRecurrencePresets: settings.customRecurrencePresets ?? [],
         deletedPresetFallbacks: {},
@@ -210,16 +208,18 @@ export const WasteOutputPanel = () => {
       const nextSettings = result ?? (await getWasteManagementSettings());
       setSettings(nextSettings);
       setEmailReminderConfig(
-        ensureTransportSelection(
-          nextSettings?.emailReminderConfig ??
-            buildDefaultEmailReminderConfig({
-              calendarWebUrl: nextSettings?.calendarWebUrl,
-              transportOptions: (nextSettings?.availableInterfaces ?? []).filter(
-                (option) => option.typeKey === 'mail_transport'
-              ),
-            }),
-          (nextSettings?.availableInterfaces ?? []).filter(
-            (option) => option.typeKey === 'mail_transport'
+        withFixedWasteEmailReminderPaths(
+          ensureTransportSelection(
+            nextSettings?.emailReminderConfig ??
+              buildDefaultEmailReminderConfig({
+                calendarWebUrl: nextSettings?.calendarWebUrl,
+                transportOptions: (nextSettings?.availableInterfaces ?? []).filter(
+                  (option) => option.typeKey === 'mail_transport'
+                ),
+              }),
+            (nextSettings?.availableInterfaces ?? []).filter(
+              (option) => option.typeKey === 'mail_transport'
+            )
           )
         )
       );

--- a/packages/plugin-waste-management/tests/waste-management.output-panel.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.output-panel.test.tsx
@@ -588,12 +588,6 @@ describe('WasteOutputPanel', () => {
     fireEvent.click(screen.getByLabelText('output.emailReminder.fields.publicSignupEnabled'));
     fireEvent.change(screen.getByLabelText('output.emailReminder.fields.transportId'), { target: { value: 'mail-transport-2' } });
     fireEvent.change(screen.getByLabelText('output.emailReminder.fields.publicBaseUrl'), { target: { value: 'https://public.example.org' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiConfirmPath'), { target: { value: '/confirm-new' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribePath'), { target: { value: '/unsubscribe-new' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.signupSuccessPath'), { target: { value: '/signup-ok' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.activationSuccessPath'), { target: { value: '/activation-ok' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessPath'), { target: { value: '/unsubscribe-ok' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.invalidTokenPath'), { target: { value: '/token-invalid' } });
     fireEvent.change(screen.getByLabelText('output.emailReminder.fields.fromName'), { target: { value: 'Landkreis' } });
     fireEvent.change(screen.getByLabelText('output.emailReminder.fields.fromEmail'), { target: { value: 'noreply@example.org' } });
     fireEvent.change(screen.getByLabelText('output.emailReminder.fields.replyToEmail'), { target: { value: 'service@example.org' } });
@@ -695,6 +689,82 @@ describe('WasteOutputPanel', () => {
     );
 
     expect(screen.getByText('output.emailReminder.messages.noMailTransport')).toBeTruthy();
+  });
+
+  it('does not render internal email reminder path fields on the direct configuration card', () => {
+    render(
+      <WasteEmailReminderConfigurationSection
+        hasMailTransportOptions
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        running={false}
+        transportOptions={[
+          {
+            id: 'mail-transport-1',
+            name: 'Zentraler Mailtransport',
+            typeKey: 'mail_transport',
+            enabled: true,
+            visibleStatus: 'ok',
+            isSelected: true,
+          },
+        ]}
+        translate={(key) => key}
+        value={{
+          enabled: true,
+          publicSignupEnabled: true,
+          transportId: 'mail-transport-1',
+          publicBaseUrl: 'https://example.org',
+          doiConfirmPath: '/email-reminders/confirm',
+          unsubscribePath: '/email-reminders/unsubscribe',
+          signupSuccessPath: '/email-reminders/pending',
+          activationSuccessPath: '/email-reminders/active',
+          unsubscribeSuccessPath: '/email-reminders/unsubscribed',
+          invalidTokenPath: '/email-reminders/token-invalid',
+          fromName: 'Abfallwirtschaft',
+          fromEmail: 'abfall@example.org',
+          replyToEmail: 'reply@example.org',
+          serviceLabel: 'Muelli',
+          privacyPolicyUrl: 'https://example.org/privacy',
+          imprintUrl: 'https://example.org/imprint',
+          consentVersion: 'v1',
+          dataControllerLabel: 'Abfallwirtschaft',
+          dataProtectionContactEmail: 'dsb@example.org',
+          consentLabel: 'Ich stimme zu.',
+          doiSubjectTemplate: 'Bitte bestaetigen',
+          doiButtonLabel: 'Aktivieren',
+          doiPreheader: 'Preheader',
+          doiFallbackText: 'Fallback',
+          doiIntroText: 'Intro',
+          doiExpiryNoticeText: '48h',
+          reminderSubjectTemplate: 'Erinnerung',
+          unsubscribeLinkLabel: 'Abmelden',
+          reminderIntroTemplate: 'Intro Erinnerung',
+          reminderListIntroTemplate: 'Liste',
+          reminderOutroText: 'Outro',
+          reminderReasonText: 'Grund',
+          unsubscribeSuccessHeadline: 'Erfolg',
+          unsubscribeAlreadyDoneHeadline: 'Schon erledigt',
+          unsubscribeErrorHeadline: 'Fehler',
+          unsubscribeSuccessBody: 'Body Erfolg',
+          unsubscribeAlreadyDoneBody: 'Body Schon erledigt',
+          unsubscribeErrorBody: 'Body Fehler',
+          doiTokenTtlHours: 48,
+          pendingSubscriptionTtlHours: 72,
+          materializationLookaheadDays: 7,
+          maxSubscriptionsPerEmailAndLocation: 5,
+          signupRateLimitPerIpPerHour: 20,
+          signupRateLimitPerEmailPerHour: 10,
+          unsubscribeTokenTtlDays: 30,
+        }}
+      />
+    );
+
+    expect(screen.queryByLabelText('output.emailReminder.fields.doiConfirmPath')).toBeNull();
+    expect(screen.queryByLabelText('output.emailReminder.fields.unsubscribePath')).toBeNull();
+    expect(screen.queryByLabelText('output.emailReminder.fields.signupSuccessPath')).toBeNull();
+    expect(screen.queryByLabelText('output.emailReminder.fields.activationSuccessPath')).toBeNull();
+    expect(screen.queryByLabelText('output.emailReminder.fields.unsubscribeSuccessPath')).toBeNull();
+    expect(screen.queryByLabelText('output.emailReminder.fields.invalidTokenPath')).toBeNull();
   });
 
   it('still allows saving a disabled reminder configuration when no mail transport remains', () => {


### PR DESCRIPTION
## Summary
- enrich the public waste ICS export with calendar-level pickup location context and aggregated event descriptions from fraction, tour, and pickup notes
- document the public ICS contract and capture follow-up work for later personalized ICS links
- lock waste email reminder system paths in auth-runtime and remove those internal path fields from the waste-management UI

## Why
The public ICS export should carry the relevant waste collection context directly in calendar clients without requiring per-event duplication of address data beyond the right level. At the same time, internal reminder callback and success paths should not be user-configurable in the settings UI because the runtime relies on fixed system routes.

## Impact
- ICS consumers now see richer event descriptions and a calendar-level location description
- the default public ICS remains location-based, without personalized alarms
- waste reminder settings no longer expose or persist custom internal system paths

## Validation
- `pnpm --dir apps/public-waste-calendar-web exec vitest run src/lib/public-waste-repository.server.test.ts src/lib/public-waste-ical.server.test.ts src/lib/public-waste-endpoints.server.test.ts`
- `pnpm nx run public-waste-calendar-web:test:types`
- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/waste-management/core/settings-write-support.test.ts`
- `pnpm nx run plugin-waste-management:test:unit --testFiles=tests/waste-management.output-panel.test.tsx`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run plugin-waste-management:test:types`
