### PR TITLE
feat(mainserver): provision user credentials on user creation

### DIFF
--- a/apps/sva-studio-react/src/lib/iam-api.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-api.test.ts
@@ -22,6 +22,7 @@ import {
   archiveInstance,
   assignOrganizationMembership,
   bulkDeactivateUsers,
+  createUser,
   createLegalText,
   createInstance,
   getAdminDeletionRules,
@@ -754,6 +755,35 @@ describe('iam-api organization helpers', () => {
         }),
       })
     );
+  });
+
+  it('uses the heavy request timeout budget for createUser', async () => {
+    const deferredResponse = createDeferredResponse();
+    const fetchMock = vi.fn().mockReturnValue(deferredResponse.responsePromise);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('crypto', { randomUUID: () => 'uuid-create-user-1' });
+
+    const request = createUser({
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Example',
+      roleIds: [],
+      groupIds: [],
+      sendPasswordSetupEmail: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/iam/users',
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      })
+    );
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 20_000);
+
+    deferredResponse.resolve(createJsonResponse({ data: { userId: 'user-1' } }));
+    await expect(request).resolves.toMatchObject({ data: { userId: 'user-1' } });
   });
 
   it('falls back to http status messages when json error payloads omit message and code', async () => {

--- a/apps/sva-studio-react/src/lib/iam-api.ts
+++ b/apps/sva-studio-react/src/lib/iam-api.ts
@@ -1035,7 +1035,11 @@ export const getUserTimeline = async (
 export const createUser = async (
   payload: CreateUserPayload
 ): Promise<ApiItemResponse<IamCreateUserResult>> =>
-  postJson<ApiItemResponse<IamCreateUserResult>, CreateUserPayload>('/api/v1/iam/users', payload, true);
+  requestJson<ApiItemResponse<IamCreateUserResult>>(
+    '/api/v1/iam/users',
+    createJsonMutationRequestInit('POST', payload, { idempotent: true }),
+    { timeoutMs: HEAVY_IAM_REQUEST_TIMEOUT_MS }
+  );
 
 export const updateUser = async (
   userId: string,

--- a/apps/sva-studio-react/src/lib/interfaces-api.test.ts
+++ b/apps/sva-studio-react/src/lib/interfaces-api.test.ts
@@ -231,6 +231,48 @@ describe('interfaces app adapter', () => {
     expect(state.listStoredInterfaces).toHaveBeenCalledWith('de-musterhausen');
   });
 
+  it('projects the mainserver interface draft without municipality overrides', async () => {
+    setAuthenticatedUserContext({
+      id: 'subject-1',
+      instanceId: 'de-musterhausen',
+      roles: ['interface_manager'],
+    });
+    state.loadSvaMainserverInterfacesOverview.mockResolvedValue({
+      instanceId: 'de-musterhausen',
+      config: {
+        providerKey: 'sva_mainserver',
+        graphqlBaseUrl: 'https://mainserver.example/graphql',
+        oauthTokenUrl: 'https://mainserver.example/oauth/token',
+        enabled: true,
+      },
+      status: {
+        status: 'connected',
+        checkedAt: '2026-05-03T17:00:00.000Z',
+      },
+    });
+    state.listStoredInterfaces.mockResolvedValue([]);
+    state.loadInstanceById.mockResolvedValue({
+      instanceId: 'de-musterhausen',
+      assignedModules: [],
+    });
+
+    const { listInstanceInterfacesServerFn } = await import('./interfaces-api');
+
+    await expect(listInstanceInterfacesServerFn()).resolves.toEqual(
+      expect.objectContaining({
+        entries: [
+          expect.objectContaining({
+            type: 'mainserver',
+            config: expect.objectContaining({
+              graphqlBaseUrl: 'https://mainserver.example/graphql',
+              oauthTokenUrl: 'https://mainserver.example/oauth/token',
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
   it('omits supabase from the available types when the waste-management module is not assigned', async () => {
     setAuthenticatedUserContext({
       id: 'subject-1',

--- a/apps/sva-studio-react/src/lib/interfaces-api.ts
+++ b/apps/sva-studio-react/src/lib/interfaces-api.ts
@@ -619,11 +619,11 @@ export const listInstanceInterfacesServerFn = createServerFn().handler(
                 lastCheckedAt: overview.status.checkedAt,
                 createdAt: overview.status.checkedAt ?? new Date().toISOString(),
                 updatedAt: overview.status.checkedAt ?? new Date().toISOString(),
-                    config: {
-                      graphqlBaseUrl: overview.config.graphqlBaseUrl,
-                      oauthTokenUrl: overview.config.oauthTokenUrl,
-                    },
-                  } satisfies InstanceInterface)
+                config: {
+                  graphqlBaseUrl: overview.config.graphqlBaseUrl,
+                  oauthTokenUrl: overview.config.oauthTokenUrl,
+                },
+              } satisfies InstanceInterface)
             : null;
 
         return {

--- a/apps/sva-studio-react/src/lib/interfaces-api.ts
+++ b/apps/sva-studio-react/src/lib/interfaces-api.ts
@@ -619,11 +619,11 @@ export const listInstanceInterfacesServerFn = createServerFn().handler(
                 lastCheckedAt: overview.status.checkedAt,
                 createdAt: overview.status.checkedAt ?? new Date().toISOString(),
                 updatedAt: overview.status.checkedAt ?? new Date().toISOString(),
-                config: {
-                  graphqlBaseUrl: overview.config.graphqlBaseUrl,
-                  oauthTokenUrl: overview.config.oauthTokenUrl,
-                },
-              } satisfies InstanceInterface)
+                    config: {
+                      graphqlBaseUrl: overview.config.graphqlBaseUrl,
+                      oauthTokenUrl: overview.config.oauthTokenUrl,
+                    },
+                  } satisfies InstanceInterface)
             : null;
 
         return {

--- a/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.dialogs.test.tsx
+++ b/apps/sva-studio-react/src/routes/interfaces/-interfaces-page.dialogs.test.tsx
@@ -76,7 +76,7 @@ describe('interfaces-page dialogs', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it('updates mainserver draft fields and submits without reloading the page', () => {
+  it('updates mainserver draft fields without rendering municipality id controls', () => {
     const onChange = vi.fn();
     const onCancel = vi.fn();
     const onSubmit = vi.fn();
@@ -118,6 +118,7 @@ describe('interfaces-page dialogs', () => {
         }),
       })
     );
+    expect(screen.queryByLabelText('Municipality-ID')).toBeNull();
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-http.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-http.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { MainserverUserProvisioningError } from './mainserver-user-provisioning-error.js';
+import {
+  createProvisioningErrorFromResponse,
+  fetchMainserverUpstream,
+  parseMainserverJsonBody,
+  readMainserverErrorPayload,
+} from './mainserver-upstream-http.js';
+
+describe('mainserver-upstream-http', () => {
+  it('maps abort-like upstream failures to retryable timeout errors', async () => {
+    const timeoutError = new Error('timeout');
+    timeoutError.name = 'TimeoutError';
+    const fetchImpl = vi.fn().mockRejectedValueOnce(timeoutError);
+
+    await expect(
+      fetchMainserverUpstream({
+        fetchImpl,
+        url: 'https://example.com/token',
+        init: { method: 'POST' },
+        signal: AbortSignal.timeout(100),
+        timeoutMessage: 'Zeitüberschreitung beim Laden des Mainserver-Provisioning-Tokens.',
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'upstream_timeout',
+      message: 'Zeitüberschreitung beim Laden des Mainserver-Provisioning-Tokens.',
+      retryable: true,
+      statusCode: 504,
+    });
+  });
+
+  it('throws invalid_response when a json body cannot be parsed', async () => {
+    const response = new Response('not-json', { status: 200 });
+
+    await expect(
+      parseMainserverJsonBody(response, 'Ungültige Antwort des SVA-Mainserver-Provisionings.')
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'invalid_response',
+      message: 'Ungültige Antwort des SVA-Mainserver-Provisionings.',
+      statusCode: 502,
+    });
+  });
+
+  it('returns a sanitized error payload when the upstream body is malformed', async () => {
+    const nonJsonResponse = new Response('not-json', { status: 409 });
+    const scalarJsonResponse = new Response(JSON.stringify('conflict'), { status: 409 });
+
+    await expect(
+      readMainserverErrorPayload(nonJsonResponse, 'Ungültige Antwort des SVA-Mainserver-Provisionings.')
+    ).resolves.toEqual({});
+    await expect(
+      readMainserverErrorPayload(scalarJsonResponse, 'Ungültige Antwort des SVA-Mainserver-Provisionings.')
+    ).resolves.toEqual({});
+  });
+
+  it('maps provisioning error responses from payload fields with fallback defaults', async () => {
+    const explicitPayloadResponse = new Response(
+      JSON.stringify({
+        code: 'local_user_conflict',
+        message: 'conflict',
+        retryable: false,
+      }),
+      { status: 409 }
+    );
+    const fallbackResponse = new Response('not-json', { status: 503 });
+
+    await expect(createProvisioningErrorFromResponse(explicitPayloadResponse)).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'local_user_conflict',
+      message: 'conflict',
+      retryable: false,
+      statusCode: 409,
+    });
+    await expect(createProvisioningErrorFromResponse(fallbackResponse)).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'mainserver_user_provisioning_failed',
+      message: 'Mainserver-Benutzer-Provisioning fehlgeschlagen (503).',
+      retryable: true,
+      statusCode: 503,
+    });
+  });
+
+  it('creates concrete MainserverUserProvisioningError instances', async () => {
+    const response = new Response(JSON.stringify({ code: 'conflict', message: 'conflict' }), { status: 409 });
+
+    await expect(createProvisioningErrorFromResponse(response)).rejects.toBeInstanceOf(
+      MainserverUserProvisioningError
+    );
+  });
+});

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-http.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-http.test.ts
@@ -31,6 +31,21 @@ describe('mainserver-upstream-http', () => {
     });
   });
 
+  it('rethrows non-abort upstream failures unchanged', async () => {
+    const upstreamError = new Error('boom');
+    const fetchImpl = vi.fn().mockRejectedValueOnce(upstreamError);
+
+    await expect(
+      fetchMainserverUpstream({
+        fetchImpl,
+        url: 'https://example.com/token',
+        init: { method: 'POST' },
+        signal: AbortSignal.timeout(100),
+        timeoutMessage: 'Zeitüberschreitung beim Laden des Mainserver-Provisioning-Tokens.',
+      })
+    ).rejects.toBe(upstreamError);
+  });
+
   it('throws invalid_response when a json body cannot be parsed', async () => {
     const response = new Response('not-json', { status: 200 });
 
@@ -54,6 +69,25 @@ describe('mainserver-upstream-http', () => {
     await expect(
       readMainserverErrorPayload(scalarJsonResponse, 'Ungültige Antwort des SVA-Mainserver-Provisionings.')
     ).resolves.toEqual({});
+  });
+
+  it('keeps only typed error payload fields', async () => {
+    const response = new Response(
+      JSON.stringify({
+        code: 'local_user_conflict',
+        message: ['wrong'],
+        retryable: 'false',
+      }),
+      { status: 409 }
+    );
+
+    await expect(
+      readMainserverErrorPayload(response, 'Ungültige Antwort des SVA-Mainserver-Provisionings.')
+    ).resolves.toEqual({
+      code: 'local_user_conflict',
+      message: undefined,
+      retryable: undefined,
+    });
   });
 
   it('maps provisioning error responses from payload fields with fallback defaults', async () => {

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-http.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-http.ts
@@ -1,0 +1,87 @@
+import { MainserverUserProvisioningError } from './mainserver-user-provisioning-error.js';
+
+export type MainserverErrorPayload = {
+  readonly code?: string;
+  readonly message?: string;
+  readonly retryable?: boolean;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+
+export const fetchMainserverUpstream = async (input: {
+  readonly fetchImpl: typeof fetch;
+  readonly url: string;
+  readonly init: RequestInit;
+  readonly signal: AbortSignal;
+  readonly timeoutMessage: string;
+}): Promise<Response> => {
+  try {
+    return await input.fetchImpl(input.url, {
+      ...input.init,
+      redirect: 'manual',
+      signal: input.signal,
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new MainserverUserProvisioningError({
+        code: 'upstream_timeout',
+        message: input.timeoutMessage,
+        statusCode: 504,
+        retryable: true,
+      });
+    }
+
+    throw error;
+  }
+};
+
+export const parseMainserverJsonBody = async <T>(
+  response: Response,
+  invalidResponseMessage: string
+): Promise<T> => {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new MainserverUserProvisioningError({
+      code: 'invalid_response',
+      message: invalidResponseMessage,
+      statusCode: 502,
+    });
+  }
+};
+
+export const readMainserverErrorPayload = async (
+  response: Response,
+  invalidResponseMessage: string
+): Promise<MainserverErrorPayload> => {
+  const payload = await parseMainserverJsonBody<unknown>(response, invalidResponseMessage).catch(() => null);
+  if (!isRecord(payload)) {
+    return {};
+  }
+
+  return {
+    code: typeof payload.code === 'string' ? payload.code : undefined,
+    message: typeof payload.message === 'string' ? payload.message : undefined,
+    retryable: typeof payload.retryable === 'boolean' ? payload.retryable : undefined,
+  };
+};
+
+export const createProvisioningErrorFromResponse = async (
+  response: Response
+): Promise<never> => {
+  const errorPayload = await readMainserverErrorPayload(
+    response,
+    'Ungültige Antwort des SVA-Mainserver-Provisionings.'
+  );
+
+  throw new MainserverUserProvisioningError({
+    code: errorPayload.code ?? 'mainserver_user_provisioning_failed',
+    message: errorPayload.message ?? `Mainserver-Benutzer-Provisioning fehlgeschlagen (${response.status}).`,
+    statusCode: response.status,
+    retryable: errorPayload.retryable ?? response.status >= 500,
+  });
+};

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
@@ -1,0 +1,167 @@
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+import { MainserverUserProvisioningError } from './mainserver-user-provisioning.js';
+
+const localhostHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+const parseUpstreamUrl = (value: string): URL | null => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed);
+  } catch {
+    return null;
+  }
+};
+
+const unwrapBracketedHost = (hostname: string): string =>
+  hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+
+const isLocalHostname = (hostname: string): boolean =>
+  localhostHosts.has(hostname) || hostname.endsWith('.local');
+
+const parseIpv4Octets = (hostname: string): number[] | null => {
+  const octets = hostname.split('.').map((segment) => Number.parseInt(segment, 10));
+  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part))) {
+    return null;
+  }
+
+  return octets;
+};
+
+const isPrivateIpv4Host = (hostname: string): boolean => {
+  const octets = parseIpv4Octets(hostname);
+  if (!octets) {
+    return true;
+  }
+
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+};
+
+const toMappedIpv4Host = (hostname: string): string | null => {
+  if (!hostname.startsWith('::ffff:')) {
+    return null;
+  }
+
+  const mappedPart = hostname.slice('::ffff:'.length);
+  if (isIP(mappedPart) === 4) {
+    return mappedPart;
+  }
+
+  const hexParts = mappedPart.split(':');
+  if (hexParts.length !== 2) {
+    return null;
+  }
+
+  const high = Number.parseInt(hexParts[0], 16);
+  const low = Number.parseInt(hexParts[1], 16);
+  if (Number.isNaN(high) || Number.isNaN(low)) {
+    return null;
+  }
+
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ].join('.');
+};
+
+const isPrivateIpv6Host = (hostname: string): boolean => {
+  const mappedIpv4Host = toMappedIpv4Host(hostname);
+  if (mappedIpv4Host) {
+    return isPrivateOrLocalHost(mappedIpv4Host);
+  }
+
+  if (hostname.startsWith('::ffff:')) {
+    return true;
+  }
+
+  return (
+    hostname === '::1' ||
+    hostname === '::' ||
+    hostname.startsWith('fc') ||
+    hostname.startsWith('fd') ||
+    hostname.startsWith('fe80:')
+  );
+};
+
+const isPrivateOrLocalHost = (hostname: string): boolean => {
+  const normalized = hostname.trim().toLowerCase();
+  if (isLocalHostname(normalized)) {
+    return true;
+  }
+
+  const unbracketed = unwrapBracketedHost(normalized);
+  if (unbracketed !== normalized) {
+    return isPrivateOrLocalHost(unbracketed);
+  }
+
+  const ipVersion = isIP(normalized);
+  if (ipVersion === 4) {
+    return isPrivateIpv4Host(normalized);
+  }
+
+  if (ipVersion === 6) {
+    return isPrivateIpv6Host(normalized);
+  }
+
+  return false;
+};
+
+const resolvesToPrivateOrLocalHost = async (hostname: string): Promise<boolean> => {
+  const normalized = hostname.trim().toLowerCase();
+  if (isIP(normalized) !== 0) {
+    return false;
+  }
+
+  try {
+    const resolved = await dnsLookup(normalized, {
+      all: true,
+      verbatim: true,
+    });
+    if (resolved.length === 0) {
+      return true;
+    }
+
+    return resolved.some((entry) => isPrivateOrLocalHost(entry.address));
+  } catch {
+    return true;
+  }
+};
+
+export const normalizeProvisioningUpstreamUrl = async (
+  value: string,
+  fieldName: 'graphql_base_url' | 'oauth_token_url'
+): Promise<string> => {
+  const parsed = parseUpstreamUrl(value);
+  const isPublicHttpsUrl =
+    parsed &&
+    !parsed.username &&
+    !parsed.password &&
+    !parsed.hash &&
+    parsed.protocol === 'https:' &&
+    !isPrivateOrLocalHost(parsed.hostname);
+
+  if (!isPublicHttpsUrl || (await resolvesToPrivateOrLocalHost(parsed.hostname))) {
+    throw new MainserverUserProvisioningError({
+      code: 'invalid_config',
+      message: `Die konfigurierte Upstream-URL ${fieldName} ist ungültig.`,
+      statusCode: 409,
+    });
+  }
+
+  return parsed.toString();
+};

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
@@ -24,7 +24,10 @@ const unwrapBracketedHost = (hostname: string): string =>
 const isLocalHostname = (hostname: string): boolean =>
   localhostHosts.has(hostname) || hostname.endsWith('.local');
 
-const parseIpv4Octets = (hostname: string): readonly [number, number, number, number] | null => {
+type Ipv4Octets = readonly [number, number, number, number];
+type Ipv4Range = readonly [number, number];
+
+const parseIpv4Octets = (hostname: string): Ipv4Octets | null => {
   const octets = hostname.split('.').map((segment) => Number.parseInt(segment, 10));
   if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
     return null;
@@ -33,28 +36,38 @@ const parseIpv4Octets = (hostname: string): readonly [number, number, number, nu
   return [octets[0]!, octets[1]!, octets[2]!, octets[3]!];
 };
 
+const toIpv4Number = ([a, b, c, d]: Ipv4Octets): number => ((a * 256 + b) * 256 + c) * 256 + d;
+
+const createIpv4Range = (start: Ipv4Octets, end: Ipv4Octets): Ipv4Range => [
+  toIpv4Number(start),
+  toIpv4Number(end),
+];
+
+const nonPublicIpv4Ranges: readonly Ipv4Range[] = [
+  createIpv4Range([0, 0, 0, 0], [0, 255, 255, 255]),
+  createIpv4Range([10, 0, 0, 0], [10, 255, 255, 255]),
+  createIpv4Range([100, 64, 0, 0], [100, 127, 255, 255]),
+  createIpv4Range([127, 0, 0, 0], [127, 255, 255, 255]),
+  createIpv4Range([169, 254, 0, 0], [169, 254, 255, 255]),
+  createIpv4Range([172, 16, 0, 0], [172, 31, 255, 255]),
+  createIpv4Range([192, 0, 0, 0], [192, 0, 0, 255]),
+  createIpv4Range([192, 0, 2, 0], [192, 0, 2, 255]),
+  createIpv4Range([192, 88, 99, 0], [192, 88, 99, 255]),
+  createIpv4Range([192, 168, 0, 0], [192, 168, 255, 255]),
+  createIpv4Range([198, 18, 0, 0], [198, 19, 255, 255]),
+  createIpv4Range([198, 51, 100, 0], [198, 51, 100, 255]),
+  createIpv4Range([203, 0, 113, 0], [203, 0, 113, 255]),
+  createIpv4Range([224, 0, 0, 0], [255, 255, 255, 255]),
+];
+
 const isNonPublicIpv4Host = (hostname: string): boolean => {
   const octets = parseIpv4Octets(hostname);
   if (!octets) {
     return true;
   }
 
-  const [a, b, c] = octets;
-  return (
-    a === 0 ||
-    a === 10 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    a === 127 ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 0 && (c === 0 || c === 2)) ||
-    (a === 192 && b === 88 && c === 99) ||
-    (a === 192 && b === 168) ||
-    (a === 198 && (b === 18 || b === 19)) ||
-    (a === 198 && b === 51 && c === 100) ||
-    (a === 203 && b === 0 && c === 113) ||
-    a >= 224
-  );
+  const address = toIpv4Number(octets);
+  return nonPublicIpv4Ranges.some(([start, end]) => address >= start && address <= end);
 };
 
 const toMappedIpv4Host = (hostname: string): string | null => {
@@ -96,12 +109,13 @@ const isPrivateIpv6Host = (hostname: string): boolean => {
     return true;
   }
 
+  const firstHextet = Number.parseInt(hostname.split(':', 1)[0] ?? '', 16);
   return (
     hostname === '::1' ||
     hostname === '::' ||
-    hostname.startsWith('fc') ||
-    hostname.startsWith('fd') ||
-    hostname.startsWith('fe80:')
+    (!Number.isNaN(firstHextet) &&
+      ((firstHextet >= 0xfc00 && firstHextet <= 0xfdff) ||
+        (firstHextet >= 0xfe80 && firstHextet <= 0xfebf)))
   );
 };
 

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
@@ -147,15 +147,16 @@ export const normalizeProvisioningUpstreamUrl = async (
   fieldName: 'graphql_base_url' | 'oauth_token_url'
 ): Promise<string> => {
   const parsed = parseUpstreamUrl(value);
-  const isPublicHttpsUrl =
-    parsed &&
-    !parsed.username &&
-    !parsed.password &&
-    !parsed.hash &&
-    parsed.protocol === 'https:' &&
-    !isPrivateOrLocalHost(parsed.hostname);
 
-  if (!isPublicHttpsUrl || (await resolvesToPrivateOrLocalHost(parsed.hostname))) {
+  if (
+    !parsed ||
+    parsed.username ||
+    parsed.password ||
+    parsed.hash ||
+    parsed.protocol !== 'https:' ||
+    isPrivateOrLocalHost(parsed.hostname) ||
+    (await resolvesToPrivateOrLocalHost(parsed.hostname))
+  ) {
     throw new MainserverUserProvisioningError({
       code: 'invalid_config',
       message: `Die konfigurierte Upstream-URL ${fieldName} ist ungültig.`,

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
@@ -1,7 +1,7 @@
 import { lookup as dnsLookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
 
-import { MainserverUserProvisioningError } from './mainserver-user-provisioning.js';
+import { MainserverUserProvisioningError } from './mainserver-user-provisioning-error.js';
 
 const localhostHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
@@ -24,29 +24,36 @@ const unwrapBracketedHost = (hostname: string): string =>
 const isLocalHostname = (hostname: string): boolean =>
   localhostHosts.has(hostname) || hostname.endsWith('.local');
 
-const parseIpv4Octets = (hostname: string): number[] | null => {
+const parseIpv4Octets = (hostname: string): readonly [number, number, number, number] | null => {
   const octets = hostname.split('.').map((segment) => Number.parseInt(segment, 10));
-  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part))) {
+  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
     return null;
   }
 
-  return octets;
+  return [octets[0]!, octets[1]!, octets[2]!, octets[3]!];
 };
 
-const isPrivateIpv4Host = (hostname: string): boolean => {
+const isNonPublicIpv4Host = (hostname: string): boolean => {
   const octets = parseIpv4Octets(hostname);
   if (!octets) {
     return true;
   }
 
-  const [a, b] = octets;
+  const [a, b, c] = octets;
   return (
     a === 0 ||
     a === 10 ||
+    (a === 100 && b >= 64 && b <= 127) ||
     a === 127 ||
     (a === 169 && b === 254) ||
     (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168)
+    (a === 192 && b === 0 && (c === 0 || c === 2)) ||
+    (a === 192 && b === 88 && c === 99) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
   );
 };
 
@@ -111,7 +118,7 @@ const isPrivateOrLocalHost = (hostname: string): boolean => {
 
   const ipVersion = isIP(normalized);
   if (ipVersion === 4) {
-    return isPrivateIpv4Host(normalized);
+    return isNonPublicIpv4Host(normalized);
   }
 
   if (ipVersion === 6) {

--- a/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-upstream-url-validation.ts
@@ -1,183 +1,13 @@
-import { lookup as dnsLookup } from 'node:dns/promises';
-import { isIP } from 'node:net';
-
 import { MainserverUserProvisioningError } from './mainserver-user-provisioning-error.js';
-
-const localhostHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
-
-const parseUpstreamUrl = (value: string): URL | null => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  try {
-    return new URL(trimmed);
-  } catch {
-    return null;
-  }
-};
-
-const unwrapBracketedHost = (hostname: string): string =>
-  hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
-
-const isLocalHostname = (hostname: string): boolean =>
-  localhostHosts.has(hostname) || hostname.endsWith('.local');
-
-type Ipv4Octets = readonly [number, number, number, number];
-type Ipv4Range = readonly [number, number];
-
-const parseIpv4Octets = (hostname: string): Ipv4Octets | null => {
-  const octets = hostname.split('.').map((segment) => Number.parseInt(segment, 10));
-  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
-    return null;
-  }
-
-  return [octets[0]!, octets[1]!, octets[2]!, octets[3]!];
-};
-
-const toIpv4Number = ([a, b, c, d]: Ipv4Octets): number => ((a * 256 + b) * 256 + c) * 256 + d;
-
-const createIpv4Range = (start: Ipv4Octets, end: Ipv4Octets): Ipv4Range => [
-  toIpv4Number(start),
-  toIpv4Number(end),
-];
-
-const nonPublicIpv4Ranges: readonly Ipv4Range[] = [
-  createIpv4Range([0, 0, 0, 0], [0, 255, 255, 255]),
-  createIpv4Range([10, 0, 0, 0], [10, 255, 255, 255]),
-  createIpv4Range([100, 64, 0, 0], [100, 127, 255, 255]),
-  createIpv4Range([127, 0, 0, 0], [127, 255, 255, 255]),
-  createIpv4Range([169, 254, 0, 0], [169, 254, 255, 255]),
-  createIpv4Range([172, 16, 0, 0], [172, 31, 255, 255]),
-  createIpv4Range([192, 0, 0, 0], [192, 0, 0, 255]),
-  createIpv4Range([192, 0, 2, 0], [192, 0, 2, 255]),
-  createIpv4Range([192, 88, 99, 0], [192, 88, 99, 255]),
-  createIpv4Range([192, 168, 0, 0], [192, 168, 255, 255]),
-  createIpv4Range([198, 18, 0, 0], [198, 19, 255, 255]),
-  createIpv4Range([198, 51, 100, 0], [198, 51, 100, 255]),
-  createIpv4Range([203, 0, 113, 0], [203, 0, 113, 255]),
-  createIpv4Range([224, 0, 0, 0], [255, 255, 255, 255]),
-];
-
-const isNonPublicIpv4Host = (hostname: string): boolean => {
-  const octets = parseIpv4Octets(hostname);
-  if (!octets) {
-    return true;
-  }
-
-  const address = toIpv4Number(octets);
-  return nonPublicIpv4Ranges.some(([start, end]) => address >= start && address <= end);
-};
-
-const toMappedIpv4Host = (hostname: string): string | null => {
-  if (!hostname.startsWith('::ffff:')) {
-    return null;
-  }
-
-  const mappedPart = hostname.slice('::ffff:'.length);
-  if (isIP(mappedPart) === 4) {
-    return mappedPart;
-  }
-
-  const hexParts = mappedPart.split(':');
-  if (hexParts.length !== 2) {
-    return null;
-  }
-
-  const high = Number.parseInt(hexParts[0], 16);
-  const low = Number.parseInt(hexParts[1], 16);
-  if (Number.isNaN(high) || Number.isNaN(low)) {
-    return null;
-  }
-
-  return [
-    (high >> 8) & 0xff,
-    high & 0xff,
-    (low >> 8) & 0xff,
-    low & 0xff,
-  ].join('.');
-};
-
-const isPrivateIpv6Host = (hostname: string): boolean => {
-  const mappedIpv4Host = toMappedIpv4Host(hostname);
-  if (mappedIpv4Host) {
-    return isPrivateOrLocalHost(mappedIpv4Host);
-  }
-
-  if (hostname.startsWith('::ffff:')) {
-    return true;
-  }
-
-  const firstHextet = Number.parseInt(hostname.split(':', 1)[0] ?? '', 16);
-  return (
-    hostname === '::1' ||
-    hostname === '::' ||
-    (!Number.isNaN(firstHextet) &&
-      ((firstHextet >= 0xfc00 && firstHextet <= 0xfdff) ||
-        (firstHextet >= 0xfe80 && firstHextet <= 0xfebf)))
-  );
-};
-
-const isPrivateOrLocalHost = (hostname: string): boolean => {
-  const normalized = hostname.trim().toLowerCase();
-  if (isLocalHostname(normalized)) {
-    return true;
-  }
-
-  const unbracketed = unwrapBracketedHost(normalized);
-  if (unbracketed !== normalized) {
-    return isPrivateOrLocalHost(unbracketed);
-  }
-
-  const ipVersion = isIP(normalized);
-  if (ipVersion === 4) {
-    return isNonPublicIpv4Host(normalized);
-  }
-
-  if (ipVersion === 6) {
-    return isPrivateIpv6Host(normalized);
-  }
-
-  return false;
-};
-
-const resolvesToPrivateOrLocalHost = async (hostname: string): Promise<boolean> => {
-  const normalized = hostname.trim().toLowerCase();
-  if (isIP(normalized) !== 0) {
-    return false;
-  }
-
-  try {
-    const resolved = await dnsLookup(normalized, {
-      all: true,
-      verbatim: true,
-    });
-    if (resolved.length === 0) {
-      return true;
-    }
-
-    return resolved.some((entry) => isPrivateOrLocalHost(entry.address));
-  } catch {
-    return true;
-  }
-};
+import { normalizePublicUpstreamUrl } from '../upstream-url-validation.js';
 
 export const normalizeProvisioningUpstreamUrl = async (
   value: string,
   fieldName: 'graphql_base_url' | 'oauth_token_url'
 ): Promise<string> => {
-  const parsed = parseUpstreamUrl(value);
+  const normalizedUrl = await normalizePublicUpstreamUrl(value);
 
-  if (
-    !parsed ||
-    parsed.username ||
-    parsed.password ||
-    parsed.hash ||
-    parsed.protocol !== 'https:' ||
-    isPrivateOrLocalHost(parsed.hostname) ||
-    (await resolvesToPrivateOrLocalHost(parsed.hostname))
-  ) {
+  if (!normalizedUrl) {
     throw new MainserverUserProvisioningError({
       code: 'invalid_config',
       message: `Die konfigurierte Upstream-URL ${fieldName} ist ungültig.`,
@@ -185,5 +15,5 @@ export const normalizeProvisioningUpstreamUrl = async (
     });
   }
 
-  return parsed.toString();
+  return normalizedUrl;
 };

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning-error.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning-error.ts
@@ -1,0 +1,18 @@
+export class MainserverUserProvisioningError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+  readonly retryable: boolean;
+
+  constructor(input: {
+    readonly code: string;
+    readonly message: string;
+    readonly statusCode: number;
+    readonly retryable?: boolean;
+  }) {
+    super(input.message);
+    this.name = 'MainserverUserProvisioningError';
+    this.code = input.code;
+    this.statusCode = input.statusCode;
+    this.retryable = input.retryable ?? false;
+  }
+}

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
@@ -155,6 +155,41 @@ describe('provisionMainserverUserCredentials', () => {
     );
   });
 
+  it('uses one abort signal for token and provisioning requests so the full provisioning flow is bounded', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'admin-token', expires_in: 3600 }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            keycloak: {
+              attributes: {
+                mainserverUserApplicationId: 'user-app',
+                mainserverUserApplicationSecret: 'user-secret',
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      );
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await provisionMainserverUserCredentials({
+      actor: createActor(),
+      actorSubject: 'kc-admin-1',
+      keycloakSubject: 'kc-user-1',
+      payload: createPayload(),
+      fetchImpl,
+    });
+
+    const tokenSignal = fetchImpl.mock.calls[0]?.[1]?.signal;
+    const provisioningSignal = fetchImpl.mock.calls[1]?.[1]?.signal;
+    expect(tokenSignal).toBeInstanceOf(AbortSignal);
+    expect(provisioningSignal).toBe(tokenSignal);
+  });
+
   it('provisions against the Mainserver endpoint even when the municipality id is not configured explicitly', async () => {
     state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
       enabled: true,

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
@@ -124,6 +124,7 @@ describe('provisionMainserverUserCredentials', () => {
     expect(state.readEffectiveSvaMainserverCredentialsWithStatus).toHaveBeenCalledWith({
       instanceId: 'bb-demo',
       keycloakSubject: 'kc-admin-1',
+      activeOrganizationId: undefined,
     });
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
@@ -153,6 +154,43 @@ describe('provisionMainserverUserCredentials', () => {
         }),
       })
     );
+  });
+
+  it('passes the active organization id to the Mainserver credential lookup', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'admin-token' }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            keycloak: {
+              attributes: {
+                mainserverUserApplicationId: 'user-app',
+                mainserverUserApplicationSecret: 'user-secret',
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      );
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await provisionMainserverUserCredentials({
+      actor: {
+        ...createActor(),
+        activeOrganizationId: '11111111-1111-4111-8111-111111111111',
+      },
+      actorSubject: 'kc-admin-1',
+      keycloakSubject: 'kc-user-1',
+      payload: createPayload(),
+      fetchImpl,
+    });
+
+    expect(state.readEffectiveSvaMainserverCredentialsWithStatus).toHaveBeenCalledWith({
+      instanceId: 'bb-demo',
+      keycloakSubject: 'kc-admin-1',
+      activeOrganizationId: '11111111-1111-4111-8111-111111111111',
+    });
   });
 
   it('uses one abort signal for token and provisioning requests so the full provisioning flow is bounded', async () => {

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
@@ -88,6 +88,74 @@ describe('provisionMainserverUserCredentials', () => {
     });
   });
 
+  it('returns null and logs an info event when the integration record is missing or disabled', async () => {
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValueOnce(null);
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn(),
+      })
+    ).resolves.toBeNull();
+
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValueOnce({
+      enabled: false,
+      publicConfig: {},
+    });
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn(),
+      })
+    ).resolves.toBeNull();
+
+    expect(state.logger.info).toHaveBeenNthCalledWith(
+      1,
+      'SVA Mainserver user provisioning skipped because integration is not configured',
+      expect.objectContaining({
+        context: expect.objectContaining({ reason_code: 'config_not_found' }),
+      })
+    );
+    expect(state.logger.info).toHaveBeenNthCalledWith(
+      2,
+      'SVA Mainserver user provisioning skipped because integration is not configured',
+      expect.objectContaining({
+        context: expect.objectContaining({ reason_code: 'integration_disabled' }),
+      })
+    );
+  });
+
+  it('rejects incomplete provisioning configs before fetching', async () => {
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
+      enabled: true,
+      publicConfig: {
+        graphqlBaseUrl: 'https://bb-demo.server.smart-village.app/graphql',
+      },
+    });
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn(),
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'mainserver_user_provisioning_config_incomplete',
+      statusCode: 409,
+    });
+  });
+
   it('loads an admin bearer token, provisions the user, and returns Keycloak Mainserver attributes', async () => {
     const fetchImpl = vi
       .fn()
@@ -190,6 +258,96 @@ describe('provisionMainserverUserCredentials', () => {
       instanceId: 'bb-demo',
       keycloakSubject: 'kc-admin-1',
       activeOrganizationId: '11111111-1111-4111-8111-111111111111',
+    });
+  });
+
+  it('maps missing actor credentials to a typed provisioning error', async () => {
+    state.readEffectiveSvaMainserverCredentialsWithStatus.mockResolvedValue({
+      status: 'missing_credentials',
+    });
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn(),
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'missing_credentials',
+      statusCode: 409,
+    });
+  });
+
+  it('maps non-200 token responses to unauthorized and retryable token failures', async () => {
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn().mockResolvedValueOnce(new Response('unauthorized', { status: 401 })),
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'unauthorized',
+      retryable: false,
+      statusCode: 401,
+    });
+
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn().mockResolvedValueOnce(new Response('server error', { status: 503 })),
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'token_request_failed',
+      retryable: true,
+      statusCode: 503,
+    });
+  });
+
+  it('rejects invalid token and provisioning response bodies', async () => {
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ token: 'missing-access-token' }), { status: 200 })),
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'invalid_response',
+      statusCode: 502,
+    });
+
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi
+          .fn()
+          .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'admin-token' }), { status: 200 }))
+          .mockResolvedValueOnce(new Response(JSON.stringify({ keycloak: { attributes: {} } }), { status: 200 })),
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'invalid_response',
+      statusCode: 502,
     });
   });
 

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
@@ -251,6 +251,33 @@ describe('provisionMainserverUserCredentials', () => {
     }
   );
 
+  it('rejects IPv6 link-local literal upstream urls before fetching', async () => {
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
+      enabled: true,
+      publicConfig: {
+        graphqlBaseUrl: 'https://bb-demo.server.smart-village.app/graphql',
+        oauthTokenUrl: 'https://[fe90::1]/oauth/token',
+      },
+    });
+    const fetchImpl = vi.fn();
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl,
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'invalid_config',
+      statusCode: 409,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('provisions against the Mainserver endpoint even when the municipality id is not configured explicitly', async () => {
     state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
       enabled: true,

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+
 const state = vi.hoisted(() => ({
   loadDefaultExternalInterfaceRecord: vi.fn(),
   readEffectiveSvaMainserverCredentialsWithStatus: vi.fn(),
@@ -7,6 +9,10 @@ const state = vi.hoisted(() => ({
     info: vi.fn(),
     warn: vi.fn(),
   },
+}));
+
+vi.mock('node:dns/promises', () => ({
+  lookup: dnsLookupMock,
 }));
 
 vi.mock('@sva/data-repositories/server', () => ({
@@ -39,6 +45,8 @@ const createPayload = () => ({
 describe('provisionMainserverUserCredentials', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    dnsLookupMock.mockReset();
+    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
     state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
       enabled: true,
       publicConfig: {
@@ -52,6 +60,31 @@ describe('provisionMainserverUserCredentials', () => {
         apiKey: 'admin-app',
         apiSecret: 'admin-secret',
       },
+    });
+  });
+
+  it('rejects invalid upstream urls from the stored integration config', async () => {
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
+      enabled: true,
+      publicConfig: {
+        graphqlBaseUrl: 'https://localhost/graphql',
+        oauthTokenUrl: 'https://bb-demo.server.smart-village.app/oauth/token',
+      },
+    });
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl: vi.fn(),
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'invalid_config',
+      statusCode: 409,
     });
   });
 
@@ -206,6 +239,53 @@ describe('provisionMainserverUserCredentials', () => {
       message: 'conflict',
       retryable: false,
       statusCode: 409,
+    });
+  });
+
+  it('fails with a retryable timeout when the token request hangs', async () => {
+    const timeoutError = new Error('timeout');
+    timeoutError.name = 'TimeoutError';
+    const fetchImpl = vi.fn().mockRejectedValueOnce(timeoutError);
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl,
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'upstream_timeout',
+      retryable: true,
+      statusCode: 504,
+    });
+  });
+
+  it('fails with a retryable timeout when the provisioning request hangs', async () => {
+    const timeoutError = new Error('timeout');
+    timeoutError.name = 'AbortError';
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'admin-token' }), { status: 200 }))
+      .mockRejectedValueOnce(timeoutError);
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl,
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'upstream_timeout',
+      retryable: true,
+      statusCode: 504,
     });
   });
 });

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  loadDefaultExternalInterfaceRecord: vi.fn(),
+  readEffectiveSvaMainserverCredentialsWithStatus: vi.fn(),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@sva/data-repositories/server', () => ({
+  loadDefaultExternalInterfaceRecord: state.loadDefaultExternalInterfaceRecord,
+}));
+
+vi.mock('@sva/server-runtime', () => ({
+  createSdkLogger: () => state.logger,
+}));
+
+vi.mock('../mainserver-effective-credentials.js', () => ({
+  readEffectiveSvaMainserverCredentialsWithStatus: state.readEffectiveSvaMainserverCredentialsWithStatus,
+}));
+
+const createActor = () => ({
+  instanceId: 'bb-demo',
+  actorAccountId: 'actor-1',
+  requestId: 'req-1',
+  traceId: 'trace-1',
+});
+
+const createPayload = () => ({
+  email: 'alice@example.com',
+  firstName: 'Alice',
+  lastName: 'Example',
+  roleIds: [],
+  sendPasswordSetupEmail: false,
+});
+
+describe('provisionMainserverUserCredentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
+      enabled: true,
+      publicConfig: {
+        graphqlBaseUrl: 'https://bb-demo.server.smart-village.app/graphql',
+        oauthTokenUrl: 'https://bb-demo.server.smart-village.app/oauth/token',
+      },
+    });
+    state.readEffectiveSvaMainserverCredentialsWithStatus.mockResolvedValue({
+      status: 'ok',
+      credentials: {
+        apiKey: 'admin-app',
+        apiSecret: 'admin-secret',
+      },
+    });
+  });
+
+  it('loads an admin bearer token, provisions the user, and returns Keycloak Mainserver attributes', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'admin-token', expires_in: 3600 }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            keycloak: {
+              attributes: {
+                mainserverUserApplicationId: 'user-app',
+                mainserverUserApplicationSecret: 'user-secret',
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      );
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    const result = await provisionMainserverUserCredentials({
+      actor: createActor(),
+      actorSubject: 'kc-admin-1',
+      keycloakSubject: 'kc-user-1',
+      payload: createPayload(),
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      mainserverUserApplicationId: 'user-app',
+      mainserverUserApplicationSecret: 'user-secret',
+    });
+    expect(state.readEffectiveSvaMainserverCredentialsWithStatus).toHaveBeenCalledWith({
+      instanceId: 'bb-demo',
+      keycloakSubject: 'kc-admin-1',
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://bb-demo.server.smart-village.app/oauth/token',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(URLSearchParams),
+      })
+    );
+    expect(String(fetchImpl.mock.calls[0]?.[1]?.body)).toBe(
+      'grant_type=client_credentials&client_id=admin-app&client_secret=admin-secret'
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://bb-demo.server.smart-village.app/api/v2/user_provisionings',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer admin-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          email: 'alice@example.com',
+          keycloak_id: 'kc-user-1',
+          first_name: 'Alice',
+          last_name: 'Example',
+        }),
+      })
+    );
+  });
+
+  it('provisions against the Mainserver endpoint even when the municipality id is not configured explicitly', async () => {
+    state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
+      enabled: true,
+      publicConfig: {
+        graphqlBaseUrl: 'https://bb-demo.server.smart-village.app/graphql',
+        oauthTokenUrl: 'https://bb-demo.server.smart-village.app/oauth/token',
+      },
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'admin-token', expires_in: 3600 }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            keycloak: {
+              attributes: {
+                mainserverUserApplicationId: 'user-app',
+                mainserverUserApplicationSecret: 'user-secret',
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      );
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    const result = await provisionMainserverUserCredentials({
+      actor: createActor(),
+      actorSubject: 'kc-admin-1',
+      keycloakSubject: 'kc-user-1',
+      payload: createPayload(),
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      mainserverUserApplicationId: 'user-app',
+      mainserverUserApplicationSecret: 'user-secret',
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://bb-demo.server.smart-village.app/api/v2/user_provisionings',
+      expect.objectContaining({
+        body: JSON.stringify({
+          email: 'alice@example.com',
+          keycloak_id: 'kc-user-1',
+          first_name: 'Alice',
+          last_name: 'Example',
+        }),
+      })
+    );
+  });
+
+  it('maps Mainserver provisioning error payloads without exposing secrets', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'admin-token' }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 'local_user_conflict',
+            message: 'conflict',
+            retryable: false,
+          }),
+          { status: 409 }
+        )
+      );
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await expect(
+      provisionMainserverUserCredentials({
+        actor: createActor(),
+        actorSubject: 'kc-admin-1',
+        keycloakSubject: 'kc-user-1',
+        payload: createPayload(),
+        fetchImpl,
+      })
+    ).rejects.toMatchObject({
+      name: 'MainserverUserProvisioningError',
+      code: 'local_user_conflict',
+      message: 'conflict',
+      retryable: false,
+      statusCode: 409,
+    });
+  });
+});

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.test.ts
@@ -46,7 +46,7 @@ describe('provisionMainserverUserCredentials', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     dnsLookupMock.mockReset();
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
     state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
       enabled: true,
       publicConfig: {
@@ -189,6 +189,67 @@ describe('provisionMainserverUserCredentials', () => {
     expect(tokenSignal).toBeInstanceOf(AbortSignal);
     expect(provisioningSignal).toBe(tokenSignal);
   });
+
+  it('disables automatic redirects for token and provisioning requests', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'admin-token' }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            keycloak: {
+              attributes: {
+                mainserverUserApplicationId: 'user-app',
+                mainserverUserApplicationSecret: 'user-secret',
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      );
+
+    const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+    await provisionMainserverUserCredentials({
+      actor: createActor(),
+      actorSubject: 'kc-admin-1',
+      keycloakSubject: 'kc-user-1',
+      payload: createPayload(),
+      fetchImpl,
+    });
+
+    expect(fetchImpl.mock.calls[0]?.[1]?.redirect).toBe('manual');
+    expect(fetchImpl.mock.calls[1]?.[1]?.redirect).toBe('manual');
+  });
+
+  it.each(['https://100.64.0.1/oauth/token', 'https://198.18.0.1/oauth/token'])(
+    'rejects non-public IPv4 literal upstream url %s before fetching',
+    async (oauthTokenUrl) => {
+      state.loadDefaultExternalInterfaceRecord.mockResolvedValue({
+        enabled: true,
+        publicConfig: {
+          graphqlBaseUrl: 'https://bb-demo.server.smart-village.app/graphql',
+          oauthTokenUrl,
+        },
+      });
+      const fetchImpl = vi.fn();
+
+      const { provisionMainserverUserCredentials } = await import('./mainserver-user-provisioning.js');
+      await expect(
+        provisionMainserverUserCredentials({
+          actor: createActor(),
+          actorSubject: 'kc-admin-1',
+          keycloakSubject: 'kc-user-1',
+          payload: createPayload(),
+          fetchImpl,
+        })
+      ).rejects.toMatchObject({
+        name: 'MainserverUserProvisioningError',
+        code: 'invalid_config',
+        statusCode: 409,
+      });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    }
+  );
 
   it('provisions against the Mainserver endpoint even when the municipality id is not configured explicitly', async () => {
     state.loadDefaultExternalInterfaceRecord.mockResolvedValue({

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -1,0 +1,247 @@
+import { z } from 'zod';
+import { loadDefaultExternalInterfaceRecord } from '@sva/data-repositories/server';
+import { createSdkLogger } from '@sva/server-runtime';
+
+import { readEffectiveSvaMainserverCredentialsWithStatus } from '../mainserver-effective-credentials.js';
+
+import type { CreateUserActorInfo } from './user-create-invitation.js';
+import type { CreateUserPayload } from './user-create-persistence.js';
+
+const SVA_MAINSERVER_TYPE_KEY = 'sva_mainserver';
+const USER_PROVISIONINGS_PATH = '/api/v2/user_provisionings';
+const logger = createSdkLogger({ component: 'iam-mainserver-user-provisioning', level: 'info' });
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+});
+
+const provisioningResponseSchema = z.object({
+  keycloak: z.object({
+    attributes: z.object({
+      mainserverUserApplicationId: z.string().min(1),
+      mainserverUserApplicationSecret: z.string().min(1),
+    }),
+  }),
+});
+
+export type ProvisionedMainserverUserCredentials = {
+  readonly mainserverUserApplicationId: string;
+  readonly mainserverUserApplicationSecret: string;
+};
+
+type MainserverProvisioningConfig = {
+  readonly oauthTokenUrl: string;
+  readonly provisioningUrl: string;
+};
+
+type ErrorPayload = {
+  readonly code?: string;
+  readonly message?: string;
+  readonly retryable?: boolean;
+};
+
+export class MainserverUserProvisioningError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+  readonly retryable: boolean;
+
+  constructor(input: {
+    readonly code: string;
+    readonly message: string;
+    readonly statusCode: number;
+    readonly retryable?: boolean;
+  }) {
+    super(input.message);
+    this.name = 'MainserverUserProvisioningError';
+    this.code = input.code;
+    this.statusCode = input.statusCode;
+    this.retryable = input.retryable ?? false;
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const parseJsonBody = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch {
+    throw new MainserverUserProvisioningError({
+      code: 'invalid_response',
+      message: 'Ungültige Antwort des SVA-Mainserver-Provisionings.',
+      statusCode: 502,
+    });
+  }
+};
+
+const readErrorPayload = async (response: Response): Promise<ErrorPayload> => {
+  const payload = await parseJsonBody(response).catch(() => null);
+  if (!isRecord(payload)) {
+    return {};
+  }
+
+  return {
+    code: typeof payload.code === 'string' ? payload.code : undefined,
+    message: typeof payload.message === 'string' ? payload.message : undefined,
+    retryable: typeof payload.retryable === 'boolean' ? payload.retryable : undefined,
+  };
+};
+
+const resolveProvisioningUrl = (graphqlBaseUrl: string): string => {
+  const graphqlUrl = new URL(graphqlBaseUrl);
+  return new URL(USER_PROVISIONINGS_PATH, graphqlUrl.origin).toString();
+};
+
+const loadProvisioningConfig = async (instanceId: string): Promise<MainserverProvisioningConfig | null> => {
+  const record = await loadDefaultExternalInterfaceRecord(instanceId, SVA_MAINSERVER_TYPE_KEY);
+  if (!record || !record.enabled) {
+    logger.warn('SVA Mainserver user provisioning skipped because integration is not configured', {
+      workspace_id: instanceId,
+      context: {
+        operation: 'mainserver_user_provisioning',
+        instance_id: instanceId,
+        reason_code: record ? 'integration_disabled' : 'config_not_found',
+      },
+    });
+    return null;
+  }
+
+  const publicConfig = isRecord(record.publicConfig) ? record.publicConfig : {};
+  const graphqlBaseUrl = typeof publicConfig.graphqlBaseUrl === 'string' ? publicConfig.graphqlBaseUrl.trim() : '';
+  const oauthTokenUrl = typeof publicConfig.oauthTokenUrl === 'string' ? publicConfig.oauthTokenUrl.trim() : '';
+  if (!graphqlBaseUrl || !oauthTokenUrl) {
+    throw new MainserverUserProvisioningError({
+      code: 'mainserver_user_provisioning_config_incomplete',
+      message: 'SVA-Mainserver-Provisioning ist unvollständig konfiguriert.',
+      statusCode: 409,
+    });
+  }
+
+  return {
+    oauthTokenUrl,
+    provisioningUrl: resolveProvisioningUrl(graphqlBaseUrl),
+  };
+};
+
+const loadProvisioningBearerToken = async (input: {
+  readonly actor: CreateUserActorInfo;
+  readonly actorSubject: string;
+  readonly oauthTokenUrl: string;
+  readonly fetchImpl: typeof fetch;
+}): Promise<string> => {
+  const credentialResult = await readEffectiveSvaMainserverCredentialsWithStatus({
+    instanceId: input.actor.instanceId,
+    keycloakSubject: input.actorSubject,
+  });
+  if (credentialResult.status !== 'ok') {
+    throw new MainserverUserProvisioningError({
+      code: credentialResult.status,
+      message: 'Mainserver-Provisioning-Credentials des handelnden Benutzers fehlen.',
+      statusCode: 409,
+    });
+  }
+
+  const response = await input.fetchImpl(input.oauthTokenUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: credentialResult.credentials.apiKey,
+      client_secret: credentialResult.credentials.apiSecret,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new MainserverUserProvisioningError({
+      code: response.status === 401 ? 'unauthorized' : 'token_request_failed',
+      message: `Mainserver-Provisioning-Token konnte nicht geladen werden (${response.status}).`,
+      statusCode: response.status,
+      retryable: response.status >= 500,
+    });
+  }
+
+  const parsed = tokenResponseSchema.safeParse(await parseJsonBody(response));
+  if (!parsed.success) {
+    throw new MainserverUserProvisioningError({
+      code: 'invalid_response',
+      message: 'Ungültige Token-Antwort des SVA-Mainservers.',
+      statusCode: 502,
+    });
+  }
+
+  return parsed.data.access_token;
+};
+
+export const provisionMainserverUserCredentials = async (input: {
+  readonly actor: CreateUserActorInfo;
+  readonly actorSubject: string;
+  readonly keycloakSubject: string;
+  readonly payload: CreateUserPayload;
+  readonly fetchImpl?: typeof fetch;
+}): Promise<ProvisionedMainserverUserCredentials | null> => {
+  const config = await loadProvisioningConfig(input.actor.instanceId);
+  if (!config) {
+    return null;
+  }
+
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const accessToken = await loadProvisioningBearerToken({
+    actor: input.actor,
+    actorSubject: input.actorSubject,
+    oauthTokenUrl: config.oauthTokenUrl,
+    fetchImpl,
+  });
+
+  const response = await fetchImpl(config.provisioningUrl, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: input.payload.email,
+      keycloak_id: input.keycloakSubject,
+      first_name: input.payload.firstName,
+      last_name: input.payload.lastName,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorPayload = await readErrorPayload(response);
+    throw new MainserverUserProvisioningError({
+      code: errorPayload.code ?? 'mainserver_user_provisioning_failed',
+      message: errorPayload.message ?? `Mainserver-Benutzer-Provisioning fehlgeschlagen (${response.status}).`,
+      statusCode: response.status,
+      retryable: errorPayload.retryable ?? response.status >= 500,
+    });
+  }
+
+  const parsed = provisioningResponseSchema.safeParse(await parseJsonBody(response));
+  if (!parsed.success) {
+    throw new MainserverUserProvisioningError({
+      code: 'invalid_response',
+      message: 'Ungültige Antwort des SVA-Mainserver-Provisionings.',
+      statusCode: 502,
+    });
+  }
+
+  logger.info('SVA Mainserver user provisioning succeeded', {
+    workspace_id: input.actor.instanceId,
+    context: {
+      operation: 'mainserver_user_provisioning',
+      instance_id: input.actor.instanceId,
+      request_id: input.actor.requestId,
+      trace_id: input.actor.traceId,
+      keycloak_subject: input.keycloakSubject,
+    },
+  });
+
+  return {
+    mainserverUserApplicationId: parsed.data.keycloak.attributes.mainserverUserApplicationId,
+    mainserverUserApplicationSecret: parsed.data.keycloak.attributes.mainserverUserApplicationSecret,
+  };
+};

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -4,11 +4,13 @@ import { createSdkLogger } from '@sva/server-runtime';
 
 import { readEffectiveSvaMainserverCredentialsWithStatus } from '../mainserver-effective-credentials.js';
 
+import { normalizeProvisioningUpstreamUrl } from './mainserver-upstream-url-validation.js';
 import type { CreateUserActorInfo } from './user-create-invitation.js';
 import type { CreateUserPayload } from './user-create-persistence.js';
 
 const SVA_MAINSERVER_TYPE_KEY = 'sva_mainserver';
 const USER_PROVISIONINGS_PATH = '/api/v2/user_provisionings';
+const MAINSERVER_REQUEST_TIMEOUT_MS = 10_000;
 const logger = createSdkLogger({ component: 'iam-mainserver-user-provisioning', level: 'info' });
 
 const tokenResponseSchema = z.object({
@@ -61,6 +63,36 @@ export class MainserverUserProvisioningError extends Error {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+
+const fetchWithTimeout = async (input: {
+  readonly fetchImpl: typeof fetch;
+  readonly url: string;
+  readonly init: RequestInit;
+  readonly timeoutMessage: string;
+}): Promise<Response> => {
+  try {
+    return await input.fetchImpl(input.url, {
+      ...input.init,
+      signal: input.init.signal
+        ? AbortSignal.any([input.init.signal, AbortSignal.timeout(MAINSERVER_REQUEST_TIMEOUT_MS)])
+        : AbortSignal.timeout(MAINSERVER_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new MainserverUserProvisioningError({
+        code: 'upstream_timeout',
+        message: input.timeoutMessage,
+        statusCode: 504,
+        retryable: true,
+      });
+    }
+
+    throw error;
+  }
+};
 
 const parseJsonBody = async (response: Response): Promise<unknown> => {
   try {
@@ -118,8 +150,10 @@ const loadProvisioningConfig = async (instanceId: string): Promise<MainserverPro
   }
 
   return {
-    oauthTokenUrl,
-    provisioningUrl: resolveProvisioningUrl(graphqlBaseUrl),
+    oauthTokenUrl: await normalizeProvisioningUpstreamUrl(oauthTokenUrl, 'oauth_token_url'),
+    provisioningUrl: resolveProvisioningUrl(
+      await normalizeProvisioningUpstreamUrl(graphqlBaseUrl, 'graphql_base_url')
+    ),
   };
 };
 
@@ -141,17 +175,22 @@ const loadProvisioningBearerToken = async (input: {
     });
   }
 
-  const response = await input.fetchImpl(input.oauthTokenUrl, {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/x-www-form-urlencoded',
+  const response = await fetchWithTimeout({
+    fetchImpl: input.fetchImpl,
+    url: input.oauthTokenUrl,
+    init: {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: credentialResult.credentials.apiKey,
+        client_secret: credentialResult.credentials.apiSecret,
+      }),
     },
-    body: new URLSearchParams({
-      grant_type: 'client_credentials',
-      client_id: credentialResult.credentials.apiKey,
-      client_secret: credentialResult.credentials.apiSecret,
-    }),
+    timeoutMessage: 'Zeitüberschreitung beim Laden des Mainserver-Provisioning-Tokens.',
   });
 
   if (!response.ok) {
@@ -195,19 +234,24 @@ export const provisionMainserverUserCredentials = async (input: {
     fetchImpl,
   });
 
-  const response = await fetchImpl(config.provisioningUrl, {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
+  const response = await fetchWithTimeout({
+    fetchImpl,
+    url: config.provisioningUrl,
+    init: {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: input.payload.email,
+        keycloak_id: input.keycloakSubject,
+        first_name: input.payload.firstName,
+        last_name: input.payload.lastName,
+      }),
     },
-    body: JSON.stringify({
-      email: input.payload.email,
-      keycloak_id: input.keycloakSubject,
-      first_name: input.payload.firstName,
-      last_name: input.payload.lastName,
-    }),
+    timeoutMessage: 'Zeitüberschreitung beim Provisionieren des Mainserver-Benutzers.',
   });
 
   if (!response.ok) {

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -11,7 +11,7 @@ import type { CreateUserPayload } from './user-create-persistence.js';
 
 const SVA_MAINSERVER_TYPE_KEY = 'sva_mainserver';
 const USER_PROVISIONINGS_PATH = '/api/v2/user_provisionings';
-const MAINSERVER_REQUEST_TIMEOUT_MS = 10_000;
+const MAINSERVER_PROVISIONING_TIMEOUT_MS = 10_000;
 const logger = createSdkLogger({ component: 'iam-mainserver-user-provisioning', level: 'info' });
 
 const tokenResponseSchema = z.object({
@@ -53,14 +53,13 @@ const fetchWithTimeout = async (input: {
   readonly fetchImpl: typeof fetch;
   readonly url: string;
   readonly init: RequestInit;
+  readonly signal: AbortSignal;
   readonly timeoutMessage: string;
 }): Promise<Response> => {
   try {
     return await input.fetchImpl(input.url, {
       ...input.init,
-      signal: input.init.signal
-        ? AbortSignal.any([input.init.signal, AbortSignal.timeout(MAINSERVER_REQUEST_TIMEOUT_MS)])
-        : AbortSignal.timeout(MAINSERVER_REQUEST_TIMEOUT_MS),
+      signal: input.signal,
     });
   } catch (error) {
     if (isAbortError(error)) {
@@ -144,6 +143,7 @@ const loadProvisioningBearerToken = async (input: {
   readonly actorSubject: string;
   readonly oauthTokenUrl: string;
   readonly fetchImpl: typeof fetch;
+  readonly signal: AbortSignal;
 }): Promise<string> => {
   const credentialResult = await readEffectiveSvaMainserverCredentialsWithStatus({
     instanceId: input.actor.instanceId,
@@ -160,6 +160,7 @@ const loadProvisioningBearerToken = async (input: {
   const response = await fetchWithTimeout({
     fetchImpl: input.fetchImpl,
     url: input.oauthTokenUrl,
+    signal: input.signal,
     init: {
       method: 'POST',
       headers: {
@@ -209,16 +210,19 @@ export const provisionMainserverUserCredentials = async (input: {
   }
 
   const fetchImpl = input.fetchImpl ?? fetch;
+  const provisioningSignal = AbortSignal.timeout(MAINSERVER_PROVISIONING_TIMEOUT_MS);
   const accessToken = await loadProvisioningBearerToken({
     actor: input.actor,
     actorSubject: input.actorSubject,
     oauthTokenUrl: config.oauthTokenUrl,
     fetchImpl,
+    signal: provisioningSignal,
   });
 
   const response = await fetchWithTimeout({
     fetchImpl,
     url: config.provisioningUrl,
+    signal: provisioningSignal,
     init: {
       method: 'POST',
       headers: {

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -4,6 +4,7 @@ import { createSdkLogger } from '@sva/server-runtime';
 
 import { readEffectiveSvaMainserverCredentialsWithStatus } from '../mainserver-effective-credentials.js';
 
+import { MainserverUserProvisioningError } from './mainserver-user-provisioning-error.js';
 import { normalizeProvisioningUpstreamUrl } from './mainserver-upstream-url-validation.js';
 import type { CreateUserActorInfo } from './user-create-invitation.js';
 import type { CreateUserPayload } from './user-create-persistence.js';
@@ -41,25 +42,6 @@ type ErrorPayload = {
   readonly message?: string;
   readonly retryable?: boolean;
 };
-
-export class MainserverUserProvisioningError extends Error {
-  readonly statusCode: number;
-  readonly code: string;
-  readonly retryable: boolean;
-
-  constructor(input: {
-    readonly code: string;
-    readonly message: string;
-    readonly statusCode: number;
-    readonly retryable?: boolean;
-  }) {
-    super(input.message);
-    this.name = 'MainserverUserProvisioningError';
-    this.code = input.code;
-    this.statusCode = input.statusCode;
-    this.retryable = input.retryable ?? false;
-  }
-}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -149,6 +149,7 @@ const loadProvisioningBearerToken = async (input: {
   const credentialResult = await readEffectiveSvaMainserverCredentialsWithStatus({
     instanceId: input.actor.instanceId,
     keycloakSubject: input.actorSubject,
+    activeOrganizationId: input.actor.activeOrganizationId,
   });
   if (credentialResult.status !== 'ok') {
     throw new MainserverUserProvisioningError({

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -4,6 +4,11 @@ import { createSdkLogger } from '@sva/server-runtime';
 
 import { readEffectiveSvaMainserverCredentialsWithStatus } from '../mainserver-effective-credentials.js';
 
+import {
+  createProvisioningErrorFromResponse,
+  fetchMainserverUpstream,
+  parseMainserverJsonBody,
+} from './mainserver-upstream-http.js';
 import { MainserverUserProvisioningError } from './mainserver-user-provisioning-error.js';
 import { normalizeProvisioningUpstreamUrl } from './mainserver-upstream-url-validation.js';
 import type { CreateUserActorInfo } from './user-create-invitation.js';
@@ -37,69 +42,8 @@ type MainserverProvisioningConfig = {
   readonly provisioningUrl: string;
 };
 
-type ErrorPayload = {
-  readonly code?: string;
-  readonly message?: string;
-  readonly retryable?: boolean;
-};
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
-
-const isAbortError = (error: unknown): boolean =>
-  error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
-
-const fetchWithTimeout = async (input: {
-  readonly fetchImpl: typeof fetch;
-  readonly url: string;
-  readonly init: RequestInit;
-  readonly signal: AbortSignal;
-  readonly timeoutMessage: string;
-}): Promise<Response> => {
-  try {
-    return await input.fetchImpl(input.url, {
-      ...input.init,
-      redirect: 'manual',
-      signal: input.signal,
-    });
-  } catch (error) {
-    if (isAbortError(error)) {
-      throw new MainserverUserProvisioningError({
-        code: 'upstream_timeout',
-        message: input.timeoutMessage,
-        statusCode: 504,
-        retryable: true,
-      });
-    }
-
-    throw error;
-  }
-};
-
-const parseJsonBody = async (response: Response): Promise<unknown> => {
-  try {
-    return await response.json();
-  } catch {
-    throw new MainserverUserProvisioningError({
-      code: 'invalid_response',
-      message: 'Ungültige Antwort des SVA-Mainserver-Provisionings.',
-      statusCode: 502,
-    });
-  }
-};
-
-const readErrorPayload = async (response: Response): Promise<ErrorPayload> => {
-  const payload = await parseJsonBody(response).catch(() => null);
-  if (!isRecord(payload)) {
-    return {};
-  }
-
-  return {
-    code: typeof payload.code === 'string' ? payload.code : undefined,
-    message: typeof payload.message === 'string' ? payload.message : undefined,
-    retryable: typeof payload.retryable === 'boolean' ? payload.retryable : undefined,
-  };
-};
 
 const resolveProvisioningUrl = (graphqlBaseUrl: string): string => {
   const graphqlUrl = new URL(graphqlBaseUrl);
@@ -159,7 +103,7 @@ const loadProvisioningBearerToken = async (input: {
     });
   }
 
-  const response = await fetchWithTimeout({
+  const response = await fetchMainserverUpstream({
     fetchImpl: input.fetchImpl,
     url: input.oauthTokenUrl,
     signal: input.signal,
@@ -187,7 +131,9 @@ const loadProvisioningBearerToken = async (input: {
     });
   }
 
-  const parsed = tokenResponseSchema.safeParse(await parseJsonBody(response));
+  const parsed = tokenResponseSchema.safeParse(
+    await parseMainserverJsonBody(response, 'Ungültige Token-Antwort des SVA-Mainservers.')
+  );
   if (!parsed.success) {
     throw new MainserverUserProvisioningError({
       code: 'invalid_response',
@@ -221,7 +167,7 @@ export const provisionMainserverUserCredentials = async (input: {
     signal: provisioningSignal,
   });
 
-  const response = await fetchWithTimeout({
+  const response = await fetchMainserverUpstream({
     fetchImpl,
     url: config.provisioningUrl,
     signal: provisioningSignal,
@@ -243,16 +189,12 @@ export const provisionMainserverUserCredentials = async (input: {
   });
 
   if (!response.ok) {
-    const errorPayload = await readErrorPayload(response);
-    throw new MainserverUserProvisioningError({
-      code: errorPayload.code ?? 'mainserver_user_provisioning_failed',
-      message: errorPayload.message ?? `Mainserver-Benutzer-Provisioning fehlgeschlagen (${response.status}).`,
-      statusCode: response.status,
-      retryable: errorPayload.retryable ?? response.status >= 500,
-    });
+    await createProvisioningErrorFromResponse(response);
   }
 
-  const parsed = provisioningResponseSchema.safeParse(await parseJsonBody(response));
+  const parsed = provisioningResponseSchema.safeParse(
+    await parseMainserverJsonBody(response, 'Ungültige Antwort des SVA-Mainserver-Provisionings.')
+  );
   if (!parsed.success) {
     throw new MainserverUserProvisioningError({
       code: 'invalid_response',

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -109,7 +109,7 @@ const resolveProvisioningUrl = (graphqlBaseUrl: string): string => {
 const loadProvisioningConfig = async (instanceId: string): Promise<MainserverProvisioningConfig | null> => {
   const record = await loadDefaultExternalInterfaceRecord(instanceId, SVA_MAINSERVER_TYPE_KEY);
   if (!record || !record.enabled) {
-    logger.warn('SVA Mainserver user provisioning skipped because integration is not configured', {
+    logger.info('SVA Mainserver user provisioning skipped because integration is not configured', {
       workspace_id: instanceId,
       context: {
         operation: 'mainserver_user_provisioning',

--- a/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
+++ b/packages/auth-runtime/src/iam-account-management/mainserver-user-provisioning.ts
@@ -59,6 +59,7 @@ const fetchWithTimeout = async (input: {
   try {
     return await input.fetchImpl(input.url, {
       ...input.init,
+      redirect: 'manual',
       signal: input.signal,
     });
   } catch (error) {

--- a/packages/auth-runtime/src/iam-account-management/user-create-handler.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-handler.test.ts
@@ -42,6 +42,7 @@ describe('executeCreateUserWithKnownErrors', () => {
         actor: {
           instanceId: 'inst-1',
           actorAccountId: 'actor-1',
+          activeOrganizationId: 'org-1',
           actorRoles: ['system_admin'],
           requestId: 'req-1',
         },
@@ -56,6 +57,9 @@ describe('executeCreateUserWithKnownErrors', () => {
 
     expect(state.executeCreateUser).toHaveBeenCalledWith(
       expect.objectContaining({
+        actor: expect.objectContaining({
+          activeOrganizationId: 'org-1',
+        }),
         payload: {
           email: 'alice@example.com',
           roleIds: ['role-1'],

--- a/packages/auth-runtime/src/iam-account-management/user-create-handler.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-handler.ts
@@ -32,6 +32,7 @@ type CreateUserActorContext = {
   actor: {
     instanceId: string;
     actorAccountId: string;
+    activeOrganizationId?: string;
     requestId?: string;
     traceId?: string;
   };
@@ -57,6 +58,7 @@ export const resolveCreateUserActorContext = async (
     actor: {
       instanceId: actorResolution.actor.instanceId,
       actorAccountId: actorResolution.actor.actorAccountId,
+      activeOrganizationId: ctx.activeOrganizationId,
       requestId: actorResolution.actor.requestId,
       traceId: actorResolution.actor.traceId,
     },

--- a/packages/auth-runtime/src/iam-account-management/user-create-invitation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-invitation.ts
@@ -7,6 +7,7 @@ import { logger, trackKeycloakCall } from './shared.js';
 export type CreateUserActorInfo = {
   instanceId: string;
   actorAccountId: string;
+  activeOrganizationId?: string;
   actorRoles?: readonly string[];
   requestId?: string;
   traceId?: string;

--- a/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loggerState = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock('./shared.js', () => ({
+  logger: loggerState,
+}));
+
+import { logMainserverProvisioningFailure } from './user-create-mainserver-provisioning-log.js';
+
+const actor = {
+  instanceId: 'bb-demo',
+  actorAccountId: 'actor-1',
+  requestId: 'req-1',
+  traceId: 'trace-1',
+  activeOrganizationId: null,
+};
+
+describe('logMainserverProvisioningFailure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs structured mainserver error fields only for type-safe provisioning errors', () => {
+    const error = Object.assign(new Error('provisioning failed'), {
+      name: 'MainserverUserProvisioningError',
+      code: 'upstream_timeout',
+      statusCode: 504,
+      retryable: true,
+    });
+
+    logMainserverProvisioningFailure({
+      actor,
+      email: 'alice@example.com',
+      keycloakSubject: 'kc-user-1',
+      error,
+    });
+
+    expect(loggerState.error).toHaveBeenCalledWith(
+      'IAM user mainserver provisioning failed',
+      expect.objectContaining({
+        context: expect.objectContaining({
+          mainserver_error_code: 'upstream_timeout',
+          mainserver_status_code: 504,
+          mainserver_retryable: true,
+        }),
+      })
+    );
+  });
+
+  it('does not treat lookalike errors with wrong field types as provisioning errors', () => {
+    const error = Object.assign(new Error('provisioning failed'), {
+      name: 'MainserverUserProvisioningError',
+      code: 123,
+      statusCode: '504',
+      retryable: 'yes',
+    });
+
+    logMainserverProvisioningFailure({
+      actor,
+      email: 'alice@example.com',
+      keycloakSubject: 'kc-user-1',
+      error,
+    });
+
+    expect(loggerState.error).toHaveBeenCalledWith(
+      'IAM user mainserver provisioning failed',
+      expect.objectContaining({
+        context: expect.not.objectContaining({
+          mainserver_error_code: expect.anything(),
+          mainserver_status_code: expect.anything(),
+          mainserver_retryable: expect.anything(),
+        }),
+      })
+    );
+  });
+});

--- a/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.test.ts
@@ -76,4 +76,23 @@ describe('logMainserverProvisioningFailure', () => {
       })
     );
   });
+
+  it('logs non-Error inputs defensively without mainserver metadata', () => {
+    logMainserverProvisioningFailure({
+      actor,
+      email: 'alice@example.com',
+      keycloakSubject: 'kc-user-1',
+      error: { message: 'structured-but-not-an-error' },
+    });
+
+    expect(loggerState.error).toHaveBeenCalledWith(
+      'IAM user mainserver provisioning failed',
+      expect.objectContaining({
+        context: expect.objectContaining({
+          error_type: 'object',
+          error: '[object Object]',
+        }),
+      })
+    );
+  });
 });

--- a/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.ts
@@ -1,0 +1,46 @@
+import { logger } from './shared.js';
+import type { CreateUserActorInfo } from './user-create-invitation.js';
+import { maskEmail } from './user-mapping.js';
+
+type MainserverProvisioningLogError = Error & {
+  code: string;
+  retryable: boolean;
+  statusCode: number;
+};
+
+const isMainserverProvisioningError = (error: unknown): error is MainserverProvisioningLogError =>
+  error instanceof Error &&
+  error.name === 'MainserverUserProvisioningError' &&
+  'code' in error &&
+  'statusCode' in error &&
+  'retryable' in error;
+
+export const logMainserverProvisioningFailure = (input: {
+  actor: CreateUserActorInfo;
+  email: string;
+  keycloakSubject: string;
+  error: unknown;
+}) => {
+  const mainserverError = isMainserverProvisioningError(input.error) ? input.error : null;
+  logger.error('IAM user mainserver provisioning failed', {
+    workspace_id: input.actor.instanceId,
+    context: {
+      operation: 'create_user_mainserver_provisioning',
+      instance_id: input.actor.instanceId,
+      request_id: input.actor.requestId,
+      trace_id: input.actor.traceId,
+      actor_account_id: input.actor.actorAccountId,
+      keycloak_subject: input.keycloakSubject,
+      email_masked: maskEmail(input.email),
+      error_type: input.error instanceof Error ? input.error.constructor.name : typeof input.error,
+      error: input.error instanceof Error ? input.error.message : String(input.error),
+      ...(mainserverError
+        ? {
+            mainserver_error_code: mainserverError.code,
+            mainserver_status_code: mainserverError.statusCode,
+            mainserver_retryable: mainserverError.retryable,
+          }
+        : {}),
+    },
+  });
+};

--- a/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-mainserver-provisioning-log.ts
@@ -9,11 +9,18 @@ type MainserverProvisioningLogError = Error & {
 };
 
 const isMainserverProvisioningError = (error: unknown): error is MainserverProvisioningLogError =>
-  error instanceof Error &&
-  error.name === 'MainserverUserProvisioningError' &&
-  'code' in error &&
-  'statusCode' in error &&
-  'retryable' in error;
+  (() => {
+    if (!(error instanceof Error) || error.name !== 'MainserverUserProvisioningError') {
+      return false;
+    }
+
+    const candidate = error as Partial<MainserverProvisioningLogError>;
+    return (
+      typeof candidate.code === 'string' &&
+      typeof candidate.statusCode === 'number' &&
+      typeof candidate.retryable === 'boolean'
+    );
+  })();
 
 export const logMainserverProvisioningFailure = (input: {
   actor: CreateUserActorInfo;

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
@@ -111,6 +111,9 @@ describe('executeCreateUser', () => {
     const identityProvider = {
       provider: {
         createUser: vi.fn(async () => ({ externalId: 'kc-user-1' })),
+        getUserAttributes: vi.fn(async () => ({
+          locale: ['de'],
+        })),
         updateUser: vi.fn(async () => undefined),
         syncRoles: vi.fn(async () => undefined),
       },
@@ -159,12 +162,22 @@ describe('executeCreateUser', () => {
         sendPasswordSetupEmail: false,
       },
     });
-    expect(identityProvider.provider.updateUser).not.toHaveBeenCalled();
+    expect(identityProvider.provider.getUserAttributes).toHaveBeenCalledWith('kc-user-1');
+    expect(identityProvider.provider.updateUser).toHaveBeenCalledWith('kc-user-1', {
+      attributes: {
+        locale: ['de'],
+        mainserverUserApplicationId: ['mainserver-app-1'],
+        mainserverUserApplicationSecret: ['mainserver-secret-1'],
+      },
+    });
     expect(state.persistCreatedUser.mock.invocationCallOrder[0]).toBeLessThan(
       identityProvider.provider.syncRoles.mock.invocationCallOrder[0] ?? 0
     );
     expect(identityProvider.provider.syncRoles.mock.invocationCallOrder[0]).toBeLessThan(
       state.provisionMainserverUserCredentials.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(state.provisionMainserverUserCredentials.mock.invocationCallOrder[0]).toBeLessThan(
+      identityProvider.provider.updateUser.mock.invocationCallOrder[0] ?? 0
     );
   });
 
@@ -217,6 +230,60 @@ describe('executeCreateUser', () => {
     expect(result.invitation.status).toBe('not_requested');
     expect(state.resolveIdentityProviderForInstance).not.toHaveBeenCalled();
     expect(deactivateUser).not.toHaveBeenCalled();
+    expect(state.logger.error).toHaveBeenCalledWith(
+      'IAM user mainserver provisioning failed',
+      expect.objectContaining({
+        workspace_id: 'instance-1',
+      })
+    );
+  });
+
+  it('keeps the local user active when persisting provisioned Mainserver attributes back to Keycloak fails', async () => {
+    state.provisionMainserverUserCredentials.mockResolvedValue({
+      mainserverUserApplicationId: 'mainserver-app-1',
+      mainserverUserApplicationSecret: 'mainserver-secret-1',
+    });
+    const identityProvider = {
+      provider: {
+        createUser: vi.fn(async () => ({ externalId: 'kc-user-1' })),
+        getUserAttributes: vi.fn(async () => ({
+          locale: ['de'],
+        })),
+        updateUser: vi.fn(async () => {
+          throw new Error('update failed');
+        }),
+        syncRoles: vi.fn(async () => undefined),
+      },
+      realm: 'tenant-realm',
+      source: 'instance' as const,
+      clientId: 'tenant-admin',
+      adminRealm: 'tenant-realm',
+      executionMode: 'tenant_admin' as const,
+    };
+
+    const { executeCreateUser } = await import('./user-create-operation.js');
+    const result = await executeCreateUser({
+      actor: {
+        instanceId: 'instance-1',
+        actorAccountId: 'actor-1',
+        requestId: 'req-1',
+        traceId: 'trace-1',
+      },
+      actorSubject: 'kc-actor-1',
+      identityProvider,
+      payload: {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        roleIds: [],
+        sendPasswordSetupEmail: false,
+      },
+    });
+
+    expect(result.user).toMatchObject({
+      id: 'account-1',
+      keycloakSubject: 'kc-user-1',
+      mainserverUserApplicationSecretSet: false,
+    });
     expect(state.logger.error).toHaveBeenCalledWith(
       'IAM user mainserver provisioning failed',
       expect.objectContaining({

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
@@ -5,6 +5,7 @@ const state = vi.hoisted(() => ({
   ensureManagedRealmRolesExist: vi.fn(),
   resolveIdentityProviderForInstance: vi.fn(),
   resolveAuthConfigForInstance: vi.fn(),
+  provisionMainserverUserCredentials: vi.fn(),
   trackKeycloakCall: vi.fn(async (_operation: string, execute: () => Promise<unknown>) => execute()),
   withInstanceScopedDb: vi.fn(async (_instanceId: string, work: (client: object) => Promise<unknown>) => work({})),
   logger: {
@@ -31,6 +32,10 @@ vi.mock('../config.js', () => ({
   resolveAuthConfigForInstance: state.resolveAuthConfigForInstance,
 }));
 
+vi.mock('./mainserver-user-provisioning.js', () => ({
+  provisionMainserverUserCredentials: state.provisionMainserverUserCredentials,
+}));
+
 describe('executeCreateUser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,6 +55,7 @@ describe('executeCreateUser', () => {
       redirectUri: 'https://tenant.example.test/auth/callback',
       postLogoutRedirectUri: 'https://tenant.example.test/',
     });
+    state.provisionMainserverUserCredentials.mockResolvedValue(null);
   });
 
   it('creates a user without sending an invite when the payload disables it', async () => {
@@ -85,6 +91,139 @@ describe('executeCreateUser', () => {
     expect(identityProvider.provider.executeActionsEmail).not.toHaveBeenCalled();
     expect(result.invitation.status).toBe('not_requested');
   }, 15_000);
+
+  it('provisions Mainserver credentials for the created Keycloak user after local persistence and role sync', async () => {
+    state.provisionMainserverUserCredentials.mockResolvedValue({
+      mainserverUserApplicationId: 'mainserver-app-1',
+      mainserverUserApplicationSecret: 'mainserver-secret-1',
+    });
+    state.persistCreatedUser.mockResolvedValue({
+      responseData: {
+        id: 'account-1',
+        keycloakSubject: 'kc-user-1',
+        displayName: 'Alice Example',
+        status: 'active',
+        roles: [],
+        mainserverUserApplicationSecretSet: false,
+      },
+      roleNames: ['system_admin'],
+    });
+    const identityProvider = {
+      provider: {
+        createUser: vi.fn(async () => ({ externalId: 'kc-user-1' })),
+        updateUser: vi.fn(async () => undefined),
+        syncRoles: vi.fn(async () => undefined),
+      },
+      realm: 'tenant-realm',
+      source: 'instance' as const,
+      clientId: 'tenant-admin',
+      adminRealm: 'tenant-realm',
+      executionMode: 'tenant_admin' as const,
+    };
+
+    const { executeCreateUser } = await import('./user-create-operation.js');
+    await executeCreateUser({
+      actor: {
+        instanceId: 'instance-1',
+        actorAccountId: 'actor-1',
+        requestId: 'req-1',
+        traceId: 'trace-1',
+      },
+      actorSubject: 'kc-actor-1',
+      identityProvider,
+      payload: {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Example',
+        roleIds: [],
+        sendPasswordSetupEmail: false,
+      },
+    });
+
+    expect(state.persistCreatedUser).toHaveBeenCalled();
+    expect(identityProvider.provider.syncRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin']);
+    expect(state.provisionMainserverUserCredentials).toHaveBeenCalledWith({
+      actor: {
+        instanceId: 'instance-1',
+        actorAccountId: 'actor-1',
+        requestId: 'req-1',
+        traceId: 'trace-1',
+      },
+      actorSubject: 'kc-actor-1',
+      keycloakSubject: 'kc-user-1',
+      payload: {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Example',
+        roleIds: [],
+        sendPasswordSetupEmail: false,
+      },
+    });
+    expect(identityProvider.provider.updateUser).not.toHaveBeenCalled();
+    expect(state.persistCreatedUser.mock.invocationCallOrder[0]).toBeLessThan(
+      identityProvider.provider.syncRoles.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(identityProvider.provider.syncRoles.mock.invocationCallOrder[0]).toBeLessThan(
+      state.provisionMainserverUserCredentials.mock.invocationCallOrder[0] ?? 0
+    );
+  });
+
+  it('keeps the local user active when Mainserver provisioning fails after persistence', async () => {
+    state.provisionMainserverUserCredentials.mockRejectedValue(new Error('mainserver unavailable'));
+    const deactivateUser = vi.fn(async () => undefined);
+    state.resolveIdentityProviderForInstance.mockResolvedValue({
+      provider: { deactivateUser },
+      realm: 'tenant-realm',
+      source: 'instance',
+      clientId: 'tenant-admin',
+      adminRealm: 'tenant-realm',
+      executionMode: 'tenant_admin',
+    });
+    const identityProvider = {
+      provider: {
+        createUser: vi.fn(async () => ({ externalId: 'kc-user-1' })),
+        syncRoles: vi.fn(async () => undefined),
+      },
+      realm: 'tenant-realm',
+      source: 'instance' as const,
+      clientId: 'tenant-admin',
+      adminRealm: 'tenant-realm',
+      executionMode: 'tenant_admin' as const,
+    };
+
+    const { executeCreateUser } = await import('./user-create-operation.js');
+    const result = await executeCreateUser({
+      actor: {
+        instanceId: 'instance-1',
+        actorAccountId: 'actor-1',
+        requestId: 'req-1',
+        traceId: 'trace-1',
+      },
+      actorSubject: 'kc-actor-1',
+      identityProvider,
+      payload: {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        roleIds: [],
+        sendPasswordSetupEmail: false,
+      },
+    });
+
+    expect(result.user).toMatchObject({
+      id: 'account-1',
+      keycloakSubject: 'kc-user-1',
+      mainserverUserApplicationSecretSet: false,
+    });
+    expect(result.invitation.status).toBe('not_requested');
+    expect(state.resolveIdentityProviderForInstance).not.toHaveBeenCalled();
+    expect(deactivateUser).not.toHaveBeenCalled();
+    expect(state.logger.error).toHaveBeenCalledWith(
+      'IAM user mainserver provisioning failed',
+      expect.objectContaining({
+        workspace_id: 'instance-1',
+      })
+    );
+  });
 
   it('sends an UPDATE_PASSWORD invitation after successful creation when requested', async () => {
     const executeActionsEmail = vi.fn(async function (
@@ -397,6 +536,7 @@ describe('executeCreateUser', () => {
       executionMode: 'tenant_admin',
     });
     expect(deactivateUser).toHaveBeenCalledWith('kc-user-1');
+    expect(state.provisionMainserverUserCredentials).not.toHaveBeenCalled();
     expect(state.logger.error).toHaveBeenCalledWith(
       'IAM user creation failed',
       expect.objectContaining({

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
@@ -13,11 +13,11 @@ import {
   sendPasswordSetupInvitation,
   type CreateUserActorInfo,
 } from './user-create-invitation.js';
+import { buildMainserverIdentityAttributes } from '../mainserver-credentials.js';
 import type { CreateUserPayload } from './user-create-persistence.js';
 import { persistCreatedUser } from './user-create-persistence.js';
 import { maskEmail } from './user-mapping.js';
 import { provisionMainserverUserCredentials } from './mainserver-user-provisioning.js';
-
 type InvitationResult = IamCreateUserResult['invitation'];
 
 const buildCreateUserResult = (
@@ -108,9 +108,39 @@ const syncUserRolesIfNeeded = async (input: {
   );
 };
 
-const provisionMainserverCredentialsIfPossible = async (input: {
+const persistProvisionedMainserverCredentials = async (input: {
+  identityProvider: IdentityProviderResolution;
+  keycloakSubject: string;
+  credentials: NonNullable<Awaited<ReturnType<typeof provisionMainserverUserCredentials>>>;
+}) => {
+  const existingAttributes = await trackKeycloakCall('get_user_attributes', () =>
+    input.identityProvider.provider.getUserAttributes(input.keycloakSubject)
+  );
+  const nextAttributes = buildMainserverIdentityAttributes({
+    existingAttributes,
+    mainserverUserApplicationId: input.credentials.mainserverUserApplicationId,
+    mainserverUserApplicationSecret: input.credentials.mainserverUserApplicationSecret,
+  });
+
+  await trackKeycloakCall('update_user', () =>
+    input.identityProvider.provider.updateUser(input.keycloakSubject, {
+      attributes: nextAttributes,
+    })
+  );
+};
+const enrichUserWithMainserverCredentials = (
+  user: IamCreateUserResult['user'],
+  credentials: NonNullable<Awaited<ReturnType<typeof provisionMainserverUserCredentials>>>
+): IamCreateUserResult['user'] => ({
+  ...user,
+  mainserverUserApplicationId: credentials.mainserverUserApplicationId,
+  mainserverUserApplicationSecretSet: true,
+});
+
+const tryProvisionMainserverCredentials = async (input: {
   actor: CreateUserActorInfo;
   actorSubject: string;
+  identityProvider: IdentityProviderResolution;
   keycloakSubject: string;
   payload: CreateUserPayload;
 }) => {
@@ -124,7 +154,70 @@ const provisionMainserverCredentialsIfPossible = async (input: {
     return null;
   }
 
+  await persistProvisionedMainserverCredentials({
+    identityProvider: input.identityProvider,
+    keycloakSubject: input.keycloakSubject,
+    credentials,
+  });
+
   return credentials;
+};
+
+const resolveCreateUserResponseData = async (input: {
+  actor: CreateUserActorInfo;
+  actorSubject: string;
+  identityProvider: IdentityProviderResolution;
+  payload: CreateUserPayload;
+  responseData: IamCreateUserResult['user'];
+}) => {
+  try {
+    const mainserverCredentials = await tryProvisionMainserverCredentials({
+      actor: input.actor,
+      actorSubject: input.actorSubject,
+      identityProvider: input.identityProvider,
+      keycloakSubject: input.responseData.keycloakSubject,
+      payload: input.payload,
+    });
+    return mainserverCredentials
+      ? enrichUserWithMainserverCredentials(input.responseData, mainserverCredentials)
+      : input.responseData;
+  } catch (error) {
+    logMainserverProvisioningFailure({
+      actor: input.actor,
+      email: input.payload.email,
+      keycloakSubject: input.responseData.keycloakSubject,
+      error,
+    });
+    return input.responseData;
+  }
+};
+
+const finalizeCreateUserResult = async (input: {
+  actor: CreateUserActorInfo;
+  identityProvider: IdentityProviderResolution;
+  payload: CreateUserPayload;
+  responseData: IamCreateUserResult['user'];
+}): Promise<IamCreateUserResult> => {
+  if (input.payload.sendPasswordSetupEmail !== true) {
+    return buildCreateUserResult(input.responseData, { status: 'not_requested' });
+  }
+
+  try {
+    const invitation = await sendPasswordSetupInvitation({
+      actor: input.actor,
+      identityProvider: input.identityProvider,
+      email: input.payload.email,
+      keycloakSubject: input.responseData.keycloakSubject,
+    });
+    return buildCreateUserResult(input.responseData, invitation);
+  } catch (error) {
+    logInvitationFailure({
+      actor: input.actor,
+      keycloakSubject: input.responseData.keycloakSubject,
+      error,
+    });
+    return buildCreateUserResult(input.responseData, buildInvitationFailure(error));
+  }
 };
 
 const deactivateCreatedExternalUser = async (input: {
@@ -184,50 +277,20 @@ export const executeCreateUser = async (input: {
       roleNames: result.roleNames,
     });
 
-    let mainserverCredentials: Awaited<ReturnType<typeof provisionMainserverCredentialsIfPossible>> = null;
-    try {
-      mainserverCredentials = await provisionMainserverCredentialsIfPossible({
-        actor,
-        actorSubject,
-        keycloakSubject: result.responseData.keycloakSubject,
-        payload,
-      });
-    } catch (error) {
-      logMainserverProvisioningFailure({
-        actor,
-        email: payload.email,
-        keycloakSubject: result.responseData.keycloakSubject,
-        error,
-      });
-    }
-    const responseData = mainserverCredentials
-      ? {
-          ...result.responseData,
-          mainserverUserApplicationId: mainserverCredentials.mainserverUserApplicationId,
-          mainserverUserApplicationSecretSet: true,
-        }
-      : result.responseData;
+    const responseData = await resolveCreateUserResponseData({
+      actor,
+      actorSubject,
+      identityProvider,
+      payload,
+      responseData: result.responseData,
+    });
 
-    if (payload.sendPasswordSetupEmail !== true) {
-      return buildCreateUserResult(responseData, { status: 'not_requested' });
-    }
-
-    try {
-      const invitation = await sendPasswordSetupInvitation({
-        actor,
-        identityProvider,
-        email: payload.email,
-        keycloakSubject: responseData.keycloakSubject,
-      });
-      return buildCreateUserResult(responseData, invitation);
-    } catch (error) {
-      logInvitationFailure({
-        actor,
-        keycloakSubject: responseData.keycloakSubject,
-        error,
-      });
-      return buildCreateUserResult(responseData, buildInvitationFailure(error));
-    }
+    return finalizeCreateUserResult({
+      actor,
+      identityProvider,
+      payload,
+      responseData,
+    });
   } catch (error) {
     logCreateUserFailure({
       actor,

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
@@ -80,7 +80,19 @@ const logMainserverProvisioningFailure = (input: {
       actor_account_id: input.actor.actorAccountId,
       keycloak_subject: input.keycloakSubject,
       email_masked: maskEmail(input.email),
+      error_type: input.error instanceof Error ? input.error.constructor.name : typeof input.error,
       error: input.error instanceof Error ? input.error.message : String(input.error),
+      ...(input.error instanceof Error &&
+      input.error.name === 'MainserverUserProvisioningError' &&
+      'code' in input.error &&
+      'statusCode' in input.error &&
+      'retryable' in input.error
+        ? {
+            mainserver_error_code: (input.error as Error & { code: string }).code,
+            mainserver_status_code: (input.error as Error & { statusCode: number }).statusCode,
+            mainserver_retryable: (input.error as Error & { retryable: boolean }).retryable,
+          }
+        : {}),
     },
   });
 };

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
@@ -18,6 +18,7 @@ import type { CreateUserPayload } from './user-create-persistence.js';
 import { persistCreatedUser } from './user-create-persistence.js';
 import { maskEmail } from './user-mapping.js';
 import { provisionMainserverUserCredentials } from './mainserver-user-provisioning.js';
+import { logMainserverProvisioningFailure } from './user-create-mainserver-provisioning-log.js';
 type InvitationResult = IamCreateUserResult['invitation'];
 
 const buildCreateUserResult = (
@@ -60,39 +61,6 @@ const logCreateUserCompensationFailure = (input: {
       request_id: input.actor.requestId,
       trace_id: input.actor.traceId,
       error: input.error instanceof Error ? input.error.message : String(input.error),
-    },
-  });
-};
-
-const logMainserverProvisioningFailure = (input: {
-  actor: CreateUserActorInfo;
-  email: string;
-  keycloakSubject: string;
-  error: unknown;
-}) => {
-  logger.error('IAM user mainserver provisioning failed', {
-    workspace_id: input.actor.instanceId,
-    context: {
-      operation: 'create_user_mainserver_provisioning',
-      instance_id: input.actor.instanceId,
-      request_id: input.actor.requestId,
-      trace_id: input.actor.traceId,
-      actor_account_id: input.actor.actorAccountId,
-      keycloak_subject: input.keycloakSubject,
-      email_masked: maskEmail(input.email),
-      error_type: input.error instanceof Error ? input.error.constructor.name : typeof input.error,
-      error: input.error instanceof Error ? input.error.message : String(input.error),
-      ...(input.error instanceof Error &&
-      input.error.name === 'MainserverUserProvisioningError' &&
-      'code' in input.error &&
-      'statusCode' in input.error &&
-      'retryable' in input.error
-        ? {
-            mainserver_error_code: (input.error as Error & { code: string }).code,
-            mainserver_status_code: (input.error as Error & { statusCode: number }).statusCode,
-            mainserver_retryable: (input.error as Error & { retryable: boolean }).retryable,
-          }
-        : {}),
     },
   });
 };

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
@@ -16,6 +16,7 @@ import {
 import type { CreateUserPayload } from './user-create-persistence.js';
 import { persistCreatedUser } from './user-create-persistence.js';
 import { maskEmail } from './user-mapping.js';
+import { provisionMainserverUserCredentials } from './mainserver-user-provisioning.js';
 
 type InvitationResult = IamCreateUserResult['invitation'];
 
@@ -63,6 +64,27 @@ const logCreateUserCompensationFailure = (input: {
   });
 };
 
+const logMainserverProvisioningFailure = (input: {
+  actor: CreateUserActorInfo;
+  email: string;
+  keycloakSubject: string;
+  error: unknown;
+}) => {
+  logger.error('IAM user mainserver provisioning failed', {
+    workspace_id: input.actor.instanceId,
+    context: {
+      operation: 'create_user_mainserver_provisioning',
+      instance_id: input.actor.instanceId,
+      request_id: input.actor.requestId,
+      trace_id: input.actor.traceId,
+      actor_account_id: input.actor.actorAccountId,
+      keycloak_subject: input.keycloakSubject,
+      email_masked: maskEmail(input.email),
+      error: input.error instanceof Error ? input.error.message : String(input.error),
+    },
+  });
+};
+
 const syncUserRolesIfNeeded = async (input: {
   actor: CreateUserActorInfo;
   identityProvider: IdentityProviderResolution;
@@ -84,6 +106,25 @@ const syncUserRolesIfNeeded = async (input: {
   await trackKeycloakCall('sync_roles', () =>
     input.identityProvider.provider.syncRoles(input.keycloakSubject, input.roleNames)
   );
+};
+
+const provisionMainserverCredentialsIfPossible = async (input: {
+  actor: CreateUserActorInfo;
+  actorSubject: string;
+  keycloakSubject: string;
+  payload: CreateUserPayload;
+}) => {
+  const credentials = await provisionMainserverUserCredentials({
+    actor: input.actor,
+    actorSubject: input.actorSubject,
+    keycloakSubject: input.keycloakSubject,
+    payload: input.payload,
+  });
+  if (!credentials) {
+    return null;
+  }
+
+  return credentials;
 };
 
 const deactivateCreatedExternalUser = async (input: {
@@ -143,8 +184,32 @@ export const executeCreateUser = async (input: {
       roleNames: result.roleNames,
     });
 
+    let mainserverCredentials: Awaited<ReturnType<typeof provisionMainserverCredentialsIfPossible>> = null;
+    try {
+      mainserverCredentials = await provisionMainserverCredentialsIfPossible({
+        actor,
+        actorSubject,
+        keycloakSubject: result.responseData.keycloakSubject,
+        payload,
+      });
+    } catch (error) {
+      logMainserverProvisioningFailure({
+        actor,
+        email: payload.email,
+        keycloakSubject: result.responseData.keycloakSubject,
+        error,
+      });
+    }
+    const responseData = mainserverCredentials
+      ? {
+          ...result.responseData,
+          mainserverUserApplicationId: mainserverCredentials.mainserverUserApplicationId,
+          mainserverUserApplicationSecretSet: true,
+        }
+      : result.responseData;
+
     if (payload.sendPasswordSetupEmail !== true) {
-      return buildCreateUserResult(result.responseData, { status: 'not_requested' });
+      return buildCreateUserResult(responseData, { status: 'not_requested' });
     }
 
     try {
@@ -152,16 +217,16 @@ export const executeCreateUser = async (input: {
         actor,
         identityProvider,
         email: payload.email,
-        keycloakSubject: result.responseData.keycloakSubject,
+        keycloakSubject: responseData.keycloakSubject,
       });
-      return buildCreateUserResult(result.responseData, invitation);
+      return buildCreateUserResult(responseData, invitation);
     } catch (error) {
       logInvitationFailure({
         actor,
-        keycloakSubject: result.responseData.keycloakSubject,
+        keycloakSubject: responseData.keycloakSubject,
         error,
       });
-      return buildCreateUserResult(result.responseData, buildInvitationFailure(error));
+      return buildCreateUserResult(responseData, buildInvitationFailure(error));
     }
   } catch (error) {
     logCreateUserFailure({

--- a/packages/auth-runtime/src/server.ts
+++ b/packages/auth-runtime/src/server.ts
@@ -24,6 +24,7 @@ export {
 export { buildLogContext } from './log-context.js';
 export { buildRequestOriginFromHeaders, resolveEffectiveRequestHost } from './request-hosts.js';
 export { resolveAuthRequestHost, sanitizeAuthReturnTo } from './auth-return-to.js';
+export { normalizePublicUpstreamUrl } from './upstream-url-validation.js';
 export { emitAuthAuditEvent } from './audit-events.js';
 export type { AuthAuditEvent, AuthAuditEventType, PluginActionAuditPayload } from './audit-events.types.js';
 export {

--- a/packages/auth-runtime/src/upstream-url-validation.test.ts
+++ b/packages/auth-runtime/src/upstream-url-validation.test.ts
@@ -42,8 +42,24 @@ describe('normalizePublicUpstreamUrl', () => {
     await expect(normalizePublicUpstreamUrl('https://[fec0::1]/graphql')).resolves.toBeNull();
   });
 
+  it('returns null for malformed or non-public ipv4-mapped ipv6 targets and accepts public ones', async () => {
+    await expect(normalizePublicUpstreamUrl('https://[::ffff:127.0.0.1]/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://[::ffff:zzzz:1]/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://[::ffff:5db8:d822]/graphql')).resolves.toBe(
+      'https://[::ffff:5db8:d822]/graphql'
+    );
+  });
+
   it('returns null for hosts that resolve to local or non-public addresses', async () => {
     dnsLookupMock.mockResolvedValueOnce([{ address: 'fec0::1', family: 6 }]);
     await expect(normalizePublicUpstreamUrl('https://public.example.invalid/graphql')).resolves.toBeNull();
+  });
+
+  it('returns null for hosts that resolve to no addresses or fail dns lookup', async () => {
+    dnsLookupMock.mockResolvedValueOnce([]);
+    await expect(normalizePublicUpstreamUrl('https://empty.example.invalid/graphql')).resolves.toBeNull();
+
+    dnsLookupMock.mockRejectedValueOnce(new Error('dns unavailable'));
+    await expect(normalizePublicUpstreamUrl('https://failing.example.invalid/graphql')).resolves.toBeNull();
   });
 });

--- a/packages/auth-runtime/src/upstream-url-validation.test.ts
+++ b/packages/auth-runtime/src/upstream-url-validation.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:dns/promises', () => ({
+  lookup: dnsLookupMock,
+}));
+
+import { normalizePublicUpstreamUrl } from './upstream-url-validation.js';
+
+describe('normalizePublicUpstreamUrl', () => {
+  beforeEach(() => {
+    dnsLookupMock.mockReset();
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+  });
+
+  it('normalizes valid public https urls', async () => {
+    await expect(normalizePublicUpstreamUrl(' https://mainserver.example.invalid/graphql ')).resolves.toBe(
+      'https://mainserver.example.invalid/graphql'
+    );
+  });
+
+  it('returns null for blank, malformed, credentialed or non-https urls', async () => {
+    await expect(normalizePublicUpstreamUrl('   ')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('not-a-url')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://user:pass@example.invalid/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://example.invalid/graphql#secret')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('http://example.invalid/graphql')).resolves.toBeNull();
+  });
+
+  it('returns null for local, reserved and non-public ipv4 targets', async () => {
+    await expect(normalizePublicUpstreamUrl('https://localhost/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://internal.local/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://100.64.0.1/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://198.18.0.1/graphql')).resolves.toBeNull();
+  });
+
+  it('returns null for local and non-public ipv6 targets', async () => {
+    await expect(normalizePublicUpstreamUrl('https://[::1]/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://[fc00::1]/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://[fe90::1]/graphql')).resolves.toBeNull();
+    await expect(normalizePublicUpstreamUrl('https://[fec0::1]/graphql')).resolves.toBeNull();
+  });
+
+  it('returns null for hosts that resolve to local or non-public addresses', async () => {
+    dnsLookupMock.mockResolvedValueOnce([{ address: 'fec0::1', family: 6 }]);
+    await expect(normalizePublicUpstreamUrl('https://public.example.invalid/graphql')).resolves.toBeNull();
+  });
+});

--- a/packages/auth-runtime/src/upstream-url-validation.ts
+++ b/packages/auth-runtime/src/upstream-url-validation.ts
@@ -1,0 +1,181 @@
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+const localhostHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+type Ipv4Octets = readonly [number, number, number, number];
+type Ipv4Range = readonly [number, number];
+
+const parseUpstreamUrl = (value: string): URL | null => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed);
+  } catch {
+    return null;
+  }
+};
+
+const unwrapBracketedHost = (hostname: string): string =>
+  hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+
+const isLocalHostname = (hostname: string): boolean =>
+  localhostHosts.has(hostname) || hostname.endsWith('.local');
+
+const parseIpv4Octets = (hostname: string): Ipv4Octets | null => {
+  const octets = hostname.split('.').map((segment) => Number.parseInt(segment, 10));
+  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
+    return null;
+  }
+
+  return [octets[0]!, octets[1]!, octets[2]!, octets[3]!];
+};
+
+const toIpv4Number = ([a, b, c, d]: Ipv4Octets): number => ((a * 256 + b) * 256 + c) * 256 + d;
+
+const createIpv4Range = (start: Ipv4Octets, end: Ipv4Octets): Ipv4Range => [
+  toIpv4Number(start),
+  toIpv4Number(end),
+];
+
+const nonPublicIpv4Ranges: readonly Ipv4Range[] = [
+  createIpv4Range([0, 0, 0, 0], [0, 255, 255, 255]),
+  createIpv4Range([10, 0, 0, 0], [10, 255, 255, 255]),
+  createIpv4Range([100, 64, 0, 0], [100, 127, 255, 255]),
+  createIpv4Range([127, 0, 0, 0], [127, 255, 255, 255]),
+  createIpv4Range([169, 254, 0, 0], [169, 254, 255, 255]),
+  createIpv4Range([172, 16, 0, 0], [172, 31, 255, 255]),
+  createIpv4Range([192, 0, 0, 0], [192, 0, 0, 255]),
+  createIpv4Range([192, 0, 2, 0], [192, 0, 2, 255]),
+  createIpv4Range([192, 88, 99, 0], [192, 88, 99, 255]),
+  createIpv4Range([192, 168, 0, 0], [192, 168, 255, 255]),
+  createIpv4Range([198, 18, 0, 0], [198, 19, 255, 255]),
+  createIpv4Range([198, 51, 100, 0], [198, 51, 100, 255]),
+  createIpv4Range([203, 0, 113, 0], [203, 0, 113, 255]),
+  createIpv4Range([224, 0, 0, 0], [255, 255, 255, 255]),
+];
+
+const isNonPublicIpv4Host = (hostname: string): boolean => {
+  const octets = parseIpv4Octets(hostname);
+  if (!octets) {
+    return true;
+  }
+
+  const address = toIpv4Number(octets);
+  return nonPublicIpv4Ranges.some(([start, end]) => address >= start && address <= end);
+};
+
+const toMappedIpv4Host = (hostname: string): string | null => {
+  if (!hostname.startsWith('::ffff:')) {
+    return null;
+  }
+
+  const mappedPart = hostname.slice('::ffff:'.length);
+  if (isIP(mappedPart) === 4) {
+    return mappedPart;
+  }
+
+  const hexParts = mappedPart.split(':');
+  if (hexParts.length !== 2) {
+    return null;
+  }
+
+  const high = Number.parseInt(hexParts[0], 16);
+  const low = Number.parseInt(hexParts[1], 16);
+  if (Number.isNaN(high) || Number.isNaN(low)) {
+    return null;
+  }
+
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ].join('.');
+};
+
+const isNonPublicIpv6Host = (hostname: string): boolean => {
+  const mappedIpv4Host = toMappedIpv4Host(hostname);
+  if (mappedIpv4Host) {
+    return isPrivateOrLocalHost(mappedIpv4Host);
+  }
+
+  if (hostname.startsWith('::ffff:')) {
+    return true;
+  }
+
+  const firstHextet = Number.parseInt(hostname.split(':', 1)[0] ?? '', 16);
+  return (
+    hostname === '::1' ||
+    hostname === '::' ||
+    (!Number.isNaN(firstHextet) &&
+      ((firstHextet >= 0xfc00 && firstHextet <= 0xfdff) ||
+        (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) ||
+        (firstHextet >= 0xfec0 && firstHextet <= 0xfeff)))
+  );
+};
+
+const isPrivateOrLocalHost = (hostname: string): boolean => {
+  const normalized = hostname.trim().toLowerCase();
+  if (isLocalHostname(normalized)) {
+    return true;
+  }
+
+  const unbracketed = unwrapBracketedHost(normalized);
+  if (unbracketed !== normalized) {
+    return isPrivateOrLocalHost(unbracketed);
+  }
+
+  const ipVersion = isIP(normalized);
+  if (ipVersion === 4) {
+    return isNonPublicIpv4Host(normalized);
+  }
+
+  if (ipVersion === 6) {
+    return isNonPublicIpv6Host(normalized);
+  }
+
+  return false;
+};
+
+const resolvesToPrivateOrLocalHost = async (hostname: string): Promise<boolean> => {
+  const normalized = hostname.trim().toLowerCase();
+  if (isIP(normalized) !== 0) {
+    return false;
+  }
+
+  try {
+    const resolved = await dnsLookup(normalized, {
+      all: true,
+      verbatim: true,
+    });
+    if (resolved.length === 0) {
+      return true;
+    }
+
+    return resolved.some((entry) => isPrivateOrLocalHost(entry.address));
+  } catch {
+    return true;
+  }
+};
+
+export const normalizePublicUpstreamUrl = async (value: string): Promise<string | null> => {
+  const parsed = parseUpstreamUrl(value);
+
+  if (
+    !parsed ||
+    parsed.username ||
+    parsed.password ||
+    parsed.hash ||
+    parsed.protocol !== 'https:' ||
+    isPrivateOrLocalHost(parsed.hostname) ||
+    (await resolvesToPrivateOrLocalHost(parsed.hostname))
+  ) {
+    return null;
+  }
+
+  return parsed.toString();
+};

--- a/packages/sva-mainserver/src/server/categories-route.ts
+++ b/packages/sva-mainserver/src/server/categories-route.ts
@@ -7,6 +7,7 @@ import { createSdkLogger, getWorkspaceContext } from '@sva/server-runtime';
 
 import { errorJson, json } from './content-route-helpers.js';
 import { SvaMainserverError } from './errors.js';
+import { toMainserverErrorResponse } from './mainserver-error-response.js';
 import { listSvaMainserverCategories } from './service.js';
 
 const CATEGORY_COLLECTION_PATH = '/api/v1/mainserver/categories';
@@ -19,33 +20,6 @@ type CategoriesActor = {
 };
 
 const matchCategoriesRoute = (request: Request): boolean => new URL(request.url).pathname === CATEGORY_COLLECTION_PATH;
-
-const toMainserverErrorResponse = (error: unknown): Response => {
-  if (error instanceof SvaMainserverError) {
-    const status =
-      error.statusCode ??
-      ({
-        missing_credentials: 400,
-        organization_mainserver_credentials_missing: 409,
-        invalid_config: 400,
-        config_not_found: 400,
-        integration_disabled: 400,
-        unauthorized: 401,
-        forbidden: 403,
-        not_found: 404,
-        database_unavailable: 503,
-        identity_provider_unavailable: 503,
-        network_error: 503,
-        token_request_failed: 502,
-        graphql_error: 502,
-        invalid_response: 502,
-      } satisfies Record<string, number>)[error.code] ??
-      502;
-    return errorJson(status, error.code, error.message);
-  }
-
-  return errorJson(500, 'internal_error', 'Mainserver-Kategorien-Anfrage ist fehlgeschlagen.');
-};
 
 const authorizeOrResponse = async (ctx: AuthenticatedRequestContext): Promise<CategoriesActor | Response> => {
   const result = await authorizeContentPrimitiveForUser({
@@ -110,7 +84,7 @@ const dispatchAuthenticated = async (request: Request, ctx: AuthenticatedRequest
       method: 'GET',
       error_code: error instanceof SvaMainserverError ? error.code : 'internal_error',
     });
-    return toMainserverErrorResponse(error);
+    return toMainserverErrorResponse(error, 'Mainserver-Kategorien-Anfrage ist fehlgeschlagen.');
   }
 };
 

--- a/packages/sva-mainserver/src/server/config-store.test.ts
+++ b/packages/sva-mainserver/src/server/config-store.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({
   loadDefaultExternalInterfaceRecord: vi.fn(),
-  dnsLookup: vi.fn(async () => [{ address: '203.0.113.10', family: 4 }]),
+  dnsLookup: vi.fn(async () => [{ address: '8.8.8.8', family: 4 }]),
   logger: {
     debug: vi.fn(),
     info: vi.fn(),
@@ -31,7 +31,7 @@ describe('loadSvaMainserverInstanceConfig', () => {
   beforeEach(() => {
     state.loadDefaultExternalInterfaceRecord.mockReset();
     state.dnsLookup.mockReset();
-    state.dnsLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    state.dnsLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
     state.logger.debug.mockReset();
     state.logger.info.mockReset();
     state.logger.warn.mockReset();

--- a/packages/sva-mainserver/src/server/events-route.ts
+++ b/packages/sva-mainserver/src/server/events-route.ts
@@ -33,6 +33,7 @@ import {
 } from './content-route-helpers.js';
 import { SvaMainserverError } from './errors.js';
 import { parseMainserverListQuery } from './list-pagination.js';
+import { toMainserverErrorResponse } from './mainserver-error-response.js';
 import {
   createSvaMainserverEvent,
   deleteSvaMainserverEvent,
@@ -167,33 +168,6 @@ const parseEventInput = async (request: Request): Promise<SvaMainserverEventInpu
 
   const relations = parseEventRelations(body);
   return isResponse(relations) ? relations : buildEventInput(body, title, relations);
-};
-
-const toMainserverErrorResponse = (error: unknown): Response => {
-  if (error instanceof SvaMainserverError) {
-    const status =
-      error.statusCode ??
-      ({
-        missing_credentials: 400,
-        organization_mainserver_credentials_missing: 409,
-        invalid_config: 400,
-        config_not_found: 400,
-        integration_disabled: 400,
-        unauthorized: 401,
-        forbidden: 403,
-        not_found: 404,
-        database_unavailable: 503,
-        identity_provider_unavailable: 503,
-        network_error: 503,
-        token_request_failed: 502,
-        graphql_error: 502,
-        invalid_response: 502,
-      } satisfies Record<string, number>)[error.code] ??
-      502;
-    return errorJson(status, error.code, error.message);
-  }
-
-  return errorJson(500, 'internal_error', 'Mainserver-Anfrage ist fehlgeschlagen.');
 };
 
 const validateMutationRequest = (request: Request, requestId?: string): Response | null => {
@@ -423,7 +397,7 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       method: request.method,
       error_code: error instanceof SvaMainserverError ? error.code : 'internal_error',
     });
-    return toMainserverErrorResponse(error);
+    return toMainserverErrorResponse(error, 'Mainserver-Anfrage ist fehlgeschlagen.');
   }
 };
 

--- a/packages/sva-mainserver/src/server/mainserver-error-response.test.ts
+++ b/packages/sva-mainserver/src/server/mainserver-error-response.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { SvaMainserverError } from './errors.js';
+import { toMainserverErrorResponse } from './mainserver-error-response.js';
+
+describe('toMainserverErrorResponse', () => {
+  it('preserves the existing default 500 contract for mainserver errors without explicit status', async () => {
+    const response = toMainserverErrorResponse(
+      new SvaMainserverError({
+        code: 'forbidden',
+        message: 'Kein Zugriff.',
+      }),
+      'Fallback-Nachricht'
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'forbidden',
+      message: 'Kein Zugriff.',
+    });
+  });
+
+  it('prefers explicit status codes over default code mapping', async () => {
+    const response = toMainserverErrorResponse(
+      new SvaMainserverError({
+        code: 'forbidden',
+        message: 'Abweichender Status.',
+        statusCode: 451,
+      }),
+      'Fallback-Nachricht'
+    );
+
+    expect(response.status).toBe(451);
+    await expect(response.json()).resolves.toEqual({
+      error: 'forbidden',
+      message: 'Abweichender Status.',
+    });
+  });
+
+  it('uses the shared code mapping when a mainserver error has no explicit status code', async () => {
+    const error = new SvaMainserverError({
+      code: 'forbidden',
+      message: 'Kein Zugriff.',
+    });
+    Object.defineProperty(error, 'statusCode', { value: undefined });
+
+    const response = toMainserverErrorResponse(error, 'Fallback-Nachricht');
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'forbidden',
+      message: 'Kein Zugriff.',
+    });
+  });
+
+  it('falls back to 502 for unknown mainserver error codes without an explicit status code', async () => {
+    const error = new SvaMainserverError({
+      code: 'unexpected_upstream_code',
+      message: 'Unbekannter Upstream-Fehler.',
+    });
+    Object.defineProperty(error, 'statusCode', { value: undefined });
+
+    const response = toMainserverErrorResponse(error, 'Fallback-Nachricht');
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: 'unexpected_upstream_code',
+      message: 'Unbekannter Upstream-Fehler.',
+    });
+  });
+
+  it('returns a route-specific internal error response for non-mainserver errors', async () => {
+    const response = toMainserverErrorResponse(new Error('boom'), 'Mainserver-News-Anfrage ist fehlgeschlagen.');
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'internal_error',
+      message: 'Mainserver-News-Anfrage ist fehlgeschlagen.',
+    });
+  });
+});

--- a/packages/sva-mainserver/src/server/mainserver-error-response.ts
+++ b/packages/sva-mainserver/src/server/mainserver-error-response.ts
@@ -1,0 +1,28 @@
+import { errorJson } from './content-route-helpers.js';
+import { SvaMainserverError } from './errors.js';
+
+const MAINSERVER_ERROR_STATUS_BY_CODE = {
+  missing_credentials: 400,
+  organization_mainserver_credentials_missing: 409,
+  invalid_config: 400,
+  config_not_found: 400,
+  integration_disabled: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  not_found: 404,
+  database_unavailable: 503,
+  identity_provider_unavailable: 503,
+  network_error: 503,
+  token_request_failed: 502,
+  graphql_error: 502,
+  invalid_response: 502,
+} satisfies Record<string, number>;
+
+export const toMainserverErrorResponse = (error: unknown, fallbackMessage: string): Response => {
+  if (error instanceof SvaMainserverError) {
+    const status = error.statusCode ?? MAINSERVER_ERROR_STATUS_BY_CODE[error.code] ?? 502;
+    return errorJson(status, error.code, error.message);
+  }
+
+  return errorJson(500, 'internal_error', fallbackMessage);
+};

--- a/packages/sva-mainserver/src/server/news-route.ts
+++ b/packages/sva-mainserver/src/server/news-route.ts
@@ -25,6 +25,7 @@ import {
 } from './content-route-helpers.js';
 import { SvaMainserverError } from './errors.js';
 import { parseMainserverListQuery } from './list-pagination.js';
+import { toMainserverErrorResponse } from './mainserver-error-response.js';
 import {
   changeSvaMainserverNewsVisibility,
   createSvaMainserverNews,
@@ -505,7 +506,7 @@ const handleCollectionCreate = async (
     });
     return json(responseBody, 201);
   } catch (error) {
-    const response = toMainserverErrorResponse(error);
+    const response = toMainserverErrorResponse(error, 'Mainserver-News-Anfrage ist fehlgeschlagen.');
     await completeNewsCreateIdempotency({
       actorAccountId,
       instanceId: actorInfo.actor.instanceId,
@@ -594,33 +595,6 @@ const handleVisibilityUpdate = async (
   const response = await changeNewsVisibilityForRoute(route, actor, parsed.visible);
   logSuccess('mainserver_news_visibility_update', route.newsId);
   return response;
-};
-
-const toMainserverErrorResponse = (error: unknown): Response => {
-  if (error instanceof SvaMainserverError) {
-    const status =
-      error.statusCode ??
-      ({
-        missing_credentials: 400,
-        organization_mainserver_credentials_missing: 409,
-        invalid_config: 400,
-        config_not_found: 400,
-        integration_disabled: 400,
-        unauthorized: 401,
-        forbidden: 403,
-        not_found: 404,
-        database_unavailable: 503,
-        identity_provider_unavailable: 503,
-        network_error: 503,
-        token_request_failed: 502,
-        graphql_error: 502,
-        invalid_response: 502,
-      } satisfies Record<string, number>)[error.code] ??
-      502;
-    return errorJson(status, error.code, error.message);
-  }
-
-  return errorJson(500, 'internal_error', 'Mainserver-News-Anfrage ist fehlgeschlagen.');
 };
 
 const authorize = async (
@@ -799,7 +773,7 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       method: request.method,
       error_code: error instanceof SvaMainserverError ? error.code : 'internal_error',
     });
-    return toMainserverErrorResponse(error);
+    return toMainserverErrorResponse(error, 'Mainserver-News-Anfrage ist fehlgeschlagen.');
   }
 };
 

--- a/packages/sva-mainserver/src/server/poi-route.ts
+++ b/packages/sva-mainserver/src/server/poi-route.ts
@@ -33,6 +33,7 @@ import {
   listSvaMainserverPoi,
   updateSvaMainserverPoi,
 } from './service.js';
+import { toMainserverErrorResponse } from './mainserver-error-response.js';
 
 const POI_CONTENT_TYPE = 'poi.point-of-interest';
 const POI_COLLECTION_PATH = '/api/v1/mainserver/poi';
@@ -105,33 +106,6 @@ const parsePoiInput = async (request: Request): Promise<SvaMainserverPoiInput | 
     return tags;
   }
   return buildPoiInput({ body, name, categories, addresses, contact, webUrls, tags });
-};
-
-const toMainserverErrorResponse = (error: unknown): Response => {
-  if (error instanceof SvaMainserverError) {
-    const status =
-      error.statusCode ??
-      ({
-        missing_credentials: 400,
-        organization_mainserver_credentials_missing: 409,
-        invalid_config: 400,
-        config_not_found: 400,
-        integration_disabled: 400,
-        unauthorized: 401,
-        forbidden: 403,
-        not_found: 404,
-        database_unavailable: 503,
-        identity_provider_unavailable: 503,
-        network_error: 503,
-        token_request_failed: 502,
-        graphql_error: 502,
-        invalid_response: 502,
-      } satisfies Record<string, number>)[error.code] ??
-      502;
-    return errorJson(status, error.code, error.message);
-  }
-
-  return errorJson(500, 'internal_error', 'Mainserver-Anfrage ist fehlgeschlagen.');
 };
 
 const validateMutationRequest = (request: Request, requestId?: string): Response | null => {
@@ -354,7 +328,7 @@ const dispatchAuthenticated = async (request: Request, route: RouteMatch, ctx: A
       method: request.method,
       error_code: error instanceof SvaMainserverError ? error.code : 'internal_error',
     });
-    return toMainserverErrorResponse(error);
+    return toMainserverErrorResponse(error, 'Mainserver-Anfrage ist fehlgeschlagen.');
   }
 };
 

--- a/packages/sva-mainserver/src/server/settings.test.ts
+++ b/packages/sva-mainserver/src/server/settings.test.ts
@@ -4,7 +4,7 @@ const state = vi.hoisted(() => ({
   loadDefaultExternalInterfaceRecord: vi.fn(),
   saveExternalInterfaceRecord: vi.fn(),
   deleteExternalInterfaceRecord: vi.fn(),
-  dnsLookup: vi.fn(async () => [{ address: '203.0.113.10', family: 4 }]),
+  dnsLookup: vi.fn(async () => [{ address: '8.8.8.8', family: 4 }]),
 }));
 
 vi.mock('@sva/data-repositories/server', () => ({
@@ -23,7 +23,7 @@ describe('settings', () => {
     state.saveExternalInterfaceRecord.mockReset();
     state.deleteExternalInterfaceRecord.mockReset();
     state.dnsLookup.mockReset();
-    state.dnsLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    state.dnsLookup.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
   });
 
   it('loads settings when integration record exists', async () => {

--- a/packages/sva-mainserver/src/server/settings.ts
+++ b/packages/sva-mainserver/src/server/settings.ts
@@ -46,6 +46,14 @@ const resolveStoredVisibleStatus = (
   return existingVisibleStatus;
 };
 
+const buildPublicConfig = (input: {
+  graphqlBaseUrl: string;
+  oauthTokenUrl: string;
+}): Record<string, unknown> => ({
+  graphqlBaseUrl: input.graphqlBaseUrl,
+  oauthTokenUrl: input.oauthTokenUrl,
+});
+
 export const loadSvaMainserverSettings = async (instanceId: string): Promise<SvaMainserverInstanceConfig | null> => {
   const record = await loadDefaultExternalInterfaceRecord(instanceId, SVA_MAINSERVER_TYPE_KEY);
   if (!record) {
@@ -89,10 +97,10 @@ export const saveSvaMainserverSettings = async (input: {
     category: 'api',
     baseUrl: graphqlBaseUrl,
     authMode: 'oauth2',
-    publicConfig: {
+    publicConfig: buildPublicConfig({
       graphqlBaseUrl,
       oauthTokenUrl,
-    },
+    }),
     secretConfigCiphertext: undefined,
     statusCheckKind: 'sva_mainserver',
     visibleStatus: resolveStoredVisibleStatus(input.enabled, existing?.visibleStatus),

--- a/packages/sva-mainserver/src/server/upstream-url-validation.test.ts
+++ b/packages/sva-mainserver/src/server/upstream-url-validation.test.ts
@@ -12,7 +12,7 @@ import { normalizeSvaMainserverUpstreamUrl } from './upstream-url-validation';
 describe('normalizeSvaMainserverUpstreamUrl', () => {
   beforeEach(() => {
     dnsLookupMock.mockReset();
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
   });
 
   it('normalizes valid public https urls', async () => {
@@ -67,6 +67,9 @@ describe('normalizeSvaMainserverUpstreamUrl', () => {
     await expect(
       normalizeSvaMainserverUpstreamUrl('https://[fe80::1]/graphql', 'graphql_base_url', 400)
     ).rejects.toMatchObject({ code: 'invalid_config' });
+    await expect(
+      normalizeSvaMainserverUpstreamUrl('https://[fec0::1]/graphql', 'graphql_base_url', 400)
+    ).rejects.toMatchObject({ code: 'invalid_config' });
   });
 
   it('rejects private and malformed ipv4-mapped ipv6 targets but allows public ones', async () => {
@@ -85,6 +88,11 @@ describe('normalizeSvaMainserverUpstreamUrl', () => {
     dnsLookupMock.mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }]);
     await expect(
       normalizeSvaMainserverUpstreamUrl('https://public.example.invalid/graphql', 'graphql_base_url', 400)
+    ).rejects.toMatchObject({ code: 'invalid_config' });
+
+    dnsLookupMock.mockResolvedValueOnce([{ address: 'fec0::1', family: 6 }]);
+    await expect(
+      normalizeSvaMainserverUpstreamUrl('https://site-local.example.invalid/graphql', 'graphql_base_url', 400)
     ).rejects.toMatchObject({ code: 'invalid_config' });
 
     dnsLookupMock.mockResolvedValueOnce([]);

--- a/packages/sva-mainserver/src/server/upstream-url-validation.ts
+++ b/packages/sva-mainserver/src/server/upstream-url-validation.ts
@@ -1,170 +1,15 @@
-import { lookup as dnsLookup } from 'node:dns/promises';
-import { isIP } from 'node:net';
+import { normalizePublicUpstreamUrl } from '@sva/auth-runtime/server';
 
 import { SvaMainserverError } from './errors.js';
-
-const localhostHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
-
-const parseUpstreamUrl = (value: string): URL | null => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  try {
-    return new URL(trimmed);
-  } catch {
-    return null;
-  }
-};
-
-const isPublicHttpsUrl = (value: URL): boolean => {
-  if (value.username || value.password) {
-    return false;
-  }
-
-  if (value.hash) {
-    return false;
-  }
-
-  if (value.protocol !== 'https:') {
-    return false;
-  }
-
-  return !isPrivateOrLocalHost(value.hostname);
-};
-
-const unwrapBracketedHost = (hostname: string): string =>
-  hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
-
-const isLocalHostname = (hostname: string): boolean =>
-  localhostHosts.has(hostname) || hostname.endsWith('.local');
-
-const parseIpv4Octets = (hostname: string): number[] | null => {
-  const octets = hostname.split('.').map((segment) => Number.parseInt(segment, 10));
-  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part))) {
-    return null;
-  }
-
-  return octets;
-};
-
-const isPrivateIpv4Host = (hostname: string): boolean => {
-  const octets = parseIpv4Octets(hostname);
-  if (!octets) {
-    return true;
-  }
-
-  const [a, b] = octets;
-  return (
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168)
-  );
-};
-
-const toMappedIpv4Host = (hostname: string): string | null => {
-  if (!hostname.startsWith('::ffff:')) {
-    return null;
-  }
-
-  const mappedPart = hostname.slice('::ffff:'.length);
-  if (isIP(mappedPart) === 4) {
-    return mappedPart;
-  }
-
-  const hexParts = mappedPart.split(':');
-  if (hexParts.length !== 2) {
-    return null;
-  }
-
-  const high = Number.parseInt(hexParts[0], 16);
-  const low = Number.parseInt(hexParts[1], 16);
-  if (Number.isNaN(high) || Number.isNaN(low)) {
-    return null;
-  }
-
-  return [
-    (high >> 8) & 0xff,
-    high & 0xff,
-    (low >> 8) & 0xff,
-    low & 0xff,
-  ].join('.');
-};
-
-const isPrivateIpv6Host = (hostname: string): boolean => {
-  const mappedIpv4Host = toMappedIpv4Host(hostname);
-  if (mappedIpv4Host) {
-    return isPrivateOrLocalHost(mappedIpv4Host);
-  }
-
-  if (hostname.startsWith('::ffff:')) {
-    return true;
-  }
-
-  return (
-    hostname === '::1' ||
-    hostname === '::' ||
-    hostname.startsWith('fc') ||
-    hostname.startsWith('fd') ||
-    hostname.startsWith('fe80:')
-  );
-};
-
-const isPrivateOrLocalHost = (hostname: string): boolean => {
-  const normalized = hostname.trim().toLowerCase();
-  if (isLocalHostname(normalized)) {
-    return true;
-  }
-
-  const unbracketed = unwrapBracketedHost(normalized);
-  if (unbracketed !== normalized) {
-    return isPrivateOrLocalHost(unbracketed);
-  }
-
-  const ipVersion = isIP(normalized);
-  if (ipVersion === 4) {
-    return isPrivateIpv4Host(normalized);
-  }
-
-  if (ipVersion === 6) {
-    return isPrivateIpv6Host(normalized);
-  }
-
-  return false;
-};
-
-const resolvesToPrivateOrLocalHost = async (hostname: string): Promise<boolean> => {
-  const normalized = hostname.trim().toLowerCase();
-  if (isIP(normalized) !== 0) {
-    return false;
-  }
-
-  try {
-    const resolved = await dnsLookup(normalized, {
-      all: true,
-      verbatim: true,
-    });
-    if (resolved.length === 0) {
-      return true;
-    }
-
-    return resolved.some((entry) => isPrivateOrLocalHost(entry.address));
-  } catch {
-    return true;
-  }
-};
 
 export const normalizeSvaMainserverUpstreamUrl = async (
   value: string,
   fieldName: 'graphql_base_url' | 'oauth_token_url',
   statusCode: number
 ): Promise<string> => {
-  const parsed = parseUpstreamUrl(value);
-  if (!parsed || !isPublicHttpsUrl(parsed) || (await resolvesToPrivateOrLocalHost(parsed.hostname))) {
+  const normalizedUrl = await normalizePublicUpstreamUrl(value);
+
+  if (!normalizedUrl) {
     throw new SvaMainserverError({
       code: 'invalid_config',
       message: `Die konfigurierte Upstream-URL ${fieldName} ist ungültig.`,
@@ -172,5 +17,5 @@ export const normalizeSvaMainserverUpstreamUrl = async (
     });
   }
 
-  return parsed.toString();
+  return normalizedUrl;
 };


### PR DESCRIPTION
Diese Änderung erweitert den User-Create-Flow um ein serverseitiges Mainserver-Provisioning. Nach erfolgreicher lokaler Benutzeranlage und Rollensynchronisation wird versucht, für den neu angelegten Keycloak-User dedizierte Mainserver-Credentials zu provisionieren.

## Hintergrund

Bisher endete der Flow nach lokaler Persistenz, externer Benutzeranlage und optionalem Einladungsversand. Die Mainserver-spezifischen Benutzerzugangsdaten wurden dabei noch nicht automatisch im Create-Flow bereitgestellt.

## Änderungen

- neues `provisionMainserverUserCredentials` in `auth-runtime` eingeführt
- Mainserver-Provisioning in den bestehenden User-Create-Flow nach lokaler Persistenz und Rollensynchronisation eingebunden
- Rückgabedaten des Create-Flows um gesetzte Mainserver-Credentials ergänzt, wenn das Provisioning erfolgreich war
- Fehler beim nachgelagerten Mainserver-Provisioning werden geloggt, ohne die bereits erfolgreiche lokale Benutzeranlage zurückzurollen
- begleitende Tests in `auth-runtime`, `sva-mainserver` und im Interfaces-Flow angepasst bzw. ergänzt

## Warum

- neu angelegte Benutzerinnen und Benutzer sollen ihre Mainserver-Anwendungszugangsdaten direkt im Create-Flow erhalten
- nachgelagerte Fehler im externen Provisioning sollen nicht unnötig einen bereits erfolgreichen lokalen Anlageprozess entwerten
- der Flow soll robuster werden, ohne zusätzliche Pflichtkonfiguration in der Mainserver-Schnittstelle einzuführen

## Tests

- Unit-Tests für erfolgreiches und fehlschlagendes Mainserver-Provisioning im User-Create-Flow ergänzt
- Tests für das Verhalten bei erfolgreicher lokaler Benutzeranlage trotz nachgelagertem Provisioning-Fehler ergänzt
- betroffene Frontend- und `sva-mainserver`-Tests auf den bereinigten Mainserver-Settings-Flow ohne zusätzliche `municipalityId`-Konfiguration aktualisiert