### PR TITLE
[codex] Simplify SMTP interfaces and fix Sonar blockers

### DIFF
--- a/apps/sva-studio-react/src/components/ui/dialog.a11y.test.tsx
+++ b/apps/sva-studio-react/src/components/ui/dialog.a11y.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { expectNoA11yViolations } from '@/test/a11y';
 
@@ -20,6 +20,6 @@ describe('ui/dialog accessibility', () => {
       </Dialog>
     );
 
-    await expectNoA11yViolations(screen.getByRole('dialog'));
+    await expect(expectNoA11yViolations(screen.getByRole('dialog'))).resolves.toBeUndefined();
   });
 });

--- a/apps/sva-studio-react/src/components/ui/label.a11y.test.tsx
+++ b/apps/sva-studio-react/src/components/ui/label.a11y.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from '@testing-library/react';
-import { afterEach, describe, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { expectNoA11yViolations } from '@/test/a11y';
 
@@ -18,6 +18,6 @@ describe('ui/label accessibility', () => {
       </div>
     );
 
-    await expectNoA11yViolations(container);
+    await expect(expectNoA11yViolations(container)).resolves.toBeUndefined();
   });
 });

--- a/apps/sva-studio-react/src/i18n/resources/de/interfaces.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/interfaces.resources.ts
@@ -87,7 +87,7 @@ export const interfacesDEResources = {
     mailTransport: {
       label: 'Mail-Transport',
       description:
-        'Zentrale technische Mail-Anbindung mit SMTP- oder Provider-Parametern für transaktionale Zustellung.',
+        'Zentrale technische SMTP-Anbindung für transaktionale Zustellung.',
     },
   },
   create: {
@@ -129,15 +129,8 @@ export const interfacesDEResources = {
     },
     mailTransport: {
       transportId: 'Transport-ID',
-      transportType: 'Transporttyp',
-      transportTypeOptions: {
-        smtp: 'SMTP',
-        providerApi: 'Provider-API',
-      },
       host: 'SMTP-Host',
       port: 'Port',
-      endpoint: 'Provider-Endpoint',
-      providerMode: 'Provider-Modus',
       securityMode: 'Sicherheitsmodus',
       securityModeOptions: {
         none: 'Keine',

--- a/apps/sva-studio-react/src/i18n/resources/en/interfaces.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/interfaces.resources.ts
@@ -41,7 +41,7 @@ export const interfacesENResources = {
     mailTransport: {
       label: 'Mail transport',
       description:
-        'Central technical mail integration with SMTP or provider parameters for transactional delivery.',
+        'Central technical SMTP integration for transactional delivery.',
     },
   },
   form: {
@@ -71,15 +71,8 @@ export const interfacesENResources = {
     },
     mailTransport: {
       transportId: 'Transport ID',
-      transportType: 'Transport type',
-      transportTypeOptions: {
-        smtp: 'SMTP',
-        providerApi: 'Provider API',
-      },
       host: 'SMTP host',
       port: 'Port',
-      endpoint: 'Provider endpoint',
-      providerMode: 'Provider mode',
       securityMode: 'Security mode',
       securityModeOptions: {
         none: 'None',

--- a/apps/sva-studio-react/src/lib/instance-interfaces-server.test.ts
+++ b/apps/sva-studio-react/src/lib/instance-interfaces-server.test.ts
@@ -792,6 +792,28 @@ describe('instance-interfaces-server', () => {
         enabled: true,
         config: {
           transportId: 'mail-1',
+          host: 'https://api.mail.example',
+          port: '587',
+          securityMode: 'starttls',
+          authMode: 'basic',
+          username: 'mailer',
+          password: 'secret',
+          defaultFromEmail: '',
+          defaultFromName: '',
+          defaultReplyToEmail: '',
+          maxBatchSize: '',
+          rateLimitPerMinute: '',
+        },
+      })
+    ).rejects.toThrow('invalid_config');
+
+    await expect(
+      upsertStoredInterface('de-test', {
+        type: 'mailTransport',
+        name: 'Mail-Transport',
+        enabled: true,
+        config: {
+          transportId: 'mail-1',
           host: '',
           port: '587',
           securityMode: 'starttls',

--- a/apps/sva-studio-react/src/lib/instance-interfaces-server.test.ts
+++ b/apps/sva-studio-react/src/lib/instance-interfaces-server.test.ts
@@ -294,7 +294,6 @@ describe('instance-interfaces-server', () => {
       enabled: true,
       config: {
         transportId: 'mail-1',
-        transportType: 'smtp',
         host: 'smtp.example.org',
         port: '587',
         securityMode: 'starttls',
@@ -306,8 +305,6 @@ describe('instance-interfaces-server', () => {
         defaultReplyToEmail: 'service@example.org',
         maxBatchSize: '25',
         rateLimitPerMinute: '60',
-        providerMode: '',
-        endpoint: '',
       },
     });
 
@@ -334,7 +331,6 @@ describe('instance-interfaces-server', () => {
         enabled: true,
         config: {
           transportId: 'mail-1',
-          transportType: 'smtp',
           host: 'smtp.example.org',
           port: '587',
           securityMode: 'starttls',
@@ -346,8 +342,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: 'service@example.org',
           maxBatchSize: '25',
           rateLimitPerMinute: '60',
-          providerMode: '',
-          endpoint: '',
         },
       },
       'existing-mail-id'
@@ -776,7 +770,6 @@ describe('instance-interfaces-server', () => {
         enabled: true,
         config: {
           transportId: 'mail-1',
-          transportType: 'smtp',
           host: '',
           port: '587',
           securityMode: 'starttls',
@@ -788,8 +781,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: '',
           maxBatchSize: '',
           rateLimitPerMinute: '',
-          providerMode: '',
-          endpoint: '',
         },
       })
     ).rejects.toThrow('invalid_config');
@@ -801,7 +792,6 @@ describe('instance-interfaces-server', () => {
         enabled: true,
         config: {
           transportId: 'mail-1',
-          transportType: 'provider_api',
           host: '',
           port: '587',
           securityMode: 'starttls',
@@ -813,8 +803,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: '',
           maxBatchSize: '',
           rateLimitPerMinute: '',
-          providerMode: '',
-          endpoint: '',
         },
       })
     ).rejects.toThrow('invalid_config');
@@ -826,7 +814,6 @@ describe('instance-interfaces-server', () => {
         enabled: true,
         config: {
           transportId: 'mail-1',
-          transportType: 'smtp',
           host: 'smtp.example.org',
           port: '0',
           securityMode: 'starttls',
@@ -838,8 +825,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: '',
           maxBatchSize: '',
           rateLimitPerMinute: '',
-          providerMode: '',
-          endpoint: '',
         },
       })
     ).rejects.toThrow('invalid_config');
@@ -847,7 +832,7 @@ describe('instance-interfaces-server', () => {
     expect(state.saveExternalInterfaceRecord).not.toHaveBeenCalled();
   });
 
-  it('maps stored mail transport rows and derives health for SMTP and provider transports', async () => {
+  it('maps stored mail transport rows and derives health for SMTP and legacy provider transports', async () => {
     state.listExternalInterfaceRecords.mockResolvedValue([
       {
         id: 'mail-provider-1',
@@ -885,11 +870,9 @@ describe('instance-interfaces-server', () => {
       expect.objectContaining({
         type: 'mailTransport',
         config: expect.objectContaining({
-          transportType: 'provider_api',
+          host: 'https://api.mail.example',
           securityMode: 'starttls',
           authMode: 'basic',
-          endpoint: 'https://api.mail.example',
-          providerMode: 'transactional',
           maxBatchSize: '50',
           rateLimitPerMinute: '120',
         }),
@@ -905,7 +888,6 @@ describe('instance-interfaces-server', () => {
         enabled: true,
         config: {
           transportId: '',
-          transportType: 'smtp',
           host: '',
           port: '',
           securityMode: 'starttls',
@@ -916,8 +898,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: '',
           maxBatchSize: '',
           rateLimitPerMinute: '',
-          providerMode: '',
-          endpoint: '',
         },
         createdAt: '2026-05-12T08:00:00.000Z',
         updatedAt: '2026-05-12T08:00:00.000Z',
@@ -934,11 +914,10 @@ describe('instance-interfaces-server', () => {
         id: 'mail-provider-2',
         instanceId: 'de-test',
         type: 'mailTransport',
-        name: 'Provider',
+        name: 'Legacy',
         enabled: true,
         config: {
           transportId: 'provider-mail',
-          transportType: 'provider_api',
           host: '',
           port: '',
           securityMode: 'starttls',
@@ -949,8 +928,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: '',
           maxBatchSize: '',
           rateLimitPerMinute: '',
-          providerMode: 'transactional',
-          endpoint: '',
         },
         createdAt: '2026-05-12T08:00:00.000Z',
         updatedAt: '2026-05-12T08:00:00.000Z',
@@ -958,7 +935,7 @@ describe('instance-interfaces-server', () => {
     ).toEqual(
       expect.objectContaining({
         status: 'error',
-        statusMessage: 'Mail-Transport unvollständig (Provider-Endpoint erforderlich).',
+        statusMessage: 'Mail-Transport unvollständig (SMTP-Host und Port erforderlich).',
       })
     );
 
@@ -967,13 +944,12 @@ describe('instance-interfaces-server', () => {
         id: 'mail-provider-3',
         instanceId: 'de-test',
         type: 'mailTransport',
-        name: 'Provider',
+        name: 'Legacy',
         enabled: true,
         config: {
           transportId: 'provider-mail',
-          transportType: 'provider_api',
-          host: '',
-          port: '',
+          host: 'https://api.mail.example',
+          port: '443',
           securityMode: 'starttls',
           authMode: 'basic',
           username: '',
@@ -982,8 +958,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: '',
           maxBatchSize: '',
           rateLimitPerMinute: '',
-          providerMode: 'transactional',
-          endpoint: 'https://api.mail.example',
         },
         createdAt: '2026-05-12T08:00:00.000Z',
         updatedAt: '2026-05-12T08:00:00.000Z',
@@ -1055,7 +1029,6 @@ describe('instance-interfaces-server', () => {
         enabled: true,
         config: {
           transportId: 'mail-1',
-          transportType: 'smtp',
           host: 'smtp.example.org',
           port: '587',
           securityMode: 'starttls',
@@ -1067,8 +1040,6 @@ describe('instance-interfaces-server', () => {
           defaultReplyToEmail: '',
           maxBatchSize: '',
           rateLimitPerMinute: '',
-          providerMode: '',
-          endpoint: '',
         },
       },
       'existing-mail-id'

--- a/apps/sva-studio-react/src/lib/instance-interfaces-server.ts
+++ b/apps/sva-studio-react/src/lib/instance-interfaces-server.ts
@@ -5,7 +5,6 @@ import type {
   ExternalInterfaceVisibleStatus,
   MailTransportAuthMode,
   MailTransportSecurityMode,
-  MailTransportType,
 } from '@sva/core';
 import { mailTransportContract } from '@sva/core';
 import {
@@ -83,9 +82,6 @@ const coerceOptionalText = (value: unknown): string =>
 
 const coerceOptionalNumberString = (value: unknown): string =>
   typeof value === 'number' && Number.isFinite(value) ? String(value) : '';
-
-const coerceMailTransportType = (value: unknown): MailTransportType =>
-  typeof value === 'string' && mailTransportContract.isTransportType(value) ? value : 'smtp';
 
 const coerceMailSecurityMode = (value: unknown): MailTransportSecurityMode =>
   typeof value === 'string' && mailTransportContract.isSecurityMode(value) ? value : 'starttls';
@@ -166,8 +162,7 @@ const mapRecordToStoredEntry = (record: ExternalInterfaceRecord): PersistedStore
       enabled: record.enabled,
       config: {
         transportId: coerceText(record.publicConfig.transportId),
-        transportType: coerceMailTransportType(record.publicConfig.transportType),
-        host: coerceText(record.publicConfig.host),
+        host: coerceText(record.publicConfig.host) || coerceOptionalText(record.publicConfig.endpoint),
         port:
           typeof record.publicConfig.port === 'string'
             ? record.publicConfig.port
@@ -180,8 +175,6 @@ const mapRecordToStoredEntry = (record: ExternalInterfaceRecord): PersistedStore
         defaultReplyToEmail: coerceOptionalText(record.publicConfig.defaultReplyToEmail),
         maxBatchSize: coerceOptionalNumberString(record.publicConfig.maxBatchSize),
         rateLimitPerMinute: coerceOptionalNumberString(record.publicConfig.rateLimitPerMinute),
-        providerMode: coerceOptionalText(record.publicConfig.mode),
-        endpoint: coerceOptionalText(record.publicConfig.endpoint),
       },
       createdAt,
       updatedAt,
@@ -352,14 +345,11 @@ const assertValidMailTransportDraft = (
 ): void => {
   const validationRules = [
     !input.transportId || !input.displayName,
-    !mailTransportContract.isTransportType(draft.config.transportType),
     !mailTransportContract.isSecurityMode(draft.config.securityMode),
     !mailTransportContract.isAuthMode(draft.config.authMode),
     draft.config.authMode === 'basic' && !input.nextPassword.trim(),
     draft.config.authMode === 'basic' && !draft.config.username.trim(),
-    draft.config.transportType === 'smtp' && !draft.config.host.trim(),
-    draft.config.transportType === 'provider_api' && !draft.config.endpoint.trim(),
-    draft.config.transportType === 'provider_api' && !draft.config.providerMode.trim(),
+    !draft.config.host.trim(),
   ];
 
   if (validationRules.some(Boolean)) {
@@ -387,6 +377,7 @@ const buildMailTransportPublicConfig = (input: {
     'port',
     'endpoint',
     'mode',
+    'transportType',
   ] as const) {
     delete nextPublicConfig[key];
   }
@@ -400,25 +391,15 @@ const buildMailTransportPublicConfig = (input: {
     rateLimitPerMinute: input.rateLimitPerMinute,
   };
 
-  const transportConfig =
-    input.draft.config.transportType === 'smtp'
-      ? {
-          host: input.draft.config.host.trim(),
-          port: input.port,
-        }
-      : {
-          endpoint: input.draft.config.endpoint.trim(),
-          mode: input.draft.config.providerMode.trim(),
-        };
-
   return {
     ...nextPublicConfig,
     transportId: input.transportId,
-    transportType: input.draft.config.transportType,
+    transportType: 'smtp',
     securityMode: input.draft.config.securityMode,
     authMode: input.draft.config.authMode,
     ...Object.fromEntries(Object.entries(optionalFields).flatMap(([key, value]) => (value !== undefined ? [[key, value]] : []))),
-    ...transportConfig,
+    host: input.draft.config.host.trim(),
+    port: input.port,
   };
 };
 
@@ -435,10 +416,7 @@ const buildMailTransportRecord = (input: {
   const nextPassword = input.draft.config.password || input.previousSecrets.password || '';
   assertValidMailTransportDraft(input.draft, { displayName, transportId, nextPassword });
 
-  const port =
-    input.draft.config.transportType === 'smtp'
-      ? parseRequiredPort(input.draft.config.port)
-      : undefined;
+  const port = parseRequiredPort(input.draft.config.port);
   const maxBatchSize = parseOptionalPositiveInteger(input.draft.config.maxBatchSize);
   const rateLimitPerMinute = parseOptionalPositiveInteger(input.draft.config.rateLimitPerMinute);
   const existingPublicConfig = input.existing?.publicConfig ?? {};
@@ -454,10 +432,7 @@ const buildMailTransportRecord = (input: {
     enabled: input.draft.enabled,
     isDefault: input.existing?.isDefault ?? !input.hasDefaultRecord,
     category: 'api',
-    baseUrl:
-      input.draft.config.transportType === 'smtp'
-        ? input.draft.config.host.trim()
-        : input.draft.config.endpoint.trim(),
+    baseUrl: input.draft.config.host.trim(),
     authMode: input.draft.config.authMode,
     publicConfig: buildMailTransportPublicConfig({
       draft: input.draft,
@@ -691,18 +666,10 @@ export const checkStoredInterfaceHealth = (entry: StoredEntry): InterfaceHealthR
         checkedAt,
       };
     }
-    if (entry.config.transportType === 'smtp') {
-      if (!entry.config.host || !entry.config.port) {
-        return {
-          status: 'error',
-          statusMessage: 'Mail-Transport unvollständig (SMTP-Host und Port erforderlich).',
-          checkedAt,
-        };
-      }
-    } else if (!entry.config.endpoint) {
+    if (!entry.config.host || !entry.config.port) {
       return {
         status: 'error',
-        statusMessage: 'Mail-Transport unvollständig (Provider-Endpoint erforderlich).',
+        statusMessage: 'Mail-Transport unvollständig (SMTP-Host und Port erforderlich).',
         checkedAt,
       };
     }

--- a/apps/sva-studio-react/src/lib/instance-interfaces-server.ts
+++ b/apps/sva-studio-react/src/lib/instance-interfaces-server.ts
@@ -339,6 +339,11 @@ const trimToUndefined = (value: string): string | undefined => {
   return trimmed ? trimmed : undefined;
 };
 
+const isObviouslyUrlLikeMailHost = (value: string): boolean => {
+  const trimmed = value.trim();
+  return trimmed.includes('://') || trimmed.includes('/') || trimmed.includes('?') || trimmed.includes('#');
+};
+
 const assertValidMailTransportDraft = (
   draft: Extract<InstanceInterfaceDraft, { type: 'mailTransport' }>,
   input: { readonly displayName: string; readonly transportId: string; readonly nextPassword: string }
@@ -350,6 +355,7 @@ const assertValidMailTransportDraft = (
     draft.config.authMode === 'basic' && !input.nextPassword.trim(),
     draft.config.authMode === 'basic' && !draft.config.username.trim(),
     !draft.config.host.trim(),
+    isObviouslyUrlLikeMailHost(draft.config.host),
   ];
 
   if (validationRules.some(Boolean)) {

--- a/apps/sva-studio-react/src/lib/instance-interfaces.ts
+++ b/apps/sva-studio-react/src/lib/instance-interfaces.ts
@@ -1,7 +1,6 @@
 import type {
   MailTransportAuthMode,
   MailTransportSecurityMode,
-  MailTransportType,
 } from '@sva/core';
 import type { SvaMainserverConnectionStatus } from '@sva/sva-mainserver';
 
@@ -30,7 +29,6 @@ export type InstanceInterfaceSupabaseConfig = Readonly<{
 
 export type InstanceInterfaceMailTransportConfig = Readonly<{
   transportId: string;
-  transportType: MailTransportType;
   host: string;
   port: string;
   securityMode: MailTransportSecurityMode;
@@ -41,8 +39,6 @@ export type InstanceInterfaceMailTransportConfig = Readonly<{
   defaultReplyToEmail: string;
   maxBatchSize: string;
   rateLimitPerMinute: string;
-  providerMode: string;
-  endpoint: string;
 }>;
 
 type InstanceInterfaceBase = Readonly<{
@@ -142,7 +138,6 @@ export const createEmptyInstanceInterfaceDraft = (
       enabled: true,
       config: {
         transportId: '',
-        transportType: 'smtp',
         host: '',
         port: '587',
         securityMode: 'starttls',
@@ -154,8 +149,6 @@ export const createEmptyInstanceInterfaceDraft = (
         defaultReplyToEmail: '',
         maxBatchSize: '',
         rateLimitPerMinute: '',
-        providerMode: '',
-        endpoint: '',
       },
     };
   }

--- a/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.materialization.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.materialization.ts
@@ -224,7 +224,9 @@ export type MaterializedLocationTourPickupDateRecord = Omit<WasteLocationTourPic
 
 export const buildMaterializedLocationTourPickupDates = (input: WasteMaterializationContext): readonly MaterializedLocationTourPickupDateRecord[] => {
   const yearWindow = getEffectiveYearWindow(input.currentYear, input.nextYear);
-  const collectionYearWindow = Array.from(new Set([yearWindow[0] - 1, ...yearWindow])).sort();
+  const collectionYearWindow = Array.from(new Set([yearWindow[0] - 1, ...yearWindow])).sort(
+    (left, right) => left - right
+  );
   const syncYearSet = new Set(yearWindow);
   const rules = buildMaterializationRules({ ...input, currentYear: yearWindow[0], nextYear: yearWindow[1] });
   const tourById = new Map(input.tours.map((tour) => [tour.id, tour] as const));

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.controller.test.ts
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.controller.test.ts
@@ -109,7 +109,6 @@ describe('interfaces page controller helpers', () => {
           type: 'mailTransport',
           config: {
             transportId: 'mail-1',
-            transportType: 'smtp',
             host: 'smtp.example.org',
             port: '587',
             securityMode: 'starttls',
@@ -120,8 +119,6 @@ describe('interfaces page controller helpers', () => {
             defaultReplyToEmail: 'service@example.org',
             maxBatchSize: '50',
             rateLimitPerMinute: '120',
-            providerMode: '',
-            endpoint: '',
           },
         })
       )
@@ -131,7 +128,6 @@ describe('interfaces page controller helpers', () => {
       enabled: true,
       config: {
         transportId: 'mail-1',
-        transportType: 'smtp',
         host: 'smtp.example.org',
         port: '587',
         securityMode: 'starttls',
@@ -143,8 +139,6 @@ describe('interfaces page controller helpers', () => {
         defaultReplyToEmail: 'service@example.org',
         maxBatchSize: '50',
         rateLimitPerMinute: '120',
-        providerMode: '',
-        endpoint: '',
       },
     });
   });
@@ -170,7 +164,6 @@ describe('interfaces page controller helpers', () => {
           enabled: true,
           config: {
             transportId: 'mail-1',
-            transportType: 'smtp',
             host: 'smtp.example.org',
             port: '587',
             securityMode: 'starttls',
@@ -182,8 +175,6 @@ describe('interfaces page controller helpers', () => {
             defaultReplyToEmail: 'service@example.org',
             maxBatchSize: '50',
             rateLimitPerMinute: '120',
-            providerMode: '',
-            endpoint: '',
           },
         },
       })

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.dialogs.test.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.dialogs.test.tsx
@@ -20,7 +20,6 @@ const createMailTransportDraft = (): Extract<InstanceInterfaceDraft, { type: 'ma
   enabled: true,
   config: {
     transportId: 'mail-1',
-    transportType: 'smtp',
     host: 'smtp.example.org',
     port: '587',
     securityMode: 'starttls',
@@ -32,8 +31,6 @@ const createMailTransportDraft = (): Extract<InstanceInterfaceDraft, { type: 'ma
     defaultReplyToEmail: 'service@example.org',
     maxBatchSize: '50',
     rateLimitPerMinute: '120',
-    providerMode: '',
-    endpoint: '',
   },
 });
 
@@ -125,7 +122,7 @@ describe('interfaces-page dialogs', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  it('updates mail transport select and numeric fields through the shared patch helper', () => {
+  it('updates mail transport fields through the shared patch helper without exposing transport type selection', () => {
     const onChange = vi.fn();
 
     render(
@@ -138,9 +135,7 @@ describe('interfaces-page dialogs', () => {
       />
     );
 
-    fireEvent.change(screen.getByLabelText('Transporttyp'), {
-      target: { value: 'smtp' },
-    });
+    expect(screen.queryByLabelText('Transporttyp')).toBeNull();
     fireEvent.change(screen.getByLabelText('Port'), {
       target: { value: '2525' },
     });
@@ -154,24 +149,17 @@ describe('interfaces-page dialogs', () => {
     expect(onChange).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        type: 'mailTransport',
-        config: expect.objectContaining({ transportType: 'smtp' }),
+        config: expect.objectContaining({ port: '2525' }),
       })
     );
     expect(onChange).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        config: expect.objectContaining({ port: '2525' }),
-      })
-    );
-    expect(onChange).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({
         config: expect.objectContaining({ securityMode: 'tls' }),
       })
     );
     expect(onChange).toHaveBeenNthCalledWith(
-      4,
+      3,
       expect.objectContaining({
         config: expect.objectContaining({ authMode: 'none' }),
       })

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.dialogs.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.dialogs.tsx
@@ -341,21 +341,6 @@ const MailTransportFields = ({
             onChange={(event) => updateConfig({ transportId: event.currentTarget.value })}
           />
         </div>
-        <div className="grid gap-2">
-          <Label htmlFor="mail-transport-type">{t('interfaces.forms.mailTransport.transportType')}</Label>
-          <select
-            id="mail-transport-type"
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            value={draft.config.transportType}
-            onChange={(event) =>
-              updateConfig({
-                transportType: event.currentTarget.value as typeof draft.config.transportType,
-              })
-            }
-          >
-            <option value="smtp">{t('interfaces.forms.mailTransport.transportTypeOptions.smtp')}</option>
-          </select>
-        </div>
       </div>
 
       <div className="grid gap-2 md:grid-cols-2">

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.test.tsx
@@ -107,7 +107,6 @@ const mailTransportEntry = {
   updatedAt: '2026-03-15T20:03:00.000Z',
   config: {
     transportId: 'mail-transport-1',
-    transportType: 'smtp',
     host: 'smtp.example.org',
     port: '587',
     securityMode: 'starttls',
@@ -118,8 +117,6 @@ const mailTransportEntry = {
     defaultReplyToEmail: 'service@example.org',
     maxBatchSize: '50',
     rateLimitPerMinute: '120',
-    providerMode: '',
-    endpoint: '',
   },
 } as const;
 
@@ -400,7 +397,6 @@ describe('InterfacesPage', () => {
             name: 'Zentraler Mailversand',
             config: expect.objectContaining({
               transportId: 'mail-transport-1',
-              transportType: 'smtp',
               host: 'smtp.example.org',
               port: '587',
               securityMode: 'starttls',
@@ -432,9 +428,7 @@ describe('InterfacesPage', () => {
     fireEvent.click(screen.getByRole('radio', { name: /Mail-Transport/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
 
-    const transportTypeSelect = screen.getByLabelText('Transporttyp');
-    expect(within(transportTypeSelect).getByRole('option', { name: /SMTP/i })).toBeTruthy();
-    expect(within(transportTypeSelect).queryByRole('option', { name: /Provider-API/i })).toBeNull();
+    expect(screen.queryByLabelText('Transporttyp')).toBeNull();
   });
 
   it('shows the persisted healthcheck message below the interface status', async () => {
@@ -459,7 +453,7 @@ describe('InterfacesPage', () => {
     });
   });
 
-  it('renders endpoint and status fallbacks for disabled or provider-api interfaces', async () => {
+  it('renders endpoint and status fallbacks for disabled interfaces and SMTP transports', async () => {
     state.listInterfaces.mockResolvedValue(
       createListResponse([
         {
@@ -475,12 +469,11 @@ describe('InterfacesPage', () => {
         },
         {
           ...mailTransportEntry,
-          id: 'mail-provider',
+          id: 'mail-smtp',
           status: 'error',
           config: {
             ...mailTransportEntry.config,
-            transportType: 'provider_api',
-            endpoint: 'https://mail.example/api',
+            host: 'smtp.mail.example',
           },
         },
       ])
@@ -492,7 +485,7 @@ describe('InterfacesPage', () => {
       expect(screen.getByText('2 Schnittstelle(n)')).toBeTruthy();
     });
 
-    expect(screen.getAllByText('https://mail.example/api').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('smtp.mail.example').length).toBeGreaterThan(0);
     expect(screen.getAllByText('-').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Deaktiviert').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Fehler').length).toBeGreaterThan(0);

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.tsx
@@ -44,7 +44,7 @@ const getInterfaceEndpoint = (entry: InstanceInterface): string => {
   if (entry.type === 'supabase') {
     return entry.config.projectUrl || '-';
   }
-  return entry.config.transportType === 'smtp' ? entry.config.host || '-' : entry.config.endpoint || '-';
+  return entry.config.host || '-';
 };
 
 const renderInterfaceRowActions = (

--- a/packages/auth-runtime/src/middleware-guards.ts
+++ b/packages/auth-runtime/src/middleware-guards.ts
@@ -58,9 +58,7 @@ export const ensureAccountLifecycleAllowsAccess = async (
 ): Promise<Response | null> => {
   void request;
   void user;
-  if (options?.isLocalDevelopmentAuth || !user.instanceId) {
-    return null;
-  }
+  void options;
   return null;
 };
 


### PR DESCRIPTION
## What changed
- simplify the Studio mail transport UI to a strict SMTP-only configuration flow
- remove unused provider-mode transport fields from the Studio-side interface draft/model path
- fix Sonar-reported blockers by making test assertions explicit and removing a no-op branch in auth middleware guards
- fix the Sonar reliability issue in waste materialization by using an explicit numeric compare function for year sorting

## Why it changed
- creating an SMTP integration exposed unnecessary generic mail transport options although the runtime only supports SMTP
- SonarCloud reported blocker issues in the affected UI tests and middleware guard, plus a critical reliability issue in waste materialization sorting

## User and developer impact
- interface administrators now see a smaller, SMTP-focused mail transport form
- persisted legacy provider-shaped mail transport rows are still read defensively on the Studio side, but new edits are normalized to SMTP
- Sonar findings for the touched files should clear on the next analysis run

## Root cause
- the Studio frontend still mirrored an older generic mail transport abstraction while the runtime had already converged on SMTP
- the affected tests relied on a custom accessibility helper that Sonar did not recognize as an assertion
- a numeric year array used the default JavaScript sort semantics instead of an explicit comparator

## Validation
- `pnpm exec vitest run src/lib/waste-management-mainserver-sync.materialization.test.ts`
- `pnpm exec vitest run src/components/ui/dialog.a11y.test.tsx src/components/ui/label.a11y.test.tsx src/test/a11y.test.ts`
- `pnpm exec vitest run src/middleware-guards.test.ts`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run sva-studio-react:test:types`
- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main`
