### PR TITLE
fix(auth-runtime): preserve existing keycloak client access settings during reconciliation

### DIFF
--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -524,6 +524,51 @@ describe('Keycloak admin client', () => {
     expect(String(rotateCall?.[0])).toContain('/clients/client-1/client-secret');
   });
 
+  it('preserves existing OIDC client access settings when adding missing redirect and origin entries', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(
+        createJsonResponse(200, [
+          {
+            id: 'client-1',
+            clientId: 'web-app',
+            rootUrl: 'https://new.example',
+            redirectUris: ['https://legacy.example/callback'],
+            webOrigins: ['https://legacy.example'],
+            attributes: { 'post.logout.redirect.uris': 'https://legacy.example/logout' },
+          },
+        ])
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const client = await createClient(fetchImpl);
+
+    await client.ensureOidcClient({
+      clientId: 'web-app',
+      redirectUris: ['https://new.example/callback'],
+      postLogoutRedirectUris: ['https://new.example/logout'],
+      webOrigins: ['https://new.example'],
+      rootUrl: 'https://new.example',
+    });
+
+    const updateCall = fetchImpl.mock.calls.find(
+      (call) => String(call[0]).includes('/clients/client-1') && call[1]?.method === 'PUT'
+    );
+    expect(updateCall).toBeDefined();
+    const body = JSON.parse(String(updateCall?.[1]?.body)) as {
+      redirectUris?: string[];
+      webOrigins?: string[];
+      attributes?: { 'post.logout.redirect.uris'?: string };
+    };
+    expect(body.redirectUris).toEqual(['https://legacy.example/callback', 'https://new.example/callback']);
+    expect(body.webOrigins).toEqual(['https://legacy.example', 'https://new.example']);
+    expect(body.attributes?.['post.logout.redirect.uris']?.split('##')).toEqual([
+      'https://legacy.example/logout',
+      'https://new.example/logout',
+    ]);
+  });
+
   it('grants required realm-management client roles to the tenant admin service account', async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/auth-runtime/src/keycloak-admin-client/core.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.ts
@@ -230,6 +230,11 @@ const toSortedUniqueStrings = (values: readonly string[] | undefined): string[] 
     left.localeCompare(right)
   );
 
+const mergeSortedUniqueStrings = (
+  left: readonly string[] | undefined,
+  right: readonly string[] | undefined
+): string[] => toSortedUniqueStrings([...(left ?? []), ...(right ?? [])]);
+
 const areStringSetsEqual = (left: readonly string[] | undefined, right: readonly string[] | undefined): boolean => {
   const normalizedLeft = toSortedUniqueStrings(left);
   const normalizedRight = toSortedUniqueStrings(right);
@@ -1133,17 +1138,21 @@ export class KeycloakAdminClient implements IdentityProviderPort {
       standardFlowEnabled: input.standardFlowEnabled ?? true,
       directAccessGrantsEnabled: input.directAccessGrantsEnabled ?? false,
       serviceAccountsEnabled: input.serviceAccountsEnabled ?? false,
-      redirectUris: [...toSortedUniqueStrings(input.redirectUris)],
-      webOrigins: [...toSortedUniqueStrings(input.webOrigins)],
+      redirectUris: mergeSortedUniqueStrings(existing?.redirectUris, input.redirectUris),
+      webOrigins: mergeSortedUniqueStrings(existing?.webOrigins, input.webOrigins),
       attributes: {
-        'post.logout.redirect.uris': toSortedUniqueStrings(input.postLogoutRedirectUris).join('##'),
+        ...existing?.attributes,
+        'post.logout.redirect.uris': mergeSortedUniqueStrings(
+          readPostLogoutRedirectUris(existing?.attributes),
+          input.postLogoutRedirectUris
+        ).join('##'),
       },
       rootUrl: input.rootUrl,
       baseUrl: '/',
       adminUrl: input.rootUrl,
     };
 
-    await this.upsertOidcClient(existing, payload, input.clientId, input.postLogoutRedirectUris);
+    await this.upsertOidcClient(existing, payload, input.clientId);
     await this.syncOidcClientSecret(existing, input);
   }
 
@@ -1165,8 +1174,7 @@ export class KeycloakAdminClient implements IdentityProviderPort {
       baseUrl: string;
       adminUrl: string;
     },
-    clientId: string,
-    postLogoutRedirectUris: readonly string[]
+    clientId: string
   ): Promise<void> {
     if (!existing) {
       await this.createOidcClient(payload, clientId);
@@ -1179,7 +1187,10 @@ export class KeycloakAdminClient implements IdentityProviderPort {
       existing.serviceAccountsEnabled !== payload.serviceAccountsEnabled ||
       !areStringSetsEqual(existing.redirectUris, payload.redirectUris) ||
       !areStringSetsEqual(existing.webOrigins, payload.webOrigins) ||
-      !areStringSetsEqual(readPostLogoutRedirectUris(existing.attributes), postLogoutRedirectUris);
+      !areStringSetsEqual(
+        readPostLogoutRedirectUris(existing.attributes),
+        readPostLogoutRedirectUris(payload.attributes)
+      );
     if (requiresUpdate) {
       await this.updateOidcClient(existing, payload, clientId);
     }


### PR DESCRIPTION
Beim Anlegen bzw. Abgleichen von Instanzen mit bereits vorhandenen Keycloak-Clients wurden bestehende Zugriffseinstellungen bislang vollständig überschrieben. Dadurch konnten bereits gepflegte Einträge in `Valid redirect URIs`, `Valid post logout redirect URIs` und `Web Origins` verloren gehen.

Diese Änderung stellt sicher, dass vorhandene Client-Konfigurationen erhalten bleiben und nur fehlende Soll-Werte ergänzt werden.

## Änderungen

- bestehende `redirectUris` werden mit den erwarteten Werten zusammengeführt statt ersetzt
- bestehende `webOrigins` werden mit den erwarteten Werten zusammengeführt statt ersetzt
- bestehende `post.logout.redirect.uris` werden mit den erwarteten Werten zusammengeführt statt ersetzt
- bestehende sonstige Client-Attribute bleiben beim Update erhalten
- die Drift-Prüfung berücksichtigt nun die zusammengeführte Post-Logout-URI-Menge, damit keine unnötigen `PUT`-Updates ausgelöst werden
- Regressionstest für vorhandene Clients mit Legacy-/Bestandswerten ergänzt

## Problem

Für bereits existierende Keycloak-Clients war das bisherige Verhalten zu destruktiv:
- manuell gepflegte oder historisch gewachsene Zugriffseinstellungen wurden entfernt
- Instanz-Provisionierung konnte bestehende, gültige Client-Konfiguration unbeabsichtigt verschlechtern
- der Abgleich war nicht robust gegenüber vorab vorhandenen zusätzlichen Einträgen

## Lösung

Beim Reconciliation-Update werden vorhandene und benötigte Werte nun dedupliziert vereinigt. Dadurch bleibt bestehende Konfiguration erhalten, während die für die Instanz erforderlichen Einträge weiterhin sichergestellt werden.

## Auswirkungen

- sichereres Provisioning für Instanzen mit bereits existierenden Keycloak-Clients
- keine unbeabsichtigte Entfernung vorhandener Redirect-/Logout-/Origin-Konfiguration
- weiterhin idempotentes Verhalten beim Client-Abgleich

## Tests

- Regressionstest für das Beibehalten bestehender Zugriffseinstellungen ergänzt
- `pnpm nx run auth-runtime:test:unit --testFiles=src/keycloak-admin-client/core.test.ts -t "preserves existing OIDC client access settings"`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run auth-runtime:check:runtime`
- `pnpm nx run auth-runtime:lint`