### PR TITLE
Align localhost runtime docs, dialog accessibility, and test tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,21 @@
   - reine `import type`-Pfade dürfen typbezogen bleiben, Runtime-Pfade nicht
   - Runtime-Imports auf andere Workspace-Packages müssen im lokalen `package.json` unter `dependencies` stehen
 
+## Komplexitäts- und Ownership-Disziplin
+
+- Ziel ist nicht minimale LOC, sondern minimale langfristige Ownership bei voller Qualität.
+- Vor neuer Eigenlogik prüfen:
+  - Gibt es bereits eine robuste Lösung im Projekt oder Workspace?
+  - Deckt TypeScript/Stdlib, Browser-/Node-Plattform oder Datenbank die Anforderung korrekt ab?
+  - Reduziert ein etabliertes externes Package die Ownership gegenüber einer Eigenentwicklung?
+  - Erst danach minimale Eigenimplementierung schreiben.
+- Neue Dependencies sind zulässig, wenn sie komplexe oder riskante Domänen besser abdecken als lokale Eigenlogik, z. B. Auth, Crypto, Parser, Datums-/Zeitzonenlogik, Accessibility-Primitives, Virtualisierung, i18n, Validierung oder Security-Middleware.
+- Keine neue Dependency für triviale Hilfslogik, wenn vorhandene Plattform-, Workspace- oder Design-System-Mittel die Edge Cases ausreichend abdecken.
+- Keine Abstraktion ohne belegten Bedarf: keine Interfaces mit einer Implementierung, Factories mit einem Produkt, Provider/Services/Hooks ohne klaren Mehrwert oder Config für Werte, die nicht variieren.
+- Vereinfachungen dürfen niemals Testabdeckung, Typklarheit, Security, Accessibility, i18n, Fehlerbehandlung, Datenintegrität, Server-Runtime-Regeln oder bestehende Architekturgrenzen unterlaufen.
+- UI-Implementierungen folgen der Reihenfolge: native Browser-/HTML-Funktion, vorhandene shadcn/ui- oder Design-System-Komponente, vorhandene Workspace-Komponente, dann minimale neue Komponente.
+- Bei Review und Refactoring gezielt nach entfernbarer Komplexität suchen: handgerollte Standardfunktionen, tote Flexibilität, ungenutzte Layer, vermeidbare Dependencies und spekulative Erweiterbarkeit. Solche Funde sind Ergänzungen zu normalen Correctness-, Security-, Test- und UX-Reviews, kein Ersatz.
+
 ## Tipps zur Entwicklungsumgebung
 
 - Dies ist ein pnpm-Workspace-Monorepo; Packages sind nach Funktionalität organisiert

--- a/apps/sva-studio-react/src/components/ModalDialog.tsx
+++ b/apps/sva-studio-react/src/components/ModalDialog.tsx
@@ -76,6 +76,12 @@ export const ModalDialog = ({
     [onClose]
   );
 
+  const contentAccessibilityProps = description
+    ? {}
+    : ({
+        'aria-describedby': undefined,
+      } satisfies Pick<React.ComponentProps<typeof DialogPrimitive.Content>, 'aria-describedby'>);
+
   return (
     <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
       <DialogPrimitive.Portal>
@@ -85,6 +91,7 @@ export const ModalDialog = ({
           onClick={requestClose}
         />
         <DialogPrimitive.Content
+          {...contentAccessibilityProps}
           role={role}
           className={cn(
             'fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 shadow-2xl focus-visible:outline-none animate-modal-content',

--- a/apps/sva-studio-react/src/components/ui/sheet.tsx
+++ b/apps/sva-studio-react/src/components/ui/sheet.tsx
@@ -64,34 +64,43 @@ export const SheetContent = ({
   description,
   side = 'left',
   'aria-label': ariaLabel,
-}: SheetContentProps) => (
-  <DialogPrimitive.Portal>
-    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-foreground/40 lg:hidden" />
-    <DialogPrimitive.Close
-      aria-label={closeLabel}
-      className="fixed inset-0 z-50 cursor-default lg:hidden"
-      data-slot="sheet-close-overlay"
-      tabIndex={-1}
-      type="button"
-    />
-    <DialogPrimitive.Content
-      aria-label={ariaLabel}
-      className={cn(
-        'fixed top-0 z-50 h-full w-[18rem] border-border bg-sidebar shadow-shell focus-visible:outline-none lg:hidden',
-        getSheetPositionClasses(side),
-        className
-      )}
-    >
-      <DialogPrimitive.Title className="sr-only">{ariaLabel}</DialogPrimitive.Title>
-      {description ? <DialogPrimitive.Description className="sr-only">{description}</DialogPrimitive.Description> : null}
+}: SheetContentProps) => {
+  const contentAccessibilityProps = description
+    ? {}
+    : ({
+        'aria-describedby': undefined,
+      } satisfies Pick<React.ComponentProps<typeof DialogPrimitive.Content>, 'aria-describedby'>);
+
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-foreground/40 lg:hidden" />
       <DialogPrimitive.Close
         aria-label={closeLabel}
-        className="absolute right-3 top-3 z-10 rounded-md border border-border bg-sidebar px-3 py-1 text-sm font-medium text-sidebar-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="fixed inset-0 z-50 cursor-default lg:hidden"
+        data-slot="sheet-close-overlay"
+        tabIndex={-1}
         type="button"
+      />
+      <DialogPrimitive.Content
+        {...contentAccessibilityProps}
+        aria-label={ariaLabel}
+        className={cn(
+          'fixed top-0 z-50 h-full w-[18rem] border-border bg-sidebar shadow-shell focus-visible:outline-none lg:hidden',
+          getSheetPositionClasses(side),
+          className
+        )}
       >
-        {closeLabel}
-      </DialogPrimitive.Close>
-      <div className="h-full">{children}</div>
-    </DialogPrimitive.Content>
-  </DialogPrimitive.Portal>
-);
+        <DialogPrimitive.Title className="sr-only">{ariaLabel}</DialogPrimitive.Title>
+        {description ? <DialogPrimitive.Description className="sr-only">{description}</DialogPrimitive.Description> : null}
+        <DialogPrimitive.Close
+          aria-label={closeLabel}
+          className="absolute right-3 top-3 z-10 rounded-md border border-border bg-sidebar px-3 py-1 text-sm font-medium text-sidebar-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          type="button"
+        >
+          {closeLabel}
+        </DialogPrimitive.Close>
+        <div className="h-full">{children}</div>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+};

--- a/apps/sva-studio-react/vite.config.ts
+++ b/apps/sva-studio-react/vite.config.ts
@@ -26,7 +26,7 @@ const configuredDevHost = process.env.HOST?.trim();
 const allowedHosts = [
   'localhost',
   '127.0.0.1',
-  '.lvh.me',
+  '.localhost',
   ...(configuredParentDomain ? [configuredParentDomain, `.${configuredParentDomain}`] : []),
 ];
 
@@ -284,6 +284,10 @@ const config = defineConfig({
     ...(tanstackDevtoolsEnabled ? [devtools()] : []),
     tailwindcss(),
     tanstackStart({
+      router: {
+        routeFileIgnorePattern:
+          '^(?:use-user-(?:edit|list)-controller|user-(?:assignment-options|edit-model|list-model)(?:\\.test)?)\\.tsx?$',
+      },
       server: {
         entry: tanstackServerEntry,
       },

--- a/docs/development/runtime-profile-betrieb.md
+++ b/docs/development/runtime-profile-betrieb.md
@@ -165,7 +165,7 @@ pnpm env:up:local-keycloak
 
 Für zusätzliche lokale Instanzen oder weitere lokale Datenbanken ist `../guides/lokale-instanz-db-initialisierung.md` der kanonische Bootstrap-Pfad.
 
-Für lokale Multi-Tenant-Hosttests ist `../guides/instance-registry-local-development.md` der kanonische Pfad. Offiziell unterstützt sind `studio.lvh.me` und `<instanceId>.studio.lvh.me`.
+Für lokale Multi-Tenant-Hosttests ist `../guides/instance-registry-local-development.md` der kanonische Pfad. Offiziell unterstützt sind `studio.localhost` und `<instanceId>.studio.localhost`.
 
 ### Lokal mit Builder.io
 
@@ -313,7 +313,7 @@ Ausnahme für `studio` in der frühen Testphase:
 Zusatzprüfungen:
 
 - lokal: OTEL Collector `http://127.0.0.1:13133/healthz`
-- lokal im Multi-Tenant-Pfad: Root-Host `studio.lvh.me`, Tenant-Host `demo2.studio.lvh.me` und fail-closed-Fall `blocked.studio.lvh.me`
+- lokal im Multi-Tenant-Pfad: Root-Host `studio.localhost`, Tenant-Host `demo2.studio.localhost` und fail-closed-Fall `blocked.studio.localhost`
 - Remote: Service-/Task-Status für `app`, `redis`, `postgres` bevorzugt über Portainer-API
 - Remote: `otel-collector` nur dann zusätzlich, wenn `ENABLE_OTEL` im Zielprofil aktiviert ist
 - Remote: öffentliche Smoke-Probes gegen Root-Host `/`, `/health/live`, `/health/ready`, `/auth/login`, `/api/v1/iam/me/context`

--- a/docs/guides/instance-registry-local-development.md
+++ b/docs/guides/instance-registry-local-development.md
@@ -6,18 +6,18 @@ Diese Anleitung beschreibt den lokalen Standardpfad und den registry-nahen Multi
 
 ## Unterstützte Hosts
 
-- Root-Host: `studio.lvh.me`
-- Tenant-Hosts: `<instanceId>.studio.lvh.me`
+- Root-Host: `studio.localhost`
+- Tenant-Hosts: `<instanceId>.studio.localhost`
 
-`lvh.me` zeigt lokal auf `127.0.0.1` und erlaubt damit reproduzierbare Host-Tests ohne eigene `/etc/hosts`-Einträge.
+`.localhost` ist als lokaler Loopback-Namensraum reserviert und erlaubt reproduzierbare Host-Tests ohne eigene `/etc/hosts`-Einträge.
 
 ## Voraussetzungen
 
 - `IAM_DATABASE_URL` zeigt auf die lokale IAM-Postgres-Datenbank
 - Migration `0025_iam_instance_registry_provisioning.sql` ist ausgerollt
 - lokale Seeds enthalten mindestens zwei aktive Instanzen und einen negativen Fall
-- für Browser- oder Playwright-Tests ist `SVA_PARENT_DOMAIN=studio.lvh.me` gesetzt
-- die Dev- oder Playwright-Instanz erlaubt `studio.lvh.me` und `*.studio.lvh.me` als lokale Hosts
+- für Browser- oder Playwright-Tests ist `SVA_PARENT_DOMAIN=studio.localhost` gesetzt
+- die Dev- oder Playwright-Instanz erlaubt `studio.localhost` und `*.studio.localhost` als lokale Hosts
 - im Standardprofil `local-keycloak` ist `svs-intern-studio-staging` der globale Keycloak-Realm und `de-musterhausen` die fachliche Test-Instanz
 
 ## Schneller Standardpfad
@@ -25,27 +25,27 @@ Diese Anleitung beschreibt den lokalen Standardpfad und den registry-nahen Multi
 1. IAM-Migrationen ausführen.
 2. lokale Seeds laden
 3. App auf dem Root-Host starten
-4. `http://studio.lvh.me:3000` öffnen
-5. Tenant-Kontexte über `http://<instanceId>.studio.lvh.me:3000` prüfen
+4. `http://studio.localhost:3000` öffnen
+5. Tenant-Kontexte über `http://<instanceId>.studio.localhost:3000` prüfen
 
 Empfohlene Seed-Instanzen:
 
 - `de-musterhausen`
 - `demo2`
 - `demo`
-- negativer Fall über unbekannten Host, zum Beispiel `blocked.studio.lvh.me`
+- negativer Fall über unbekannten Host, zum Beispiel `blocked.studio.localhost`
 
 Verifikation:
 
 ```bash
-curl -i http://studio.lvh.me:3000/
-curl -i http://demo2.studio.lvh.me:3000/
-curl -i http://blocked.studio.lvh.me:3000/auth/me
+curl -i http://studio.localhost:3000/
+curl -i http://demo2.studio.localhost:3000/
+curl -i http://blocked.studio.localhost:3000/auth/me
 ```
 
 ## Registry-naher Multi-Tenant-Pfad
 
-1. Root-Host unter `studio.lvh.me` verwenden
+1. Root-Host unter `studio.localhost` verwenden
 2. Instanzen über `/admin/instances` oder die Ops-CLI anlegen
 3. nach erfolgreicher Anlage Tenant-Host direkt öffnen
 4. unbekannte oder suspendierte Hosts auf identisches fail-closed-Verhalten prüfen
@@ -62,21 +62,21 @@ Verifikation:
 pnpm exec tsx scripts/ops/instance-registry.ts create \
   --instance-id demo2 \
   --display-name "Demo 2" \
-  --parent-domain studio.lvh.me \
+  --parent-domain studio.localhost \
   --auth-realm demo2 \
   --auth-client-id sva-studio \
   --actor-id local-admin
 pnpm exec tsx scripts/ops/instance-registry.ts activate \
   --instance-id demo2 \
   --actor-id local-admin
-curl -i http://demo2.studio.lvh.me:3000/
+curl -i http://demo2.studio.localhost:3000/
 ```
 
 Für Playwright ist der offizielle Multi-Tenant-Pfad:
 
 ```bash
-PLAYWRIGHT_BASE_URL=http://studio.lvh.me:4173 \
-PLAYWRIGHT_TENANT_LOGIN_URL=http://demo2.studio.lvh.me:4173/auth/login?returnTo=%2Fadmin%2Finstances \
+PLAYWRIGHT_BASE_URL=http://studio.localhost:4173 \
+PLAYWRIGHT_TENANT_LOGIN_URL=http://demo2.studio.localhost:4173/auth/login?returnTo=%2Fadmin%2Finstances \
 pnpm nx run sva-studio-react:test:e2e -- --grep "tenant-host login"
 ```
 
@@ -93,7 +93,7 @@ pnpm exec tsx scripts/ops/instance-registry.ts list --json
 pnpm exec tsx scripts/ops/instance-registry.ts create \
   --instance-id demo \
   --display-name "Demo" \
-  --parent-domain studio.lvh.me \
+  --parent-domain studio.localhost \
   --auth-realm demo \
   --auth-client-id sva-studio \
   --actor-id local-admin

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -441,7 +441,7 @@ test('sva-studio-react vite SSR config resolves mail-runtime from workspace sour
 
   assert.match(viteConfig, /'@sva\/mail-runtime': resolveAppPath\('\.\.\/\.\.\/packages\/mail-runtime\/src\/index\.ts'\)/);
   assert.match(viteConfig, /'@sva\/mail-runtime',/);
-  assert.match(viteConfig, /'localhost'/);
+  assert.match(viteConfig, /'\.localhost'/);
   assert.doesNotMatch(viteConfig, /lvh\.me/);
 });
 

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -441,6 +441,8 @@ test('sva-studio-react vite SSR config resolves mail-runtime from workspace sour
 
   assert.match(viteConfig, /'@sva\/mail-runtime': resolveAppPath\('\.\.\/\.\.\/packages\/mail-runtime\/src\/index\.ts'\)/);
   assert.match(viteConfig, /'@sva\/mail-runtime',/);
+  assert.match(viteConfig, /'localhost'/);
+  assert.doesNotMatch(viteConfig, /lvh\.me/);
 });
 
 test('sva-studio-react vitest shared config resolves mail-runtime from workspace source', () => {

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -31,7 +31,7 @@
         "toolingScripts"
       ],
       "options": {
-        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts ../../scripts/ci/pr-review-intake.test.ts ../../scripts/ci/test-runner-standardization.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ops/runtime-env.remote.test.ts ../../scripts/ops/runtime/acceptance-deploy.test.ts ../../scripts/ops/runtime/acceptance-runtime-checks.test.ts ../../scripts/ops/runtime/doctor.test.ts ../../scripts/ops/runtime/local-command.test.ts ../../scripts/ops/runtime/remote-verification.test.ts ../../scripts/ops/runtime/smoke.test.ts ../../scripts/ops/runtime/studio-image-verify-evidence.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts ../../scripts/ci/pr-review-intake.test.ts ../../scripts/ci/test-runner-standardization.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:coverage": {
@@ -44,7 +44,7 @@
         "toolingScripts"
       ],
       "options": {
-        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts ../../scripts/ci/pr-review-intake.test.ts ../../scripts/ci/test-runner-standardization.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
+        "command": "pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/guardrail-report.test.ts ../../scripts/ops/runtime-env-guardrails.test.ts ../../scripts/ops/runtime-env.test.ts ../../scripts/ops/runtime-env.remote.test.ts ../../scripts/ops/runtime/acceptance-deploy.test.ts ../../scripts/ops/runtime/acceptance-runtime-checks.test.ts ../../scripts/ops/runtime/doctor.test.ts ../../scripts/ops/runtime/local-command.test.ts ../../scripts/ops/runtime/remote-verification.test.ts ../../scripts/ops/runtime/smoke.test.ts ../../scripts/ops/runtime/studio-image-verify-evidence.test.ts ../../scripts/ci/pr-scope.test.ts ../../scripts/ci/affected-unit-gate.test.ts ../../scripts/ci/run-pr-gate.test.ts ../../scripts/ci/run-integration-gate.test.ts ../../scripts/ci/check-db-schema-snapshot.test.ts ../../scripts/ci/pr-review-intake.test.ts ../../scripts/ci/test-runner-standardization.test.ts --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"
       }
     },
     "test:integration": {

--- a/tooling/testing/src/msw/setup.ts
+++ b/tooling/testing/src/msw/setup.ts
@@ -1,7 +1,40 @@
 import { afterAll, afterEach, beforeAll } from 'vitest';
 
-import { resetStudioMswHandlers } from './reset.ts';
-import { studioMswServer } from './server.ts';
+const installTestLocalStorage = (): void => {
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => {
+        storage.clear();
+      },
+      getItem: (key: string) => {
+        return storage.get(String(key)) ?? null;
+      },
+      key: (index: number) => {
+        return [...storage.keys()][index] ?? null;
+      },
+      removeItem: (key: string) => {
+        storage.delete(String(key));
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(String(key), String(value));
+      },
+      get length() {
+        return storage.size;
+      },
+    } satisfies Storage,
+    writable: true,
+  });
+};
+
+installTestLocalStorage();
+
+const [{ resetStudioMswHandlers }, { studioMswServer }] = await Promise.all([
+  import('./reset.ts'),
+  import('./server.ts'),
+]);
 
 (globalThis as { __studioMswServer?: typeof studioMswServer }).__studioMswServer = studioMswServer;
 

--- a/tooling/testing/src/msw/setup.ts
+++ b/tooling/testing/src/msw/setup.ts
@@ -1,6 +1,10 @@
 import { afterAll, afterEach, beforeAll } from 'vitest';
 
 const installTestLocalStorage = (): void => {
+  if ('localStorage' in globalThis) {
+    return;
+  }
+
   const storage = new Map<string, string>();
 
   Object.defineProperty(globalThis, 'localStorage', {


### PR DESCRIPTION
## Summary
- switch remaining local multi-tenant runtime guidance and guardrails from `lvh.me` to `.localhost`
- fix dialog and sheet accessibility wiring when no description is rendered and ignore auth artifacts in the app worktree
- expand runtime/tooling test coverage with localStorage setup and the broader runtime script suite, plus ignore generated controller route files in Vite routing

## Testing
- `pnpm exec tsc --noEmit -p apps/sva-studio-react/tsconfig.json --pretty false`
- `node --import tsx --test packages/data/src/runtime-safety.test.ts`
- `pnpm nx run tooling-testing:test:unit`