### PR TITLE
[codex] Harden media QR downloads and document Sonar CPD exclusions

### DIFF
--- a/apps/sva-studio-react/src/routes/admin/media/-media-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/media/-media-detail-page.test.tsx
@@ -138,9 +138,11 @@ describe('MediaDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog', { name: 'QR-Code zur öffentlichen URL' })).toBeTruthy();
       expect(screen.getByRole('link', { name: 'QR-Code als PNG laden' }).getAttribute('href')).toBe('data:image/png;base64,qrpng');
+      expect(screen.getByRole('link', { name: 'QR-Code als PNG laden' }).getAttribute('download')).toBe('detail-asset-qr.png');
       expect(screen.getByRole('link', { name: 'QR-Code als SVG laden' }).getAttribute('href')).toContain(
         'data:image/svg+xml'
       );
+      expect(screen.getByRole('link', { name: 'QR-Code als SVG laden' }).getAttribute('download')).toBe('detail-asset-qr.svg');
     });
   });
 

--- a/apps/sva-studio-react/src/routes/admin/media/-media-detail-workspace-header.tsx
+++ b/apps/sva-studio-react/src/routes/admin/media/-media-detail-workspace-header.tsx
@@ -25,11 +25,26 @@ const isVisualPreview = (mimeType: string | undefined): boolean => typeof mimeTy
 const previewAltText = (asset: IamRegisteredMediaAsset): string =>
   asset.metadata.altText?.trim() || asset.metadata.title?.trim() || asset.id;
 
+const trimEdgeCharacters = (value: string, character: string): string => {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === character) {
+    start += 1;
+  }
+
+  while (end > start && value[end - 1] === character) {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+};
+
 const createQrDownloadName = (asset: IamRegisteredMediaAsset) =>
-  `${(asset.metadata.title?.trim() || asset.id)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '') || asset.id}-qr`;
+  `${trimEdgeCharacters(
+    (asset.metadata.title?.trim() || asset.id).toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    '-'
+  ) || asset.id}-qr`;
 
 const copyTextToClipboard = async (value: string) => {
   if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {

--- a/docs/development/testing-coverage.md
+++ b/docs/development/testing-coverage.md
@@ -82,8 +82,14 @@ zuordnen.
 
 Die CPD-Ausnahmen in `sonar-project.properties` sind auf generierte Artefakte, Übersetzungsressourcen und
 dokumentierte Migrationsspiegel beschränkt. Aktuell betrifft das die Data-Repository-Extraktion
-(`packages/data-repositories/src/**`) und die verbleibenden App-Spiegel der Studio-UI-Extraktion.
-Neue fachliche Duplikate sollen weiterhin refaktoriert werden.
+(`packages/data-repositories/src/**`), die verbleibenden App-Spiegel der Studio-UI-Extraktion und die
+i18n-Ressourcen unter `apps/sva-studio-react/src/i18n/resources/**`.
+
+Für diese i18n-Ressourcen gilt bewusst folgende Entscheidung: Sie bleiben in SonarCloud sichtbar, werden aber
+von der Copy-Paste-Detection ausgenommen, weil parallele DE/EN-Objektstrukturen dort überwiegend
+Übersetzungs-Spiegel statt fachlich refaktorierbarer Duplikate darstellen. Neue fachliche Duplikate sollen
+weiterhin refaktoriert werden; die Ausnahme gilt nicht für Runtime-Logik außerhalb der reinen
+Ressourcenmodule.
 
 ### Baseline aktualisieren
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,7 +27,7 @@ sonar.coverage.exclusions=apps/sva-studio-react/src/routeTree.gen.ts,apps/sva-st
 # Copy-Paste-Detection-Ausschlüsse:
 # - Übersetzungsressourcen inkl. Plugin-Translations und generierte Artefakte
 # - dokumentierte Migrationsspiegel während der Data-Repository- und Studio-UI-Extraktion
-sonar.cpd.exclusions=apps/sva-studio-react/src/i18n/resources.ts,packages/plugin-news/src/plugin.translations*.ts,packages/plugin-waste-management/src/plugin.translations*.ts,apps/sva-studio-react/src/routeTree.gen.ts,apps/sva-studio-react/src/components/ui/**,apps/sva-studio-react/src/components/StudioDataTable.tsx,apps/sva-studio-react/src/components/StudioListPageTemplate.tsx,packages/data-repositories/src/**
+sonar.cpd.exclusions=apps/sva-studio-react/src/i18n/resources.ts,apps/sva-studio-react/src/i18n/resources/**,packages/plugin-news/src/plugin.translations*.ts,packages/plugin-waste-management/src/plugin.translations*.ts,apps/sva-studio-react/src/routeTree.gen.ts,apps/sva-studio-react/src/components/ui/**,apps/sva-studio-react/src/components/StudioDataTable.tsx,apps/sva-studio-react/src/components/StudioListPageTemplate.tsx,packages/data-repositories/src/**
 
 # Ausschlüsse
 sonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**,**/*.config.*,**/e2e/**,**/test-results/**,**/playwright-report/**,deploy/**,dev/**,scripts/**,concepts/**,artifacts/**,tooling/**,openspec/**

--- a/tooling/testing/tests/sonar-project-properties.test.ts
+++ b/tooling/testing/tests/sonar-project-properties.test.ts
@@ -31,15 +31,16 @@ describe('sonar-project.properties', () => {
     expect(tests).toContain('packages/waste-management-runtime/src');
   });
 
-  it('keeps plugin translation resources out of copy-paste detection only', () => {
+  it('keeps translation resources out of copy-paste detection only', () => {
     const cpdExclusions = readPropertyValues('sonar.cpd.exclusions');
     const sonarExclusions = readPropertyValues('sonar.exclusions');
-    const pluginTranslationPatterns = [
+    const translationPatterns = [
+      'apps/sva-studio-react/src/i18n/resources/**',
       'packages/plugin-news/src/plugin.translations*.ts',
       'packages/plugin-waste-management/src/plugin.translations*.ts',
     ];
 
-    for (const pattern of pluginTranslationPatterns) {
+    for (const pattern of translationPatterns) {
       expect(cpdExclusions).toContain(pattern);
       expect(sonarExclusions).not.toContain(pattern);
     }


### PR DESCRIPTION
## Was wurde geändert?
- QR-Code-Downloads im Media-Detailbereich erzeugen jetzt stabile Dateinamen für PNG und SVG.
- Die Dateinamenbereinigung verwendet kein regex-basiertes Edge-Trimming mehr, und der Routen-Test deckt die `download`-Attribute explizit ab.
- Sonar CPD ignoriert jetzt gezielt `apps/sva-studio-react/src/i18n/resources/**`, und die Entscheidung ist in der Entwicklungsdoku festgehalten.
- Der Guardrail-Test für `sonar-project.properties` prüft die neue Übersetzungsressourcen-Ausnahme explizit.

## Warum?
- Die Media-Änderung härtet den QR-Download-Pfad ab und sichert das gewünschte Browser-Verhalten im Test ab.
- Die Sonar-Änderung entfernt systematische DE/EN-Übersetzungs-Spiegel aus der Copy-Paste-Detection, ohne die Dateien vollständig aus Sonar auszublenden.

## Auswirkungen
- Medien-QR-Codes werden mit vorhersehbaren Download-Dateinamen ausgeliefert.
- Sonar meldet reine i18n-Ressourcenspiegel nicht mehr als neue CPD-Duplikate.
- Die Ausnahme bleibt auf Ressourcenmodule begrenzt und ist dokumentiert.

## Verifikation
- `pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/admin/media/-media-detail-page.test.tsx`
- `pnpm exec vitest run tooling/testing/tests/sonar-project-properties.test.ts --config vitest.config.ts`
- `pnpm nx affected --target=test:unit --base=origin/main`
