### PR TITLE
[codex] Show past public waste calendar events

### DIFF
--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
@@ -127,4 +127,32 @@ describe('PublicWasteCalendarPanels', () => {
     fireEvent.keyDown(screen.getByRole('tab', { name: 'Monat' }), { key: 'ArrowLeft' });
     expect(screen.getByRole('tab', { name: 'Liste' }).getAttribute('aria-selected')).toBe('true');
   });
+
+  it('allows month navigation back to the earliest available month in the previous year', () => {
+    render(
+      <PublicWasteCalendarPanels
+        model={createFilteredPublicWasteCalendarModelFixture({
+          listEntries: [
+            createPublicWasteCalendarEntryFixture({
+              id: 'pickup-oldest',
+              date: '2025-01-15',
+            }),
+            createPublicWasteCalendarEntryFixture(),
+          ],
+        })}
+        onToggleFraction={vi.fn()}
+        onActivateEntry={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Monat' }));
+
+    const previousMonthButton = screen.getByRole('button', { name: 'Vorheriger Monat' });
+    for (let index = 0; index < 16; index += 1) {
+      fireEvent.click(previousMonthButton);
+    }
+
+    expect(screen.getByRole('heading', { name: 'Januar 2025' })).toBeTruthy();
+    expect(previousMonthButton.getAttribute('disabled')).not.toBeNull();
+  });
 });

--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
@@ -28,6 +28,7 @@ const toMonthKey = (value: Date): string => {
 };
 
 const startOfMonth = (value: Date): Date => new Date(value.getFullYear(), value.getMonth(), 1);
+const startOfYear = (value: Date): Date => new Date(value.getFullYear(), 0, 1);
 
 const addMonths = (value: Date, amount: number): Date => new Date(value.getFullYear(), value.getMonth() + amount, 1);
 
@@ -79,6 +80,19 @@ const groupEntriesByDay = (entries: readonly PublicWasteCalendarEntry[]) =>
       return groups;
     }, new Map()).entries()
   );
+
+const compareMonths = (left: Date, right: Date): number =>
+  left.getFullYear() - right.getFullYear() || left.getMonth() - right.getMonth();
+
+const clampMonth = (value: Date, minMonth: Date, maxMonth: Date): Date => {
+  if (compareMonths(value, minMonth) < 0) {
+    return minMonth;
+  }
+  if (compareMonths(value, maxMonth) > 0) {
+    return maxMonth;
+  }
+  return value;
+};
 
 const renderPickupDot = (entry: PublicWasteCalendarEntry) => (
   <span
@@ -186,8 +200,18 @@ export function PublicWasteCalendarPanels(props: Readonly<{
 }>) {
   const tabs: ReadonlyArray<'list' | 'month' | 'year'> = ['list', 'month', 'year'];
   const today = React.useRef(new Date()).current;
-  const minMonth = React.useRef(startOfMonth(addYears(today, -1))).current;
+  const lowerBoundMonth = React.useRef(startOfYear(addYears(today, -1))).current;
   const maxMonth = React.useRef(startOfMonth(addYears(today, 1))).current;
+  const earliestEntryMonth = React.useMemo(() => {
+    const earliestEntry = props.model.listEntries[0];
+    if (!earliestEntry) {
+      return startOfMonth(today);
+    }
+
+    const month = startOfMonth(toDate(earliestEntry.date));
+    return compareMonths(month, lowerBoundMonth) < 0 ? lowerBoundMonth : month;
+  }, [lowerBoundMonth, props.model.listEntries, today]);
+  const minMonth = earliestEntryMonth;
   const minYear = minMonth.getFullYear();
   const maxYear = maxMonth.getFullYear();
   const entriesByDate = React.useMemo(
@@ -195,8 +219,12 @@ export function PublicWasteCalendarPanels(props: Readonly<{
     [props.model.listEntries]
   );
   const [activeTab, setActiveTab] = React.useState<'list' | 'month' | 'year'>('list');
-  const [visibleMonth, setVisibleMonth] = React.useState<Date>(() => startOfMonth(today));
-  const [visibleYear, setVisibleYear] = React.useState<number>(today.getFullYear());
+  const [visibleMonth, setVisibleMonth] = React.useState<Date>(() =>
+    clampMonth(startOfMonth(today), minMonth, maxMonth)
+  );
+  const [visibleYear, setVisibleYear] = React.useState<number>(() =>
+    Math.min(maxYear, Math.max(minYear, today.getFullYear()))
+  );
   const monthGroups = groupEntriesByMonth(props.model.listEntries);
   const monthCells = React.useMemo(() => buildMonthCells(visibleMonth, entriesByDate), [entriesByDate, visibleMonth]);
   const visibleYearMonths = React.useMemo(
@@ -208,6 +236,15 @@ export function PublicWasteCalendarPanels(props: Readonly<{
   const canGoToNextMonth = toMonthKey(visibleMonth) < toMonthKey(maxMonth);
   const canGoToPreviousYear = visibleYear > minYear;
   const canGoToNextYear = visibleYear < maxYear;
+
+  React.useEffect(() => {
+    setVisibleMonth((current) => clampMonth(current, minMonth, maxMonth));
+  }, [maxMonth, minMonth]);
+
+  React.useEffect(() => {
+    setVisibleYear((current) => Math.min(maxYear, Math.max(minYear, current)));
+  }, [maxYear, minYear]);
+
   const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, tab: 'list' | 'month' | 'year') => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
       return;

--- a/apps/public-waste-calendar-web/src/lib/public-waste-api.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-api.ts
@@ -41,7 +41,7 @@ export const loadResolvedPublicWasteCalendar = async (input: {
     locationKey: buildPublicWasteLocationKey(input.input.selection),
     ...projectPublicWasteCalendar({
       referenceDate: input.input.referenceDate,
-      upcomingEntries: entries,
+      entries,
     }),
   };
 };

--- a/apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-bootstrap.server.test.ts
@@ -81,6 +81,7 @@ describe('public waste bootstrap', () => {
 
     expect(
       readPublicWasteBootstrapStateFromEnvironment({
+        env: {},
         rawConfigJson: JSON.stringify({
           instanceId: 'bb-prignitz-json',
           supabase: { databaseUrl: 'postgres://json', schemaName: 'public-json' },

--- a/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.test.ts
@@ -224,6 +224,45 @@ describe('public waste calendar occurrences', () => {
     ]);
   });
 
+  it('includes past occurrences back to the start of the previous year', () => {
+    const entries = calculatePublicWasteCalendarEntries({
+      referenceDate: '2026-12-31',
+      selection: {
+        cityId: 'c-1',
+        streetId: 's-1',
+      },
+      linkedTours: [
+        {
+          linkId: 'link-1',
+          locationId: 'loc-1',
+          startDate: '2025-01-01',
+          endDate: '2026-12-31',
+          tour: {
+            id: 'tour-paper',
+            name: 'Papiertour',
+            recurrence: null,
+            customDates: [{ date: '2025-01-08' }],
+            fractions: [{ id: 'paper', label: 'Papier', color: '#0000FF' }],
+          },
+        },
+      ],
+      tourDateShifts: [],
+      globalDateShifts: [],
+    });
+
+    expect(entries).toEqual([
+      {
+        id: 'tour-paper:2025-01-08:paper',
+        date: '2025-01-08',
+        fractionId: 'paper',
+        fractionLabel: 'Papier',
+        fractionColor: '#0000FF',
+        tourName: 'Papiertour',
+        note: null,
+      },
+    ]);
+  });
+
   it('applies configured holiday postponements to public calendar entries', () => {
     const entries = calculatePublicWasteCalendarEntries({
       referenceDate: '2026-01-01',

--- a/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.ts
@@ -8,6 +8,7 @@ import {
   isDateWithinRange,
   normalizeDateOnly,
   parseDateOnlyUtc,
+  startOfPreviousYearUtc,
 } from './public-waste-date-utils.js';
 
 type PublicWasteLinkedFraction = {
@@ -239,11 +240,12 @@ const calculateTourOccurrences = (
 export const calculatePublicWasteCalendarEntries = (
   input: CalculatePublicWasteCalendarEntriesInput
 ): readonly PublicWasteCalendarEntry[] => {
-  const windowStart = normalizeDateOnly(input.referenceDate);
-  if (!windowStart) {
+  const normalizedReferenceDate = normalizeDateOnly(input.referenceDate);
+  if (!normalizedReferenceDate) {
     return [];
   }
-  const windowEnd = addYearsUtc(windowStart, 1);
+  const windowStart = startOfPreviousYearUtc(normalizedReferenceDate);
+  const windowEnd = addYearsUtc(normalizedReferenceDate, 1);
   const entries = new Map<string, PublicWasteCalendarEntry>();
   const holidayRules = (input.holidayRules ?? [])
     .map((rule) => ({

--- a/apps/public-waste-calendar-web/src/lib/public-waste-date-utils.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-date-utils.ts
@@ -17,6 +17,14 @@ export const addYearsUtc = (value: string, years: number): string => {
   return formatDateOnlyUtc(date);
 };
 
+export const startOfYearUtc = (value: string): string => {
+  const date = parseDateOnlyUtc(value);
+  date.setUTCMonth(0, 1);
+  return formatDateOnlyUtc(date);
+};
+
+export const startOfPreviousYearUtc = (value: string): string => startOfYearUtc(addYearsUtc(value, -1));
+
 export const isDateWithinRange = (date: string, startDate: string, endDate: string): boolean =>
   date >= startDate && date <= endDate;
 

--- a/apps/public-waste-calendar-web/src/lib/public-waste-demo-runtime.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-demo-runtime.ts
@@ -213,7 +213,7 @@ export const resolveDemoPublicWastePageState = (input: {
     locationKey,
     ...projectPublicWasteCalendar({
       referenceDate: DEMO_REFERENCE_DATE,
-      upcomingEntries: calendarEntries,
+      entries: calendarEntries,
     }),
   };
 

--- a/apps/public-waste-calendar-web/src/lib/public-waste-pdf-settings.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-pdf-settings.server.test.ts
@@ -68,6 +68,8 @@ describe('public waste pdf settings', () => {
   });
 
   it('loads the default interface when no selected record exists', async () => {
+    vi.stubEnv('PUBLIC_WASTE_PDF_BRANDING_ASSET_URL', '');
+    vi.stubEnv('PUBLIC_WASTE_PDF_CONTACT_BLOCK', '');
     listExternalInterfaceRecordsMock.mockResolvedValue([]);
     loadDefaultExternalInterfaceRecordMock.mockResolvedValue(
       createExternalInterfaceRecord({

--- a/apps/public-waste-calendar-web/src/lib/public-waste-projection.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-projection.test.ts
@@ -3,10 +3,18 @@ import { describe, expect, it } from 'vitest';
 import { projectPublicWasteCalendar } from './public-waste-projection.js';
 
 describe('public waste projection', () => {
-  it('sorts upcoming entries and derives fraction filters', () => {
+  it('sorts entries, keeps the next pickup date in the future, and derives fraction filters', () => {
     const result = projectPublicWasteCalendar({
       referenceDate: '2026-05-18',
-      upcomingEntries: [
+      entries: [
+        {
+          id: 'pickup-0',
+          date: '2025-12-19',
+          fractionId: 'rest',
+          fractionLabel: 'Restmüll',
+          fractionColor: '#444444',
+          note: null,
+        },
         {
           id: 'pickup-2',
           date: '2026-05-21',
@@ -27,10 +35,11 @@ describe('public waste projection', () => {
     });
 
     expect(result.nextPickupDate).toBe('2026-05-19');
-    expect(result.listEntries.map((entry) => entry.id)).toEqual(['pickup-1', 'pickup-2']);
+    expect(result.listEntries.map((entry) => entry.id)).toEqual(['pickup-0', 'pickup-1', 'pickup-2']);
     expect(result.fractionOptions).toEqual([
       { id: 'bio', label: 'Bioabfall', color: '#00AA00' },
       { id: 'paper', label: 'Papier', color: '#0000FF' },
+      { id: 'rest', label: 'Restmüll', color: '#444444' },
     ]);
   });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-projection.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-projection.test.ts
@@ -42,4 +42,30 @@ describe('public waste projection', () => {
       { id: 'rest', label: 'Restmüll', color: '#444444' },
     ]);
   });
+
+  it('normalizes ISO timestamps before comparing the next pickup date', () => {
+    const result = projectPublicWasteCalendar({
+      referenceDate: '2026-05-19T12:00:00Z',
+      entries: [
+        {
+          id: 'pickup-1',
+          date: '2026-05-19',
+          fractionId: 'bio',
+          fractionLabel: 'Bioabfall',
+          fractionColor: '#00AA00',
+          note: null,
+        },
+        {
+          id: 'pickup-2',
+          date: '2026-05-21',
+          fractionId: 'paper',
+          fractionLabel: 'Papier',
+          fractionColor: '#0000FF',
+          note: null,
+        },
+      ],
+    });
+
+    expect(result.nextPickupDate).toBe('2026-05-19');
+  });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-projection.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-projection.ts
@@ -1,5 +1,7 @@
 import type { PublicWasteCalendarEntry, PublicWasteFractionOption } from './public-waste-contract.js';
 
+import { normalizeDateOnly } from './public-waste-date-utils.js';
+
 export type ProjectPublicWasteCalendarInput = {
   readonly referenceDate: string;
   readonly entries: readonly PublicWasteCalendarEntry[];
@@ -71,7 +73,10 @@ export const projectPublicWasteCalendar = (
   input: ProjectPublicWasteCalendarInput
 ): PublicWasteCalendarProjection => {
   const listEntries = [...input.entries].sort(compareEntries);
-  const nextPickupDate = listEntries.find((entry) => entry.date >= input.referenceDate)?.date ?? null;
+  const normalizedReferenceDate = normalizeDateOnly(input.referenceDate);
+  const nextPickupDate = normalizedReferenceDate
+    ? (listEntries.find((entry) => entry.date >= normalizedReferenceDate)?.date ?? null)
+    : null;
 
   return {
     nextPickupDate,

--- a/apps/public-waste-calendar-web/src/lib/public-waste-projection.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-projection.ts
@@ -2,7 +2,7 @@ import type { PublicWasteCalendarEntry, PublicWasteFractionOption } from './publ
 
 export type ProjectPublicWasteCalendarInput = {
   readonly referenceDate: string;
-  readonly upcomingEntries: readonly PublicWasteCalendarEntry[];
+  readonly entries: readonly PublicWasteCalendarEntry[];
 };
 
 export type PublicWasteCalendarProjection = {
@@ -70,10 +70,11 @@ const deriveFractionOptions = (entries: readonly PublicWasteCalendarEntry[]): re
 export const projectPublicWasteCalendar = (
   input: ProjectPublicWasteCalendarInput
 ): PublicWasteCalendarProjection => {
-  const listEntries = [...input.upcomingEntries].sort(compareEntries);
+  const listEntries = [...input.entries].sort(compareEntries);
+  const nextPickupDate = listEntries.find((entry) => entry.date >= input.referenceDate)?.date ?? null;
 
   return {
-    nextPickupDate: listEntries[0]?.date ?? null,
+    nextPickupDate,
     listEntries,
     monthBuckets: groupEntriesByMonth(listEntries),
     yearBuckets: groupEntriesByYear(listEntries),

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
@@ -224,6 +224,58 @@ describe('public waste repository', () => {
     );
   });
 
+  it('returns past entries back to the start of the previous year when available', async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            link_id: 'link-1',
+            location_id: 'location-1',
+            link_start_date: '2025-01-01',
+            link_end_date: '2026-12-31',
+            tour_id: 'tour-1',
+            tour_name: 'Papiertour',
+            tour_description: null,
+            tour_recurrence: null,
+            tour_custom_recurrence_interval_days: null,
+            tour_first_date: null,
+            tour_end_date: null,
+            tour_custom_dates: [{ date: '2025-01-08' }],
+            fraction_id: 'fraction-1',
+            fraction_label: 'Papier',
+            fraction_color: '#0000FF',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const repository = createPublicWasteRepository({
+      schemaName: 'waste',
+      execute,
+    });
+
+    await expect(
+      repository.loadCalendarEntries({
+        selection: {
+          cityId: 'city-1',
+          streetId: 'street-1',
+        },
+        referenceDate: '2026-12-31',
+      })
+    ).resolves.toContainEqual(
+      expect.objectContaining({
+        id: 'tour-1:2025-01-08:fraction-1',
+        date: '2025-01-08',
+        fractionLabel: 'Papier',
+      })
+    );
+  });
+
   it('adds imported pickup dates when a tour has no reconstructable recurrence dates', async () => {
     const execute = vi
       .fn()

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
@@ -11,7 +11,12 @@ import type {
 } from './public-waste-contract.js';
 import { calculatePublicWasteCalendarEntries } from './public-waste-calendar-occurrences.js';
 import { PUBLIC_WASTE_CATCH_ALL_STREET_ID } from './public-waste-contract.js';
-import { addYearsUtc, isDateWithinRange, normalizeDateOnly } from './public-waste-date-utils.js';
+import {
+  addYearsUtc,
+  isDateWithinRange,
+  normalizeDateOnly,
+  startOfPreviousYearUtc,
+} from './public-waste-date-utils.js';
 
 type SqlExecutionResult<TRow> = {
   readonly rowCount: number;
@@ -414,8 +419,9 @@ export const createPublicWasteRepository = (input: {
       });
       const tourIds = Array.from(new Set(linkedToursResult.rows.map((row) => row.tour_id)));
 
-      const windowStart = normalizeDateOnly(query.referenceDate);
-      const windowEnd = windowStart ? addYearsUtc(windowStart, 1) : null;
+      const normalizedReferenceDate = normalizeDateOnly(query.referenceDate);
+      const windowStart = normalizedReferenceDate ? startOfPreviousYearUtc(normalizedReferenceDate) : null;
+      const windowEnd = normalizedReferenceDate ? addYearsUtc(normalizedReferenceDate, 1) : null;
 
       const [tourDateShiftsResult, globalDateShiftsResult, importedPickupDatesResult, holidayRulesResult] = await Promise.all([
         tourIds.length === 0

--- a/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.test.ts
@@ -8,11 +8,20 @@ describe('public waste request parsing', () => {
     vi.setSystemTime(new Date('2026-06-07T12:00:00.000Z'));
   });
 
-  it('falls back to the current date when referenceDate is missing or blank and trims valid values', () => {
+  it('falls back to the current date when referenceDate is missing or blank and normalizes valid values', () => {
     expect(readPublicWasteReferenceDate(new URL('https://example.test/public-waste'))).toBe('2026-06-07');
     expect(readPublicWasteReferenceDate(new URL('https://example.test/public-waste?referenceDate='))).toBe('2026-06-07');
     expect(readPublicWasteReferenceDate(new URL('https://example.test/public-waste?referenceDate=%20%202026-01-01%20'))).toBe(
       '2026-01-01'
+    );
+    expect(readPublicWasteReferenceDate(new URL('https://example.test/public-waste?referenceDate=2026-01-01T15:30:00Z'))).toBe(
+      '2026-01-01'
+    );
+  });
+
+  it('falls back to the current date when referenceDate cannot be normalized to a date-only value', () => {
+    expect(readPublicWasteReferenceDate(new URL('https://example.test/public-waste?referenceDate=not-a-date'))).toBe(
+      '2026-06-07'
     );
   });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.ts
@@ -3,6 +3,7 @@ import type {
   PublicWasteSelectionState,
 } from './public-waste-contract.js';
 import { isPublicWasteStreetSelectionId, isPublicWasteUuid } from './public-waste-contract.js';
+import { normalizeDateOnly } from './public-waste-date-utils.js';
 
 const readRequiredParam = (url: URL, key: string): string => {
   const value = url.searchParams.get(key)?.trim();
@@ -57,7 +58,7 @@ export const readPublicWasteResolvedSelection = (url: URL): PublicWasteResolvedS
 });
 
 export const readPublicWasteReferenceDate = (url: URL): string =>
-  url.searchParams.get('referenceDate')?.trim() || new Date().toISOString().slice(0, 10);
+  normalizeDateOnly(url.searchParams.get('referenceDate')) ?? new Date().toISOString().slice(0, 10);
 
 export const readPublicWasteFractionIds = (url: URL): readonly string[] =>
   Array.from(new Set(url.searchParams.getAll('fractionId').map((value) => value.trim()).filter(Boolean)));

--- a/apps/public-waste-calendar-web/src/routes/index.test.tsx
+++ b/apps/public-waste-calendar-web/src/routes/index.test.tsx
@@ -140,6 +140,7 @@ describe('PublicWasteIndexPage', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Rathenow' }));
+    await act(async () => {});
     fireEvent.change(await screen.findByRole('textbox', { name: 'Straße suchen' }), {
       target: { value: 'Hafen' },
     });
@@ -148,6 +149,7 @@ describe('PublicWasteIndexPage', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Am alten Hafen' }));
+    await act(async () => {});
     fireEvent.change(await screen.findByRole('textbox', { name: 'Hausnummer suchen' }), {
       target: { value: '12' },
     });
@@ -285,6 +287,7 @@ describe('PublicWasteIndexPage', () => {
       expect(screen.getByRole('button', { name: 'Rathenow' })).toBeTruthy();
     });
     fireEvent.click(screen.getByRole('button', { name: 'Rathenow' }));
+    await act(async () => {});
 
     fireEvent.change(await screen.findByRole('textbox', { name: 'Straße suchen' }), {
       target: { value: 'Hafen' },
@@ -293,6 +296,7 @@ describe('PublicWasteIndexPage', () => {
       expect(screen.getByRole('button', { name: 'Am alten Hafen' })).toBeTruthy();
     });
     fireEvent.click(screen.getByRole('button', { name: 'Am alten Hafen' }));
+    await act(async () => {});
 
     fireEvent.change(await screen.findByRole('textbox', { name: 'Hausnummer suchen' }), {
       target: { value: '12' },

--- a/openspec/specs/public-waste-calendar/spec.md
+++ b/openspec/specs/public-waste-calendar/spec.md
@@ -91,17 +91,20 @@ Das System SHALL genau einen zuletzt gewählten Standort pro Browser für die ö
 
 Das System SHALL für einen vollständig aufgelösten Standort drei komplementäre Kalenderdarstellungen bereitstellen.
 
-#### Scenario: Terminliste beginnt mit dem nächsten Termin
+#### Scenario: Terminliste zeigt verfügbare Vergangenheits- und Zukunftstermine chronologisch
 
 - **WHEN** der Kalender für einen Standort geladen ist
-- **THEN** beginnt die Terminliste mit dem nächsten verfügbaren Termin
-- **AND** listet nachfolgende Termine in zeitlich aufsteigender Reihenfolge
+- **THEN** zeigt die Terminliste verfügbare Termine in zeitlich aufsteigender Reihenfolge
+- **AND** sie kann je nach Datenlage auch vergangene Termine bis zum Anfang des Vorjahres enthalten
+- **AND** künftige Termine bleiben ohne Lücken im selben Kalenderdatensatz sichtbar
 
 #### Scenario: Monats- und Jahresansicht haben ein begrenztes Navigationsfenster
 
 - **WHEN** Benutzerinnen oder Benutzer den Monats- oder Jahreskalender verwenden
 - **THEN** startet die Ansicht beim aktuellen Zeitpunkt
-- **AND** erlaubt Navigation höchstens ein Jahr in die Vergangenheit und ein Jahr in die Zukunft
+- **AND** erlaubt Navigation rückwärts höchstens bis zum frühesten verfügbaren Monat des Standorts
+- **AND** die Rückwärtsnavigation reicht dabei nie vor den Jahresanfang des Vorjahres
+- **AND** die Vorwärtsnavigation bleibt höchstens ein Jahr in die Zukunft begrenzt
 
 #### Scenario: Klick auf einen Termin öffnet ein Detail-Modal
 
@@ -131,11 +134,12 @@ Das System SHALL globale PDF- und iCal-Aktionen aus demselben finalen Standortko
 - **AND** die öffentliche Runtime erzeugt das PDF serverseitig ad hoc
 - **AND** es wird kein persistentes PDF-Artefakt gespeichert
 
-#### Scenario: iCal-Feed liefert alle verfügbaren künftigen Termine
+#### Scenario: iCal-Feed liefert dieselbe Terminspanne wie die öffentliche Kalenderansicht
 
 - **WHEN** ein Benutzer oder ein Kalender-Client den iCal-Link eines vollständig aufgelösten Standorts aufruft
 - **THEN** liefert die App einen serverseitig erzeugten iCal-Feed
 - **AND** der Feed enthält alle verfügbaren künftigen Termine dieses Standorts
+- **AND** der Feed kann je nach Datenlage zusätzlich vergangene Termine bis zum Anfang des Vorjahres enthalten
 - **AND** der Feed ist konsistent zu den in der App sichtbaren Kalenderdaten
 
 ### Requirement: Öffentliche App ist für eingebettete Nutzung barrierearm und schlicht


### PR DESCRIPTION
## Was wurde geändert?
- der öffentliche Webabfallkalender liefert verfügbare Termine nun auch rückwirkend bis zum Jahresanfang des Vorjahres
- `nextPickupDate` bleibt auf den nächsten zukünftigen Termin fokussiert, obwohl die Listen- und Kalenderansichten ältere Einträge mitführen
- die Monatsnavigation richtet sich nach dem frühesten verfügbaren Monat und stoppt spätestens am Beginn des Vorjahres
- die OpenSpec-Spezifikation für `public-waste-calendar` wurde auf das neue Verhalten nachgezogen

## Warum?
Bisher blendete der Webabfallkalender vergangene Termine vollständig aus. Gewünscht war, dass Benutzerinnen und Benutzer sowie iCal-Clients je nach Datenlage auch zurückliegende Abholtermine sehen können, ohne den Zukunftsbezug der nächsten Abholung zu verlieren.

## Auswirkungen
- Listen-, Monats-, Jahres- und iCal-Ansicht verwenden jetzt dieselbe erweiterte Terminspanne
- die UI bleibt bei der Navigation begrenzt und springt nicht vor den frühesten verfügbaren Monat
- bestehende Zukunftslogik für den nächsten Abholtermin bleibt erhalten

## Validierung
- `pnpm exec vitest run src/lib/public-waste-calendar-occurrences.test.ts src/lib/public-waste-projection.test.ts src/lib/public-waste-repository.server.test.ts src/components/public-waste-calendar-panels.test.tsx`
- `pnpm nx run public-waste-calendar-web:test:types`
- `openspec validate public-waste-calendar --strict`
