### PR TITLE
[codex] update public waste web action layout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "06:00"
       timezone: "Europe/Berlin"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 100
     labels:
       - "dependencies"
     groups:
@@ -36,10 +36,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "06:15"
       timezone: "Europe/Berlin"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 100
     labels:
       - "dependencies"

--- a/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
@@ -1,6 +1,6 @@
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PublicWasteApp } from './public-waste-app.js';
 import {
@@ -19,7 +19,22 @@ const renderCompletePublicWasteApp = (overrides: Partial<CompletePublicWasteAppT
       selection={publicWasteSelectionFixture}
       selectionState="complete"
       selectionSummary={publicWasteSelectionSummaryFixture}
-      calendarModel={createPublicWasteCalendarModelFixture()}
+      calendarModel={createPublicWasteCalendarModelFixture({
+        fractionOptions: [
+          { id: 'bio', label: 'Bioabfall', color: '#00AA00' },
+          { id: 'paper', label: 'Papier', color: '#0000FF' },
+        ],
+        listEntries: [
+          createPublicWasteCalendarEntryFixture(),
+          createPublicWasteCalendarEntryFixture({
+            id: 'pickup-2',
+            date: '2026-05-20',
+            fractionId: 'paper',
+            fractionLabel: 'Papier',
+            fractionColor: '#0000FF',
+          }),
+        ],
+      })}
       icalUrl="https://example.invalid/calendar.ics"
       onChangeLocation={() => undefined}
       {...overrides}
@@ -35,22 +50,77 @@ describe('PublicWasteApp', () => {
     fetchMock.mockReset();
   });
 
-  it('renders header actions for calendar import and the on-demand pdf export', () => {
-    renderCompletePublicWasteApp();
-
-    expect(screen.getByRole('link', { name: 'In Kalender übernehmen' }).getAttribute('href')).toBe(
-      'https://example.invalid/calendar.ics'
-    );
-    expect(screen.getByRole('button', { name: 'Druckversion herunterladen' })).toBeTruthy();
-    expect(screen.getByLabelText('PDF-Jahr')).toBeTruthy();
-    expectPublicWasteSelectionHeader();
-    expect(screen.getByRole('button', { name: 'Adresse ändern' })).toBeTruthy();
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
-  it('revokes the generated object url after the download was triggered', async () => {
+  it('renders address left, fractions right, and a horizontal action block', () => {
+    renderCompletePublicWasteApp();
+
+    expectPublicWasteSelectionHeader();
+    expect(screen.getByRole('button', { name: 'Adresse ändern' })).toBeTruthy();
+    expect(screen.getByRole('group', { name: 'Abfallfraktionen' })).toBeTruthy();
+    expect(screen.getByRole('checkbox', { name: 'Bioabfall' })).toBeTruthy();
+    expect(screen.getByRole('checkbox', { name: 'Papier' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'PDF-Download' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'E-Mail-Abo' })).toBeTruthy();
+  });
+
+  it('uses a single open action panel at a time', () => {
+    renderCompletePublicWasteApp();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Kalenderexport' }));
+    expect(screen.getByText('Kalender exportieren')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'PDF-Download' }));
+    expect(screen.queryByText('Kalender exportieren')).toBeNull();
+    expect(screen.getByRole('button', { name: 'PDF herunterladen' })).toBeTruthy();
+  });
+
+  it('updates the visible calendar entries from the right-side fraction list', () => {
+    renderCompletePublicWasteApp();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Bioabfall' }));
+
+    const pickupLists = screen.getAllByRole('list');
+    expect(pickupLists.at(-1)?.textContent).not.toContain('Bioabfall');
+    expect(pickupLists.at(-1)?.textContent).toContain('Papier');
+  });
+
+  it('builds a reminder-enabled calendar export from the active fractions', () => {
+    renderCompletePublicWasteApp({
+      calendarReminderOptions: {
+        fractions: [
+          {
+            id: 'bio',
+            label: 'Bioabfall',
+            slots: [{ id: 'bio:calendar:first', maxLeadDays: 2, defaultLeadDays: 1 }],
+          },
+          {
+            id: 'paper',
+            label: 'Papier',
+            slots: [{ id: 'paper:calendar:first', maxLeadDays: 4, defaultLeadDays: 2 }],
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Kalenderexport' }));
+
+    const exportLink = screen.getByRole('link', { name: 'Kalender exportieren' });
+    expect(exportLink.getAttribute('href')).toContain('fractionId=bio');
+    expect(exportLink.getAttribute('href')).toContain('fractionId=paper');
+    expect(exportLink.getAttribute('href')).toContain('reminderItem=bio%7Cbio%3Acalendar%3Afirst');
+    expect(exportLink.getAttribute('href')).toContain('reminderItem=paper%7Cpaper%3Acalendar%3Afirst');
+    expect(screen.queryByRole('checkbox', { name: 'Mit Erinnerungen exportieren' })).toBeNull();
+  });
+
+  it('downloads a pdf for the active fractions and selected year from the action panel', async () => {
     const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:public-waste-pdf');
     const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     fetchMock.mockResolvedValue(
       new Response(new Blob(['pdf'], { type: 'application/pdf' }), {
         status: 200,
@@ -62,150 +132,29 @@ describe('PublicWasteApp', () => {
 
     renderCompletePublicWasteApp();
 
-    const anchorClick = vi.fn();
-    const appendSpy = vi.spyOn(document.body, 'append').mockImplementation(() => undefined);
-    const originalCreateElement = document.createElement.bind(document);
-    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      if (tagName === 'a') {
-        const anchor = originalCreateElement(tagName) as HTMLAnchorElement;
-        vi.spyOn(anchor, 'click').mockImplementation(anchorClick);
-        vi.spyOn(anchor, 'remove').mockImplementation(() => undefined);
-        return anchor;
-      }
-
-      return originalCreateElement(tagName);
+    fireEvent.click(screen.getByRole('tab', { name: 'PDF-Download' }));
+    fireEvent.change(screen.getByLabelText('PDF-Jahr'), {
+      target: { value: '2026' },
     });
-    const timeoutCallCountBeforeClick = setTimeoutSpy.mock.calls.length;
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Druckversion herunterladen' }));
+      fireEvent.click(screen.getByRole('button', { name: 'PDF herunterladen' }));
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
     await waitFor(() => {
-      expect(createObjectUrlSpy).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
-    expect(appendSpy).toHaveBeenCalledTimes(1);
-    expect(anchorClick).toHaveBeenCalledTimes(1);
-    const newTimeoutCalls = setTimeoutSpy.mock.calls.slice(timeoutCallCountBeforeClick);
-    expect(newTimeoutCalls.some((call) => call[1] === 0)).toBe(true);
-
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('fractionId=bio');
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('fractionId=paper');
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('year=2026');
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(1);
     expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:public-waste-pdf');
 
-    createElementSpy.mockRestore();
-    appendSpy.mockRestore();
     createObjectUrlSpy.mockRestore();
     revokeObjectUrlSpy.mockRestore();
-    setTimeoutSpy.mockRestore();
   });
 
-  it('starts with all fractions selected and filters the visible entries without clearing the selection summary', () => {
-    renderCompletePublicWasteApp({
-      calendarModel: createPublicWasteCalendarModelFixture({
-        listEntries: [
-          createPublicWasteCalendarEntryFixture(),
-          createPublicWasteCalendarEntryFixture({
-            id: 'pickup-2',
-            date: '2026-05-20',
-            fractionId: 'paper',
-            fractionLabel: 'Papier',
-            fractionColor: '#0000FF',
-          }),
-        ],
-        fractionOptions: [
-          { id: 'bio', label: 'Bioabfall' },
-          { id: 'paper', label: 'Papier' },
-        ],
-      }),
-    });
-
-    expect((screen.getByRole('checkbox', { name: 'Bioabfall' }) as HTMLInputElement).checked).toBe(true);
-    expect((screen.getByRole('checkbox', { name: 'Papier' }) as HTMLInputElement).checked).toBe(true);
-
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Bioabfall' }));
-
-    expectPublicWasteSelectionHeader();
-    expect(screen.getByRole('heading', { name: 'Mai 2026' })).toBeTruthy();
-    const pickupLists = screen.getAllByRole('list');
-    expect(pickupLists.at(-1)?.textContent).not.toContain('Bioabfall');
-    expect(pickupLists.at(-1)?.textContent).toContain('Papier');
-  });
-
-  it('allows deselecting all fractions so that no pickup entries remain visible', () => {
-    renderCompletePublicWasteApp({
-      calendarModel: createPublicWasteCalendarModelFixture({
-        listEntries: [
-          createPublicWasteCalendarEntryFixture(),
-          createPublicWasteCalendarEntryFixture({
-            id: 'pickup-2',
-            date: '2026-05-20',
-            fractionId: 'paper',
-            fractionLabel: 'Papier',
-            fractionColor: '#0000FF',
-          }),
-        ],
-        fractionOptions: [
-          { id: 'bio', label: 'Bioabfall' },
-          { id: 'paper', label: 'Papier' },
-        ],
-      }),
-    });
-
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Bioabfall' }));
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Papier' }));
-
-    expect((screen.getByRole('checkbox', { name: 'Bioabfall' }) as HTMLInputElement).checked).toBe(false);
-    expect((screen.getByRole('checkbox', { name: 'Papier' }) as HTMLInputElement).checked).toBe(false);
-    expect(screen.queryByRole('button', { name: 'Termin Bioabfall am 2026-05-19' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Termin Papier am 2026-05-20' })).toBeNull();
-  });
-
-  it('renders the reduced selection form while the location is still incomplete', () => {
-    render(
-      <PublicWasteApp
-        selectionState="incomplete"
-        nextStepLabel="Ort"
-        selectionOptions={[
-          { id: 'c-1', label: 'Musterstadt' },
-          { id: 'c-2', label: 'Nebenort' },
-        ]}
-        selectionPath={[]}
-        onEditSelectionStep={() => undefined}
-        onSelectOption={() => undefined}
-      />
-    );
-
-    expect(screen.getByRole('heading', { name: 'Standort wählen' })).toBeTruthy();
-    fireEvent.change(screen.getByRole('textbox', { name: 'Ort suchen' }), { target: { value: 'Mus' } });
-    expect(screen.getByRole('button', { name: 'Musterstadt' })).toBeTruthy();
-    expect(screen.queryByRole('link', { name: 'iCal abonnieren' })).toBeNull();
-  });
-
-  it('opens a pickup detail dialog when an entry is activated and keeps global actions outside the dialog', () => {
-    renderCompletePublicWasteApp({
-      calendarModel: createPublicWasteCalendarModelFixture({
-        listEntries: [
-          createPublicWasteCalendarEntryFixture({
-            tourName: 'Biotour Nord',
-            tourDescription: 'Wöchentliche Leerung im Innenstadtbereich.',
-            note: 'Bitte Tonne ab 6 Uhr bereitstellen.',
-          }),
-        ],
-      }),
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Termin Bioabfall am 2026-05-19' }));
-
-    const dialog = screen.getByRole('dialog');
-    expect(screen.getAllByText('Wöchentliche Leerung im Innenstadtbereich.')).toHaveLength(2);
-    expect(dialog).toBeTruthy();
-    expect(within(dialog).getByText('Biotour Nord')).toBeTruthy();
-    expect(within(dialog).getByText('Wöchentliche Leerung im Innenstadtbereich.')).toBeTruthy();
-    expect(within(dialog).getByText('Bitte Tonne ab 6 Uhr bereitstellen.')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'In Kalender übernehmen' })).toBeTruthy();
-  });
-
-  it('offers a reminder setup action and submits the selected fractions, slots, email, and consent', async () => {
+  it('submits the e-mail signup from the active fractions with automatic default reminder slots', async () => {
     fetchMock.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -237,25 +186,28 @@ describe('PublicWasteApp', () => {
               { id: 'bio:second', maxLeadDays: 5, defaultLeadDays: 3 },
             ],
           },
+          {
+            id: 'paper',
+            label: 'Papier',
+            color: '#0000FF',
+            slots: [{ id: 'paper:first', maxLeadDays: 4, defaultLeadDays: 2 }],
+          },
         ],
       },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'E-Mail-Erinnerung einrichten' }));
-    const reminderRegion = screen.getByRole('region', { name: 'E-Mail-Erinnerung' });
-    fireEvent.click(within(reminderRegion).getByRole('checkbox', { name: 'Bioabfall' }));
-    fireEvent.change(within(reminderRegion).getByLabelText('E-Mail-Adresse'), {
+    fireEvent.click(screen.getByRole('tab', { name: 'E-Mail-Abo' }));
+    const emailPanel = screen.getAllByRole('tabpanel')[0] as HTMLElement;
+    fireEvent.change(within(emailPanel).getByLabelText('E-Mail-Adresse'), {
       target: { value: 'person@example.invalid' },
     });
-    fireEvent.change(within(reminderRegion).getByLabelText('Zeitfenster für Bioabfall'), {
-      target: { value: 'bio:second' },
-    });
     fireEvent.click(
-      within(reminderRegion).getByRole('checkbox', {
+      within(emailPanel).getByRole('checkbox', {
         name: 'Ich stimme der Verarbeitung meiner Daten zu. Datenschutzerklärung',
       })
     );
-    fireEvent.click(within(reminderRegion).getByRole('button', { name: 'Erinnerung anfordern' }));
+
+    fireEvent.click(within(emailPanel).getByRole('button', { name: 'E-Mail-Abo anfordern' }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -268,7 +220,10 @@ describe('PublicWasteApp', () => {
           body: JSON.stringify({
             selection: publicWasteSelectionFixture,
             email: 'person@example.invalid',
-            items: [{ fractionId: 'bio', slotId: 'bio:second' }],
+            items: [
+              { fractionId: 'bio', slotId: 'bio:first' },
+              { fractionId: 'paper', slotId: 'paper:first' },
+            ],
             consentAccepted: true,
           }),
         })
@@ -277,5 +232,27 @@ describe('PublicWasteApp', () => {
 
     expect(screen.getByText('Bestätigungslink versendet')).toBeTruthy();
     expect(screen.getByText('Bitte prüfen Sie Ihr E-Mail-Postfach.')).toBeTruthy();
+    expect(within(emailPanel).queryByLabelText('Zeitfenster für Bioabfall')).toBeNull();
+  });
+
+  it('opens a pickup detail dialog and keeps the global actions outside the dialog', () => {
+    renderCompletePublicWasteApp({
+      calendarModel: createPublicWasteCalendarModelFixture({
+        listEntries: [
+          createPublicWasteCalendarEntryFixture({
+            tourName: 'Biotour Nord',
+            tourDescription: 'Wöchentliche Leerung im Innenstadtbereich.',
+            note: 'Bitte Tonne ab 6 Uhr bereitstellen.',
+          }),
+        ],
+      }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Termin Bioabfall am 2026-05-19' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(within(dialog).getByText('Biotour Nord')).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
   });
 });

--- a/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
@@ -80,6 +80,23 @@ describe('PublicWasteApp', () => {
     expect(screen.getByRole('button', { name: 'PDF herunterladen' })).toBeTruthy();
   });
 
+  it('supports keyboard navigation across the action tabs and links the active panel accessibly', () => {
+    renderCompletePublicWasteApp();
+
+    const calendarTab = screen.getByRole('tab', { name: 'Kalenderexport' });
+    fireEvent.keyDown(calendarTab, { key: 'ArrowRight' });
+
+    const pdfTab = screen.getByRole('tab', { name: 'PDF-Download' });
+    expect(pdfTab.getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(pdfTab);
+
+    const panel = screen
+      .getAllByRole('tabpanel')
+      .find((element) => element.getAttribute('id') === pdfTab.getAttribute('aria-controls'));
+    expect(panel).toBeTruthy();
+    expect(panel.getAttribute('aria-labelledby')).toBe(pdfTab.getAttribute('id'));
+  });
+
   it('updates the visible calendar entries from the right-side fraction list', () => {
     renderCompletePublicWasteApp();
 
@@ -233,6 +250,98 @@ describe('PublicWasteApp', () => {
     expect(screen.getByText('Bestätigungslink versendet')).toBeTruthy();
     expect(screen.getByText('Bitte prüfen Sie Ihr E-Mail-Postfach.')).toBeTruthy();
     expect(within(emailPanel).queryByLabelText('Zeitfenster für Bioabfall')).toBeNull();
+  });
+
+  it('clears a previous e-mail signup success when the active fractions change', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'pending',
+          headline: 'Bestätigungslink versendet',
+          message: 'Bitte prüfen Sie Ihr E-Mail-Postfach.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      )
+    );
+
+    renderCompletePublicWasteApp({
+      reminderSignup: {
+        enabled: true,
+        consentLabel: 'Ich stimme der Verarbeitung meiner Daten zu.',
+        privacyPolicyUrl: 'https://example.invalid/datenschutz',
+        fractions: [
+          {
+            id: 'bio',
+            label: 'Bioabfall',
+            color: '#008800',
+            slots: [{ id: 'bio:first', maxLeadDays: 2, defaultLeadDays: 1 }],
+          },
+          {
+            id: 'paper',
+            label: 'Papier',
+            color: '#0000FF',
+            slots: [{ id: 'paper:first', maxLeadDays: 4, defaultLeadDays: 2 }],
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'E-Mail-Abo' }));
+    const emailPanel = screen
+      .getAllByRole('tabpanel')
+      .find((element) => element.getAttribute('id') === 'public-waste-action-panel-email') as HTMLElement;
+    fireEvent.change(within(emailPanel).getByLabelText('E-Mail-Adresse'), {
+      target: { value: 'person@example.invalid' },
+    });
+    fireEvent.click(
+      within(emailPanel).getByRole('checkbox', {
+        name: 'Ich stimme der Verarbeitung meiner Daten zu. Datenschutzerklärung',
+      })
+    );
+    fireEvent.click(within(emailPanel).getByRole('button', { name: 'E-Mail-Abo anfordern' }));
+
+    await screen.findByText('Bestätigungslink versendet');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Papier' }));
+
+    expect(screen.queryByText('Bestätigungslink versendet')).toBeNull();
+    const refreshedEmailPanel = screen
+      .getAllByRole('tabpanel')
+      .find((element) => element.getAttribute('id') === 'public-waste-action-panel-email');
+    expect(refreshedEmailPanel).toBeTruthy();
+    expect(within(refreshedEmailPanel as HTMLElement).getByLabelText('E-Mail-Adresse')).toBeTruthy();
+  });
+
+  it('uses noopener noreferrer for the privacy policy link', () => {
+    renderCompletePublicWasteApp({
+      reminderSignup: {
+        enabled: true,
+        consentLabel: 'Ich stimme der Verarbeitung meiner Daten zu.',
+        privacyPolicyUrl: 'https://example.invalid/datenschutz',
+        fractions: [
+          {
+            id: 'bio',
+            label: 'Bioabfall',
+            color: '#008800',
+            slots: [{ id: 'bio:first', maxLeadDays: 2, defaultLeadDays: 1 }],
+          },
+          {
+            id: 'paper',
+            label: 'Papier',
+            color: '#0000FF',
+            slots: [{ id: 'paper:first', maxLeadDays: 4, defaultLeadDays: 2 }],
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'E-Mail-Abo' }));
+    expect(screen.getByRole('link', { name: 'Datenschutzerklärung' }).getAttribute('rel')).toBe('noopener noreferrer');
   });
 
   it('opens a pickup detail dialog and keeps the global actions outside the dialog', () => {

--- a/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
@@ -94,6 +94,9 @@ describe('PublicWasteApp', () => {
       .getAllByRole('tabpanel')
       .find((element) => element.getAttribute('id') === pdfTab.getAttribute('aria-controls'));
     expect(panel).toBeTruthy();
+    if (!panel) {
+      throw new Error('Expected the PDF action panel to exist');
+    }
     expect(panel.getAttribute('aria-labelledby')).toBe(pdfTab.getAttribute('id'));
   });
 

--- a/apps/public-waste-calendar-web/src/components/public-waste-app.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-app.tsx
@@ -1,12 +1,18 @@
+import { IconCalendarPlus, IconFileTypePdf, IconMail } from '@tabler/icons-react';
 import React from 'react';
 
+import {
+  buildPublicWasteIcalUrl,
+  requestPublicWasteReminderSignup,
+  type PublicWasteCalendarResponse,
+} from '../lib/public-waste-api.js';
 import type {
   PublicWasteCalendarEntry,
-  PublicWasteReminderSignupView,
+  PublicWasteReminderFractionOption,
+  PublicWasteReminderSelectionItem,
   PublicWasteResolvedSelection,
   PublicWasteSelectableEntry,
 } from '../lib/public-waste-contract.js';
-import { requestPublicWasteReminderSignup } from '../lib/public-waste-api.js';
 import {
   filterPublicWasteCalendarFractions,
   type PublicWasteCalendarViewModel,
@@ -32,11 +38,16 @@ type CompletePublicWasteAppProps = {
   readonly selectionSummary: string;
   readonly calendarModel: PublicWasteCalendarViewModel;
   readonly icalUrl: string;
-  readonly reminderSignup?: PublicWasteReminderSignupView;
+  readonly calendarReminderOptions?: PublicWasteCalendarResponse['calendarReminderOptions'];
+  readonly reminderSignup?: PublicWasteCalendarResponse['reminderSignup'];
   readonly onChangeLocation: () => void;
 };
 
 type PublicWasteAppProps = IncompletePublicWasteAppProps | CompletePublicWasteAppProps;
+
+type ActionPanel = 'calendar' | 'pdf' | 'email';
+type ReminderSelectionState = Record<string, string>;
+const EMPTY_REMINDER_FRACTIONS: readonly PublicWasteReminderFractionOption[] = [];
 
 const splitSelectionSummary = (
   selectionSummary: string
@@ -63,6 +74,82 @@ const splitSelectionSummary = (
   return [cityPart, streetLine, houseNumberLine];
 };
 
+const buildReminderSlotSelection = (
+  activeFractionIds: readonly string[],
+  fractions: readonly PublicWasteReminderFractionOption[],
+  previous: ReminderSelectionState
+): ReminderSelectionState => {
+  const activeFractionSet = new Set(activeFractionIds);
+  const next: ReminderSelectionState = {};
+
+  for (const fraction of fractions) {
+    if (!activeFractionSet.has(fraction.id) || fraction.slots.length === 0) {
+      continue;
+    }
+
+    const previousSlotId = previous[fraction.id];
+    next[fraction.id] = fraction.slots.some((slot) => slot.id === previousSlotId) ? previousSlotId : fraction.slots[0]!.id;
+  }
+
+  return next;
+};
+
+const areReminderSelectionsEqual = (left: ReminderSelectionState, right: ReminderSelectionState): boolean => {
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+
+  if (leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+
+  return leftEntries.every(([fractionId, slotId]) => right[fractionId] === slotId);
+};
+
+const resolveReminderContext = (
+  activeFractionIds: readonly string[],
+  fractionOptions: readonly { readonly id: string; readonly label: string }[],
+  reminderFractions: readonly PublicWasteReminderFractionOption[]
+) => {
+  const reminderFractionMap = new Map(reminderFractions.map((fraction) => [fraction.id, fraction]));
+  const fractionLabelMap = new Map(fractionOptions.map((fraction) => [fraction.id, fraction.label]));
+  const supportedFractions = activeFractionIds
+    .map((fractionId) => reminderFractionMap.get(fractionId))
+    .filter((fraction): fraction is PublicWasteReminderFractionOption => fraction !== undefined);
+  const unsupportedLabels = activeFractionIds
+    .filter((fractionId) => !reminderFractionMap.has(fractionId))
+    .map((fractionId) => fractionLabelMap.get(fractionId) ?? fractionId);
+
+  return {
+    supportedFractions,
+    unsupportedLabels,
+    isFullySupported: activeFractionIds.length > 0 && unsupportedLabels.length === 0 && supportedFractions.length > 0,
+  };
+};
+
+const buildReminderItems = (
+  fractions: readonly PublicWasteReminderFractionOption[],
+  selectedSlots: ReminderSelectionState
+): readonly PublicWasteReminderSelectionItem[] =>
+  fractions
+    .map((fraction) => {
+      const slotId = selectedSlots[fraction.id];
+      return slotId
+        ? {
+            fractionId: fraction.id,
+            slotId,
+          }
+        : null;
+    })
+    .filter((item): item is PublicWasteReminderSelectionItem => item !== null);
+
+const hasCompleteReminderItems = (
+  context: Readonly<{
+    isFullySupported: boolean;
+    supportedFractions: readonly PublicWasteReminderFractionOption[];
+  }>,
+  items: readonly PublicWasteReminderSelectionItem[]
+): boolean => context.isFullySupported && items.length === context.supportedFractions.length;
+
 export function PublicWasteApp(props: Readonly<PublicWasteAppProps>) {
   if (props.selectionState === 'incomplete') {
     return (
@@ -81,15 +168,16 @@ export function PublicWasteApp(props: Readonly<PublicWasteAppProps>) {
 
 function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
   const [selectedEntry, setSelectedEntry] = React.useState<PublicWasteCalendarEntry | null>(null);
-  const [reminderOpen, setReminderOpen] = React.useState(false);
+  const [activeActionPanel, setActiveActionPanel] = React.useState<ActionPanel | null>(null);
   const [email, setEmail] = React.useState('');
   const [consentAccepted, setConsentAccepted] = React.useState(false);
-  const [selectedItems, setSelectedItems] = React.useState<Record<string, string>>({});
   const [reminderError, setReminderError] = React.useState<string | null>(null);
   const [reminderSuccess, setReminderSuccess] = React.useState<null | { readonly headline: string; readonly message: string }>(
     null
   );
   const [reminderSubmitting, setReminderSubmitting] = React.useState(false);
+  const [calendarReminderSlots, setCalendarReminderSlots] = React.useState<ReminderSelectionState>({});
+  const [emailReminderSlots, setEmailReminderSlots] = React.useState<ReminderSelectionState>({});
   const {
     selectedFractions,
     pdfYear,
@@ -106,30 +194,77 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
   const deferredFractions = React.useDeferredValue(selectedFractions);
   const filteredModel = filterPublicWasteCalendarFractions(props.calendarModel, deferredFractions);
   const [cityLine, streetLine, houseNumberLine] = splitSelectionSummary(props.selectionSummary);
-  const reminderFractions = props.reminderSignup?.fractions ?? [];
+  const emailReminderFractions = props.reminderSignup?.fractions ?? EMPTY_REMINDER_FRACTIONS;
+  const calendarReminderFractions = props.calendarReminderOptions?.fractions ?? EMPTY_REMINDER_FRACTIONS;
+  const emailReminderContext = React.useMemo(
+    () => resolveReminderContext(selectedFractions, props.calendarModel.fractionOptions, emailReminderFractions),
+    [emailReminderFractions, props.calendarModel.fractionOptions, selectedFractions]
+  );
+  const calendarReminderContext = React.useMemo(
+    () => resolveReminderContext(selectedFractions, props.calendarModel.fractionOptions, calendarReminderFractions),
+    [calendarReminderFractions, props.calendarModel.fractionOptions, selectedFractions]
+  );
 
-  const toggleReminderFraction = (fractionId: string, checked: boolean) => {
-    setSelectedItems((current) => {
-      if (checked) {
-        const fraction = reminderFractions.find((entry) => entry.id === fractionId);
-        return {
-          ...current,
-          [fractionId]: fraction?.slots[0]?.id ?? '',
-        };
+  React.useEffect(() => {
+    setCalendarReminderSlots((current) =>
+      {
+        const next = buildReminderSlotSelection(selectedFractions, calendarReminderContext.supportedFractions, current);
+        return areReminderSelectionsEqual(current, next) ? current : next;
       }
+    );
+  }, [calendarReminderContext.supportedFractions, selectedFractions]);
 
-      const next = { ...current };
-      delete next[fractionId];
-      return next;
-    });
+  React.useEffect(() => {
+    setEmailReminderSlots((current) =>
+      {
+        const next = buildReminderSlotSelection(selectedFractions, emailReminderContext.supportedFractions, current);
+        return areReminderSelectionsEqual(current, next) ? current : next;
+      }
+    );
+  }, [emailReminderContext.supportedFractions, selectedFractions]);
+
+  React.useEffect(() => {
+    setActiveActionPanel(null);
+    setReminderError(null);
+    setReminderSuccess(null);
+    setConsentAccepted(false);
+    setEmail('');
+  }, [props.calendarModel.locationKey]);
+
+  const toggleActionPanel = (panel: ActionPanel) => {
+    setActiveActionPanel((current) => (current === panel ? null : panel));
+    setReminderError(null);
   };
 
+  const calendarReminderItems = React.useMemo(
+    () => buildReminderItems(calendarReminderContext.supportedFractions, calendarReminderSlots),
+    [calendarReminderContext.supportedFractions, calendarReminderSlots]
+  );
+  const emailReminderItems = React.useMemo(
+    () => buildReminderItems(emailReminderContext.supportedFractions, emailReminderSlots),
+    [emailReminderContext.supportedFractions, emailReminderSlots]
+  );
+  const canUseCalendarReminderExport = hasCompleteReminderItems(calendarReminderContext, calendarReminderItems);
+  const canSubmitEmailReminderSelection = hasCompleteReminderItems(emailReminderContext, emailReminderItems);
+  const calendarExportUrl = buildPublicWasteIcalUrl({
+    selection: props.selection,
+    calendarName: props.selectionSummary,
+    fractionIds: selectedFractions,
+    reminderItems: canUseCalendarReminderExport ? calendarReminderItems : [],
+  });
+  const canSubmitEmailReminder =
+    canSubmitEmailReminderSelection &&
+    consentAccepted &&
+    email.trim().length > 0 &&
+    !reminderSubmitting;
+
   const submitReminderSignup = async () => {
-    const items = Object.entries(selectedItems)
-      .filter(([, slotId]) => slotId.length > 0)
-      .map(([fractionId, slotId]) => ({ fractionId, slotId }));
-    if (!props.reminderSignup || items.length === 0 || !consentAccepted || email.trim().length === 0) {
-      setReminderError('Bitte wählen Sie mindestens eine Abfallart, eine E-Mail-Adresse und die Datenschutz-Einwilligung aus.');
+    if (!props.reminderSignup?.enabled) {
+      setReminderError('Der E-Mail-Erinnerungsdienst ist derzeit nicht verfügbar.');
+      return;
+    }
+    if (!canSubmitEmailReminderSelection || !consentAccepted || email.trim().length === 0) {
+      setReminderError('Bitte wählen Sie gültige Fraktionen, eine E-Mail-Adresse und die Datenschutz-Einwilligung aus.');
       return;
     }
 
@@ -140,7 +275,7 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
       const response = await requestPublicWasteReminderSignup({
         selection: props.selection,
         email: email.trim(),
-        items,
+        items: emailReminderItems,
         consentAccepted: true,
       });
       setReminderSuccess({
@@ -154,117 +289,181 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
     }
   };
 
+  const actionPanelDescription =
+    selectedFractions.length === 0
+      ? 'Wählen Sie rechts mindestens eine Fraktion aus, um diese Aktion zu nutzen.'
+      : `Aktiv ausgewählt: ${selectedFractions.length} Fraktion${selectedFractions.length === 1 ? '' : 'en'}.`;
+
   return (
     <section className="selection-panel">
       <PublicWasteSelectionHeader
         cityLine={cityLine}
         streetLine={streetLine}
         houseNumberLine={houseNumberLine}
-        icalUrl={props.icalUrl}
-        pdfYear={pdfYear}
-        pdfRunning={pdfRunning}
-        selectedFractionCount={selectedFractions.length}
-        yearOptions={yearOptions}
+        fractionOptions={props.calendarModel.fractionOptions}
+        activeFractionIds={selectedFractions}
         onChangeLocation={props.onChangeLocation}
-        onSelectPdfYear={setPdfYear}
-        onDownloadPdf={() => {
-          void downloadPdf();
-        }}
+        onToggleFraction={toggleFraction}
       />
-      {props.reminderSignup?.enabled ? (
-        <section className="reminder-panel" aria-label="E-Mail-Erinnerung">
-          <div className="reminder-panel-header">
-            <div>
-              <h3 className="section-title">E-Mail-Erinnerung</h3>
-              <p className="selection-step-copy">Lassen Sie sich für diesen Standort per E-Mail an anstehende Entsorgungstermine erinnern.</p>
-            </div>
-            <button type="button" className="selection-trigger reminder-trigger" onClick={() => setReminderOpen((current) => !current)}>
-              {reminderOpen ? 'Formular schließen' : 'E-Mail-Erinnerung einrichten'}
-            </button>
-          </div>
-          {reminderOpen ? (
-            reminderSuccess ? (
-              <div className="reminder-feedback reminder-feedback-success">
-                <strong>{reminderSuccess.headline}</strong>
-                <p className="body-copy">{reminderSuccess.message}</p>
-              </div>
-            ) : (
-              <div className="reminder-form-shell">
-                <div className="reminder-fraction-list">
-                  {reminderFractions.map((fraction) => (
-                    <div key={fraction.id} className="reminder-fraction-card">
-                      <label className="reminder-fraction-checkbox">
-                        <input
-                          type="checkbox"
-                          checked={Object.prototype.hasOwnProperty.call(selectedItems, fraction.id)}
-                          onChange={(event) => toggleReminderFraction(fraction.id, event.target.checked)}
-                        />
-                        <span>{fraction.label}</span>
-                      </label>
-                      {Object.prototype.hasOwnProperty.call(selectedItems, fraction.id) ? (
-                        <label className="reminder-field">
-                          <span>Zeitfenster für {fraction.label}</span>
-                          <select
-                            aria-label={`Zeitfenster für ${fraction.label}`}
-                            value={selectedItems[fraction.id] ?? ''}
-                            onChange={(event) =>
-                              setSelectedItems((current) => ({
-                                ...current,
-                                [fraction.id]: event.target.value,
-                              }))
-                            }
-                          >
-                            {fraction.slots.map((slot) => (
-                              <option key={slot.id} value={slot.id}>
-                                {slot.defaultLeadDays} Tage vorher, spätestens {slot.maxLeadDays} Tage
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      ) : null}
-                    </div>
-                  ))}
-                </div>
-                <label className="reminder-field">
-                  <span>E-Mail-Adresse</span>
-                  <input
-                    aria-label="E-Mail-Adresse"
-                    type="email"
-                    value={email}
-                    onChange={(event) => setEmail(event.target.value)}
-                  />
-                </label>
-                <label className="reminder-consent">
-                  <input
-                    type="checkbox"
-                    checked={consentAccepted}
-                    onChange={(event) => setConsentAccepted(event.target.checked)}
-                  />
-                  <span>{props.reminderSignup.consentLabel}</span>
-                  <a href={props.reminderSignup.privacyPolicyUrl} target="_blank" rel="noreferrer">
-                    Datenschutzerklärung
-                  </a>
-                </label>
-                {reminderError ? <p className="reminder-error">{reminderError}</p> : null}
-                <button
-                  type="button"
-                  className="selection-trigger reminder-submit"
-                  disabled={reminderSubmitting}
-                  onClick={() => {
-                    void submitReminderSignup();
+
+      <section className="action-hub" aria-label="Kalenderaktionen">
+        <div className="action-hub-toolbar" role="tablist" aria-label="Export- und Abo-Aktionen">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeActionPanel === 'calendar'}
+            className={`action-hub-trigger${activeActionPanel === 'calendar' ? ' is-active' : ''}`}
+            onClick={() => toggleActionPanel('calendar')}
+          >
+            <IconCalendarPlus size={20} stroke={1.8} aria-hidden="true" />
+            <span>Kalenderexport</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeActionPanel === 'pdf'}
+            className={`action-hub-trigger${activeActionPanel === 'pdf' ? ' is-active' : ''}`}
+            onClick={() => toggleActionPanel('pdf')}
+          >
+            <IconFileTypePdf size={20} stroke={1.8} aria-hidden="true" />
+            <span>PDF-Download</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeActionPanel === 'email'}
+            className={`action-hub-trigger${activeActionPanel === 'email' ? ' is-active' : ''}`}
+            onClick={() => toggleActionPanel('email')}
+          >
+            <IconMail size={20} stroke={1.8} aria-hidden="true" />
+            <span>E-Mail-Abo</span>
+          </button>
+        </div>
+
+        {activeActionPanel ? (
+          <div className="action-panel" role="tabpanel">
+            <p className="action-panel-intro">{actionPanelDescription}</p>
+
+            {activeActionPanel === 'calendar' ? (
+              <div className="action-panel-body">
+                {canUseCalendarReminderExport ? (
+                  <p className="action-panel-copy">
+                    Der Export übernimmt automatisch die Standard-Erinnerungen der aktiven Fraktionen.
+                  </p>
+                ) : (
+                  <p className="action-panel-copy">
+                    Der Export enthält die aktiven Abholtermine ohne zusätzliche Erinnerungen.
+                  </p>
+                )}
+                {!calendarReminderContext.isFullySupported && calendarReminderContext.supportedFractions.length > 0 ? (
+                  <p className="action-warning">
+                    Für die aktuelle Fraktionsauswahl sind nicht für alle Fraktionen Kalender-Erinnerungen verfügbar. Der Export wird deshalb ohne Erinnerungen erstellt.
+                  </p>
+                ) : null}
+                <a
+                  href={selectedFractions.length > 0 ? calendarExportUrl : undefined}
+                  className={`action-cta-link${selectedFractions.length === 0 ? ' is-disabled' : ''}`}
+                  aria-disabled={selectedFractions.length === 0}
+                  onClick={(event) => {
+                    if (selectedFractions.length === 0) {
+                      event.preventDefault();
+                    }
                   }}
                 >
-                  {reminderSubmitting ? 'Wird angefordert…' : 'Erinnerung anfordern'}
+                  Kalender exportieren
+                </a>
+              </div>
+            ) : null}
+
+            {activeActionPanel === 'pdf' ? (
+              <div className="action-panel-body">
+                <label className="action-field">
+                  <span>Jahr</span>
+                  <select aria-label="PDF-Jahr" value={pdfYear} onChange={(event) => setPdfYear(Number.parseInt(event.target.value, 10))}>
+                    {yearOptions.map((year) => (
+                      <option key={year} value={year}>
+                        {year}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {pdfError ? <p className="action-warning">{pdfError}</p> : null}
+                <button
+                  type="button"
+                  className="action-cta-button"
+                  disabled={selectedFractions.length === 0 || pdfRunning}
+                  onClick={() => {
+                    void downloadPdf();
+                  }}
+                >
+                  {pdfRunning ? 'PDF wird erstellt…' : 'PDF herunterladen'}
                 </button>
               </div>
-            )
-          ) : null}
-        </section>
-      ) : null}
-      {pdfError ? <p className="body-copy">{pdfError}</p> : null}
+            ) : null}
+
+            {activeActionPanel === 'email' ? (
+              <div className="action-panel-body">
+                {reminderSuccess ? (
+                  <div className="reminder-feedback reminder-feedback-success">
+                    <strong>{reminderSuccess.headline}</strong>
+                    <p className="body-copy">{reminderSuccess.message}</p>
+                  </div>
+                ) : (
+                  <>
+                    {emailReminderContext.isFullySupported ? (
+                      <>
+                        <p className="action-panel-copy">
+                          Das Abo verwendet automatisch die Standard-Erinnerungen der aktiven Fraktionen.
+                        </p>
+                        <label className="action-field">
+                          <span>E-Mail-Adresse</span>
+                          <input
+                            aria-label="E-Mail-Adresse"
+                            type="email"
+                            value={email}
+                            onChange={(event) => setEmail(event.target.value)}
+                          />
+                        </label>
+                        <label className="reminder-consent">
+                          <input
+                            type="checkbox"
+                            checked={consentAccepted}
+                            onChange={(event) => setConsentAccepted(event.target.checked)}
+                          />
+                          <span>{props.reminderSignup?.consentLabel ?? 'Ich stimme der Verarbeitung meiner Daten zu.'}</span>
+                          {props.reminderSignup?.privacyPolicyUrl ? (
+                            <a href={props.reminderSignup.privacyPolicyUrl} target="_blank" rel="noreferrer">
+                              Datenschutzerklärung
+                            </a>
+                          ) : null}
+                        </label>
+                      </>
+                    ) : (
+                      <p className="action-warning">
+                        Für die aktuelle Fraktionsauswahl sind nicht für alle Fraktionen E-Mail-Erinnerungen verfügbar. Passen Sie die Fraktionsliste rechts an, um das Abo zu aktivieren.
+                      </p>
+                    )}
+                    {reminderError ? <p className="action-warning">{reminderError}</p> : null}
+                    <button
+                      type="button"
+                      className="action-cta-button"
+                      disabled={!canSubmitEmailReminder}
+                      onClick={() => {
+                        void submitReminderSignup();
+                      }}
+                    >
+                      {reminderSubmitting ? 'Wird angefordert…' : 'E-Mail-Abo anfordern'}
+                    </button>
+                  </>
+                )}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+
       <PublicWasteCalendarPanels
         model={filteredModel}
-        onToggleFraction={toggleFraction}
         onActivateEntry={setSelectedEntry}
       />
       <PublicWasteEventDialog entry={selectedEntry} onClose={() => setSelectedEntry(null)} />

--- a/apps/public-waste-calendar-web/src/components/public-waste-app.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-app.tsx
@@ -48,6 +48,7 @@ type PublicWasteAppProps = IncompletePublicWasteAppProps | CompletePublicWasteAp
 type ActionPanel = 'calendar' | 'pdf' | 'email';
 type ReminderSelectionState = Record<string, string>;
 const EMPTY_REMINDER_FRACTIONS: readonly PublicWasteReminderFractionOption[] = [];
+const ACTION_PANELS: readonly ActionPanel[] = ['calendar', 'pdf', 'email'];
 
 const splitSelectionSummary = (
   selectionSummary: string
@@ -150,6 +151,9 @@ const hasCompleteReminderItems = (
   items: readonly PublicWasteReminderSelectionItem[]
 ): boolean => context.isFullySupported && items.length === context.supportedFractions.length;
 
+const getActionTabId = (panel: ActionPanel): string => `public-waste-action-tab-${panel}`;
+const getActionPanelId = (panel: ActionPanel): string => `public-waste-action-panel-${panel}`;
+
 export function PublicWasteApp(props: Readonly<PublicWasteAppProps>) {
   if (props.selectionState === 'incomplete') {
     return (
@@ -194,6 +198,8 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
   const deferredFractions = React.useDeferredValue(selectedFractions);
   const filteredModel = filterPublicWasteCalendarFractions(props.calendarModel, deferredFractions);
   const [cityLine, streetLine, houseNumberLine] = splitSelectionSummary(props.selectionSummary);
+  const selectedFractionKey = selectedFractions.join('|');
+  const previousSelectedFractionKeyRef = React.useRef(selectedFractionKey);
   const emailReminderFractions = props.reminderSignup?.fractions ?? EMPTY_REMINDER_FRACTIONS;
   const calendarReminderFractions = props.calendarReminderOptions?.fractions ?? EMPTY_REMINDER_FRACTIONS;
   const emailReminderContext = React.useMemo(
@@ -231,9 +237,40 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
     setEmail('');
   }, [props.calendarModel.locationKey]);
 
+  React.useEffect(() => {
+    if (previousSelectedFractionKeyRef.current === selectedFractionKey) {
+      return;
+    }
+
+    previousSelectedFractionKeyRef.current = selectedFractionKey;
+    setReminderError(null);
+    setReminderSuccess(null);
+  }, [selectedFractionKey]);
+
   const toggleActionPanel = (panel: ActionPanel) => {
     setActiveActionPanel((current) => (current === panel ? null : panel));
     setReminderError(null);
+  };
+
+  const handleActionTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, panel: ActionPanel) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+      return;
+    }
+
+    event.preventDefault();
+    const currentIndex = ACTION_PANELS.indexOf(panel);
+    const nextIndex =
+      event.key === 'ArrowRight'
+        ? (currentIndex + 1) % ACTION_PANELS.length
+        : (currentIndex - 1 + ACTION_PANELS.length) % ACTION_PANELS.length;
+    const nextPanel = ACTION_PANELS[nextIndex];
+
+    if (!nextPanel) {
+      return;
+    }
+
+    setActiveActionPanel(nextPanel);
+    document.getElementById(getActionTabId(nextPanel))?.focus();
   };
 
   const calendarReminderItems = React.useMemo(
@@ -310,30 +347,42 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
         <div className="action-hub-toolbar" role="tablist" aria-label="Export- und Abo-Aktionen">
           <button
             type="button"
+            id={getActionTabId('calendar')}
             role="tab"
+            aria-controls={getActionPanelId('calendar')}
             aria-selected={activeActionPanel === 'calendar'}
+            tabIndex={activeActionPanel === null || activeActionPanel === 'calendar' ? 0 : -1}
             className={`action-hub-trigger${activeActionPanel === 'calendar' ? ' is-active' : ''}`}
             onClick={() => toggleActionPanel('calendar')}
+            onKeyDown={(event) => handleActionTabKeyDown(event, 'calendar')}
           >
             <IconCalendarPlus size={20} stroke={1.8} aria-hidden="true" />
             <span>Kalenderexport</span>
           </button>
           <button
             type="button"
+            id={getActionTabId('pdf')}
             role="tab"
+            aria-controls={getActionPanelId('pdf')}
             aria-selected={activeActionPanel === 'pdf'}
+            tabIndex={activeActionPanel === 'pdf' ? 0 : -1}
             className={`action-hub-trigger${activeActionPanel === 'pdf' ? ' is-active' : ''}`}
             onClick={() => toggleActionPanel('pdf')}
+            onKeyDown={(event) => handleActionTabKeyDown(event, 'pdf')}
           >
             <IconFileTypePdf size={20} stroke={1.8} aria-hidden="true" />
             <span>PDF-Download</span>
           </button>
           <button
             type="button"
+            id={getActionTabId('email')}
             role="tab"
+            aria-controls={getActionPanelId('email')}
             aria-selected={activeActionPanel === 'email'}
+            tabIndex={activeActionPanel === 'email' ? 0 : -1}
             className={`action-hub-trigger${activeActionPanel === 'email' ? ' is-active' : ''}`}
             onClick={() => toggleActionPanel('email')}
+            onKeyDown={(event) => handleActionTabKeyDown(event, 'email')}
           >
             <IconMail size={20} stroke={1.8} aria-hidden="true" />
             <span>E-Mail-Abo</span>
@@ -341,7 +390,12 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
         </div>
 
         {activeActionPanel ? (
-          <div className="action-panel" role="tabpanel">
+          <div
+            id={getActionPanelId(activeActionPanel)}
+            className="action-panel"
+            role="tabpanel"
+            aria-labelledby={getActionTabId(activeActionPanel)}
+          >
             <p className="action-panel-intro">{actionPanelDescription}</p>
 
             {activeActionPanel === 'calendar' ? (
@@ -432,7 +486,7 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
                           />
                           <span>{props.reminderSignup?.consentLabel ?? 'Ich stimme der Verarbeitung meiner Daten zu.'}</span>
                           {props.reminderSignup?.privacyPolicyUrl ? (
-                            <a href={props.reminderSignup.privacyPolicyUrl} target="_blank" rel="noreferrer">
+                            <a href={props.reminderSignup.privacyPolicyUrl} target="_blank" rel="noopener noreferrer">
                               Datenschutzerklärung
                             </a>
                           ) : null}

--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
@@ -128,6 +128,53 @@ describe('PublicWasteCalendarPanels', () => {
     expect(screen.getByRole('tab', { name: 'Liste' }).getAttribute('aria-selected')).toBe('true');
   });
 
+  it('renders upcoming entries before a separate past section in the list view', () => {
+    render(
+      <PublicWasteCalendarPanels
+        model={createFilteredPublicWasteCalendarModelFixture({
+          nextPickupDate: '2026-05-19',
+          listEntries: [
+            createPublicWasteCalendarEntryFixture({
+              id: 'pickup-past',
+              date: '2026-05-12',
+              fractionLabel: 'Restmüll',
+              fractionId: 'rest',
+              fractionColor: '#444444',
+            }),
+            createPublicWasteCalendarEntryFixture({
+              id: 'pickup-next',
+              date: '2026-05-19',
+              fractionLabel: 'Bioabfall',
+            }),
+            createPublicWasteCalendarEntryFixture({
+              id: 'pickup-future',
+              date: '2026-05-21',
+              fractionLabel: 'Papier',
+              fractionId: 'paper',
+              fractionColor: '#0000FF',
+            }),
+          ],
+          activeFractionIds: ['rest', 'bio', 'paper'],
+          fractionOptions: [
+            { id: 'rest', label: 'Restmüll', color: '#444444' },
+            { id: 'bio', label: 'Bioabfall', color: '#00AA00' },
+            { id: 'paper', label: 'Papier', color: '#0000FF' },
+          ],
+        })}
+        onToggleFraction={vi.fn()}
+        onActivateEntry={vi.fn()}
+      />
+    );
+
+    const buttons = screen.getAllByRole('button', { name: /Termin .* am 2026-05-/ });
+    expect(buttons.map((button) => button.getAttribute('aria-label'))).toEqual([
+      'Termin Bioabfall am 2026-05-19',
+      'Termin Papier am 2026-05-21',
+      'Termin Restmüll am 2026-05-12',
+    ]);
+    expect(screen.getByRole('heading', { name: 'Vergangene Termine' })).toBeTruthy();
+  });
+
   it('allows month navigation back to the earliest available month in the previous year', () => {
     render(
       <PublicWasteCalendarPanels

--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
@@ -24,7 +24,6 @@ describe('PublicWasteCalendarPanels', () => {
           listEntries: [],
           fractionOptions: [{ id: 'bio', label: 'Bioabfall', color: '#00AA00' }],
         })}
-        onToggleFraction={vi.fn()}
         onActivateEntry={vi.fn()}
       />
     );
@@ -32,30 +31,6 @@ describe('PublicWasteCalendarPanels', () => {
     expect(screen.queryByRole('link', { name: 'In Kalender übernehmen' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Druckversion herunterladen' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'PDF 2026' })).toBeNull();
-  });
-
-  it('renders fraction badges with the configured fraction background colors', () => {
-    render(
-      <PublicWasteCalendarPanels
-        model={createFilteredPublicWasteCalendarModelFixture({
-          listEntries: [],
-          activeFractionIds: ['bio', 'paper'],
-          fractionOptions: [
-            { id: 'bio', label: 'Bioabfall', color: '#00AA00' },
-            { id: 'paper', label: 'Papier', color: '#0000FF' },
-          ],
-        })}
-        onToggleFraction={vi.fn()}
-        onActivateEntry={vi.fn()}
-      />
-    );
-
-    expect(screen.getByText('Bioabfall').closest('label')?.getAttribute('style')).toContain(
-      'background-color: #00AA00'
-    );
-    expect(screen.getByText('Papier').closest('label')?.getAttribute('style')).toContain(
-      'background-color: #0000FF'
-    );
   });
 
   it('renders three tabs and allows switching to the month and year calendar views', () => {
@@ -80,7 +55,6 @@ describe('PublicWasteCalendarPanels', () => {
             { id: 'paper', label: 'Papier', color: '#0000FF' },
           ],
         })}
-        onToggleFraction={vi.fn()}
         onActivateEntry={onActivateEntry}
       />
     );
@@ -115,7 +89,6 @@ describe('PublicWasteCalendarPanels', () => {
           listEntries: [],
           fractionOptions: [{ id: 'bio', label: 'Bioabfall', color: '#00AA00' }],
         })}
-        onToggleFraction={vi.fn()}
         onActivateEntry={vi.fn()}
       />
     );
@@ -161,7 +134,6 @@ describe('PublicWasteCalendarPanels', () => {
             { id: 'paper', label: 'Papier', color: '#0000FF' },
           ],
         })}
-        onToggleFraction={vi.fn()}
         onActivateEntry={vi.fn()}
       />
     );
@@ -187,7 +159,6 @@ describe('PublicWasteCalendarPanels', () => {
             createPublicWasteCalendarEntryFixture(),
           ],
         })}
-        onToggleFraction={vi.fn()}
         onActivateEntry={vi.fn()}
       />
     );

--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
@@ -68,6 +68,33 @@ const groupEntriesByMonth = (entries: readonly PublicWasteCalendarEntry[]) =>
     }, new Map()).entries()
   );
 
+const partitionListEntries = (
+  entries: readonly PublicWasteCalendarEntry[],
+  nextPickupDate: string | null
+): Readonly<{
+  upcomingEntries: readonly PublicWasteCalendarEntry[];
+  pastEntries: readonly PublicWasteCalendarEntry[];
+}> => {
+  if (!nextPickupDate) {
+    return { upcomingEntries: [], pastEntries: entries };
+  }
+
+  return entries.reduce<{
+    upcomingEntries: PublicWasteCalendarEntry[];
+    pastEntries: PublicWasteCalendarEntry[];
+  }>(
+    (result, entry) => {
+      if (entry.date >= nextPickupDate) {
+        result.upcomingEntries.push(entry);
+      } else {
+        result.pastEntries.push(entry);
+      }
+      return result;
+    },
+    { upcomingEntries: [], pastEntries: [] }
+  );
+};
+
 const groupEntriesByDay = (entries: readonly PublicWasteCalendarEntry[]) =>
   Array.from(
     entries.reduce<Map<string, PublicWasteCalendarEntry[]>>((groups, entry) => {
@@ -120,6 +147,57 @@ const renderPickupEntryButton = (
     {props.children}
   </button>
 );
+
+const renderListMonthGroups = (input: Readonly<{
+  entries: readonly PublicWasteCalendarEntry[];
+  headingIdPrefix: string;
+  onActivateEntry: (entry: PublicWasteCalendarEntry) => void;
+}>) =>
+  groupEntriesByMonth(input.entries).map(([monthKey, monthEntries]) => (
+    <section
+      key={`${input.headingIdPrefix}-${monthKey}`}
+      className="pickup-month-group"
+      aria-labelledby={`${input.headingIdPrefix}-${monthKey}`}
+    >
+      <h3 id={`${input.headingIdPrefix}-${monthKey}`} className="pickup-month-title">
+        {capitalize(monthYearFormatter.format(toDate(`${monthKey}-01`)))}
+      </h3>
+      <ul className="pickup-list">
+        {groupEntriesByDay(monthEntries).map(([date, dayEntries]) => {
+          const dayDate = toDate(date);
+          return (
+            <li key={date} className="pickup-item">
+              <div className="pickup-row">
+                <div className="pickup-date">
+                  <span className="pickup-weekday">{capitalize(weekdayFormatter.format(dayDate))}</span>
+                  <span className="pickup-day">{date.slice(8, 10)}</span>
+                </div>
+                <div className="pickup-entry-group">
+                  {dayEntries.map((entry) =>
+                    renderPickupEntryButton(entry, {
+                      className: 'pickup-button',
+                      onActivateEntry: input.onActivateEntry,
+                      children: (
+                        <>
+                          {renderPickupDot(entry)}
+                          <span className="pickup-copy">
+                            <strong className="pickup-label">{entry.fractionLabel}</strong>
+                            {entry.tourDescription ? (
+                              <span className="pickup-description">{entry.tourDescription}</span>
+                            ) : null}
+                          </span>
+                        </>
+                      ),
+                    })
+                  )}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  ));
 
 const buildMonthCells = (
   visibleMonth: Date,
@@ -225,7 +303,10 @@ export function PublicWasteCalendarPanels(props: Readonly<{
   const [visibleYear, setVisibleYear] = React.useState<number>(() =>
     Math.min(maxYear, Math.max(minYear, today.getFullYear()))
   );
-  const monthGroups = groupEntriesByMonth(props.model.listEntries);
+  const { upcomingEntries, pastEntries } = React.useMemo(
+    () => partitionListEntries(props.model.listEntries, props.model.nextPickupDate),
+    [props.model.listEntries, props.model.nextPickupDate]
+  );
   const monthCells = React.useMemo(() => buildMonthCells(visibleMonth, entriesByDate), [entriesByDate, visibleMonth]);
   const visibleYearMonths = React.useMemo(
     () => Array.from({ length: 12 }, (_, index) => new Date(visibleYear, index, 1)),
@@ -339,47 +420,23 @@ export function PublicWasteCalendarPanels(props: Readonly<{
           aria-labelledby="public-waste-tab-list"
           className="pickup-months"
         >
-          {monthGroups.map(([monthKey, monthEntries]) => (
-            <section key={monthKey} className="pickup-month-group" aria-labelledby={`month-${monthKey}`}>
-              <h3 id={`month-${monthKey}`} className="pickup-month-title">
-                {capitalize(monthYearFormatter.format(toDate(`${monthKey}-01`)))}
+          {renderListMonthGroups({
+            entries: upcomingEntries,
+            headingIdPrefix: 'upcoming-month',
+            onActivateEntry: props.onActivateEntry,
+          })}
+          {pastEntries.length > 0 ? (
+            <section className="pickup-past-group" aria-labelledby="past-pickups-heading">
+              <h3 id="past-pickups-heading" className="pickup-month-title">
+                Vergangene Termine
               </h3>
-              <ul className="pickup-list">
-                {groupEntriesByDay(monthEntries).map(([date, dayEntries]) => {
-                  const dayDate = toDate(date);
-                  return (
-                    <li key={date} className="pickup-item">
-                      <div className="pickup-row">
-                        <div className="pickup-date">
-                          <span className="pickup-weekday">{capitalize(weekdayFormatter.format(dayDate))}</span>
-                          <span className="pickup-day">{date.slice(8, 10)}</span>
-                        </div>
-                        <div className="pickup-entry-group">
-                          {dayEntries.map((entry) => (
-                            renderPickupEntryButton(entry, {
-                              className: 'pickup-button',
-                              onActivateEntry: props.onActivateEntry,
-                              children: (
-                                <>
-                                  {renderPickupDot(entry)}
-                                  <span className="pickup-copy">
-                                    <strong className="pickup-label">{entry.fractionLabel}</strong>
-                                    {entry.tourDescription ? (
-                                      <span className="pickup-description">{entry.tourDescription}</span>
-                                    ) : null}
-                                  </span>
-                                </>
-                              ),
-                            })
-                          ))}
-                        </div>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
+              {renderListMonthGroups({
+                entries: pastEntries,
+                headingIdPrefix: 'past-month',
+                onActivateEntry: props.onActivateEntry,
+              })}
             </section>
-          ))}
+          ) : null}
         </div>
       ) : activeTab === 'month' ? (
         <section

--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
@@ -39,21 +39,6 @@ const isSameMonth = (left: Date, right: Date): boolean =>
 
 const getWeekdayOffset = (value: Date): number => (value.getDay() + 6) % 7;
 
-const parseHexColorChannel = (value: string, startIndex: number): number => Number.parseInt(value.slice(startIndex, startIndex + 2), 16);
-
-const deriveReadableTextColor = (backgroundColor?: string): string | undefined => {
-  if (!backgroundColor || !/^#[0-9a-f]{6}$/i.test(backgroundColor)) {
-    return undefined;
-  }
-
-  const red = parseHexColorChannel(backgroundColor, 1);
-  const green = parseHexColorChannel(backgroundColor, 3);
-  const blue = parseHexColorChannel(backgroundColor, 5);
-  const luminance = (red * 0.299 + green * 0.587 + blue * 0.114) / 255;
-
-  return luminance > 0.62 ? 'rgb(24 24 24)' : 'rgb(255 255 255)';
-};
-
 const groupEntriesByMonth = (entries: readonly PublicWasteCalendarEntry[]) =>
   Array.from(
     entries.reduce<Map<string, PublicWasteCalendarEntry[]>>((groups, entry) => {
@@ -273,7 +258,6 @@ const buildYearMonthCells = (
 
 export function PublicWasteCalendarPanels(props: Readonly<{
   model: FilteredPublicWasteCalendarViewModel;
-  onToggleFraction: (fractionId: string) => void;
   onActivateEntry: (entry: PublicWasteCalendarEntry) => void;
 }>) {
   const tabs: ReadonlyArray<'list' | 'month' | 'year'> = ['list', 'month', 'year'];
@@ -342,36 +326,6 @@ export function PublicWasteCalendarPanels(props: Readonly<{
 
   return (
     <section className="calendar-panel" aria-label="Kalenderansicht">
-      <div className="filter-list" aria-label="Fraktionsfilter">
-        {props.model.fractionOptions.map((fraction) => {
-          const checked = props.model.activeFractionIds.includes(fraction.id);
-          const textColor = deriveReadableTextColor(fraction.color);
-          return (
-            <label
-              key={fraction.id}
-              className={`filter-chip${checked ? ' is-active' : ''}`}
-              style={
-                fraction.color
-                  ? {
-                      backgroundColor: fraction.color,
-                      borderColor: fraction.color,
-                      ...(textColor ? { color: textColor } : {}),
-                    }
-                  : undefined
-              }
-            >
-              <input
-                type="checkbox"
-                className="filter-chip-input"
-                checked={checked}
-                onChange={() => props.onToggleFraction(fraction.id)}
-              />
-              <span className="filter-indicator" aria-hidden="true" />
-              <span className="filter-chip-text">{fraction.label}</span>
-            </label>
-          );
-        })}
-      </div>
       <div className="calendar-tabs" role="tablist" aria-label="Kalenderansichten">
         <button
           type="button"

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-header.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-header.tsx
@@ -1,35 +1,47 @@
-import { IconCalendarPlus, IconFileTypePdf, IconPencil } from '@tabler/icons-react';
+import { IconPencil } from '@tabler/icons-react';
+
+import type { PublicWasteFractionOption } from '../lib/public-waste-contract.js';
 
 type PublicWasteSelectionHeaderProps = {
   readonly cityLine: string;
   readonly streetLine: string;
   readonly houseNumberLine?: string;
-  readonly icalUrl: string;
-  readonly pdfYear: number;
-  readonly pdfRunning: boolean;
-  readonly selectedFractionCount: number;
-  readonly yearOptions: readonly number[];
+  readonly fractionOptions: readonly PublicWasteFractionOption[];
+  readonly activeFractionIds: readonly string[];
   readonly onChangeLocation: () => void;
-  readonly onSelectPdfYear: (year: number) => void;
-  readonly onDownloadPdf: () => void;
+  readonly onToggleFraction: (fractionId: string) => void;
+};
+
+const parseHexColorChannel = (value: string, startIndex: number): number => Number.parseInt(value.slice(startIndex, startIndex + 2), 16);
+
+const deriveReadableTextColor = (backgroundColor?: string): string | undefined => {
+  if (!backgroundColor || !/^#[0-9a-f]{6}$/i.test(backgroundColor)) {
+    return undefined;
+  }
+
+  const red = parseHexColorChannel(backgroundColor, 1);
+  const green = parseHexColorChannel(backgroundColor, 3);
+  const blue = parseHexColorChannel(backgroundColor, 5);
+  const luminance = (red * 0.299 + green * 0.587 + blue * 0.114) / 255;
+
+  return luminance > 0.62 ? 'rgb(24 24 24)' : 'rgb(255 255 255)';
 };
 
 export const PublicWasteSelectionHeader = ({
   cityLine,
   streetLine,
   houseNumberLine,
-  icalUrl,
-  pdfYear,
-  pdfRunning,
-  selectedFractionCount,
-  yearOptions,
+  fractionOptions,
+  activeFractionIds,
   onChangeLocation,
-  onSelectPdfYear,
-  onDownloadPdf,
+  onToggleFraction,
 }: Readonly<PublicWasteSelectionHeaderProps>) => (
-  <div className="selection-header">
+  <section className="selection-header" aria-label="Standort und Fraktionen">
     <div className="selection-header-main">
-      <h2 className="section-title">Abholort</h2>
+      <div className="selection-section-heading">
+        <h2 className="section-title">Adresse</h2>
+        <p className="selection-step-copy">Der gewählte Standort bleibt erhalten, während Sie Ansichten und Aktionen über die aktiven Fraktionen steuern.</p>
+      </div>
       <div className="selection-summary-block">
         <p className="selection-summary-line">{cityLine}</p>
         <p className="selection-summary-line">{streetLine}</p>
@@ -42,30 +54,44 @@ export const PublicWasteSelectionHeader = ({
         </button>
       </div>
     </div>
-    <div className="selection-header-actions">
-      <a href={icalUrl} className="header-action-link">
-        <IconCalendarPlus size={18} stroke={1.75} aria-hidden="true" />
-        <span>In Kalender übernehmen</span>
-      </a>
-      <label className="header-action-link">
-        <span>PDF-Jahr</span>
-        <select aria-label="PDF-Jahr" value={pdfYear} onChange={(event) => onSelectPdfYear(Number.parseInt(event.target.value, 10))}>
-          {yearOptions.map((year) => (
-            <option key={year} value={year}>
-              {year}
-            </option>
-          ))}
-        </select>
-      </label>
-      <button
-        type="button"
-        className="header-action-link"
-        disabled={selectedFractionCount === 0 || pdfRunning}
-        onClick={onDownloadPdf}
-      >
-        <IconFileTypePdf size={18} stroke={1.75} aria-hidden="true" />
-        <span>{pdfRunning ? 'PDF wird erstellt…' : 'Druckversion herunterladen'}</span>
-      </button>
+    <div className="selection-header-fractions">
+      <div className="selection-section-heading">
+        <h2 className="section-title">Abfallfraktionen</h2>
+        <p className="selection-step-copy">Diese Auswahl steuert Liste, Kalenderexport, PDF-Download und E-Mail-Abo gemeinsam.</p>
+      </div>
+      <div className="selection-fraction-list" role="group" aria-label="Abfallfraktionen">
+        {fractionOptions.map((fraction) => {
+          const checked = activeFractionIds.includes(fraction.id);
+          const textColor = deriveReadableTextColor(fraction.color);
+          return (
+            <label
+              key={fraction.id}
+              className={`selection-fraction-item${checked ? ' is-active' : ''}`}
+              style={
+                fraction.color
+                  ? {
+                      ...(checked ? { backgroundColor: fraction.color, borderColor: fraction.color } : { borderColor: fraction.color }),
+                      ...(textColor && checked ? { color: textColor } : {}),
+                    }
+                  : undefined
+              }
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => onToggleFraction(fraction.id)}
+                aria-label={fraction.label}
+              />
+              <span
+                className="selection-fraction-swatch"
+                aria-hidden="true"
+                style={fraction.color ? { backgroundColor: fraction.color } : undefined}
+              />
+              <span className="selection-fraction-copy">{fraction.label}</span>
+            </label>
+          );
+        })}
+      </div>
     </div>
-  </div>
+  </section>
 );

--- a/apps/public-waste-calendar-web/src/lib/public-waste-api.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  buildPublicWasteIcalUrl,
   buildPublicWastePdfDownloadUrl,
   loadNextPublicWasteSelection,
   loadResolvedPublicWasteCalendar,
@@ -75,5 +76,23 @@ describe('public waste api', () => {
         fractionIds: ['bio', 'paper'],
       })
     ).toBe('/api/public-waste/pdf?regionId=r-1&cityId=c-1&streetId=s-1&houseNumberId=h-1&year=2026&fractionId=bio&fractionId=paper');
+  });
+
+  it('builds the calendar export url from selection, fractions, and optional reminder slots', () => {
+    expect(
+      buildPublicWasteIcalUrl({
+        selection: {
+          regionId: 'r-1',
+          cityId: 'c-1',
+          streetId: 's-1',
+          houseNumberId: 'h-1',
+        },
+        calendarName: 'Musterstadt, Hauptstraße 1',
+        fractionIds: ['bio', 'paper'],
+        reminderItems: [{ fractionId: 'bio', slotId: 'bio:calendar:first' }],
+      })
+    ).toBe(
+      '/api/public-waste/ical?regionId=r-1&cityId=c-1&streetId=s-1&houseNumberId=h-1&calendarName=Musterstadt%2C+Hauptstra%C3%9Fe+1&fractionId=bio&fractionId=paper&reminderItem=bio%7Cbio%3Acalendar%3Afirst'
+    );
   });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-api.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-api.ts
@@ -1,5 +1,7 @@
 import {
   buildPublicWasteLocationKey,
+  type PublicWasteReminderSelectionItem,
+  type PublicWasteCalendarReminderView,
   type PublicWasteReminderSignupRequest,
   type PublicWasteReminderSignupResponse,
   type PublicWasteReminderSignupView,
@@ -58,6 +60,7 @@ export type PublicWasteSelectionResponse = {
 export type PublicWasteCalendarResponse = Awaited<ReturnType<typeof loadResolvedPublicWasteCalendar>> & {
   readonly selectionSummary: string;
   readonly icalUrl: string;
+  readonly calendarReminderOptions?: PublicWasteCalendarReminderView;
   readonly reminderSignup?: PublicWasteReminderSignupView;
 };
 
@@ -70,6 +73,31 @@ const toSearchParams = (selection: PublicWasteSelectionState): URLSearchParams =
   return params;
 };
 
+const appendFractionIds = (params: URLSearchParams, fractionIds: readonly string[]) => {
+  for (const fractionId of fractionIds) {
+    params.append('fractionId', fractionId);
+  }
+};
+
+const appendReminderItems = (params: URLSearchParams, items: readonly PublicWasteReminderSelectionItem[]) => {
+  for (const item of items) {
+    params.append('reminderItem', `${item.fractionId}|${item.slotId}`);
+  }
+};
+
+export const buildPublicWasteIcalUrl = (input: {
+  readonly selection: PublicWasteResolvedSelection;
+  readonly calendarName: string;
+  readonly fractionIds: readonly string[];
+  readonly reminderItems?: readonly PublicWasteReminderSelectionItem[];
+}): string => {
+  const params = toSearchParams(input.selection);
+  params.set('calendarName', input.calendarName);
+  appendFractionIds(params, input.fractionIds);
+  appendReminderItems(params, input.reminderItems ?? []);
+  return `/api/public-waste/ical?${params.toString()}`;
+};
+
 export const buildPublicWastePdfDownloadUrl = (input: {
   readonly selection: PublicWasteResolvedSelection;
   readonly year: number;
@@ -77,9 +105,7 @@ export const buildPublicWastePdfDownloadUrl = (input: {
 }): string => {
   const params = toSearchParams(input.selection);
   params.set('year', String(input.year));
-  for (const fractionId of input.fractionIds) {
-    params.append('fractionId', fractionId);
-  }
+  appendFractionIds(params, input.fractionIds);
   return `/api/public-waste/pdf?${params.toString()}`;
 };
 

--- a/apps/public-waste-calendar-web/src/lib/public-waste-contract.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-contract.ts
@@ -66,6 +66,17 @@ export type PublicWasteReminderFractionOption = Readonly<{
   readonly slots: readonly PublicWasteReminderFractionSlotOption[];
 }>;
 
+export type PublicWasteReminderChannel = 'email' | 'calendar';
+
+export type PublicWasteCalendarReminderView = Readonly<{
+  readonly fractions: readonly PublicWasteReminderFractionOption[];
+}>;
+
+export type PublicWasteReminderSelectionItem = Readonly<{
+  readonly fractionId: string;
+  readonly slotId: string;
+}>;
+
 export type PublicWasteReminderSignupView = Readonly<{
   readonly enabled: boolean;
   readonly consentLabel: string;
@@ -76,10 +87,7 @@ export type PublicWasteReminderSignupView = Readonly<{
 export type PublicWasteReminderSignupRequest = Readonly<{
   readonly selection: PublicWasteResolvedSelection;
   readonly email: string;
-  readonly items: readonly {
-    readonly fractionId: string;
-    readonly slotId: string;
-  }[];
+  readonly items: readonly PublicWasteReminderSelectionItem[];
   readonly consentAccepted: boolean;
 }>;
 

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
@@ -45,14 +45,25 @@ describe('public waste endpoints', () => {
           },
         ]),
         loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
-        loadReminderSignupOptions: vi.fn().mockResolvedValue([
-          {
-            id: 'bio',
-            label: 'Bioabfall',
-            color: '#008800',
-            slots: [{ id: 'bio:first', maxLeadDays: 2, defaultLeadDays: 1 }],
-          },
-        ]),
+        loadReminderOptions: vi.fn().mockImplementation(async ({ channel }) =>
+          channel === 'email'
+            ? [
+                {
+                  id: 'bio',
+                  label: 'Bioabfall',
+                  color: '#008800',
+                  slots: [{ id: 'bio:first', maxLeadDays: 2, defaultLeadDays: 1 }],
+                },
+              ]
+            : [
+                {
+                  id: 'bio',
+                  label: 'Bioabfall',
+                  color: '#008800',
+                  slots: [{ id: 'bio:calendar:first', maxLeadDays: 2, defaultLeadDays: 1 }],
+                },
+              ]
+        ),
       },
       request: new Request(
         'https://example.invalid/public-waste/calendar?regionId=11111111-1111-4111-8111-111111111111&cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&houseNumberId=44444444-4444-4444-8444-444444444444&referenceDate=2026-05-18'
@@ -100,6 +111,15 @@ describe('public waste endpoints', () => {
             id: 'bio',
             label: 'Bioabfall',
             slots: [{ id: 'bio:first', maxLeadDays: 2, defaultLeadDays: 1 }],
+          },
+        ],
+      },
+      calendarReminderOptions: {
+        fractions: [
+          {
+            id: 'bio',
+            label: 'Bioabfall',
+            slots: [{ id: 'bio:calendar:first', maxLeadDays: 2, defaultLeadDays: 1 }],
           },
         ],
       },
@@ -225,6 +245,7 @@ describe('public waste endpoints', () => {
           },
         ]),
         loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
+        loadReminderOptions: vi.fn().mockResolvedValue([]),
       },
       request: new Request(
         'https://example.invalid/public-waste/calendar.ics?regionId=11111111-1111-4111-8111-111111111111&cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&houseNumberId=44444444-4444-4444-8444-444444444444&calendarName=Musterstadt'
@@ -259,6 +280,7 @@ describe('public waste endpoints', () => {
           },
         ]),
         loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
+        loadReminderOptions: vi.fn().mockResolvedValue([]),
       },
       request: new Request(
         'https://example.invalid/public-waste/calendar.ics?cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&calendarName=Musterstadt'
@@ -286,6 +308,7 @@ describe('public waste endpoints', () => {
           },
         ]),
         loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
+        loadReminderOptions: vi.fn().mockResolvedValue([]),
       },
       request: new Request(
         'https://example.invalid/public-waste/calendar.ics?cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&calendarName=Musterstadt'
@@ -298,6 +321,38 @@ describe('public waste endpoints', () => {
     expect(body).not.toContain('\\nHinweis: Bereitstellung am Vorabend.');
   });
 
+  it('renders calendar alarms for explicitly selected reminder slots', async () => {
+    const response = await handlePublicWasteIcalRequest({
+      repository: {
+        loadCalendarEntries: vi.fn().mockResolvedValue([
+          {
+            id: 'pickup-1',
+            date: '2026-05-19',
+            fractionId: 'bio',
+            fractionLabel: 'Bioabfall',
+            note: null,
+          },
+        ]),
+        loadSelectionSummary: vi.fn().mockResolvedValue('Musterstadt, Hauptstraße 1'),
+        loadReminderOptions: vi.fn().mockResolvedValue([
+          {
+            id: 'bio',
+            label: 'Bioabfall',
+            slots: [{ id: 'bio:calendar:first', maxLeadDays: 3, defaultLeadDays: 2 }],
+          },
+        ]),
+      },
+      request: new Request(
+        'https://example.invalid/public-waste/calendar.ics?cityId=22222222-2222-4222-8222-222222222222&streetId=33333333-3333-4333-8333-333333333333&calendarName=Musterstadt&fractionId=bio&reminderItem=bio|bio:calendar:first'
+      ),
+    });
+
+    const body = await response.text();
+    expect(body).toContain('BEGIN:VALARM');
+    expect(body).toContain('TRIGGER:-P2D');
+    expect(body).toContain('DESCRIPTION:Erinnerung: Bioabfall');
+  });
+
   it('accepts the catch-all street sentinel for resolved calendar requests', async () => {
     const loadCalendarEntries = vi.fn().mockResolvedValue([]);
     const loadSelectionSummary = vi.fn().mockResolvedValue('Musterstadt, Alle Straßen');
@@ -306,7 +361,7 @@ describe('public waste endpoints', () => {
       repository: {
         loadCalendarEntries,
         loadSelectionSummary,
-        loadReminderSignupOptions: vi.fn().mockResolvedValue([]),
+        loadReminderOptions: vi.fn().mockResolvedValue([]),
       },
       request: new Request(
         'https://example.invalid/public-waste/calendar?cityId=22222222-2222-4222-8222-222222222222&streetId=all&referenceDate=2026-05-18'
@@ -347,7 +402,7 @@ describe('public waste endpoints', () => {
 
     const response = await handlePublicWasteReminderSignupRequest({
       repository: {
-        loadReminderSignupOptions: vi.fn().mockResolvedValue([
+        loadReminderOptions: vi.fn().mockResolvedValue([
           {
             id: 'bio',
             label: 'Bioabfall',
@@ -430,7 +485,7 @@ describe('public waste endpoints', () => {
 
     const response = await handlePublicWasteReminderSignupRequest({
       repository: {
-        loadReminderSignupOptions: vi.fn().mockResolvedValue([
+        loadReminderOptions: vi.fn().mockResolvedValue([
           {
             id: 'bio',
             label: 'Bioabfall',

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
@@ -17,6 +17,7 @@ import type { PublicWastePdfStaticConfig } from './public-waste-pdf-settings.ser
 import {
   readPublicWasteCalendarName,
   readPublicWasteFractionIds,
+  readPublicWasteReminderItems,
   readPublicWasteReferenceDate,
   readPublicWasteResolvedSelection,
   readPublicWasteSelectionState,
@@ -49,6 +50,22 @@ const normalizeDateForIcal = (value: string): string => value.replaceAll('-', ''
 const normalizeEventDescriptionPart = (value: string | undefined | null): string | null => {
   const normalized = value?.trim();
   return normalized ? normalized : null;
+};
+
+const filterCalendarEntriesByFractionIds = <
+  TEntry extends {
+    readonly fractionId: string;
+  },
+>(
+  entries: readonly TEntry[],
+  fractionIds: readonly string[]
+): readonly TEntry[] => {
+  if (fractionIds.length === 0) {
+    return entries;
+  }
+
+  const allowedFractionIds = new Set(fractionIds);
+  return entries.filter((entry) => allowedFractionIds.has(entry.fractionId));
 };
 
 const buildPublicWasteIcalEventDescription = (entry: {
@@ -145,14 +162,14 @@ export const handlePublicWasteSelectionRequest = async (input: {
 };
 
 export const handlePublicWasteCalendarRequest = async (input: {
-  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderSignupOptions'>;
+  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderOptions'>;
   readonly request: Request;
   readonly reminderConfig?: WasteManagementEmailReminderConfig;
 }): Promise<Response> => {
   try {
     const url = new URL(input.request.url);
     const selection = readPublicWasteResolvedSelection(url);
-    const [payload, selectionSummary, reminderFractions] = await Promise.all([
+    const [payload, selectionSummary, emailReminderFractions, calendarReminderFractions] = await Promise.all([
       loadResolvedPublicWasteCalendar({
         repository: input.repository,
         input: {
@@ -162,30 +179,39 @@ export const handlePublicWasteCalendarRequest = async (input: {
       }),
       input.repository.loadSelectionSummary({ selection }),
       input.reminderConfig?.enabled && input.reminderConfig.publicSignupEnabled
-        ? input.repository.loadReminderSignupOptions({ selection })
+        ? input.repository.loadReminderOptions({ selection, channel: 'email' })
         : Promise.resolve([]),
+      input.repository.loadReminderOptions({ selection, channel: 'calendar' }),
     ]);
+    const baseIcalUrl = `/api/public-waste/ical?${new URLSearchParams({
+      ...(selection.regionId ? { regionId: selection.regionId } : {}),
+      cityId: selection.cityId,
+      streetId: selection.streetId,
+      ...(selection.houseNumberId ? { houseNumberId: selection.houseNumberId } : {}),
+      calendarName: selectionSummary,
+    }).toString()}`;
 
     return jsonResponse({
       ...payload,
       selectionSummary,
-      ...(input.reminderConfig?.enabled && input.reminderConfig.publicSignupEnabled && reminderFractions.length > 0
+      ...(calendarReminderFractions.length > 0
+        ? {
+            calendarReminderOptions: {
+              fractions: calendarReminderFractions,
+            },
+          }
+        : {}),
+      ...(input.reminderConfig?.enabled && input.reminderConfig.publicSignupEnabled && emailReminderFractions.length > 0
         ? {
             reminderSignup: {
               enabled: true,
               consentLabel: input.reminderConfig.consentLabel,
               privacyPolicyUrl: input.reminderConfig.privacyPolicyUrl,
-              fractions: reminderFractions,
+              fractions: emailReminderFractions,
             },
           }
         : {}),
-      icalUrl: `/api/public-waste/ical?${new URLSearchParams({
-        ...(selection.regionId ? { regionId: selection.regionId } : {}),
-        cityId: selection.cityId,
-        streetId: selection.streetId,
-        ...(selection.houseNumberId ? { houseNumberId: selection.houseNumberId } : {}),
-        calendarName: selectionSummary,
-      }).toString()}`,
+      icalUrl: baseIcalUrl,
     });
   } catch {
     return jsonResponse({ error: 'invalid_request', message: INVALID_REQUEST_MESSAGE }, 400);
@@ -219,7 +245,7 @@ const isPublicWasteReminderSignupRequest = (value: unknown): value is PublicWast
 };
 
 export const handlePublicWasteReminderSignupRequest = async (input: {
-  readonly repository: Pick<PublicWasteRepository, 'loadReminderSignupOptions' | 'loadSelectionSummary'>;
+  readonly repository: Pick<PublicWasteRepository, 'loadReminderOptions' | 'loadSelectionSummary'>;
   readonly request: Request;
   readonly reminderConfig?: WasteManagementEmailReminderConfig;
   readonly submitReminderSignup?: (input: {
@@ -239,8 +265,9 @@ export const handlePublicWasteReminderSignupRequest = async (input: {
       return new Response(INVALID_REQUEST_MESSAGE, { status: 400 });
     }
 
-    const allowedFractions = await input.repository.loadReminderSignupOptions({
+    const allowedFractions = await input.repository.loadReminderOptions({
       selection: payload.selection,
+      channel: 'email',
     });
     const allowedFractionMap = new Map(allowedFractions.map((fraction) => [fraction.id, fraction]));
     const hasInvalidItem = payload.items.some((item) => {
@@ -346,13 +373,15 @@ export const handlePublicWastePdfRequest = async (input: {
 };
 
 export const handlePublicWasteIcalRequest = async (input: {
-  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries' | 'loadSelectionSummary'>;
+  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderOptions'>;
   readonly request: Request;
 }): Promise<Response> => {
   try {
     const url = new URL(input.request.url);
     const selection = readPublicWasteResolvedSelection(url);
-    const [calendar, selectionSummary] = await Promise.all([
+    const fractionIds = readPublicWasteFractionIds(url);
+    const reminderItems = readPublicWasteReminderItems(url);
+    const [calendar, selectionSummary, calendarReminderFractions] = await Promise.all([
       loadResolvedPublicWasteCalendar({
         repository: input.repository,
         input: {
@@ -361,18 +390,47 @@ export const handlePublicWasteIcalRequest = async (input: {
         },
       }),
       input.repository.loadSelectionSummary({ selection }),
+      reminderItems.length > 0
+        ? input.repository.loadReminderOptions({ selection, channel: 'calendar' })
+        : Promise.resolve([]),
     ]);
+    const filteredEntries = filterCalendarEntriesByFractionIds(calendar.listEntries, fractionIds);
+    const allowedReminderSlots = new Map(
+      calendarReminderFractions.map((fraction) => [
+        fraction.id,
+        new Map(fraction.slots.map((slot) => [slot.id, slot])),
+      ])
+    );
+    const reminderSlotSelections = new Map<string, { readonly defaultLeadDays: number }>();
+    for (const item of reminderItems) {
+      const slot = allowedReminderSlots.get(item.fractionId)?.get(item.slotId);
+      if (!slot) {
+        throw new Error('invalid_query_param:reminderItem');
+      }
+
+      reminderSlotSelections.set(item.fractionId, slot);
+    }
 
     const body = renderPublicWasteIcal({
       calendarName: readPublicWasteCalendarName(url),
       calendarDescription: `Abholort: ${selectionSummary}`,
-      events: calendar.listEntries.map((entry) => {
+      events: filteredEntries.map((entry) => {
         const description = buildPublicWasteIcalEventDescription(entry);
+        const reminderSlot = reminderSlotSelections.get(entry.fractionId);
         return {
           uid: `${entry.id}@public-waste-calendar`,
           startDate: normalizeDateForIcal(entry.date),
           summary: entry.fractionLabel,
           ...(description ? { description } : {}),
+          ...(reminderSlot
+            ? {
+                alarms: [
+                  {
+                    triggerDaysBefore: reminderSlot.defaultLeadDays,
+                  },
+                ],
+              }
+            : {}),
         };
       }),
     });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.test.ts
@@ -48,4 +48,23 @@ describe('public waste iCal', () => {
     expect(ical).not.toContain('\rHauptstraße 1');
     expect(ical).not.toContain('\rTour: Innenstadt');
   });
+
+  it('renders optional display alarms for reminder-enabled events', () => {
+    const ical = renderPublicWasteIcal({
+      calendarName: 'Abfallkalender Musterstadt',
+      events: [
+        {
+          uid: 'pickup-1@example.invalid',
+          startDate: '20260519',
+          summary: 'Bioabfall',
+          alarms: [{ triggerDaysBefore: 2 }],
+        },
+      ],
+    });
+
+    expect(ical).toContain('BEGIN:VALARM');
+    expect(ical).toContain('ACTION:DISPLAY');
+    expect(ical).toContain('TRIGGER:-P2D');
+    expect(ical).toContain('DESCRIPTION:Erinnerung: Bioabfall');
+  });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-ical.server.ts
@@ -6,6 +6,10 @@ export type PublicWasteIcalModel = {
     readonly startDate: string;
     readonly summary: string;
     readonly description?: string;
+    readonly alarms?: readonly {
+      readonly triggerDaysBefore: number;
+      readonly description?: string;
+    }[];
   }[];
 };
 
@@ -32,6 +36,13 @@ export const renderPublicWasteIcal = (input: PublicWasteIcalModel): string =>
       `DTSTART;VALUE=DATE:${event.startDate}`,
       `SUMMARY:${escapeIcalText(event.summary)}`,
       ...(event.description ? [`DESCRIPTION:${escapeIcalText(event.description)}`] : []),
+      ...(event.alarms ?? []).flatMap((alarm) => [
+        'BEGIN:VALARM',
+        'ACTION:DISPLAY',
+        `TRIGGER:-P${alarm.triggerDaysBefore}D`,
+        `DESCRIPTION:${escapeIcalText(alarm.description ?? `Erinnerung: ${event.summary}`)}`,
+        'END:VALARM',
+      ]),
       'END:VEVENT',
     ]),
     'END:VCALENDAR',

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
@@ -669,12 +669,13 @@ describe('public waste repository', () => {
     });
 
     await expect(
-      repository.loadReminderSignupOptions({
+      repository.loadReminderOptions({
         selection: {
           cityId: 'city-1',
           streetId: 'street-1',
           houseNumberId: 'house-1',
         },
+        channel: 'email',
       })
     ).resolves.toEqual([
       {
@@ -685,6 +686,85 @@ describe('public waste repository', () => {
           { id: 'bio:first', maxLeadDays: 2, defaultLeadDays: 1 },
           { id: 'bio:second', maxLeadDays: 5, defaultLeadDays: 3 },
         ],
+      },
+    ]);
+  });
+
+  it('loads only calendar-capable reminder fractions with valid calendar slots for the current location', async () => {
+    const execute = vi.fn().mockResolvedValueOnce({
+      rowCount: 3,
+      rows: [
+        {
+          fraction_id: 'bio',
+          fraction_label: 'Bioabfall',
+          fraction_color: '#008800',
+          reminder_config: {
+            reminderCount: 'twice',
+            channels: {
+              push: false,
+              email: true,
+              calendar: false,
+            },
+            email: {
+              slots: [{ id: 'bio:first', maxLeadDays: 2, defaultLeadDays: 1 }],
+            },
+          },
+        },
+        {
+          fraction_id: 'paper',
+          fraction_label: 'Papier',
+          fraction_color: '#0000ff',
+          reminder_config: {
+            reminderCount: 'once',
+            channels: {
+              push: false,
+              email: false,
+              calendar: true,
+            },
+            calendar: {
+              slots: [{ id: 'paper:calendar', maxLeadDays: 2, defaultLeadDays: 1 }],
+            },
+          },
+        },
+        {
+          fraction_id: 'glass',
+          fraction_label: 'Altglas',
+          fraction_color: '#666666',
+          reminder_config: {
+            reminderCount: 'once',
+            channels: {
+              push: false,
+              email: false,
+              calendar: true,
+            },
+            calendar: {
+              slots: [],
+            },
+          },
+        },
+      ],
+    });
+
+    const repository = createPublicWasteRepository({
+      schemaName: 'waste',
+      execute,
+    });
+
+    await expect(
+      repository.loadReminderOptions({
+        selection: {
+          cityId: 'city-1',
+          streetId: 'street-1',
+          houseNumberId: 'house-1',
+        },
+        channel: 'calendar',
+      })
+    ).resolves.toEqual([
+      {
+        id: 'paper',
+        label: 'Papier',
+        color: '#0000ff',
+        slots: [{ id: 'paper:calendar', maxLeadDays: 2, defaultLeadDays: 1 }],
       },
     ]);
   });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
@@ -2,6 +2,7 @@ import type { WasteHolidayRuleRecord } from '@sva/core';
 
 import type {
   PublicWasteCalendarEntry,
+  PublicWasteReminderChannel,
   PublicWasteReminderFractionOption,
   PublicWasteReminderFractionSlotOption,
   PublicWasteResolvedSelection,
@@ -118,6 +119,7 @@ type PersistedReminderSlot = {
 type PersistedReminderConfig = {
   readonly channels?: unknown;
   readonly email?: unknown;
+  readonly calendar?: unknown;
 };
 
 export type PublicWasteRepository = ReturnType<typeof createPublicWasteRepository>;
@@ -222,23 +224,26 @@ const normalizeReminderSlot = (value: unknown): PublicWasteReminderFractionSlotO
   };
 };
 
-const normalizeReminderSignupFraction = (row: ReminderFractionRow): PublicWasteReminderFractionOption | null => {
+const normalizeReminderFraction = (
+  row: ReminderFractionRow,
+  channel: PublicWasteReminderChannel
+): PublicWasteReminderFractionOption | null => {
   if (!isRecord(row.reminder_config)) {
     return null;
   }
 
   const config = row.reminder_config as PersistedReminderConfig;
   const channels = isRecord(config.channels) ? config.channels : null;
-  if (!channels || channels.email !== true) {
+  if (!channels || channels[channel] !== true) {
     return null;
   }
 
-  const emailConfig = isRecord(config.email) ? config.email : null;
-  if (!emailConfig || !Array.isArray(emailConfig.slots)) {
+  const channelConfig = isRecord(config[channel]) ? config[channel] : null;
+  if (!channelConfig || !Array.isArray(channelConfig.slots)) {
     return null;
   }
 
-  const slots = emailConfig.slots
+  const slots = channelConfig.slots
     .map(normalizeReminderSlot)
     .filter((slot): slot is PublicWasteReminderFractionSlotOption => slot !== null);
   if (slots.length === 0) {
@@ -807,8 +812,9 @@ export const createPublicWasteRepository = (input: {
       return [row.city_label, [row.street_label, row.house_number_label].filter(Boolean).join(' ')].filter(Boolean).join(', ');
     },
 
-    async loadReminderSignupOptions(query: {
+    async loadReminderOptions(query: {
       readonly selection: PublicWasteResolvedSelection;
+      readonly channel: PublicWasteReminderChannel;
     }): Promise<readonly PublicWasteReminderFractionOption[]> {
       const streetSelectionFilter = createStreetSelectionFilter(query.selection.streetId);
       const result = await input.execute<ReminderFractionRow>({
@@ -840,7 +846,7 @@ export const createPublicWasteRepository = (input: {
       });
 
       return result.rows
-        .map(normalizeReminderSignupFraction)
+        .map((row) => normalizeReminderFraction(row, query.channel))
         .filter((fraction): fraction is PublicWasteReminderFractionOption => fraction !== null);
     },
   };

--- a/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { readPublicWasteReferenceDate } from './public-waste-request-parsing.server.js';
+import { readPublicWasteReferenceDate, readPublicWasteReminderItems } from './public-waste-request-parsing.server.js';
 
 describe('public waste request parsing', () => {
   beforeEach(() => {
@@ -23,5 +23,16 @@ describe('public waste request parsing', () => {
     expect(readPublicWasteReferenceDate(new URL('https://example.test/public-waste?referenceDate=not-a-date'))).toBe(
       '2026-06-07'
     );
+  });
+
+  it('parses reminder items for calendar exports', () => {
+    expect(
+      readPublicWasteReminderItems(
+        new URL('https://example.test/public-waste?reminderItem=bio|bio:calendar:first&reminderItem=paper|paper:calendar:first')
+      )
+    ).toEqual([
+      { fractionId: 'bio', slotId: 'bio:calendar:first' },
+      { fractionId: 'paper', slotId: 'paper:calendar:first' },
+    ]);
   });
 });

--- a/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-request-parsing.server.ts
@@ -1,4 +1,5 @@
 import type {
+  PublicWasteReminderSelectionItem,
   PublicWasteResolvedSelection,
   PublicWasteSelectionState,
 } from './public-waste-contract.js';
@@ -62,6 +63,29 @@ export const readPublicWasteReferenceDate = (url: URL): string =>
 
 export const readPublicWasteFractionIds = (url: URL): readonly string[] =>
   Array.from(new Set(url.searchParams.getAll('fractionId').map((value) => value.trim()).filter(Boolean)));
+
+export const readPublicWasteReminderItems = (url: URL): readonly PublicWasteReminderSelectionItem[] =>
+  url.searchParams
+    .getAll('reminderItem')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => {
+      const separatorIndex = value.indexOf('|');
+      if (separatorIndex <= 0 || separatorIndex >= value.length - 1) {
+        throw new Error('invalid_query_param:reminderItem');
+      }
+
+      const fractionId = value.slice(0, separatorIndex).trim();
+      const slotId = value.slice(separatorIndex + 1).trim();
+      if (!fractionId || !slotId) {
+        throw new Error('invalid_query_param:reminderItem');
+      }
+
+      return {
+        fractionId,
+        slotId,
+      };
+    });
 
 export const readPublicWasteCalendarName = (url: URL): string =>
   url.searchParams.get('calendarName')?.trim() || 'Abfallkalender';

--- a/apps/public-waste-calendar-web/src/routes/index.test.tsx
+++ b/apps/public-waste-calendar-web/src/routes/index.test.tsx
@@ -160,7 +160,7 @@ describe('PublicWasteIndexPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '12' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('link', { name: 'In Kalender übernehmen' })).toBeTruthy();
+      expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
     });
 
     expect(document.cookie).toContain(
@@ -180,7 +180,7 @@ describe('PublicWasteIndexPage', () => {
     expect(screen.getByText('Rathenow')).toBeTruthy();
     expect(screen.getByText('Am alten Hafen')).toBeTruthy();
     expect(screen.getByText('12')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'In Kalender übernehmen' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
   });
 
   it('clears stale stored selections and falls back to the next valid selection step', async () => {
@@ -307,7 +307,7 @@ describe('PublicWasteIndexPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '12' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'E-Mail-Erinnerung einrichten' })).toBeTruthy();
+      expect(screen.getByRole('tab', { name: 'E-Mail-Abo' })).toBeTruthy();
     });
   });
 });

--- a/apps/public-waste-calendar-web/src/routes/index.tsx
+++ b/apps/public-waste-calendar-web/src/routes/index.tsx
@@ -330,6 +330,7 @@ export function PublicWasteIndexPage() {
             selectionSummary={pageState.selectionSummary}
             calendarModel={pageState}
             icalUrl={pageState.icalUrl}
+            calendarReminderOptions={pageState.calendarReminderOptions}
             reminderSignup={pageState.reminderSignup}
             onChangeLocation={handleResetLocation}
           />

--- a/apps/public-waste-calendar-web/src/server/public-waste-runtime.test.ts
+++ b/apps/public-waste-calendar-web/src/server/public-waste-runtime.test.ts
@@ -134,7 +134,7 @@ describe('public waste runtime', () => {
           listSelectionOptions: vi.fn(),
           loadCalendarEntries: vi.fn(),
           loadSelectionSummary: vi.fn(),
-          loadReminderSignupOptions: vi.fn(),
+          loadReminderOptions: vi.fn(),
         },
         pool: {
           connect: poolConnect,
@@ -216,7 +216,7 @@ describe('public waste runtime', () => {
           listSelectionOptions: vi.fn(),
           loadCalendarEntries: vi.fn(),
           loadSelectionSummary: vi.fn().mockResolvedValue('Perleberg, Ackerstr. 12'),
-          loadReminderSignupOptions: vi.fn().mockResolvedValue([
+          loadReminderOptions: vi.fn().mockResolvedValue([
             {
               id: 'bio',
               label: 'Bioabfall',

--- a/apps/public-waste-calendar-web/src/server/public-waste-runtime.ts
+++ b/apps/public-waste-calendar-web/src/server/public-waste-runtime.ts
@@ -29,7 +29,7 @@ export const PUBLIC_WASTE_RUNTIME_APP_NAME = 'public-waste-calendar-web';
 
 type PublicWasteRuntimeRepository = Pick<
   PublicWasteRepository,
-  'listSelectionOptions' | 'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderSignupOptions'
+  'listSelectionOptions' | 'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderOptions'
 >;
 
 type RepositoryHandle = {

--- a/apps/public-waste-calendar-web/src/styles.css
+++ b/apps/public-waste-calendar-web/src/styles.css
@@ -80,31 +80,42 @@ body {
 
 .selection-header {
   display: grid;
-  gap: calc(1rem + 12px) 1.5rem;
-  grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+  gap: 1.25rem;
+  grid-template-columns: minmax(0, 1.15fr) minmax(15rem, 0.85fr);
   align-items: start;
-  margin-bottom: 12px;
+  margin-bottom: 0.5rem;
+  padding: 1.15rem;
+  border: 1px solid rgb(220 220 220);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(180deg, rgb(255 255 255) 0%, rgb(248 248 248) 100%);
+  box-shadow: 0 22px 55px -42px rgb(30 30 30 / 0.65);
 }
 
 .selection-header-main {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.9rem;
   min-width: 0;
 }
 
-.selection-header-actions {
+.selection-header-fractions,
+.selection-section-heading {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .selection-summary-block {
   display: grid;
-  gap: 0.15rem;
+  gap: 0.2rem;
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  background: rgb(255 255 255 / 0.72);
+  border: 1px solid rgb(230 230 230);
 }
 
 .selection-summary-line {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1.08rem;
   line-height: 1.35;
 }
 
@@ -117,13 +128,161 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
-  padding: 0;
-  border: 0;
-  background: transparent;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid rgb(196 196 196);
+  border-radius: 999px;
+  background: rgb(255 255 255);
   color: rgb(54 54 54);
   font: inherit;
   text-decoration: none;
   cursor: pointer;
+}
+
+.selection-fraction-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.selection-fraction-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 3rem;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid rgb(220 220 220);
+  border-radius: 1rem;
+  background: rgb(250 250 250);
+  cursor: pointer;
+}
+
+.selection-fraction-item input {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+}
+
+.selection-fraction-swatch {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 999px;
+  background: rgb(42 42 42);
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.08);
+}
+
+.selection-fraction-copy {
+  font-size: 0.97rem;
+  line-height: 1.25;
+}
+
+.selection-fraction-item.is-active {
+  border-color: rgb(170 170 170);
+  box-shadow: 0 10px 22px -18px rgb(0 0 0 / 0.45);
+}
+
+.action-hub {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  border: 1px solid rgb(220 220 220);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(180deg, rgb(252 252 252) 0%, rgb(246 246 246) 100%);
+}
+
+.action-hub-toolbar {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.action-hub-trigger,
+.action-cta-button,
+.action-cta-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  min-height: 3rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid rgb(150 150 150);
+  border-radius: 1rem;
+  background: rgb(255 255 255);
+  color: inherit;
+  font: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.action-hub-trigger {
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 5.25rem;
+  text-align: center;
+}
+
+.action-hub-trigger.is-active {
+  border-color: rgb(32 32 32);
+  background: rgb(242 242 242);
+}
+
+.action-panel {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  border: 1px solid rgb(224 224 224);
+  border-radius: 1.1rem;
+  background: rgb(255 255 255);
+}
+
+.action-panel-body,
+.action-slot-list,
+.action-field {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.action-panel-intro,
+.action-panel-copy {
+  margin: 0;
+  color: rgb(88 88 88);
+  line-height: 1.5;
+}
+
+.action-field input,
+.action-field select {
+  min-height: 2.9rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid rgb(188 188 188);
+  border-radius: 0.85rem;
+  font: inherit;
+  background: rgb(255 255 255);
+}
+
+.action-toggle,
+.reminder-consent {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.action-warning {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgb(237 211 170);
+  border-radius: 0.95rem;
+  background: rgb(255 249 238);
+  color: rgb(101 64 0);
+  line-height: 1.5;
+}
+
+.action-cta-button:disabled,
+.action-cta-link.is-disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .selection-summary-link-icon {
@@ -304,6 +463,9 @@ body {
 .selection-result:focus-visible,
 .selection-trigger:focus-visible,
 .selection-summary-link:focus-visible,
+.action-hub-trigger:focus-visible,
+.action-cta-button:focus-visible,
+.action-cta-link:focus-visible,
 .pickup-button:focus-visible,
 .dialog-close:focus-visible {
   outline: 2px solid rgb(64 64 64);
@@ -668,6 +830,10 @@ body {
 
 @media (max-width: 720px) {
   .selection-header {
+    grid-template-columns: 1fr;
+  }
+
+  .action-hub-toolbar {
     grid-template-columns: 1fr;
   }
 

--- a/apps/public-waste-calendar-web/tests/public-waste-calendar.e2e.ts
+++ b/apps/public-waste-calendar-web/tests/public-waste-calendar.e2e.ts
@@ -85,12 +85,19 @@ test('resolves a location, restores it from cookie, and exposes accessible expor
 
   await page.goto('/');
 
+  await page.getByRole('textbox', { name: 'Ort suchen' }).fill('Rat');
   await page.getByRole('button', { name: 'Rathenow' }).click();
+  await page.getByRole('textbox', { name: 'Straße suchen' }).fill('Hafen');
   await page.getByRole('button', { name: 'Am alten Hafen' }).click();
+  await page.getByRole('textbox', { name: 'Hausnummer suchen' }).fill('12');
   await page.getByRole('button', { name: '12' }).click();
 
-  await expect(page.getByText('Rathenow, Am alten Hafen 12')).toBeVisible();
-  await expect(page.getByRole('link', { name: 'iCal abonnieren' })).toBeVisible();
+  await expect(page.getByText('Rathenow')).toBeVisible();
+  await expect(page.getByText('Am alten Hafen')).toBeVisible();
+  await expect(page.getByText('12')).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Kalenderexport' }).click();
+  await expect(page.getByRole('link', { name: 'Kalender exportieren' })).toBeVisible();
 
   await page.getByRole('button', { name: 'Termin Bioabfall am 2026-05-19' }).click();
 
@@ -99,6 +106,9 @@ test('resolves a location, restores it from cookie, and exposes accessible expor
 
   await page.reload();
 
-  await expect(page.getByText('Gespeicherte Adresse geladen. Sie können die Auswahl ändern.')).toBeVisible();
-  await expect(page.getByRole('link', { name: 'iCal abonnieren' })).toBeVisible();
+  await expect(page.getByText('Rathenow')).toBeVisible();
+  await expect(page.getByText('Am alten Hafen')).toBeVisible();
+  await expect(page.getByText('12')).toBeVisible();
+  await page.getByRole('tab', { name: 'Kalenderexport' }).click();
+  await expect(page.getByRole('link', { name: 'Kalender exportieren' })).toBeVisible();
 });

--- a/openspec/changes/add-public-waste-email-reminders/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/add-public-waste-email-reminders/specs/public-waste-calendar/spec.md
@@ -16,11 +16,11 @@ Das System SHALL die Einrichtung der E-Mail-Erinnerung über ein Formular in der
 - **THEN** bietet das Formular nur Abfallarten an, deren Reminder-Konfiguration den Kanal `email` aktiviert hat
 - **AND** es bietet nur Fraktionen an, die mindestens einen gültigen E-Mail-Slot besitzen
 
-#### Scenario: Slot-Auswahl erfolgt pro gewählter Fraktion
+#### Scenario: Standardslots werden pro gewählter Fraktion automatisch verwendet
 - **WHEN** ein Benutzer mehrere Abfallarten auswählt
-- **THEN** zeigt das Formular für jede gewählte Fraktion deren zulässige E-Mail-Zeitfenster separat an
-- **AND** unterschiedliche Fraktionen dürfen unterschiedliche Zeitfenster erhalten
-- **AND** das Formular erzwingt keinen global gemeinsamen Zeitslot über alle Fraktionen
+- **THEN** verwendet das Formular für jede gewählte Fraktion deren zulässigen Standard-Slot automatisch
+- **AND** unterschiedliche Fraktionen dürfen unterschiedliche Standardslots erhalten
+- **AND** das Formular fragt diese Slot-Auswahl nicht zusätzlich ab
 
 #### Scenario: Datenschutz-Einwilligung ist Pflicht
 - **WHEN** ein Benutzer das Formular ohne bestätigte Datenschutz-Checkbox absenden will

--- a/openspec/changes/update-public-waste-action-layout/proposal.md
+++ b/openspec/changes/update-public-waste-action-layout/proposal.md
@@ -1,0 +1,15 @@
+# Change: Öffentliche Waste-Weboberfläche mit Aktionspanels und rechter Fraktionsliste
+
+## Why
+Die öffentliche Waste-Weboberfläche verteilt Standortkontext, Fraktionsauswahl und globale Aktionen derzeit auf getrennte Bereiche. Dadurch wirkt die Bedienung unruhig, und Kalenderexport, PDF-Download sowie E-Mail-Abo verwenden kein einheitliches Aktionsmodell.
+
+## What Changes
+- Die vollständige Ansicht für aufgelöste Standorte wird in einen zweispaltigen Kontextblock mit Adresse links und vertikaler Fraktionsliste rechts umgebaut.
+- Darunter entsteht ein gemeinsamer horizontaler Aktionsblock für Kalenderexport, PDF-Download und E-Mail-Abo mit genau einem gleichzeitig geöffneten Optionspanel.
+- Die öffentliche Datenprojektion erweitert die Reminder-Informationen um kalenderfähige Slots, damit der iCal-Export optional `VALARM`-Einträge für die aktuell aktiven Fraktionen erzeugen kann.
+- Das E-Mail-Abo nutzt die rechte Fraktionsliste als führende Auswahl und zeigt im Aktionspanel nur noch E-Mail-, Datenschutz- und Slot-Felder für die aktiven Fraktionen.
+
+## Impact
+- Affected specs: `public-waste-calendar`
+- Affected code: `apps/public-waste-calendar-web/src/components`, `apps/public-waste-calendar-web/src/lib/public-waste-*.ts`, `apps/public-waste-calendar-web/src/styles.css`
+- Affected arc42 sections: keine

--- a/openspec/changes/update-public-waste-action-layout/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/update-public-waste-action-layout/specs/public-waste-calendar/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+### Requirement: Öffentliche App erlaubt Fraktionsfilter auf geladenen Kalenderdaten
+
+Das System SHALL Benutzerinnen und Benutzern erlauben, die sichtbaren Abfallarten nach dem Laden des Kalenders in einem eigenständigen Kontextblock der vollständigen Standortansicht zu filtern.
+
+#### Scenario: Fraktionsfilter erscheint rechts neben der Adresse
+
+- **WHEN** der Standort vollständig aufgelöst ist
+- **THEN** zeigt die App die Adresse links und die auswählbaren Abfallfraktionen als vertikale Liste rechts daneben
+- **AND** Änderungen an den Fraktionen wirken auf Kalenderdarstellungen und globale Aktionen aus demselben geladenen Kalenderzustand
+- **AND** die Standortauswahl muss nicht erneut durchlaufen werden
+
+### Requirement: Öffentliche App liefert PDF- und iCal-Aktionen konsistent zum Standort
+
+Das System SHALL globale PDF-, iCal- und Erinnerungsaktionen aus demselben finalen Standortkontext und aus derselben aktiven Fraktionsauswahl ableiten wie die Kalenderansicht.
+
+#### Scenario: Aktionen erscheinen in einem gemeinsamen horizontalen Block
+
+- **WHEN** der Standort vollständig aufgelöst ist
+- **THEN** zeigt die App unter Adresse und Fraktionsliste einen horizontalen Block mit den Aktionen `Kalenderexport`, `PDF-Download` und `E-Mail-Abo`
+- **AND** genau ein zugehöriges Optionspanel ist gleichzeitig geöffnet
+- **AND** ein erneuter Klick auf die aktive Aktion schließt deren Panel wieder
+
+#### Scenario: PDF-Aktion erzeugt das Dokument ad hoc in der öffentlichen Runtime
+
+- **WHEN** Benutzerinnen oder Benutzer das Panel `PDF-Download` öffnen
+- **THEN** können sie dort das Jahr wählen und den Download für die aktuell aktiven Fraktionen auslösen
+- **AND** die öffentliche Runtime erzeugt das PDF serverseitig ad hoc
+- **AND** es wird kein persistentes PDF-Artefakt gespeichert
+
+#### Scenario: iCal-Feed nutzt verfügbare Standard-Reminder ohne zusätzliche Abfrage
+
+- **WHEN** Benutzerinnen oder Benutzer das Panel `Kalenderexport` öffnen
+- **THEN** können sie den Export für die aktuell aktiven Fraktionen direkt auslösen, ohne zuvor Reminder-Slots auswählen zu müssen
+- **AND** die App übernimmt verfügbare kalenderfähige Standard-Reminder automatisch
+- **AND** der serverseitig erzeugte iCal-Feed bleibt konsistent zu den in der App sichtbaren Kalenderdaten
+
+#### Scenario: Gemischte Fraktionsauswahl ohne gemeinsame Reminder-Fähigkeit bleibt fail-closed
+
+- **WHEN** die aktuell aktiven Fraktionen nicht für alle gewählten Fraktionen gültige kalender- oder e-mailfähige Reminder-Slots besitzen
+- **THEN** zeigt die App eine klare Hinweisnachricht im jeweiligen Aktionspanel
+- **AND** sie erzeugt keinen impliziten Reminder-Fallback
+- **AND** Nutzerinnen und Nutzer können die Fraktionsauswahl anpassen, um wieder gültige Reminder-Optionen zu erhalten
+
+### Requirement: Öffentliche App bietet ein kontextbezogenes E-Mail-Abo für aktive Fraktionen
+
+Das System SHALL das öffentliche E-Mail-Abo im gemeinsamen Aktionsmodell bereitstellen und dabei die aktive Fraktionsauswahl als führende Quelle verwenden.
+
+#### Scenario: E-Mail-Abo nutzt aktive Fraktionen statt eigener Fraktionsauswahl
+
+- **WHEN** Benutzerinnen oder Benutzer das Panel `E-Mail-Abo` öffnen
+- **THEN** zeigt die App nur Felder für E-Mail-Adresse und Datenschutz-Einwilligung der aktuell aktiven Fraktionen
+- **AND** verfügbare Reminder-Slots der aktiven Fraktionen werden automatisch mit ihren Standardwerten verwendet
+- **AND** das Panel enthält keine zweite, davon getrennte Fraktionsauswahl
+- **AND** Erfolgs- und Fehlerzustände bleiben innerhalb desselben Aktionspanels sichtbar

--- a/openspec/changes/update-public-waste-action-layout/tasks.md
+++ b/openspec/changes/update-public-waste-action-layout/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementierung
+- [ ] 1.1 OpenSpec-Delta für das neue Aktionslayout und den kalenderfähigen Reminder-Export anlegen und validieren
+- [ ] 1.2 Öffentliche Reminder-Projektion kanalbewusst erweitern und den iCal-Endpoint für optionale `VALARM`-Parameter ausbauen
+- [ ] 1.3 UI in Kontextblock, horizontale Aktionsleiste und kontextsensitives Single-Panel umbauen
+- [ ] 1.4 Komponententests, Endpoint-Tests und API-bezogene Tests für Layout, Reminder-Slots und iCal-Reminder ergänzen oder anpassen
+- [ ] 1.5 Relevante Vitest- und Type-Checks für `public-waste-calendar-web` grün ausführen

--- a/openspec/specs/public-waste-calendar/spec.md
+++ b/openspec/specs/public-waste-calendar/spec.md
@@ -91,12 +91,13 @@ Das System SHALL genau einen zuletzt gewählten Standort pro Browser für die ö
 
 Das System SHALL für einen vollständig aufgelösten Standort drei komplementäre Kalenderdarstellungen bereitstellen.
 
-#### Scenario: Terminliste zeigt verfügbare Vergangenheits- und Zukunftstermine chronologisch
+#### Scenario: Terminliste beginnt mit dem nächsten Termin und trennt Vergangenes separat ab
 
 - **WHEN** der Kalender für einen Standort geladen ist
-- **THEN** zeigt die Terminliste verfügbare Termine in zeitlich aufsteigender Reihenfolge
+- **THEN** beginnt die Terminliste mit dem nächsten verfügbaren Termin
+- **AND** zeigt danach weitere künftige Termine in zeitlich aufsteigender Reihenfolge
 - **AND** sie kann je nach Datenlage auch vergangene Termine bis zum Anfang des Vorjahres enthalten
-- **AND** künftige Termine bleiben ohne Lücken im selben Kalenderdatensatz sichtbar
+- **AND** vergangene Termine erscheinen mit einer eigenen Überschrift erst nach dem Block der künftigen Termine
 
 #### Scenario: Monats- und Jahresansicht haben ein begrenztes Navigationsfenster
 


### PR DESCRIPTION
## Was wurde geändert?
- Die Public-Waste-Weboberfläche wurde neu strukturiert: Adresse links, vertikale Fraktionsliste rechts und darunter ein gemeinsamer Aktionsblock für Kalenderexport, PDF-Download und E-Mail-Abo.
- Der Aktionsblock arbeitet jetzt als Single-Panel-Muster mit kontextabhängigen Optionen je Aktion.
- Der öffentliche Kalenderdatenfluss wurde um kanalbewusste Reminder-Projektionen erweitert, damit der ICS-Export optional Kalender-Erinnerungen als `VALARM` erzeugen kann.
- Die E-Mail-Abo-Logik nutzt jetzt die aktive Fraktionsauswahl als führende Auswahl und bleibt mit Datenschutz-Einwilligung und Slot-Validierung innerhalb des neuen Panels.
- OpenSpec wurde für das neue Bedienmodell ergänzt und angepasst.
- Die Dependabot-Konfiguration wurde von wöchentlichen auf monatliche Läufe umgestellt und das PR-Limit erhöht.

## Warum wurde das geändert?
- Die bisherige Public-Waste-Oberfläche verteilte Standort, Fraktionsauswahl und Folgeaktionen auf mehrere Stellen und führte zu einem unruhigen Bedienmodell.
- Kalenderexport, PDF-Download und E-Mail-Abo sollten einheitlich über die aktuelle Fraktionsauswahl gesteuert werden.
- Für den Kalenderexport fehlte bisher eine öffentliche Reminder-Projektion für kalenderfähige Slots.

## Nutzer- und Entwicklerauswirkung
- Nutzer sehen ein kompakteres, konsistenteres Aktionsmodell und können Fraktionen zentral für alle drei Aktionen steuern.
- Vergangene Termine bleiben in der Listenansicht am Ende unter eigener Headline sichtbar.
- Entwickler haben eine klarere kanalbezogene Reminder-Projektion für `email` und `calendar`.

## Root Cause
- Die alte Public-Waste-Ansicht koppelte Auswahl- und Aktionslogik nicht konsistent an dieselbe Fraktionsquelle.
- Der bisherige Public-Contract deckte Reminder-Daten nur für den E-Mail-Kanal ab.

## Validierung
- `pnpm nx run public-waste-calendar-web:test:types`
- `pnpm exec vitest run src/lib/public-waste-endpoints.server.test.ts src/lib/public-waste-repository.server.test.ts src/routes/index.test.tsx`
- `openspec validate update-public-waste-action-layout --strict`
