### PR TITLE
[codex] Cascade role deletions and clear related warnings

### DIFF
--- a/apps/sva-studio-react/src/i18n/resources/de/admin/roles.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/admin/roles.resources.ts
@@ -110,7 +110,8 @@ export const rolesAdminDEResources = {
   },
   confirm: {
     deleteTitle: 'Rolle löschen',
-    deleteDescription: 'Die Rolle wird dauerhaft gelöscht, sofern keine Abhängigkeiten bestehen.',
+    deleteDescription:
+      'Beim Löschen werden bestehende Benutzer- und Gruppenzuordnungen dieser Rolle entfernt und anschließend die Rolle dauerhaft gelöscht.',
   },
   sync: {
     synced: 'Synchronisiert',

--- a/apps/sva-studio-react/src/i18n/resources/en/admin/roles.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/admin/roles.resources.ts
@@ -110,7 +110,8 @@ export const rolesAdminENResources = {
   },
   confirm: {
     deleteTitle: 'Delete role',
-    deleteDescription: 'The role is deleted permanently if no dependencies exist.',
+    deleteDescription:
+      'Deleting this role removes its existing user and group assignments first and then deletes the role permanently.',
   },
   sync: {
     synced: 'Synced',

--- a/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.test.ts
+++ b/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.test.ts
@@ -1,6 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { decodeBucketMediaId, encodeBucketMediaId } from './-media-ui.shared.js';
+
+const mediaUiSharedSourcePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  './-media-ui.shared.tsx'
+);
 
 describe('bucket media id encoding', () => {
   it('round-trips non-ascii storage keys', () => {
@@ -9,5 +18,14 @@ describe('bucket media id encoding', () => {
     const encoded = encodeBucketMediaId(storageKey);
 
     expect(decodeBucketMediaId(encoded)).toBe(storageKey);
+  });
+
+  it('avoids legacy char-code and regex replacement helpers in the base64url fallback', () => {
+    const source = fs.readFileSync(mediaUiSharedSourcePath, 'utf8');
+
+    expect(source).not.toContain('String.fromCharCode');
+    expect(source).not.toContain('.charCodeAt(');
+    expect(source).not.toContain('.replace(/\\+/g,');
+    expect(source).not.toContain('.replace(/\\//g,');
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.tsx
@@ -9,13 +9,14 @@ const textDecoder = new TextDecoder();
 const bytesToBase64 = (bytes: Uint8Array): string => {
   let binary = '';
   for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
+    binary += String.fromCodePoint(byte);
   }
 
   return btoa(binary);
 };
 
-const base64ToBytes = (value: string): Uint8Array => Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+const base64ToBytes = (value: string): Uint8Array =>
+  Uint8Array.from(atob(value), (char) => char.codePointAt(0) ?? 0);
 
 const encodeBase64Url = (value: string): string => {
   if (typeof Buffer !== 'undefined') {
@@ -23,8 +24,8 @@ const encodeBase64Url = (value: string): string => {
   }
 
   return bytesToBase64(textEncoder.encode(value))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
     .replace(/=+$/g, '');
 };
 
@@ -33,7 +34,7 @@ const decodeBase64Url = (value: string): string => {
     return Buffer.from(value, 'base64url').toString('utf-8');
   }
 
-  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const normalized = value.replaceAll('-', '+').replaceAll('_', '/');
   const padding = normalized.length % 4 === 0 ? '' : '='.repeat(4 - (normalized.length % 4));
   return textDecoder.decode(base64ToBytes(`${normalized}${padding}`));
 };

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.test.tsx
@@ -241,6 +241,11 @@ describe('RolesPage', () => {
     expect(row).toBeTruthy();
     fireEvent.click(within(row!).getByRole('button', { name: 'Rolle löschen' }));
     const dialog = screen.getByRole('alertdialog', { name: 'Rolle löschen' });
+    expect(
+      within(dialog).getByText(
+        'Beim Löschen werden bestehende Benutzer- und Gruppenzuordnungen dieser Rolle entfernt und anschließend die Rolle dauerhaft gelöscht.'
+      )
+    ).toBeTruthy();
     fireEvent.click(within(dialog).getByRole('button', { name: 'Rolle löschen' }));
 
     expect(deleteRole).toHaveBeenCalledWith('role-custom');

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx
@@ -19,7 +19,13 @@ import type { RoleReconcileReport } from '../../../lib/iam-api';
 import { hasPlatformInstanceAdminAccess } from '../../../lib/iam-admin-access';
 import { isTenantRoleReadOnly, isTenantRoleVisible } from '../../../lib/iam-role-governance';
 import { IamRuntimeDiagnosticDetails } from '../-iam-runtime-diagnostic-details';
-import { roleErrorMessage, roleStatusLabel, roleStatusTone, roleTypeLabel } from './-roles-shared';
+import {
+  getRoleDeleteConfirmationContent,
+  roleErrorMessage,
+  roleStatusLabel,
+  roleStatusTone,
+  roleTypeLabel,
+} from './-roles-shared';
 
 const RECONCILE_OUTCOME_LABEL_KEYS = {
   success: 'admin.roles.messages.reconcileOutcome.success',
@@ -48,6 +54,7 @@ export const RolesPage = () => {
 
   const [search, setSearch] = React.useState('');
   const [deleteRoleId, setDeleteRoleId] = React.useState<string | null>(null);
+  const deleteConfirmation = getRoleDeleteConfirmationContent();
   const visibleRoles = React.useMemo(
     () => (isPlatformScope ? rolesApi.roles : rolesApi.roles.filter((role) => isTenantRoleVisible(role))),
     [isPlatformScope, rolesApi.roles]
@@ -302,9 +309,9 @@ export const RolesPage = () => {
 
       <ConfirmDialog
         open={Boolean(deleteRoleId)}
-        title={t('admin.roles.confirm.deleteTitle')}
-        description={t('admin.roles.confirm.deleteDescription')}
-        confirmLabel={t('admin.roles.actions.delete')}
+        title={deleteConfirmation.title}
+        description={deleteConfirmation.description}
+        confirmLabel={deleteConfirmation.confirmLabel}
         cancelLabel={t('account.actions.cancel')}
         onCancel={() => setDeleteRoleId(null)}
         onConfirm={() => {

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-shared.test.ts
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-shared.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRoleDeleteConfirmationContent } from './-roles-shared';
+
+describe('role shared helpers', () => {
+  it('returns the centralized delete confirmation content for cascading role removal', () => {
+    expect(getRoleDeleteConfirmationContent()).toEqual({
+      title: 'Rolle löschen',
+      description:
+        'Beim Löschen werden bestehende Benutzer- und Gruppenzuordnungen dieser Rolle entfernt und anschließend die Rolle dauerhaft gelöscht.',
+      confirmLabel: 'Rolle löschen',
+    });
+  });
+});

--- a/apps/sva-studio-react/src/routes/admin/roles/-roles-shared.ts
+++ b/apps/sva-studio-react/src/routes/admin/roles/-roles-shared.ts
@@ -58,6 +58,16 @@ export const roleTypeLabel = (role: RoleSummary): string => {
   return t('admin.roles.labels.customRole');
 };
 
+export const getRoleDeleteConfirmationContent = (): Readonly<{
+  title: string;
+  description: string;
+  confirmLabel: string;
+}> => ({
+  title: t('admin.roles.confirm.deleteTitle'),
+  description: t('admin.roles.confirm.deleteDescription'),
+  confirmLabel: t('admin.roles.actions.delete'),
+});
+
 export const roleErrorMessage = (
   error: IamHttpError | null,
   fallbackKey: TranslationKey,

--- a/docs/api/iam-v1.yaml
+++ b/docs/api/iam-v1.yaml
@@ -1173,6 +1173,7 @@ paths:
                 $ref: '#/components/schemas/RoleMutationResponse'
     delete:
       summary: Custom-Rolle loeschen
+      description: Entfernt vorhandene direkte Benutzer- und Gruppenzuordnungen der Rolle und loescht anschliessend die studioverwaltete Rolle.
       parameters:
         - name: roleId
           in: path

--- a/docs/api/iam-v1.yaml
+++ b/docs/api/iam-v1.yaml
@@ -1172,8 +1172,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/RoleMutationResponse'
     delete:
-      summary: Custom-Rolle loeschen
-      description: Entfernt vorhandene direkte Benutzer- und Gruppenzuordnungen der Rolle und loescht anschliessend die studioverwaltete Rolle.
+      summary: Custom-Rolle löschen
+      description: Entfernt vorhandene direkte Benutzer- und Gruppenzuordnungen der Rolle und löscht anschließend die studioverwaltete Rolle.
       parameters:
         - name: roleId
           in: path

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -564,9 +564,10 @@ Fehlerpfad:
 5. `system_admin` verwaltet Custom-Rollen auf `/admin/roles` mit `POST/PATCH/DELETE /api/v1/iam/roles`.
 6. Auf Tenant-Hosts löst der Backend-Service den Adminpfad strikt aus `iam.instances.authRealm` plus `tenantAdminClient.clientId` und tenantlokalem Admin-Secret auf und führt Rollen- und Nutzer-CRUD Keycloak-First innerhalb desselben Tenant-Realms aus.
 7. Root-/Plattform-Pfade verwenden einen separaten Plattform-Admin-Client nur für Instanz-Provisioning, Reconcile und explizites Break-Glass.
-8. Nach erfolgreichem Tenant-Sync schreibt der Service das lokale IAM-Mapping.
-9. Bei Erfolg werden `role.sync_succeeded` und `role.created|updated|deleted` auditierbar protokolliert.
-10. Bei Fehlern werden `sync_state`, `last_error_code`, Metriken und `role.sync_failed` aktualisiert.
+8. Beim Löschen einer Custom-Rolle entfernt der Service nach erfolgreichem Tenant-Sync zuerst direkte Benutzer- und Gruppenzuordnungen der Rolle und danach das lokale IAM-Mapping.
+9. Die Admin-UI zeigt vor dem Bestätigen nur eine allgemeine Warnung an, dass damit auch bestehende Benutzer- und Gruppenzuordnungen entfernt werden.
+10. Bei Erfolg werden `role.sync_succeeded` und `role.created|updated|deleted` auditierbar protokolliert; der Löschpfad ergänzt dabei Zähler für entfernte Benutzer- und Gruppenzuordnungen.
+11. Bei Fehlern werden `sync_state`, `last_error_code`, Metriken und `role.sync_failed` aktualisiert.
 
 Fehlerpfad:
 

--- a/docs/guides/iam-service-api-dokumentation.md
+++ b/docs/guides/iam-service-api-dokumentation.md
@@ -95,6 +95,9 @@ Diese Anleitung beschreibt die aktuell stabilen IAM-v1-Endpunkte, Response-Envel
   - akzeptiert dieselbe additive `permissionAssignments[]`-Struktur wie `POST`
   - nicht scope-fähige Permissions bleiben binäre Zuweisungen; ein mitgesendeter `accessScope` wird serverseitig auf `all` normalisiert
 - `DELETE /api/v1/iam/roles/{roleId}`
+  - entfernt bestehende direkte Benutzer- und Gruppenzuordnungen der Rolle implizit mit, bevor die Rolle selbst gelöscht wird
+  - der Response bleibt das normale Rollen-Mutationsmodell; die Löschwirkung wird über Audit-Events und Aktivitätslogs nachvollziehbar gemacht
+  - die Admin-UI kündigt diesen Kaskadeneffekt vor dem Bestätigen allgemein an, ohne zusätzliche Sonderfälle oder Vorbedingungen einzuführen
 
 ### Groups
 

--- a/docs/guides/keycloak-rollen-sync-runbook.md
+++ b/docs/guides/keycloak-rollen-sync-runbook.md
@@ -39,11 +39,12 @@ Empfohlene Startwerte:
 
 1. `POST /api/v1/iam/roles` legt zuerst die Realm-Rolle in Keycloak an und schreibt danach das DB-Mapping.
 2. `PATCH /api/v1/iam/roles/:id` aktualisiert zuerst Keycloak und dann das DB-Mapping.
-3. `DELETE /api/v1/iam/roles/:id` entfernt zuerst die Realm-Rolle in Keycloak und danach die DB-Datensätze.
+3. `DELETE /api/v1/iam/roles/:id` entfernt zuerst die Realm-Rolle in Keycloak und danach im Tenant alle direkten Benutzerzuordnungen (`iam.account_roles`), Gruppenzuordnungen (`iam.group_roles`) und die verbleibenden Rollen-Datensätze.
 4. Bei erfolgreichem Abschluss wird `sync_state = 'synced'` gesetzt.
-5. Bei Fehlern setzt der Service `sync_state = 'failed'`, schreibt `last_error_code` und emittiert Audit-Events.
-6. Falls der synchrone Pfad nach erfolgreichem Keycloak-Schritt an der DB scheitert, läuft eine Compensation.
-7. Idempotency für mutierende Endpunkte ist pro Mandant isoliert (`instance_id`, `actor_account_id`, `endpoint`, `idempotency_key`) und verhindert damit Kollisionen über Instanzgrenzen.
+5. Die Bestätigung in der Admin-UI warnt allgemein davor, dass vorhandene Benutzer- und Gruppenzuordnungen mit entfernt werden.
+6. Bei Fehlern setzt der Service `sync_state = 'failed'`, schreibt `last_error_code` und emittiert Audit-Events.
+7. Falls der synchrone Pfad nach erfolgreichem Keycloak-Schritt an der DB scheitert, läuft eine Compensation.
+8. Idempotency für mutierende Endpunkte ist pro Mandant isoliert (`instance_id`, `actor_account_id`, `endpoint`, `idempotency_key`) und verhindert damit Kollisionen über Instanzgrenzen.
 
 ## Sync-Zustände
 
@@ -166,6 +167,11 @@ Pflichtfelder:
 - `request_id`
 - `trace_id` optional
 - `span_id` optional
+
+Zusatzfelder beim Rollenlöschen:
+
+- `removed_account_role_assignments`
+- `removed_group_role_assignments`
 
 Redaktionsregeln:
 

--- a/docs/superpowers/plans/2026-06-17-iam-role-delete-cascade-assignments.md
+++ b/docs/superpowers/plans/2026-06-17-iam-role-delete-cascade-assignments.md
@@ -1,0 +1,43 @@
+# IAM Role Delete Cascade Assignments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rollenlöschung soll direkte Benutzer- und Gruppenzuordnungen implizit entfernen und die UI soll diesen Kaskadeneffekt klar ankündigen.
+
+**Architecture:** Der bestehende Delete-Flow bleibt Keycloak-first, erweitert aber die lokale Persistenz um deterministisches Aufräumen von `iam.account_roles` und `iam.group_roles`, bevor `iam.roles` entfernt wird. Die Rollenliste behält ihren bestehenden Bestätigungsdialog, bekommt aber eine präzisere Warnformulierung.
+
+**Tech Stack:** TypeScript, React, Vitest, Nx, OpenSpec
+
+---
+
+### Task 1: Spezifikation und Persistenzpfad anpassen
+
+**Files:**
+- Modify: `openspec/changes/update-iam-role-delete-cascade-assignments/specs/iam-core/spec.md`
+- Modify: `packages/iam-admin/src/role-mutation-persistence.ts`
+- Test: `packages/iam-admin/src/role-mutation-persistence.test.ts`
+
+- [ ] Bestehende Delete-Schutzregel durch Kaskadenlöschung für `iam.account_roles` und `iam.group_roles` ersetzen
+- [ ] Persistenztest auf SQL-Reihenfolge und Wegfall des Konflikts für bestehende Zuweisungen anpassen
+
+### Task 2: Delete-Handler und UI-Texte anpassen
+
+**Files:**
+- Modify: `apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx`
+- Modify: `apps/sva-studio-react/src/routes/admin/roles/-roles-page.test.tsx`
+- Modify: `apps/sva-studio-react/src/i18n/resources/de/admin/roles.resources.ts`
+- Modify: `apps/sva-studio-react/src/i18n/resources/en/admin/roles.resources.ts`
+
+- [ ] Warnhinweis im Delete-Dialog auf Kaskadenlöschung umformulieren
+- [ ] UI-Test auf den neuen Hinweis und unveränderten Delete-Call anpassen
+
+### Task 3: Dokumentation und gezielte Verifikation
+
+**Files:**
+- Modify: `docs/guides/keycloak-rollen-sync-runbook.md`
+- Modify: `docs/guides/iam-service-api-dokumentation.md`
+- Modify: `docs/api/iam-v1.yaml`
+- Modify: `docs/architecture/06-runtime-view.md`
+
+- [ ] Doku auf kaskadierendes Entfernen von User- und Gruppenzuordnungen vor dem Rollendelete aktualisieren
+- [ ] Relevante Vitest-/Nx-Targets und OpenSpec-Validierung ausführen

--- a/openspec/changes/update-iam-role-delete-cascade-assignments/proposal.md
+++ b/openspec/changes/update-iam-role-delete-cascade-assignments/proposal.md
@@ -1,0 +1,17 @@
+# Change: Rollenlöschung kaskadiert über Benutzer- und Gruppen-Zuordnungen
+
+## Why
+
+Der aktuelle Rollenlöschpfad blockiert Custom-Rollen, solange direkte Benutzerzuordnungen bestehen. Das erzeugt unnötige Reibung in der Administration, obwohl die gewünschte Fachsemantik lautet, dass beim bestätigten Löschen auch die bestehenden Rollenzuordnungen entfernt werden.
+
+## What Changes
+
+- `DELETE /api/v1/iam/roles/:id` entfernt vor dem eigentlichen Rollendelete alle direkten Benutzerzuordnungen und Gruppenzuordnungen der Rolle im aktiven Tenant.
+- Die Rollenverwaltung weist im Bestätigungsdialog darauf hin, dass Rollenzuordnungen und die Rolle selbst gelöscht werden.
+- Tests, API-Doku und Betriebsdokumentation werden auf die neue Löschsemantik angepasst.
+
+## Impact
+
+- Affected specs: `iam-core`, `account-ui`
+- Affected code: `packages/iam-admin/src/role-mutation-persistence.ts`, `packages/iam-admin/src/role-delete-handler.ts`, `apps/sva-studio-react/src/routes/admin/roles/-roles-page.tsx`
+- Affected arc42 sections: `docs/architecture/06-runtime-view.md`

--- a/openspec/changes/update-iam-role-delete-cascade-assignments/specs/account-ui/spec.md
+++ b/openspec/changes/update-iam-role-delete-cascade-assignments/specs/account-ui/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Rollen-Verwaltungsseite
+
+Das System MUST eine Rollen-Verwaltungsseite unter `/admin/roles` bereitstellen, die das Anzeigen und Bearbeiten von System- und Custom-Rollen ermöglicht.
+
+#### Scenario: Rollenansicht bleibt der zentrale Einstieg für Rechtepflege
+
+- **WENN** ein Administrator `/admin/roles` öffnet
+- **DANN** bleibt die Rollenliste mit Suche, Sortierung, Rollenmetadaten und Aktionen der primäre Einstiegspunkt
+- **UND** Rollenrechte werden innerhalb derselben Seite oder desselben Bedienflusses vertieft statt in ein separates Top-Level-Modul ausgelagert
+- **UND** die bestehende Expand-, Detail- oder gleichwertige Arbeitsbereichslogik bleibt mit vorhandenen Admin-Patterns konsistent
+
+#### Scenario: Detailroute bleibt Teil desselben Rollenverwaltungsflusses
+
+- **WENN** eine Rolle aus der Rollenliste in einen vertieften Arbeitsbereich geöffnet wird
+- **DANN** ist eine dedizierte Detailroute wie `/admin/roles/$roleId` zulässig, sofern sie Teil desselben Rollenverwaltungsflusses bleibt
+- **UND** die Rollenliste weiterhin der primäre Einstiegspunkt ist
+- **UND** kein separates Top-Level-Admin-Modul für Rechtepflege entsteht
+
+#### Scenario: Rollenmetadaten und Editierbarkeit sind eindeutig sichtbar
+
+- **WENN** eine Rolle in der Rollenansicht dargestellt wird
+- **DANN** sind mindestens `externalRoleName`, `managedBy`, `roleLevel`, Sync-Zustand und Mitgliederzahl sichtbar
+- **UND** System-Rollen und extern verwaltete Rollen sind als read-only kenntlich
+- **UND** destruktive oder fachlich nicht zulässige Aktionen sind nicht nur deaktiviert, sondern auch verständlich begründet
+
+#### Scenario: Rollenrechte werden fachlich lesbarer dargestellt
+
+- **WENN** ein Administrator die Rechte einer Rolle öffnet
+- **DANN** priorisiert die UI fachliche Bezeichnungen, Gruppierungen oder Beschreibungen der Rechte
+- **UND** technische Werte wie `permissionKey` bleiben höchstens ergänzende Detailinformation
+- **UND** die Oberfläche zwingt Administratoren nicht zur ausschließlichen Interpretation roher technischer Schlüssel
+
+#### Scenario: Rollenansicht verzahnt sich mit bestehender IAM-Prüfung
+
+- **WENN** ein Administrator aus einer Rolle heraus eine Rechteentscheidung nachvollziehen möchte
+- **DANN** bietet die Rollenansicht einen klaren Einstieg in die bestehende IAM-Rechteübersicht oder Szenario-Prüfung
+- **UND** es wird kein davon losgelöster zweiter Prüfworkflow mit abweichender Logik eingeführt
+
+#### Scenario: Cockpit-Einstieg genügt für die erste Ausbaustufe
+
+- **WENN** die Rollenverwaltung eine bestehende IAM-Prüffunktion integriert
+- **DANN** genügt ein klarer Einstieg in das bestehende IAM-Cockpit oder eine gleichwertige Transparenzfunktion
+- **UND** fehlende eingebettete Prüfformen machen die Rollenverwaltung in dieser Ausbaustufe nicht unvollständig
+
+#### Scenario: Bestätigtes Löschen weist auf Kaskadeneffekt hin
+
+- **WENN** ein Administrator eine löschbare Custom-Rolle aus der Rollenliste löschen möchte
+- **DANN** erklärt der Bestätigungsdialog vor dem Absenden, dass bestehende Benutzer- und Gruppenzuordnungen der Rolle ebenfalls entfernt werden
+- **UND** der Administrator kann den Löschvorgang an dieser Stelle noch abbrechen

--- a/openspec/changes/update-iam-role-delete-cascade-assignments/specs/iam-core/spec.md
+++ b/openspec/changes/update-iam-role-delete-cascade-assignments/specs/iam-core/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Studio-Rollen-Lebenszyklus mit Keycloak-Synchronisierung
+
+Das System MUST Rollen-CRUD aus dem Studio mit Keycloak Realm Roles synchronisieren, sodass für studioverwaltete Rollen keine manuelle Keycloak-Pflege erforderlich ist.
+
+#### Scenario: Custom-Rolle erstellen
+
+- **WHEN** ein `system_admin` eine neue Custom-Rolle im Studio erstellt
+- **THEN** wird die Rolle in Keycloak als Realm Role angelegt
+- **AND** danach wird die Rolle in `iam.roles` persistiert
+- **AND** die API-Antwort enthält `syncState = "synced"`
+
+#### Scenario: Custom-Rolle aktualisieren
+
+- **WHEN** ein `system_admin` eine bestehende Custom-Rolle aktualisiert
+- **THEN** werden die relevanten Metadaten in Keycloak und IAM-Datenbank konsistent aktualisiert
+- **AND** die Antwort enthält den finalen Synchronisierungsstatus
+
+#### Scenario: Custom-Rolle löschen
+
+- **WHEN** ein `system_admin` eine löschbare Custom-Rolle entfernt
+- **THEN** werden vor dem eigentlichen Rollen-Delete alle direkten Benutzerzuordnungen in `iam.account_roles` dieser Rolle entfernt
+- **AND** werden vor dem eigentlichen Rollen-Delete alle Gruppenzuordnungen in `iam.group_roles` dieser Rolle entfernt
+- **AND** die zugehörige Keycloak-Rolle wird entfernt
+- **AND** das Mapping wird aus dem IAM-Speicher gelöscht

--- a/openspec/changes/update-iam-role-delete-cascade-assignments/tasks.md
+++ b/openspec/changes/update-iam-role-delete-cascade-assignments/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementierung
+
+- [x] 1.1 OpenSpec-Deltas für kaskadierendes Rollenlöschen in `iam-core` und den Warnhinweis in `account-ui` ergänzen
+- [x] 1.2 Backend-Persistenz so ändern, dass `DELETE /api/v1/iam/roles/:id` direkte Benutzer- und Gruppenzuordnungen vor dem Rollen-Delete entfernt
+- [x] 1.3 Audit-, Invalidierungs- und Delete-Handler-Tests auf die neue Kaskaden-Semantik anpassen
+- [x] 1.4 Rollen-UI-Dialogtext und zugehörige UI-Tests auf die neue Warnsemantik anpassen
+- [x] 1.5 Relevante Dokumentation in `docs/guides/`, `docs/api/` und `docs/architecture/` aktualisieren
+- [x] 1.6 Kleinsten relevanten Gate-Pfad ausführen und Ergebnisse prüfen

--- a/packages/auth-runtime/src/iam-account-management/role-mutation-persistence.ts
+++ b/packages/auth-runtime/src/iam-account-management/role-mutation-persistence.ts
@@ -11,6 +11,7 @@ import { withInstanceScopedDb } from './shared-runtime.js';
 
 export const {
   deleteRoleFromDatabase,
+  listDirectRoleAssignmentSubjects,
   markDeleteRoleSyncState,
   markRoleSyncState,
   persistCreatedRole,

--- a/packages/auth-runtime/src/iam-account-management/roles-handlers.delete.ts
+++ b/packages/auth-runtime/src/iam-account-management/roles-handlers.delete.ts
@@ -7,6 +7,7 @@ import { asApiItem, createApiError } from './api-helpers.js';
 import { mapRoleSyncErrorCode, sanitizeRoleErrorMessage } from './role-audit.js';
 import {
   deleteRoleFromDatabase,
+  listDirectRoleAssignmentSubjects,
   markDeleteRoleSyncState,
   resolveDeletableRole,
 } from './role-mutation-persistence.js';
@@ -26,6 +27,7 @@ export const deleteRoleInternal = createDeleteRoleHandlerInternal({
   iamRoleSyncCounter,
   isIdentityRoleNotFoundError: (error) => error instanceof KeycloakAdminRequestError && error.statusCode === 404,
   jsonResponse,
+  listDirectRoleAssignmentSubjects,
   logger,
   mapRoleSyncErrorCode,
   markDeleteRoleSyncState,

--- a/packages/auth-runtime/src/iam-media/storage-s3.test.ts
+++ b/packages/auth-runtime/src/iam-media/storage-s3.test.ts
@@ -495,5 +495,6 @@ describe('media storage s3 adapter', () => {
 
     expect(source).not.toContain('replace(/\\/+$/, \'\')');
     expect(source).not.toContain('replace(/^\\/+|\\/+$/g, \'\')');
+    expect(source).not.toContain('.charCodeAt(');
   });
 });

--- a/packages/auth-runtime/src/iam-media/storage-s3.ts
+++ b/packages/auth-runtime/src/iam-media/storage-s3.ts
@@ -51,11 +51,13 @@ const mimeTypeExtensions: Readonly<Record<string, string>> = {
   'image/webp': 'webp',
 };
 
+const SOLIDUS_CODE_POINT = 47;
+
 const resolveObjectExtension = (mimeType: string): string => mimeTypeExtensions[mimeType] ?? 'bin';
 
 const trimTrailingSlashes = (value: string): string => {
   let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+  while (end > 0 && value.codePointAt(end - 1) === SOLIDUS_CODE_POINT) {
     end -= 1;
   }
   return value.slice(0, end);
@@ -65,10 +67,10 @@ const trimSurroundingSlashes = (value: string): string => {
   let start = 0;
   let end = value.length;
 
-  while (start < end && value.charCodeAt(start) === 47) {
+  while (start < end && value.codePointAt(start) === SOLIDUS_CODE_POINT) {
     start += 1;
   }
-  while (end > start && value.charCodeAt(end - 1) === 47) {
+  while (end > start && value.codePointAt(end - 1) === SOLIDUS_CODE_POINT) {
     end -= 1;
   }
 

--- a/packages/auth-runtime/src/keycloak-account-action-support.test.ts
+++ b/packages/auth-runtime/src/keycloak-account-action-support.test.ts
@@ -104,5 +104,6 @@ describe('keycloak account action support', () => {
     const source = fs.readFileSync(new URL('./keycloak-account-action-support.ts', import.meta.url), 'utf8');
 
     expect(source).not.toContain('replace(/\\/+$/u, \'\')');
+    expect(source).not.toContain('.charCodeAt(');
   });
 });

--- a/packages/auth-runtime/src/keycloak-account-action-support.ts
+++ b/packages/auth-runtime/src/keycloak-account-action-support.ts
@@ -6,6 +6,7 @@ const logger = createSdkLogger({ component: 'keycloak-account-action-support', l
 
 const UPDATE_EMAIL_FEATURE = 'UPDATE_EMAIL';
 const CACHE_TTL_MS = 60_000;
+const SOLIDUS_CODE_POINT = 47;
 
 type CachedSupport = {
   readonly supported: boolean;
@@ -36,7 +37,7 @@ const requireEnv = (key: string): string => {
 
 const normalizeBaseUrl = (value: string): string => {
   let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+  while (end > 0 && value.codePointAt(end - 1) === SOLIDUS_CODE_POINT) {
     end -= 1;
   }
   return value.slice(0, end);

--- a/packages/iam-admin/src/role-delete-handler.test.ts
+++ b/packages/iam-admin/src/role-delete-handler.test.ts
@@ -31,6 +31,7 @@ const existingRole = {
 
 const identityProvider = {
   provider: {
+    assignRealmRoles: vi.fn(async () => undefined),
     createRole: vi.fn(async () => undefined),
     deleteRole: vi.fn(async () => undefined),
   },
@@ -59,6 +60,7 @@ const createDeps = (
     },
     isIdentityRoleNotFoundError: vi.fn(() => false),
     jsonResponse: vi.fn(createJsonResponse),
+    listDirectRoleAssignmentSubjects: vi.fn(async () => []),
     logger: {
       error: vi.fn(),
     },
@@ -76,6 +78,7 @@ const createDeps = (
 describe('createDeleteRoleHandlerInternal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    identityProvider.provider.assignRealmRoles.mockClear();
     identityProvider.provider.createRole.mockClear();
     identityProvider.provider.deleteRole.mockClear();
   });
@@ -172,5 +175,23 @@ describe('createDeleteRoleHandlerInternal', () => {
         displayName: 'Editor',
       },
     });
+  });
+
+  it('replays direct user role mappings when compensation recreates a deleted role', async () => {
+    const deps = createDeps({
+      deleteRoleFromDatabase: vi.fn(async () => {
+        throw new Error('db write failed');
+      }),
+      listDirectRoleAssignmentSubjects: vi.fn(async () => ['kc-user-1', 'kc-user-2']),
+    });
+    const handler = createDeleteRoleHandlerInternal(deps);
+
+    const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'DELETE' }), ctx);
+
+    expect(response.status).toBe(500);
+    expect(identityProvider.provider.createRole).toHaveBeenCalledOnce();
+    expect(identityProvider.provider.assignRealmRoles).toHaveBeenCalledTimes(2);
+    expect(identityProvider.provider.assignRealmRoles).toHaveBeenNthCalledWith(1, 'kc-user-1', ['editor']);
+    expect(identityProvider.provider.assignRealmRoles).toHaveBeenNthCalledWith(2, 'kc-user-2', ['editor']);
   });
 });

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -7,6 +7,7 @@ export type DeleteRoleActor = UpdateRoleActor;
 
 export type DeleteRoleIdentityProvider<TAttributes = unknown> = {
   readonly provider: {
+    readonly assignRealmRoles?: (externalId: string, roles: readonly string[]) => Promise<void>;
     readonly createRole: (input: {
       readonly externalName: string;
       readonly description?: string;
@@ -45,6 +46,10 @@ export type DeleteRoleHandlerDeps<
   };
   readonly isIdentityRoleNotFoundError: (error: unknown) => boolean;
   readonly jsonResponse: (status: number, payload: unknown) => Response;
+  readonly listDirectRoleAssignmentSubjects: (input: {
+    readonly instanceId: string;
+    readonly roleId: string;
+  }) => Promise<readonly string[]>;
   readonly logger: {
     readonly error: (message: string, meta: Readonly<Record<string, unknown>>) => void;
   };
@@ -108,6 +113,10 @@ export const createDeleteRoleHandlerInternal =
       }
 
       const externalRoleName = getRoleExternalName(existing);
+      const directAssignmentSubjects = await deps.listDirectRoleAssignmentSubjects({
+        instanceId: actor.instanceId,
+        roleId,
+      });
       await deps.markDeleteRoleSyncState({
         actor,
         roleId,
@@ -161,6 +170,16 @@ export const createDeleteRoleHandlerInternal =
               }),
             })
           );
+          if (directAssignmentSubjects.length > 0) {
+            if (!identityProvider.provider.assignRealmRoles) {
+              throw new Error('assignRealmRoles provider capability unavailable');
+            }
+            await Promise.all(
+              directAssignmentSubjects.map((subject) =>
+                identityProvider.provider.assignRealmRoles!(subject, [externalRoleName])
+              )
+            );
+          }
         } catch (compensationError) {
           deps.iamRoleSyncCounter.add(1, {
             operation: 'delete',

--- a/packages/iam-admin/src/role-mutation-persistence.test.ts
+++ b/packages/iam-admin/src/role-mutation-persistence.test.ts
@@ -33,15 +33,19 @@ const roleListRow = {
   permission_rows: [{ id: 'permission-1', permission_key: 'content.updatePayload', description: 'Update content' }],
 };
 
-const createClient = (queuedRows: readonly (readonly Record<string, unknown>[])[] = []) => {
-  const queue = [...queuedRows];
+type QueuedQueryResult = readonly Record<string, unknown>[] | { readonly rows: readonly Record<string, unknown>[]; readonly rowCount?: number };
+
+const createClient = (queuedResults: readonly QueuedQueryResult[] = []) => {
+  const queue = [...queuedResults];
   const queries: { text: string; values: readonly unknown[] }[] = [];
   const client: QueryClient = {
     async query<Row = unknown>(text: string, values: readonly unknown[] = []) {
       queries.push({ text, values });
-      const rows = queue.shift() ?? [];
+      const next = queue.shift() ?? [];
+      const rows = Array.isArray(next) ? next : next.rows;
+      const rowCount = Array.isArray(next) ? next.length : (next.rowCount ?? next.rows.length);
       return {
-        rowCount: rows.length,
+        rowCount,
         rows: rows as Row[],
       };
     },
@@ -272,11 +276,6 @@ describe('role mutation persistence', () => {
   });
 
   it('protects delete resolution and deletes editable roles', async () => {
-    const dependency = createDeps(createClient([[mutableRole], [{ used: 2 }]]).client);
-    await expect(
-      createRoleMutationPersistence(dependency).resolveDeletableRole(actor, roleId)
-    ).resolves.toMatchObject({ status: 409 });
-
     const deletableLegacyBootstrapRole = {
       ...mutableRole,
       role_key: 'editor',
@@ -284,12 +283,18 @@ describe('role mutation persistence', () => {
       external_role_name: 'editor',
       is_system_role: true,
     };
-    const legacyDeletable = createDeps(createClient([[deletableLegacyBootstrapRole], [{ used: 0 }]]).client);
+    const legacyDeletable = createDeps(createClient([[deletableLegacyBootstrapRole]]).client);
     await expect(
       createRoleMutationPersistence(legacyDeletable).resolveDeletableRole(actor, roleId)
     ).resolves.toEqual(deletableLegacyBootstrapRole);
 
-    const { client, queries } = createClient([[mutableRole], [{ used: 0 }], [], []]);
+    const { client, queries } = createClient([
+      [mutableRole],
+      { rows: [], rowCount: 2 },
+      { rows: [], rowCount: 3 },
+      [],
+      [],
+    ]);
     const deps = createDeps(client);
     await expect(createRoleMutationPersistence(deps).resolveDeletableRole(actor, roleId)).resolves.toEqual(mutableRole);
 
@@ -300,9 +305,20 @@ describe('role mutation persistence', () => {
       externalRoleName: 'Editor',
     });
 
+    expect(queries.at(-4)?.text).toContain('DELETE FROM iam.account_roles');
+    expect(queries.at(-3)?.text).toContain('DELETE FROM iam.group_roles');
     expect(queries.at(-2)?.text).toContain('DELETE FROM iam.role_permissions');
     expect(queries.at(-1)?.text).toContain('DELETE FROM iam.roles');
-    expect(deps.emitActivityLog).toHaveBeenCalledWith(client, expect.objectContaining({ eventType: 'role.deleted' }));
+    expect(deps.emitActivityLog).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        eventType: 'role.deleted',
+        payload: expect.objectContaining({
+          removed_account_role_assignments: 2,
+          removed_group_role_assignments: 3,
+        }),
+      })
+    );
     expect(deps.notifyPermissionInvalidation).toHaveBeenCalledWith(
       client,
       expect.objectContaining({ trigger: 'role_deleted' })

--- a/packages/iam-admin/src/role-mutation-persistence.ts
+++ b/packages/iam-admin/src/role-mutation-persistence.ts
@@ -227,6 +227,29 @@ export const createRoleMutationPersistence = (deps: RoleMutationPersistenceDeps)
     };
   };
 
+  const listDirectRoleAssignmentSubjects = async (
+    client: QueryClient,
+    input: {
+      readonly instanceId: string;
+      readonly roleId: string;
+    }
+  ): Promise<readonly string[]> => {
+    const result = await client.query<{ keycloak_subject: string }>(
+      `
+SELECT DISTINCT a.keycloak_subject
+FROM iam.account_roles ar
+JOIN iam.accounts a
+  ON a.instance_id = ar.instance_id
+ AND a.id = ar.account_id
+WHERE ar.instance_id = $1
+  AND ar.role_id = $2::uuid
+ORDER BY a.keycloak_subject ASC
+`,
+      [input.instanceId, input.roleId]
+    );
+    return result.rows.map((row) => row.keycloak_subject);
+  };
+
   const deleteRoleRecords = async (
     client: QueryClient,
     input: {
@@ -669,6 +692,8 @@ ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
 
   return {
     deleteRoleFromDatabase,
+    listDirectRoleAssignmentSubjects: async (input: { readonly instanceId: string; readonly roleId: string }) =>
+      deps.withInstanceScopedDb(input.instanceId, (client) => listDirectRoleAssignmentSubjects(client, input)),
     markDeleteRoleSyncState,
     markRoleSyncState,
     persistCreatedRole,

--- a/packages/iam-admin/src/role-mutation-persistence.ts
+++ b/packages/iam-admin/src/role-mutation-persistence.ts
@@ -129,6 +129,11 @@ type RoleActivityLogInput = {
   readonly traceId?: string;
 };
 
+type DeletedRoleAssignmentCounts = Readonly<{
+  removedAccountRoleAssignments: number;
+  removedGroupRoleAssignments: number;
+}>;
+
 export type RoleMutationPersistenceDeps = {
   readonly createApiError: (
     status: number,
@@ -162,6 +167,80 @@ export type RoleMutationPersistenceDeps = {
 };
 
 export const createRoleMutationPersistence = (deps: RoleMutationPersistenceDeps) => {
+  const emitDeleteSuccessEvents = async (
+    client: QueryClient,
+    input: {
+      readonly actor: RoleMutationPersistenceActor;
+      readonly roleId: string;
+      readonly roleKey: string;
+      readonly externalRoleName: string;
+      readonly deletedAssignments: DeletedRoleAssignmentCounts;
+    }
+  ) => {
+    await deps.emitActivityLog(client, {
+      instanceId: input.actor.instanceId,
+      accountId: input.actor.actorAccountId,
+      eventType: 'role.deleted',
+      result: 'success',
+      payload: {
+        role_id: input.roleId,
+        role_key: input.roleKey,
+        removed_account_role_assignments: input.deletedAssignments.removedAccountRoleAssignments,
+        removed_group_role_assignments: input.deletedAssignments.removedGroupRoleAssignments,
+      },
+      requestId: input.actor.requestId,
+      traceId: input.actor.traceId,
+    });
+    await deps.emitRoleAuditEvent(client, {
+      instanceId: input.actor.instanceId,
+      accountId: input.actor.actorAccountId,
+      roleId: input.roleId,
+      eventType: 'role.sync_succeeded',
+      operation: 'delete',
+      result: 'success',
+      roleKey: input.roleKey,
+      externalRoleName: input.externalRoleName,
+      requestId: input.actor.requestId,
+      traceId: input.actor.traceId,
+    });
+  };
+
+  const deleteRoleAssignments = async (
+    client: QueryClient,
+    input: {
+      readonly instanceId: string;
+      readonly roleId: string;
+    }
+  ): Promise<DeletedRoleAssignmentCounts> => {
+    const deletedAccountRoles = await client.query(
+      'DELETE FROM iam.account_roles WHERE instance_id = $1 AND role_id = $2::uuid;',
+      [input.instanceId, input.roleId]
+    );
+    const deletedGroupRoles = await client.query(
+      'DELETE FROM iam.group_roles WHERE instance_id = $1 AND role_id = $2::uuid;',
+      [input.instanceId, input.roleId]
+    );
+
+    return {
+      removedAccountRoleAssignments: deletedAccountRoles.rowCount,
+      removedGroupRoleAssignments: deletedGroupRoles.rowCount,
+    };
+  };
+
+  const deleteRoleRecords = async (
+    client: QueryClient,
+    input: {
+      readonly instanceId: string;
+      readonly roleId: string;
+    }
+  ) => {
+    await client.query('DELETE FROM iam.role_permissions WHERE instance_id = $1 AND role_id = $2::uuid;', [
+      input.instanceId,
+      input.roleId,
+    ]);
+    await client.query('DELETE FROM iam.roles WHERE instance_id = $1 AND id = $2::uuid;', [input.instanceId, input.roleId]);
+  };
+
   const validateRequestedPermissions = async (input: {
     readonly actor: RoleMutationPersistenceActor;
     readonly permissionIds?: readonly string[];
@@ -521,22 +600,6 @@ ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
       );
     }
 
-    const dependency = await deps.withInstanceScopedDb(actor.instanceId, async (client) => {
-      const result = await client.query<{ readonly used: number }>(
-        `
-SELECT COUNT(*)::int AS used
-FROM iam.account_roles
-WHERE instance_id = $1
-  AND role_id = $2::uuid;
-`,
-        [actor.instanceId, roleId]
-      );
-      return result.rows[0]?.used ?? 0;
-    });
-    if (dependency > 0) {
-      return deps.createApiError(409, 'conflict', 'Rolle wird noch von Nutzern verwendet.', actor.requestId);
-    }
-
     return existing;
   };
 
@@ -582,38 +645,20 @@ WHERE instance_id = $1
     readonly externalRoleName: string;
   }) => {
     await deps.withInstanceScopedDb(input.actor.instanceId, async (client) => {
-      await client.query('DELETE FROM iam.role_permissions WHERE instance_id = $1 AND role_id = $2::uuid;', [
-        input.actor.instanceId,
-        input.roleId,
-      ]);
-      await client.query('DELETE FROM iam.roles WHERE instance_id = $1 AND id = $2::uuid;', [
-        input.actor.instanceId,
-        input.roleId,
-      ]);
-
-      await deps.emitActivityLog(client, {
+      const deletedAssignments = await deleteRoleAssignments(client, {
         instanceId: input.actor.instanceId,
-        accountId: input.actor.actorAccountId,
-        eventType: 'role.deleted',
-        result: 'success',
-        payload: {
-          role_id: input.roleId,
-          role_key: input.roleKey,
-        },
-        requestId: input.actor.requestId,
-        traceId: input.actor.traceId,
-      });
-      await deps.emitRoleAuditEvent(client, {
-        instanceId: input.actor.instanceId,
-        accountId: input.actor.actorAccountId,
         roleId: input.roleId,
-        eventType: 'role.sync_succeeded',
-        operation: 'delete',
-        result: 'success',
+      });
+      await deleteRoleRecords(client, {
+        instanceId: input.actor.instanceId,
+        roleId: input.roleId,
+      });
+      await emitDeleteSuccessEvents(client, {
+        actor: input.actor,
+        roleId: input.roleId,
         roleKey: input.roleKey,
         externalRoleName: input.externalRoleName,
-        requestId: input.actor.requestId,
-        traceId: input.actor.traceId,
+        deletedAssignments,
       });
       await deps.notifyPermissionInvalidation(client, {
         instanceId: input.actor.instanceId,

--- a/packages/plugin-news/src/news.detail-settings-tab.tsx
+++ b/packages/plugin-news/src/news.detail-settings-tab.tsx
@@ -110,7 +110,11 @@ function NewsPublicationModeFieldset({
           <legend className="text-sm font-medium text-foreground">{pt('fields.publicationMode')}</legend>
 
           {(['draft', 'immediate', 'scheduled'] as const).map((option) => (
-            <div key={option} className="flex gap-3 rounded-xl border border-border/60 p-4 text-sm">
+            <label
+              key={option}
+              htmlFor={`publication-mode-${option}`}
+              className="flex gap-3 rounded-xl border border-border/60 p-4 text-sm"
+            >
               <input
                 id={`publication-mode-${option}`}
                 type="radio"
@@ -119,15 +123,15 @@ function NewsPublicationModeFieldset({
                 checked={field.value === option}
                 onChange={(event) => field.onChange(event.target.value)}
               />
-              <label htmlFor={`publication-mode-${option}`} className="space-y-1">
+              <span className="space-y-1">
                 <span className="block font-medium text-foreground">
                   {pt(`publicationModes.${option}.label`)}
                 </span>
                 <span className="block text-muted-foreground">
                   {pt(`publicationModes.${option}.description`)}
                 </span>
-              </label>
-            </div>
+              </span>
+            </label>
           ))}
         </fieldset>
       )}

--- a/packages/plugin-news/src/news.detail-settings-tab.tsx
+++ b/packages/plugin-news/src/news.detail-settings-tab.tsx
@@ -110,23 +110,24 @@ function NewsPublicationModeFieldset({
           <legend className="text-sm font-medium text-foreground">{pt('fields.publicationMode')}</legend>
 
           {(['draft', 'immediate', 'scheduled'] as const).map((option) => (
-            <label key={option} className="flex gap-3 rounded-xl border border-border/60 p-4 text-sm">
+            <div key={option} className="flex gap-3 rounded-xl border border-border/60 p-4 text-sm">
               <input
+                id={`publication-mode-${option}`}
                 type="radio"
                 name={field.name}
                 value={option}
                 checked={field.value === option}
                 onChange={(event) => field.onChange(event.target.value)}
               />
-              <span className="space-y-1">
+              <label htmlFor={`publication-mode-${option}`} className="space-y-1">
                 <span className="block font-medium text-foreground">
                   {pt(`publicationModes.${option}.label`)}
                 </span>
                 <span className="block text-muted-foreground">
                   {pt(`publicationModes.${option}.description`)}
                 </span>
-              </span>
-            </label>
+              </label>
+            </div>
           ))}
         </fieldset>
       )}

--- a/packages/plugin-news/tests/news.detail-page.test.tsx
+++ b/packages/plugin-news/tests/news.detail-page.test.tsx
@@ -237,6 +237,7 @@ describe('NewsDetailPage', () => {
     const source = fs.readFileSync(newsDetailSettingsSourcePath, 'utf8');
 
     expect(source).toContain('htmlFor={`publication-mode-${option}`}');
-    expect(source).not.toContain('<label key={option} className="flex gap-3 rounded-xl border border-border/60 p-4 text-sm">');
+    expect(source).toContain('<span className="space-y-1">');
+    expect(source).not.toContain('<div key={option} className="flex gap-3 rounded-xl border border-border/60 p-4 text-sm">');
   });
 });

--- a/packages/plugin-news/tests/news.detail-page.test.tsx
+++ b/packages/plugin-news/tests/news.detail-page.test.tsx
@@ -1,4 +1,7 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import React from 'react';
+import { fileURLToPath } from 'node:url';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -11,6 +14,10 @@ import { listNewsCategories } from '../src/news.api.js';
 import { NewsDetailPage } from '../src/news.detail-page.js';
 
 const navigateMock = vi.fn();
+const newsDetailSettingsSourcePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../src/news.detail-settings-tab.tsx'
+);
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
@@ -224,5 +231,12 @@ describe('NewsDetailPage', () => {
     await waitFor(() => {
       expect(screen.queryByLabelText('Zeitpunkt der Veröffentlichung')).toBeNull();
     });
+  });
+
+  it('renders publication mode radio labels through explicit htmlFor bindings', () => {
+    const source = fs.readFileSync(newsDetailSettingsSourcePath, 'utf8');
+
+    expect(source).toContain('htmlFor={`publication-mode-${option}`}');
+    expect(source).not.toContain('<label key={option} className="flex gap-3 rounded-xl border border-border/60 p-4 text-sm">');
   });
 });

--- a/packages/plugin-waste-management/src/waste-management.tours-custom-dates.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tours-custom-dates.tsx
@@ -420,7 +420,7 @@ export const WasteToursCustomDatesField = ({
                                 {assignments.map((assignment) => (
                                   <div key={assignment.id} className="rounded-2xl border border-border/70 bg-card p-4">
                                     <div className="grid gap-3 lg:grid-cols-[minmax(0,18rem)_minmax(0,1fr)_auto] lg:items-start">
-                                      <div
+                                      <fieldset
                                         className="space-y-2"
                                         onBlur={(event) => {
                                           const nextTarget = event.relatedTarget;
@@ -430,6 +430,7 @@ export const WasteToursCustomDatesField = ({
                                           setActiveLocationPickerId((current) => (current === assignment.id ? null : current));
                                         }}
                                       >
+                                        <legend className="sr-only">{pt('tours.customDates.fields.location')}</legend>
                                         <label
                                           className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
                                           htmlFor={`assignment-location-${assignment.id}`}
@@ -468,6 +469,7 @@ export const WasteToursCustomDatesField = ({
                                               <button
                                                 type="button"
                                                 role="option"
+                                                aria-selected={assignment.locationId.length === 0}
                                                 className={[
                                                   'flex w-full items-start rounded-lg px-3 py-2 text-left text-sm transition-colors',
                                                   assignment.locationId.length === 0
@@ -537,7 +539,7 @@ export const WasteToursCustomDatesField = ({
                                         {duplicateAssignmentId === assignment.id ? (
                                           <p className="text-xs text-destructive">{pt('tours.customDates.messages.duplicateLocation')}</p>
                                         ) : null}
-                                      </div>
+                                      </fieldset>
                                       <div className="space-y-2">
                                         <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground" htmlFor={`assignment-note-${assignment.id}`}>
                                           {pt('tours.customDates.fields.note')}

--- a/packages/plugin-waste-management/tests/waste-management.tours-custom-dates.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.tours-custom-dates.test.tsx
@@ -336,4 +336,33 @@ describe('WasteToursCustomDatesField', () => {
     fireEvent.click(screen.getByRole('button', { name: 'cancel' }));
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('exposes the location picker as a labeled group and marks the empty option as selected when no location is chosen', () => {
+    render(
+      <WasteToursCustomDatesField
+        customDates={[{ date: '2027-01-01' }]}
+        dateLocationAssignments={[
+          {
+            id: 'assignment-1',
+            pickupDate: '2027-01-01',
+            locationId: '',
+            note: '',
+          },
+        ]}
+        locations={[{ id: 'location-1', label: 'Musterhausen / Markt' }]}
+        firstDate="2027-01-01"
+        endDate=""
+        onChange={vi.fn()}
+        onAssignmentsChange={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'tours.customDates.actions.editAssignments' }));
+    fireEvent.focus(screen.getByLabelText('tours.customDates.fields.location'));
+
+    expect(screen.getByRole('group', { name: 'tours.customDates.fields.location' })).toBeTruthy();
+    expect(
+      screen.getByRole('option', { name: 'tours.customDates.fields.locationPlaceholder' }).getAttribute('aria-selected')
+    ).toBe('true');
+  });
 });


### PR DESCRIPTION
## Summary
- cascade IAM role deletion to remove direct user and group assignments before deleting the role and warn about that effect in the admin UI
- add regression coverage, OpenSpec updates, and API/runtime documentation for the new delete semantics
- clear related Sonar findings in media/auth helpers, news publication-mode labeling, and waste-management custom-date accessibility

## Validation
- `openspec validate update-iam-role-delete-cascade-assignments --strict`
- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main`
- `pnpm check:server-runtime`
- `pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/admin/media/-media-ui.shared.test.ts`
- `pnpm nx run plugin-news:test:unit --testFiles=tests/news.detail-page.test.tsx`
- `pnpm test:pr`
