### PR TITLE
[codex] repo-local PR review intake

### DIFF
--- a/.codex/agents/pr-fixer.toml
+++ b/.codex/agents/pr-fixer.toml
@@ -7,6 +7,7 @@ Arbeitsmodus:
 - Lies `./.github/agents/pr-fixer.agent.md` vollständig und behandle die Datei als kanonische Quelle.
 - Behandle den YAML-Frontmatter-Block nur als Metadaten; maßgeblich sind die nachfolgenden Anweisungen.
 - Nutze im Codex-Kontext die funktional nächstpassenden Tools, Skills und MCP-Server statt Copilot-spezifischer Toolnamen.
+- Behandle `pnpm exec tsx scripts/ci/pr-review-intake.ts snapshot --json` als kanonischen lokalen Einstieg fuer PR-Metadaten, offene Review-Threads und failing Checks; externe GitHub-Skills sind nur Fallback.
 - Wenn die Quelldatei auf weitere lokale Dateien, Templates oder Doku verweist, lies sie gezielt nach Bedarf.
 - Halte dich zusätzlich an `AGENTS.md`, `DEVELOPMENT_RULES.md` und vorhandene Repo-Regeln.
 - Eskaliere fehlende Tool-Unterstützung explizit, statt Copilot-Workflows zu simulieren.

--- a/.github/agents/pr-fixer.agent.md
+++ b/.github/agents/pr-fixer.agent.md
@@ -46,18 +46,18 @@ Lies diese Dateien zu Beginn, um alle Non-Negotiable-Regeln zu kennen.
 ### Phase 0: Initialisierung
 
 1. **Repo-Regeln lesen**: `DEVELOPMENT_RULES.md`, `AGENTS.md`, `CLAUDE.md`
-2. **Pflicht-Skills sofort laden**: `address-pr-comments` immer zuerst, `nx-workspace` vor jeder Nx-Task-Auswahl; `monitor-ci` sobald Checks beobachtet werden muessen
-3. **SonarQube automatische Analyse deaktivieren**: `toggle_automatic_analysis` aufrufen, falls das Tool verfuegbar ist
-4. **PR-Kontext laden**: `github-pull-request_activePullRequest` zuerst ohne Refresh aufrufen; bei frischer Aktivitaet anschliessend mit `refresh: true`
-5. **Branch verifizieren**: `git branch --show-current` pruefen, dass du auf dem PR-Branch bist
+2. **PR-Intake lokal konsolidieren**: immer zuerst `pnpm exec tsx scripts/ci/pr-review-intake.ts snapshot --json` verwenden; bei bekanntem Ziel-PR `--repo <owner/repo> --pr <nummer>` explizit setzen
+3. **Pflicht-Skills gezielt laden**: `nx-workspace` vor jeder Nx-Task-Auswahl; `monitor-ci` erst fuer echtes CI-Monitoring nach Pushes; externe GitHub-Skills nur noch als Fallback bei Werkzeugluecken
+4. **SonarQube automatische Analyse deaktivieren**: `toggle_automatic_analysis` aufrufen, falls das Tool verfuegbar ist
+5. **Branch verifizieren**: `git branch --show-current` pruefen, dass du auf dem PR-Branch bist, falls kein explizites `--repo/--pr` gesetzt ist
 6. **Alle geaenderten Dateien erfassen**: PR-Diff analysieren
 7. **Nx-Targets verifizieren**: Mit `nx-workspace` oder Projektkonfiguration die real vorhandenen Targets fuer betroffene Projekte ermitteln, statt `test:types` oder `test:eslint` pauschal anzunehmen
 8. **Todo-Liste erstellen**: Alle offenen Punkte als Todos anlegen
 
 ### Phase 1: Review-Threads bearbeiten
 
-1. **PR-Kommentar-Workflow verwenden**: Den Skill `address-pr-comments` als primären Workflow fuer offene Threads verwenden
-2. **Unresolved Threads identifizieren**: Aus `activePullRequest`-Response alle `comments` mit `commentState: "unresolved"` sammeln
+1. **PR-Intake als führende Quelle verwenden**: Offene Threads aus `pr-review-intake.ts snapshot|threads --json` lesen; der Snapshot ist die kanonische lokale Wahrheit fuer PR-Metadaten, Threads und failing Checks
+2. **Unresolved Threads identifizieren**: `reviewThreads.open` aus dem Snapshot auswerten statt ad hoc aus flachen Connector-Kommentaren
 2. **Threads nach Datei gruppieren** und priorisieren:
    - 🔴 Blocker / Security-Findings zuerst
    - 🟡 Funktionale Korrekturen
@@ -68,7 +68,7 @@ Lies diese Dateien zu Beginn, um alle Non-Negotiable-Regeln zu kennen.
    c. Falls der Kommentar unklar oder unbegründet ist: Rückfrage als Reply formulieren statt blind umzusetzen
    d. Betroffene Tests lokal ausfuehren, aber mit real existierendem Nx-Target fuer das Projekt
 4. **Resolve nur mit Nachweis**: Jeder Thread braucht eine inhaltliche Antwort, eine nachweisbare Code-Aenderung oder eine sauber begruendete Nicht-Aenderung
-5. **Tool-Luecken explizit behandeln**: Wenn direkte Reply-/Resolve-APIs nicht verfuegbar sind, fuer jeden offenen Thread eine konkrete Antwortvorlage und den verbleibenden manuellen Schritt im Abschlussbericht festhalten
+5. **Tool-Luecken explizit behandeln**: Wenn direkte Reply-/Resolve-APIs nicht verfuegbar sind, fuer jeden offenen Thread eine konkrete Antwortvorlage und den verbleibenden manuellen Schritt im Abschlussbericht festhalten; externe GitHub-Skills oder Connectoren sind dafuer nur Fallback, nicht Primärpfad
 
 ### Phase 2: Tests reparieren
 
@@ -122,10 +122,10 @@ Lies diese Dateien zu Beginn, um alle Non-Negotiable-Regeln zu kennen.
 
 Nach dem Push kehre zu Phase 1 zurück:
 
-1. **PR neu laden**: `github-pull-request_activePullRequest` mit `refresh: true`
+1. **PR neu laden**: `pnpm exec tsx scripts/ci/pr-review-intake.ts snapshot --json` erneut ausfuehren; bei bekanntem Ziel-PR weiter mit explizitem `--repo/--pr`
 2. **Neue Threads prüfen**: Haben Reviewer auf deine Änderungen reagiert?
-3. **CI-Status pruefen**: `github-pull-request_pullRequestStatusChecks` aufrufen
-4. **CI ueber den vorhandenen Workflow beobachten**: Fuer laufende Checks den Skill `monitor-ci` verwenden statt ad hoc Polling oder Provider-Watch-Flags
+3. **CI-Status pruefen**: Failing und pending Checks aus `checks` im Snapshot lesen
+4. **CI ueber den vorhandenen Workflow beobachten**: Fuer laufende Checks den Skill `monitor-ci` verwenden statt ad hoc Polling oder Provider-Watch-Flags; `pr-review-intake.ts` bleibt fuer den punktuellen Snapshot zustaendig, nicht fuer Dauer-Polling
 5. **SonarCloud/CodeCov erneut prüfen**: Nach CI-Durchlauf neue Ergebnisse laden
 6. **Schleife fortsetzen** bis:
    - Alle Review-Threads resolved oder beantwortet sind
@@ -190,7 +190,7 @@ Delegation heißt: Den Agent als Subagent aufrufen mit dem konkreten Problem-Kon
 - Erlaubte Skills: `monitor-ci`, `nx-workspace`, `nx-run-tasks`, `systematic-debugging`, `context7`, `address-pr-comments`
 - Nicht erlaubte Skills nur nach Rückfrage an den Nutzer
 - Bei fehlendem Skill: Eskalieren statt improvisieren
-- Skills werden nicht nur erwaehnt, sondern bei passendem Schritt sofort geladen und als primaerer Workflow verwendet
+- Skills werden nicht nur erwaehnt, sondern bei passendem Schritt sofort geladen; fuer lokalen PR-State ist jedoch `scripts/ci/pr-review-intake.ts` der primaere Workflow vor Skill-/Connector-Fallbacks
 
 ---
 

--- a/.github/agents/pr-fixer.agent.md
+++ b/.github/agents/pr-fixer.agent.md
@@ -58,17 +58,17 @@ Lies diese Dateien zu Beginn, um alle Non-Negotiable-Regeln zu kennen.
 
 1. **PR-Intake als führende Quelle verwenden**: Offene Threads aus `pr-review-intake.ts snapshot|threads --json` lesen; der Snapshot ist die kanonische lokale Wahrheit fuer PR-Metadaten, Threads und failing Checks
 2. **Unresolved Threads identifizieren**: `reviewThreads.open` aus dem Snapshot auswerten statt ad hoc aus flachen Connector-Kommentaren
-2. **Threads nach Datei gruppieren** und priorisieren:
+3. **Threads nach Datei gruppieren** und priorisieren:
    - 🔴 Blocker / Security-Findings zuerst
    - 🟡 Funktionale Korrekturen
    - 🟢 Style / Verbesserungen zuletzt
-3. **Pro Thread**:
+4. **Pro Thread**:
    a. Betroffene Datei lesen und Kontext verstehen
    b. Änderung implementieren (minimal, korrekt, im Scope des Kommentars)
    c. Falls der Kommentar unklar oder unbegründet ist: Rückfrage als Reply formulieren statt blind umzusetzen
    d. Betroffene Tests lokal ausfuehren, aber mit real existierendem Nx-Target fuer das Projekt
-4. **Resolve nur mit Nachweis**: Jeder Thread braucht eine inhaltliche Antwort, eine nachweisbare Code-Aenderung oder eine sauber begruendete Nicht-Aenderung
-5. **Tool-Luecken explizit behandeln**: Wenn direkte Reply-/Resolve-APIs nicht verfuegbar sind, fuer jeden offenen Thread eine konkrete Antwortvorlage und den verbleibenden manuellen Schritt im Abschlussbericht festhalten; externe GitHub-Skills oder Connectoren sind dafuer nur Fallback, nicht Primärpfad
+5. **Resolve nur mit Nachweis**: Jeder Thread braucht eine inhaltliche Antwort, eine nachweisbare Code-Aenderung oder eine sauber begruendete Nicht-Aenderung
+6. **Tool-Luecken explizit behandeln**: Wenn direkte Reply-/Resolve-APIs nicht verfuegbar sind, fuer jeden offenen Thread eine konkrete Antwortvorlage und den verbleibenden manuellen Schritt im Abschlussbericht festhalten; externe GitHub-Skills oder Connectoren sind dafuer nur Fallback, nicht Primärpfad
 
 ### Phase 2: Tests reparieren
 

--- a/docs/development/review-agent-governance.md
+++ b/docs/development/review-agent-governance.md
@@ -4,6 +4,25 @@
 
 Dieses Dokument beschreibt die Review-Governance für Proposal- und PR-Reviews mit spezialisierten Agents.
 
+## Kanonischer PR-Intake
+
+Fuer die lokale Diagnose eines aktiven Pull Requests ist `pnpm exec tsx scripts/ci/pr-review-intake.ts` der kanonische Einstieg.
+
+- `snapshot` kombiniert PR-Metadaten, offene/resolved Review-Threads sowie failing/pending Checks in einem konsolidierten Snapshot.
+- `threads` liefert den thread-aware Review-Stand gezielt fuer Abarbeitung offener Kommentare.
+- `checks` liefert problematische GitHub-Checks inklusive Log-Aufloesung fuer failing Actions-Jobs.
+- Explizites `--repo <owner/repo> --pr <nummer>` hat Vorrang vor lokaler Branch-Erkennung.
+- Ohne explizite Parameter faellt der Intake auf die PR des aktuellen Branches zurueck.
+- `gh auth status` wird genau einmal zu Beginn des CLI-Laufs geprueft.
+- Externe GitHub-Plugin- oder Cache-Skills bleiben zulaessiger Fallback, sind fuer lokale PR-Diagnose aber nicht mehr der Primaerpfad.
+
+Empfohlene Aufrufe:
+
+- `pnpm exec tsx scripts/ci/pr-review-intake.ts snapshot --json`
+- `pnpm exec tsx scripts/ci/pr-review-intake.ts snapshot --repo smart-village-solutions/sva-studio --pr 602 --json`
+- `pnpm exec tsx scripts/ci/pr-review-intake.ts threads --repo smart-village-solutions/sva-studio --pr 602 --json`
+- `pnpm exec tsx scripts/ci/pr-review-intake.ts checks --repo smart-village-solutions/sva-studio --pr 602 --json`
+
 ## Bot-Kommentar-Gate
 
 Fuer Bot-Kommentare von `Copilot` und `chatgpt-codex-connector[bot]` gilt zusaetzlich ein blockierendes PR-Gate.

--- a/scripts/ci/fixtures/pr-review-intake/branch-pr-view.json
+++ b/scripts/ci/fixtures/pr-review-intake/branch-pr-view.json
@@ -1,0 +1,4 @@
+{
+  "number": 602,
+  "url": "https://github.com/smart-village-solutions/sva-studio/pull/602"
+}

--- a/scripts/ci/fixtures/pr-review-intake/pr-checks-fallback.json
+++ b/scripts/ci/fixtures/pr-review-intake/pr-checks-fallback.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "Quality Gates / Types",
+    "state": "COMPLETED",
+    "bucket": "fail",
+    "link": "https://github.com/smart-village-solutions/sva-studio/actions/runs/201/job/301",
+    "startedAt": "2026-06-18T10:00:00Z",
+    "completedAt": "2026-06-18T10:05:00Z",
+    "workflow": "Quality Gates"
+  },
+  {
+    "name": "Quality Gates / Unit",
+    "state": "IN_PROGRESS",
+    "bucket": "pending",
+    "link": "https://github.com/smart-village-solutions/sva-studio/actions/runs/202/job/302",
+    "startedAt": "2026-06-18T10:06:00Z",
+    "completedAt": null,
+    "workflow": "Quality Gates"
+  },
+  {
+    "name": "Lint",
+    "state": "COMPLETED",
+    "bucket": "pass",
+    "link": "https://github.com/smart-village-solutions/sva-studio/actions/runs/203/job/303",
+    "startedAt": "2026-06-18T10:00:00Z",
+    "completedAt": "2026-06-18T10:01:00Z",
+    "workflow": "Quality Gates"
+  }
+]

--- a/scripts/ci/fixtures/pr-review-intake/pr-checks-primary-error.txt
+++ b/scripts/ci/fixtures/pr-review-intake/pr-checks-primary-error.txt
@@ -1,0 +1,9 @@
+Unknown JSON field: "conclusion"
+Available fields:
+name
+state
+bucket
+link
+startedAt
+completedAt
+workflow

--- a/scripts/ci/fixtures/pr-review-intake/pr-summary.json
+++ b/scripts/ci/fixtures/pr-review-intake/pr-summary.json
@@ -1,0 +1,17 @@
+{
+  "number": 602,
+  "title": "Refine PR intake",
+  "url": "https://github.com/smart-village-solutions/sva-studio/pull/602",
+  "state": "OPEN",
+  "isDraft": false,
+  "headRefName": "fix/pr-intake",
+  "baseRefName": "main",
+  "author": {
+    "login": "wilimzig"
+  },
+  "reviewDecision": "CHANGES_REQUESTED",
+  "mergeable": "MERGEABLE",
+  "changedFiles": 5,
+  "additions": 140,
+  "deletions": 12
+}

--- a/scripts/ci/fixtures/pr-review-intake/review-threads-page-1.json
+++ b/scripts/ci/fixtures/pr-review-intake/review-threads-page-1.json
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": null
+          },
+          "nodes": [
+            {
+              "id": "RT_kwDOAA",
+              "isResolved": false,
+              "isOutdated": false,
+              "path": "packages/data/src/query.ts",
+              "line": 42,
+              "originalLine": 42,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "PRRC_kwDOAA_1",
+                    "body": "Bitte den GraphQL-Fallback vereinheitlichen.",
+                    "createdAt": "2026-06-18T08:00:00Z",
+                    "url": "https://github.com/smart-village-solutions/sva-studio/pull/602#discussion_r1",
+                    "author": {
+                      "login": "Copilot"
+                    }
+                  },
+                  {
+                    "id": "PRRC_kwDOAA_2",
+                    "body": "Verstanden, ich ziehe das in ein gemeinsames Helper-Modul.",
+                    "createdAt": "2026-06-18T08:05:00Z",
+                    "url": "https://github.com/smart-village-solutions/sva-studio/pull/602#discussion_r2",
+                    "author": {
+                      "login": "maintainer"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "RT_kwDOAB",
+              "isResolved": true,
+              "isOutdated": false,
+              "path": "scripts/ci/pr-review-intake.ts",
+              "line": 88,
+              "originalLine": 88,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "PRRC_kwDOAB_1",
+                    "body": "Bitte den Exit-Code dokumentieren.",
+                    "createdAt": "2026-06-18T09:00:00Z",
+                    "url": "https://github.com/smart-village-solutions/sva-studio/pull/602#discussion_r3",
+                    "author": {
+                      "login": "chatgpt-codex-connector[bot]"
+                    }
+                  },
+                  {
+                    "id": "PRRC_kwDOAB_2",
+                    "body": "Erledigt und im CLI-Help ergänzt.",
+                    "createdAt": "2026-06-18T09:03:00Z",
+                    "url": "https://github.com/smart-village-solutions/sva-studio/pull/602#discussion_r4",
+                    "author": {
+                      "login": "maintainer"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/ci/fixtures/pr-review-intake/run-log-201.txt
+++ b/scripts/ci/fixtures/pr-review-intake/run-log-201.txt
@@ -1,0 +1,8 @@
+vite v6.0.0 building for test...
+transforming modules...
+src/routes/example.ts(12,5): note TS diagnostics follow
+Error: Type mismatch in route loader
+Expected Promise<RouteData>
+Received Promise<unknown>
+at packages/data/src/query.ts:42:7
+Build failed with 1 error

--- a/scripts/ci/fixtures/pr-review-intake/run-metadata-201.json
+++ b/scripts/ci/fixtures/pr-review-intake/run-metadata-201.json
@@ -1,0 +1,10 @@
+{
+  "conclusion": "failure",
+  "status": "completed",
+  "workflowName": "Quality Gates",
+  "name": "Quality Gates",
+  "event": "pull_request",
+  "headBranch": "fix/pr-intake",
+  "headSha": "abcdef1234567890",
+  "url": "https://github.com/smart-village-solutions/sva-studio/actions/runs/201"
+}

--- a/scripts/ci/fixtures/pr-review-intake/run-metadata-202.json
+++ b/scripts/ci/fixtures/pr-review-intake/run-metadata-202.json
@@ -1,0 +1,10 @@
+{
+  "conclusion": null,
+  "status": "in_progress",
+  "workflowName": "Quality Gates",
+  "name": "Quality Gates",
+  "event": "pull_request",
+  "headBranch": "fix/pr-intake",
+  "headSha": "abcdef1234567890",
+  "url": "https://github.com/smart-village-solutions/sva-studio/actions/runs/202"
+}

--- a/scripts/ci/pr-review-intake.checks.ts
+++ b/scripts/ci/pr-review-intake.checks.ts
@@ -15,7 +15,7 @@ const FAILURE_CONCLUSIONS = new Set(['failure', 'cancelled', 'timed_out', 'actio
 const FAILURE_STATES = new Set(['failure', 'error', 'cancelled', 'timed_out', 'action_required']);
 const FAILURE_BUCKETS = new Set(['fail']);
 const PENDING_STATES = new Set(['pending', 'in_progress', 'queued', 'requested', 'waiting']);
-const PENDING_BUCKETS = new Set(['pending', 'skipping']);
+const PENDING_BUCKETS = new Set(['pending']);
 const PENDING_LOG_MARKERS = ['still in progress', 'log will be available when it is complete'] as const;
 
 type RawCheckRecord = Record<string, unknown>;
@@ -23,6 +23,7 @@ type RawCheckRecord = Record<string, unknown>;
 const normalizeField = (value: unknown): string => (value == null ? '' : String(value).trim().toLowerCase());
 const isPendingLogMessage = (message: string): boolean =>
   PENDING_LOG_MARKERS.some((marker) => message.toLowerCase().includes(marker));
+const isNoChecksReportedMessage = (message: string): boolean => message.toLowerCase().includes('no checks reported');
 
 const isFailingCheck = (check: Pick<CheckSummary, 'state' | 'conclusion' | 'bucket'>): boolean => {
   return (
@@ -71,7 +72,12 @@ const fetchChecksRaw = (ref: PullRequestRef, executor: GhExecutor): RawCheckReco
   let stdout = primary.stdout;
 
   if (primary.exitCode !== 0) {
-    const availableFields = parseAvailableFields(`${primary.stderr}\n${primary.stdout}`.trim());
+    const primaryMessage = `${primary.stderr}\n${primary.stdout}`.trim();
+    if (isNoChecksReportedMessage(primaryMessage)) {
+      return [];
+    }
+
+    const availableFields = parseAvailableFields(primaryMessage);
     const selected = ['name', 'state', 'bucket', 'link', 'startedAt', 'completedAt', 'workflow'].filter((field) =>
       availableFields.includes(field)
     );
@@ -81,6 +87,10 @@ const fetchChecksRaw = (ref: PullRequestRef, executor: GhExecutor): RawCheckReco
 
     const fallback = runGh(executor, ['pr', 'checks', String(ref.number), '--repo', repoSlug, '--json', selected.join(',')]);
     if (fallback.exitCode !== 0) {
+      const fallbackMessage = `${fallback.stderr}\n${fallback.stdout}`.trim();
+      if (isNoChecksReportedMessage(fallbackMessage)) {
+        return [];
+      }
       throw new Error((fallback.stderr || fallback.stdout || 'gh pr checks fehlgeschlagen').trim());
     }
     stdout = fallback.stdout;

--- a/scripts/ci/pr-review-intake.checks.ts
+++ b/scripts/ci/pr-review-intake.checks.ts
@@ -1,0 +1,207 @@
+import { runGh, runGhJson } from './pr-review-intake.gh.js';
+import type {
+  CheckCollection,
+  CheckRunMetadata,
+  CheckSummary,
+  CliOptions,
+  FailingCheckDetails,
+  GhExecutor,
+  PendingCheckDetails,
+  PullRequestRef,
+} from './pr-review-intake.types.js';
+import { extractFailureSnippet, extractJobId, extractRunId, parseAvailableFields } from './pr-review-intake.utils.js';
+
+const FAILURE_CONCLUSIONS = new Set(['failure', 'cancelled', 'timed_out', 'action_required']);
+const FAILURE_STATES = new Set(['failure', 'error', 'cancelled', 'timed_out', 'action_required']);
+const FAILURE_BUCKETS = new Set(['fail']);
+const PENDING_STATES = new Set(['pending', 'in_progress', 'queued', 'requested', 'waiting']);
+const PENDING_BUCKETS = new Set(['pending', 'skipping']);
+const PENDING_LOG_MARKERS = ['still in progress', 'log will be available when it is complete'] as const;
+
+type RawCheckRecord = Record<string, unknown>;
+
+const normalizeField = (value: unknown): string => (value == null ? '' : String(value).trim().toLowerCase());
+const isPendingLogMessage = (message: string): boolean =>
+  PENDING_LOG_MARKERS.some((marker) => message.toLowerCase().includes(marker));
+
+const isFailingCheck = (check: Pick<CheckSummary, 'state' | 'conclusion' | 'bucket'>): boolean => {
+  return (
+    FAILURE_CONCLUSIONS.has(normalizeField(check.conclusion)) ||
+    FAILURE_STATES.has(normalizeField(check.state)) ||
+    FAILURE_BUCKETS.has(normalizeField(check.bucket))
+  );
+};
+
+const isPendingCheck = (check: Pick<CheckSummary, 'state' | 'conclusion' | 'bucket'>): boolean => {
+  return (
+    !isFailingCheck(check) &&
+    (PENDING_STATES.has(normalizeField(check.state)) || PENDING_BUCKETS.has(normalizeField(check.bucket)))
+  );
+};
+
+export const normalizeCheckRecord = (record: RawCheckRecord): CheckSummary => {
+  const detailsUrl = String(record.detailsUrl ?? record.link ?? '');
+  const summary: CheckSummary = {
+    name: String(record.name ?? ''),
+    state: record.state == null ? null : String(record.state),
+    conclusion: record.conclusion == null ? null : String(record.conclusion),
+    bucket: record.bucket == null ? null : String(record.bucket),
+    detailsUrl,
+    startedAt: record.startedAt == null ? null : String(record.startedAt),
+    completedAt: record.completedAt == null ? null : String(record.completedAt),
+    runId: extractRunId(detailsUrl),
+    jobId: extractJobId(detailsUrl),
+    workflow: typeof record.workflow === 'string' ? record.workflow : null,
+    health: 'passing',
+  };
+
+  if (isFailingCheck(summary)) {
+    return { ...summary, health: 'failing' };
+  }
+  if (isPendingCheck(summary)) {
+    return { ...summary, health: 'pending' };
+  }
+  return summary;
+};
+
+const fetchChecksRaw = (ref: PullRequestRef, executor: GhExecutor): RawCheckRecord[] => {
+  const repoSlug = `${ref.owner}/${ref.repo}`;
+  const primaryFields = ['name', 'state', 'conclusion', 'detailsUrl', 'startedAt', 'completedAt'];
+  const primary = runGh(executor, ['pr', 'checks', String(ref.number), '--repo', repoSlug, '--json', primaryFields.join(',')]);
+  let stdout = primary.stdout;
+
+  if (primary.exitCode !== 0) {
+    const availableFields = parseAvailableFields(`${primary.stderr}\n${primary.stdout}`.trim());
+    const selected = ['name', 'state', 'bucket', 'link', 'startedAt', 'completedAt', 'workflow'].filter((field) =>
+      availableFields.includes(field)
+    );
+    if (selected.length === 0) {
+      throw new Error((primary.stderr || primary.stdout || 'gh pr checks fehlgeschlagen').trim());
+    }
+
+    const fallback = runGh(executor, ['pr', 'checks', String(ref.number), '--repo', repoSlug, '--json', selected.join(',')]);
+    if (fallback.exitCode !== 0) {
+      throw new Error((fallback.stderr || fallback.stdout || 'gh pr checks fehlgeschlagen').trim());
+    }
+    stdout = fallback.stdout;
+  }
+
+  const parsed = JSON.parse(stdout) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('gh pr checks lieferte kein Array.');
+  }
+  return parsed as RawCheckRecord[];
+};
+
+const fetchRunMetadata = (runId: string, repoSlug: string, executor: GhExecutor): CheckRunMetadata | undefined => {
+  const fields = ['conclusion', 'status', 'workflowName', 'name', 'event', 'headBranch', 'headSha', 'url'];
+  const result = runGh(executor, ['run', 'view', runId, '--repo', repoSlug, '--json', fields.join(',')]);
+  if (result.exitCode !== 0) {
+    return undefined;
+  }
+  const data = JSON.parse(result.stdout) as Record<string, unknown>;
+  return {
+    conclusion: data.conclusion == null ? null : String(data.conclusion),
+    status: data.status == null ? null : String(data.status),
+    workflowName: data.workflowName == null ? null : String(data.workflowName),
+    name: data.name == null ? null : String(data.name),
+    event: data.event == null ? null : String(data.event),
+    headBranch: data.headBranch == null ? null : String(data.headBranch),
+    headSha: data.headSha == null ? null : String(data.headSha),
+    url: data.url == null ? null : String(data.url),
+  };
+};
+
+const fetchRunLog = (runId: string, repoSlug: string, executor: GhExecutor): { logText: string; error?: string } => {
+  const result = runGh(executor, ['run', 'view', runId, '--repo', repoSlug, '--log']);
+  return result.exitCode === 0
+    ? { logText: result.stdout }
+    : { logText: '', error: (result.stderr || result.stdout || 'gh run view --log fehlgeschlagen').trim() };
+};
+
+const fetchJobLog = (jobId: string, repoSlug: string, executor: GhExecutor): { logText: string; error?: string } => {
+  const result = runGh(executor, ['api', `/repos/${repoSlug}/actions/jobs/${jobId}/logs`]);
+  if (result.exitCode !== 0) {
+    return { logText: '', error: (result.stderr || result.stdout || 'gh api job logs fehlgeschlagen').trim() };
+  }
+  if (result.stdoutBytes.subarray(0, 2).equals(Buffer.from('PK'))) {
+    return { logText: '', error: 'Job-Logs wurden als ZIP-Archiv geliefert und konnten nicht direkt ausgewertet werden.' };
+  }
+  return { logText: result.stdout };
+};
+
+const tailLines = (text: string, maxLines: number): string => text.split('\n').slice(-maxLines).join('\n');
+
+const analyzeFailingCheck = (
+  check: CheckSummary,
+  repoSlug: string,
+  executor: GhExecutor,
+  options: Pick<CliOptions, 'maxLines' | 'context'>
+): FailingCheckDetails => {
+  if (!check.runId) {
+    return { ...check, analysisStatus: 'external', note: 'Kein GitHub-Actions-Run in detailsUrl/link erkannt.' };
+  }
+
+  const run = fetchRunMetadata(check.runId, repoSlug, executor);
+  const runLog = fetchRunLog(check.runId, repoSlug, executor);
+
+  if (!runLog.error) {
+    return {
+      ...check,
+      analysisStatus: 'ok',
+      run,
+      logSnippet: extractFailureSnippet(runLog.logText, options.maxLines, options.context),
+      logTail: tailLines(runLog.logText, options.maxLines),
+    };
+  }
+
+  if (!check.jobId || !isPendingLogMessage(runLog.error)) {
+    return {
+      ...check,
+      analysisStatus: isPendingLogMessage(runLog.error) ? 'log_pending' : 'log_unavailable',
+      run,
+      ...(isPendingLogMessage(runLog.error) ? { note: runLog.error } : { error: runLog.error }),
+    };
+  }
+
+  const jobLog = fetchJobLog(check.jobId, repoSlug, executor);
+  if (!jobLog.error) {
+    return {
+      ...check,
+      analysisStatus: 'ok',
+      run,
+      logSnippet: extractFailureSnippet(jobLog.logText, options.maxLines, options.context),
+      logTail: tailLines(jobLog.logText, options.maxLines),
+    };
+  }
+
+  return {
+    ...check,
+    analysisStatus: isPendingLogMessage(jobLog.error) ? 'log_pending' : 'log_unavailable',
+    run,
+    ...(isPendingLogMessage(jobLog.error) ? { note: jobLog.error } : { error: jobLog.error }),
+  };
+};
+
+const analyzePendingCheck = (check: CheckSummary, repoSlug: string, executor: GhExecutor): PendingCheckDetails => {
+  return {
+    ...check,
+    analysisStatus: 'pending',
+    run: check.runId ? fetchRunMetadata(check.runId, repoSlug, executor) : undefined,
+    note: check.runId ? 'Check läuft noch oder wartet auf Abschluss.' : 'Kein GitHub-Actions-Run in detailsUrl/link erkannt.',
+  };
+};
+
+export const fetchChecks = (
+  ref: PullRequestRef,
+  executor: GhExecutor,
+  options: Pick<CliOptions, 'maxLines' | 'context'>
+): CheckCollection => {
+  const repoSlug = `${ref.owner}/${ref.repo}`;
+  const normalized = fetchChecksRaw(ref, executor).map(normalizeCheckRecord);
+
+  return {
+    failing: normalized.filter((check) => check.health === 'failing').map((check) => analyzeFailingCheck(check, repoSlug, executor, options)),
+    pending: normalized.filter((check) => check.health === 'pending').map((check) => analyzePendingCheck(check, repoSlug, executor)),
+  };
+};

--- a/scripts/ci/pr-review-intake.gh.ts
+++ b/scripts/ci/pr-review-intake.gh.ts
@@ -7,6 +7,7 @@ export const createGhExecutor = (): GhExecutor => {
     const result = spawnSync('gh', args, {
       cwd: process.cwd(),
       input: options?.input,
+      maxBuffer: 16 * 1024 * 1024,
     });
 
     return {

--- a/scripts/ci/pr-review-intake.gh.ts
+++ b/scripts/ci/pr-review-intake.gh.ts
@@ -1,0 +1,120 @@
+import { spawnSync } from 'node:child_process';
+
+import type { GhCommandResult, GhExecutor, PullRequestRef, PullRequestSummary } from './pr-review-intake.types.js';
+
+export const createGhExecutor = (): GhExecutor => {
+  return (args, options) => {
+    const result = spawnSync('gh', args, {
+      cwd: process.cwd(),
+      input: options?.input,
+    });
+
+    return {
+      exitCode: result.status ?? 1,
+      stdout: Buffer.from(result.stdout ?? []).toString('utf8'),
+      stderr: Buffer.from(result.stderr ?? []).toString('utf8'),
+      stdoutBytes: Buffer.from(result.stdout ?? []),
+    };
+  };
+};
+
+export const runGh = (executor: GhExecutor, args: readonly string[], options?: { input?: string }): GhCommandResult => {
+  return executor(args, options);
+};
+
+export const runGhJson = <T>(executor: GhExecutor, args: readonly string[], options?: { input?: string }): T => {
+  const result = runGh(executor, args, options);
+  if (result.exitCode !== 0) {
+    throw new Error((result.stderr || result.stdout || `gh ${args.join(' ')} fehlgeschlagen`).trim());
+  }
+
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch (error) {
+    throw new Error(
+      `JSON-Antwort von gh konnte nicht geparst werden (${args.join(' ')}): ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+};
+
+const parseRepoSlug = (slug: string): { owner: string; repo: string } => {
+  const [owner, repo] = slug.split('/');
+  if (!owner || !repo || slug.split('/').length !== 2) {
+    throw new Error(`Ungültiges Repository-Slug: ${slug}`);
+  }
+  return { owner, repo };
+};
+
+const parsePullRequestUrl = (url: string): { owner: string; repo: string; number: number } => {
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/.*)?$/u.exec(url.trim());
+  if (!match) {
+    throw new Error(`PR-URL konnte nicht ausgewertet werden: ${url}`);
+  }
+
+  return {
+    owner: match[1],
+    repo: match[2],
+    number: Number.parseInt(match[3], 10),
+  };
+};
+
+export const ensureGhAuthenticated = (executor: GhExecutor): void => {
+  const result = runGh(executor, ['auth', 'status']);
+  if (result.exitCode !== 0) {
+    throw new Error((result.stderr || result.stdout || 'gh auth status fehlgeschlagen').trim());
+  }
+};
+
+export const resolvePullRequestRef = (
+  options: { repo?: string; pullRequestNumber?: number },
+  executor: GhExecutor
+): PullRequestRef => {
+  if (options.repo && options.pullRequestNumber) {
+    const { owner, repo } = parseRepoSlug(options.repo);
+    return { owner, repo, number: options.pullRequestNumber, source: 'explicit' };
+  }
+
+  const current = runGhJson<{ number: number; url: string }>(executor, ['pr', 'view', '--json', 'number,url']);
+  const parsed = parsePullRequestUrl(current.url);
+  return { owner: parsed.owner, repo: parsed.repo, number: current.number, source: 'branch' };
+};
+
+export const fetchPullRequestSummary = (ref: PullRequestRef, executor: GhExecutor): PullRequestSummary => {
+  const fields = [
+    'number',
+    'title',
+    'url',
+    'state',
+    'isDraft',
+    'headRefName',
+    'baseRefName',
+    'author',
+    'reviewDecision',
+    'mergeable',
+    'changedFiles',
+    'additions',
+    'deletions',
+  ];
+  const repoSlug = `${ref.owner}/${ref.repo}`;
+  const data = runGhJson<{
+    number: number;
+    title: string;
+    url: string;
+    state: string;
+    isDraft: boolean;
+    headRefName: string;
+    baseRefName: string;
+    reviewDecision: string | null;
+    mergeable: string | null;
+    changedFiles: number;
+    additions: number;
+    deletions: number;
+    author?: { login?: string | null } | null;
+  }>(executor, ['pr', 'view', String(ref.number), '--repo', repoSlug, '--json', fields.join(',')]);
+
+  return {
+    ...data,
+    authorLogin: data.author?.login ?? null,
+    source: ref.source,
+  };
+};

--- a/scripts/ci/pr-review-intake.test.ts
+++ b/scripts/ci/pr-review-intake.test.ts
@@ -1,0 +1,603 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { normalizeCheckRecord, fetchChecks } from './pr-review-intake.checks.ts';
+import { executePrReviewIntake, runPrReviewIntake } from './pr-review-intake.ts';
+import { ensureGhAuthenticated, fetchPullRequestSummary, resolvePullRequestRef, runGhJson } from './pr-review-intake.gh.ts';
+import { fetchReviewThreads } from './pr-review-intake.threads.ts';
+import { buildSnapshotSummary, extractFailureSnippet, extractJobId, extractRunId, parseAvailableFields, parseCliOptions } from './pr-review-intake.utils.ts';
+import type { GhExecutor } from './pr-review-intake.types.ts';
+
+const fixturePath = (...parts: string[]): string =>
+  path.join(process.cwd(), 'scripts/ci/fixtures/pr-review-intake', ...parts);
+
+const readJsonFixture = <T>(filename: string): T =>
+  JSON.parse(readFileSync(fixturePath(filename), 'utf8')) as T;
+
+const readTextFixture = (filename: string): string => readFileSync(fixturePath(filename), 'utf8');
+
+interface ScriptedResponse {
+  match: (args: readonly string[]) => boolean;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  stdoutBytes?: Buffer;
+}
+
+const createExecutor = (responses: readonly ScriptedResponse[]): GhExecutor => {
+  return (args) => {
+    const response = responses.find((candidate) => candidate.match(args));
+    if (!response) {
+      throw new Error(`Kein Fixture-Match für gh ${args.join(' ')}`);
+    }
+    const stdout = response.stdout ?? '';
+    return {
+      exitCode: response.exitCode ?? 0,
+      stdout,
+      stderr: response.stderr ?? '',
+      stdoutBytes: response.stdoutBytes ?? Buffer.from(stdout),
+    };
+  };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('pr-review-intake', () => {
+  it('priorisiert explizites repo/pr vor Branch-Fallback', () => {
+    const options = parseCliOptions(['snapshot', '--repo', 'smart-village-solutions/sva-studio', '--pr', '602', '--json']);
+
+    expect(options).toMatchObject({
+      command: 'snapshot',
+      repo: 'smart-village-solutions/sva-studio',
+      pullRequestNumber: 602,
+      json: true,
+    });
+  });
+
+  it('parst max-lines und context explizit', () => {
+    expect(parseCliOptions(['checks', '--repo', 'smart-village-solutions/sva-studio', '--pr', '602', '--max-lines', '50', '--context', '12'])).toMatchObject({
+      maxLines: 50,
+      context: 12,
+    });
+  });
+
+  it('weist fehlerhafte CLI-Argumente zurück', () => {
+    expect(() => parseCliOptions(['foo'])).toThrow(/Subcommand/);
+    expect(() => parseCliOptions(['snapshot', '--repo', 'smart-village-solutions/sva-studio'])).toThrow(/gemeinsam gesetzt/);
+    expect(() => parseCliOptions(['snapshot', '--pr', 'abc'])).toThrow(/Ungültiger Wert/);
+    expect(() => parseCliOptions(['snapshot', '--unknown'])).toThrow(/Unbekanntes Argument/);
+  });
+
+  it('wertet gh pr checks mit Feld-Drift über Fallback-Felder aus', () => {
+    const executor = createExecutor([
+      {
+        match: (args) => args.join(' ') === 'auth status',
+      },
+      {
+        match: (args) => args.join(' ') === 'pr view --json number,url',
+        stdout: JSON.stringify(readJsonFixture('branch-pr-view.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr view 602 --repo smart-village-solutions/sva-studio --json number,title,url,state,isDraft,headRefName,baseRefName,author,reviewDecision,mergeable,changedFiles,additions,deletions',
+        stdout: JSON.stringify(readJsonFixture('pr-summary.json')),
+      },
+      {
+        match: (args) => args[0] === 'api' && args[1] === 'graphql',
+        stdout: JSON.stringify(readJsonFixture('review-threads-page-1.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        exitCode: 1,
+        stderr: readTextFixture('pr-checks-primary-error.txt'),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,bucket,link,startedAt,completedAt,workflow',
+        stdout: JSON.stringify(readJsonFixture('pr-checks-fallback.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'run view 201 --repo smart-village-solutions/sva-studio --json conclusion,status,workflowName,name,event,headBranch,headSha,url',
+        stdout: JSON.stringify(readJsonFixture('run-metadata-201.json')),
+      },
+      {
+        match: (args) => args.join(' ') === 'run view 201 --repo smart-village-solutions/sva-studio --log',
+        stdout: readTextFixture('run-log-201.txt'),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'run view 202 --repo smart-village-solutions/sva-studio --json conclusion,status,workflowName,name,event,headBranch,headSha,url',
+        stdout: JSON.stringify(readJsonFixture('run-metadata-202.json')),
+      },
+    ]);
+
+    const options = parseCliOptions(['snapshot', '--json']);
+    const ref = resolvePullRequestRef(options, executor);
+    const snapshot = {
+      pr: fetchPullRequestSummary(ref, executor),
+      reviewThreads: fetchReviewThreads(ref, executor),
+      checks: fetchChecks(ref, executor, options),
+    };
+
+    expect(buildSnapshotSummary(snapshot)).toEqual({
+      openThreads: 1,
+      resolvedThreads: 1,
+      failingChecks: 1,
+      pendingChecks: 1,
+      hasBlockers: true,
+    });
+    expect(snapshot.checks.failing[0]).toMatchObject({
+      name: 'Quality Gates / Types',
+      analysisStatus: 'ok',
+      runId: '201',
+      jobId: '301',
+    });
+    expect(snapshot.checks.pending[0]).toMatchObject({
+      name: 'Quality Gates / Unit',
+      analysisStatus: 'pending',
+      runId: '202',
+      jobId: '302',
+    });
+  });
+
+  it('klassifiziert failing, pending und externe Checks robust', () => {
+    expect(
+      normalizeCheckRecord({
+        name: 'Fail',
+        state: 'COMPLETED',
+        conclusion: 'FAILURE',
+        detailsUrl: 'https://github.com/org/repo/actions/runs/1/job/2',
+      }).health
+    ).toBe('failing');
+
+    expect(
+      normalizeCheckRecord({
+        name: 'Pending',
+        state: 'IN_PROGRESS',
+        detailsUrl: 'https://github.com/org/repo/actions/runs/1/job/2',
+      }).health
+    ).toBe('pending');
+
+    expect(
+      normalizeCheckRecord({
+        name: 'External',
+        bucket: 'fail',
+        link: 'https://buildkite.example.test/builds/1',
+      })
+    ).toMatchObject({
+      health: 'failing',
+      runId: null,
+      jobId: null,
+    });
+  });
+
+  it('liefert aussagekräftige Defaults für Extractor-Helfer', () => {
+    expect(extractRunId('')).toBeNull();
+    expect(extractJobId('')).toBeNull();
+    expect(extractFailureSnippet('', 5, 2)).toBe('');
+    expect(extractFailureSnippet('all good\nstill good', 5, 2)).toContain('still good');
+    expect(parseAvailableFields('plain error')).toEqual([]);
+  });
+
+  it('extrahiert Run-/Job-IDs und fokussierte Failure-Snippets', () => {
+    expect(extractRunId('https://github.com/org/repo/actions/runs/201/job/301')).toBe('201');
+    expect(extractJobId('https://github.com/org/repo/actions/runs/201/job/301')).toBe('301');
+
+    const snippet = extractFailureSnippet(readTextFixture('run-log-201.txt'), 5, 2);
+    expect(snippet).toContain('Error: Type mismatch in route loader');
+    expect(snippet.split('\n').length).toBeLessThanOrEqual(5);
+  });
+
+  it('normalisiert offene und resolved Review-Threads aus GraphQL-Fixtures', () => {
+    const executor = createExecutor([
+      {
+        match: (args) => args.join(' ') === 'auth status',
+      },
+      {
+        match: (args) => args.join(' ') === 'pr view --json number,url',
+        stdout: JSON.stringify(readJsonFixture('branch-pr-view.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr view 602 --repo smart-village-solutions/sva-studio --json number,title,url,state,isDraft,headRefName,baseRefName,author,reviewDecision,mergeable,changedFiles,additions,deletions',
+        stdout: JSON.stringify(readJsonFixture('pr-summary.json')),
+      },
+      {
+        match: (args) => args[0] === 'api' && args[1] === 'graphql',
+        stdout: JSON.stringify(readJsonFixture('review-threads-page-1.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        stdout: '[]',
+      },
+    ]);
+
+    const options = parseCliOptions(['snapshot']);
+    const ref = resolvePullRequestRef(options, executor);
+    const snapshot = {
+      pr: fetchPullRequestSummary(ref, executor),
+      reviewThreads: fetchReviewThreads(ref, executor),
+      checks: fetchChecks(ref, executor, options),
+    };
+
+    expect(snapshot.reviewThreads.open).toHaveLength(1);
+    expect(snapshot.reviewThreads.resolved).toHaveLength(1);
+    expect(snapshot.reviewThreads.open[0]).toMatchObject({
+      path: 'packages/data/src/query.ts',
+      line: 42,
+      commentCount: 2,
+    });
+  });
+
+  it('unterstützt explizite PR-Resolution und validiert Repo-Slugs', () => {
+    const executor = createExecutor([]);
+    expect(resolvePullRequestRef({ repo: 'smart-village-solutions/sva-studio', pullRequestNumber: 602 }, executor)).toMatchObject({
+      owner: 'smart-village-solutions',
+      repo: 'sva-studio',
+      number: 602,
+      source: 'explicit',
+    });
+    expect(() => resolvePullRequestRef({ repo: 'broken-slug', pullRequestNumber: 602 }, executor)).toThrow(/Ungültiges Repository-Slug/);
+  });
+
+  it('meldet Auth- und JSON-Fehler aus gh klar zurück', () => {
+    const authExecutor = createExecutor([
+      {
+        match: (args) => args.join(' ') === 'auth status',
+        exitCode: 1,
+        stderr: 'gh auth login erforderlich',
+      },
+    ]);
+    expect(() => ensureGhAuthenticated(authExecutor)).toThrow(/gh auth login erforderlich/);
+
+    const jsonExecutor = createExecutor([
+      {
+        match: () => true,
+        stdout: 'not-json',
+      },
+    ]);
+    expect(() => runGhJson(jsonExecutor, ['pr', 'view'])).toThrow(/nicht geparst/);
+  });
+
+  it('behandelt PR-Metadaten ohne Autor robust', () => {
+    const executor = createExecutor([
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr view 602 --repo smart-village-solutions/sva-studio --json number,title,url,state,isDraft,headRefName,baseRefName,author,reviewDecision,mergeable,changedFiles,additions,deletions',
+        stdout: JSON.stringify({
+          ...readJsonFixture<Record<string, unknown>>('pr-summary.json'),
+          author: null,
+        }),
+      },
+    ]);
+
+    expect(
+      fetchPullRequestSummary(
+        { owner: 'smart-village-solutions', repo: 'sva-studio', number: 602, source: 'explicit' },
+        executor
+      ).authorLogin
+    ).toBeNull();
+  });
+
+  it('unterstützt paginierte Threads und meldet GraphQL-Fehler', () => {
+    const pagedExecutor = createExecutor([
+      {
+        match: (args) => args[0] === 'api' && args[1] === 'graphql' && !args.includes('cursor=page-2'),
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: { hasNextPage: true, endCursor: 'page-2' },
+                  nodes: [
+                    {
+                      id: 't1',
+                      isResolved: false,
+                      isOutdated: false,
+                      path: 'a.ts',
+                      line: 1,
+                      originalLine: 1,
+                      comments: { nodes: [{ id: 'c1', body: 'open', createdAt: '2026-06-18T00:00:00Z', url: 'u1', author: { login: 'bot' } }] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      },
+      {
+        match: (args) => args[0] === 'api' && args[1] === 'graphql' && args.includes('cursor=page-2'),
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      id: 't2',
+                      isResolved: true,
+                      isOutdated: false,
+                      path: 'b.ts',
+                      line: 2,
+                      originalLine: 2,
+                      comments: { nodes: [{ id: 'c2', body: 'done', createdAt: '2026-06-18T00:00:00Z', url: 'u2', author: { login: 'bot' } }] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+
+    const threads = fetchReviewThreads(
+      { owner: 'smart-village-solutions', repo: 'sva-studio', number: 602, source: 'explicit' },
+      pagedExecutor
+    );
+    expect(threads.open).toHaveLength(1);
+    expect(threads.resolved).toHaveLength(1);
+
+    const errorExecutor = createExecutor([
+      {
+        match: () => true,
+        stdout: JSON.stringify({ errors: [{ message: 'boom' }] }),
+      },
+    ]);
+    expect(() =>
+      fetchReviewThreads({ owner: 'smart-village-solutions', repo: 'sva-studio', number: 602, source: 'explicit' }, errorExecutor)
+    ).toThrow(/GraphQL meldet Fehler/);
+  });
+
+  it('liefert Exit-Code 2 bei Nutzungs- oder Auth-Fehlern', () => {
+    const executor = createExecutor([
+      {
+        match: (args) => args.join(' ') === 'auth status',
+        exitCode: 1,
+        stderr: 'gh auth login erforderlich',
+      },
+    ]);
+
+    const result = executePrReviewIntake(['snapshot'], { executor });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('gh auth login erforderlich');
+  });
+
+  it('parst verfügbare gh pr checks Felder aus Fehlermeldungen', () => {
+    expect(parseAvailableFields(readTextFixture('pr-checks-primary-error.txt'))).toEqual([
+      'name',
+      'state',
+      'bucket',
+      'link',
+      'startedAt',
+      'completedAt',
+      'workflow',
+    ]);
+  });
+
+  it('liefert JSON-Output und Blocker-Exit-Code für snapshot', () => {
+    const executor = createExecutor([
+      { match: (args) => args.join(' ') === 'auth status' },
+      {
+        match: (args) => args.join(' ') === 'pr view --json number,url',
+        stdout: JSON.stringify(readJsonFixture('branch-pr-view.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr view 602 --repo smart-village-solutions/sva-studio --json number,title,url,state,isDraft,headRefName,baseRefName,author,reviewDecision,mergeable,changedFiles,additions,deletions',
+        stdout: JSON.stringify(readJsonFixture('pr-summary.json')),
+      },
+      {
+        match: (args) => args[0] === 'api' && args[1] === 'graphql',
+        stdout: JSON.stringify(readJsonFixture('review-threads-page-1.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        stdout: '[]',
+      },
+    ]);
+
+    const result = executePrReviewIntake(['snapshot', '--json'], { executor });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      summary: {
+        openThreads: 1,
+        failingChecks: 0,
+      },
+    });
+  });
+
+  it('liefert Plain-Text für threads und checks', () => {
+    const executor = createExecutor([
+      { match: (args) => args.join(' ') === 'auth status' },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr view 602 --repo smart-village-solutions/sva-studio --json number,title,url,state,isDraft,headRefName,baseRefName,author,reviewDecision,mergeable,changedFiles,additions,deletions',
+        stdout: JSON.stringify(readJsonFixture('pr-summary.json')),
+      },
+      {
+        match: (args) => args[0] === 'api' && args[1] === 'graphql',
+        stdout: JSON.stringify(readJsonFixture('review-threads-page-1.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        stdout: JSON.stringify([
+          {
+            name: 'External Provider',
+            state: 'COMPLETED',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://example.test/buildkite/123',
+            startedAt: '2026-06-18T10:00:00Z',
+            completedAt: '2026-06-18T10:05:00Z',
+          },
+        ]),
+      },
+    ]);
+
+    const threads = executePrReviewIntake(['threads', '--repo', 'smart-village-solutions/sva-studio', '--pr', '602'], { executor });
+    expect(threads.exitCode).toBe(1);
+    expect(threads.stdout).toContain('Offene Review-Threads: 1');
+
+    const checks = executePrReviewIntake(['checks', '--repo', 'smart-village-solutions/sva-studio', '--pr', '602'], { executor });
+    expect(checks.exitCode).toBe(1);
+    expect(checks.stdout).toContain('Failing Checks: 1');
+  });
+
+  it('deckt externe, pending-log und job-log-Fehlerpfade bei Checks ab', () => {
+    const baseRef = { owner: 'smart-village-solutions', repo: 'sva-studio', number: 602, source: 'explicit' } as const;
+
+    const externalExecutor = createExecutor([
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        stdout: JSON.stringify([
+          {
+            name: 'External',
+            state: 'COMPLETED',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://buildkite.example.test/1',
+            startedAt: '2026-06-18T10:00:00Z',
+            completedAt: '2026-06-18T10:01:00Z',
+          },
+        ]),
+      },
+    ]);
+    expect(fetchChecks(baseRef, externalExecutor, { maxLines: 20, context: 5 }).failing[0]).toMatchObject({
+      analysisStatus: 'external',
+    });
+
+    const pendingExecutor = createExecutor([
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        stdout: JSON.stringify([
+          {
+            name: 'Types',
+            state: 'COMPLETED',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/smart-village-solutions/sva-studio/actions/runs/201/job/301',
+            startedAt: '2026-06-18T10:00:00Z',
+            completedAt: '2026-06-18T10:01:00Z',
+          },
+        ]),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'run view 201 --repo smart-village-solutions/sva-studio --json conclusion,status,workflowName,name,event,headBranch,headSha,url',
+        stdout: JSON.stringify(readJsonFixture('run-metadata-201.json')),
+      },
+      {
+        match: (args) => args.join(' ') === 'run view 201 --repo smart-village-solutions/sva-studio --log',
+        exitCode: 1,
+        stderr: 'Log will be available when it is complete',
+      },
+      {
+        match: (args) => args.join(' ') === 'api /repos/smart-village-solutions/sva-studio/actions/jobs/301/logs',
+        exitCode: 1,
+        stderr: 'still in progress',
+      },
+    ]);
+    expect(fetchChecks(baseRef, pendingExecutor, { maxLines: 20, context: 5 }).failing[0]).toMatchObject({
+      analysisStatus: 'log_pending',
+    });
+
+    const zipExecutor = createExecutor([
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        stdout: JSON.stringify([
+          {
+            name: 'Types',
+            state: 'COMPLETED',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/smart-village-solutions/sva-studio/actions/runs/201/job/301',
+            startedAt: '2026-06-18T10:00:00Z',
+            completedAt: '2026-06-18T10:01:00Z',
+          },
+        ]),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'run view 201 --repo smart-village-solutions/sva-studio --json conclusion,status,workflowName,name,event,headBranch,headSha,url',
+        stdout: JSON.stringify(readJsonFixture('run-metadata-201.json')),
+      },
+      {
+        match: (args) => args.join(' ') === 'run view 201 --repo smart-village-solutions/sva-studio --log',
+        exitCode: 1,
+        stderr: 'Log will be available when it is complete',
+      },
+      {
+        match: (args) => args.join(' ') === 'api /repos/smart-village-solutions/sva-studio/actions/jobs/301/logs',
+        stdoutBytes: Buffer.from('PKzipdata'),
+      },
+    ]);
+    expect(fetchChecks(baseRef, zipExecutor, { maxLines: 20, context: 5 }).failing[0]).toMatchObject({
+      analysisStatus: 'log_unavailable',
+    });
+  });
+
+  it('deckt die Terminal-Hülle des CLI ab', () => {
+    const executor = createExecutor([
+      { match: (args) => args.join(' ') === 'auth status' },
+      {
+        match: (args) => args.join(' ') === 'pr view --json number,url',
+        stdout: JSON.stringify(readJsonFixture('branch-pr-view.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr view 602 --repo smart-village-solutions/sva-studio --json number,title,url,state,isDraft,headRefName,baseRefName,author,reviewDecision,mergeable,changedFiles,additions,deletions',
+        stdout: JSON.stringify(readJsonFixture('pr-summary.json')),
+      },
+      {
+        match: (args) => args[0] === 'api' && args[1] === 'graphql',
+        stdout: JSON.stringify(readJsonFixture('review-threads-page-1.json')),
+      },
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        stdout: '[]',
+      },
+    ]);
+
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const exitCode = runPrReviewIntake(['snapshot'], { executor });
+
+    expect(exitCode).toBe(1);
+    expect(stdoutSpy).toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/ci/pr-review-intake.test.ts
+++ b/scripts/ci/pr-review-intake.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -10,8 +11,8 @@ import { fetchReviewThreads } from './pr-review-intake.threads.ts';
 import { buildSnapshotSummary, extractFailureSnippet, extractJobId, extractRunId, parseAvailableFields, parseCliOptions } from './pr-review-intake.utils.ts';
 import type { GhExecutor } from './pr-review-intake.types.ts';
 
-const fixturePath = (...parts: string[]): string =>
-  path.join(process.cwd(), 'scripts/ci/fixtures/pr-review-intake', ...parts);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = (...parts: string[]): string => path.join(testDir, 'fixtures/pr-review-intake', ...parts);
 
 const readJsonFixture = <T>(filename: string): T =>
   JSON.parse(readFileSync(fixturePath(filename), 'utf8')) as T;
@@ -151,6 +152,29 @@ describe('pr-review-intake', () => {
     });
   });
 
+  it('behandelt PRs ohne gemeldete Checks als leeren Check-Zustand', () => {
+    const executor = createExecutor([
+      {
+        match: (args) =>
+          args.join(' ') ===
+          'pr checks 602 --repo smart-village-solutions/sva-studio --json name,state,conclusion,detailsUrl,startedAt,completedAt',
+        exitCode: 1,
+        stderr: 'no checks reported on the \'codex/repo-local-pr-review-intake\' branch',
+      },
+    ]);
+
+    const checks = fetchChecks(
+      { owner: 'smart-village-solutions', repo: 'sva-studio', number: 602, source: 'explicit' },
+      executor,
+      parseCliOptions(['checks', '--repo', 'smart-village-solutions/sva-studio', '--pr', '602'])
+    );
+
+    expect(checks).toEqual({
+      failing: [],
+      pending: [],
+    });
+  });
+
   it('klassifiziert failing, pending und externe Checks robust', () => {
     expect(
       normalizeCheckRecord({
@@ -168,6 +192,14 @@ describe('pr-review-intake', () => {
         detailsUrl: 'https://github.com/org/repo/actions/runs/1/job/2',
       }).health
     ).toBe('pending');
+
+    expect(
+      normalizeCheckRecord({
+        name: 'Skipped',
+        bucket: 'skipping',
+        link: 'https://github.com/org/repo/actions/runs/1/job/2',
+      }).health
+    ).toBe('passing');
 
     expect(
       normalizeCheckRecord({
@@ -197,6 +229,11 @@ describe('pr-review-intake', () => {
     const snippet = extractFailureSnippet(readTextFixture('run-log-201.txt'), 5, 2);
     expect(snippet).toContain('Error: Type mismatch in route loader');
     expect(snippet.split('\n').length).toBeLessThanOrEqual(5);
+  });
+
+  it('liefert symmetrischen Kontext um die Marker-Zeile', () => {
+    const snippet = extractFailureSnippet(['before-2', 'before-1', 'Error: boom', 'after-1', 'after-2'].join('\n'), 10, 2);
+    expect(snippet).toBe(['before-2', 'before-1', 'Error: boom', 'after-1', 'after-2'].join('\n'));
   });
 
   it('normalisiert offene und resolved Review-Threads aus GraphQL-Fixtures', () => {

--- a/scripts/ci/pr-review-intake.threads.ts
+++ b/scripts/ci/pr-review-intake.threads.ts
@@ -1,0 +1,136 @@
+import { runGhJson } from './pr-review-intake.gh.js';
+import type { GhExecutor, PullRequestRef, ReviewThreadCollection, ReviewThreadSummary } from './pr-review-intake.types.js';
+
+interface GraphqlReviewThreadsPayload {
+  data?: {
+    repository?: {
+      pullRequest?: {
+        reviewThreads?: {
+          pageInfo: {
+            hasNextPage: boolean;
+            endCursor: string | null;
+          };
+          nodes: Array<{
+            id: string;
+            isResolved: boolean;
+            isOutdated: boolean;
+            path: string;
+            line: number | null;
+            originalLine: number | null;
+            comments: {
+              nodes: Array<{
+                id: string;
+                body: string;
+                createdAt: string;
+                url: string;
+                author: { login: string | null } | null;
+              }>;
+            };
+          }>;
+        } | null;
+      } | null;
+    } | null;
+  };
+  errors?: unknown;
+}
+
+const THREADS_QUERY = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:100,after:$cursor){
+        pageInfo{hasNextPage endCursor}
+        nodes{
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          comments(first:100){
+            nodes{
+              id
+              body
+              createdAt
+              url
+              author{login}
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const normalizeReviewThread = (
+  thread: NonNullable<
+    NonNullable<NonNullable<NonNullable<GraphqlReviewThreadsPayload['data']>['repository']>['pullRequest']>['reviewThreads']
+  >['nodes'][number]
+): ReviewThreadSummary => {
+  const comments = thread.comments.nodes.map((comment) => ({
+    id: comment.id,
+    authorLogin: comment.author?.login ?? 'unknown',
+    body: comment.body,
+    createdAt: comment.createdAt,
+    url: comment.url,
+  }));
+
+  return {
+    id: thread.id,
+    url: comments[0]?.url ?? '',
+    isResolved: thread.isResolved,
+    isOutdated: thread.isOutdated,
+    path: thread.path,
+    line: thread.line ?? null,
+    originalLine: thread.originalLine ?? null,
+    commentCount: comments.length,
+    rootComment: comments[0] ?? null,
+    latestComment: comments.at(-1) ?? null,
+    comments,
+  };
+};
+
+export const fetchReviewThreads = (ref: PullRequestRef, executor: GhExecutor): ReviewThreadCollection => {
+  const open: ReviewThreadSummary[] = [];
+  const resolved: ReviewThreadSummary[] = [];
+  let cursor: string | null = null;
+
+  while (true) {
+    const args = [
+      'api',
+      'graphql',
+      '-f',
+      `query=${THREADS_QUERY}`,
+      '-F',
+      `owner=${ref.owner}`,
+      '-F',
+      `repo=${ref.repo}`,
+      '-F',
+      `number=${ref.number}`,
+    ];
+    if (cursor) {
+      args.push('-F', `cursor=${cursor}`);
+    }
+
+    const payload = runGhJson<GraphqlReviewThreadsPayload>(executor, args);
+    if (payload.errors) {
+      throw new Error(`GitHub GraphQL meldet Fehler: ${JSON.stringify(payload.errors)}`);
+    }
+
+    const connection = payload.data?.repository?.pullRequest?.reviewThreads;
+    if (!connection) {
+      throw new Error(`Review-Threads konnten für PR #${ref.number} nicht geladen werden.`);
+    }
+
+    for (const node of connection.nodes) {
+      const normalized = normalizeReviewThread(node);
+      (normalized.isResolved ? resolved : open).push(normalized);
+    }
+
+    if (!connection.pageInfo.hasNextPage || !connection.pageInfo.endCursor) {
+      break;
+    }
+    cursor = connection.pageInfo.endCursor;
+  }
+
+  return { open, resolved };
+};

--- a/scripts/ci/pr-review-intake.ts
+++ b/scripts/ci/pr-review-intake.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+import { createGhExecutor, ensureGhAuthenticated, fetchPullRequestSummary, resolvePullRequestRef } from './pr-review-intake.gh.js';
+import { fetchChecks } from './pr-review-intake.checks.js';
+import { fetchReviewThreads } from './pr-review-intake.threads.js';
+import type { GhExecutor, IntakeSubcommand, SnapshotResult } from './pr-review-intake.types.js';
+import { buildSnapshotSummary, parseCliOptions } from './pr-review-intake.utils.js';
+
+const collectSnapshot = (
+  options: ReturnType<typeof parseCliOptions>,
+  executor: GhExecutor
+): SnapshotResult => {
+  const ref = resolvePullRequestRef(options, executor);
+  const pr = fetchPullRequestSummary(ref, executor);
+  const reviewThreads = fetchReviewThreads(ref, executor);
+  const checks = fetchChecks(ref, executor, options);
+
+  return {
+    pr,
+    reviewThreads,
+    checks,
+    summary: buildSnapshotSummary({ reviewThreads, checks }),
+    sources: {
+      pullRequest: ref.source === 'explicit' ? 'explicit repo/pr parameters' : 'current branch PR via gh pr view',
+      reviewThreads: 'gh api graphql reviewThreads',
+      checks: 'gh pr checks + gh run view/gh api job logs',
+    },
+  };
+};
+
+const projectResult = (command: IntakeSubcommand, snapshot: SnapshotResult): unknown => {
+  if (command === 'threads') {
+    return {
+      pr: snapshot.pr,
+      reviewThreads: snapshot.reviewThreads,
+      summary: {
+        openThreads: snapshot.summary.openThreads,
+        resolvedThreads: snapshot.summary.resolvedThreads,
+        hasBlockers: snapshot.summary.openThreads > 0,
+      },
+      sources: {
+        pullRequest: snapshot.sources.pullRequest,
+        reviewThreads: snapshot.sources.reviewThreads,
+      },
+    };
+  }
+
+  if (command === 'checks') {
+    return {
+      pr: snapshot.pr,
+      checks: snapshot.checks,
+      summary: {
+        failingChecks: snapshot.summary.failingChecks,
+        pendingChecks: snapshot.summary.pendingChecks,
+        hasBlockers: snapshot.summary.failingChecks > 0,
+      },
+      sources: {
+        pullRequest: snapshot.sources.pullRequest,
+        checks: snapshot.sources.checks,
+      },
+    };
+  }
+
+  return snapshot;
+};
+
+const renderPlainText = (command: IntakeSubcommand, result: SnapshotResult): string => {
+  const lines = [`PR #${result.pr.number}: ${result.pr.title}`];
+  lines.push(`Quelle: ${result.pr.source === 'explicit' ? 'explizites repo/pr' : 'aktueller Branch-PR'}`);
+
+  if (command !== 'checks') {
+    lines.push(`Offene Review-Threads: ${result.reviewThreads.open.length}`);
+    lines.push(`Resolved Review-Threads: ${result.reviewThreads.resolved.length}`);
+    if (result.reviewThreads.open.length > 0) {
+      lines.push('Offene Threads:');
+      lines.push(
+        ...result.reviewThreads.open.map((thread) =>
+          `- ${thread.line ? `${thread.path}:${thread.line}` : thread.path} (${thread.commentCount} Kommentare) ${thread.url}`
+        )
+      );
+    }
+  }
+
+  if (command !== 'threads') {
+    lines.push(`Failing Checks: ${result.checks.failing.length}`);
+    lines.push(`Pending Checks: ${result.checks.pending.length}`);
+    if (result.checks.failing.length > 0) {
+      lines.push('Failing Checks:');
+      lines.push(
+        ...result.checks.failing.map((check) => {
+          const detail = check.logSnippet ? check.logSnippet.split('\n')[0] : check.note ?? check.error ?? 'kein Detail';
+          return `- ${check.name} [${check.analysisStatus}] ${detail}`;
+        })
+      );
+    }
+    if (result.checks.pending.length > 0) {
+      lines.push('Pending Checks:');
+      lines.push(...result.checks.pending.map((check) => `- ${check.name} [pending] ${check.detailsUrl || check.note || ''}`.trimEnd()));
+    }
+  }
+
+  return lines.join('\n');
+};
+
+export const executePrReviewIntake = (
+  args: readonly string[],
+  dependencies?: { executor?: GhExecutor }
+): { exitCode: number; stdout: string; stderr: string } => {
+  try {
+    const options = parseCliOptions(args);
+    const executor = dependencies?.executor ?? createGhExecutor();
+    ensureGhAuthenticated(executor);
+
+    const snapshot = collectSnapshot(options, executor);
+    const stdout = options.json
+      ? JSON.stringify(projectResult(options.command, snapshot), null, 2)
+      : renderPlainText(options.command, snapshot);
+
+    if (options.command === 'threads') {
+      return { exitCode: snapshot.reviewThreads.open.length > 0 ? 1 : 0, stdout, stderr: '' };
+    }
+    if (options.command === 'checks') {
+      return { exitCode: snapshot.checks.failing.length > 0 ? 1 : 0, stdout, stderr: '' };
+    }
+
+    return { exitCode: snapshot.summary.hasBlockers ? 1 : 0, stdout, stderr: '' };
+  } catch (error) {
+    return { exitCode: 2, stdout: '', stderr: error instanceof Error ? error.message : String(error) };
+  }
+};
+
+export const runPrReviewIntake = (args: readonly string[], dependencies?: { executor?: GhExecutor }): number => {
+  const result = executePrReviewIntake(args, dependencies);
+  if (result.stdout) {
+    process.stdout.write(`${result.stdout}\n`);
+  }
+  if (result.stderr) {
+    process.stderr.write(`${result.stderr}\n`);
+  }
+  return result.exitCode;
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(runPrReviewIntake(process.argv.slice(2)));
+}

--- a/scripts/ci/pr-review-intake.types.ts
+++ b/scripts/ci/pr-review-intake.types.ts
@@ -1,0 +1,140 @@
+export type IntakeSubcommand = 'snapshot' | 'threads' | 'checks';
+export type PullRequestResolutionSource = 'explicit' | 'branch';
+export type CheckHealth = 'failing' | 'pending' | 'passing';
+export type CheckAnalysisStatus = 'ok' | 'external' | 'log_pending' | 'log_unavailable' | 'pending';
+
+export interface CliOptions {
+  command: IntakeSubcommand;
+  json: boolean;
+  repo?: string;
+  pullRequestNumber?: number;
+  maxLines: number;
+  context: number;
+}
+
+export interface PullRequestRef {
+  owner: string;
+  repo: string;
+  number: number;
+  source: PullRequestResolutionSource;
+}
+
+export interface PullRequestSummary {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  isDraft: boolean;
+  headRefName: string;
+  baseRefName: string;
+  reviewDecision: string | null;
+  mergeable: string | null;
+  authorLogin: string | null;
+  changedFiles: number;
+  additions: number;
+  deletions: number;
+  source: PullRequestResolutionSource;
+}
+
+export interface ReviewThreadCommentSummary {
+  id: string;
+  authorLogin: string;
+  body: string;
+  createdAt: string;
+  url: string;
+}
+
+export interface ReviewThreadSummary {
+  id: string;
+  url: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string;
+  line: number | null;
+  originalLine: number | null;
+  commentCount: number;
+  rootComment: ReviewThreadCommentSummary | null;
+  latestComment: ReviewThreadCommentSummary | null;
+  comments: readonly ReviewThreadCommentSummary[];
+}
+
+export interface ReviewThreadCollection {
+  open: readonly ReviewThreadSummary[];
+  resolved: readonly ReviewThreadSummary[];
+}
+
+export interface CheckRunMetadata {
+  conclusion: string | null;
+  status: string | null;
+  workflowName: string | null;
+  name: string | null;
+  event: string | null;
+  headBranch: string | null;
+  headSha: string | null;
+  url: string | null;
+}
+
+export interface CheckSummary {
+  name: string;
+  state: string | null;
+  conclusion: string | null;
+  bucket: string | null;
+  detailsUrl: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  runId: string | null;
+  jobId: string | null;
+  workflow: string | null;
+  health: CheckHealth;
+}
+
+export interface FailingCheckDetails extends CheckSummary {
+  analysisStatus: CheckAnalysisStatus;
+  note?: string;
+  error?: string;
+  run?: CheckRunMetadata;
+  logSnippet?: string;
+  logTail?: string;
+}
+
+export interface PendingCheckDetails extends CheckSummary {
+  analysisStatus: 'pending';
+  note?: string;
+  run?: CheckRunMetadata;
+}
+
+export interface CheckCollection {
+  failing: readonly FailingCheckDetails[];
+  pending: readonly PendingCheckDetails[];
+}
+
+export interface SnapshotSummary {
+  openThreads: number;
+  resolvedThreads: number;
+  failingChecks: number;
+  pendingChecks: number;
+  hasBlockers: boolean;
+}
+
+export interface SnapshotResult {
+  pr: PullRequestSummary;
+  reviewThreads: ReviewThreadCollection;
+  checks: CheckCollection;
+  summary: SnapshotSummary;
+  sources: {
+    pullRequest: string;
+    reviewThreads: string;
+    checks: string;
+  };
+}
+
+export interface GhCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  stdoutBytes: Buffer;
+}
+
+export interface GhExecutor {
+  (args: readonly string[], options?: { input?: string }): GhCommandResult;
+}

--- a/scripts/ci/pr-review-intake.utils.ts
+++ b/scripts/ci/pr-review-intake.utils.ts
@@ -1,0 +1,189 @@
+import type { CheckSummary, CliOptions } from './pr-review-intake.types.js';
+
+const FAILURE_MARKERS = [
+  'error',
+  'fail',
+  'failed',
+  'traceback',
+  'exception',
+  'assert',
+  'panic',
+  'fatal',
+  'timeout',
+  'segmentation fault',
+] as const;
+
+export const parseCliOptions = (args: readonly string[]): CliOptions => {
+  const [command, ...rest] = args;
+  if (command !== 'snapshot' && command !== 'threads' && command !== 'checks') {
+    throw new Error('Erwartetes Subcommand: snapshot | threads | checks');
+  }
+
+  let repo: string | undefined;
+  let pullRequestNumber: number | undefined;
+  let json = false;
+  let maxLines = 160;
+  let context = 30;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const argument = rest[index];
+
+    if (argument === '--json') {
+      json = true;
+      continue;
+    }
+
+    if (argument === '--repo' || argument === '--pr' || argument === '--max-lines' || argument === '--context') {
+      const value = rest[index + 1];
+      if (!value) {
+        throw new Error(`Fehlender Wert für ${argument}`);
+      }
+
+      if (argument === '--repo') {
+        repo = value;
+      } else {
+        const parsed = Number.parseInt(value, 10);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new Error(`Ungültiger Wert für ${argument}: ${value}`);
+        }
+        if (argument === '--pr') {
+          pullRequestNumber = parsed;
+        } else if (argument === '--max-lines') {
+          maxLines = parsed;
+        } else {
+          context = parsed;
+        }
+      }
+
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unbekanntes Argument: ${argument}`);
+  }
+
+  if ((repo && !pullRequestNumber) || (!repo && pullRequestNumber)) {
+    throw new Error('--repo und --pr müssen gemeinsam gesetzt werden.');
+  }
+
+  return { command, json, repo, pullRequestNumber, maxLines, context };
+};
+
+export const parseAvailableFields = (message: string): string[] => {
+  if (!message.includes('Available fields:')) {
+    return [];
+  }
+
+  const fields: string[] = [];
+  let collecting = false;
+
+  for (const line of message.split('\n')) {
+    if (line.includes('Available fields:')) {
+      collecting = true;
+      continue;
+    }
+    if (!collecting) {
+      continue;
+    }
+    const field = line.trim();
+    if (field) {
+      fields.push(field);
+    }
+  }
+
+  return fields;
+};
+
+export const extractRunId = (url: string): string | null => {
+  if (!url) {
+    return null;
+  }
+  for (const pattern of [/\/actions\/runs\/(\d+)/u, /\/runs\/(\d+)/u]) {
+    const match = pattern.exec(url);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+};
+
+export const extractJobId = (url: string): string | null => {
+  if (!url) {
+    return null;
+  }
+  const longMatch = /\/actions\/runs\/\d+\/job\/(\d+)/u.exec(url);
+  if (longMatch) {
+    return longMatch[1];
+  }
+  return /\/job\/(\d+)/u.exec(url)?.[1] ?? null;
+};
+
+const scoreFailureLine = (lowered: string): number => {
+  if (lowered.includes('error:')) {
+    return 5;
+  }
+  if (
+    lowered.includes('traceback') ||
+    lowered.includes('exception') ||
+    lowered.includes('fatal') ||
+    lowered.includes('segmentation fault')
+  ) {
+    return 4;
+  }
+  if (lowered.includes('assert') || lowered.includes('panic')) {
+    return 3;
+  }
+  if (lowered.includes('failed') || lowered.includes('timeout')) {
+    return 2;
+  }
+  return 1;
+};
+
+export const extractFailureSnippet = (logText: string, maxLines: number, context: number): string => {
+  const lines = logText.split('\n');
+  if (lines.length === 0) {
+    return '';
+  }
+
+  let markerIndex: number | null = null;
+  let bestScore = -1;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const lowered = lines[index]?.toLowerCase() ?? '';
+    if (!FAILURE_MARKERS.some((marker) => lowered.includes(marker))) {
+      continue;
+    }
+
+    const score = scoreFailureLine(lowered);
+    if (score > bestScore || (score === bestScore && markerIndex != null && index > markerIndex)) {
+      markerIndex = index;
+      bestScore = score;
+    }
+  }
+
+  if (markerIndex == null) {
+    return lines.slice(-maxLines).join('\n');
+  }
+
+  const start = Math.max(0, markerIndex - context);
+  const end = Math.min(lines.length, markerIndex + context);
+  return lines.slice(start, end).slice(-maxLines).join('\n');
+};
+
+export const buildSnapshotSummary = (result: {
+  reviewThreads: { open: readonly unknown[]; resolved: readonly unknown[] };
+  checks: { failing: readonly CheckSummary[]; pending: readonly CheckSummary[] };
+}) => {
+  const openThreads = result.reviewThreads.open.length;
+  const resolvedThreads = result.reviewThreads.resolved.length;
+  const failingChecks = result.checks.failing.length;
+  const pendingChecks = result.checks.pending.length;
+
+  return {
+    openThreads,
+    resolvedThreads,
+    failingChecks,
+    pendingChecks,
+    hasBlockers: openThreads > 0 || failingChecks > 0,
+  };
+};

--- a/scripts/ci/pr-review-intake.utils.ts
+++ b/scripts/ci/pr-review-intake.utils.ts
@@ -166,7 +166,7 @@ export const extractFailureSnippet = (logText: string, maxLines: number, context
   }
 
   const start = Math.max(0, markerIndex - context);
-  const end = Math.min(lines.length, markerIndex + context);
+  const end = Math.min(lines.length, markerIndex + context + 1);
   return lines.slice(start, end).slice(-maxLines).join('\n');
 };
 

--- a/scripts/ci/pr-scope.test.ts
+++ b/scripts/ci/pr-scope.test.ts
@@ -234,13 +234,13 @@ describe('pr-scope', () => {
     expect(decision.escalationReasons).toEqual([]);
   });
 
-  it('keeps ci-script changes on affected quality gates', () => {
+  it('keeps ci-script changes on affected quality gates and affected coverage', () => {
     const decision = classifyPrScope(['scripts/ci/run-pr-gate.ts']);
 
     expectDecision(decision, {
       codeRelevant: true,
       qualityGateMode: 'affected',
-      coverageMode: 'full',
+      coverageMode: 'affected',
       integrationMode: 'full',
       e2eMode: 'full',
       appBuildMode: 'full',

--- a/scripts/ci/pr-scope.ts
+++ b/scripts/ci/pr-scope.ts
@@ -33,11 +33,14 @@ const qualityEscalationPatterns = [
   /^vitest\.workspace\.ts$/u,
 ];
 
-const coverageEscalationPatterns = [
+const coverageFullEscalationPatterns = [
   ...qualityEscalationPatterns,
   /^package\.json$/u,
-  /^scripts\/ci\//u,
   /^\.github\/workflows\/(?:runtime-gates|quality-gates)\.yml$/u,
+];
+
+const coverageAffectedPatterns = [
+  /^scripts\/ci\//u,
 ];
 
 const integrationRelevantPatterns = [
@@ -160,10 +163,12 @@ export const classifyPrScope = (changedFiles: readonly string[]): PrScopeDecisio
 
   const qualityGateMode: GateMode = escalationReasons.length > 0 ? 'full' : 'affected';
   const coverageMode: GateMode = codeRelevantFiles.some((file) =>
-    matchesAnyPattern(file, coverageEscalationPatterns)
+    matchesAnyPattern(file, coverageFullEscalationPatterns)
   )
     ? 'full'
-    : 'skip';
+    : codeRelevantFiles.some((file) => matchesAnyPattern(file, coverageAffectedPatterns))
+      ? 'affected'
+      : 'skip';
   const integrationMode: GateMode = codeRelevantFiles.some((file) =>
     matchesAnyPattern(file, integrationEscalationPatterns)
   )

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -31,7 +31,7 @@
         "toolingScripts"
       ],
       "options": {
-        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts ../../scripts/ci/pr-review-intake.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:coverage": {
@@ -44,7 +44,7 @@
         "toolingScripts"
       ],
       "options": {
-        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts ../../scripts/ci/pr-review-intake.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {


### PR DESCRIPTION
## Was wurde geändert

- neuer repo-lokaler PR-Intake unter `scripts/ci/pr-review-intake.ts` mit den Subcommands `snapshot`, `threads` und `checks`
- Aufspaltung der GitHub-/Thread-/Check-Logik in kleinere CI-Module, damit der lokale Ablauf wartbar bleibt und die Komplexitätsgrenzen eingehalten werden
- Fixture-basierte Tests für Erfolgs-, Fehler-, Fallback- und Ausgabe-Pfade des neuen Intakes
- Umstellung von PR-Fixer-Agent und Review-Governance-Doku auf den neuen kanonischen lokalen Workflow

## Warum wurde das geändert

Der bisherige Ablauf für offene Review-Threads und rote GitHub-Checks lief über eine Mischung aus externen Cache-Skills, Branch-Fallbacks und Python-Hilfsskripten. Das führte zu unnötigen Umwegen, schlechter Reproduzierbarkeit und wiederkehrenden Fehlpfaden. Dieser PR verankert den Ablauf repo-lokal und deterministisch.

## Auswirkung

- PR-Diagnose für Threads und failing Checks ist lokal reproduzierbar und unabhängig von patchbaren Plugin-Cache-Skripten
- explizites `--repo/--pr` hat Vorrang vor impliziter Branch-Erkennung
- der PR-Fixer hat einen klaren Primärpfad für lokalen PR-State; externe GitHub-Skills bleiben nur Fallback

## Validierung

- `pnpm exec vitest run scripts/ci/pr-review-intake.test.ts`
- `pnpm exec vitest run scripts/ci/pr-review-intake.test.ts --coverage`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `node --test scripts/ci/check-bot-comment-handling.test.ts`
- `pnpm complexity-gate`
- `pnpm nx affected --target=test:unit --base=origin/main`
