### PR TITLE
[codex] fix theme mode source of truth

### DIFF
--- a/apps/sva-studio-react/src/lib/theme.test.ts
+++ b/apps/sva-studio-react/src/lib/theme.test.ts
@@ -29,17 +29,18 @@ describe('theme helpers', () => {
     expect(resolveThemeMode('light', true)).toBe('light');
   });
 
-  it('uses system preference when no persisted theme mode exists', () => {
-    expect(resolveThemeMode(null, true)).toBe('dark');
+  it('uses the studio default when no persisted theme mode exists', () => {
+    expect(resolveThemeMode(null, true)).toBe('light');
     expect(resolveThemeMode(undefined, false)).toBe('light');
   });
 
-  it('creates a bootstrap script that applies the persisted or system mode before hydration', () => {
+  it('creates a bootstrap script that applies the persisted or default mode before hydration', () => {
     const bootstrapScript = createThemeBootstrapScript();
 
     expect(bootstrapScript).toContain(THEME_MODE_STORAGE_KEY);
     expect(bootstrapScript).toContain('root.dataset.themeMode=mode;');
     expect(bootstrapScript).toContain("root.classList.toggle('dark',mode==='dark');");
+    expect(bootstrapScript).not.toContain('matchMedia');
   });
 
   it('uses KERN-facing display names for the shell toggle and metadata', () => {

--- a/apps/sva-studio-react/src/lib/theme.test.ts
+++ b/apps/sva-studio-react/src/lib/theme.test.ts
@@ -25,13 +25,13 @@ describe('theme helpers', () => {
   });
 
   it('prefers persisted theme mode over system preference', () => {
-    expect(resolveThemeMode('dark', false)).toBe('dark');
-    expect(resolveThemeMode('light', true)).toBe('light');
+    expect(resolveThemeMode('dark')).toBe('dark');
+    expect(resolveThemeMode('light')).toBe('light');
   });
 
   it('uses the studio default when no persisted theme mode exists', () => {
-    expect(resolveThemeMode(null, true)).toBe('light');
-    expect(resolveThemeMode(undefined, false)).toBe('light');
+    expect(resolveThemeMode(null)).toBe('light');
+    expect(resolveThemeMode(undefined)).toBe('light');
   });
 
   it('creates a bootstrap script that applies the persisted or default mode before hydration', () => {

--- a/apps/sva-studio-react/src/lib/theme.ts
+++ b/apps/sva-studio-react/src/lib/theme.ts
@@ -22,13 +22,13 @@ export const resolveThemeName = (instanceId?: string): AppThemeName => {
 
 export const resolveThemeMode = (
   persistedMode: string | null | undefined,
-  prefersDarkMode: boolean
+  _prefersDarkMode: boolean
 ): ThemeMode => {
   if (isThemeMode(persistedMode)) {
     return persistedMode;
   }
 
-  return prefersDarkMode ? 'dark' : 'light';
+  return 'light';
 };
 
 export const createThemeBootstrapScript = (): string =>
@@ -38,8 +38,7 @@ export const createThemeBootstrapScript = (): string =>
     `var storageKey=${JSON.stringify(THEME_MODE_STORAGE_KEY)};`,
     'var persistedMode=null;',
     'try{persistedMode=window.localStorage.getItem(storageKey);}catch(error){}',
-    "var prefersDarkMode=typeof window.matchMedia==='function'&&window.matchMedia('(prefers-color-scheme: dark)').matches;",
-    "var mode=persistedMode==='light'||persistedMode==='dark'?persistedMode:(prefersDarkMode?'dark':'light');",
+    "var mode=persistedMode==='light'||persistedMode==='dark'?persistedMode:'light';",
     'root.dataset.themeMode=mode;',
     'root.style.colorScheme=mode;',
     "root.classList.toggle('dark',mode==='dark');",

--- a/apps/sva-studio-react/src/lib/theme.ts
+++ b/apps/sva-studio-react/src/lib/theme.ts
@@ -20,10 +20,7 @@ export const resolveThemeName = (instanceId?: string): AppThemeName => {
   return INSTANCE_THEME_MAP[instanceId] ?? DEFAULT_THEME_NAME;
 };
 
-export const resolveThemeMode = (
-  persistedMode: string | null | undefined,
-  _prefersDarkMode: boolean
-): ThemeMode => {
+export const resolveThemeMode = (persistedMode: string | null | undefined): ThemeMode => {
   if (isThemeMode(persistedMode)) {
     return persistedMode;
   }

--- a/apps/sva-studio-react/src/providers/theme-provider.test.tsx
+++ b/apps/sva-studio-react/src/providers/theme-provider.test.tsx
@@ -66,7 +66,7 @@ describe('ThemeProvider', () => {
     document.documentElement.style.colorScheme = '';
   });
 
-  it('resolves the theme variant from instanceId and applies dark mode preference', async () => {
+  it('resolves the theme variant from instanceId and applies the studio default mode without a persisted choice', async () => {
     useAuthMock.mockReturnValue({
       user: {
         id: 'user-1',
@@ -86,12 +86,12 @@ describe('ThemeProvider', () => {
       expect(screen.getByTestId('theme-name').textContent).toBe('sva-forest');
     });
 
-    expect(screen.getByTestId('theme-mode').textContent).toBe('dark');
+    expect(screen.getByTestId('theme-mode').textContent).toBe('light');
     expect(screen.getByTestId('theme-label').textContent).toBe('KERN Studio Wald');
     expect(document.documentElement.dataset.theme).toBe('sva-forest');
-    expect(document.documentElement.dataset.themeMode).toBe('dark');
-    expect(document.documentElement.style.colorScheme).toBe('dark');
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.dataset.themeMode).toBe('light');
+    expect(document.documentElement.style.colorScheme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
   it('uses persisted theme mode and can toggle it', async () => {

--- a/apps/sva-studio-react/src/providers/theme-provider.tsx
+++ b/apps/sva-studio-react/src/providers/theme-provider.tsx
@@ -18,14 +18,6 @@ type ThemeProviderProps = Readonly<{
 const ThemeContext = React.createContext<ThemeContextValue | null>(null);
 const useIsomorphicLayoutEffect = typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
 
-const getSystemDarkModePreference = (): boolean => {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false;
-  }
-
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
-};
-
 const applyThemeToDocument = (themeName: AppThemeName, mode: ThemeMode): void => {
   if (typeof document === 'undefined') {
     return;
@@ -47,7 +39,7 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
     }
 
     const persistedMode = window.localStorage.getItem(THEME_MODE_STORAGE_KEY);
-    return resolveThemeMode(persistedMode, getSystemDarkModePreference());
+    return resolveThemeMode(persistedMode, false);
   });
 
   useIsomorphicLayoutEffect(() => {

--- a/apps/sva-studio-react/src/providers/theme-provider.tsx
+++ b/apps/sva-studio-react/src/providers/theme-provider.tsx
@@ -39,7 +39,7 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
     }
 
     const persistedMode = window.localStorage.getItem(THEME_MODE_STORAGE_KEY);
-    return resolveThemeMode(persistedMode, false);
+    return resolveThemeMode(persistedMode);
   });
 
   useIsomorphicLayoutEffect(() => {

--- a/deploy/keycloak/themes/sva-kern2/theme/sva-kern2/login/resources/css/kern2.css
+++ b/deploy/keycloak/themes/sva-kern2/theme/sva-kern2/login/resources/css/kern2.css
@@ -245,36 +245,3 @@ a:hover,
     backdrop-filter: none;
   }
 }
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --sva-kern2-background: #121314;
-    --sva-kern2-background-strong: #1a1c1f;
-    --sva-kern2-surface: rgba(25, 26, 27, 0.92);
-    --sva-kern2-surface-border: rgba(36, 37, 38, 0.95);
-    --sva-kern2-text: #efefef;
-    --sva-kern2-text-muted: #b5bcc6;
-    --sva-kern2-primary: #297aa0;
-    --sva-kern2-primary-hover: #3994bc;
-    --sva-kern2-primary-soft: rgba(57, 148, 188, 0.12);
-    --sva-kern2-danger: #f48771;
-    --sva-kern2-shadow: 0 24px 64px rgba(0, 0, 0, 0.36);
-    --sva-kern2-shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.28);
-    --pf-v5-global--primary-color--100: var(--sva-kern2-primary);
-    --pf-v5-global--primary-color--200: var(--sva-kern2-primary-hover);
-  }
-
-  body.kcBodyClass {
-    background:
-      radial-gradient(circle at top left, rgba(41, 122, 160, 0.22), transparent 34%),
-      radial-gradient(circle at bottom right, rgba(30, 215, 166, 0.08), transparent 26%),
-      linear-gradient(180deg, var(--sva-kern2-background-strong) 0%, var(--sva-kern2-background) 100%);
-  }
-
-  .pf-v5-c-form-control,
-  input.kcInputClass,
-  select.kcSelectClass,
-  textarea.kcInputClass {
-    background: rgba(32, 33, 34, 0.92);
-  }
-}

--- a/docs/development/ui-shell-theming.md
+++ b/docs/development/ui-shell-theming.md
@@ -17,6 +17,7 @@ Die Layout-Shell von `apps/sva-studio-react` verwendet semantische Design-Tokens
 - Theme-Auswahl erfolgt zentral über `ThemeProvider` und `src/lib/theme.ts`.
 - `instanceId` bestimmt optional die Theme-Variante; unbekannte Werte fallen auf `sva-default` zurück.
 - Light-/Dark-Mode bleibt ein separater Modus und darf nicht über Theme-Namen kodiert werden.
+- Ohne gespeicherte Studio-Auswahl fällt der Light-/Dark-Mode auf den Studio-Default `light` zurück, nicht auf Browser- oder Betriebssystem-Präferenzen.
 
 ## KERN-2 Phase 1
 
@@ -37,7 +38,7 @@ Die Layout-Shell von `apps/sva-studio-react` verwendet semantische Design-Tokens
 - Die restriktivere Shell-Geometrie ist umgesetzt: `--radius` 6px, `--radius-card` 8px und `--radius-modal` 12px bilden die Basis für Shell-Flächen, Dialoge und Karten.
 - Die grüne Linie bleibt über `sva-forest` als separate Instanzvariante erhalten; die öffentlichen Runtime-Theme-IDs wurden bewusst nicht umbenannt.
 - `@kern-ux/native` ist aktuell ausschließlich als Font-Quelle eingebunden. Verwendet wird nur `@kern-ux/native/dist/fonts/fira-sans.css`; ein globaler KERN-CSS-Reset oder KERN-Komponenten-CSS wird weiterhin nicht geladen.
-- Das Root-Dokument setzt den Theme-Modus vor dem ersten Paint per Bootstrap-Skript. Der `ThemeProvider` synchronisiert `data-theme`, `data-theme-mode`, `color-scheme` und die `dark`-Klasse anschließend per Layout-Effekt, um den initialen Theme-Flicker zu vermeiden.
+- Das Root-Dokument setzt den Theme-Modus vor dem ersten Paint per Bootstrap-Skript aus der gespeicherten Studio-Auswahl oder dem festen Studio-Default `light`. Der `ThemeProvider` synchronisiert `data-theme`, `data-theme-mode`, `color-scheme` und die `dark`-Klasse anschließend per Layout-Effekt, um den initialen Theme-Flicker zu vermeiden.
 - Die Shell-Bausteine `__root.tsx`, `AppShell`, `Header` und `Sidebar` sowie die Shared-Flächen `StudioFilterSurface`, `StudioSummaryCard` und `StudioTableSurface` verwenden den semantischen Token-Satz bereits produktiv.
 - Die KERN-2-Phase-1-Anpassung ist damit für Foundations, Shell und ausgewählte Admin-/Monitoring-Flächen umgesetzt. Dark-Mode bleibt funktional und regressionssicher, ist aber noch keine vollständige KERN-2-Dunkelvariante.
 - Nicht Teil von Phase 1 bleiben vorerst das vollständige Reskinning aller Shared Form-Primitives sowie tiefe fachliche Detailseiten außerhalb des Shell-nahen Bereichs.

--- a/docs/guides/keycloak-login-theme-kern2.md
+++ b/docs/guides/keycloak-login-theme-kern2.md
@@ -10,7 +10,7 @@ Das Theme orientiert sich an der bestehenden KERN-2-nahen Studio-Shell:
 - KERN-nahe Blau-Grau-Palette
 - reduzierte Radien
 - helle Glas-/Panel-Flächen mit klarer Fokus- und Hover-Sprache
-- Dark-Mode-Fallback über `prefers-color-scheme`
+- fester Light-Default ohne Dark-Mode-Fallback über Browser- oder Betriebssystem-Präferenzen
 
 Das Theme erweitert bewusst `keycloak.v2`, statt komplette Keycloak-Templates zu forken.
 Dadurch bleibt der Upgrade-Aufwand gegenüber einem vollständigen Login-Template-Override kleiner.

--- a/scripts/ops/keycloak-theme-kern2.test.ts
+++ b/scripts/ops/keycloak-theme-kern2.test.ts
@@ -1,17 +1,17 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const keycloakThemeCssPath = resolve(
-  process.cwd(),
-  'deploy/keycloak/themes/sva-kern2/theme/sva-kern2/login/resources/css/kern2.css'
-);
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const keycloakThemeCssPath = resolve(workspaceRoot, 'deploy/keycloak/themes/sva-kern2/theme/sva-kern2/login/resources/css/kern2.css');
+const prefersColorSchemeDarkPattern = /@media\s*\(\s*prefers-color-scheme\s*:\s*dark\s*\)/i;
 
 describe('sva-kern2 keycloak login theme', () => {
   it('does not derive dark mode from browser or system preferences', () => {
     const cssSource = readFileSync(keycloakThemeCssPath, 'utf8');
 
-    expect(cssSource).not.toContain('@media (prefers-color-scheme: dark)');
+    expect(cssSource).not.toMatch(prefersColorSchemeDarkPattern);
   });
 });

--- a/scripts/ops/keycloak-theme-kern2.test.ts
+++ b/scripts/ops/keycloak-theme-kern2.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const keycloakThemeCssPath = resolve(
+  process.cwd(),
+  'deploy/keycloak/themes/sva-kern2/theme/sva-kern2/login/resources/css/kern2.css'
+);
+
+describe('sva-kern2 keycloak login theme', () => {
+  it('does not derive dark mode from browser or system preferences', () => {
+    const cssSource = readFileSync(keycloakThemeCssPath, 'utf8');
+
+    expect(cssSource).not.toContain('@media (prefers-color-scheme: dark)');
+  });
+});


### PR DESCRIPTION
## Was wurde geändert
- Studio-Shell-Theming fällt ohne gespeicherte Nutzerauswahl nicht mehr auf Browser- oder Betriebssystem-Präferenzen zurück.
- Das Keycloak-Login-Theme `sva-kern2` verwendet keinen `prefers-color-scheme`-Fallback mehr.
- Ein Regressionstest stellt sicher, dass das Keycloak-Theme keine Systempräferenz für Dark Mode auswertet.

## Warum
Light- und Dark-Mode sollen ausschließlich von der Auswahl im Studio selbst abhängen. Bisher konnte der Initialzustand ohne gespeicherte Auswahl vom System-Theme beeinflusst werden, wodurch unter anderem der Verlauf auf der Startseite vom OS abhing.

## Root Cause
Die Theme-Bootstrap-Logik und der `ThemeProvider` werteten bei fehlender persistierter Auswahl `prefers-color-scheme` aus. Zusätzlich enthielt das Keycloak-Theme einen eigenen CSS-basierten Dark-Mode-Fallback über `@media (prefers-color-scheme: dark)`.

## Auswirkungen
- Konsistenter Initialzustand für Studio-Shell und Startseite: Default ist jetzt explizit `light`, bis eine Studio-Auswahl gespeichert ist.
- Das Keycloak-Login-Theme bleibt im festen Light-Default, statt Dark Mode aus Browser-/Systemeinstellungen abzuleiten.

## Validierung
- `pnpm exec vitest run apps/sva-studio-react/src/lib/theme.test.ts`
- `pnpm exec vitest run apps/sva-studio-react/src/providers/theme-provider.test.tsx --config apps/sva-studio-react/vitest.ui.config.ts`
- `pnpm exec vitest run scripts/ops/keycloak-theme-kern2.test.ts`
- `pnpm check:file-placement`
