### PR TITLE
Keycloak-Rollenabgleich auf technische Sonderrollen begrenzen

### DIFF
--- a/apps/sva-studio-react/e2e/smoke.spec.ts
+++ b/apps/sva-studio-react/e2e/smoke.spec.ts
@@ -297,7 +297,12 @@ test('tenant-host login fails closed when canonical auth redirect prerequisites 
   const tenantLoginUrl = process.env.PLAYWRIGHT_TENANT_LOGIN_URL
     ?? `http://demo2.studio.localhost:${playwrightPort}/auth/login?returnTo=%2Fadmin%2Finstances`;
   const parsedTenantLoginUrl = new URL(tenantLoginUrl);
-  const tenantRequestPort = parsedTenantLoginUrl.port || (parsedTenantLoginUrl.protocol === 'https:' ? '443' : '80');
+  const tenantRequestPort = parsedTenantLoginUrl.port
+    || (parsedTenantLoginUrl.hostname === 'demo2.studio.localhost'
+      ? playwrightPort
+      : parsedTenantLoginUrl.protocol === 'https:'
+        ? '443'
+        : '80');
   const requestUrl =
     parsedTenantLoginUrl.hostname === 'demo2.studio.localhost'
       ? new URL(`${parsedTenantLoginUrl.pathname}${parsedTenantLoginUrl.search}`, `http://127.0.0.1:${tenantRequestPort}`).toString()

--- a/apps/sva-studio-react/e2e/smoke.spec.ts
+++ b/apps/sva-studio-react/e2e/smoke.spec.ts
@@ -41,6 +41,21 @@ const isAcceptedAuthRedirect = (location: string | null | undefined) =>
     )
   );
 
+const resolvePlaywrightServerPort = () => {
+  if (process.env.PLAYWRIGHT_PORT) {
+    return process.env.PLAYWRIGHT_PORT;
+  }
+
+  const configuredBaseUrl = process.env.PLAYWRIGHT_DE_MUSTERHAUSEN_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL;
+
+  if (!configuredBaseUrl) {
+    return '4173';
+  }
+
+  const parsedBaseUrl = new URL(configuredBaseUrl);
+  return parsedBaseUrl.port || (parsedBaseUrl.protocol === 'https:' ? '443' : '80');
+};
+
 const expectInterfacesShellReady = async (page: Page, timeout = 20_000) => {
   await expect(page.getByRole('heading', { name: 'Schnittstellen', exact: true })).toBeVisible({ timeout });
 };
@@ -278,13 +293,14 @@ test('GET /auth/login returns redirect response', async ({ request }) => {
 });
 
 test('tenant-host login fails closed when canonical auth redirect prerequisites are unavailable', async ({ request }) => {
-  const playwrightPort = process.env.PLAYWRIGHT_PORT ?? '4173';
+  const playwrightPort = resolvePlaywrightServerPort();
   const tenantLoginUrl = process.env.PLAYWRIGHT_TENANT_LOGIN_URL
     ?? `http://demo2.studio.localhost:${playwrightPort}/auth/login?returnTo=%2Fadmin%2Finstances`;
   const parsedTenantLoginUrl = new URL(tenantLoginUrl);
+  const tenantRequestPort = parsedTenantLoginUrl.port || (parsedTenantLoginUrl.protocol === 'https:' ? '443' : '80');
   const requestUrl =
     parsedTenantLoginUrl.hostname === 'demo2.studio.localhost'
-      ? new URL(`${parsedTenantLoginUrl.pathname}${parsedTenantLoginUrl.search}`, `http://127.0.0.1:${playwrightPort}`).toString()
+      ? new URL(`${parsedTenantLoginUrl.pathname}${parsedTenantLoginUrl.search}`, `http://127.0.0.1:${tenantRequestPort}`).toString()
       : tenantLoginUrl;
 
   const response = await request.get(requestUrl, {

--- a/apps/sva-studio-react/src/i18n/resources/de/account/fields.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/account/fields.resources.ts
@@ -10,6 +10,7 @@ export const fieldsAccountDEResources = {
   language: 'Sprache',
   timezone: 'Zeitzone',
   role: 'Rolle',
+  keycloakRoles: 'Technische Keycloak-Rollen',
   status: 'Status',
   lastLogin: 'Letzter Login',
 } as const;

--- a/apps/sva-studio-react/src/i18n/resources/en/account/fields.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/account/fields.resources.ts
@@ -10,6 +10,7 @@ export const fieldsAccountENResources = {
   language: 'Language',
   timezone: 'Timezone',
   role: 'Role',
+  keycloakRoles: 'Technical Keycloak roles',
   status: 'Status',
   lastLogin: 'Last login',
 } as const;

--- a/apps/sva-studio-react/src/providers/auth-provider.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.tsx
@@ -48,6 +48,7 @@ type SessionUser = {
   instanceId?: string;
   assignedModules?: string[];
   groups?: readonly IamUserGroupAssignment[];
+  keycloakRoles?: string[];
   permissionActions?: readonly string[];
   roles: string[];
   permissionStatus?: 'ok' | 'degraded';

--- a/apps/sva-studio-react/src/routes/account/-account-profile-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/account/-account-profile-page.test.tsx
@@ -36,6 +36,7 @@ type ProfileFixture = {
     roles?: string;
   };
   roles: ProfileRoleFixture[];
+  keycloakRoles?: string[];
   mainserverUserApplicationSecretSet: boolean;
 };
 
@@ -435,6 +436,7 @@ describe('AccountProfilePage', () => {
           { roleId: 'role-1', roleName: 'Editor' },
           { roleId: 'role-2', roleName: 'Reviewer' },
         ],
+        keycloakRoles: ['legacy_editor', 'system_admin'],
       })
     );
 
@@ -451,6 +453,9 @@ describe('AccountProfilePage', () => {
     expect(statusField.value).toBe('Aktiv');
     expect(roleField.readOnly).toBe(true);
     expect(roleField.value).toBe('Editor, Reviewer');
+    expect((screen.getByLabelText('Technische Keycloak-Rollen') as HTMLInputElement).value).toBe(
+      'legacy_editor, system_admin'
+    );
   });
 
   it('shows load error with retry and keeps display name fallback from auth user', async () => {

--- a/apps/sva-studio-react/src/routes/account/-account-profile-page.tsx
+++ b/apps/sva-studio-react/src/routes/account/-account-profile-page.tsx
@@ -309,6 +309,7 @@ export const AccountProfilePage = () => {
     '-';
   const email = profile?.email ?? '-';
   const roleNames = profile?.roles.map((role) => role.roleName).join(', ') || '-';
+  const keycloakRoleNames = profile?.keycloakRoles?.join(', ') || '-';
   const hasProjectionWarning =
     profile?.mappingStatus === 'manual_review' || Boolean(profile?.diagnostics?.length);
   const projectionStatusLabel = profile?.mappingStatus
@@ -509,6 +510,10 @@ export const AccountProfilePage = () => {
           <div className="grid gap-2 text-sm text-foreground md:col-span-2">
             <Label htmlFor="account-roles-readonly">{t('account.fields.role')}</Label>
             <Input id="account-roles-readonly" value={roleNames} readOnly aria-readonly="true" />
+          </div>
+          <div className="grid gap-2 text-sm text-foreground md:col-span-2">
+            <Label htmlFor="account-keycloak-roles-readonly">{t('account.fields.keycloakRoles')}</Label>
+            <Input id="account-keycloak-roles-readonly" value={keycloakRoleNames} readOnly aria-readonly="true" />
           </div>
         </section>
 

--- a/apps/sva-studio-react/stagehand/stories/state.test.ts
+++ b/apps/sva-studio-react/stagehand/stories/state.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -110,7 +110,7 @@ describe('stagehand story state', () => {
 
   it('writes an overlay without mutating the source catalog', () => {
     const filePath = createTempCatalogFile();
-    const overlayPath = join(tmpdir(), `stagehand-story-overlay-${Date.now()}.json`);
+    const overlayPath = join(dirname(filePath), 'stagehand-story-overlay.json');
 
     writeStagehandStoryCheckOverlay(overlayPath, {
       generatedAt: '2026-05-16T18:00:00.000Z',

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -158,14 +158,14 @@ Referenzen:
 - Auf dem Root-Host wird derselbe IAM-v1-Routenvertrag im `platform`-Scope ausgewertet; Plattform-User und Plattform-Rollen stammen aus dem Plattform-Realm und benötigen keine tenantgebundene `instanceId`.
 - Tenant-Admin-abhängige Reconcile- und Sync-Pfade reagieren fail-closed, sobald blockerrelevanter Drift in Registry oder Provisioning erkannt wird.
 
-### Fortschreibung 2026-04: Studio als Keycloak-first Admin-UI
+### Fortschreibung 2026-06: Keycloak-Rollenabgleich auf technische Sonderrollen begrenzt
 
-- Studio wird für Benutzer, Realm-Rollen und Rollenzuordnungen als auditierte Admin-UI über Keycloak positioniert; Keycloak bleibt System of Record.
-- Platform-Scope und Tenant-Scope sind strategisch getrennte Admin-Pfade: Platform-Scope nutzt ausschließlich den Platform-Admin-Keycloak-Client, Tenant-Scope ausschließlich den Tenant-Admin-Keycloak-Client der Instanz.
-- Tenant-Listen folgen dem Keycloak-Realm als Benutzergrenze. Fehlende Studio-Zuordnungen werden nicht versteckt, sondern über `mappingStatus`, `editability` und stabile Diagnosecodes angezeigt.
-- Mutationen sind Keycloak-first. Studio-Read-Models werden nachgelagert synchronisiert oder als Drift/Diagnose sichtbar gemacht.
-- Nutzernahe Credential-Änderungen bleiben ebenfalls Keycloak-first: Sichtbar angeboten wird im Studio derzeit nur der Passwort-Wechsel; dieser wird über einen serverseitigen AIA-Einstieg (`/auth/account-action`) kontrolliert in den Keycloak-Self-Service-Flow delegiert. Der E-Mail-Wechsel bleibt bis zur Keycloak-seitigen Freischaltung von `UPDATE_EMAIL` ausgeblendet.
-- `manual_review` bleibt bewusst ein fachlicher Restzustand für nicht deterministisch behebbaren Abgleich; technische Fehler wie `IDP_UNAVAILABLE` und `IDP_FORBIDDEN` bleiben getrennt sichtbar.
+- Keycloak bleibt führend für Identität, Login, Realm-Zugang, Benutzerkonto und technische Sonderrollen; tenantlokale Fachrollen, Gruppen und Permissions sind ausschließlich IAM-DB-kanonisch.
+- Der technische Rollenschnitt ist hart begrenzt: `system_admin` im Tenant-Kontext und `instance_registry_admin` im Plattform-Kontext. Andere Keycloak-Realm-Rollen begründen keine tenantseitige Fachautorisierung.
+- `/auth/me` und Session-Projektionen liefern getrennte Sichten: `roles` enthält kanonische IAM-Rollen inklusive gruppenabgeleiteter Rollen, `keycloakRoles` enthält rohe Keycloak-Rollen nur für Diagnose und Betrieb.
+- Platform-Scope und Tenant-Scope bleiben getrennte Admin-Pfade: Platform-Scope nutzt den Platform-Admin-Keycloak-Client, Tenant-Scope den Tenant-Admin-Keycloak-Client der Instanz. Der breite Rollenabgleich ist dabei kein Sollmodell mehr.
+- Rollen-CRUD für normale Tenant-Rollen ist DB-only. Keycloak-Mutationen bleiben auf technische Sonderrollen, Realm-Zugang und benutzernahe Identity-/Credential-Flows beschränkt.
+- Reconcile repariert fehlende oder abweichende technische Sonderrollen. Fehlende fachliche DB-Rollen in Keycloak sind kein Fehler; nicht-technische Keycloak-Rollen werden nur als Legacy-/Drift-Diagnose oder `manual_review` berichtet.
 - Browser- und UI-Verträge behalten `classification`, `requestId` und `safeDetails` vollständig, damit Diagnose, Operator-Handlung und Fachzustand nicht auseinanderlaufen.
 
 ### Fortschreibung 2026-04: Tenant-IAM-Betriebsstatus auf der Instanz-Detailseite

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -170,14 +170,15 @@ Abhängigkeiten des aktuellen Systems.
 ### Verantwortungsgrenzen im IAM-Pfad
 
 - Keycloak ist führend für Authentifizierung, Token-Claims und IdP-nahe Admin-Operationen.
-- Postgres ist führend für Studio-verwaltete IAM-Fachdaten wie Accounts, Rollen, Permissions und Auditdaten.
+- Postgres ist führend für Studio-verwaltete IAM-Fachdaten wie Accounts, tenantlokale Fachrollen, Gruppen, Permissions und Auditdaten.
+- Der Keycloak-Rollenabgleich ist auf technische Sonderrollen begrenzt: `system_admin` im Tenant-Kontext und `instance_registry_admin` im Plattform-Kontext.
 - `iam.instances` modelliert ausschließlich Tenant-Instanzen; der Root-Host ist ein separater Plattform-Scope.
 - `iam.instances` fuehrt fuer jede tenantfaehige Instanz getrennte Auth-Vertraege fuer Login (`authClientId`) und Tenant-Administration (`tenantAdminClient`) als kanonische Registry-Basisdaten.
 - Redis hält lediglich Permission-Snapshots zur Beschleunigung des Authorize-Pfads.
 - `packages/auth-runtime` haelt zusaetzlich nur sehr kurzlebige In-Process-Caches fuer Session-Resolution und Account-Lifecycle-Pruefung, um wiederholte Authorize-Requests derselben Session ohne neuen Redis-/DB-Roundtrip abzufangen.
 - Der SVA-Mainserver bleibt fachliche Source of Truth für seine GraphQL-Daten; Studio hält nur Endpunktkonfiguration und kurzlebige Laufzeit-Caches für Credentials und Access-Tokens.
 - Fachmodule konsumieren zentrale IAM-Entscheidungen und duplizieren keine eigene Berechtigungsauflösung gegen IAM-Tabellen.
-- `packages/iam-admin` hält zusätzlich die tenantseitige Governance-Trennung für Rollen und Permissions: Root-only-Rollen/-Permissions werden vor Admin-CRUD gefiltert oder abgewiesen, während `system_admin` als geschützte Tenant-Sonderrolle erhalten bleibt.
+- `packages/iam-admin` hält zusätzlich die tenantseitige Governance-Trennung für Rollen und Permissions: Root-only-Rollen/-Permissions werden vor Admin-CRUD gefiltert oder abgewiesen, normale Tenant-Rollen werden DB-only gepflegt, während `system_admin` als geschützte technische Tenant-Sonderrolle in IAM und Keycloak erhalten bleibt.
 
 ### Fortschreibung 2026-05: Scoped Rollen-Permissions fuer Datensatzrechte
 
@@ -211,18 +212,20 @@ Abhängigkeiten des aktuellen Systems.
    - rendert unter `/monitoring` den betrieblichen Einstieg fuer Plugin-Jobs und den GUI-gestuetzten Authorize-Benchmark.
    - trennt bewusst Monitoring-Operations von der IAM-Cockpit-Oberflaeche und zeigt nur sichere Ergebnisfelder, Kennzahlen und Report-Referenzen an.
 
-### Fortschreibung 2026-04: Keycloak-Admin-UI-Bausteine
+### Fortschreibung 2026-06: IAM-Admin-Bausteine mit begrenztem Keycloak-Rollenabgleich
 
 1. `@sva/core`
-   - Definiert additive Verträge für `mappingStatus`, `editability`, objektbezogene Diagnosecodes und Sync-/Reconcile-Objektlisten.
+   - Definiert additive Verträge für `mappingStatus`, `editability`, objektbezogene Diagnosecodes, kanonische IAM-Rollen und getrennte technische `keycloakRoles`.
 2. `packages/iam-admin/src/identity-provider-port.ts`
-   - Kapselt Keycloak-nahe Listen-, Count-, Mutations- und explizite Role-Assignment-Operationen.
+   - Kapselt Keycloak-nahe Listen-, Count-, Mutations- und explizite Role-Assignment-Operationen; Call-Sites dürfen tenantseitig nur technische Sonderrollen synchronisieren.
 3. `packages/iam-admin/src/keycloak-admin-client`
    - Implementiert serverseitige Pagination/Count für Realm-Rollen und User sowie differenzierte Fehlerabbildung für Keycloak-Admin-Aufrufe.
 4. `packages/iam-admin/src`
-   - Trennt Platform-Admin-Client, Tenant-Admin-Client, Keycloak-first Mutationen, Read-Model-Synchronisation und Drift-/Diagnoseprojektion.
+   - Trennt Platform-Admin-Client, Tenant-Admin-Client, DB-only-Rollen-CRUD, technische Keycloak-Sonderrollen-Synchronisation und Drift-/Diagnoseprojektion.
+   - `role-governance.ts` definiert den technischen Keycloak-Schnitt (`system_admin`, `instance_registry_admin`); `reconcile-core.ts` repariert nur diesen Schnitt und berichtet nicht-technische Keycloak-Rollen als Legacy-/Drift-Diagnose.
+   - `user-projection.ts` hält `roles` IAM-kanonisch und reicht rohe Keycloak-Rollen separat als `keycloakRoles` durch.
 5. `apps/sva-studio-react/src/routes/admin/users` und `apps/sva-studio-react/src/routes/admin/roles`
-   - Rendern Mappingstatus, Bearbeitbarkeit und Diagnosecodes; blockierte oder read-only Aktionen bleiben sichtbar, aber deaktiviert.
+   - Rendern IAM-Rollen als fachliche Sicht sowie Keycloak-Rollen nur als technische Diagnose; blockierte oder read-only Aktionen bleiben sichtbar, aber deaktiviert.
 
 ### Fortschreibung 2026-04: Diagnosegrenzen im IAM-Pfad
 

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -251,7 +251,7 @@ Fehlerpfad:
    - Bei Tenant-Hosts wird `instanceId` aus dem zuvor aufgelösten Auth-Scope aus Host, Registry und Realm in den Session-User übernommen.
    - Ein fehlender `instanceId`-Claim blockiert den Tenant-Login nicht; ein widersprüchlicher Claim beendet den Callback fail-closed als Scope-Konflikt.
 5. Session-Cookie wird mit expliziter Laufzeit aus `expiresAt` gesetzt; Redis-TTL wird technisch aus der Restlaufzeit plus Puffer abgeleitet
-6. App ruft `/auth/me` fuer minimalen Auth-Kontext (`id`, `instanceId`, Rollen)
+6. App ruft `/auth/me` fuer minimalen Auth-Kontext (`id`, `instanceId`, kanonische IAM-`roles`, technische `keycloakRoles`)
 7. Falls UI Profildaten wie Name oder E-Mail braucht, laedt sie diese ueber dedizierte Profil-Endpunkte getrennt nach
 
 Fehlerpfad:
@@ -332,7 +332,7 @@ Fehlerpfad:
 2. Der Server unterscheidet Root-Host-Platform-Scope und Tenant-Instance-Scope. Im Platform-Scope nutzt er den Plattform-Realm ohne `instanceId`; im Tenant-Scope lädt er den Instanzkontext und prüft vor jeder tenantlokalen Admin-Mutation blockerrelevanten Drift aus Registry, Preflight und Provisioning-Plan.
 3. Beim Keycloak-User-Sync ist der aktive Tenant-Realm die führende Benutzergrenze; fehlende `instanceId`-Attribute blockieren den Import nicht.
 4. Liegt ein Blocker vor, endet der Lauf sofort fail-closed mit technischem Fehlervertrag inklusive `classification`, `requestId` und freigegebenen Safe-Details.
-5. Ohne Blocker führt `packages/iam-admin` den Sync oder Reconcile deterministisch aus und trennt pro Eintrag zwischen korrigiert, fehlgeschlagen und fachlichem Restzustand `manual_review`.
+5. Ohne Blocker führt `packages/iam-admin` den Sync oder Reconcile deterministisch aus. Der Rollen-Reconcile repariert nur technische Sonderrollen; nicht-technische Keycloak-Rollen werden als Legacy-/Drift-Diagnose oder fachlicher Restzustand `manual_review` berichtet.
 6. Die Handler antworten immer mit genau einem Abschlusszustand `success`, `partial_failure`, `blocked` oder `failed` sowie aggregierten Zählwerten.
 7. Read-Pfade für Profil, User-Liste und Rollenansicht laden anschließend denselben kanonischen Projektionskern nach, damit UI und Fachzustand übereinstimmen.
 
@@ -375,22 +375,22 @@ Fehlerpfad:
 - fehlt die Zuweisung, blockiert das Routing die Plugin-Route vor dem Rendern.
 - direkte API-Aufrufe bleiben zusätzlich durch fehlende modulbezogene Permissions abgesichert.
 
-### Szenario 2f: Keycloak-first User- und Rollenverwaltung
+### Szenario 2f: IAM-User- und Rollenverwaltung mit technischem Keycloak-Schnitt
 
-1. `/admin/users` und `/admin/roles` laden Listen über den aktiven Keycloak-Admin-Pfad.
+1. `/admin/users` verbindet Keycloak-Identität mit der IAM-DB-Projektion; `/admin/roles` lädt tenantlokale Fachrollen kanonisch aus der IAM-Datenbank.
 2. Im Platform-Scope wird nur der Platform-Admin-Keycloak-Client verwendet.
 3. Im Tenant-Scope wird nur der Tenant-Admin-Keycloak-Client der Instanz verwendet; fehlt dieser, endet der Request mit `tenant_admin_client_not_configured`.
 4. Tenant-Userlisten lesen den vollständigen Realm-Ausschnitt aus Keycloak und verbinden ihn anschließend mit Studio-Read-Models.
-5. Keycloak-Objekte ohne Studio-Zuordnung bleiben als `unmapped` oder `manual_review` sichtbar.
-6. Mutierende Aktionen schreiben zuerst Keycloak, synchronisieren anschließend Studio-Read-Models und erzeugen Audit-Events.
+5. Keycloak-Rollen ohne technische Sonderrollenbedeutung bleiben als `keycloakRoles`, `unmapped` oder `manual_review` sichtbar, begründen aber keine fachliche Tenant-Autorisierung.
+6. Mutierende Rollenaktionen für normale Tenant-Rollen schreiben DB-only und erzeugen Audit-Events. Keycloak-Mutationen bleiben auf technische Sonderrollen, Identität und Credential-nahe Operationen begrenzt.
 7. Read-only- oder blockierte Objekte werden in der UI mit Diagnosecode angezeigt und serverseitig erneut vor der Mutation geprüft.
 
 Fehlerpfad:
 
 - Keycloak `403` wird als `IDP_FORBIDDEN` beziehungsweise `idp_forbidden` eingeordnet.
 - föderierte oder profilrichtliniengeschützte Felder werden als `read_only_federated_field` sichtbar und nicht überschrieben.
-- verbotene Rollenzuordnungen werden als `forbidden_role_mapping` sichtbar.
-- Built-in-Rollen bleiben als Rollenobjekt read-only, dürfen aber abhängig von der aktiven Rechte-Matrix zugewiesen oder entfernt werden.
+- verbotene technische Rollenzuordnungen werden als `forbidden_role_mapping` sichtbar.
+- Built-in- und Legacy-Keycloak-Rollen bleiben technische Diagnoseobjekte und dürfen nicht als tenantlokale Fachrollen materialisiert werden.
 
 ### Szenario 2b: Forced Reauth für einen Benutzer
 

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -116,7 +116,7 @@ gleichzeitig beeinflussen.
 
 - Mandantenisolation basiert auf kanonischem Scope `instanceId` als fachlichem String-Schlüssel (inkl. Mapping zu `workspace_id` in Logs)
 - Im tenant-spezifischen Login ist Host/Registry/Realm die führende Quelle für diesen Scope; ein fehlender benutzerbezogener `instanceId`-Claim blockiert die Session nicht.
-- Keycloak ist führend für Authentifizierung; Postgres ist führend für Studio-verwaltete IAM-Fachdaten
+- Keycloak ist führend für Authentifizierung, Realm-Zugang und technische Sonderrollen; Postgres ist führend für Studio-verwaltete IAM-Fachdaten inklusive tenantlokaler Rollen, Gruppen und Permissions
 - Autorisierungspfade erzwingen `instanceId`-Filterung vor Rollen-/Policy-Evaluation
 - Effektive Berechtigungen aggregieren direkte Nutzerrechte, direkte Rollen und gruppenvermittelte Rollen; die Provenance hält `direct_user`, `direct_role` und `group_role` als strukturierte Quelle fest
 - Rollen-Permission-Zuordnungen koennen fuer explizit scope-faehige Datensatzrechte zusaetzlich einen Assignment-Scope `all|own|organization` tragen; dieser Scope lebt auf `iam.role_permissions.access_scope` und nicht im generischen `iam.permissions.scope`
@@ -141,10 +141,10 @@ gleichzeitig beeinflussen.
   - Plattform-Scope: `iam.platform_activity_logs` + OTEL via Server-Runtime-Logger
 - Audit-Daten enthalten korrelierbare IDs (`request_id`, `trace_id`) und pseudonymisierte Actor-Referenzen
 - Der Root-Host ist ein expliziter Plattform-Scope und keine Pseudo-Instanz in `iam.instances`
-- Studio-verwaltete Rollen werden über `managed_by = 'studio'` und `instance_id` gegen fremdverwaltete Keycloak-Rollen abgegrenzt
+- Studio-verwaltete Rollen werden über `managed_by = 'studio'` und `instance_id` in der IAM-Datenbank abgegrenzt; Keycloak spiegelt tenantseitig nur die technische Sonderrolle `system_admin`
 - Keycloak bleibt von direkten Nutzerrechten fachlich entkoppelt; diese Konfiguration ist ausschließlich Studio-intern und wird nicht in den IdP gespiegelt
 - `role_key` ist die stabile technische Identität, `display_name` der editierbare UI-Name
-- Rollen-Alias-Mapping für erhöhte Berechtigungen (z. B. `Admin -> system_admin`) wird ausschließlich aus `realm_access` übernommen; `resource_access`-Rollen bleiben client-spezifisch und erhalten keine globalen Privileg-Aliasse
+- Rohe Keycloak-Rollen aus `realm_access` werden separat als `keycloakRoles` geführt; tenantseitige Fachautorisierung nutzt ausschließlich IAM-Rollen, Gruppen und Permissions. Nur der technische Tenant-Schnitt `system_admin` bleibt Keycloak-relevant.
 - Idempotency-Schlüssel für mutierende IAM-Endpoints sind mandantenspezifisch gescoped: (`instance_id`, `actor_account_id`, `endpoint`, `idempotency_key`)
 - Keycloak-Provisioning-Runs nutzen denselben kanonischen Header `Idempotency-Key`, aber einen plattformweiten Run-Scope aus (`instance_id`, `mutation`, `idempotency_key`); der gespeicherte Payload-Fingerprint basiert nur auf stabilen Request-Eingaben, nicht auf aus aktuellem Instanzzustand abgeleiteten Reconcile-Intents.
 - Inhalts-Schreibpfade folgen denselben Guardrails: CSRF-Header, Idempotency-Key bei Create, permission-basierte Freigabe (`content.read|create|update`) und revisionssichere History-Events
@@ -168,7 +168,7 @@ gleichzeitig beeinflussen.
 - Aktionshierarchien auf operativen Detailseiten verwenden genau eine Primäraktion im Überblick; Spezial- und Folgeaktionen werden sichtbar nachgeordnet gruppiert, damit Operatoren nicht mehrere gleichgewichtete Handlungsoptionen im Erstblick interpretieren müssen.
 - Dezente Motion auf der Instanz-Detailseite ist nur zulässig, wenn sie Blickführung, Statusfeedback oder Prozesszustände unterstützt; `prefers-reduced-motion`, Fokusindikatoren, Statuskontrast und Incident-Lesbarkeit haben stets Vorrang vor dekorativer Wirkung.
 - Root-/Plattform-Zugriff umfasst Instanz-Lifecycle, Provisioning, Platform-User, Platform-Rollen, Platform-Sync und explizites Break-Glass; tenantlokale Daten bleiben davon getrennt
-- User-, Rollen- und Rollenzuordnungsänderungen folgen einem Keycloak-first-Vertrag. Studio schreibt erst Keycloak, synchronisiert danach die lokalen Read-Models und macht Abweichungen über `mappingStatus`, `editability` und Diagnosecodes sichtbar.
+- User-Identity-Änderungen folgen weiter dem Keycloak-Admin-Vertrag. Rollen- und Rollenzuordnungsänderungen für normale Tenant-Rollen sind DB-only; Keycloak-Sync ist auf `system_admin`, `instance_registry_admin` und explizit technische Realm-Artefakte begrenzt.
 - `system_admin` bleibt die einzige geschützte tenantlokale Defaultrolle; frühere Standardrollen wie `app_manager`, `designer` oder `editor` gehören nicht mehr zum tenantlokalen Sollmodell, werden nicht mehr als Systemrollen behandelt und sind höchstens noch historische Altartefakte für explizite Migrations- und Repair-Pfade.
 - Tenant-Userlisten richten sich nach dem Tenant-Realm in Keycloak; ungemappte oder mehrdeutige Benutzer werden als `unmapped` beziehungsweise `manual_review` angezeigt.
 - Keycloak-Built-in-Rollen bleiben als Rollenobjekte read-only, werden aber in Listen nicht ausgeblendet.
@@ -324,6 +324,7 @@ gleichzeitig beeinflussen.
 - Ersatzbilder wie leere Rollen, UUID-Anzeigenamen oder `Ausstehend` sind nur zulässig, wenn der kanonische Projektionskern genau diesen Fachzustand liefert.
 - `IamHttpError` bleibt bis in die Browser-Schicht mit `classification`, `requestId` und `safeDetails` erhalten; relevante Klassen sind insbesondere `registry_or_provisioning_drift`, `keycloak_reconcile`, `auth_resolution`, `oidc_discovery_or_exchange`, `frontend_state_or_permission_staleness` und `legacy_workaround_or_regression`.
 - Reconcile- und Sync-Berichte serialisieren deterministische Abschlusszustände und Aggregationen statt impliziter Erfolgssignale.
+- Rollen-Reconcile materialisiert keine tenantlokalen Fachrollen mehr in Keycloak; technische Sonderrollen werden repariert, nicht-technische Keycloak-Rollen werden als Legacy-/Drift-Diagnose ausgewiesen.
 - Tenant-Admin-abhängige Mutationen arbeiten fail-closed gegen blockerrelevanten Drift; ein grüner Basis-Health-Status überschreibt diesen Befund nicht.
 
 ### Fortschreibung 2026-04: Tenant-IAM-Status als öffentlicher Diagnosekern

--- a/docs/architecture/iam-service-architektur.md
+++ b/docs/architecture/iam-service-architektur.md
@@ -51,7 +51,7 @@ Außerhalb des Scopes:
 | Verantwortung | Führendes System |
 | --- | --- |
 | Authentifizierung, Session-Einstieg, Token-Claims | Keycloak |
-| IAM-Fachdaten, Rollenkatalog, Zuordnungen, Audit | Postgres |
+| IAM-Fachdaten, tenantlokaler Rollenkatalog, Zuordnungen, Audit | Postgres |
 | Schnelle Laufzeitauflösung effektiver Rechte | Redis-Cache auf Basis Postgres |
 | Fachliche Autorisierungsentscheidung | IAM Permission Engine |
 
@@ -66,7 +66,7 @@ Außerhalb des Scopes:
 
 - Verwaltet Benutzerprofile, Rollenzuweisungen und Rollen-Lifecycle.
 - Nutzt eine IdP-Abstraktionsschicht für Keycloak-Admin-Operationen.
-- Führt schreibende Rollenoperationen Keycloak-first mit lokaler Persistenz und Compensation aus.
+- Führt normale tenantlokale Rollenoperationen DB-only aus; Keycloak-Mutationen bleiben auf technische Sonderrollen und Identity-nahe Operationen begrenzt.
 - Verwaltet fuer scope-faehige Datensatzrechte additive Rollen-Permission-Zuordnungen als `permissionAssignments[]` mit `accessScope`.
 
 ### 3. Permission Engine
@@ -174,15 +174,15 @@ Außerhalb des Scopes:
 
 - Keycloak bleibt System of Record für Authentifizierung.
 - Postgres bleibt System of Record für Studio-verwaltete IAM-Fachdaten.
-- Studioverwaltete Rollen werden über technische Merkmale eindeutig vom externen Realm-Bestand abgegrenzt.
+- Studioverwaltete Fachrollen werden in Postgres eindeutig vom externen Realm-Bestand abgegrenzt.
 
 ### Sync-Regeln
 
-- Schreibende Rollenoperationen laufen Keycloak-first.
-- Nach erfolgreichem IdP-Write wird das lokale Mapping aktualisiert.
-- Bei lokalem Folgefehler wird eine Compensation ausgelöst.
-- Reconcile-Läufe erkennen Drift und korrigieren nur den Managed-Scope.
-- Orphaned, studio-markierte Keycloak-Rollen werden standardmäßig report-only behandelt.
+- Schreibende Rollenoperationen für normale Tenant-Rollen laufen DB-only.
+- Technische Sonderrollen (`system_admin`, `instance_registry_admin`) dürfen gezielt in Keycloak abgeglichen werden.
+- Nach erfolgreichem technischem IdP-Write wird das lokale Mapping aktualisiert; bei lokalem Folgefehler wird eine Compensation ausgelöst.
+- Reconcile-Läufe erkennen Drift und korrigieren nur den technischen Managed-Scope.
+- Nicht-technische Keycloak-Rollen werden standardmäßig report-only als Legacy-/Drift-Diagnose behandelt.
 
 ## Cache- und Invalidierungsmodell
 

--- a/docs/guides/iam-service-api-dokumentation.md
+++ b/docs/guides/iam-service-api-dokumentation.md
@@ -144,15 +144,17 @@ Diese Anleitung beschreibt die aktuell stabilen IAM-v1-Endpunkte, Response-Envel
 - `tenant_admin_client_not_configured`
 - `internal_error`
 
-## Keycloak-first Admin-Vertrag
+## IAM-Admin-Vertrag mit begrenztem Keycloak-Rollenabgleich
 
-- Keycloak ist für Benutzer, Realm-Rollen und Rollenzuordnungen die führende Quelle. Studio mutiert zuerst Keycloak und synchronisiert danach die Studio-Read-Models.
+- Keycloak ist führend für Identität, Login, Realm-Zugang, Benutzerkonto und technische Sonderrollen. Tenantlokale Fachrollen, Gruppen und Permissions sind IAM-DB-kanonisch.
+- Der Keycloak-Rollenabgleich ist auf `system_admin` im Tenant-Scope und `instance_registry_admin` im Platform-Scope begrenzt. Normale Tenant-Rollen werden DB-only erstellt, geändert, gelöscht und zugewiesen.
+- `/auth/me` liefert getrennte Rollensichten: `roles` enthält kanonische IAM-Rollen inklusive gruppenabgeleiteter Rollen, `keycloakRoles` enthält rohe Keycloak-Rollen als technische Diagnose.
 - Root-/Platform-Scope nutzt ausschließlich den Platform-Admin-Keycloak-Client. Tenant-Scope nutzt ausschließlich den Tenant-Admin-Keycloak-Client der Instanz; ein Fallback auf Platform- oder globale Admin-Credentials ist nicht zulässig.
 - `user === null` im Frontend ist ein Loading-/Unknown-Zustand und darf keinen Platform-Scope auslösen.
 - `mappingStatus` hat die stabilen Werte `mapped`, `unmapped` und `manual_review`.
 - `editability` hat die stabilen Werte `editable`, `read_only` und `blocked`.
 - Objektbezogene Diagnosen werden als stabile Codes übertragen, zum Beispiel `missing_instance_attribute`, `mapping_missing`, `forbidden_role_mapping`, `read_only_federated_field` und `idp_forbidden`.
-- Sync- und Reconcile-Reports verwenden die Abschlusszustände `success`, `partial_failure`, `blocked` und `failed` und dürfen betroffene Objektlisten sowie Zähler additiv enthalten.
+- Sync- und Reconcile-Reports verwenden die Abschlusszustände `success`, `partial_failure`, `blocked` und `failed` und dürfen betroffene Objektlisten sowie Zähler additiv enthalten. Reconcile repariert nur technische Sonderrollen; nicht-technische Keycloak-Rollen werden als Legacy-/Drift-Diagnose oder `manual_review` gemeldet.
 - Keycloak-Fehler werden differenziert gemappt; insbesondere `403` aus Keycloak wird als IdP-Berechtigungsproblem (`IDP_FORBIDDEN` beziehungsweise API-Diagnose `idp_forbidden`) sichtbar.
 
 ## Wichtige Vertragszusagen fuer scoped Rollen-Permissions

--- a/docs/guides/keycloak-rollen-sync-runbook.md
+++ b/docs/guides/keycloak-rollen-sync-runbook.md
@@ -1,17 +1,17 @@
-# Keycloak-Rollen-Sync und Reconcile-Runbook
+# Keycloak-Sonderrollen-Sync und Reconcile-Runbook
 
 ## Zweck
 
-Dieses Runbook beschreibt den Betrieb des Studio-verwalteten Rollen-Katalog-Syncs zwischen `iam.roles` und Keycloak-Realm-Rollen.
+Dieses Runbook beschreibt den Betrieb des eng begrenzten Rollenabgleichs zwischen IAM und Keycloak. Keycloak wird nur noch für technische Sonderrollen abgeglichen; tenantlokale Fachrollen bleiben IAM-DB-kanonisch.
 
 ## Geltungsbereich
 
-- Source of Truth ist die IAM-Datenbank.
-- Synchronisiert werden nur studio-verwaltete Rollen mit `managed_by = 'studio'`.
-- Rollen mit `managed_by = 'external'` sind read-only und werden nicht in den Keycloak-Sync/Reconcile aufgenommen.
+- Source of Truth für tenantlokale Fachrollen ist die IAM-Datenbank.
+- Synchronisiert werden nur technische Sonderrollen: `system_admin` im Tenant-Kontext und `instance_registry_admin` im Plattform-Kontext.
+- Rollen mit `managed_by = 'external'` sowie normale fachliche Tenant-Rollen sind nicht Teil des Keycloak-Syncs.
 - Der technische Schlüssel `role_key` ist stabil und bleibt nach der Erstellung unverändert.
-- Der Anzeigename wird separat als `display_name` gepflegt und nach Keycloak als Attribut repliziert.
-- Orphaned Keycloak-Rollen werden im Reconcile-Lauf standardmäßig nur gemeldet (`report-only`), nicht automatisch gelöscht.
+- Der Anzeigename wird separat als `display_name` gepflegt. Für normale Tenant-Rollen bleibt diese Pflege DB-only.
+- Nicht-technische Keycloak-Rollen werden im Reconcile-Lauf nur als Legacy-/Drift-Diagnose gemeldet (`report-only`), nicht automatisch gelöscht oder in IAM importiert.
 
 ## Relevante Betriebsparameter
 
@@ -27,7 +27,7 @@ IAM_ROLE_RECONCILE_INSTANCE_IDS=<uuid-1>,<uuid-2>
 Wichtig:
 
 - `KEYCLOAK_ADMIN_REALM` ist nur der technische Token-Realm des Service-Accounts.
-- Der Rollen-Sync arbeitet pro `instance_id` gegen den in `iam.instances.authRealm` hinterlegten Ziel-Realm.
+- Der technische Sonderrollen-Sync arbeitet pro `instance_id` gegen den in `iam.instances.authRealm` hinterlegten Ziel-Realm.
 - Fehlt `authRealm` oder `authClientId` bei einer aktiven Instanz, muss der Lauf fail-closed behandelt und vor dem nächsten Reconcile korrigiert werden.
 
 Empfohlene Startwerte:
@@ -37,20 +37,22 @@ Empfohlene Startwerte:
 
 ## Normaler Betriebsablauf
 
-1. `POST /api/v1/iam/roles` legt zuerst die Realm-Rolle in Keycloak an und schreibt danach das DB-Mapping.
-2. `PATCH /api/v1/iam/roles/:id` aktualisiert zuerst Keycloak und dann das DB-Mapping.
-3. `DELETE /api/v1/iam/roles/:id` entfernt zuerst die Realm-Rolle in Keycloak und danach im Tenant alle direkten Benutzerzuordnungen (`iam.account_roles`), Gruppenzuordnungen (`iam.group_roles`) und die verbleibenden Rollen-Datensätze.
-4. Bei erfolgreichem Abschluss wird `sync_state = 'synced'` gesetzt.
+1. `POST /api/v1/iam/roles`, `PATCH /api/v1/iam/roles/:id` und `DELETE /api/v1/iam/roles/:id` für normale Tenant-Rollen schreiben ausschließlich die IAM-Datenbank.
+2. Technische Sonderrollenpfade stellen `system_admin` gezielt in Keycloak und IAM sicher.
+3. User-Create und User-Update persistieren fachliche Rollen in IAM und synchronisieren nach Keycloak nur die technische Teilmenge.
+4. Bei erfolgreichem Abschluss einer DB-only-Rollenmutation gilt der IAM-Zustand als abgeschlossen; es wird kein neuer Keycloak-Sync-State für fachliche Rollen eingeführt.
 5. Die Bestätigung in der Admin-UI warnt allgemein davor, dass vorhandene Benutzer- und Gruppenzuordnungen mit entfernt werden.
-6. Bei Fehlern setzt der Service `sync_state = 'failed'`, schreibt `last_error_code` und emittiert Audit-Events.
-7. Falls der synchrone Pfad nach erfolgreichem Keycloak-Schritt an der DB scheitert, läuft eine Compensation.
+6. Bei Fehlern im technischen Sonderrollenpfad setzt der Service `sync_state = 'failed'`, schreibt `last_error_code` und emittiert Audit-Events.
+7. Falls ein technischer Keycloak-Schritt erfolgreich war und der nachgelagerte IAM-Schritt scheitert, läuft eine Compensation.
 8. Idempotency für mutierende Endpunkte ist pro Mandant isoliert (`instance_id`, `actor_account_id`, `endpoint`, `idempotency_key`) und verhindert damit Kollisionen über Instanzgrenzen.
 
 ## Sync-Zustände
 
-- `synced`: DB und Keycloak sind konsistent, kein manueller Eingriff nötig.
-- `pending`: ein Write oder Reconcile-Lauf ist aktiv oder wurde begonnen.
-- `failed`: der letzte Sync-Versuch ist fehlgeschlagen; `last_error_code` bestimmt die Triage.
+- `synced`: technische Sonderrolle ist in DB und Keycloak konsistent, kein manueller Eingriff nötig.
+- `pending`: ein technischer Write oder Reconcile-Lauf ist aktiv oder wurde begonnen.
+- `failed`: der letzte technische Sync-Versuch ist fehlgeschlagen; `last_error_code` bestimmt die Triage.
+
+Für normale tenantlokale Fachrollen sind diese Zustände keine Keycloak-Wahrheit mehr.
 
 Häufige Fehlercodes:
 
@@ -73,12 +75,12 @@ Häufige Fehlercodes:
    - `reconcile`: letzter aggregierter Rollenabgleich aus `iam.roles` und `iam.activity_logs`
    - `overall`: verdichteter Operator-Befund mit Präzedenz `blocked` vor `degraded` vor `unknown` vor `ready`
 4. Falls `access = unknown`, zuerst die Aktion `Tenant-IAM-Zugriff prüfen` auslösen, bevor ein erneuter Reconcile-Lauf bewertet wird.
-5. `POST /api/v1/iam/admin/reconcile` als `system_admin` ausführen (wirkt auf die `instanceId` des authentifizierten Actors).
+5. `POST /api/v1/iam/admin/reconcile` als `system_admin` ausführen (wirkt auf die `instanceId` des authentifizierten Actors und repariert nur technische Sonderrollen).
 6. Ergebnis bewerten:
    - `corrected`: Drift wurde behoben.
    - `failed`: Korrekturversuch ist fehlgeschlagen; Ursache im Keycloak-/DB-Pfad analysieren.
-   - `requires_manual_action`: meist orphaned Keycloak-Rolle, manuelle Freigabe erforderlich.
-7. Bei orphaned Rollen vor einer Löschung immer Freigabe und Nutzungsprüfung dokumentieren.
+   - `requires_manual_action`: meist Legacy- oder orphaned-Keycloak-Rolle außerhalb des technischen Schnitts, manuelle Freigabe erforderlich.
+7. Bei Legacy- oder orphaned Rollen vor einer Löschung immer Freigabe und Nutzungsprüfung dokumentieren; eine fehlende fachliche IAM-Rolle in Keycloak ist kein Driftfehler.
 
 ## Repair-Pfad für Legacy-Admin-Artefakte
 
@@ -117,14 +119,14 @@ Leitplanken:
 ### Sync-Fehlerquote erhöht
 
 1. `iam_role_sync_operations_total` nach `operation`, `result` und `error_code` auswerten.
-2. Prüfen, ob die Fehler nur den `retry`-Pfad oder alle Write-Operationen betreffen.
+2. Prüfen, ob die Fehler nur technische Sonderrollenpfade betreffen. Retry-/Sync-Aktionen für nicht-technische Rollen sind erwartbar blockiert und kein Keycloak-Störfall.
 3. `iam_keycloak_request_duration_seconds` und `iam_circuit_breaker_state` parallel prüfen.
 4. Bei `IDP_FORBIDDEN` zuerst den Scope bestimmen:
    - Root-Host/Platform-Scope: Plattform-Service-Account und Plattform-Realm prüfen.
    - Tenant-Host/Instance-Scope: `tenantAdminClient.clientId`, Tenant-Admin-Client-Secret, Realm-Zuordnung und Rechte im Tenant-Realm prüfen.
 5. Bei Tenant-`IDP_FORBIDDEN` keinen Fallback auf globale Plattform-Credentials verwenden; stattdessen Tenant-Admin-Client über die Instanzverwaltung neu provisionieren, Secret rotieren oder den Tenant-Admin zurücksetzen.
 6. Die Rollenmatrix des betroffenen Service-Accounts gegen `docs/guides/keycloak-service-account-setup-iam.md` prüfen.
-7. Bei `DB_WRITE_FAILED` Postgres-Verfügbarkeit und Migration `0007_iam_role_catalog_sync.sql` verifizieren.
+7. Bei `DB_WRITE_FAILED` Postgres-Verfügbarkeit und die IAM-Rollenpersistenz verifizieren.
 
 ### Tenant-IAM-Access-Probe schlägt fehl
 
@@ -147,7 +149,7 @@ Leitplanken:
 2. Letzten geplanten oder manuellen Reconcile-Lauf im Log suchen (`operation = reconcile_roles` oder `reconcile_roles_scheduler`).
 3. Prüfen, ob nur `requires_manual_action` vorliegt oder echte `failed`-Einträge existieren.
 4. Bei `LEGACY_ADMIN_ARTIFACT_DRIFT` den Repair-Pfad für `admins` und `core_admin` aus diesem Runbook abarbeiten.
-5. Bei ausschließlich orphaned Rollen Freigabeprozess starten; bei fehlenden Rollen oder Metadatenabweichungen Reconcile erneut ausführen.
+5. Bei ausschließlich orphaned oder Legacy-Keycloak-Rollen Freigabeprozess starten. Nur bei fehlenden oder abweichenden technischen Sonderrollen Reconcile erneut ausführen.
 
 ## Audit- und Logging-Nachweise
 

--- a/docs/guides/keycloak-service-account-setup-iam.md
+++ b/docs/guides/keycloak-service-account-setup-iam.md
@@ -1,10 +1,10 @@
-# Keycloak Service-Account Setup für IAM-User- und Rollen-Management
+# Keycloak Service-Account Setup für IAM-User-Management und technische Sonderrollen
 
 ## Ziel
 
 Diese Anleitung beschreibt die minimale Keycloak-Konfiguration für den IAM-Service des SVA Studio (`sva-studio-iam-service`).
-Sie deckt sowohl User-Management als auch den Studio-verwalteten Rollen-Katalog-Sync nach Keycloak ab.
-Studio ist für Benutzer, Rollen und Rollenzuordnungen eine auditierte Admin-UI über Keycloak: Keycloak bleibt System of Record, Studio schreibt Keycloak-first und aktualisiert anschließend seine Read-Models.
+Sie deckt User-Management sowie den eng begrenzten Abgleich technischer Sonderrollen nach Keycloak ab.
+Keycloak bleibt System of Record für Identität, Login, Realm-Zugang und technische Sonderrollen. Tenantlokale Fachrollen, Gruppen, Permissions und Rollenzuordnungen sind IAM-DB-kanonisch und werden nicht mehr allgemein als Keycloak-Rollenkatalog gespiegelt.
 
 Der fachliche Sollzustand tenant-spezifischer Realms, inklusive `sva-studio`-Client, `instanceId`-Claim, Protocol Mappern und minimalen Tenant-Admin-Rollen, ist separat unter [Keycloak-Tenant-Realm-Bootstrap für Studio](./keycloak-tenant-realm-bootstrap.md) dokumentiert.
 Der vollständige Root-Host-Betriebspfad für Preflight, Plan und Provisioning-Läufe ist unter [Instanzverwaltung als Keycloak-Control-Plane](./instance-keycloak-provisioning.md) beschrieben.
@@ -33,10 +33,10 @@ Begründung und Scope:
 
 | Rolle | Erlaubte Operationen | Nicht damit begründete Operationen |
 | --- | --- | --- |
-| `manage-users` | User anlegen, aktualisieren, deaktivieren; Rollenzuweisungen an User schreiben | Realm-Rollenkatalog ändern |
+| `manage-users` | User anlegen, aktualisieren, deaktivieren; technische Sonderrollen gezielt an User schreiben | allgemeinen Realm-Rollenkatalog für fachliche Tenant-Rollen ändern |
 | `view-users` | User lesen, Detailansichten laden | Schreibzugriffe auf User oder Rollen |
 | `view-realm` | Realm-Metadaten und Rollenbestand lesen | Änderungen an Rollen, Clients oder Flows |
-| `manage-realm` | Studio-verwaltete Realm-Rollen anlegen, aktualisieren und löschen | Clients, Identity Provider oder Auth-Flows verwalten |
+| `manage-realm` | technische Sonderrollen wie `system_admin` im Tenant-Realm anlegen, aktualisieren und löschen | fachliche Tenant-Rollen, Clients, Identity Provider oder Auth-Flows verwalten |
 
 Explizit verboten:
 
@@ -51,8 +51,8 @@ Für Tenant-Hosts gilt zusätzlich:
 
 - Studio verwendet ausschließlich den in der Instanz-Registry hinterlegten Tenant-Admin-Client.
 - Ein fehlender Tenant-Admin-Client oder ein fehlendes Tenant-Admin-Secret führt fail-closed zu `tenant_admin_client_not_configured`.
-- Platform- oder globale Admin-Credentials dürfen tenantlokale User-, Rollen- oder Rollenzuordnungsoperationen nicht ersetzen.
-- Built-in-/Default-Rollen aus Keycloak dürfen sichtbar und abhängig von der Rechte-Matrix zuweisbar sein; ihre Rollenobjekte selbst bleiben read-only.
+- Platform- oder globale Admin-Credentials dürfen tenantlokale User- oder technische Rollenzuordnungsoperationen nicht ersetzen.
+- Fachliche Tenant-Rollen werden DB-only gepflegt. Built-in-, Default- und Legacy-Keycloak-Rollen dürfen sichtbar sein, bleiben aber technische Diagnose und keine normative Fachsicht.
 
 ## 3. Secret-Handling
 
@@ -74,7 +74,7 @@ KEYCLOAK_ADMIN_CLIENT_SECRET=<injected-via-secrets-manager>
 Wichtig:
 
 - `KEYCLOAK_ADMIN_REALM` bezeichnet nur den Realm, in dem der technische Service-Account sein Access-Token holt.
-- Der fachliche Ziel-Realm für User-, Rollen- und Provisioning-Operationen wird pro Instanz aus `iam.instances.authRealm` aufgelöst.
+- Der fachliche Ziel-Realm für User-, technische Sonderrollen- und Provisioning-Operationen wird pro Instanz aus `iam.instances.authRealm` aufgelöst.
 - Neue produktive Instanzen benötigen deshalb in der Registry mindestens `authRealm` und `authClientId`.
 
 Für den geplanten Reconcile-Lauf zusätzlich:
@@ -99,16 +99,16 @@ Die Rotation erfolgt spätestens alle 90 Tage (BSI-Grundschutz ORP.4) im Dual-Se
 
 1. Neues Secret erzeugen (`secret_v2`) und im Secrets-Manager als neue aktive Version hinterlegen.
 2. Deployment mit `secret_v2` ausrollen, `secret_v1` bleibt im Overlap-Fenster gültig.
-3. Funktionstest der IAM-Admin-Calls (`list users`, `create user`, `create role`, `reconcile roles`) durchführen.
+3. Funktionstest der IAM-Admin-Calls (`list users`, `create user`, technische `system_admin`-Zuweisung, `reconcile roles`) durchführen.
 4. Nach erfolgreicher Stabilitätsphase (`24h` empfohlen) `secret_v1` in Keycloak deaktivieren/löschen.
 5. Rotation mit Zeitstempel und Verantwortlichem im Betriebsprotokoll dokumentieren.
 
 ## 7. Operative Checks nach Setup/Rotation
 
 - IAM-Health-Check (`/health/ready`) meldet Keycloak als `healthy`.
-- `POST /api/v1/iam/roles`, `PATCH /api/v1/iam/roles/:id` und `DELETE /api/v1/iam/roles/:id` liefern keinen `keycloak_unavailable`-Fehler.
+- `POST /api/v1/iam/roles`, `PATCH /api/v1/iam/roles/:id` und `DELETE /api/v1/iam/roles/:id` für normale Tenant-Rollen laufen DB-only und dürfen keinen Keycloak-Admin-Call benötigen.
 - `POST /api/v1/iam/admin/reconcile` erzeugt keinen Berechtigungsfehler im Keycloak-Adapter.
 - `GET /api/v1/iam/users` listet im Tenant-Scope Keycloak-Benutzer auch dann, wenn die Studio-Zuordnung fehlt; solche Objekte müssen als `unmapped` oder `manual_review` sichtbar sein.
-- `GET /api/v1/iam/roles` zeigt Built-in-Rollen als read-only und enthält bei Drift stabile Diagnosecodes.
+- `GET /api/v1/iam/roles` zeigt IAM-Rollen als kanonische Fachsicht; Keycloak-Rollen erscheinen nur als technische Diagnose oder Driftcode.
 - Keine `401`/`403`-Fehler bei Keycloak-Admin-Aufrufen.
 - Keine Secrets oder Tokens in Logs; Audit-Events enthalten nur `workspace_id`, `operation`, `result`, `error_code?`, `request_id`, `trace_id?`, `span_id?`.

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/design.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/design.md
@@ -1,48 +1,48 @@
 ## Context
-Das Zielmodell fuer Plattform- und Tenant-Rollen ist bereits auf einen engen Sonderrollenschnitt reduziert worden. In der laufenden Spezifikation und Teilen der Runtime steckt aber noch die aeltere Annahme, dass studioverwaltete Rollen grundsaetzlich mit Keycloak-Realm-Rollen gespiegelt werden. Dadurch entstehen gleichzeitig mehrere Rollenbilder:
+Das Zielmodell für Plattform- und Tenant-Rollen ist bereits auf einen engen Sonderrollenschnitt reduziert worden. In der laufenden Spezifikation und Teilen der Runtime steckt aber noch die ältere Annahme, dass studioverwaltete Rollen grundsätzlich mit Keycloak-Realm-Rollen gespiegelt werden. Dadurch entstehen gleichzeitig mehrere Rollenbilder:
 
 - rohe Keycloak-Rollen in Session und `/auth/me`
 - kanonisch projizierte Rollen in IAM-Detail- und Profilansichten
-- effektive Permissions aus IAM-Rollen, Gruppen und Modulvertraegen
+- effektive Permissions aus IAM-Rollen, Gruppen und Modulverträgen
 
-Diese Mehrfachmodellierung ist nicht nur unuebersichtlich, sondern erzeugt auch unnötige Kopplung zwischen Login-System und fachlicher Autorisierung.
+Diese Mehrfachmodellierung ist nicht nur unübersichtlich, sondern erzeugt auch unnötige Kopplung zwischen Login-System und fachlicher Autorisierung.
 
 ## Goals / Non-Goals
 - Goals:
-  - Keycloak fuer fachliche Tenant-Rollen aus der normativen Autorisierung entfernen.
-  - Keycloak als Identitaets- und Realm-System fuer OIDC, Benutzerkonto und wenige technische Sonderrollen beibehalten.
+  - Keycloak für fachliche Tenant-Rollen aus der normativen Autorisierung entfernen.
+  - Keycloak als Identitäts- und Realm-System für OIDC, Benutzerkonto und wenige technische Sonderrollen beibehalten.
   - Session-, Guard- und UI-Projektionen auf eine kanonische tenantseitige Rollen- und Permission-Sicht ausrichten.
   - Legacy-Keycloak-Rollen in Bestands-Tenants sichtbar und reparierbar halten, ohne sie weiter als Sollmodell zu materialisieren.
-  - Den Umbau in kleinen, betriebssicheren Schritten durchfuehren.
+  - Den Umbau in kleinen, betriebssicheren Schritten durchführen.
 - Non-Goals:
-  - Kompletter Rueckbau saemtlicher Keycloak-Admin-Funktionalitaet in einem Schritt
-  - Abschaffung von Keycloak als Identitaetsprovider
-  - Vollstaendige Neumodellierung aller Governance-Rollen im selben Change
-  - Sofortige harte Loeschung historischer Keycloak-Rollen in Bestandsumgebungen
+  - Kompletter Rückbau sämtlicher Keycloak-Admin-Funktionalität in einem Schritt
+  - Abschaffung von Keycloak als Identitätsprovider
+  - Vollständige Neumodellierung aller Governance-Rollen im selben Change
+  - Sofortige harte Löschung historischer Keycloak-Rollen in Bestandsumgebungen
 
 ## Decisions
-- Decision: Keycloak bleibt System of Record fuer Identitaet, Login, Realm-Scope und technische Sonderrollen, aber nicht fuer tenantlokale Fachrollen.
+- Decision: Keycloak bleibt System of Record für Identität, Login, Realm-Scope und technische Sonderrollen, aber nicht für tenantlokale Fachrollen.
   - Why: Das trennt Authentifizierung sauber von fachlicher Autorisierung, ohne den OIDC- und Admin-Betrieb neu aufzubauen.
 - Decision: Tenantlokale Custom-Rollen und Gruppen werden normativ nur noch in der IAM-Datenbank gespeichert und ausgewertet.
-  - Why: Dort liegen bereits die fachlichen Permissions, Modulvertraege und effektiven Berechtigungsauflösungen.
-- Decision: `system_admin` bleibt tenantlokal die einzige geschuetzte Sonderrolle, die bei Bedarf auch technisch in Keycloak abbildbar bleibt.
-  - Why: Fuer Bootstrap, Zugriffsschutz und Letztadmin-Semantik braucht es weiterhin eine robuste Sonderrolle.
+  - Why: Dort liegen bereits die fachlichen Permissions, Modulverträge und effektiven Berechtigungsauflösungen.
+- Decision: `system_admin` bleibt tenantlokal die einzige geschützte Sonderrolle, die bei Bedarf auch technisch in Keycloak abbildbar bleibt.
+  - Why: Für Bootstrap, Zugriffsschutz und Letztadmin-Semantik braucht es weiterhin eine robuste Sonderrolle.
 - Decision: `instance_registry_admin` bleibt die einzige relevante Plattformrolle im Root-Realm.
   - Why: Damit bleibt die Plattformverwaltung eindeutig vom Tenant-Scope getrennt.
-- Decision: Rohrollen aus Keycloak duerfen in Session- oder Diagnoseobjekten weiterhin sichtbar sein, aber nicht mehr direkt als normative UI- oder Guard-Grundlage dienen.
-  - Why: Das erlaubt Kompatibilitaet und Drift-Diagnose waehrend der Uebergangsphase.
-- Decision: `/auth/me` und Session-Projektionen liefern zwei klar getrennte Rollensichten: kanonische IAM-Rollen (einschliesslich impliziter Rollenwirkung aus Gruppenzuordnungen) und rohe Keycloak-Rollen.
-  - Why: Damit bleiben Interop- und Diagnosefaelle sichtbar, waehrend Autorisierung strikt auf der kanonischen IAM-Sicht bleibt.
-- Decision: Der Umbau erfolgt in drei Betriebsphasen: Lesepfade umstellen, Schreib-/Sync-Pfade einengen, Legacy-Abhaengigkeiten tenantweise abbauen.
+- Decision: Rohrollen aus Keycloak dürfen in Session- oder Diagnoseobjekten weiterhin sichtbar sein, aber nicht mehr direkt als normative UI- oder Guard-Grundlage dienen.
+  - Why: Das erlaubt Kompatibilität und Drift-Diagnose während der Übergangsphase.
+- Decision: `/auth/me` und Session-Projektionen liefern zwei klar getrennte Rollensichten: kanonische IAM-Rollen (einschließlich impliziter Rollenwirkung aus Gruppenzuordnungen) und rohe Keycloak-Rollen.
+  - Why: Damit bleiben Interop- und Diagnosefälle sichtbar, während Autorisierung strikt auf der kanonischen IAM-Sicht bleibt.
+- Decision: Der Umbau erfolgt in drei Betriebsphasen: Lesepfade umstellen, Schreib-/Sync-Pfade einengen, Legacy-Abhängigkeiten tenantweise abbauen.
   - Why: So wird ein Big Bang vermieden.
 
 ## Risks / Trade-offs
 - Risiko: Bestehende UI- oder API-Gates verlassen sich noch indirekt auf rohe Keycloak-Rollen.
   - Mitigation: Erst Guard- und Projektionspfade auf kanonische IAM-Sicht umstellen und mit Diagnosefeldern absichern.
 - Risiko: Bestands-Tenants enthalten noch fachlich wirksame Keycloak-Rollen, die nach dem Umschalten unbemerkt Wirkung verlieren.
-  - Mitigation: Vor dem Abschalten des breiten Syncs tenantweise Drift-Berichte und Kompatibilitaetswarnungen bereitstellen.
-- Risiko: Profile, `/auth/me` und Admin-Ansichten zeigen fuer eine Uebergangszeit unterschiedliche Rollenbilder.
-  - Mitigation: Ein explizites Doppelfeld-Modell verwenden (kanonische IAM-Sicht inkl. Gruppenableitungen plus rohe Keycloak-Sicht), Guards und APIs aber ausschliesslich gegen die kanonische IAM-Sicht evaluieren.
+  - Mitigation: Vor dem Abschalten des breiten Syncs tenantweise Drift-Berichte und Kompatibilitätswarnungen bereitstellen.
+- Risiko: Profile, `/auth/me` und Admin-Ansichten zeigen für eine Übergangszeit unterschiedliche Rollenbilder.
+  - Mitigation: Ein explizites Doppelfeld-Modell verwenden (kanonische IAM-Sicht inkl. Gruppenableitungen plus rohe Keycloak-Sicht), Guards und APIs aber ausschließlich gegen die kanonische IAM-Sicht evaluieren.
 - Risiko: Technische Sonderrollen werden versehentlich mit allgemeinen Studio-Rollen verwechselt.
   - Mitigation: Managed-Scope, Sync-Pfade und UI-Beschriftungen explizit zwischen technischen Sonderrollen und tenantlokalen Fachrollen trennen.
 
@@ -52,11 +52,11 @@ Diese Mehrfachmodellierung ist nicht nur unuebersichtlich, sondern erzeugt auch 
    - Session-/`/auth/me`-Projektion
    - Route- und API-Gates
    - Profil- und Admin-UI
-3. Schreibpfade fuer tenantlokale Custom-Rollen auf IAM-only umstellen.
-4. Reconcile- und Drift-Pfade so aendern, dass Legacy-Keycloak-Rollen nur noch berichtet und nicht mehr neu materialisiert werden.
-5. Tenantweise Pruefung und Bereinigung von Altbestaenden.
+3. Schreibpfade für tenantlokale Custom-Rollen auf IAM-only umstellen.
+4. Reconcile- und Drift-Pfade so ändern, dass Legacy-Keycloak-Rollen nur noch berichtet und nicht mehr neu materialisiert werden.
+5. Tenantweise Prüfung und Bereinigung von Altbeständen.
 6. Nach erfolgreicher Stabilisierung breite Keycloak-Rollen-Synchronisierung aus dem Happy Path entfernen.
 
 ## Open Questions
-- Soll `system_admin` langfristig technisch in Keycloak erhalten bleiben oder spaeter ebenfalls rein aus IAM-Permissions abgeleitet werden?
-- Welche bestehenden Governance-Routen sollen kurzfristig noch ueber kanonische Rollen und welche bereits direkt ueber Permissions geoeffnet werden?
+- Soll `system_admin` langfristig technisch in Keycloak erhalten bleiben oder später ebenfalls rein aus IAM-Permissions abgeleitet werden?
+- Welche bestehenden Governance-Routen sollen kurzfristig noch über kanonische Rollen und welche bereits direkt über Permissions geöffnet werden?

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/design.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/design.md
@@ -1,0 +1,62 @@
+## Context
+Das Zielmodell fuer Plattform- und Tenant-Rollen ist bereits auf einen engen Sonderrollenschnitt reduziert worden. In der laufenden Spezifikation und Teilen der Runtime steckt aber noch die aeltere Annahme, dass studioverwaltete Rollen grundsaetzlich mit Keycloak-Realm-Rollen gespiegelt werden. Dadurch entstehen gleichzeitig mehrere Rollenbilder:
+
+- rohe Keycloak-Rollen in Session und `/auth/me`
+- kanonisch projizierte Rollen in IAM-Detail- und Profilansichten
+- effektive Permissions aus IAM-Rollen, Gruppen und Modulvertraegen
+
+Diese Mehrfachmodellierung ist nicht nur unuebersichtlich, sondern erzeugt auch unnötige Kopplung zwischen Login-System und fachlicher Autorisierung.
+
+## Goals / Non-Goals
+- Goals:
+  - Keycloak fuer fachliche Tenant-Rollen aus der normativen Autorisierung entfernen.
+  - Keycloak als Identitaets- und Realm-System fuer OIDC, Benutzerkonto und wenige technische Sonderrollen beibehalten.
+  - Session-, Guard- und UI-Projektionen auf eine kanonische tenantseitige Rollen- und Permission-Sicht ausrichten.
+  - Legacy-Keycloak-Rollen in Bestands-Tenants sichtbar und reparierbar halten, ohne sie weiter als Sollmodell zu materialisieren.
+  - Den Umbau in kleinen, betriebssicheren Schritten durchfuehren.
+- Non-Goals:
+  - Kompletter Rueckbau saemtlicher Keycloak-Admin-Funktionalitaet in einem Schritt
+  - Abschaffung von Keycloak als Identitaetsprovider
+  - Vollstaendige Neumodellierung aller Governance-Rollen im selben Change
+  - Sofortige harte Loeschung historischer Keycloak-Rollen in Bestandsumgebungen
+
+## Decisions
+- Decision: Keycloak bleibt System of Record fuer Identitaet, Login, Realm-Scope und technische Sonderrollen, aber nicht fuer tenantlokale Fachrollen.
+  - Why: Das trennt Authentifizierung sauber von fachlicher Autorisierung, ohne den OIDC- und Admin-Betrieb neu aufzubauen.
+- Decision: Tenantlokale Custom-Rollen und Gruppen werden normativ nur noch in der IAM-Datenbank gespeichert und ausgewertet.
+  - Why: Dort liegen bereits die fachlichen Permissions, Modulvertraege und effektiven Berechtigungsauflösungen.
+- Decision: `system_admin` bleibt tenantlokal die einzige geschuetzte Sonderrolle, die bei Bedarf auch technisch in Keycloak abbildbar bleibt.
+  - Why: Fuer Bootstrap, Zugriffsschutz und Letztadmin-Semantik braucht es weiterhin eine robuste Sonderrolle.
+- Decision: `instance_registry_admin` bleibt die einzige relevante Plattformrolle im Root-Realm.
+  - Why: Damit bleibt die Plattformverwaltung eindeutig vom Tenant-Scope getrennt.
+- Decision: Rohrollen aus Keycloak duerfen in Session- oder Diagnoseobjekten weiterhin sichtbar sein, aber nicht mehr direkt als normative UI- oder Guard-Grundlage dienen.
+  - Why: Das erlaubt Kompatibilitaet und Drift-Diagnose waehrend der Uebergangsphase.
+- Decision: `/auth/me` und Session-Projektionen liefern zwei klar getrennte Rollensichten: kanonische IAM-Rollen (einschliesslich impliziter Rollenwirkung aus Gruppenzuordnungen) und rohe Keycloak-Rollen.
+  - Why: Damit bleiben Interop- und Diagnosefaelle sichtbar, waehrend Autorisierung strikt auf der kanonischen IAM-Sicht bleibt.
+- Decision: Der Umbau erfolgt in drei Betriebsphasen: Lesepfade umstellen, Schreib-/Sync-Pfade einengen, Legacy-Abhaengigkeiten tenantweise abbauen.
+  - Why: So wird ein Big Bang vermieden.
+
+## Risks / Trade-offs
+- Risiko: Bestehende UI- oder API-Gates verlassen sich noch indirekt auf rohe Keycloak-Rollen.
+  - Mitigation: Erst Guard- und Projektionspfade auf kanonische IAM-Sicht umstellen und mit Diagnosefeldern absichern.
+- Risiko: Bestands-Tenants enthalten noch fachlich wirksame Keycloak-Rollen, die nach dem Umschalten unbemerkt Wirkung verlieren.
+  - Mitigation: Vor dem Abschalten des breiten Syncs tenantweise Drift-Berichte und Kompatibilitaetswarnungen bereitstellen.
+- Risiko: Profile, `/auth/me` und Admin-Ansichten zeigen fuer eine Uebergangszeit unterschiedliche Rollenbilder.
+  - Mitigation: Ein explizites Doppelfeld-Modell verwenden (kanonische IAM-Sicht inkl. Gruppenableitungen plus rohe Keycloak-Sicht), Guards und APIs aber ausschliesslich gegen die kanonische IAM-Sicht evaluieren.
+- Risiko: Technische Sonderrollen werden versehentlich mit allgemeinen Studio-Rollen verwechselt.
+  - Mitigation: Managed-Scope, Sync-Pfade und UI-Beschriftungen explizit zwischen technischen Sonderrollen und tenantlokalen Fachrollen trennen.
+
+## Migration Plan
+1. Spezifikation auf die neue Sync-Grenze ausrichten.
+2. Lesepfade vereinheitlichen:
+   - Session-/`/auth/me`-Projektion
+   - Route- und API-Gates
+   - Profil- und Admin-UI
+3. Schreibpfade fuer tenantlokale Custom-Rollen auf IAM-only umstellen.
+4. Reconcile- und Drift-Pfade so aendern, dass Legacy-Keycloak-Rollen nur noch berichtet und nicht mehr neu materialisiert werden.
+5. Tenantweise Pruefung und Bereinigung von Altbestaenden.
+6. Nach erfolgreicher Stabilisierung breite Keycloak-Rollen-Synchronisierung aus dem Happy Path entfernen.
+
+## Open Questions
+- Soll `system_admin` langfristig technisch in Keycloak erhalten bleiben oder spaeter ebenfalls rein aus IAM-Permissions abgeleitet werden?
+- Welche bestehenden Governance-Routen sollen kurzfristig noch ueber kanonische Rollen und welche bereits direkt ueber Permissions geoeffnet werden?

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/proposal.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/proposal.md
@@ -1,12 +1,12 @@
 # Change: Keycloak-Rollenabgleich auf technische Sonderrollen begrenzen
 
 ## Why
-Die bestehende Spezifikation beschreibt Keycloak weiterhin als System of Record fuer Realm-Rollen und fordert fuer studioverwaltete Rollen einen bidirektionalen Abgleich. Das widerspricht dem bereits normierten Zwei-Ebenen-Modell aus Plattformrolle `instance_registry_admin`, tenantlokaler Sonderrolle `system_admin` und sonstiger fachlicher Autorisierung aus der IAM-Datenbank. Solange fachliche Rollen parallel in Keycloak und in der IAM-Datenbank gepflegt werden, bleiben doppelte Wahrheiten, widerspruechliche UI-Projektionen und riskante Drift-Pfade bestehen.
+Die bestehende Spezifikation beschreibt Keycloak weiterhin als System of Record für Realm-Rollen und fordert für studioverwaltete Rollen einen bidirektionalen Abgleich. Das widerspricht dem bereits normierten Zwei-Ebenen-Modell aus Plattformrolle `instance_registry_admin`, tenantlokaler Sonderrolle `system_admin` und sonstiger fachlicher Autorisierung aus der IAM-Datenbank. Solange fachliche Rollen parallel in Keycloak und in der IAM-Datenbank gepflegt werden, bleiben doppelte Wahrheiten, widersprüchliche UI-Projektionen und riskante Drift-Pfade bestehen.
 
 ## What Changes
 - Begrenze den normativen Keycloak-Rollenabgleich auf technische Sonderrollen und Realm-Zugangskontrakte.
-- Definiere Keycloak fuer Rollen nicht mehr als generelle Quelle tenantlokaler Fachautorisierung.
-- Verlagere tenantlokale Custom-Rollen, Gruppen und deren Permissions vollstaendig in die IAM-Datenbank.
+- Definiere Keycloak für Rollen nicht mehr als generelle Quelle tenantlokaler Fachautorisierung.
+- Verlagere tenantlokale Custom-Rollen, Gruppen und deren Permissions vollständig in die IAM-Datenbank.
 - Stelle Session-, Guard- und Profilprojektionen auf kanonische IAM-Rollen und Permissions um, statt rohe Keycloak-Rollenlisten fachlich auszuwerten.
 - Liefere in `/auth/me` beide Sichten explizit getrennt aus: kanonische IAM-Rollen (inklusive impliziter Rollenwirkung aus Gruppenzuordnungen) und rohe Keycloak-Rollen als technische Sicht.
 - Erhalte Legacy-Keycloak-Rollen nur noch als Diagnose-, Drift- und Migrationsinput.

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/proposal.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/proposal.md
@@ -1,0 +1,36 @@
+# Change: Keycloak-Rollenabgleich auf technische Sonderrollen begrenzen
+
+## Why
+Die bestehende Spezifikation beschreibt Keycloak weiterhin als System of Record fuer Realm-Rollen und fordert fuer studioverwaltete Rollen einen bidirektionalen Abgleich. Das widerspricht dem bereits normierten Zwei-Ebenen-Modell aus Plattformrolle `instance_registry_admin`, tenantlokaler Sonderrolle `system_admin` und sonstiger fachlicher Autorisierung aus der IAM-Datenbank. Solange fachliche Rollen parallel in Keycloak und in der IAM-Datenbank gepflegt werden, bleiben doppelte Wahrheiten, widerspruechliche UI-Projektionen und riskante Drift-Pfade bestehen.
+
+## What Changes
+- Begrenze den normativen Keycloak-Rollenabgleich auf technische Sonderrollen und Realm-Zugangskontrakte.
+- Definiere Keycloak fuer Rollen nicht mehr als generelle Quelle tenantlokaler Fachautorisierung.
+- Verlagere tenantlokale Custom-Rollen, Gruppen und deren Permissions vollstaendig in die IAM-Datenbank.
+- Stelle Session-, Guard- und Profilprojektionen auf kanonische IAM-Rollen und Permissions um, statt rohe Keycloak-Rollenlisten fachlich auszuwerten.
+- Liefere in `/auth/me` beide Sichten explizit getrennt aus: kanonische IAM-Rollen (inklusive impliziter Rollenwirkung aus Gruppenzuordnungen) und rohe Keycloak-Rollen als technische Sicht.
+- Erhalte Legacy-Keycloak-Rollen nur noch als Diagnose-, Drift- und Migrationsinput.
+- Halte den Umbaupfad additiv: erst Lesepfade und Projektionen umstellen, dann Sync einschränken, zuletzt Legacy-Cleanup aktivieren.
+
+## Impact
+- Affected specs:
+  - `iam-core`
+  - `iam-access-control`
+  - `instance-provisioning`
+  - `account-ui`
+- Affected code:
+  - `packages/auth-runtime/src/*`
+  - `packages/iam-admin/src/*`
+  - `packages/data/src/iam/*`
+  - `packages/instance-registry/src/*`
+  - `apps/sva-studio-react/src/lib/*`
+  - `apps/sva-studio-react/src/routes/account/*`
+  - `apps/sva-studio-react/src/routes/admin/*`
+- Affected arc42 sections:
+  - `docs/architecture/04-solution-strategy.md`
+  - `docs/architecture/05-building-block-view.md`
+  - `docs/architecture/06-runtime-view.md`
+  - `docs/architecture/08-cross-cutting-concepts.md`
+  - `docs/architecture/09-architecture-decisions.md`
+  - `docs/architecture/10-quality-requirements.md`
+  - `docs/architecture/11-risks-and-technical-debt.md`

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/account-ui/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/account-ui/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+### Requirement: Rollenanzeigen nutzen eine kanonische Fachsicht
+Das System SHALL in Profil-, Session- und Tenant-Admin-Ansichten eine kanonische Rollen- und Permission-Sicht verwenden, statt rohe Keycloak-Rollenlisten als primaere Benutzerdarstellung auszugeben.
+
+#### Scenario: Account-Seite zeigt fachlich kanonische Rollen
+- **WHEN** ein authentifizierter Tenant-Benutzer `/account` aufruft
+- **THEN** zeigt die Seite die kanonischen tenantlokalen Rollen aus dem IAM-Modell an
+- **AND** umfasst diese kanonische Sicht auch implizite Rollenwirkung aus Gruppenzuordnungen
+- **AND** zeigt die Seite rohe Keycloak-Rollen in einer getrennten technischen Ansicht
+- **AND** werden technische oder Legacy-Rollen nicht unkommentiert als normale Fachrollen dargestellt
+
+#### Scenario: Admin-Ansicht unterscheidet kanonische Rollen von Rohrollen
+- **WHEN** eine Benutzer- oder Rollenansicht Diagnosedaten zu Auth oder Sync einblendet
+- **THEN** sind kanonische Tenant-Rollen und rohe Keycloak-Rollen klar getrennt beschriftet
+- **AND** bleibt fuer Administratoren erkennbar, welche Sicht fuer Autorisierung normativ ist
+
+## MODIFIED Requirements
+### Requirement: Protected-Route-Guard
+Das System MUST einen generischen Route-Guard bereitstellen, der Routen basierend auf Authentifizierungsstatus und der kanonischen tenantseitigen Rollen- oder Permission-Sicht schuetzt. Rohe Keycloak-Rollen duerfen nur dort direkt ausgewertet werden, wo eine ausdrueckliche technische Sonderrolle oder ein Plattform-Scope betroffen ist.
+
+#### Scenario: Unauthentifizierter Zugriff auf geschützte Route
+- **WHEN** ein nicht-authentifizierter Nutzer eine geschuetzte Route aufruft
+- **THEN** wird der Nutzer zur Login-Seite weitergeleitet
+- **AND** nach erfolgreicher Authentifizierung wird er zur urspruenglichen URL zurueckgeleitet
+
+#### Scenario: Authentifizierter Nutzer ohne ausreichende fachliche Autorisierung
+- **WHEN** ein authentifizierter Nutzer eine Route aufruft, fuer die eine bestimmte kanonische Rolle oder Permission erforderlich ist
+- **AND** der Nutzer diese fachliche Freigabe im IAM-Modell nicht besitzt
+- **THEN** wird der Nutzer auf die Startseite weitergeleitet
+- **AND** eine verstaendliche Fehlermeldung wird angezeigt (`t('auth.insufficientRole')`)
+
+#### Scenario: Admin-Route-Schutz folgt kanonischer Tenant-Sicht
+- **WHEN** die Route `/admin/users` aufgerufen wird
+- **THEN** prueft der Guard ueber den `routerContext`, ob der Nutzer die dafuer vorgesehene kanonische Tenant-Freigabe besitzt, etwa `system_admin` oder die entsprechende Verwaltungs-Permission
+- **AND** verlaesst sich diese Entscheidung nicht auf rohe Legacy-Keycloak-Rollen wie `app_manager`
+
+### Requirement: Account-Profilseite
+Das System MUST eine Account-Profilseite unter `/account` bereitstellen, auf der authentifizierte Nutzer ihre eigenen Basis-Daten einsehen und bearbeiten koennen.
+
+#### Scenario: Profil anzeigen
+- **WHEN** ein authentifizierter Nutzer `/account` aufruft
+- **THEN** werden Benutzername, Name, E-Mail, Telefon, Position, Abteilung, Sprache und Zeitzone angezeigt
+- **AND** die kanonischen Rollen und der Account-Status sind sichtbar (read-only)
+- **AND** eine getrennte technische Ansicht fuer rohe Keycloak-Rollen ist verfuegbar
+- **AND** ein Avatar oder Platzhalter-Bild wird angezeigt
+- **AND** die Seite zeigt einen Loading-State (`aria-busy="true"`) waehrend die Daten geladen werden
+- **AND** bei einem Ladefehler wird eine Fehlermeldung mit Retry-Button angezeigt
+
+#### Scenario: Basis-Daten bearbeiten
+- **WHEN** ein Nutzer seine Basis-Daten (Benutzername, Name, E-Mail, Telefon, Position, Abteilung, Sprache, Zeitzone) aendert
+- **AND** das Formular absendet
+- **THEN** werden die identitaetsbezogenen Aenderungen in der IAM-Datenbank und in Keycloak gespeichert
+- **AND** die Benutzerverwaltung zeigt bei der naechsten Datenladung den aktualisierten Anzeigenamen und die aktualisierte E-Mail
+- **AND** Aenderungen an Vor- und Nachname aktualisieren den `displayName`, sofern kein abweichender benutzerdefinierter Anzeigename gepflegt wurde
+- **AND** eine Erfolgsbestaetigung wird angezeigt (`role="status"`, `aria-live="polite"`)
+- **AND** der `AuthProvider`-State wird aktualisiert
+- **AND** der Fokus wird nach dem Speichern auf die Erfolgsbestaetigung gesetzt

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/account-ui/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/account-ui/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 ### Requirement: Rollenanzeigen nutzen eine kanonische Fachsicht
-Das System SHALL in Profil-, Session- und Tenant-Admin-Ansichten eine kanonische Rollen- und Permission-Sicht verwenden, statt rohe Keycloak-Rollenlisten als primaere Benutzerdarstellung auszugeben.
+Das System SHALL in Profil-, Session- und Tenant-Admin-Ansichten eine kanonische Rollen- und Permission-Sicht verwenden, statt rohe Keycloak-Rollenlisten als primäre Benutzerdarstellung auszugeben.
 
 #### Scenario: Account-Seite zeigt fachlich kanonische Rollen
 - **WHEN** ein authentifizierter Tenant-Benutzer `/account` aufruft
@@ -12,46 +12,46 @@ Das System SHALL in Profil-, Session- und Tenant-Admin-Ansichten eine kanonische
 #### Scenario: Admin-Ansicht unterscheidet kanonische Rollen von Rohrollen
 - **WHEN** eine Benutzer- oder Rollenansicht Diagnosedaten zu Auth oder Sync einblendet
 - **THEN** sind kanonische Tenant-Rollen und rohe Keycloak-Rollen klar getrennt beschriftet
-- **AND** bleibt fuer Administratoren erkennbar, welche Sicht fuer Autorisierung normativ ist
+- **AND** bleibt für Administratoren erkennbar, welche Sicht für Autorisierung normativ ist
 
 ## MODIFIED Requirements
 ### Requirement: Protected-Route-Guard
-Das System MUST einen generischen Route-Guard bereitstellen, der Routen basierend auf Authentifizierungsstatus und der kanonischen tenantseitigen Rollen- oder Permission-Sicht schuetzt. Rohe Keycloak-Rollen duerfen nur dort direkt ausgewertet werden, wo eine ausdrueckliche technische Sonderrolle oder ein Plattform-Scope betroffen ist.
+Das System MUST einen generischen Route-Guard bereitstellen, der Routen basierend auf Authentifizierungsstatus und der kanonischen tenantseitigen Rollen- oder Permission-Sicht schützt. Rohe Keycloak-Rollen dürfen nur dort direkt ausgewertet werden, wo eine ausdrückliche technische Sonderrolle oder ein Plattform-Scope betroffen ist.
 
 #### Scenario: Unauthentifizierter Zugriff auf geschützte Route
-- **WHEN** ein nicht-authentifizierter Nutzer eine geschuetzte Route aufruft
+- **WHEN** ein nicht-authentifizierter Nutzer eine geschützte Route aufruft
 - **THEN** wird der Nutzer zur Login-Seite weitergeleitet
-- **AND** nach erfolgreicher Authentifizierung wird er zur urspruenglichen URL zurueckgeleitet
+- **AND** nach erfolgreicher Authentifizierung wird er zur ursprünglichen URL zurückgeleitet
 
 #### Scenario: Authentifizierter Nutzer ohne ausreichende fachliche Autorisierung
-- **WHEN** ein authentifizierter Nutzer eine Route aufruft, fuer die eine bestimmte kanonische Rolle oder Permission erforderlich ist
+- **WHEN** ein authentifizierter Nutzer eine Route aufruft, für die eine bestimmte kanonische Rolle oder Permission erforderlich ist
 - **AND** der Nutzer diese fachliche Freigabe im IAM-Modell nicht besitzt
 - **THEN** wird der Nutzer auf die Startseite weitergeleitet
-- **AND** eine verstaendliche Fehlermeldung wird angezeigt (`t('auth.insufficientRole')`)
+- **AND** eine verständliche Fehlermeldung wird angezeigt (`t('auth.insufficientRole')`)
 
 #### Scenario: Admin-Route-Schutz folgt kanonischer Tenant-Sicht
 - **WHEN** die Route `/admin/users` aufgerufen wird
-- **THEN** prueft der Guard ueber den `routerContext`, ob der Nutzer die dafuer vorgesehene kanonische Tenant-Freigabe besitzt, etwa `system_admin` oder die entsprechende Verwaltungs-Permission
-- **AND** verlaesst sich diese Entscheidung nicht auf rohe Legacy-Keycloak-Rollen wie `app_manager`
+- **THEN** prüft der Guard über den `routerContext`, ob der Nutzer die dafür vorgesehene kanonische Tenant-Freigabe besitzt, etwa `system_admin` oder die entsprechende Verwaltungs-Permission
+- **AND** verlässt sich diese Entscheidung nicht auf rohe Legacy-Keycloak-Rollen wie `app_manager`
 
 ### Requirement: Account-Profilseite
-Das System MUST eine Account-Profilseite unter `/account` bereitstellen, auf der authentifizierte Nutzer ihre eigenen Basis-Daten einsehen und bearbeiten koennen.
+Das System MUST eine Account-Profilseite unter `/account` bereitstellen, auf der authentifizierte Nutzer ihre eigenen Basis-Daten einsehen und bearbeiten können.
 
 #### Scenario: Profil anzeigen
 - **WHEN** ein authentifizierter Nutzer `/account` aufruft
 - **THEN** werden Benutzername, Name, E-Mail, Telefon, Position, Abteilung, Sprache und Zeitzone angezeigt
 - **AND** die kanonischen Rollen und der Account-Status sind sichtbar (read-only)
-- **AND** eine getrennte technische Ansicht fuer rohe Keycloak-Rollen ist verfuegbar
+- **AND** eine getrennte technische Ansicht für rohe Keycloak-Rollen ist verfügbar
 - **AND** ein Avatar oder Platzhalter-Bild wird angezeigt
-- **AND** die Seite zeigt einen Loading-State (`aria-busy="true"`) waehrend die Daten geladen werden
+- **AND** die Seite zeigt einen Loading-State (`aria-busy="true"`) während die Daten geladen werden
 - **AND** bei einem Ladefehler wird eine Fehlermeldung mit Retry-Button angezeigt
 
 #### Scenario: Basis-Daten bearbeiten
-- **WHEN** ein Nutzer seine Basis-Daten (Benutzername, Name, E-Mail, Telefon, Position, Abteilung, Sprache, Zeitzone) aendert
+- **WHEN** ein Nutzer seine Basis-Daten (Benutzername, Name, E-Mail, Telefon, Position, Abteilung, Sprache, Zeitzone) ändert
 - **AND** das Formular absendet
-- **THEN** werden die identitaetsbezogenen Aenderungen in der IAM-Datenbank und in Keycloak gespeichert
-- **AND** die Benutzerverwaltung zeigt bei der naechsten Datenladung den aktualisierten Anzeigenamen und die aktualisierte E-Mail
-- **AND** Aenderungen an Vor- und Nachname aktualisieren den `displayName`, sofern kein abweichender benutzerdefinierter Anzeigename gepflegt wurde
-- **AND** eine Erfolgsbestaetigung wird angezeigt (`role="status"`, `aria-live="polite"`)
+- **THEN** werden die identitätsbezogenen Änderungen in der IAM-Datenbank und in Keycloak gespeichert
+- **AND** die Benutzerverwaltung zeigt bei der nächsten Datenladung den aktualisierten Anzeigenamen und die aktualisierte E-Mail
+- **AND** Änderungen an Vor- und Nachname aktualisieren den `displayName`, sofern kein abweichender benutzerdefinierter Anzeigename gepflegt wurde
+- **AND** eine Erfolgsbestätigung wird angezeigt (`role="status"`, `aria-live="polite"`)
 - **AND** der `AuthProvider`-State wird aktualisiert
-- **AND** der Fokus wird nach dem Speichern auf die Erfolgsbestaetigung gesetzt
+- **AND** der Fokus wird nach dem Speichern auf die Erfolgsbestätigung gesetzt

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-access-control/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-access-control/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+### Requirement: Tenant-Autorisierung wird normativ aus IAM-Rollen, Gruppen und Permissions abgeleitet
+Das System SHALL tenantlokale Autorisierungsentscheidungen normativ aus dem IAM-Datenmodell der aktiven Instanz ableiten. Rohrollen aus Keycloak duerfen tenantseitige Fachautorisierung nicht eigenstaendig begruenden.
+
+#### Scenario: Tenant-Gate ignoriert rohe Keycloak-Fachrolle ohne IAM-Wirkung
+- **WHEN** ein Benutzer in Keycloak eine historische oder externe Realm-Rolle besitzt, die im tenantlokalen IAM-Modell keiner wirksamen Rolle oder Permission entspricht
+- **THEN** gewaehrt ein Tenant-UI- oder API-Gate dadurch keinen fachlichen Zugriff
+- **AND** bleibt der Zugriff fail-closed auf die IAM-basierte Autorisierungsentscheidung beschraenkt
+
+#### Scenario: IAM-Permission wirkt ohne zusaetzliche Keycloak-Fachrolle
+- **WHEN** ein Benutzer im Tenant-Realm die erforderliche IAM-Rolle, Gruppenmitgliedschaft oder effektive Permission besitzt
+- **THEN** gewaehrt das System den vorgesehenen Tenant-Zugriff
+- **AND** verlangt dafuer keine zusaetzliche fachliche Keycloak-Realm-Rolle ausserhalb des normativen Sonderrollenschnitts
+
+### Requirement: Legacy-Keycloak-Rollen bleiben Diagnose- statt Normierungsquelle
+Das System SHALL historische oder externe Keycloak-Rollen fuer Tenant-Benutzer nur noch als Diagnose-, Drift- oder Interop-Artefakte behandeln, sofern sie nicht zu den ausdruecklich verwalteten Sonderrollen gehoeren.
+
+#### Scenario: Diagnose zeigt Legacy-Rolle ohne Fachwirkung
+- **WHEN** eine Analyse, Permissions-Uebersicht oder Reconcile-Ausgabe eine historische Keycloak-Rolle fuer einen Tenant-Benutzer findet
+- **THEN** kennzeichnet das System diese Rolle als Legacy-, externes oder technisches Artefakt
+- **AND** beschreibt ihre fehlende normative Fachwirkung eindeutig
+
+## MODIFIED Requirements
+### Requirement: Stabile Rollenidentität für Autorisierung und IdP-Sync
+Das System SHALL fuer Rollen einen stabilen technischen Schluessel (`role_key`) verwenden, der unabhaengig von UI-Anzeigenamen ist und fuer IAM-Autorisierungsaufloesung sowie verbleibende technische Interop- oder Sonderrollenpfade genutzt wird.
+
+#### Scenario: Anzeigename wird geändert
+- **WHEN** ein Admin den Anzeigenamen einer Custom-Rolle aendert
+- **THEN** bleibt der technische `role_key` unveraendert
+- **AND** bestehende Rollen-Zuweisungen und Berechtigungsaufloesungen bleiben gueltig
+- **AND** es entsteht keine neue Rolle durch Umbenennung
+
+#### Scenario: Rollenauflösung bleibt IAM-deterministisch
+- **WHEN** eine Rollen-Zuweisung fuer einen Benutzer ausgewertet wird
+- **THEN** nutzt die Access-Control-Aufloesung den stabilen `role_key` als Referenz
+- **AND** ist fuer tenantseitige Fachautorisierung nicht von Keycloak-Display-Metadaten oder einem allgemeinen Realm-Rollenabgleich abhaengig
+
+### Requirement: Managed Scope für externe Rollen
+Das System MUST bei Synchronisierung und Reconciliation strikt zwischen technisch verwalteten Sonderrollen, tenantlokalen IAM-Rollen und sonstigen externen Keycloak-Rollen unterscheiden.
+
+#### Scenario: Externe, nicht verwaltete Keycloak-Rolle
+- **WHEN** eine Rolle in Keycloak existiert, aber nicht zum technisch verwalteten Sonderrollen-Scope gehoert
+- **THEN** wird diese Rolle durch den Standard-Reconcile-Lauf nicht als normative tenantlokale Fachrolle behandelt
+- **AND** sie hat keine automatische Wirkung auf den Studio-Rollenkatalog
+- **AND** der Managed-Scope wird nicht mehr allgemein aus allen studioverwalteten Tenant-Rollen abgeleitet
+
+#### Scenario: Drift innerhalb des technischen Managed Scope
+- **WHEN** eine ausdruecklich verwaltete Sonderrolle im zustaendigen Realm von ihrem Sollzustand abweicht
+- **THEN** darf der Reconcile-Lauf die Abweichung gemaess Richtlinie korrigieren
+- **AND** die Korrektur wird mit `request_id` und Ergebnisstatus auditierbar protokolliert

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-access-control/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-access-control/spec.md
@@ -1,50 +1,50 @@
 ## ADDED Requirements
 ### Requirement: Tenant-Autorisierung wird normativ aus IAM-Rollen, Gruppen und Permissions abgeleitet
-Das System SHALL tenantlokale Autorisierungsentscheidungen normativ aus dem IAM-Datenmodell der aktiven Instanz ableiten. Rohrollen aus Keycloak duerfen tenantseitige Fachautorisierung nicht eigenstaendig begruenden.
+Das System SHALL tenantlokale Autorisierungsentscheidungen normativ aus dem IAM-Datenmodell der aktiven Instanz ableiten. Rohrollen aus Keycloak dürfen tenantseitige Fachautorisierung nicht eigenständig begründen.
 
 #### Scenario: Tenant-Gate ignoriert rohe Keycloak-Fachrolle ohne IAM-Wirkung
 - **WHEN** ein Benutzer in Keycloak eine historische oder externe Realm-Rolle besitzt, die im tenantlokalen IAM-Modell keiner wirksamen Rolle oder Permission entspricht
-- **THEN** gewaehrt ein Tenant-UI- oder API-Gate dadurch keinen fachlichen Zugriff
-- **AND** bleibt der Zugriff fail-closed auf die IAM-basierte Autorisierungsentscheidung beschraenkt
+- **THEN** gewährt ein Tenant-UI- oder API-Gate dadurch keinen fachlichen Zugriff
+- **AND** bleibt der Zugriff fail-closed auf die IAM-basierte Autorisierungsentscheidung beschränkt
 
-#### Scenario: IAM-Permission wirkt ohne zusaetzliche Keycloak-Fachrolle
+#### Scenario: IAM-Permission wirkt ohne zusätzliche Keycloak-Fachrolle
 - **WHEN** ein Benutzer im Tenant-Realm die erforderliche IAM-Rolle, Gruppenmitgliedschaft oder effektive Permission besitzt
-- **THEN** gewaehrt das System den vorgesehenen Tenant-Zugriff
-- **AND** verlangt dafuer keine zusaetzliche fachliche Keycloak-Realm-Rolle ausserhalb des normativen Sonderrollenschnitts
+- **THEN** gewährt das System den vorgesehenen Tenant-Zugriff
+- **AND** verlangt dafür keine zusätzliche fachliche Keycloak-Realm-Rolle außerhalb des normativen Sonderrollenschnitts
 
 ### Requirement: Legacy-Keycloak-Rollen bleiben Diagnose- statt Normierungsquelle
-Das System SHALL historische oder externe Keycloak-Rollen fuer Tenant-Benutzer nur noch als Diagnose-, Drift- oder Interop-Artefakte behandeln, sofern sie nicht zu den ausdruecklich verwalteten Sonderrollen gehoeren.
+Das System SHALL historische oder externe Keycloak-Rollen für Tenant-Benutzer nur noch als Diagnose-, Drift- oder Interop-Artefakte behandeln, sofern sie nicht zu den ausdrücklich verwalteten Sonderrollen gehören.
 
 #### Scenario: Diagnose zeigt Legacy-Rolle ohne Fachwirkung
-- **WHEN** eine Analyse, Permissions-Uebersicht oder Reconcile-Ausgabe eine historische Keycloak-Rolle fuer einen Tenant-Benutzer findet
+- **WHEN** eine Analyse, Permissions-Übersicht oder Reconcile-Ausgabe eine historische Keycloak-Rolle für einen Tenant-Benutzer findet
 - **THEN** kennzeichnet das System diese Rolle als Legacy-, externes oder technisches Artefakt
 - **AND** beschreibt ihre fehlende normative Fachwirkung eindeutig
 
 ## MODIFIED Requirements
 ### Requirement: Stabile Rollenidentität für Autorisierung und IdP-Sync
-Das System SHALL fuer Rollen einen stabilen technischen Schluessel (`role_key`) verwenden, der unabhaengig von UI-Anzeigenamen ist und fuer IAM-Autorisierungsaufloesung sowie verbleibende technische Interop- oder Sonderrollenpfade genutzt wird.
+Das System SHALL für Rollen einen stabilen technischen Schlüssel (`role_key`) verwenden, der unabhängig von UI-Anzeigenamen ist und für IAM-Autorisierungsauflösung sowie verbleibende technische Interop- oder Sonderrollenpfade genutzt wird.
 
 #### Scenario: Anzeigename wird geändert
-- **WHEN** ein Admin den Anzeigenamen einer Custom-Rolle aendert
-- **THEN** bleibt der technische `role_key` unveraendert
-- **AND** bestehende Rollen-Zuweisungen und Berechtigungsaufloesungen bleiben gueltig
+- **WHEN** ein Admin den Anzeigenamen einer Custom-Rolle ändert
+- **THEN** bleibt der technische `role_key` unverändert
+- **AND** bestehende Rollen-Zuweisungen und Berechtigungsauflösungen bleiben gültig
 - **AND** es entsteht keine neue Rolle durch Umbenennung
 
 #### Scenario: Rollenauflösung bleibt IAM-deterministisch
-- **WHEN** eine Rollen-Zuweisung fuer einen Benutzer ausgewertet wird
-- **THEN** nutzt die Access-Control-Aufloesung den stabilen `role_key` als Referenz
-- **AND** ist fuer tenantseitige Fachautorisierung nicht von Keycloak-Display-Metadaten oder einem allgemeinen Realm-Rollenabgleich abhaengig
+- **WHEN** eine Rollen-Zuweisung für einen Benutzer ausgewertet wird
+- **THEN** nutzt die Access-Control-Auflösung den stabilen `role_key` als Referenz
+- **AND** ist für tenantseitige Fachautorisierung nicht von Keycloak-Display-Metadaten oder einem allgemeinen Realm-Rollenabgleich abhängig
 
 ### Requirement: Managed Scope für externe Rollen
 Das System MUST bei Synchronisierung und Reconciliation strikt zwischen technisch verwalteten Sonderrollen, tenantlokalen IAM-Rollen und sonstigen externen Keycloak-Rollen unterscheiden.
 
 #### Scenario: Externe, nicht verwaltete Keycloak-Rolle
-- **WHEN** eine Rolle in Keycloak existiert, aber nicht zum technisch verwalteten Sonderrollen-Scope gehoert
+- **WHEN** eine Rolle in Keycloak existiert, aber nicht zum technisch verwalteten Sonderrollen-Scope gehört
 - **THEN** wird diese Rolle durch den Standard-Reconcile-Lauf nicht als normative tenantlokale Fachrolle behandelt
 - **AND** sie hat keine automatische Wirkung auf den Studio-Rollenkatalog
 - **AND** der Managed-Scope wird nicht mehr allgemein aus allen studioverwalteten Tenant-Rollen abgeleitet
 
 #### Scenario: Drift innerhalb des technischen Managed Scope
-- **WHEN** eine ausdruecklich verwaltete Sonderrolle im zustaendigen Realm von ihrem Sollzustand abweicht
-- **THEN** darf der Reconcile-Lauf die Abweichung gemaess Richtlinie korrigieren
+- **WHEN** eine ausdrücklich verwaltete Sonderrolle im zuständigen Realm von ihrem Sollzustand abweicht
+- **THEN** darf der Reconcile-Lauf die Abweichung gemäß Richtlinie korrigieren
 - **AND** die Korrektur wird mit `request_id` und Ergebnisstatus auditierbar protokolliert

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-core/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-core/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+### Requirement: Keycloak-Rollenabgleich ist auf technische Sonderrollen begrenzt
+Das System SHALL Keycloak-Rollen nur noch dort normativ verwalten oder abgleichen, wo sie fuer Plattform-Scope, Tenant-Bootstrap oder technische Realm-Vertraege erforderlich sind. Tenantlokale Fachrollen werden nicht mehr allgemein als Keycloak-Realm-Rollen materialisiert oder gepflegt.
+
+#### Scenario: Tenant-Custom-Rolle bleibt IAM-lokal
+- **WHEN** ein `system_admin` im Tenant-Realm eine editierbare Custom-Rolle erstellt, aendert oder loescht
+- **THEN** persistiert das System diese Mutation im tenantlokalen IAM-Rollenmodell
+- **AND** fuehrt dafuer keine allgemeine Keycloak-Realm-Rollenmutation aus
+- **AND** behandelt eine fehlende korrespondierende Keycloak-Rolle nicht als Drift des Sollmodells
+
+#### Scenario: Technische Sonderrolle bleibt synchronisierbar
+- **WHEN** der Bootstrap-, Repair- oder Schutzpfad die tenantlokale Sonderrolle `system_admin` oder die Plattformrolle `instance_registry_admin` prueft
+- **THEN** darf das System diese technische Sonderrolle weiterhin gezielt in Keycloak abgleichen
+- **AND** bleibt dieser Abgleich auf den jeweils zustaendigen Realm-Scope beschraenkt
+
+### Requirement: Kanonische Session-Projektion trennt technische und fachliche Rollen
+Das System SHALL fuer Session-, `/auth/me`- und Profilprojektionen zwischen rohen Keycloak-Rollen und der kanonischen fachlichen Rollen- und Permission-Sicht unterscheiden. Die kanonische Sicht umfasst direkte IAM-Rollen sowie implizite Rollenwirkung aus Gruppenzuordnungen.
+
+#### Scenario: Tenant-Session nutzt kanonische Fachsicht
+- **WHEN** ein Benutzer sich in einem Tenant-Realm erfolgreich anmeldet
+- **THEN** enthaelt die fachliche Session-Projektion die kanonischen tenantlokalen Rollen und Permissions aus IAM
+- **AND** enthaelt diese kanonische Sicht auch implizite Rollenwirkung aus IAM-Gruppenzuordnungen
+- **AND** werden rohe Keycloak-Rollen in einem getrennten Rollenfeld bereitgestellt
+- **AND** dienen rohe Keycloak-Rollen nicht direkt als normative Quelle fuer Tenant-UI oder Tenant-Gates
+
+#### Scenario: `/auth/me` liefert beide Rollensichten explizit getrennt
+- **WHEN** ein authentifizierter Tenant-Benutzer `/auth/me` aufruft
+- **THEN** liefert die Antwort eine kanonische IAM-Rollensicht inklusive gruppenabgeleiteter Rollenwirkung
+- **AND** liefert die Antwort zusaetzlich die rohe Keycloak-Rollensicht als technische Interop- und Diagnoseinformation
+- **AND** bleiben Autorisierungsentscheidungen auf die kanonische IAM-Sicht beschraenkt
+
+#### Scenario: Legacy-Keycloak-Rollen bleiben diagnostisch sichtbar
+- **WHEN** ein Tenant-Benutzer noch historische Keycloak-Rollen besitzt, die nicht mehr Teil des Sollmodells sind
+- **THEN** kann die Session- oder Diagnoseprojektion diese Rollen als Legacy- oder Rohdaten sichtbar machen
+- **AND** wertet das System sie nicht automatisch als wirksame fachliche Tenant-Rollen
+
+## MODIFIED Requirements
+### Requirement: Keycloak Admin API Integration
+Das System MUST ueber dedizierte Service-Accounts mit der Keycloak Admin REST API kommunizieren, um Benutzer, Identitaetsattribute, technische Realm-Artefakte und die wenigen normativ verbleibenden Sonderrollen im jeweiligen Platform- oder Tenant-Scope zu verwalten. Keycloak bleibt System of Record fuer Identitaeten, Login und technische Realm-Zugaenge; tenantlokale Fachrollen und deren Permissions werden normativ im Studio-IAM-Modell verwaltet.
+
+#### Scenario: Keycloak-first user mutation
+- **WHEN** ein berechtigter Admin einen User im Studio erstellt, deaktiviert oder Identitaets-/Profilfelder aendert
+- **THEN** fuehrt das System die identitaetsbezogene Mutation zuerst gegen Keycloak aus
+- **AND** synchronisiert anschliessend das Studio-Read-Model
+- **AND** direkte fachliche Tenant-Rollen werden dabei nicht als allgemeiner Keycloak-Rollenkatalog vorausgesetzt
+- **AND** bei nachgelagertem Sync-Fehler bleibt der Keycloak-Zustand sichtbar und wird als Drift gemeldet
+
+#### Scenario: Tenant-Rollenmutation bleibt fachlich im IAM-Modell
+- **WHEN** ein berechtigter Tenant-Admin eine fachliche Rolle oder deren Permissions aendert
+- **THEN** fuehrt das System die fachliche Mutation im IAM-Rollenmodell aus
+- **AND** ein technischer Keycloak-Call ist nur dann erforderlich, wenn ausdruecklich eine verbleibende Sonderrolle betroffen ist
+
+### Requirement: Keycloak User Synchronization Scope
+The system SHALL run Keycloak user synchronization as a reconciliation flow that explains differences between Keycloak and Studio instead of hiding unmapped or partially failed objects. The synchronization scope focuses on identities, scope resolution, technical realm access markers, and explicitly managed Sonderrollen rather than treating arbitrary Keycloak role catalogs as the normative source of tenant authorization.
+
+#### Scenario: Sync reports legacy role drift without reintroducing it
+- **WHEN** ein User-Sync Keycloak-Rollen findet, die ausserhalb des normativen Sonderrollenschnitts liegen
+- **THEN** enthaelt der Sync-Report diese Rollen als Legacy-, Interop- oder Driftbefund
+- **AND** das System projiziert sie nicht automatisch als kanonische tenantlokale Fachrollen
+
+#### Scenario: Partial failure remains actionable
+- **WHEN** ein Sync mit `partial_failure` endet
+- **THEN** enthaelt der Report objektbezogene Ursachen wie `missing_instance_attribute`, `forbidden_role_mapping`, `read_only_federated_field` oder `idp_forbidden`
+- **AND** Admins koennen daraus Reconcile- oder Runbook-Aktionen ableiten
+
+## REMOVED Requirements
+### Requirement: Studio-Rollen-Lebenszyklus mit Keycloak-Synchronisierung
+**Reason**: Tenantlokale Fachrollen sollen nicht mehr allgemein als Keycloak-Realm-Rollen gespiegelt werden.
+**Migration**: Rollen-CRUD fuer tenantlokale Custom-Rollen wird auf das IAM-Rollenmodell verlagert; nur technische Sonderrollen bleiben gezielt synchronisierbar.
+
+### Requirement: Deterministisches Role-Mapping und Sync-Status
+**Reason**: Ein allgemeines externes Keycloak-Mapping pro studioverwalteter Rolle ist nicht mehr Teil des Sollmodells.
+**Migration**: Mapping- und Sync-Zustaende bleiben nur dort erhalten, wo technische Sonderrollen oder explizite Interop-Artefakte weiterhin verwaltet werden.
+
+### Requirement: Reconciliation für Rollen-Drift
+**Reason**: Allgemeine Drift-Heilung zwischen IAM-Rollenbestand und Keycloak-Rollenbestand soll nicht mehr das tenantlokale Fachrollenmodell normieren.
+**Migration**: Reconcile-Pfade werden auf Identitaetsdrift, Sonderrollen und Legacy-Diagnose umgestellt; historische Keycloak-Rollen werden berichtet statt pauschal neu materialisiert.

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-core/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/iam-core/spec.md
@@ -1,33 +1,33 @@
 ## ADDED Requirements
 ### Requirement: Keycloak-Rollenabgleich ist auf technische Sonderrollen begrenzt
-Das System SHALL Keycloak-Rollen nur noch dort normativ verwalten oder abgleichen, wo sie fuer Plattform-Scope, Tenant-Bootstrap oder technische Realm-Vertraege erforderlich sind. Tenantlokale Fachrollen werden nicht mehr allgemein als Keycloak-Realm-Rollen materialisiert oder gepflegt.
+Das System SHALL Keycloak-Rollen nur noch dort normativ verwalten oder abgleichen, wo sie für Plattform-Scope, Tenant-Bootstrap oder technische Realm-Verträge erforderlich sind. Tenantlokale Fachrollen werden nicht mehr allgemein als Keycloak-Realm-Rollen materialisiert oder gepflegt.
 
 #### Scenario: Tenant-Custom-Rolle bleibt IAM-lokal
-- **WHEN** ein `system_admin` im Tenant-Realm eine editierbare Custom-Rolle erstellt, aendert oder loescht
+- **WHEN** ein `system_admin` im Tenant-Realm eine editierbare Custom-Rolle erstellt, ändert oder löscht
 - **THEN** persistiert das System diese Mutation im tenantlokalen IAM-Rollenmodell
-- **AND** fuehrt dafuer keine allgemeine Keycloak-Realm-Rollenmutation aus
+- **AND** führt dafür keine allgemeine Keycloak-Realm-Rollenmutation aus
 - **AND** behandelt eine fehlende korrespondierende Keycloak-Rolle nicht als Drift des Sollmodells
 
 #### Scenario: Technische Sonderrolle bleibt synchronisierbar
-- **WHEN** der Bootstrap-, Repair- oder Schutzpfad die tenantlokale Sonderrolle `system_admin` oder die Plattformrolle `instance_registry_admin` prueft
+- **WHEN** der Bootstrap-, Repair- oder Schutzpfad die tenantlokale Sonderrolle `system_admin` oder die Plattformrolle `instance_registry_admin` prüft
 - **THEN** darf das System diese technische Sonderrolle weiterhin gezielt in Keycloak abgleichen
-- **AND** bleibt dieser Abgleich auf den jeweils zustaendigen Realm-Scope beschraenkt
+- **AND** bleibt dieser Abgleich auf den jeweils zuständigen Realm-Scope beschränkt
 
 ### Requirement: Kanonische Session-Projektion trennt technische und fachliche Rollen
-Das System SHALL fuer Session-, `/auth/me`- und Profilprojektionen zwischen rohen Keycloak-Rollen und der kanonischen fachlichen Rollen- und Permission-Sicht unterscheiden. Die kanonische Sicht umfasst direkte IAM-Rollen sowie implizite Rollenwirkung aus Gruppenzuordnungen.
+Das System SHALL für Session-, `/auth/me`- und Profilprojektionen zwischen rohen Keycloak-Rollen und der kanonischen fachlichen Rollen- und Permission-Sicht unterscheiden. Die kanonische Sicht umfasst direkte IAM-Rollen sowie implizite Rollenwirkung aus Gruppenzuordnungen.
 
 #### Scenario: Tenant-Session nutzt kanonische Fachsicht
 - **WHEN** ein Benutzer sich in einem Tenant-Realm erfolgreich anmeldet
-- **THEN** enthaelt die fachliche Session-Projektion die kanonischen tenantlokalen Rollen und Permissions aus IAM
-- **AND** enthaelt diese kanonische Sicht auch implizite Rollenwirkung aus IAM-Gruppenzuordnungen
+- **THEN** enthält die fachliche Session-Projektion die kanonischen tenantlokalen Rollen und Permissions aus IAM
+- **AND** enthält diese kanonische Sicht auch implizite Rollenwirkung aus IAM-Gruppenzuordnungen
 - **AND** werden rohe Keycloak-Rollen in einem getrennten Rollenfeld bereitgestellt
-- **AND** dienen rohe Keycloak-Rollen nicht direkt als normative Quelle fuer Tenant-UI oder Tenant-Gates
+- **AND** dienen rohe Keycloak-Rollen nicht direkt als normative Quelle für Tenant-UI oder Tenant-Gates
 
 #### Scenario: `/auth/me` liefert beide Rollensichten explizit getrennt
 - **WHEN** ein authentifizierter Tenant-Benutzer `/auth/me` aufruft
 - **THEN** liefert die Antwort eine kanonische IAM-Rollensicht inklusive gruppenabgeleiteter Rollenwirkung
-- **AND** liefert die Antwort zusaetzlich die rohe Keycloak-Rollensicht als technische Interop- und Diagnoseinformation
-- **AND** bleiben Autorisierungsentscheidungen auf die kanonische IAM-Sicht beschraenkt
+- **AND** liefert die Antwort zusätzlich die rohe Keycloak-Rollensicht als technische Interop- und Diagnoseinformation
+- **AND** bleiben Autorisierungsentscheidungen auf die kanonische IAM-Sicht beschränkt
 
 #### Scenario: Legacy-Keycloak-Rollen bleiben diagnostisch sichtbar
 - **WHEN** ein Tenant-Benutzer noch historische Keycloak-Rollen besitzt, die nicht mehr Teil des Sollmodells sind
@@ -36,42 +36,42 @@ Das System SHALL fuer Session-, `/auth/me`- und Profilprojektionen zwischen rohe
 
 ## MODIFIED Requirements
 ### Requirement: Keycloak Admin API Integration
-Das System MUST ueber dedizierte Service-Accounts mit der Keycloak Admin REST API kommunizieren, um Benutzer, Identitaetsattribute, technische Realm-Artefakte und die wenigen normativ verbleibenden Sonderrollen im jeweiligen Platform- oder Tenant-Scope zu verwalten. Keycloak bleibt System of Record fuer Identitaeten, Login und technische Realm-Zugaenge; tenantlokale Fachrollen und deren Permissions werden normativ im Studio-IAM-Modell verwaltet.
+Das System MUST über dedizierte Service-Accounts mit der Keycloak Admin REST API kommunizieren, um Benutzer, Identitätsattribute, technische Realm-Artefakte und die wenigen normativ verbleibenden Sonderrollen im jeweiligen Platform- oder Tenant-Scope zu verwalten. Keycloak bleibt System of Record für Identitäten, Login und technische Realm-Zugänge; tenantlokale Fachrollen und deren Permissions werden normativ im Studio-IAM-Modell verwaltet.
 
 #### Scenario: Keycloak-first user mutation
-- **WHEN** ein berechtigter Admin einen User im Studio erstellt, deaktiviert oder Identitaets-/Profilfelder aendert
-- **THEN** fuehrt das System die identitaetsbezogene Mutation zuerst gegen Keycloak aus
-- **AND** synchronisiert anschliessend das Studio-Read-Model
+- **WHEN** ein berechtigter Admin einen User im Studio erstellt, deaktiviert oder Identitäts-/Profilfelder ändert
+- **THEN** führt das System die identitätsbezogene Mutation zuerst gegen Keycloak aus
+- **AND** synchronisiert anschließend das Studio-Read-Model
 - **AND** direkte fachliche Tenant-Rollen werden dabei nicht als allgemeiner Keycloak-Rollenkatalog vorausgesetzt
 - **AND** bei nachgelagertem Sync-Fehler bleibt der Keycloak-Zustand sichtbar und wird als Drift gemeldet
 
 #### Scenario: Tenant-Rollenmutation bleibt fachlich im IAM-Modell
-- **WHEN** ein berechtigter Tenant-Admin eine fachliche Rolle oder deren Permissions aendert
-- **THEN** fuehrt das System die fachliche Mutation im IAM-Rollenmodell aus
-- **AND** ein technischer Keycloak-Call ist nur dann erforderlich, wenn ausdruecklich eine verbleibende Sonderrolle betroffen ist
+- **WHEN** ein berechtigter Tenant-Admin eine fachliche Rolle oder deren Permissions ändert
+- **THEN** führt das System die fachliche Mutation im IAM-Rollenmodell aus
+- **AND** ein technischer Keycloak-Call ist nur dann erforderlich, wenn ausdrücklich eine verbleibende Sonderrolle betroffen ist
 
 ### Requirement: Keycloak User Synchronization Scope
 The system SHALL run Keycloak user synchronization as a reconciliation flow that explains differences between Keycloak and Studio instead of hiding unmapped or partially failed objects. The synchronization scope focuses on identities, scope resolution, technical realm access markers, and explicitly managed Sonderrollen rather than treating arbitrary Keycloak role catalogs as the normative source of tenant authorization.
 
 #### Scenario: Sync reports legacy role drift without reintroducing it
-- **WHEN** ein User-Sync Keycloak-Rollen findet, die ausserhalb des normativen Sonderrollenschnitts liegen
-- **THEN** enthaelt der Sync-Report diese Rollen als Legacy-, Interop- oder Driftbefund
+- **WHEN** ein User-Sync Keycloak-Rollen findet, die außerhalb des normativen Sonderrollenschnitts liegen
+- **THEN** enthält der Sync-Report diese Rollen als Legacy-, Interop- oder Driftbefund
 - **AND** das System projiziert sie nicht automatisch als kanonische tenantlokale Fachrollen
 
 #### Scenario: Partial failure remains actionable
 - **WHEN** ein Sync mit `partial_failure` endet
-- **THEN** enthaelt der Report objektbezogene Ursachen wie `missing_instance_attribute`, `forbidden_role_mapping`, `read_only_federated_field` oder `idp_forbidden`
-- **AND** Admins koennen daraus Reconcile- oder Runbook-Aktionen ableiten
+- **THEN** enthält der Report objektbezogene Ursachen wie `missing_instance_attribute`, `forbidden_role_mapping`, `read_only_federated_field` oder `idp_forbidden`
+- **AND** Admins können daraus Reconcile- oder Runbook-Aktionen ableiten
 
 ## REMOVED Requirements
 ### Requirement: Studio-Rollen-Lebenszyklus mit Keycloak-Synchronisierung
 **Reason**: Tenantlokale Fachrollen sollen nicht mehr allgemein als Keycloak-Realm-Rollen gespiegelt werden.
-**Migration**: Rollen-CRUD fuer tenantlokale Custom-Rollen wird auf das IAM-Rollenmodell verlagert; nur technische Sonderrollen bleiben gezielt synchronisierbar.
+**Migration**: Rollen-CRUD für tenantlokale Custom-Rollen wird auf das IAM-Rollenmodell verlagert; nur technische Sonderrollen bleiben gezielt synchronisierbar.
 
 ### Requirement: Deterministisches Role-Mapping und Sync-Status
 **Reason**: Ein allgemeines externes Keycloak-Mapping pro studioverwalteter Rolle ist nicht mehr Teil des Sollmodells.
-**Migration**: Mapping- und Sync-Zustaende bleiben nur dort erhalten, wo technische Sonderrollen oder explizite Interop-Artefakte weiterhin verwaltet werden.
+**Migration**: Mapping- und Sync-Zustände bleiben nur dort erhalten, wo technische Sonderrollen oder explizite Interop-Artefakte weiterhin verwaltet werden.
 
 ### Requirement: Reconciliation für Rollen-Drift
 **Reason**: Allgemeine Drift-Heilung zwischen IAM-Rollenbestand und Keycloak-Rollenbestand soll nicht mehr das tenantlokale Fachrollenmodell normieren.
-**Migration**: Reconcile-Pfade werden auf Identitaetsdrift, Sonderrollen und Legacy-Diagnose umgestellt; historische Keycloak-Rollen werden berichtet statt pauschal neu materialisiert.
+**Migration**: Reconcile-Pfade werden auf Identitätsdrift, Sonderrollen und Legacy-Diagnose umgestellt; historische Keycloak-Rollen werden berichtet statt pauschal neu materialisiert.

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/instance-provisioning/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/instance-provisioning/spec.md
@@ -1,29 +1,29 @@
 ## ADDED Requirements
 ### Requirement: Tenant-Bootstrap materialisiert keine allgemeinen Fachrollen in Keycloak
-Das System SHALL bei Tenant-Bootstrap, Repair und Reconcile in Keycloak nur die fuer Login, technische Realm-Vertraege und ausdruecklich verbleibende Sonderrollen noetigen Artefakte materialisieren. Tenantlokale Fachrollen werden nicht allgemein als Keycloak-Realm-Rollen nachgezogen.
+Das System SHALL bei Tenant-Bootstrap, Repair und Reconcile in Keycloak nur die für Login, technische Realm-Verträge und ausdrücklich verbleibende Sonderrollen nötigen Artefakte materialisieren. Tenantlokale Fachrollen werden nicht allgemein als Keycloak-Realm-Rollen nachgezogen.
 
 #### Scenario: Neuer Tenant bootstrappt nur technische Rollenartefakte
 - **WHEN** eine neue Instanz erfolgreich angelegt und der initiale Tenant-Admin gebootstrappt wird
-- **THEN** synchronisiert das System die fuer Login und Tenant-Administration erforderlichen Keycloak-Artefakte
+- **THEN** synchronisiert das System die für Login und Tenant-Administration erforderlichen Keycloak-Artefakte
 - **AND** kann es `system_admin` als technische Sonderrolle bereitstellen, wenn der Schutzpfad dies verlangt
-- **AND** erzeugt es keine allgemeinen tenantlokalen Fachrollen wie editierbare Custom-Rollen zusaetzlich in Keycloak
+- **AND** erzeugt es keine allgemeinen tenantlokalen Fachrollen wie editierbare Custom-Rollen zusätzlich in Keycloak
 
 #### Scenario: Reconcile heilt keine historischen Fachrollen in Keycloak neu
-- **WHEN** ein Bootstrap-, Repair- oder Reconcile-Pfad einen Bestands-Tenant mit historischen Keycloak-Fachrollen prueft
+- **WHEN** ein Bootstrap-, Repair- oder Reconcile-Pfad einen Bestands-Tenant mit historischen Keycloak-Fachrollen prüft
 - **THEN** darf das System diese Rollen als Legacy-Drift melden
 - **AND** materialisiert sie nicht erneut als Sollzustand des Tenant-Realm
 
 ## MODIFIED Requirements
 ### Requirement: Idempotenter Provisioning-Workflow
-Das System SHALL neue Instanzen ueber einen idempotenten Provisioning-Workflow anlegen, der technische Teilaufgaben und Teilfehler kontrolliert behandelt. Soweit der Workflow modulbezogene IAM-Basisartefakte oder deren Reparatur ableitet, verwendet er dafuer dieselbe gemeinsame Modul-IAM-Vertragsquelle wie Runtime und Diagnose. Tenantlokale Fachrollen werden dabei normativ im IAM-Modell und nicht als allgemeiner Keycloak-Rollenkatalog aufgebaut.
+Das System SHALL neue Instanzen über einen idempotenten Provisioning-Workflow anlegen, der technische Teilaufgaben und Teilfehler kontrolliert behandelt. Soweit der Workflow modulbezogene IAM-Basisartefakte oder deren Reparatur ableitet, verwendet er dafür dieselbe gemeinsame Modul-IAM-Vertragsquelle wie Runtime und Diagnose. Tenantlokale Fachrollen werden dabei normativ im IAM-Modell und nicht als allgemeiner Keycloak-Rollenkatalog aufgebaut.
 
 #### Scenario: Erfolgreiche Neuanlage einer Instanz
-- **WHEN** eine berechtigte Person eine neue Instanz mit gueltiger `instanceId` und gueltigem Ziel-Hostname anfordert
+- **WHEN** eine berechtigte Person eine neue Instanz mit gültiger `instanceId` und gültigem Ziel-Hostname anfordert
 - **THEN** legt das System einen Provisioning-Lauf an
-- **AND** erstellt oder reserviert die benoetigten Registry- und Basis-Konfigurationsartefakte
+- **AND** erstellt oder reserviert die benötigten Registry- und Basis-Konfigurationsartefakte
 - **AND** erzeugt oder validiert getrennt den Login-Client `authClientId` und den Tenant-Admin-Client `tenantAdminClient.clientId`
 - **AND** richtet die tenantlokale fachliche Rollen- und Permission-Basis im IAM-Modell aus
-- **AND** dokumentiert den Uebergang bis zum Status `active`
+- **AND** dokumentiert den Übergang bis zum Status `active`
 
 #### Scenario: Bootstrap seedet `system_admin` atomar im IAM-Modell
 - **WHEN** der Provisioning-Workflow einen neuen Tenant-Admin initialisiert

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/specs/instance-provisioning/spec.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/specs/instance-provisioning/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+### Requirement: Tenant-Bootstrap materialisiert keine allgemeinen Fachrollen in Keycloak
+Das System SHALL bei Tenant-Bootstrap, Repair und Reconcile in Keycloak nur die fuer Login, technische Realm-Vertraege und ausdruecklich verbleibende Sonderrollen noetigen Artefakte materialisieren. Tenantlokale Fachrollen werden nicht allgemein als Keycloak-Realm-Rollen nachgezogen.
+
+#### Scenario: Neuer Tenant bootstrappt nur technische Rollenartefakte
+- **WHEN** eine neue Instanz erfolgreich angelegt und der initiale Tenant-Admin gebootstrappt wird
+- **THEN** synchronisiert das System die fuer Login und Tenant-Administration erforderlichen Keycloak-Artefakte
+- **AND** kann es `system_admin` als technische Sonderrolle bereitstellen, wenn der Schutzpfad dies verlangt
+- **AND** erzeugt es keine allgemeinen tenantlokalen Fachrollen wie editierbare Custom-Rollen zusaetzlich in Keycloak
+
+#### Scenario: Reconcile heilt keine historischen Fachrollen in Keycloak neu
+- **WHEN** ein Bootstrap-, Repair- oder Reconcile-Pfad einen Bestands-Tenant mit historischen Keycloak-Fachrollen prueft
+- **THEN** darf das System diese Rollen als Legacy-Drift melden
+- **AND** materialisiert sie nicht erneut als Sollzustand des Tenant-Realm
+
+## MODIFIED Requirements
+### Requirement: Idempotenter Provisioning-Workflow
+Das System SHALL neue Instanzen ueber einen idempotenten Provisioning-Workflow anlegen, der technische Teilaufgaben und Teilfehler kontrolliert behandelt. Soweit der Workflow modulbezogene IAM-Basisartefakte oder deren Reparatur ableitet, verwendet er dafuer dieselbe gemeinsame Modul-IAM-Vertragsquelle wie Runtime und Diagnose. Tenantlokale Fachrollen werden dabei normativ im IAM-Modell und nicht als allgemeiner Keycloak-Rollenkatalog aufgebaut.
+
+#### Scenario: Erfolgreiche Neuanlage einer Instanz
+- **WHEN** eine berechtigte Person eine neue Instanz mit gueltiger `instanceId` und gueltigem Ziel-Hostname anfordert
+- **THEN** legt das System einen Provisioning-Lauf an
+- **AND** erstellt oder reserviert die benoetigten Registry- und Basis-Konfigurationsartefakte
+- **AND** erzeugt oder validiert getrennt den Login-Client `authClientId` und den Tenant-Admin-Client `tenantAdminClient.clientId`
+- **AND** richtet die tenantlokale fachliche Rollen- und Permission-Basis im IAM-Modell aus
+- **AND** dokumentiert den Uebergang bis zum Status `active`
+
+#### Scenario: Bootstrap seedet `system_admin` atomar im IAM-Modell
+- **WHEN** der Provisioning-Workflow einen neuen Tenant-Admin initialisiert
+- **THEN** seedet der Workflow die Sonderrolle `system_admin` idempotent im IAM-Modell und weist sie dem initialen Tenant-Admin zu
+- **AND** markiert der Workflow den Bootstrap nur dann als erfolgreich, wenn diese IAM-Seite erfolgreich abgeschlossen wurde
+- **AND** bleibt ein Teilfehler in diesem Schritt als wiederholbarer, diagnostizierbarer Fehlerzustand sichtbar

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/tasks.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/tasks.md
@@ -1,0 +1,34 @@
+## 1. Spezifikation und Vertragsgrenze
+- [x] 1.1 Bestehende OpenSpec-Annahmen entfernen, nach denen studioverwaltete Tenant-Rollen generell mit Keycloak-Realm-Rollen synchronisiert werden.
+- [x] 1.2 Die normative Trennung dokumentieren: Keycloak fuer Identitaet und technische Sonderrollen, IAM-Datenbank fuer fachliche Tenant-Rollen und Permissions.
+- [x] 1.3 Betroffene arc42-Abschnitte fuer die neue Verantwortungsgrenze referenzieren und spaeter aktualisieren (04, 05, 06, 08, 09, 10, 11).
+
+## 2. Lesepfade zuerst auf kanonische IAM-Sicht umstellen
+- [x] 2.0 Kanonisches Session-/`/auth/me`-Schema festlegen: getrennte Felder fuer IAM-Rollen (inkl. impliziter Rollen aus Gruppenzuordnungen) und rohe Keycloak-Rollen.
+- [x] 2.1 Session-, `/auth/me`- und Profilprojektionen auf das kanonische tenantseitige Rollen- und Permission-Modell ausrichten und beide Rollensichten konsistent befuellen.
+- [x] 2.2 Route-, Sidebar- und API-Gates von rohen Keycloak-Rollen entkoppeln und auf `system_admin`, Plattform-Scope oder explizite Permissions umstellen.
+- [x] 2.3 UI-Darstellungen fuer Rollen vereinheitlichen: kanonische IAM-Sicht als normative Fachsicht, rohe Keycloak-Rollen als getrennte technische Sicht.
+- [x] 2.4 Fruehe Verifikation fuer Phase 2 durchfuehren: `/auth/me`-Schema, Guard-Fail-Closed-Verhalten und Trennung der Rollensichten testen.
+
+## 3. Drift-Gate sowie Schreib- und Sync-Pfade einengen
+- [ ] 3.0 Drift-Berichte fuer aktive Tenants in der Zielumgebung ausfuehren und als Rollout-Freigabe fuer das Abschalten des breiten Rollenabgleichs dokumentieren.
+- [x] 3.1 Rollen-CRUD fuer tenantlokale Custom-Rollen auf IAM-only umstellen.
+- [x] 3.2 Keycloak-Rollenmutationen auf `instance_registry_admin`, `system_admin` und explizit technische Realm-Artefakte begrenzen.
+- [x] 3.3 Bestehende Reconcile-, Repair- und Bootstrap-Pfade im Code so anpassen, dass sie keine tenantlokalen Fachrollen mehr in Keycloak neu materialisieren; produktive Aktivierung bleibt an das Drift-Gate aus 3.0 gebunden.
+- [x] 3.4 Provisioning absichern: `system_admin` fuer neue Tenants idempotent im IAM-Modell seeden, bevor der Bootstrap-Lauf als erfolgreich gilt.
+
+## 4. Legacy-Kompatibilitaet und Migrationssicherheit
+- [x] 4.1 Legacy-Keycloak-Rollen in UI und Diagnose als Altbestand markieren statt als Sollmodell darzustellen.
+- [x] 4.2 Tenantweisen Bereinigungspfad dokumentieren, bevor breiter Rollenabgleich final entfernt wird.
+
+## 5. Verifikation, Tests und Dokumentation
+- [x] 5.1 Specs, Tests und Diagnosen fuer Session-Projektion, Guard-Verhalten, Rollen-CRUD und Reconcile an den neuen Grenzvertrag anpassen.
+- [x] 5.2 Verifizieren, dass `system_admin` tenantseitig voll funktionsfaehig bleibt, ohne zusaetzliche Keycloak-Fachrollen vorauszusetzen.
+- [x] 5.3 Verifizieren, dass Plattformpfade weiterhin ausschliesslich ueber `instance_registry_admin` funktionieren.
+- [x] 5.4 Architektur- und Betriebsdokumentation fuer den schrittweisen Umbaupfad aktualisieren.
+
+## 6. Rollout-Schritte nach Merge
+- [ ] 6.1 Drift-Bericht pro aktivem Tenant erzeugen und im Betriebs-/PR-Kontext ablegen.
+- [ ] 6.2 Pilot-Tenant nach dem neuen Vertrag betreiben und Login, `/auth/me`, Rollen-CRUD, User-Create/-Update und Reconcile smoke-testen.
+- [ ] 6.3 Legacy-Keycloak-Rollen tenantweise freigeben oder bereinigen; keine automatische Loeschung ohne Betriebsfreigabe.
+- [ ] 6.4 Nach erfolgreichem Pilot den breiten Keycloak-Rollenabgleich in weiteren Tenants stufenweise deaktivieren und Monitoring auf `manual_review`, `IDP_FORBIDDEN`, `IDP_UNAVAILABLE` und Drift-Backlog pruefen.

--- a/openspec/changes/refactor-keycloak-role-sync-boundary/tasks.md
+++ b/openspec/changes/refactor-keycloak-role-sync-boundary/tasks.md
@@ -1,34 +1,34 @@
 ## 1. Spezifikation und Vertragsgrenze
 - [x] 1.1 Bestehende OpenSpec-Annahmen entfernen, nach denen studioverwaltete Tenant-Rollen generell mit Keycloak-Realm-Rollen synchronisiert werden.
-- [x] 1.2 Die normative Trennung dokumentieren: Keycloak fuer Identitaet und technische Sonderrollen, IAM-Datenbank fuer fachliche Tenant-Rollen und Permissions.
-- [x] 1.3 Betroffene arc42-Abschnitte fuer die neue Verantwortungsgrenze referenzieren und spaeter aktualisieren (04, 05, 06, 08, 09, 10, 11).
+- [x] 1.2 Die normative Trennung dokumentieren: Keycloak für Identität und technische Sonderrollen, IAM-Datenbank für fachliche Tenant-Rollen und Permissions.
+- [x] 1.3 Betroffene arc42-Abschnitte für die neue Verantwortungsgrenze referenzieren und später aktualisieren (04, 05, 06, 08, 09, 10, 11).
 
 ## 2. Lesepfade zuerst auf kanonische IAM-Sicht umstellen
-- [x] 2.0 Kanonisches Session-/`/auth/me`-Schema festlegen: getrennte Felder fuer IAM-Rollen (inkl. impliziter Rollen aus Gruppenzuordnungen) und rohe Keycloak-Rollen.
-- [x] 2.1 Session-, `/auth/me`- und Profilprojektionen auf das kanonische tenantseitige Rollen- und Permission-Modell ausrichten und beide Rollensichten konsistent befuellen.
+- [x] 2.0 Kanonisches Session-/`/auth/me`-Schema festlegen: getrennte Felder für IAM-Rollen (inkl. impliziter Rollen aus Gruppenzuordnungen) und rohe Keycloak-Rollen.
+- [x] 2.1 Session-, `/auth/me`- und Profilprojektionen auf das kanonische tenantseitige Rollen- und Permission-Modell ausrichten und beide Rollensichten konsistent befüllen.
 - [x] 2.2 Route-, Sidebar- und API-Gates von rohen Keycloak-Rollen entkoppeln und auf `system_admin`, Plattform-Scope oder explizite Permissions umstellen.
-- [x] 2.3 UI-Darstellungen fuer Rollen vereinheitlichen: kanonische IAM-Sicht als normative Fachsicht, rohe Keycloak-Rollen als getrennte technische Sicht.
-- [x] 2.4 Fruehe Verifikation fuer Phase 2 durchfuehren: `/auth/me`-Schema, Guard-Fail-Closed-Verhalten und Trennung der Rollensichten testen.
+- [x] 2.3 UI-Darstellungen für Rollen vereinheitlichen: kanonische IAM-Sicht als normative Fachsicht, rohe Keycloak-Rollen als getrennte technische Sicht.
+- [x] 2.4 Frühe Verifikation für Phase 2 durchführen: `/auth/me`-Schema, Guard-Fail-Closed-Verhalten und Trennung der Rollensichten testen.
 
 ## 3. Drift-Gate sowie Schreib- und Sync-Pfade einengen
-- [ ] 3.0 Drift-Berichte fuer aktive Tenants in der Zielumgebung ausfuehren und als Rollout-Freigabe fuer das Abschalten des breiten Rollenabgleichs dokumentieren.
-- [x] 3.1 Rollen-CRUD fuer tenantlokale Custom-Rollen auf IAM-only umstellen.
+- [ ] 3.0 Drift-Berichte für aktive Tenants in der Zielumgebung ausführen und als Rollout-Freigabe für das Abschalten des breiten Rollenabgleichs dokumentieren.
+- [x] 3.1 Rollen-CRUD für tenantlokale Custom-Rollen auf IAM-only umstellen.
 - [x] 3.2 Keycloak-Rollenmutationen auf `instance_registry_admin`, `system_admin` und explizit technische Realm-Artefakte begrenzen.
 - [x] 3.3 Bestehende Reconcile-, Repair- und Bootstrap-Pfade im Code so anpassen, dass sie keine tenantlokalen Fachrollen mehr in Keycloak neu materialisieren; produktive Aktivierung bleibt an das Drift-Gate aus 3.0 gebunden.
-- [x] 3.4 Provisioning absichern: `system_admin` fuer neue Tenants idempotent im IAM-Modell seeden, bevor der Bootstrap-Lauf als erfolgreich gilt.
+- [x] 3.4 Provisioning absichern: `system_admin` für neue Tenants idempotent im IAM-Modell seeden, bevor der Bootstrap-Lauf als erfolgreich gilt.
 
-## 4. Legacy-Kompatibilitaet und Migrationssicherheit
+## 4. Legacy-Kompatibilität und Migrationssicherheit
 - [x] 4.1 Legacy-Keycloak-Rollen in UI und Diagnose als Altbestand markieren statt als Sollmodell darzustellen.
 - [x] 4.2 Tenantweisen Bereinigungspfad dokumentieren, bevor breiter Rollenabgleich final entfernt wird.
 
 ## 5. Verifikation, Tests und Dokumentation
-- [x] 5.1 Specs, Tests und Diagnosen fuer Session-Projektion, Guard-Verhalten, Rollen-CRUD und Reconcile an den neuen Grenzvertrag anpassen.
-- [x] 5.2 Verifizieren, dass `system_admin` tenantseitig voll funktionsfaehig bleibt, ohne zusaetzliche Keycloak-Fachrollen vorauszusetzen.
-- [x] 5.3 Verifizieren, dass Plattformpfade weiterhin ausschliesslich ueber `instance_registry_admin` funktionieren.
-- [x] 5.4 Architektur- und Betriebsdokumentation fuer den schrittweisen Umbaupfad aktualisieren.
+- [x] 5.1 Specs, Tests und Diagnosen für Session-Projektion, Guard-Verhalten, Rollen-CRUD und Reconcile an den neuen Grenzvertrag anpassen.
+- [x] 5.2 Verifizieren, dass `system_admin` tenantseitig voll funktionsfähig bleibt, ohne zusätzliche Keycloak-Fachrollen vorauszusetzen.
+- [x] 5.3 Verifizieren, dass Plattformpfade weiterhin ausschließlich über `instance_registry_admin` funktionieren.
+- [x] 5.4 Architektur- und Betriebsdokumentation für den schrittweisen Umbaupfad aktualisieren.
 
 ## 6. Rollout-Schritte nach Merge
 - [ ] 6.1 Drift-Bericht pro aktivem Tenant erzeugen und im Betriebs-/PR-Kontext ablegen.
 - [ ] 6.2 Pilot-Tenant nach dem neuen Vertrag betreiben und Login, `/auth/me`, Rollen-CRUD, User-Create/-Update und Reconcile smoke-testen.
-- [ ] 6.3 Legacy-Keycloak-Rollen tenantweise freigeben oder bereinigen; keine automatische Loeschung ohne Betriebsfreigabe.
-- [ ] 6.4 Nach erfolgreichem Pilot den breiten Keycloak-Rollenabgleich in weiteren Tenants stufenweise deaktivieren und Monitoring auf `manual_review`, `IDP_FORBIDDEN`, `IDP_UNAVAILABLE` und Drift-Backlog pruefen.
+- [ ] 6.3 Legacy-Keycloak-Rollen tenantweise freigeben oder bereinigen; keine automatische Löschung ohne Betriebsfreigabe.
+- [ ] 6.4 Nach erfolgreichem Pilot den breiten Keycloak-Rollenabgleich in weiteren Tenants stufenweise deaktivieren und Monitoring auf `manual_review`, `IDP_FORBIDDEN`, `IDP_UNAVAILABLE` und Drift-Backlog prüfen.

--- a/packages/auth-runtime/src/auth-route-handlers.test.ts
+++ b/packages/auth-runtime/src/auth-route-handlers.test.ts
@@ -5,6 +5,7 @@ type SessionUser = {
   id: string;
   instanceId?: string;
   roles: string[];
+  permissionStatus?: 'ok' | 'degraded';
   assignedModules?: string[];
   groups?: readonly IamUserGroupAssignment[];
 };
@@ -12,6 +13,13 @@ type SessionUser = {
 type EffectivePermission = {
   action: string;
   effect: string;
+};
+
+type AuthMePermissionPayload = {
+  user: {
+    permissionActions: string[];
+    permissionStatus: string;
+  };
 };
 
 const mocks = vi.hoisted(() => {
@@ -147,6 +155,25 @@ vi.mock('./audit-events.js', () => ({
   emitAuthAuditEvent: vi.fn(),
 }));
 
+const createAuthMeRequest = () => new Request('http://localhost/auth/me', { headers: { cookie: 'sva_session=session-1' } });
+
+const readAuthMePermissionPayload = async (response: Response): Promise<AuthMePermissionPayload> =>
+  (await response.json()) as AuthMePermissionPayload;
+
+const mockAuthenticatedSessionUserOnce = (user: SessionUser) => {
+  mocks.withAuthenticatedUser.mockImplementationOnce(
+    async (
+      _request: Request,
+      handler: (ctx: { user: SessionUser; sessionExpiresAt?: number; sessionId: string }) => Promise<Response>
+    ) =>
+      handler({
+        user,
+        sessionExpiresAt: 1_800_000_000_000,
+        sessionId: 'session-1',
+      })
+  );
+};
+
 describe('meHandler', () => {
   let meHandler: typeof import('./auth-route-handlers.js').meHandler;
 
@@ -226,7 +253,7 @@ describe('meHandler', () => {
   });
 
   it('returns no-store auth headers and deny-dominant permissionActions', async () => {
-    const response = await meHandler(new Request('http://localhost/auth/me', { headers: { cookie: 'sva_session=session-1' } }));
+    const response = await meHandler(createAuthMeRequest());
 
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toContain('application/json');
@@ -315,15 +342,9 @@ describe('meHandler', () => {
   });
 
   it('skips permission lookup and returns empty permissionActions when user has no instanceId', async () => {
-    mocks.withAuthenticatedUser.mockImplementationOnce(
-      async (
-        _request: Request,
-        handler: (ctx: { user: Omit<SessionUser, 'instanceId'>; sessionExpiresAt?: number; sessionId: string }) => Promise<Response>
-      ) =>
-        handler({ user: { id: 'kc-no-instance', roles: [] }, sessionExpiresAt: 1_800_000_000_000, sessionId: 'session-1' })
-    );
+    mockAuthenticatedSessionUserOnce({ id: 'kc-no-instance', roles: [] });
 
-    const response = await meHandler(new Request('http://localhost/auth/me', { headers: { cookie: 'sva_session=session-1' } }));
+    const response = await meHandler(createAuthMeRequest());
 
     expect(response.status).toBe(200);
     expect(mocks.resolveEffectivePermissions).not.toHaveBeenCalled();
@@ -351,7 +372,7 @@ describe('meHandler', () => {
       expect.objectContaining({ reason_code: 'permission_snapshot_unavailable' })
     );
 
-    const payload = (await response.json()) as { user: { permissionStatus: string; permissionActions: string[] } };
+    const payload = await readAuthMePermissionPayload(response);
     expect(payload.user.permissionStatus).toBe('degraded');
     expect(payload.user.permissionActions).toEqual([]);
   });
@@ -361,7 +382,7 @@ describe('meHandler', () => {
 
     mocks.resolveEffectivePermissions.mockRejectedValueOnce(new Error('Connection refused'));
 
-    const response = await meHandler(new Request('http://localhost/auth/me', { headers: { cookie: 'sva_session=session-1' } }));
+    const response = await meHandler(createAuthMeRequest());
 
     expect(response.status).toBe(200);
     expect(mocks.logger.error).toHaveBeenCalledWith(
@@ -369,8 +390,26 @@ describe('meHandler', () => {
       expect.objectContaining({ reason_code: 'permission_action_lookup_failed', error_type: 'Error' })
     );
 
-    const payload = (await response.json()) as { user: { permissionStatus: string } };
+    const payload = await readAuthMePermissionPayload(response);
     expect(payload.user.permissionStatus).toBe('degraded');
+  });
+
+  it('preserves degraded session permissionStatus when permission lookup succeeds', async () => {
+    mockAuthenticatedSessionUserOnce({
+      id: 'kc-user-1',
+      instanceId: 'de-test',
+      roles: [],
+      permissionStatus: 'degraded',
+    });
+
+    const response = await meHandler(createAuthMeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.resolveEffectivePermissions).toHaveBeenCalled();
+
+    const payload = await readAuthMePermissionPayload(response);
+    expect(payload.user.permissionStatus).toBe('degraded');
+    expect(payload.user.permissionActions).toEqual(['events.read']);
   });
 
   it('skips permissions with non-string action values', async () => {

--- a/packages/auth-runtime/src/auth-route-handlers.ts
+++ b/packages/auth-runtime/src/auth-route-handlers.ts
@@ -976,23 +976,27 @@ const createAuthMeResponse = (
   user: Record<string, unknown>,
   resolution: AuthMeResolution,
   expiresAt?: number
-) =>
-  new Response(
+) => {
+  const permissionStatus =
+    user.permissionStatus === 'degraded' || resolution.permissionStatus === 'degraded' ? 'degraded' : 'ok';
+
+  return new Response(
     JSON.stringify({
       ...(typeof expiresAt === 'number' ? { expiresAt } : {}),
       user: {
-      ...user,
-      assignedModules: resolution.assignedModules,
-      groups: resolution.groups,
-      permissionActions: resolution.permissionActions,
-      permissionStatus: resolution.permissionStatus,
-    },
+        ...user,
+        assignedModules: resolution.assignedModules,
+        groups: resolution.groups,
+        permissionActions: resolution.permissionActions,
+        permissionStatus,
+      },
     }),
     {
       status: 200,
       headers: createAuthMeHeaders(),
     }
   );
+};
 
 const resolveLoginRequestContext = async (request?: Request) => {
   const url = request ? new URL(request.url) : null;

--- a/packages/auth-runtime/src/auth-server/session.test.ts
+++ b/packages/auth-runtime/src/auth-server/session.test.ts
@@ -178,6 +178,31 @@ describe('auth server session resolution', () => {
     expect(state.getSessionControlState).toHaveBeenCalledTimes(2);
   });
 
+  it('treats tenant sessions with empty canonical IAM roles as complete', async () => {
+    const userWithoutHydratedRoles: SessionUser = {
+      id: 'user-1',
+      instanceId: 'tenant-a',
+      roles: [],
+      keycloakRoles: ['legacy_editor'],
+    };
+    state.getSession.mockResolvedValue(
+      createSession({ user: userWithoutHydratedRoles, expiresAt: 100_000 })
+    );
+
+    const { resolveSessionUser } = await import('./session.js');
+
+    await expect(resolveSessionUser('session-1')).resolves.toMatchObject({
+      kind: 'authenticated',
+      user: userWithoutHydratedRoles,
+    });
+    expect(state.buildSessionUser).not.toHaveBeenCalled();
+    expect(state.updateSession).not.toHaveBeenCalled();
+    expect(state.logger.warn).not.toHaveBeenCalledWith(
+      'Session user is missing required IAM context',
+      expect.anything()
+    );
+  });
+
   it('deletes disallowed sessions when control state invalidates them', async () => {
     state.getSession.mockResolvedValue(createSession({ sessionVersion: 1 }));
     state.getSessionControlState.mockResolvedValue({ minimumSessionVersion: 2 });

--- a/packages/auth-runtime/src/auth-server/session.ts
+++ b/packages/auth-runtime/src/auth-server/session.ts
@@ -15,8 +15,11 @@ const logger = createSdkLogger({ component: 'iam-auth', level: 'info' });
 const shouldRefreshSession = (expiresAt: number | undefined): boolean =>
   typeof expiresAt === 'number' && expiresAt <= Date.now() + TOKEN_REFRESH_SKEW_MS;
 
-const needsSessionUserHydration = (user: SessionUser | null | undefined): boolean =>
-  !user?.instanceId || user.roles.length === 0;
+const needsSessionUserHydration = (
+  user: SessionUser | null | undefined,
+  scope?: RuntimeScopeRef
+): boolean =>
+  !user?.id || (scope?.kind === 'instance' && user.instanceId !== scope.instanceId);
 
 export type SessionResolutionFailureReason =
   | 'invalid_session'
@@ -70,7 +73,7 @@ const logIncompleteSessionUser = (
     ? { kind: 'instance', instanceId: user.instanceId }
     : undefined
 ) => {
-  if (!needsSessionUserHydration(user)) {
+  if (!needsSessionUserHydration(user, scope)) {
     return;
   }
 
@@ -88,7 +91,7 @@ const hydrateSessionUserFromAccessToken = async (
   sessionId: string,
   session: { user?: SessionUser; accessToken?: string; auth?: Session['auth'] }
 ): Promise<SessionUser | null> => {
-  if (!session.accessToken || !needsSessionUserHydration(session.user)) {
+  if (!session.accessToken || !needsSessionUserHydration(session.user, session.auth)) {
     return session.user ?? null;
   }
 
@@ -102,7 +105,7 @@ const hydrateSessionUserFromAccessToken = async (
     scope: session.auth,
   });
 
-  if (!hydratedUser.id || needsSessionUserHydration(hydratedUser)) {
+  if (needsSessionUserHydration(hydratedUser, session.auth)) {
     logIncompleteSessionUser(session.user, 'access_token_hydrate', session.auth);
     return session.user ?? null;
   }
@@ -184,7 +187,7 @@ export const resolveSessionUser = async (sessionId: string): Promise<SessionReso
 
   if (!shouldRefreshSession(session.expiresAt)) {
     const user = await hydrateSessionUserFromAccessToken(sessionId, session);
-    logIncompleteSessionUser(user, 'session_read');
+    logIncompleteSessionUser(user, 'session_read', session.auth);
     const result = {
       kind: 'authenticated',
       user,

--- a/packages/auth-runtime/src/auth-server/shared.test.ts
+++ b/packages/auth-runtime/src/auth-server/shared.test.ts
@@ -36,11 +36,30 @@ describe('auth-server shared helpers', () => {
     ).toMatchObject({
       id: 'user-1',
       instanceId: 'instance-from-token',
+      roles: [],
+      keycloakRoles: ['viewer'],
       username: 'alice',
       email: 'alice@example.org',
       firstName: 'Alice',
       lastName: 'Example',
       displayName: 'Alice Example',
+    });
+  });
+
+  it('keeps only the platform technical role in canonical platform roles', () => {
+    expect(
+      buildSessionUser({
+        claims: {
+          sub: 'platform-admin',
+          realm_access: { roles: ['instance_registry_admin', 'system_admin', 'legacy_role'] },
+        },
+        clientId: 'sva-studio',
+        scope: { kind: 'platform' },
+      })
+    ).toMatchObject({
+      id: 'platform-admin',
+      roles: ['instance_registry_admin'],
+      keycloakRoles: ['instance_registry_admin', 'system_admin', 'legacy_role'],
     });
   });
 

--- a/packages/auth-runtime/src/auth-server/shared.ts
+++ b/packages/auth-runtime/src/auth-server/shared.ts
@@ -1,4 +1,5 @@
 import { extractRoles, parseJwtPayload, resolveInstanceId } from '@sva/core';
+import { filterPlatformTechnicalKeycloakRoleNames } from '@sva/iam-admin';
 
 import { TenantScopeConflictError } from '../runtime-errors.js';
 import type { RuntimeScopeRef, SessionUser } from '../types.js';
@@ -17,6 +18,7 @@ export const buildSessionUser = (input: {
   const accessTokenClaims = input.accessToken ? parseJwtPayload(input.accessToken) : null;
   const claims = { ...accessTokenClaims, ...input.claims };
   const roleClaims = accessTokenClaims ?? input.claims;
+  const keycloakRoles = extractRoles(roleClaims, input.clientId);
   const preferredUsername = readClaimString(claims, 'preferred_username');
   const username = readClaimString(claims, 'username');
   const tokenInstanceIds = [accessTokenClaims, input.claims]
@@ -43,7 +45,8 @@ export const buildSessionUser = (input: {
   return {
     id: String(claims.sub ?? ''),
     instanceId: scopedInstanceId,
-    roles: extractRoles(roleClaims, input.clientId),
+    roles: input.scope?.kind === 'platform' ? [...filterPlatformTechnicalKeycloakRoleNames(keycloakRoles)] : [],
+    keycloakRoles,
     username: preferredUsername ?? username,
     email: readClaimString(claims, 'email'),
     firstName: readClaimString(claims, 'given_name'),

--- a/packages/auth-runtime/src/effective-session-roles.test.ts
+++ b/packages/auth-runtime/src/effective-session-roles.test.ts
@@ -16,7 +16,7 @@ vi.mock('@sva/server-runtime', () => ({
 }));
 
 describe('effective session roles', () => {
-  it('merges direct and group-derived IAM roles into the session user', async () => {
+  it('uses direct and group-derived IAM roles as the canonical session roles', async () => {
     const { enrichSessionUserWithEffectiveRoles } = await import('./effective-session-roles.js');
     const withResolvedInstanceDb = vi.fn(
       async (
@@ -39,7 +39,8 @@ describe('effective session roles', () => {
     const user: SessionUser = {
       id: 'kc-user-1',
       instanceId: 'de-musterhausen',
-      roles: ['custom_editor', 'custom_curator'],
+      roles: ['legacy_keycloak_role', 'custom_curator'],
+      keycloakRoles: ['legacy_keycloak_role'],
     };
 
     await expect(
@@ -49,7 +50,7 @@ describe('effective session roles', () => {
       })
     ).resolves.toEqual({
       ...user,
-      roles: ['custom_editor', 'custom_curator', 'system_admin'],
+      roles: ['system_admin', 'custom_curator'],
     });
   });
 

--- a/packages/auth-runtime/src/effective-session-roles.test.ts
+++ b/packages/auth-runtime/src/effective-session-roles.test.ts
@@ -54,7 +54,7 @@ describe('effective session roles', () => {
     });
   });
 
-  it('keeps the session user unchanged when role hydration fails', async () => {
+  it('fails closed and marks permissions degraded when role hydration fails', async () => {
     const { enrichSessionUserWithEffectiveRoles } = await import('./effective-session-roles.js');
     const user: SessionUser = {
       id: 'kc-user-1',
@@ -69,7 +69,11 @@ describe('effective session roles', () => {
           throw new Error('db unavailable');
         }),
       })
-    ).resolves.toBe(user);
+    ).resolves.toEqual({
+      ...user,
+      roles: [],
+      permissionStatus: 'degraded',
+    });
 
     expect(loggerState.warn).toHaveBeenCalledWith(
       'Effective IAM role hydration failed for session user',

--- a/packages/auth-runtime/src/effective-session-roles.ts
+++ b/packages/auth-runtime/src/effective-session-roles.ts
@@ -120,6 +120,10 @@ export const enrichSessionUserWithEffectiveRoles = async (
       error: error instanceof Error ? error.message : String(error),
       ...buildLogContext({ kind: 'instance', instanceId }),
     });
-    return user;
+    return {
+      ...user,
+      roles: [],
+      permissionStatus: 'degraded',
+    };
   }
 };

--- a/packages/auth-runtime/src/effective-session-roles.ts
+++ b/packages/auth-runtime/src/effective-session-roles.ts
@@ -100,7 +100,7 @@ export const enrichSessionUserWithEffectiveRoles = async (
           keycloakSubject: user.id,
         })
     );
-    const mergedRoles = normalizeRoleNames([...user.roles, ...persistedRoleNames]);
+    const mergedRoles = normalizeRoleNames([...persistedRoleNames]);
 
     if (
       mergedRoles.length === user.roles.length &&

--- a/packages/auth-runtime/src/iam-account-management/profile-handlers.ts
+++ b/packages/auth-runtime/src/iam-account-management/profile-handlers.ts
@@ -341,19 +341,16 @@ const resolveProjectedProfileDetail = async (input: {
     resolveProjectedMainserverCredentialState(input.user.keycloakSubject, input.instanceId),
   ]);
 
-  const projectedDetail = await withInstanceScopedDb(input.instanceId, (client) =>
-    applyCanonicalUserDetailProjection({
-      client,
-      instanceId: input.instanceId,
-      user: input.user,
-      keycloakRoleNames:
-        keycloakRoleNamesResult.status === 'fulfilled' ? keycloakRoleNamesResult.value : null,
-      mainserverCredentialState:
-        mainserverCredentialStateResult.status === 'fulfilled'
-          ? mainserverCredentialStateResult.value
-          : DEFAULT_MAINSERVER_CREDENTIAL_STATE,
-    })
-  );
+  const projectedDetail = await applyCanonicalUserDetailProjection({
+    instanceId: input.instanceId,
+    user: input.user,
+    keycloakRoleNames:
+      keycloakRoleNamesResult.status === 'fulfilled' ? keycloakRoleNamesResult.value : null,
+    mainserverCredentialState:
+      mainserverCredentialStateResult.status === 'fulfilled'
+        ? mainserverCredentialStateResult.value
+        : DEFAULT_MAINSERVER_CREDENTIAL_STATE,
+  });
 
   return keycloakRoleNamesResult.status === 'rejected'
     ? markUserProjectionDegraded(projectedDetail)

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
@@ -547,12 +547,12 @@ describe('executeCreateUser', () => {
     expect(state.ensureManagedRealmRolesExist).toHaveBeenCalledWith({
       instanceId: 'instance-1',
       identityProvider,
-      externalRoleNames: ['system_admin', 'editor'],
+      externalRoleNames: ['system_admin'],
       actorAccountId: 'actor-1',
       requestId: 'req-1',
       traceId: 'trace-1',
     });
-    expect(identityProvider.provider.syncRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin', 'editor']);
+    expect(identityProvider.provider.syncRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin']);
   });
 
   it('deactivates the created external user when persistence fails after Keycloak creation', async () => {

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.test.ts
@@ -547,7 +547,7 @@ describe('executeCreateUser', () => {
     expect(state.ensureManagedRealmRolesExist).toHaveBeenCalledWith({
       instanceId: 'instance-1',
       identityProvider,
-      externalRoleNames: ['system_admin'],
+      roleKeys: ['system_admin'],
       actorAccountId: 'actor-1',
       requestId: 'req-1',
       traceId: 'trace-1',

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
@@ -1,4 +1,5 @@
 import type { IamCreateUserResult } from '@sva/core';
+import { filterTenantTechnicalKeycloakRoleNames } from '@sva/iam-admin';
 import {
   logger,
   resolveIdentityProviderForInstance,
@@ -71,20 +72,21 @@ const syncUserRolesIfNeeded = async (input: {
   keycloakSubject: string;
   roleNames: readonly string[];
 }) => {
-  if (input.roleNames.length === 0) {
+  const technicalRoleNames = filterTenantTechnicalKeycloakRoleNames(input.roleNames);
+  if (technicalRoleNames.length === 0) {
     return;
   }
 
   await ensureManagedRealmRolesExist({
     instanceId: input.actor.instanceId,
     identityProvider: input.identityProvider,
-    externalRoleNames: input.roleNames,
+    externalRoleNames: technicalRoleNames,
     actorAccountId: input.actor.actorAccountId,
     requestId: input.actor.requestId,
     traceId: input.actor.traceId,
   });
   await trackKeycloakCall('sync_roles', () =>
-    input.identityProvider.provider.syncRoles(input.keycloakSubject, input.roleNames)
+    input.identityProvider.provider.syncRoles(input.keycloakSubject, [...technicalRoleNames])
   );
 };
 

--- a/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-create-operation.ts
@@ -80,7 +80,7 @@ const syncUserRolesIfNeeded = async (input: {
   await ensureManagedRealmRolesExist({
     instanceId: input.actor.instanceId,
     identityProvider: input.identityProvider,
-    externalRoleNames: technicalRoleNames,
+    roleKeys: technicalRoleNames,
     actorAccountId: input.actor.actorAccountId,
     requestId: input.actor.requestId,
     traceId: input.actor.traceId,

--- a/packages/auth-runtime/src/iam-account-management/user-projection.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-projection.test.ts
@@ -122,7 +122,7 @@ describe('user projection', () => {
     );
   });
 
-  it('replaces outdated user roles with mapped canonical roles', async () => {
+  it('keeps DB roles canonical and exposes keycloak role names separately', async () => {
     const { resolveProjectedUserDetail } = await import('./user-projection.js');
     state.resolveRolesByExternalNames.mockResolvedValueOnce([
       {
@@ -140,14 +140,9 @@ describe('user projection', () => {
       keycloakRoleNames: ['news.editor'],
     });
 
-    expect(projectedUser.roles).toEqual([
-      {
-        roleId: 'role-news-editor',
-        roleKey: 'news_editor',
-        roleName: 'News Editor',
-        roleLevel: 30,
-      },
-    ]);
+    expect(projectedUser.roles).toEqual(baseUser().roles);
+    expect(projectedUser.keycloakRoles).toEqual(['news.editor']);
+    expect(state.resolveRolesByExternalNames).not.toHaveBeenCalled();
   });
 
   it('falls back to the default mainserver credential state on credential projection errors', async () => {
@@ -174,7 +169,7 @@ describe('user projection', () => {
     ).toHaveLength(1);
   });
 
-  it('applies canonical list projections and ignores recoverable keycloak lookup errors', async () => {
+  it('keeps list DB roles canonical while attaching keycloak role names', async () => {
     const { applyCanonicalUserListProjection } = await import('./user-projection.js');
     state.resolveIdentityProviderForInstance
       .mockResolvedValueOnce({
@@ -204,7 +199,17 @@ describe('user projection', () => {
       client: {},
       instanceId: 'de-musterhausen',
       users: [
-        listUser({ keycloakSubject: 'kc-user-1' }),
+        listUser({
+          keycloakSubject: 'kc-user-1',
+          roles: [
+            {
+              roleId: 'role-db-editor',
+              roleKey: 'db_editor',
+              roleName: 'DB Editor',
+              roleLevel: 20,
+            },
+          ],
+        }),
         listUser({
           id: '33333333-3333-4333-8333-333333333333',
           keycloakSubject: 'kc-user-2',
@@ -216,12 +221,15 @@ describe('user projection', () => {
 
     expect(users[0]?.roles).toEqual([
       {
-        roleId: 'role-news-editor',
-        roleKey: 'news_editor',
-        roleName: 'News Editor',
-        roleLevel: 30,
+        roleId: 'role-db-editor',
+        roleKey: 'db_editor',
+        roleName: 'DB Editor',
+        roleLevel: 20,
       },
     ]);
+    expect(users[0]?.keycloakRoles).toEqual(['news.editor']);
     expect(users[1]?.roles).toEqual([]);
+    expect(users[1]?.keycloakRoles).toBeUndefined();
+    expect(state.resolveRolesByExternalNames).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth-runtime/src/iam-account-management/user-projection.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-projection.test.ts
@@ -101,7 +101,6 @@ describe('user projection', () => {
     const { resolveProjectedUserDetail } = await import('./user-projection.js');
 
     const projectedUser = await resolveProjectedUserDetail({
-      client: {},
       instanceId: 'de-musterhausen',
       user: baseUser(),
       keycloakRoleNames: null,
@@ -134,7 +133,6 @@ describe('user projection', () => {
     ]);
 
     const projectedUser = await resolveProjectedUserDetail({
-      client: {},
       instanceId: 'de-musterhausen',
       user: baseUser(),
       keycloakRoleNames: ['news.editor'],
@@ -153,7 +151,6 @@ describe('user projection', () => {
     state.readIdentityUserAttributes.mockRejectedValueOnce(new Error('identity attributes unavailable'));
 
     const projectedUser = await applyCanonicalUserDetailProjection({
-      client: {},
       instanceId: 'de-musterhausen',
       user: {
         ...baseUser(),
@@ -196,7 +193,6 @@ describe('user projection', () => {
     ]);
 
     const users = await applyCanonicalUserListProjection({
-      client: {},
       instanceId: 'de-musterhausen',
       users: [
         listUser({

--- a/packages/auth-runtime/src/iam-account-management/user-projection.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-projection.ts
@@ -51,7 +51,6 @@ export const resolveKeycloakRoleNames = async (
 };
 
 export const resolveProjectedUserDetail = async (input: {
-  client: unknown;
   instanceId: string;
   user: IamUserDetail;
   keycloakRoleNames: readonly string[] | null;
@@ -84,7 +83,6 @@ export const isRecoverableUserProjectionError = (
   error instanceof KeycloakAdminRequestError || error instanceof KeycloakAdminUnavailableError;
 
 export const applyCanonicalUserDetailProjection = async (input: {
-  client: unknown;
   instanceId: string;
   user: IamUserDetail;
   keycloakRoleNames?: readonly string[] | null;
@@ -108,7 +106,6 @@ export const applyCanonicalUserDetailProjection = async (input: {
     ));
 
   const projectedUser = await resolveProjectedUserDetail({
-    client: input.client,
     instanceId: input.instanceId,
     user: input.user,
     keycloakRoleNames: resolvedKeycloakRoleNames,
@@ -119,7 +116,6 @@ export const applyCanonicalUserDetailProjection = async (input: {
 };
 
 export const applyCanonicalUserListProjection = async (input: {
-  client: unknown;
   instanceId: string;
   users: readonly IamUserListItem[];
   keycloakRoleNamesBySubject?: ReadonlyMap<string, readonly string[] | null>;

--- a/packages/auth-runtime/src/iam-account-management/user-projection.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-projection.ts
@@ -1,4 +1,4 @@
-import type { IamUserDetail, IamUserListItem, IamUserRoleAssignment } from '@sva/core';
+import type { IamUserDetail, IamUserListItem } from '@sva/core';
 
 import {
   KeycloakAdminRequestError,
@@ -10,10 +10,8 @@ import {
   resolveMainserverCredentialState,
 } from '../mainserver-credentials.js';
 
-import { getRoleDisplayName } from './role-audit.js';
 import {
   resolveIdentityProviderForInstance,
-  resolveRolesByExternalNames,
   trackKeycloakCall,
 } from './shared.js';
 import { markUserProjectionDegraded } from './projection-diagnostics.js';
@@ -24,21 +22,6 @@ const DEFAULT_MAINSERVER_CREDENTIAL_STATE: ProjectedMainserverCredentialState = 
   mainserverUserApplicationId: undefined,
   mainserverUserApplicationSecretSet: false,
 };
-
-const mapProjectedRoles = (
-  roles: Awaited<ReturnType<typeof resolveRolesByExternalNames>>
-): readonly IamUserRoleAssignment[] =>
-  roles.map((role) => ({
-    roleId: role.id,
-    roleKey: role.role_key,
-    roleName: getRoleDisplayName(role),
-    roleLevel: role.role_level,
-  }));
-
-const mergeProjectedRoles = (user: IamUserDetail, roles: readonly IamUserRoleAssignment[]): IamUserDetail => ({
-  ...user,
-  roles,
-});
 
 export const mergeMainserverCredentialState = (
   user: IamUserDetail,
@@ -68,7 +51,7 @@ export const resolveKeycloakRoleNames = async (
 };
 
 export const resolveProjectedUserDetail = async (input: {
-  client: Parameters<typeof resolveRolesByExternalNames>[0];
+  client: unknown;
   instanceId: string;
   user: IamUserDetail;
   keycloakRoleNames: readonly string[] | null;
@@ -77,17 +60,10 @@ export const resolveProjectedUserDetail = async (input: {
     return markUserProjectionDegraded(input.user);
   }
 
-  const mappedRoles = await resolveRolesByExternalNames(input.client, {
-    instanceId: input.instanceId,
-    externalRoleNames: input.keycloakRoleNames,
-  });
-  const projectedRoles = mapProjectedRoles(mappedRoles);
-  const currentRoleIds = new Set(input.user.roles.map((role) => role.roleId));
-  const changed =
-    currentRoleIds.size !== projectedRoles.length ||
-    projectedRoles.some((role) => !currentRoleIds.has(role.roleId));
-
-  return changed ? mergeProjectedRoles(input.user, projectedRoles) : input.user;
+  return {
+    ...input.user,
+    keycloakRoles: [...input.keycloakRoleNames],
+  };
 };
 
 export const resolveProjectedMainserverCredentialState = async (
@@ -108,7 +84,7 @@ export const isRecoverableUserProjectionError = (
   error instanceof KeycloakAdminRequestError || error instanceof KeycloakAdminUnavailableError;
 
 export const applyCanonicalUserDetailProjection = async (input: {
-  client: Parameters<typeof resolveRolesByExternalNames>[0];
+  client: unknown;
   instanceId: string;
   user: IamUserDetail;
   keycloakRoleNames?: readonly string[] | null;
@@ -142,43 +118,8 @@ export const applyCanonicalUserDetailProjection = async (input: {
   return keycloakProjectionDegraded ? markUserProjectionDegraded(mergedUser) : mergedUser;
 };
 
-const buildProjectedRolesByExternalName = async (
-  client: Parameters<typeof resolveRolesByExternalNames>[0],
-  instanceId: string,
-  keycloakRoleNamesBySubject: ReadonlyMap<string, readonly string[] | null>
-) => {
-  const externalRoleNames = [
-    ...new Set(
-      [...keycloakRoleNamesBySubject.values()]
-        .flatMap((roleNames) => roleNames ?? [])
-        .filter((roleName) => roleName.trim().length > 0)
-    ),
-  ];
-
-  if (externalRoleNames.length === 0) {
-    return new Map<string, IamUserRoleAssignment>();
-  }
-
-  const mappedRoles = await resolveRolesByExternalNames(client, {
-    instanceId,
-    externalRoleNames,
-  });
-
-  return new Map(
-    mappedRoles.map((role) => [
-      role.external_role_name ?? role.role_key,
-      {
-        roleId: role.id,
-        roleKey: role.role_key,
-        roleName: getRoleDisplayName(role),
-        roleLevel: role.role_level,
-      } satisfies IamUserRoleAssignment,
-    ])
-  );
-};
-
 export const applyCanonicalUserListProjection = async (input: {
-  client: Parameters<typeof resolveRolesByExternalNames>[0];
+  client: unknown;
   instanceId: string;
   users: readonly IamUserListItem[];
   keycloakRoleNamesBySubject?: ReadonlyMap<string, readonly string[] | null>;
@@ -203,31 +144,15 @@ export const applyCanonicalUserListProjection = async (input: {
       )
     );
 
-  const projectedRolesByExternalName = await buildProjectedRolesByExternalName(
-    input.client,
-    input.instanceId,
-    keycloakRoleNamesBySubject
-  );
-
   return input.users.map((user) => {
     const keycloakRoleNames = keycloakRoleNamesBySubject.get(user.keycloakSubject) ?? null;
     if (keycloakRoleNames === null) {
       return user;
     }
 
-    const projectedRoles = [...new Set(keycloakRoleNames)]
-      .map((roleName) => projectedRolesByExternalName.get(roleName))
-      .filter((role): role is IamUserRoleAssignment => role !== undefined);
-    const currentRoleIds = new Set(user.roles.map((role) => role.roleId));
-    const changed =
-      currentRoleIds.size !== projectedRoles.length ||
-      projectedRoles.some((role) => !currentRoleIds.has(role.roleId));
-
-    return changed
-      ? {
-          ...user,
-          roles: projectedRoles,
-        }
-      : user;
+    return {
+      ...user,
+      keycloakRoles: [...keycloakRoleNames],
+    };
   });
 };

--- a/packages/auth-runtime/src/iam-account-management/user-update-handler.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-handler.ts
@@ -1,4 +1,4 @@
-import { createUpdateUserHandlerInternal } from '@sva/iam-admin';
+import { createUpdateUserHandlerInternal, RoleMutationCapabilityUnavailableError } from '@sva/iam-admin';
 
 import { KeycloakAdminRequestError, KeycloakAdminUnavailableError } from '../keycloak-admin-client.js';
 import { jsonResponse } from '../db.js';
@@ -21,6 +21,15 @@ export const updateUserInternal = createUpdateUserHandlerInternal({
   createUserMutationErrorResponse,
   ensureManagedRealmRolesExist,
   handleKeycloakUpdateError: ({ error, requestId }) => {
+    if (error instanceof RoleMutationCapabilityUnavailableError) {
+      return createApiError(
+        503,
+        'keycloak_unavailable',
+        'Keycloak Admin API unterstützt technische Rollenzuweisungen nicht.',
+        requestId
+      );
+    }
+
     if (error instanceof KeycloakAdminRequestError || error instanceof KeycloakAdminUnavailableError) {
       return buildRoleSyncFailure({
         error,

--- a/packages/auth-runtime/src/iam-account-management/user-update-identity.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-identity.test.ts
@@ -26,6 +26,33 @@ vi.mock('./shared.js', () => ({
   trackKeycloakCall: state.trackKeycloakCall,
 }));
 
+const createCompensationPlan = (overrides: {
+  readonly keycloakSubject?: string;
+  readonly email?: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly status?: 'active' | 'inactive';
+  readonly previousRoleNames?: readonly string[];
+  readonly nextRoleNames?: readonly string[];
+} = {}) => ({
+  existing: {
+    keycloakSubject: overrides.keycloakSubject ?? 'kc-1',
+    email: overrides.email ?? 'jane@example.test',
+    firstName: overrides.firstName ?? 'Jane',
+    lastName: overrides.lastName ?? 'Doe',
+    status: overrides.status ?? 'active',
+  },
+  previousRoleNames: overrides.previousRoleNames ?? [],
+  nextRoleNames: overrides.nextRoleNames ?? [],
+});
+
+const createIdentityProviderMocks = () => ({
+  updateUser: vi.fn(async () => undefined),
+  assignRealmRoles: vi.fn(async () => undefined),
+  removeRealmRoles: vi.fn(async () => undefined),
+  syncRoles: vi.fn(async () => undefined),
+});
+
 describe('user update identity helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -66,23 +93,19 @@ describe('user update identity helpers', () => {
       .fn()
       .mockRejectedValueOnce(new Error('identity compensation failed'))
       .mockResolvedValueOnce(undefined);
-    const syncRoles = vi.fn().mockRejectedValueOnce('role compensation failed');
+    const assignRealmRoles = vi.fn().mockRejectedValueOnce('role compensation failed');
+    const removeRealmRoles = vi.fn(async () => undefined);
     const identityProvider = {
       provider: {
         updateUser,
-        syncRoles,
+        assignRealmRoles,
+        removeRealmRoles,
       },
     };
-    const plan = {
-      existing: {
-        keycloakSubject: 'kc-1',
-        email: 'jane@example.test',
-        firstName: 'Jane',
-        lastName: 'Doe',
-        status: 'active',
-      },
+    const plan = createCompensationPlan({
       previousRoleNames: ['system_admin'],
-    };
+      nextRoleNames: [],
+    });
 
     await compensateUserIdentityUpdate({
       instanceId: 'instance-1',
@@ -113,14 +136,15 @@ describe('user update identity helpers', () => {
     await compensateUserIdentityUpdate({
       instanceId: 'instance-1',
       userId: 'user-1',
-      plan: { ...plan, existing: { ...plan.existing, status: 'inactive' } } as never,
+      plan: createCompensationPlan({ status: 'inactive', previousRoleNames: ['system_admin'] }) as never,
       restoreIdentity: true,
       restoreRoles: false,
       restoreIdentityAttributes: { locale: ['de'] },
       identityProvider: {
         provider: {
           updateUser,
-          syncRoles,
+          assignRealmRoles,
+          removeRealmRoles,
         },
       } as never,
     });
@@ -129,22 +153,15 @@ describe('user update identity helpers', () => {
 
   it('returns early when neither identity nor roles must be restored and logs string compensation errors', async () => {
     const { compensateUserIdentityUpdate } = await import('./user-update-identity.js');
-    const updateUser = vi.fn(async () => undefined);
-    const syncRoles = vi.fn(async () => undefined);
+    const { assignRealmRoles, removeRealmRoles, syncRoles, updateUser } = createIdentityProviderMocks();
 
     await compensateUserIdentityUpdate({
       instanceId: 'instance-1',
       userId: 'user-1',
-      plan: {
-        existing: {
-          keycloakSubject: 'kc-1',
-          email: 'jane@example.test',
-          firstName: 'Jane',
-          lastName: 'Doe',
-          status: 'active',
-        },
+      plan: createCompensationPlan({
         previousRoleNames: ['editor'],
-      } as never,
+        nextRoleNames: ['editor'],
+      }) as never,
       restoreIdentity: false,
       restoreRoles: false,
       identityProvider: {
@@ -157,32 +174,32 @@ describe('user update identity helpers', () => {
 
     expect(state.trackKeycloakCall).not.toHaveBeenCalled();
 
-    syncRoles.mockRejectedValueOnce('sync failed');
+    assignRealmRoles.mockRejectedValueOnce('sync failed');
     await compensateUserIdentityUpdate({
       instanceId: 'instance-1',
       requestId: 'req-2',
       traceId: 'trace-2',
       userId: 'user-2',
-      plan: {
-        existing: {
-          keycloakSubject: 'kc-2',
-          email: 'john@example.test',
-          firstName: 'John',
-          lastName: 'Doe',
-          status: 'active',
-        },
-        previousRoleNames: ['editor'],
-      } as never,
+      plan: createCompensationPlan({
+        keycloakSubject: 'kc-2',
+        email: 'john@example.test',
+        firstName: 'John',
+        previousRoleNames: ['system_admin'],
+        nextRoleNames: [],
+      }) as never,
       restoreIdentity: false,
       restoreRoles: true,
       identityProvider: {
         provider: {
           updateUser,
+          assignRealmRoles,
+          removeRealmRoles,
           syncRoles,
         },
       } as never,
     });
 
+    expect(syncRoles).not.toHaveBeenCalled();
     expect(state.logger.error).toHaveBeenCalledWith(
       'IAM user role compensation failed',
       expect.objectContaining({
@@ -193,5 +210,32 @@ describe('user update identity helpers', () => {
         }),
       })
     );
+  });
+
+  it('compensates role updates with non-destructive technical deltas', async () => {
+    const { compensateUserIdentityUpdate } = await import('./user-update-identity.js');
+    const { assignRealmRoles, removeRealmRoles, syncRoles } = createIdentityProviderMocks();
+
+    await compensateUserIdentityUpdate({
+      instanceId: 'instance-1',
+      userId: 'user-1',
+      plan: createCompensationPlan({
+        previousRoleNames: ['system_admin'],
+        nextRoleNames: ['other_technical'],
+      }) as never,
+      restoreIdentity: false,
+      restoreRoles: true,
+      identityProvider: {
+        provider: {
+          assignRealmRoles,
+          removeRealmRoles,
+          syncRoles,
+        },
+      } as never,
+    });
+
+    expect(assignRealmRoles).toHaveBeenCalledWith('kc-1', ['system_admin']);
+    expect(removeRealmRoles).toHaveBeenCalledWith('kc-1', ['other_technical']);
+    expect(syncRoles).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth-runtime/src/iam-account-management/user-update-identity.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-identity.ts
@@ -3,7 +3,8 @@ import type { IdentityUserAttributes } from '../identity-provider-port.js';
 import { buildMainserverIdentityAttributes } from '../mainserver-credentials.js';
 
 import type { UpdateUserPayload, UserUpdatePlan } from './user-update-plan.js';
-import { logger, resolveIdentityProvider, trackKeycloakCall } from './shared.js';
+import { logger, trackKeycloakCall } from './shared.js';
+import type { UserUpdateIdentityProviderResolution } from './user-update-request-context.js';
 
 export const buildIdentityAttributesForUserUpdate = (input: {
   readonly existingAttributes: IdentityUserAttributes | undefined;
@@ -36,7 +37,7 @@ const resolveRoleCompensationDelta = (plan: UserUpdatePlan): {
 };
 
 const compensateUserRoleDelta = async (input: {
-  readonly identityProvider: NonNullable<ReturnType<typeof resolveIdentityProvider>>;
+  readonly identityProvider: UserUpdateIdentityProviderResolution;
   readonly keycloakSubject: string;
   readonly rolesToAssign: readonly string[];
   readonly rolesToRemove: readonly string[];
@@ -69,7 +70,7 @@ export const compensateUserIdentityUpdate = async (input: {
   restoreIdentity: boolean;
   restoreRoles: boolean;
   restoreIdentityAttributes?: IdentityUserAttributes;
-  identityProvider: NonNullable<ReturnType<typeof resolveIdentityProvider>>;
+  identityProvider: UserUpdateIdentityProviderResolution;
 }): Promise<void> => {
   const {
     identityProvider,

--- a/packages/auth-runtime/src/iam-account-management/user-update-identity.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-identity.ts
@@ -22,6 +22,44 @@ export const buildIdentityAttributesForUserUpdate = (input: {
   return attributes;
 };
 
+const resolveRoleCompensationDelta = (plan: UserUpdatePlan): {
+  readonly rolesToAssign: readonly string[];
+  readonly rolesToRemove: readonly string[];
+} => {
+  const previousRoleNames = new Set(plan.previousRoleNames);
+  const nextRoleNames = new Set(plan.nextRoleNames ?? []);
+
+  return {
+    rolesToAssign: [...previousRoleNames].filter((roleName) => !nextRoleNames.has(roleName)),
+    rolesToRemove: [...nextRoleNames].filter((roleName) => !previousRoleNames.has(roleName)),
+  };
+};
+
+const compensateUserRoleDelta = async (input: {
+  readonly identityProvider: NonNullable<ReturnType<typeof resolveIdentityProvider>>;
+  readonly keycloakSubject: string;
+  readonly rolesToAssign: readonly string[];
+  readonly rolesToRemove: readonly string[];
+}): Promise<void> => {
+  if (input.rolesToAssign.length > 0) {
+    if (!input.identityProvider.provider.assignRealmRoles) {
+      throw new Error('assignRealmRoles provider capability unavailable');
+    }
+    await trackKeycloakCall('sync_roles_compensation', () =>
+      input.identityProvider.provider.assignRealmRoles!(input.keycloakSubject, input.rolesToAssign)
+    );
+  }
+
+  if (input.rolesToRemove.length > 0) {
+    if (!input.identityProvider.provider.removeRealmRoles) {
+      throw new Error('removeRealmRoles provider capability unavailable');
+    }
+    await trackKeycloakCall('sync_roles_compensation', () =>
+      input.identityProvider.provider.removeRealmRoles!(input.keycloakSubject, input.rolesToRemove)
+    );
+  }
+};
+
 export const compensateUserIdentityUpdate = async (input: {
   instanceId: string;
   requestId?: string;
@@ -77,9 +115,11 @@ export const compensateUserIdentityUpdate = async (input: {
   }
 
   try {
-    await trackKeycloakCall('sync_roles_compensation', () =>
-      identityProvider.provider.syncRoles(plan.existing.keycloakSubject, [...plan.previousRoleNames])
-    );
+    await compensateUserRoleDelta({
+      identityProvider,
+      keycloakSubject: plan.existing.keycloakSubject,
+      ...resolveRoleCompensationDelta(plan),
+    });
   } catch (compensationError) {
     logger.error('IAM user role compensation failed', {
       workspace_id: instanceId,

--- a/packages/auth-runtime/src/iam-account-management/user-update-identity.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-identity.ts
@@ -70,7 +70,7 @@ export const compensateUserIdentityUpdate = async (input: {
   restoreIdentity: boolean;
   restoreRoles: boolean;
   restoreIdentityAttributes?: IdentityUserAttributes;
-  identityProvider: UserUpdateIdentityProviderResolution;
+  identityProvider?: UserUpdateIdentityProviderResolution;
 }): Promise<void> => {
   const {
     identityProvider,
@@ -84,7 +84,7 @@ export const compensateUserIdentityUpdate = async (input: {
     userId,
   } = input;
 
-  if (restoreIdentity) {
+  if (restoreIdentity && identityProvider) {
     try {
       await trackKeycloakCall('update_user_compensation', () =>
         identityProvider.provider.updateUser(plan.existing.keycloakSubject, {
@@ -111,7 +111,7 @@ export const compensateUserIdentityUpdate = async (input: {
     }
   }
 
-  if (!restoreRoles) {
+  if (!restoreRoles || !identityProvider) {
     return;
   }
 

--- a/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
@@ -22,7 +22,7 @@ import type { UserUpdateIdentityProviderResolution } from './user-update-request
 export const resolveUpdatedIdentityState = async (input: {
   plan: UserUpdatePlan;
   payload: UpdateUserPayload;
-  identityProvider: UserUpdateIdentityProviderResolution;
+  identityProvider?: UserUpdateIdentityProviderResolution;
 }) => {
   const shouldUpdateIdentityAttributes =
     input.payload.displayName !== undefined ||
@@ -37,20 +37,25 @@ export const resolveUpdatedIdentityState = async (input: {
 
   let existingIdentityAttributes: IdentityUserAttributes | undefined;
   let nextIdentityAttributes: IdentityUserAttributes | undefined;
-  let nextMainserverCredentialState: ReturnType<typeof resolveMainserverCredentialState>;
+  let nextMainserverCredentialState: ReturnType<typeof resolveMainserverCredentialState> | undefined;
 
   if (shouldUpdateIdentityAttributes) {
+    const identityProvider = input.identityProvider;
+    if (!identityProvider) {
+      throw new Error('identity_provider_resolution_unavailable');
+    }
     existingIdentityAttributes = await trackKeycloakCall('get_user_attributes_for_update', () =>
-      input.identityProvider.provider.getUserAttributes(input.plan.existing.keycloakSubject)
+      identityProvider.provider.getUserAttributes(input.plan.existing.keycloakSubject)
     );
     nextIdentityAttributes = buildIdentityAttributesForUserUpdate({
       existingAttributes: existingIdentityAttributes,
       payload: input.payload,
     });
     nextMainserverCredentialState = resolveMainserverCredentialState(nextIdentityAttributes);
-  } else {
+  } else if (shouldUpdateIdentity && input.identityProvider) {
+    const { identityProvider } = input;
     nextMainserverCredentialState = await trackKeycloakCall('get_user_attributes_for_response', () =>
-      input.identityProvider.provider
+      identityProvider.provider
         .getUserAttributes(input.plan.existing.keycloakSubject, getSvaMainserverCredentialAttributeNames())
         .then((attributes) => resolveMainserverCredentialState(attributes))
     );

--- a/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
@@ -1,4 +1,8 @@
-import { createUserUpdatePersistence } from '@sva/iam-admin';
+import {
+  createUserUpdatePersistence,
+  shouldUpdateUserIdentityAttributes,
+  shouldUpdateUserIdentityPayload,
+} from '@sva/iam-admin';
 
 import type { IdentityUserAttributes } from '../identity-provider-port.js';
 import {
@@ -24,16 +28,8 @@ export const resolveUpdatedIdentityState = async (input: {
   payload: UpdateUserPayload;
   identityProvider?: UserUpdateIdentityProviderResolution;
 }) => {
-  const shouldUpdateIdentityAttributes =
-    input.payload.displayName !== undefined ||
-    input.payload.mainserverUserApplicationId !== undefined ||
-    input.payload.mainserverUserApplicationSecret !== undefined;
-  const shouldUpdateIdentity =
-    input.payload.email !== undefined ||
-    input.payload.firstName !== undefined ||
-    input.payload.lastName !== undefined ||
-    input.payload.status !== undefined ||
-    shouldUpdateIdentityAttributes;
+  const shouldUpdateIdentityAttributes = shouldUpdateUserIdentityAttributes(input.payload);
+  const shouldUpdateIdentity = shouldUpdateUserIdentityPayload(input.payload);
 
   let existingIdentityAttributes: IdentityUserAttributes | undefined;
   let nextIdentityAttributes: IdentityUserAttributes | undefined;

--- a/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-operation.ts
@@ -9,7 +9,7 @@ import {
 import { assignGroups, assignRoles } from './shared-assignment.js';
 import { emitActivityLog, notifyPermissionInvalidation } from './shared-activity.js';
 import { trackKeycloakCall } from './shared-observability.js';
-import { withInstanceScopedDb, resolveIdentityProvider } from './shared-runtime.js';
+import { withInstanceScopedDb } from './shared-runtime.js';
 import { resolveUserDetail } from './user-detail-query.js';
 import { revokeUserSessions } from '../session-revocation.js';
 import { clearUserSessionLoginBlock } from '../session-revocation.js';
@@ -17,11 +17,12 @@ import {
   buildIdentityAttributesForUserUpdate,
 } from './user-update-identity.js';
 import type { UpdateUserPayload, UserUpdatePlan } from './user-update-plan.js';
+import type { UserUpdateIdentityProviderResolution } from './user-update-request-context.js';
 
 export const resolveUpdatedIdentityState = async (input: {
   plan: UserUpdatePlan;
   payload: UpdateUserPayload;
-  identityProvider: NonNullable<ReturnType<typeof resolveIdentityProvider>>;
+  identityProvider: UserUpdateIdentityProviderResolution;
 }) => {
   const shouldUpdateIdentityAttributes =
     input.payload.displayName !== undefined ||

--- a/packages/auth-runtime/src/iam-account-management/user-update-plan.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-plan.test.ts
@@ -170,7 +170,7 @@ describe('resolveUserUpdatePlan', () => {
     ).rejects.toThrow('forbidden:Gruppenrolle zu hoch');
   });
 
-  it('returns a plan with previous and next external role names and skips actor checks for system admins', async () => {
+  it('returns a plan with technical role names and skips actor checks for system admins', async () => {
     const { resolveUserUpdatePlan } = await import('./user-update-plan.js');
     state.resolveUserDetail.mockResolvedValueOnce({
       id: 'user-1',
@@ -192,8 +192,8 @@ describe('resolveUserUpdatePlan', () => {
     } as never);
 
     expect(plan).toMatchObject({
-      previousRoleNames: ['external-editor'],
-      nextRoleNames: ['editor'],
+      previousRoleNames: [],
+      nextRoleNames: [],
     });
     expect(state.ensureActorCanManageTarget).not.toHaveBeenCalled();
   });
@@ -222,8 +222,8 @@ describe('resolveUserUpdatePlan', () => {
     } as never);
 
     expect(plan).toMatchObject({
-      previousRoleNames: ['legacy-system-admin', 'system_admin'],
-      nextRoleNames: ['legacy-system-admin', 'system_admin'],
+      previousRoleNames: ['system_admin'],
+      nextRoleNames: ['system_admin'],
     });
   });
 

--- a/packages/auth-runtime/src/iam-account-management/user-update-plan.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-plan.test.ts
@@ -198,6 +198,35 @@ describe('resolveUserUpdatePlan', () => {
     expect(state.ensureActorCanManageTarget).not.toHaveBeenCalled();
   });
 
+  it('adds canonical technical role names for aliased system_admin rows', async () => {
+    const { resolveUserUpdatePlan } = await import('./user-update-plan.js');
+    state.resolveUserDetail.mockResolvedValueOnce({
+      id: 'user-1',
+      status: 'active',
+      roles: [{ roleId: 'role-admin', roleKey: 'system_admin', roleName: 'System Admin' }],
+    });
+    state.resolveRolesByIds.mockResolvedValueOnce([
+      { role_key: 'system_admin', externalName: 'legacy-system-admin' },
+    ]);
+    state.ensureTenantManageableRoleAssignments.mockResolvedValueOnce({
+      ok: true,
+      roles: [{ role_key: 'system_admin', externalName: 'legacy-system-admin' }],
+    });
+
+    const plan = await resolveUserUpdatePlan({} as never, {
+      instanceId: 'instance-1',
+      actorSubject: 'kc-actor',
+      actorRoles: ['system_admin'],
+      userId: 'user-1',
+      payload: { roleIds: ['role-admin'], status: 'active' },
+    } as never);
+
+    expect(plan).toMatchObject({
+      previousRoleNames: ['legacy-system-admin', 'system_admin'],
+      nextRoleNames: ['legacy-system-admin', 'system_admin'],
+    });
+  });
+
   it('rejects root-only tenant role assignments even for system_admin actors', async () => {
     const { resolveUserUpdatePlan } = await import('./user-update-plan.js');
     state.resolveUserDetail.mockResolvedValueOnce({

--- a/packages/auth-runtime/src/iam-account-management/user-update-plan.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-plan.ts
@@ -4,7 +4,6 @@ import type { z } from 'zod';
 
 import type { QueryClient } from '../db.js';
 
-import { getRoleExternalName } from './role-audit.js';
 import { updateUserSchema } from './schemas.js';
 import {
   ensureActorCanManageTarget,
@@ -27,12 +26,12 @@ export type UserUpdatePlan = {
   nextRoleNames?: readonly string[];
 };
 
-const resolveExternalRoleNames = async (
+const resolveTechnicalRoleNames = async (
   client: QueryClient,
   input: { instanceId: string; roleIds: readonly string[] }
 ): Promise<readonly string[]> => {
   const roles = await resolveRolesByIds(client, input);
-  return [...new Set([...roles.map((role) => getRoleExternalName(role)), ...resolveTenantTechnicalKeycloakRoleNames(roles)])];
+  return resolveTenantTechnicalKeycloakRoleNames(roles);
 };
 
 const ensureActorCanUpdateTarget = (input: {
@@ -89,10 +88,7 @@ const resolveNextRoleNames = async (
   }
 
   const assignedRoles = roleValidation.roles;
-  const nextRoleNames = [...new Set([
-    ...assignedRoles.map((role) => getRoleExternalName(role)),
-    ...resolveTenantTechnicalKeycloakRoleNames(assignedRoles),
-  ])];
+  const nextRoleNames = resolveTenantTechnicalKeycloakRoleNames(assignedRoles);
   const wouldRemoveSystemAdmin =
     hasSystemAdminRole(input.existing.roles) &&
     !assignedRoles.some((role) => role.role_key === 'system_admin') &&
@@ -207,7 +203,7 @@ export const resolveUserUpdatePlan = async (
     });
   }
 
-  const previousRoleNames = await resolveExternalRoleNames(client, {
+  const previousRoleNames = await resolveTechnicalRoleNames(client, {
     instanceId: input.instanceId,
     roleIds: existing.roles.map((role) => role.roleId),
   });

--- a/packages/auth-runtime/src/iam-account-management/user-update-plan.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-plan.ts
@@ -1,4 +1,5 @@
 import type { IamUserDetail } from '@sva/core';
+import { resolveTenantTechnicalKeycloakRoleNames } from '@sva/iam-admin';
 import type { z } from 'zod';
 
 import type { QueryClient } from '../db.js';
@@ -31,7 +32,7 @@ const resolveExternalRoleNames = async (
   input: { instanceId: string; roleIds: readonly string[] }
 ): Promise<readonly string[]> => {
   const roles = await resolveRolesByIds(client, input);
-  return roles.map((role) => getRoleExternalName(role));
+  return [...new Set([...roles.map((role) => getRoleExternalName(role)), ...resolveTenantTechnicalKeycloakRoleNames(roles)])];
 };
 
 const ensureActorCanUpdateTarget = (input: {
@@ -88,7 +89,10 @@ const resolveNextRoleNames = async (
   }
 
   const assignedRoles = roleValidation.roles;
-  const nextRoleNames = assignedRoles.map((role) => getRoleExternalName(role));
+  const nextRoleNames = [...new Set([
+    ...assignedRoles.map((role) => getRoleExternalName(role)),
+    ...resolveTenantTechnicalKeycloakRoleNames(assignedRoles),
+  ])];
   const wouldRemoveSystemAdmin =
     hasSystemAdminRole(input.existing.roles) &&
     !assignedRoles.some((role) => role.role_key === 'system_admin') &&

--- a/packages/auth-runtime/src/iam-account-management/user-update-request-context.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-request-context.test.ts
@@ -102,19 +102,23 @@ describe('resolveUpdateRequestContext', () => {
         requestId: 'req-1',
         traceId: 'trace-1',
       },
-      identityProvider: {
-        provider: {
-          assignRealmRoles: expect.any(Function),
-          removeRealmRoles: expect.any(Function),
-          users: [],
-        },
-      },
       payload: {
         displayName: 'Alice Example',
       },
+      resolveIdentityProvider: expect.any(Function),
       userId: 'user-1',
     });
     expect(state.resolveUserMutationTargetActorContext).toHaveBeenCalledOnce();
+    expect(state.requireUserMutationIdentityProvider).not.toHaveBeenCalled();
+    await expect(
+      (context as Exclude<typeof context, Response>).resolveIdentityProvider()
+    ).resolves.toEqual({
+      provider: {
+        assignRealmRoles: expect.any(Function),
+        removeRealmRoles: expect.any(Function),
+        users: [],
+      },
+    });
   });
 
   it('returns invalid_request before resolving the identity provider when the payload is invalid', async () => {
@@ -184,15 +188,12 @@ describe('resolveUpdateRequestContext', () => {
         requestId: 'req-1',
         traceId: 'trace-1',
       },
-      identityProvider: {
-        provider: {
-          users: [],
-        },
-      },
       payload: {
         firstName: 'Alice',
       },
+      resolveIdentityProvider: expect.any(Function),
       userId: 'user-1',
     });
+    expect(state.requireUserMutationIdentityProvider).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth-runtime/src/iam-account-management/user-update-request-context.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-request-context.test.ts
@@ -63,6 +63,8 @@ describe('resolveUpdateRequestContext', () => {
     });
     state.requireUserMutationIdentityProvider.mockResolvedValue({
       provider: {
+        assignRealmRoles: vi.fn(async () => undefined),
+        removeRealmRoles: vi.fn(async () => undefined),
         users: [],
       },
     });
@@ -102,6 +104,8 @@ describe('resolveUpdateRequestContext', () => {
       },
       identityProvider: {
         provider: {
+          assignRealmRoles: expect.any(Function),
+          removeRealmRoles: expect.any(Function),
           users: [],
         },
       },
@@ -139,6 +143,47 @@ describe('resolveUpdateRequestContext', () => {
     expect(state.requireUserMutationIdentityProvider).not.toHaveBeenCalled();
     await expect((response as Response).json()).resolves.toEqual({
       error: { code: 'invalid_request', message: 'Ungültiger Payload.' },
+      requestId: 'req-1',
+    });
+  });
+
+  it('fails closed when the identity provider cannot mutate technical realm roles', async () => {
+    state.parseRequestBody.mockResolvedValue({
+      ok: true,
+      data: {
+        roleIds: ['role-admin'],
+      },
+    });
+    state.requireUserMutationIdentityProvider.mockResolvedValue({
+      provider: {
+        users: [],
+      },
+    });
+
+    const { resolveUpdateRequestContext } = await import('./user-update-request-context.js');
+
+    const response = await resolveUpdateRequestContext(
+      new Request('http://localhost/api/v1/iam/users/user-1', {
+        method: 'PATCH',
+        body: JSON.stringify({ roleIds: ['role-admin'] }),
+      }),
+      {
+        sessionId: 'session-1',
+        user: {
+          id: 'kc-actor-1',
+          instanceId: 'instance-1',
+          roles: ['system_admin'],
+        },
+      }
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(503);
+    await expect((response as Response).json()).resolves.toEqual({
+      error: {
+        code: 'keycloak_unavailable',
+        message: 'Keycloak Admin API unterstützt technische Rollenzuweisungen nicht.',
+      },
       requestId: 'req-1',
     });
   });

--- a/packages/auth-runtime/src/iam-account-management/user-update-request-context.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-request-context.test.ts
@@ -147,11 +147,11 @@ describe('resolveUpdateRequestContext', () => {
     });
   });
 
-  it('fails closed when the identity provider cannot mutate technical realm roles', async () => {
+  it('allows updates without early role-capability checks', async () => {
     state.parseRequestBody.mockResolvedValue({
       ok: true,
       data: {
-        roleIds: ['role-admin'],
+        firstName: 'Alice',
       },
     });
     state.requireUserMutationIdentityProvider.mockResolvedValue({
@@ -162,10 +162,10 @@ describe('resolveUpdateRequestContext', () => {
 
     const { resolveUpdateRequestContext } = await import('./user-update-request-context.js');
 
-    const response = await resolveUpdateRequestContext(
+    const context = await resolveUpdateRequestContext(
       new Request('http://localhost/api/v1/iam/users/user-1', {
         method: 'PATCH',
-        body: JSON.stringify({ roleIds: ['role-admin'] }),
+        body: JSON.stringify({ firstName: 'Alice' }),
       }),
       {
         sessionId: 'session-1',
@@ -177,14 +177,22 @@ describe('resolveUpdateRequestContext', () => {
       }
     );
 
-    expect(response).toBeInstanceOf(Response);
-    expect((response as Response).status).toBe(503);
-    await expect((response as Response).json()).resolves.toEqual({
-      error: {
-        code: 'keycloak_unavailable',
-        message: 'Keycloak Admin API unterstützt technische Rollenzuweisungen nicht.',
+    expect(context).toEqual({
+      actor: {
+        instanceId: 'instance-1',
+        actorAccountId: 'actor-1',
+        requestId: 'req-1',
+        traceId: 'trace-1',
       },
-      requestId: 'req-1',
+      identityProvider: {
+        provider: {
+          users: [],
+        },
+      },
+      payload: {
+        firstName: 'Alice',
+      },
+      userId: 'user-1',
     });
   });
 });

--- a/packages/auth-runtime/src/iam-account-management/user-update-request-context.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-request-context.ts
@@ -1,7 +1,6 @@
 import { getWorkspaceContext } from '@sva/server-runtime';
 
 import type { AuthenticatedRequestContext } from '../middleware.js';
-import type { IdentityProviderPort } from '../identity-provider-port.js';
 
 import { createApiError, parseRequestBody } from './api-helpers.js';
 import type { IdentityProviderResolution } from './shared-runtime.js';
@@ -13,10 +12,7 @@ import {
 } from './user-mutation-request-context.shared.js';
 import type { UpdateUserPayload } from './user-update-plan.js';
 
-export type UserUpdateIdentityProviderResolution = IdentityProviderResolution & {
-  readonly provider: IdentityProviderResolution['provider'] &
-    Required<Pick<IdentityProviderPort, 'assignRealmRoles' | 'removeRealmRoles'>>;
-};
+export type UserUpdateIdentityProviderResolution = IdentityProviderResolution;
 
 export type UserUpdateRequestContext =
   | Response
@@ -26,12 +22,6 @@ export type UserUpdateRequestContext =
       payload: UpdateUserPayload;
       userId: string;
     };
-
-const hasUserUpdateRoleCapabilities = (
-  identityProvider: IdentityProviderResolution
-): identityProvider is UserUpdateIdentityProviderResolution =>
-  typeof identityProvider.provider.assignRealmRoles === 'function' &&
-  typeof identityProvider.provider.removeRealmRoles === 'function';
 
 export const resolveUpdateRequestContext = async (
   request: Request,
@@ -58,14 +48,6 @@ export const resolveUpdateRequestContext = async (
   );
   if (identityProvider instanceof Response) {
     return identityProvider;
-  }
-  if (!hasUserUpdateRoleCapabilities(identityProvider)) {
-    return createApiError(
-      503,
-      'keycloak_unavailable',
-      'Keycloak Admin API unterstützt technische Rollenzuweisungen nicht.',
-      targetActorContext.actor.requestId
-    );
   }
 
   return {

--- a/packages/auth-runtime/src/iam-account-management/user-update-request-context.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-request-context.ts
@@ -1,6 +1,7 @@
 import { getWorkspaceContext } from '@sva/server-runtime';
 
 import type { AuthenticatedRequestContext } from '../middleware.js';
+import type { IdentityProviderPort } from '../identity-provider-port.js';
 
 import { createApiError, parseRequestBody } from './api-helpers.js';
 import type { IdentityProviderResolution } from './shared-runtime.js';
@@ -12,14 +13,25 @@ import {
 } from './user-mutation-request-context.shared.js';
 import type { UpdateUserPayload } from './user-update-plan.js';
 
+export type UserUpdateIdentityProviderResolution = IdentityProviderResolution & {
+  readonly provider: IdentityProviderResolution['provider'] &
+    Required<Pick<IdentityProviderPort, 'assignRealmRoles' | 'removeRealmRoles'>>;
+};
+
 export type UserUpdateRequestContext =
   | Response
   | {
       actor: UserMutationActor;
-      identityProvider: IdentityProviderResolution;
+      identityProvider: UserUpdateIdentityProviderResolution;
       payload: UpdateUserPayload;
       userId: string;
     };
+
+const hasUserUpdateRoleCapabilities = (
+  identityProvider: IdentityProviderResolution
+): identityProvider is UserUpdateIdentityProviderResolution =>
+  typeof identityProvider.provider.assignRealmRoles === 'function' &&
+  typeof identityProvider.provider.removeRealmRoles === 'function';
 
 export const resolveUpdateRequestContext = async (
   request: Request,
@@ -46,6 +58,14 @@ export const resolveUpdateRequestContext = async (
   );
   if (identityProvider instanceof Response) {
     return identityProvider;
+  }
+  if (!hasUserUpdateRoleCapabilities(identityProvider)) {
+    return createApiError(
+      503,
+      'keycloak_unavailable',
+      'Keycloak Admin API unterstützt technische Rollenzuweisungen nicht.',
+      targetActorContext.actor.requestId
+    );
   }
 
   return {

--- a/packages/auth-runtime/src/iam-account-management/user-update-request-context.ts
+++ b/packages/auth-runtime/src/iam-account-management/user-update-request-context.ts
@@ -18,8 +18,8 @@ export type UserUpdateRequestContext =
   | Response
   | {
       actor: UserMutationActor;
-      identityProvider: UserUpdateIdentityProviderResolution;
       payload: UpdateUserPayload;
+      resolveIdentityProvider: () => Promise<UserUpdateIdentityProviderResolution | Response>;
       userId: string;
     };
 
@@ -42,18 +42,11 @@ export const resolveUpdateRequestContext = async (
     return createApiError(400, 'invalid_request', 'Ungültiger Payload.', targetActorContext.actor.requestId);
   }
 
-  const identityProvider = await requireUserMutationIdentityProvider(
-    targetActorContext.actor.instanceId,
-    targetActorContext.actor.requestId
-  );
-  if (identityProvider instanceof Response) {
-    return identityProvider;
-  }
-
   return {
     actor: targetActorContext.actor,
-    identityProvider,
     payload: parsedBody.data,
+    resolveIdentityProvider: () =>
+      requireUserMutationIdentityProvider(targetActorContext.actor.instanceId, targetActorContext.actor.requestId),
     userId: targetActorContext.userId,
   };
 };

--- a/packages/auth-runtime/src/middleware.test.ts
+++ b/packages/auth-runtime/src/middleware.test.ts
@@ -258,7 +258,7 @@ describe('auth-runtime withAuthenticatedUser', () => {
       freshReauthAt: 1_700_000_000_000,
       activeOrganizationId: '11111111-1111-1111-8111-111111111111',
       userId: 'user-1',
-      roles: ['admin', 'system_admin'],
+      roles: ['system_admin'],
     });
     expect(authServerMocks.resolveSessionUser).toHaveBeenCalledWith(
       request,

--- a/packages/auth-runtime/src/types.ts
+++ b/packages/auth-runtime/src/types.ts
@@ -22,6 +22,7 @@ export type SessionUser = {
   instanceId?: string;
   roles: string[];
   keycloakRoles?: string[];
+  permissionStatus?: 'ok' | 'degraded';
   groups?: readonly IamUserGroupAssignment[];
   username?: string;
   email?: string;

--- a/packages/auth-runtime/src/types.ts
+++ b/packages/auth-runtime/src/types.ts
@@ -21,6 +21,7 @@ export type SessionUser = {
   id: string;
   instanceId?: string;
   roles: string[];
+  keycloakRoles?: string[];
   groups?: readonly IamUserGroupAssignment[];
   username?: string;
   email?: string;

--- a/packages/core/dist/iam/account-management-contract.d.ts
+++ b/packages/core/dist/iam/account-management-contract.d.ts
@@ -131,6 +131,7 @@ export type IamUserListItem = {
     readonly department?: string;
     readonly lastLoginAt?: string;
     readonly roles: readonly IamUserRoleAssignment[];
+    readonly keycloakRoles?: readonly string[];
 };
 export type IamUserDetail = IamUserListItem & {
     readonly username?: string;

--- a/packages/core/src/iam/account-management-contract.ts
+++ b/packages/core/src/iam/account-management-contract.ts
@@ -227,6 +227,7 @@ export type IamUserListItem = {
   readonly department?: string;
   readonly lastLoginAt?: string;
   readonly roles: readonly IamUserRoleAssignment[];
+  readonly keycloakRoles?: readonly string[];
 };
 
 export type IamUserDetail = IamUserListItem & {

--- a/packages/iam-admin/src/handler-test-helpers.ts
+++ b/packages/iam-admin/src/handler-test-helpers.ts
@@ -10,3 +10,14 @@ export const createTestDepsBuilder =
     ...buildDefaults(),
     ...overrides,
   });
+
+export const dbWriteFailedErrorBody = (code: 'conflict' | 'internal_error', requestId: string) => ({
+  error: {
+    code,
+    details: {
+      syncState: 'failed',
+      syncError: { code: 'DB_WRITE_FAILED' },
+    },
+  },
+  requestId,
+});

--- a/packages/iam-admin/src/index.ts
+++ b/packages/iam-admin/src/index.ts
@@ -153,6 +153,7 @@ export {
 
 export {
   createUpdateUserHandlerInternal,
+  RoleMutationCapabilityUnavailableError,
   type UpdateAuthenticatedRequestContext,
   type UpdateUserHandlerDeps,
 } from './user-update-handler.js';

--- a/packages/iam-admin/src/index.ts
+++ b/packages/iam-admin/src/index.ts
@@ -83,6 +83,7 @@ export {
 export {
   filterPlatformTechnicalKeycloakRoleNames,
   filterTenantTechnicalKeycloakRoleNames,
+  resolveTenantTechnicalKeycloakRoleNames,
   isProtectedTenantRole,
   isTenantTechnicalKeycloakRole,
   isRootOnlyRole,

--- a/packages/iam-admin/src/index.ts
+++ b/packages/iam-admin/src/index.ts
@@ -154,6 +154,8 @@ export {
 export {
   createUpdateUserHandlerInternal,
   RoleMutationCapabilityUnavailableError,
+  shouldUpdateUserIdentityAttributes,
+  shouldUpdateUserIdentityPayload,
   type UpdateAuthenticatedRequestContext,
   type UpdateUserHandlerDeps,
 } from './user-update-handler.js';

--- a/packages/iam-admin/src/index.ts
+++ b/packages/iam-admin/src/index.ts
@@ -81,9 +81,14 @@ export {
   resolveSystemAdminCount,
 } from './actor-authorization.js';
 export {
+  filterPlatformTechnicalKeycloakRoleNames,
+  filterTenantTechnicalKeycloakRoleNames,
   isProtectedTenantRole,
+  isTenantTechnicalKeycloakRole,
   isRootOnlyRole,
   isTenantManageableRole,
+  PLATFORM_TECHNICAL_KEYCLOAK_ROLE_NAMES,
+  TENANT_TECHNICAL_KEYCLOAK_ROLE_NAMES,
 } from './role-governance.js';
 
 export {

--- a/packages/iam-admin/src/managed-role-sync.test.ts
+++ b/packages/iam-admin/src/managed-role-sync.test.ts
@@ -42,20 +42,20 @@ const createDeps = (rows = [managedRoleRow]) => {
 };
 
 describe('managed-role-sync', () => {
-  it('skips database access when no external role names are requested', async () => {
+  it('skips database access when no role keys are requested', async () => {
     const { deps } = createDeps([]);
     const sync = createManagedRoleSync(deps);
 
-    await expect(sync.loadManagedRolesByExternalNames('inst-1', [])).resolves.toEqual([]);
+    await expect(sync.loadManagedRolesByRoleKeys('inst-1', [])).resolves.toEqual([]);
 
     expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
   });
 
-  it('loads managed roles by external names with instance scope and deduplicated names', async () => {
+  it('loads managed roles by role key with instance scope and deduplicated keys', async () => {
     const { client, deps } = createDeps();
     const sync = createManagedRoleSync(deps);
 
-    await expect(sync.loadManagedRolesByExternalNames('inst-1', ['system_admin', 'system_admin'])).resolves.toEqual([
+    await expect(sync.loadManagedRolesByRoleKeys('inst-1', ['system_admin', 'system_admin'])).resolves.toEqual([
       managedRoleRow,
     ]);
 
@@ -76,7 +76,7 @@ describe('managed-role-sync', () => {
     await sync.ensureManagedRealmRolesExist({
       instanceId: 'inst-1',
       identityProvider,
-      externalRoleNames: ['system_admin', 'editor'],
+      roleKeys: ['system_admin', 'editor'],
       actorAccountId: 'actor-1',
       requestId: 'req-1',
       traceId: 'trace-1',
@@ -123,7 +123,7 @@ describe('managed-role-sync', () => {
     await sync.ensureManagedRealmRolesExist({
       instanceId: 'inst-1',
       identityProvider,
-      externalRoleNames: ['system_admin'],
+      roleKeys: ['system_admin'],
     });
 
     expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe('managed-role-sync', () => {
       sync.ensureManagedRealmRolesExist({
         instanceId: 'inst-1',
         identityProvider,
-      externalRoleNames: ['system_admin'],
+        roleKeys: ['system_admin'],
       })
     ).rejects.toThrow(error);
 

--- a/packages/iam-admin/src/managed-role-sync.test.ts
+++ b/packages/iam-admin/src/managed-role-sync.test.ts
@@ -5,13 +5,13 @@ import type { QueryClient } from './query-client.js';
 
 const managedRoleRow = {
   id: 'role-1',
-  role_key: 'editor',
-  role_name: 'editor',
-  display_name: 'Editor',
-  external_role_name: 'Editor',
-  description: 'Can edit content',
-  is_system_role: false,
-  role_level: 20,
+  role_key: 'system_admin',
+  role_name: 'system_admin',
+  display_name: 'System Admin',
+  external_role_name: 'system_admin',
+  description: 'Can manage tenant IAM',
+  is_system_role: true,
+  role_level: 90,
   managed_by: 'studio',
   sync_state: 'pending',
   last_synced_at: null,
@@ -55,12 +55,12 @@ describe('managed-role-sync', () => {
     const { client, deps } = createDeps();
     const sync = createManagedRoleSync(deps);
 
-    await expect(sync.loadManagedRolesByExternalNames('inst-1', ['Editor', 'Editor'])).resolves.toEqual([
+    await expect(sync.loadManagedRolesByExternalNames('inst-1', ['system_admin', 'system_admin'])).resolves.toEqual([
       managedRoleRow,
     ]);
 
     expect(deps.withInstanceScopedDb).toHaveBeenCalledWith('inst-1', expect.any(Function));
-    expect(client.query).toHaveBeenCalledWith(expect.stringContaining('FROM iam.roles'), ['inst-1', ['Editor']]);
+    expect(client.query).toHaveBeenCalledWith(expect.stringContaining('FROM iam.roles'), ['inst-1', ['system_admin']]);
   });
 
   it('creates missing realm roles and marks sync as successful', async () => {
@@ -68,7 +68,7 @@ describe('managed-role-sync', () => {
     const identityProvider = {
       provider: {
         getRoleByName: vi.fn(async () => null),
-        createRole: vi.fn(async () => ({ externalName: 'Editor' })),
+        createRole: vi.fn(async () => ({ externalName: 'system_admin' })),
       },
     };
     const sync = createManagedRoleSync(deps);
@@ -76,20 +76,20 @@ describe('managed-role-sync', () => {
     await sync.ensureManagedRealmRolesExist({
       instanceId: 'inst-1',
       identityProvider,
-      externalRoleNames: ['Editor'],
+      externalRoleNames: ['system_admin', 'editor'],
       actorAccountId: 'actor-1',
       requestId: 'req-1',
       traceId: 'trace-1',
     });
 
     expect(identityProvider.provider.createRole).toHaveBeenCalledWith({
-      externalName: 'Editor',
-      description: 'Can edit content',
+      externalName: 'system_admin',
+      description: 'Can manage tenant IAM',
       attributes: {
         managedBy: 'studio',
         instanceId: 'inst-1',
-        roleKey: 'editor',
-        displayName: 'Editor',
+        roleKey: 'system_admin',
+        displayName: 'System Admin',
       },
     });
     expect(deps.setRoleSyncState).toHaveBeenCalledWith(expect.anything(), {
@@ -104,8 +104,8 @@ describe('managed-role-sync', () => {
       expect.objectContaining({
         eventType: 'role.sync_succeeded',
         result: 'success',
-        roleKey: 'editor',
-        externalRoleName: 'Editor',
+        roleKey: 'system_admin',
+        externalRoleName: 'system_admin',
       })
     );
   });
@@ -114,8 +114,8 @@ describe('managed-role-sync', () => {
     const { deps } = createDeps();
     const identityProvider = {
       provider: {
-        getRoleByName: vi.fn(async () => ({ externalName: 'Editor' })),
-        createRole: vi.fn(async () => ({ externalName: 'Editor' })),
+        getRoleByName: vi.fn(async () => ({ externalName: 'system_admin' })),
+        createRole: vi.fn(async () => ({ externalName: 'system_admin' })),
       },
     };
     const sync = createManagedRoleSync(deps);
@@ -123,7 +123,7 @@ describe('managed-role-sync', () => {
     await sync.ensureManagedRealmRolesExist({
       instanceId: 'inst-1',
       identityProvider,
-      externalRoleNames: ['Editor'],
+      externalRoleNames: ['system_admin'],
     });
 
     expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe('managed-role-sync', () => {
       sync.ensureManagedRealmRolesExist({
         instanceId: 'inst-1',
         identityProvider,
-        externalRoleNames: ['Editor'],
+      externalRoleNames: ['system_admin'],
       })
     ).rejects.toThrow(error);
 

--- a/packages/iam-admin/src/managed-role-sync.test.ts
+++ b/packages/iam-admin/src/managed-role-sync.test.ts
@@ -64,7 +64,7 @@ describe('managed-role-sync', () => {
   });
 
   it('creates missing realm roles and marks sync as successful', async () => {
-    const { deps } = createDeps();
+    const { deps } = createDeps([{ ...managedRoleRow, external_role_name: 'legacy-system-admin' }]);
     const identityProvider = {
       provider: {
         getRoleByName: vi.fn(async () => null),

--- a/packages/iam-admin/src/managed-role-sync.ts
+++ b/packages/iam-admin/src/managed-role-sync.ts
@@ -1,5 +1,6 @@
 import type { IdentityProviderPort, IdentityManagedRoleAttributes } from './identity-provider-port.js';
 import { getRoleExternalName, mapRoleSyncErrorCode } from './role-audit.js';
+import { filterTenantTechnicalKeycloakRoleNames } from './role-governance.js';
 import type { QueryClient } from './query-client.js';
 import type { ManagedRoleRow } from './types.js';
 
@@ -56,7 +57,8 @@ export const createManagedRoleSync = (deps: ManagedRoleSyncDeps) => {
     instanceId: string,
     externalRoleNames: readonly string[]
   ): Promise<readonly ManagedRoleSyncRow[]> => {
-    if (externalRoleNames.length === 0) {
+    const technicalRoleNames = filterTenantTechnicalKeycloakRoleNames(externalRoleNames);
+    if (technicalRoleNames.length === 0) {
       return [];
     }
 
@@ -81,7 +83,7 @@ WHERE instance_id = $1
   AND managed_by = 'studio'
   AND COALESCE(external_role_name, role_key) = ANY($2::text[]);
 `,
-        [instanceId, [...new Set(externalRoleNames)]]
+        [instanceId, [...technicalRoleNames]]
       );
 
       return result.rows;

--- a/packages/iam-admin/src/managed-role-sync.ts
+++ b/packages/iam-admin/src/managed-role-sync.ts
@@ -1,5 +1,5 @@
 import type { IdentityProviderPort, IdentityManagedRoleAttributes } from './identity-provider-port.js';
-import { getRoleExternalName, mapRoleSyncErrorCode } from './role-audit.js';
+import { mapRoleSyncErrorCode } from './role-audit.js';
 import { filterTenantTechnicalKeycloakRoleNames } from './role-governance.js';
 import type { QueryClient } from './query-client.js';
 import type { ManagedRoleRow } from './types.js';
@@ -81,7 +81,7 @@ SELECT
 FROM iam.roles
 WHERE instance_id = $1
   AND managed_by = 'studio'
-  AND COALESCE(external_role_name, role_key) = ANY($2::text[]);
+  AND role_key = ANY($2::text[]);
 `,
         [instanceId, [...technicalRoleNames]]
       );
@@ -136,7 +136,7 @@ WHERE instance_id = $1
     const managedRoles = await loadManagedRolesByExternalNames(input.instanceId, input.externalRoleNames);
 
     for (const role of managedRoles) {
-      const externalRoleName = getRoleExternalName(role);
+      const externalRoleName = role.role_key;
       const existingRole = await deps.trackKeycloakCall('ensure_role_exists_get', () =>
         input.identityProvider.provider.getRoleByName(externalRoleName)
       );

--- a/packages/iam-admin/src/managed-role-sync.ts
+++ b/packages/iam-admin/src/managed-role-sync.ts
@@ -53,12 +53,12 @@ export type ManagedRoleIdentityProviderResolution = {
 };
 
 export const createManagedRoleSync = (deps: ManagedRoleSyncDeps) => {
-  const loadManagedRolesByExternalNames = async (
+  const loadManagedRolesByRoleKeys = async (
     instanceId: string,
-    externalRoleNames: readonly string[]
+    roleKeys: readonly string[]
   ): Promise<readonly ManagedRoleSyncRow[]> => {
-    const technicalRoleNames = filterTenantTechnicalKeycloakRoleNames(externalRoleNames);
-    if (technicalRoleNames.length === 0) {
+    const technicalRoleKeys = filterTenantTechnicalKeycloakRoleNames(roleKeys);
+    if (technicalRoleKeys.length === 0) {
       return [];
     }
 
@@ -83,7 +83,7 @@ WHERE instance_id = $1
   AND managed_by = 'studio'
   AND role_key = ANY($2::text[]);
 `,
-        [instanceId, [...technicalRoleNames]]
+        [instanceId, [...technicalRoleKeys]]
       );
 
       return result.rows;
@@ -128,12 +128,12 @@ WHERE instance_id = $1
   const ensureManagedRealmRolesExist = async (input: {
     readonly instanceId: string;
     readonly identityProvider: ManagedRoleIdentityProviderResolution;
-    readonly externalRoleNames: readonly string[];
+    readonly roleKeys: readonly string[];
     readonly actorAccountId?: string;
     readonly requestId?: string;
     readonly traceId?: string;
   }): Promise<void> => {
-    const managedRoles = await loadManagedRolesByExternalNames(input.instanceId, input.externalRoleNames);
+    const managedRoles = await loadManagedRolesByRoleKeys(input.instanceId, input.roleKeys);
 
     for (const role of managedRoles) {
       const externalRoleName = role.role_key;
@@ -187,6 +187,6 @@ WHERE instance_id = $1
 
   return {
     ensureManagedRealmRolesExist,
-    loadManagedRolesByExternalNames,
+    loadManagedRolesByRoleKeys,
   };
 };

--- a/packages/iam-admin/src/reconcile-core.test.ts
+++ b/packages/iam-admin/src/reconcile-core.test.ts
@@ -7,6 +7,96 @@ const createIdentityProvider = () => ({
   getRoleByName: vi.fn(async () => null),
 });
 
+const createRealmRole = (input: {
+  readonly description: string;
+  readonly displayName: string;
+  readonly externalName: string;
+  readonly roleKey: string;
+  readonly roleLevel?: number;
+}) => ({
+  externalName: input.externalName,
+  description: input.description,
+  clientRole: false,
+  attributes: {
+    managed_by: ['studio'],
+    instance_id: ['tenant-a'],
+    role_key: [input.roleKey],
+    display_name: [input.displayName],
+    ...(input.roleLevel === undefined ? {} : { role_level: [String(input.roleLevel)] }),
+  },
+});
+
+const createDatabaseRole = (
+  overrides: Partial<{
+    readonly description: string;
+    readonly display_name: string;
+    readonly external_role_name: string;
+    readonly id: string;
+    readonly is_system_role: boolean;
+    readonly last_error_code: string | null;
+    readonly last_synced_at: string | null;
+    readonly managed_by: string;
+    readonly role_key: string;
+    readonly role_level: number;
+    readonly role_name: string;
+    readonly sync_state: string;
+  }>
+) => ({
+  id: 'role-1',
+  role_key: 'system_admin',
+  role_name: 'system_admin',
+  display_name: 'System Admin',
+  external_role_name: 'system_admin',
+  description: 'Canonical description',
+  is_system_role: false,
+  role_level: 0,
+  managed_by: 'studio',
+  sync_state: 'failed',
+  last_synced_at: null,
+  last_error_code: 'OLD_ERROR',
+  ...overrides,
+});
+
+const createScopedDbWithRoles = (rows: readonly unknown[]) =>
+  vi.fn(async (_instanceId, work) =>
+    work({
+      query: vi.fn(async (sql: string) => (sql.includes('SELECT\n  id,') ? { rows } : { rows: [] })),
+    } as never)
+  );
+
+const expectRoleSyncMarkedSynced = (deps: RoleCatalogReconciliationDeps, roleId: string) => {
+  expect(deps.setRoleSyncState).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      instanceId: 'tenant-a',
+      roleId,
+      syncState: 'synced',
+      errorCode: null,
+      syncedAt: true,
+    })
+  );
+};
+
+const createSystemAdminProviderResolver = (input: {
+  readonly description: string;
+  readonly displayName: string;
+  readonly updateRole: ReturnType<typeof vi.fn>;
+}) =>
+  vi.fn(async () => ({
+    provider: {
+      listRoles: vi.fn(async () => [
+        createRealmRole({
+          externalName: 'system_admin',
+          description: input.description,
+          roleKey: 'system_admin',
+          displayName: input.displayName,
+        }),
+      ]),
+      getRoleByName: vi.fn(async () => null),
+      updateRole: input.updateRole,
+    } as never,
+  }));
+
 const createDeps = (overrides: Partial<RoleCatalogReconciliationDeps> = {}): RoleCatalogReconciliationDeps => ({
   resolveIdentityProviderForInstance: vi.fn(async () => ({ provider: createIdentityProvider() as never })),
   withInstanceScopedDb: vi.fn(async (_instanceId, work) =>
@@ -165,34 +255,19 @@ describe('runRoleCatalogReconciliation', () => {
           updateRole,
         } as never,
       })),
-      withInstanceScopedDb: vi.fn(async (_instanceId, work) =>
-        work({
-          query: vi.fn(async (sql: string) => {
-            if (sql.includes('SELECT\n  id,')) {
-              return {
-                rows: [
-                  {
-                    id: 'role-root-only',
-                    role_key: 'instance_registry_admin',
-                    role_name: 'instance_registry_admin',
-                    display_name: 'Instance Registry Administrator',
-                    external_role_name: 'instance_registry_admin',
-                    description: '[legacy-root-role-in-tenant]',
-                    is_system_role: false,
-                    role_level: 100,
-                    managed_by: 'studio',
-                    sync_state: 'pending',
-                    last_synced_at: null,
-                    last_error_code: null,
-                  },
-                ],
-              };
-            }
-
-            return { rows: [] };
-          }),
-        } as never)
-      ),
+      withInstanceScopedDb: createScopedDbWithRoles([
+        createDatabaseRole({
+          id: 'role-root-only',
+          role_key: 'instance_registry_admin',
+          role_name: 'instance_registry_admin',
+          display_name: 'Instance Registry Administrator',
+          external_role_name: 'instance_registry_admin',
+          description: '[legacy-root-role-in-tenant]',
+          role_level: 100,
+          sync_state: 'pending',
+          last_error_code: null,
+        }),
+      ]),
     });
 
     const report = await runRoleCatalogReconciliation({
@@ -221,30 +296,20 @@ describe('runRoleCatalogReconciliation', () => {
       resolveIdentityProviderForInstance: vi.fn(async () => ({
         provider: {
           listRoles: vi.fn(async () => [
-            {
+            createRealmRole({
               externalName: 'mainserver_editor',
               description: 'Canonical editor role',
-              clientRole: false,
-              attributes: {
-                managed_by: ['studio'],
-                instance_id: ['tenant-a'],
-                role_key: ['mainserver_editor'],
-                display_name: ['Editor'],
-                role_level: ['0'],
-              },
-            },
-            {
+              roleKey: 'mainserver_editor',
+              displayName: 'Editor',
+              roleLevel: 0,
+            }),
+            createRealmRole({
               externalName: 'Editor',
               description: 'Alias editor role',
-              clientRole: false,
-              attributes: {
-                managed_by: ['studio'],
-                instance_id: ['tenant-a'],
-                role_key: ['mainserver_editor'],
-                display_name: ['Editor'],
-                role_level: ['0'],
-              },
-            },
+              roleKey: 'mainserver_editor',
+              displayName: 'Editor',
+              roleLevel: 0,
+            }),
           ]),
           getRoleByName: vi.fn(async () => null),
         } as never,
@@ -292,55 +357,20 @@ describe('runRoleCatalogReconciliation', () => {
     );
   });
 
-  it('updates mismatched managed roles and persists synced reconcile state', async () => {
-    const updateRole = vi.fn(async () => undefined);
-    const deps = createDeps({
-      resolveIdentityProviderForInstance: vi.fn(async () => ({
-        provider: {
-          listRoles: vi.fn(async () => [
-            {
-              externalName: 'system_admin',
-              description: 'Outdated description',
-              clientRole: false,
-              attributes: {
-                managed_by: ['studio'],
-                instance_id: ['tenant-a'],
-                role_key: ['system_admin'],
-                display_name: ['Old display name'],
-              },
-            },
-          ]),
-          getRoleByName: vi.fn(async () => null),
-          updateRole,
-        } as never,
-      })),
-      withInstanceScopedDb: vi.fn(async (_instanceId, work) =>
-        work({
-          query: vi.fn(async (sql: string) => {
-            if (sql.includes('SELECT\n  id,')) {
-              return {
-                rows: [
-                  {
-                    id: 'role-1',
-                    role_key: 'system_admin',
-                    role_name: 'system_admin',
-                    display_name: 'System Admin',
-                    external_role_name: 'system_admin',
-                    description: 'Canonical description',
-                    is_system_role: false,
-                    role_level: 0,
-                    managed_by: 'studio',
-                    sync_state: 'failed',
-                    last_synced_at: null,
-                    last_error_code: 'PREVIOUS_ERROR',
-                  },
-                ],
-              };
-            }
-            return { rows: [] };
-          }),
-        } as never)
-      ),
+	  it('updates mismatched managed roles and persists synced reconcile state', async () => {
+	    const updateRole = vi.fn(async () => undefined);
+	    const deps = createDeps({
+	      resolveIdentityProviderForInstance: createSystemAdminProviderResolver({
+	        description: 'Outdated description',
+	        displayName: 'Old display name',
+	        updateRole,
+	      }),
+      withInstanceScopedDb: createScopedDbWithRoles([
+        createDatabaseRole({
+          id: 'role-1',
+          last_error_code: 'PREVIOUS_ERROR',
+        }),
+      ]),
     });
 
     const report = await runRoleCatalogReconciliation({
@@ -359,16 +389,7 @@ describe('runRoleCatalogReconciliation', () => {
         displayName: 'System Admin',
       },
     });
-    expect(deps.setRoleSyncState).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        instanceId: 'tenant-a',
-        roleId: 'role-1',
-        syncState: 'synced',
-        errorCode: null,
-        syncedAt: true,
-      })
-    );
+    expectRoleSyncMarkedSynced(deps, 'role-1');
     expect(report).toMatchObject({
       outcome: 'success',
       correctedCount: 1,
@@ -385,55 +406,20 @@ describe('runRoleCatalogReconciliation', () => {
     });
   });
 
-  it('accepts canonical identity roles for legacy external-name aliases without forcing an idp update', async () => {
-    const updateRole = vi.fn(async () => undefined);
-    const deps = createDeps({
-      resolveIdentityProviderForInstance: vi.fn(async () => ({
-        provider: {
-          listRoles: vi.fn(async () => [
-            {
-              externalName: 'system_admin',
-              description: 'Canonical description',
-              clientRole: false,
-              attributes: {
-                managed_by: ['studio'],
-                instance_id: ['tenant-a'],
-                role_key: ['system_admin'],
-                display_name: ['System Admin'],
-              },
-            },
-          ]),
-          getRoleByName: vi.fn(async () => null),
-          updateRole,
-        } as never,
-      })),
-      withInstanceScopedDb: vi.fn(async (_instanceId, work) =>
-        work({
-          query: vi.fn(async (sql: string) => {
-            if (sql.includes('SELECT\n  id,')) {
-              return {
-                rows: [
-                  {
-                    id: 'role-legacy-alias',
-                    role_key: 'system_admin',
-                    role_name: 'system_admin',
-                    display_name: 'System Admin',
-                    external_role_name: 'System Admin',
-                    description: 'Canonical description',
-                    is_system_role: false,
-                    role_level: 0,
-                    managed_by: 'studio',
-                    sync_state: 'failed',
-                    last_synced_at: null,
-                    last_error_code: 'OLD_ERROR',
-                  },
-                ],
-              };
-            }
-            return { rows: [] };
-          }),
-        } as never)
-      ),
+	  it('accepts canonical identity roles for legacy external-name aliases without forcing an idp update', async () => {
+	    const updateRole = vi.fn(async () => undefined);
+	    const deps = createDeps({
+	      resolveIdentityProviderForInstance: createSystemAdminProviderResolver({
+	        description: 'Canonical description',
+	        displayName: 'System Admin',
+	        updateRole,
+	      }),
+      withInstanceScopedDb: createScopedDbWithRoles([
+        createDatabaseRole({
+          id: 'role-legacy-alias',
+          external_role_name: 'System Admin',
+        }),
+      ]),
     });
 
     const report = await runRoleCatalogReconciliation({
@@ -443,16 +429,7 @@ describe('runRoleCatalogReconciliation', () => {
     });
 
     expect(updateRole).not.toHaveBeenCalled();
-    expect(deps.setRoleSyncState).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        instanceId: 'tenant-a',
-        roleId: 'role-legacy-alias',
-        syncState: 'synced',
-        errorCode: null,
-        syncedAt: true,
-      })
-    );
+    expectRoleSyncMarkedSynced(deps, 'role-legacy-alias');
     expect(report).toMatchObject({
       outcome: 'success',
       correctedCount: 1,
@@ -475,50 +452,23 @@ describe('runRoleCatalogReconciliation', () => {
       resolveIdentityProviderForInstance: vi.fn(async () => ({
         provider: {
           listRoles: vi.fn(async () => [
-            {
+            createRealmRole({
               externalName: 'legacy_editor',
               description: 'Legacy editor role',
-              clientRole: false,
-              attributes: {
-                managed_by: ['studio'],
-                instance_id: ['tenant-a'],
-                role_key: ['legacy_editor'],
-                display_name: ['Legacy editor'],
-              },
-            },
+              roleKey: 'legacy_editor',
+              displayName: 'Legacy editor',
+            }),
           ]),
           getRoleByName: vi.fn(async () => null),
           createRole,
           updateRole: vi.fn(async () => undefined),
         } as never,
       })),
-      withInstanceScopedDb: vi.fn(async (_instanceId, work) =>
-        work({
-          query: vi.fn(async (sql: string) => {
-            if (sql.includes('SELECT\n  id,')) {
-              return {
-                rows: [
-                  {
-                    id: 'role-system-admin',
-                    role_key: 'system_admin',
-                    role_name: 'system_admin',
-                    display_name: 'System Admin',
-                    external_role_name: 'system_admin',
-                    description: 'Canonical description',
-                    is_system_role: false,
-                    role_level: 0,
-                    managed_by: 'studio',
-                    sync_state: 'failed',
-                    last_synced_at: null,
-                    last_error_code: 'OLD_ERROR',
-                  },
-                ],
-              };
-            }
-            return { rows: [] };
-          }),
-        } as never)
-      ),
+      withInstanceScopedDb: createScopedDbWithRoles([
+        createDatabaseRole({
+          id: 'role-system-admin',
+        }),
+      ]),
     });
 
     const report = await runRoleCatalogReconciliation({

--- a/packages/iam-admin/src/reconcile-core.test.ts
+++ b/packages/iam-admin/src/reconcile-core.test.ts
@@ -357,14 +357,14 @@ describe('runRoleCatalogReconciliation', () => {
     );
   });
 
-	  it('updates mismatched managed roles and persists synced reconcile state', async () => {
-	    const updateRole = vi.fn(async () => undefined);
-	    const deps = createDeps({
-	      resolveIdentityProviderForInstance: createSystemAdminProviderResolver({
-	        description: 'Outdated description',
-	        displayName: 'Old display name',
-	        updateRole,
-	      }),
+  it('updates mismatched managed roles and persists synced reconcile state', async () => {
+    const updateRole = vi.fn(async () => undefined);
+    const deps = createDeps({
+      resolveIdentityProviderForInstance: createSystemAdminProviderResolver({
+        description: 'Outdated description',
+        displayName: 'Old display name',
+        updateRole,
+      }),
       withInstanceScopedDb: createScopedDbWithRoles([
         createDatabaseRole({
           id: 'role-1',
@@ -406,14 +406,14 @@ describe('runRoleCatalogReconciliation', () => {
     });
   });
 
-	  it('accepts canonical identity roles for legacy external-name aliases without forcing an idp update', async () => {
-	    const updateRole = vi.fn(async () => undefined);
-	    const deps = createDeps({
-	      resolveIdentityProviderForInstance: createSystemAdminProviderResolver({
-	        description: 'Canonical description',
-	        displayName: 'System Admin',
-	        updateRole,
-	      }),
+  it('accepts canonical identity roles for legacy external-name aliases without forcing an idp update', async () => {
+    const updateRole = vi.fn(async () => undefined);
+    const deps = createDeps({
+      resolveIdentityProviderForInstance: createSystemAdminProviderResolver({
+        description: 'Canonical description',
+        displayName: 'System Admin',
+        updateRole,
+      }),
       withInstanceScopedDb: createScopedDbWithRoles([
         createDatabaseRole({
           id: 'role-legacy-alias',

--- a/packages/iam-admin/src/reconcile-core.test.ts
+++ b/packages/iam-admin/src/reconcile-core.test.ts
@@ -215,7 +215,7 @@ describe('runRoleCatalogReconciliation', () => {
     expect(deps.setRoleDriftBacklog).toHaveBeenCalledWith('tenant-a', 0);
   });
 
-  it('does not import the same role key twice when multiple identity roles point to one canonical role', async () => {
+  it('reports non-technical managed Keycloak roles as manual drift instead of importing them', async () => {
     const insertAttempts: string[] = [];
     const deps = createDeps({
       resolveIdentityProviderForInstance: vi.fn(async () => ({
@@ -275,12 +275,21 @@ describe('runRoleCatalogReconciliation', () => {
     });
 
     expect(report).toMatchObject({
-      outcome: 'success',
-      correctedCount: 1,
+      outcome: 'failed',
+      correctedCount: 0,
       failedCount: 0,
-      manualReviewCount: 0,
+      manualReviewCount: 2,
     });
-    expect(insertAttempts).toHaveLength(1);
+    expect(insertAttempts).toHaveLength(0);
+    expect(report.roles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          externalRoleName: 'mainserver_editor',
+          action: 'report',
+          status: 'requires_manual_action',
+        }),
+      ])
+    );
   });
 
   it('updates mismatched managed roles and persists synced reconcile state', async () => {
@@ -290,13 +299,13 @@ describe('runRoleCatalogReconciliation', () => {
         provider: {
           listRoles: vi.fn(async () => [
             {
-              externalName: 'mainserver_editor',
+              externalName: 'system_admin',
               description: 'Outdated description',
               clientRole: false,
               attributes: {
                 managed_by: ['studio'],
                 instance_id: ['tenant-a'],
-                role_key: ['mainserver_editor'],
+                role_key: ['system_admin'],
                 display_name: ['Old display name'],
               },
             },
@@ -313,10 +322,10 @@ describe('runRoleCatalogReconciliation', () => {
                 rows: [
                   {
                     id: 'role-1',
-                    role_key: 'mainserver_editor',
-                    role_name: 'mainserver_editor',
-                    display_name: 'Editor',
-                    external_role_name: 'mainserver_editor',
+                    role_key: 'system_admin',
+                    role_name: 'system_admin',
+                    display_name: 'System Admin',
+                    external_role_name: 'system_admin',
                     description: 'Canonical description',
                     is_system_role: false,
                     role_level: 0,
@@ -341,13 +350,13 @@ describe('runRoleCatalogReconciliation', () => {
       traceId: 'trace-1',
     });
 
-    expect(updateRole).toHaveBeenCalledWith('mainserver_editor', {
+    expect(updateRole).toHaveBeenCalledWith('system_admin', {
       description: 'Canonical description',
       attributes: {
         managedBy: 'studio',
         instanceId: 'tenant-a',
-        roleKey: 'mainserver_editor',
-        displayName: 'Editor',
+        roleKey: 'system_admin',
+        displayName: 'System Admin',
       },
     });
     expect(deps.setRoleSyncState).toHaveBeenCalledWith(
@@ -367,8 +376,8 @@ describe('runRoleCatalogReconciliation', () => {
       roles: [
         {
           roleId: 'role-1',
-          roleKey: 'mainserver_editor',
-          externalRoleName: 'mainserver_editor',
+          roleKey: 'system_admin',
+          externalRoleName: 'system_admin',
           action: 'update',
           status: 'corrected',
         },
@@ -383,14 +392,14 @@ describe('runRoleCatalogReconciliation', () => {
         provider: {
           listRoles: vi.fn(async () => [
             {
-              externalName: 'mainserver_editor',
+              externalName: 'system_admin',
               description: 'Canonical description',
               clientRole: false,
               attributes: {
                 managed_by: ['studio'],
                 instance_id: ['tenant-a'],
-                role_key: ['mainserver_editor'],
-                display_name: ['Editor'],
+                role_key: ['system_admin'],
+                display_name: ['System Admin'],
               },
             },
           ]),
@@ -406,10 +415,10 @@ describe('runRoleCatalogReconciliation', () => {
                 rows: [
                   {
                     id: 'role-legacy-alias',
-                    role_key: 'mainserver_editor',
-                    role_name: 'mainserver_editor',
-                    display_name: 'Editor',
-                    external_role_name: 'Editor',
+                    role_key: 'system_admin',
+                    role_name: 'system_admin',
+                    display_name: 'System Admin',
+                    external_role_name: 'System Admin',
                     description: 'Canonical description',
                     is_system_role: false,
                     role_level: 0,
@@ -451,8 +460,8 @@ describe('runRoleCatalogReconciliation', () => {
       roles: [
         {
           roleId: 'role-legacy-alias',
-          roleKey: 'mainserver_editor',
-          externalRoleName: 'Editor',
+          roleKey: 'system_admin',
+          externalRoleName: 'System Admin',
           action: 'noop',
           status: 'corrected',
         },
@@ -460,25 +469,21 @@ describe('runRoleCatalogReconciliation', () => {
     });
   });
 
-  it('reports partial failures when one role sync succeeds and another one fails', async () => {
-    const createRole = vi.fn(async ({ externalName }: { externalName: string }) => {
-      if (externalName === 'missing_role') {
-        throw Object.assign(new Error('timeout'), { name: 'KeycloakAdminRequestError', code: 'read_timeout', statusCode: 504 });
-      }
-    });
+  it('reports partial failures when a technical role is repaired and a legacy Keycloak role needs manual review', async () => {
+    const createRole = vi.fn(async () => undefined);
     const deps = createDeps({
       resolveIdentityProviderForInstance: vi.fn(async () => ({
         provider: {
           listRoles: vi.fn(async () => [
             {
-              externalName: 'existing_role',
-              description: 'Canonical description',
+              externalName: 'legacy_editor',
+              description: 'Legacy editor role',
               clientRole: false,
               attributes: {
                 managed_by: ['studio'],
                 instance_id: ['tenant-a'],
-                role_key: ['existing_role'],
-                display_name: ['Existing role'],
+                role_key: ['legacy_editor'],
+                display_name: ['Legacy editor'],
               },
             },
           ]),
@@ -494,26 +499,12 @@ describe('runRoleCatalogReconciliation', () => {
               return {
                 rows: [
                   {
-                    id: 'role-existing',
-                    role_key: 'existing_role',
-                    role_name: 'existing_role',
-                    display_name: 'Existing role',
-                    external_role_name: 'existing_role',
+                    id: 'role-system-admin',
+                    role_key: 'system_admin',
+                    role_name: 'system_admin',
+                    display_name: 'System Admin',
+                    external_role_name: 'system_admin',
                     description: 'Canonical description',
-                    is_system_role: false,
-                    role_level: 0,
-                    managed_by: 'studio',
-                    sync_state: 'failed',
-                    last_synced_at: null,
-                    last_error_code: 'OLD_ERROR',
-                  },
-                  {
-                    id: 'role-missing',
-                    role_key: 'missing_role',
-                    role_name: 'missing_role',
-                    display_name: 'Missing role',
-                    external_role_name: 'missing_role',
-                    description: null,
                     is_system_role: false,
                     role_level: 0,
                     managed_by: 'studio',
@@ -539,13 +530,18 @@ describe('runRoleCatalogReconciliation', () => {
     expect(report).toMatchObject({
       outcome: 'partial_failure',
       correctedCount: 1,
-      failedCount: 1,
-      requiresManualActionCount: 0,
+      failedCount: 0,
+      requiresManualActionCount: 1,
     });
     expect(report.roles).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ roleKey: 'existing_role', status: 'corrected' }),
-        expect.objectContaining({ roleKey: 'missing_role', status: 'failed', errorCode: 'IDP_TIMEOUT' }),
+        expect.objectContaining({ roleKey: 'system_admin', status: 'corrected' }),
+        expect.objectContaining({
+          roleKey: 'legacy_editor',
+          externalRoleName: 'legacy_editor',
+          status: 'requires_manual_action',
+          errorCode: 'REQUIRES_MANUAL_ACTION',
+        }),
       ])
     );
   });

--- a/packages/iam-admin/src/reconcile-core.ts
+++ b/packages/iam-admin/src/reconcile-core.ts
@@ -8,7 +8,7 @@ import {
   sanitizeRoleErrorMessage,
 } from './role-audit.js';
 import type { QueryClient } from './query-client.js';
-import { isTenantManageableRole } from './role-governance.js';
+import { isTenantManageableRole, isTenantTechnicalKeycloakRole } from './role-governance.js';
 import type { ManagedRoleRow } from './types.js';
 
 type IdentityRole = Awaited<ReturnType<IdentityProviderPort['getRoleByName']>> extends infer T ? Exclude<T, null> : never;
@@ -575,6 +575,12 @@ const appendManualActionEntry = (entries: ReconcileRoleEntry[], identityRole: Id
   });
 };
 
+const isTechnicalIdentityRole = (identityRole: IdentityRole): boolean =>
+  isTenantTechnicalKeycloakRole({
+    role_key: readRoleAttribute(identityRole.attributes, 'role_key') ?? identityRole.externalName,
+    external_role_name: identityRole.externalName,
+  });
+
 const appendImportedRoleEntry = (
   entries: ReconcileRoleEntry[],
   importedRole: { roleId: string },
@@ -754,6 +760,11 @@ const reconcileManagedIdentityRoles = async (input: {
 }) => {
   const { deps } = input;
   for (const identityRole of input.managedIdpRoles) {
+    if (!isTechnicalIdentityRole(identityRole)) {
+      appendManualActionEntry(input.entries, identityRole);
+      continue;
+    }
+
     if (
       shouldSkipManagedIdentityRole({
         identityRole,
@@ -872,8 +883,14 @@ const reportRemainingPotentialStudioRoles = (input: {
   dbByExternalName: ReadonlyMap<string, ManagedRoleRow>;
   entries: ReconcileRoleEntry[];
 }) => {
+  const reportedExternalNames = new Set(input.entries.map((entry) => entry.externalRoleName));
+
   for (const identityRole of input.idpRoles) {
-    if (input.idpByExternalName.has(identityRole.externalName) || input.dbByExternalName.has(identityRole.externalName)) {
+    if (input.idpByExternalName.has(identityRole.externalName)) {
+      continue;
+    }
+
+    if (reportedExternalNames.has(identityRole.externalName)) {
       continue;
     }
 
@@ -930,19 +947,21 @@ ORDER BY role_level DESC, COALESCE(display_name, role_name) ASC;
     );
     return result.rows.filter((role) => isTenantManageableRole(role));
   });
+  const technicalDbRoles = dbRoles.filter((role) => isTenantTechnicalKeycloakRole(role));
 
   const listedIdpRoles = await deps.trackKeycloakCall('reconcile_list_roles', () => identityProvider.provider.listRoles());
   const idpRoles = await hydrateRoleDetailsForReconciliation(deps, identityProvider, listedIdpRoles);
   const managedIdpRoles = idpRoles.filter((role) => isStudioManagedIdentityRole(role, input.instanceId));
-  const idpByExternalName = new Map(managedIdpRoles.map((role) => [role.externalName, role]));
+  const technicalManagedIdpRoles = managedIdpRoles.filter(isTechnicalIdentityRole);
+  const idpByExternalName = new Map(technicalManagedIdpRoles.map((role) => [role.externalName, role]));
   const idpByRoleKey = new Map(
-    managedIdpRoles.flatMap((role) => {
+    technicalManagedIdpRoles.flatMap((role) => {
       const roleKey = readRoleAttribute(role.attributes, 'role_key');
       return roleKey ? ([[roleKey, role]] as const) : [];
     })
   );
-  const dbByExternalName = new Map(dbRoles.map((role) => [getRoleExternalName(role), role]));
-  const dbByRoleKey = new Map(dbRoles.map((role) => [role.role_key, role]));
+  const dbByExternalName = new Map(technicalDbRoles.map((role) => [getRoleExternalName(role), role]));
+  const dbByRoleKey = new Map(technicalDbRoles.map((role) => [role.role_key, role]));
   const matchedIdentityExternalNames = new Set<string>();
   const matchedIdentityRoleKeys = new Set<string>();
 
@@ -957,7 +976,7 @@ ORDER BY role_level DESC, COALESCE(display_name, role_name) ASC;
 
   await reconcileDatabaseRoles({
     deps,
-    dbRoles,
+    dbRoles: technicalDbRoles,
     idpByExternalName,
     idpByRoleKey,
     matchedIdentityExternalNames,

--- a/packages/iam-admin/src/role-create-handler.test.ts
+++ b/packages/iam-admin/src/role-create-handler.test.ts
@@ -81,7 +81,7 @@ describe('createCreateRoleHandlerInternal', () => {
     identityProvider.provider.deleteRole.mockClear();
   });
 
-  it('creates the role in Keycloak, persists it locally and completes idempotency', async () => {
+  it('persists tenant roles locally without creating Keycloak roles', async () => {
     const deps = createDeps();
     const handler = createCreateRoleHandlerInternal(deps);
 
@@ -92,16 +92,8 @@ describe('createCreateRoleHandlerInternal', () => {
       data: roleItem,
       requestId: 'req-create-role',
     });
-    expect(identityProvider.provider.createRole).toHaveBeenCalledWith({
-      externalName: 'editor',
-      description: 'Can edit content',
-      attributes: {
-        managedBy: 'studio',
-        instanceId: 'de-musterhausen',
-        roleKey: 'editor',
-        displayName: 'Editor',
-      },
-    });
+    expect(deps.requireRoleIdentityProvider).not.toHaveBeenCalled();
+    expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
     expect(deps.persistCreatedRole).toHaveBeenCalledWith({
       actor,
       roleKey: 'editor',
@@ -136,7 +128,7 @@ describe('createCreateRoleHandlerInternal', () => {
     expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
   });
 
-  it('stores a failed idempotency response when no identity provider is configured', async () => {
+  it('does not require an identity provider for local tenant roles', async () => {
     const deps = createDeps({
       requireRoleIdentityProvider: vi.fn(async () => createJsonResponse(409, { error: { code: 'tenant_admin_client_not_configured' } })),
     });
@@ -144,21 +136,19 @@ describe('createCreateRoleHandlerInternal', () => {
 
     const response = await handler(new Request('http://localhost/api/v1/iam/roles', { method: 'POST' }), ctx);
 
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(201);
     expect(deps.completeIdempotency).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       actorAccountId: 'actor-account-1',
       endpoint: 'POST:/api/v1/iam/roles',
       idempotencyKey: 'idem-role-1',
-      status: 'FAILED',
-      responseStatus: 503,
-      responseBody: expect.objectContaining({
-        error: expect.objectContaining({ code: 'keycloak_unavailable' }),
-      }),
+      status: 'COMPLETED',
+      responseStatus: 201,
+      responseBody: expect.objectContaining({ requestId: 'req-create-role' }),
     });
   });
 
-  it('returns invalid_request before idempotency or Keycloak when tenant permissions are not manageable', async () => {
+  it('returns invalid_request before idempotency when tenant permissions are not manageable', async () => {
     const invalidResponse = createJsonResponse(400, {
       error: { code: 'invalid_request', message: 'Mindestens eine Berechtigung ist im Tenant nicht verwaltbar.' },
       requestId: 'req-create-role',
@@ -176,7 +166,7 @@ describe('createCreateRoleHandlerInternal', () => {
     expect(deps.persistCreatedRole).not.toHaveBeenCalled();
   });
 
-  it('compensates Keycloak role creation when local persistence fails', async () => {
+  it('returns a local creation failure without Keycloak compensation when persistence fails', async () => {
     const deps = createDeps({
       persistCreatedRole: vi.fn(async () => {
         throw new Error('db write failed');
@@ -186,17 +176,18 @@ describe('createCreateRoleHandlerInternal', () => {
 
     const response = await handler(new Request('http://localhost/api/v1/iam/roles', { method: 'POST' }), ctx);
 
-    expect(response.status).toBe(409);
-    expect(identityProvider.provider.deleteRole).toHaveBeenCalledWith('editor');
+    expect(response.status).toBe(503);
+    expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
+    expect(identityProvider.provider.deleteRole).not.toHaveBeenCalled();
     expect(deps.completeIdempotency).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       actorAccountId: 'actor-account-1',
       endpoint: 'POST:/api/v1/iam/roles',
       idempotencyKey: 'idem-role-1',
       status: 'FAILED',
-      responseStatus: 409,
+      responseStatus: 503,
       responseBody: expect.objectContaining({
-        error: expect.objectContaining({ code: 'conflict' }),
+        error: expect.objectContaining({ code: 'keycloak_unavailable' }),
       }),
     });
   });

--- a/packages/iam-admin/src/role-create-handler.test.ts
+++ b/packages/iam-admin/src/role-create-handler.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createJsonResponse, createTestDepsBuilder } from './handler-test-helpers.js';
+import { createJsonResponse, createTestDepsBuilder, dbWriteFailedErrorBody } from './handler-test-helpers.js';
 import { createCreateRoleHandlerInternal, type CreateRoleHandlerDeps } from './role-create-handler.js';
 
 const actor = {
@@ -72,7 +72,7 @@ const createDeps = createTestDepsBuilder<
     toPayloadHash: vi.fn(() => 'payload-hash-1'),
     trackKeycloakCall: vi.fn(async (_operation, work) => work()),
     validateRequestedPermissions: vi.fn(async () => null),
-	  })) satisfies CreateRoleHandlerDeps<typeof payload, typeof identityProvider, typeof roleItem>;
+  })) satisfies CreateRoleHandlerDeps<typeof payload, typeof identityProvider, typeof roleItem>;
 
 const runCreateRoleRequest = async (deps: CreateRoleHandlerDeps<typeof payload, typeof identityProvider, typeof roleItem>) => {
   const handler = createCreateRoleHandlerInternal(deps);
@@ -119,23 +119,23 @@ describe('createCreateRoleHandlerInternal', () => {
     });
   });
 
-	  it('returns replayed idempotency responses without creating a role', async () => {
-	    const replayBody = { data: { id: 'existing-role' } };
-	    const deps = createDeps({
-	      reserveIdempotency: vi.fn(async () => ({ status: 'replay', responseStatus: 201, responseBody: replayBody })),
-	    });
-	    const response = await runCreateRoleRequest(deps);
+  it('returns replayed idempotency responses without creating a role', async () => {
+    const replayBody = { data: { id: 'existing-role' } };
+    const deps = createDeps({
+      reserveIdempotency: vi.fn(async () => ({ status: 'replay', responseStatus: 201, responseBody: replayBody })),
+    });
+    const response = await runCreateRoleRequest(deps);
 
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual(replayBody);
     expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
   });
 
-	  it('does not require an identity provider for local tenant roles', async () => {
-	    const deps = createDeps({
-	      requireRoleIdentityProvider: vi.fn(async () => createJsonResponse(409, { error: { code: 'tenant_admin_client_not_configured' } })),
-	    });
-	    const response = await runCreateRoleRequest(deps);
+  it('does not require an identity provider for local tenant roles', async () => {
+    const deps = createDeps({
+      requireRoleIdentityProvider: vi.fn(async () => createJsonResponse(409, { error: { code: 'tenant_admin_client_not_configured' } })),
+    });
+    const response = await runCreateRoleRequest(deps);
 
     expect(response.status).toBe(201);
     expect(deps.completeIdempotency).toHaveBeenCalledWith({
@@ -167,7 +167,7 @@ describe('createCreateRoleHandlerInternal', () => {
     expect(deps.persistCreatedRole).not.toHaveBeenCalled();
   });
 
-  it('returns a local creation failure without Keycloak compensation when persistence fails', async () => {
+  it('returns a DB write conflict without Keycloak compensation when local persistence fails', async () => {
     const deps = createDeps({
       persistCreatedRole: vi.fn(async () => {
         throw new Error('db write failed');
@@ -177,18 +177,30 @@ describe('createCreateRoleHandlerInternal', () => {
 
     const response = await handler(new Request('http://localhost/api/v1/iam/roles', { method: 'POST' }), ctx);
 
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject(dbWriteFailedErrorBody('conflict', 'req-create-role'));
     expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
     expect(identityProvider.provider.deleteRole).not.toHaveBeenCalled();
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Role create database write failed',
+      expect.objectContaining({
+        operation: 'create_role',
+        error_code: 'DB_WRITE_FAILED',
+        error: 'db write failed',
+      })
+    );
     expect(deps.completeIdempotency).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       actorAccountId: 'actor-account-1',
       endpoint: 'POST:/api/v1/iam/roles',
       idempotencyKey: 'idem-role-1',
       status: 'FAILED',
-      responseStatus: 503,
+      responseStatus: 409,
       responseBody: expect.objectContaining({
-        error: expect.objectContaining({ code: 'keycloak_unavailable' }),
+        error: expect.objectContaining({
+          code: 'conflict',
+          details: expect.objectContaining({ syncError: { code: 'DB_WRITE_FAILED' } }),
+        }),
       }),
     });
   });

--- a/packages/iam-admin/src/role-create-handler.test.ts
+++ b/packages/iam-admin/src/role-create-handler.test.ts
@@ -72,7 +72,12 @@ const createDeps = createTestDepsBuilder<
     toPayloadHash: vi.fn(() => 'payload-hash-1'),
     trackKeycloakCall: vi.fn(async (_operation, work) => work()),
     validateRequestedPermissions: vi.fn(async () => null),
-  })) satisfies CreateRoleHandlerDeps<typeof payload, typeof identityProvider, typeof roleItem>;
+	  })) satisfies CreateRoleHandlerDeps<typeof payload, typeof identityProvider, typeof roleItem>;
+
+const runCreateRoleRequest = async (deps: CreateRoleHandlerDeps<typeof payload, typeof identityProvider, typeof roleItem>) => {
+  const handler = createCreateRoleHandlerInternal(deps);
+  return handler(new Request('http://localhost/api/v1/iam/roles', { method: 'POST' }), ctx);
+};
 
 describe('createCreateRoleHandlerInternal', () => {
   beforeEach(() => {
@@ -114,27 +119,23 @@ describe('createCreateRoleHandlerInternal', () => {
     });
   });
 
-  it('returns replayed idempotency responses without creating a role', async () => {
-    const replayBody = { data: { id: 'existing-role' } };
-    const deps = createDeps({
-      reserveIdempotency: vi.fn(async () => ({ status: 'replay', responseStatus: 201, responseBody: replayBody })),
-    });
-    const handler = createCreateRoleHandlerInternal(deps);
-
-    const response = await handler(new Request('http://localhost/api/v1/iam/roles', { method: 'POST' }), ctx);
+	  it('returns replayed idempotency responses without creating a role', async () => {
+	    const replayBody = { data: { id: 'existing-role' } };
+	    const deps = createDeps({
+	      reserveIdempotency: vi.fn(async () => ({ status: 'replay', responseStatus: 201, responseBody: replayBody })),
+	    });
+	    const response = await runCreateRoleRequest(deps);
 
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual(replayBody);
     expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
   });
 
-  it('does not require an identity provider for local tenant roles', async () => {
-    const deps = createDeps({
-      requireRoleIdentityProvider: vi.fn(async () => createJsonResponse(409, { error: { code: 'tenant_admin_client_not_configured' } })),
-    });
-    const handler = createCreateRoleHandlerInternal(deps);
-
-    const response = await handler(new Request('http://localhost/api/v1/iam/roles', { method: 'POST' }), ctx);
+	  it('does not require an identity provider for local tenant roles', async () => {
+	    const deps = createDeps({
+	      requireRoleIdentityProvider: vi.fn(async () => createJsonResponse(409, { error: { code: 'tenant_admin_client_not_configured' } })),
+	    });
+	    const response = await runCreateRoleRequest(deps);
 
     expect(response.status).toBe(201);
     expect(deps.completeIdempotency).toHaveBeenCalledWith({

--- a/packages/iam-admin/src/role-create-handler.ts
+++ b/packages/iam-admin/src/role-create-handler.ts
@@ -1,6 +1,7 @@
-import type { ApiErrorResponse, IamRolePermissionAssignmentScope } from '@sva/core';
+import type { IamRolePermissionAssignmentScope } from '@sva/core';
 
 import { isTenantTechnicalKeycloakRole } from './role-governance.js';
+import { persistLocalRoleCreate, reserveCreateRoleIdempotency, syncTechnicalRoleCreate, type PreparedRoleCreate } from './role-create-sync.js';
 import type { IdempotencyReserveResult } from './types.js';
 
 export type CreateRoleAuthenticatedRequestContext = {
@@ -45,6 +46,11 @@ export type CreateRoleIdentityProvider<TAttributes = unknown> = {
 export type ParsedCreateRoleBody<TPayload extends CreateRolePayloadShape> =
   | { readonly ok: true; readonly data: TPayload; readonly rawBody: string }
   | { readonly ok: false };
+
+type ParsedCreateRoleSuccess<TPayload extends CreateRolePayloadShape> = Extract<
+  ParsedCreateRoleBody<TPayload>,
+  { readonly ok: true }
+>;
 
 export type CreateRoleHandlerDeps<
   TPayload extends CreateRolePayloadShape = CreateRolePayloadShape,
@@ -135,56 +141,39 @@ export type CreateRoleHandlerDeps<
     readonly permissionAssignments?: readonly {
       readonly permissionId: string;
       readonly accessScope?: IamRolePermissionAssignmentScope;
-    }[];
+  }[];
   }) => Promise<Response | null>;
 };
 
-const CREATE_ROLE_ENDPOINT = 'POST:/api/v1/iam/roles';
-
-const buildCreateRoleUnavailableBody = (requestId?: string): ApiErrorResponse => ({
-  error: {
-    code: 'keycloak_unavailable',
-    message: 'Keycloak Admin API ist nicht konfiguriert.',
-    details: {
-      syncState: 'failed',
-      syncError: { code: 'IDP_UNAVAILABLE' },
-    },
-  },
-  ...(requestId ? { requestId } : {}),
-});
-
-const buildCreateRoleDbWriteFailureBody = (requestId?: string): ApiErrorResponse => ({
-  error: {
-    code: 'conflict',
-    message: 'Rolle konnte nicht erstellt werden.',
-    details: {
-      syncState: 'failed',
-      syncError: { code: 'DB_WRITE_FAILED' },
-    },
-  },
-  ...(requestId ? { requestId } : {}),
-});
-
-const completeCreateRoleIdempotency = async (
-  deps: Pick<CreateRoleHandlerDeps, 'completeIdempotency'>,
-  input: {
-    readonly actor: CreateRoleActor;
-    readonly idempotencyKey: string;
-    readonly status: 'COMPLETED' | 'FAILED';
-    readonly responseStatus: number;
-    readonly responseBody: unknown;
-  }
-) => {
-  await deps.completeIdempotency({
-    instanceId: input.actor.instanceId,
-    actorAccountId: input.actor.actorAccountId,
-    endpoint: CREATE_ROLE_ENDPOINT,
-    idempotencyKey: input.idempotencyKey,
-    status: input.status,
-    responseStatus: input.responseStatus,
-    responseBody: input.responseBody,
-  });
+const parseCreateRoleRequest = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  request: Request,
+  actor: CreateRoleActor
+): Promise<ParsedCreateRoleSuccess<TPayload> | Response> => {
+  const parsed = await deps.parseCreateRoleBody(request);
+  return parsed.ok ? parsed : deps.createApiError(400, 'invalid_request', 'Ungültiger Payload.', actor.requestId);
 };
+
+const validateCreateRolePermissions = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  actor: CreateRoleActor,
+  data: TPayload
+): Promise<Response | null> =>
+  deps.validateRequestedPermissions?.({
+    actor,
+    permissionIds: data.permissionIds,
+    permissionAssignments: data.permissionAssignments,
+  }) ?? null;
 
 export const createCreateRoleHandlerInternal =
   <
@@ -207,208 +196,38 @@ export const createCreateRoleHandlerInternal =
       return idempotencyKey.error;
     }
 
-    const parsed = await deps.parseCreateRoleBody(request);
-    if (!parsed.ok) {
-      return deps.createApiError(400, 'invalid_request', 'Ungültiger Payload.', actor.requestId);
+    const parsed = await parseCreateRoleRequest(deps, request, actor);
+    if (parsed instanceof Response) {
+      return parsed;
     }
 
-    const permissionValidationResponse = await deps.validateRequestedPermissions?.({
-      actor,
-      permissionIds: parsed.data.permissionIds,
-      permissionAssignments: parsed.data.permissionAssignments,
-    });
+    const permissionValidationResponse = await validateCreateRolePermissions(deps, actor, parsed.data);
     if (permissionValidationResponse) {
       return permissionValidationResponse;
     }
 
-    const reserve = await deps.reserveIdempotency({
-      instanceId: actor.instanceId,
-      actorAccountId: actor.actorAccountId,
-      endpoint: CREATE_ROLE_ENDPOINT,
+    const reservedResponse = await reserveCreateRoleIdempotency(deps, {
+      actor,
       idempotencyKey: idempotencyKey.key,
-      payloadHash: deps.toPayloadHash(parsed.rawBody),
+      rawBody: parsed.rawBody,
     });
-    if (reserve.status === 'replay') {
-      return deps.jsonResponse(reserve.responseStatus, reserve.responseBody);
-    }
-    if (reserve.status === 'conflict') {
-      return deps.createApiError(409, 'idempotency_key_reuse', reserve.message, actor.requestId);
+    if (reservedResponse) {
+      return reservedResponse;
     }
 
     const roleKey = parsed.data.roleName;
     const displayName = parsed.data.displayName?.trim() || roleKey;
     const externalRoleName = roleKey;
-    const shouldSyncIdentityRole = isTenantTechnicalKeycloakRole({ role_key: roleKey, external_role_name: externalRoleName });
+    const preparedCreate = {
+      actor,
+      data: parsed.data,
+      displayName,
+      externalRoleName,
+      idempotencyKey: idempotencyKey.key,
+      roleKey,
+    } satisfies PreparedRoleCreate<TPayload>;
 
-    if (!shouldSyncIdentityRole) {
-      try {
-        const role = await deps.persistCreatedRole({
-          actor,
-          roleKey,
-          displayName,
-          externalRoleName,
-          description: parsed.data.description ?? undefined,
-          roleLevel: parsed.data.roleLevel,
-          permissionIds: parsed.data.permissionIds,
-          permissionAssignments: parsed.data.permissionAssignments,
-        });
-
-        deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'success' });
-        const responseBody = deps.asApiItem(role, actor.requestId);
-        await completeCreateRoleIdempotency(deps, {
-          actor,
-          idempotencyKey: idempotencyKey.key,
-          status: 'COMPLETED',
-          responseStatus: 201,
-          responseBody,
-        });
-        return deps.jsonResponse(201, responseBody);
-      } catch (error) {
-        deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
-        const failureResponse = deps.buildRoleSyncFailure({
-          error,
-          requestId: actor.requestId,
-          fallbackMessage: 'Rolle konnte nicht erstellt werden.',
-        });
-        await completeCreateRoleIdempotency(deps, {
-          actor,
-          idempotencyKey: idempotencyKey.key,
-          status: 'FAILED',
-          responseStatus: failureResponse.status,
-          responseBody: await failureResponse.clone().json(),
-        });
-        return failureResponse;
-      }
-    }
-
-    const identityProvider = await deps.requireRoleIdentityProvider(actor.instanceId, actor.requestId);
-    if (identityProvider instanceof Response) {
-      const responseBody = buildCreateRoleUnavailableBody(actor.requestId);
-      await completeCreateRoleIdempotency(deps, {
-        actor,
-        idempotencyKey: idempotencyKey.key,
-        status: 'FAILED',
-        responseStatus: 503,
-        responseBody,
-      });
-      return deps.jsonResponse(503, responseBody);
-    }
-
-    let createdInIdentityProvider = false;
-
-    try {
-      await deps.trackKeycloakCall('create_role', () =>
-        identityProvider.provider.createRole({
-          externalName: externalRoleName,
-          description: parsed.data.description ?? undefined,
-          attributes: deps.buildRoleAttributes({
-            instanceId: actor.instanceId,
-            roleKey,
-            displayName,
-          }),
-        })
-      );
-      createdInIdentityProvider = true;
-
-      const role = await deps.persistCreatedRole({
-        actor,
-        roleKey,
-        displayName,
-        externalRoleName,
-        description: parsed.data.description ?? undefined,
-        roleLevel: parsed.data.roleLevel,
-        permissionIds: parsed.data.permissionIds,
-        permissionAssignments: parsed.data.permissionAssignments,
-      });
-
-      deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'success' });
-      deps.iamRoleSyncCounter.add(1, { operation: 'create', result: 'success', error_code: 'none' });
-
-      const responseBody = deps.asApiItem(role, actor.requestId);
-      await completeCreateRoleIdempotency(deps, {
-        actor,
-        idempotencyKey: idempotencyKey.key,
-        status: 'COMPLETED',
-        responseStatus: 201,
-        responseBody,
-      });
-      return deps.jsonResponse(201, responseBody);
-    } catch (error) {
-      if (createdInIdentityProvider) {
-        try {
-          await deps.trackKeycloakCall('delete_role_compensation', () =>
-            identityProvider.provider.deleteRole(externalRoleName)
-          );
-        } catch (compensationError) {
-          deps.iamRoleSyncCounter.add(1, {
-            operation: 'create',
-            result: 'failure',
-            error_code: 'COMPENSATION_FAILED',
-          });
-          deps.logger.error('Role create compensation failed', {
-            operation: 'create_role_compensation',
-            instance_id: actor.instanceId,
-            request_id: actor.requestId,
-            trace_id: actor.traceId,
-            role_key: roleKey,
-            external_role_name: externalRoleName,
-            error_code: 'COMPENSATION_FAILED',
-            error: deps.sanitizeRoleErrorMessage(compensationError),
-          });
-          const responseBody = deps.createApiError(
-            500,
-            'internal_error',
-            'Rolle konnte nicht konsistent erstellt werden.',
-            actor.requestId,
-            {
-              syncState: 'failed',
-              syncError: { code: 'COMPENSATION_FAILED' },
-            }
-          );
-          await completeCreateRoleIdempotency(deps, {
-            actor,
-            idempotencyKey: idempotencyKey.key,
-            status: 'FAILED',
-            responseStatus: 500,
-            responseBody: await responseBody.clone().json(),
-          });
-          return responseBody;
-        }
-
-        deps.iamRoleSyncCounter.add(1, {
-          operation: 'create',
-          result: 'failure',
-          error_code: 'DB_WRITE_FAILED',
-        });
-        const responseBody = buildCreateRoleDbWriteFailureBody(actor.requestId);
-        await completeCreateRoleIdempotency(deps, {
-          actor,
-          idempotencyKey: idempotencyKey.key,
-          status: 'FAILED',
-          responseStatus: 409,
-          responseBody,
-        });
-        return deps.jsonResponse(409, responseBody);
-      }
-
-      deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
-      deps.iamRoleSyncCounter.add(1, {
-        operation: 'create',
-        result: 'failure',
-        error_code: deps.mapRoleSyncErrorCode(error),
-      });
-      const failureResponse = deps.buildRoleSyncFailure({
-        error,
-        requestId: actor.requestId,
-        fallbackMessage: 'Rolle konnte nicht erstellt werden.',
-      });
-      await completeCreateRoleIdempotency(deps, {
-        actor,
-        idempotencyKey: idempotencyKey.key,
-        status: 'FAILED',
-        responseStatus: failureResponse.status,
-        responseBody: await failureResponse.clone().json(),
-      });
-      return failureResponse;
-    }
+    return isTenantTechnicalKeycloakRole({ role_key: roleKey, external_role_name: externalRoleName })
+      ? syncTechnicalRoleCreate(deps, preparedCreate)
+      : persistLocalRoleCreate(deps, preparedCreate);
   };

--- a/packages/iam-admin/src/role-create-handler.ts
+++ b/packages/iam-admin/src/role-create-handler.ts
@@ -1,5 +1,6 @@
 import type { ApiErrorResponse, IamRolePermissionAssignmentScope } from '@sva/core';
 
+import { isTenantTechnicalKeycloakRole } from './role-governance.js';
 import type { IdempotencyReserveResult } from './types.js';
 
 export type CreateRoleAuthenticatedRequestContext = {
@@ -234,6 +235,52 @@ export const createCreateRoleHandlerInternal =
       return deps.createApiError(409, 'idempotency_key_reuse', reserve.message, actor.requestId);
     }
 
+    const roleKey = parsed.data.roleName;
+    const displayName = parsed.data.displayName?.trim() || roleKey;
+    const externalRoleName = roleKey;
+    const shouldSyncIdentityRole = isTenantTechnicalKeycloakRole({ role_key: roleKey, external_role_name: externalRoleName });
+
+    if (!shouldSyncIdentityRole) {
+      try {
+        const role = await deps.persistCreatedRole({
+          actor,
+          roleKey,
+          displayName,
+          externalRoleName,
+          description: parsed.data.description ?? undefined,
+          roleLevel: parsed.data.roleLevel,
+          permissionIds: parsed.data.permissionIds,
+          permissionAssignments: parsed.data.permissionAssignments,
+        });
+
+        deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'success' });
+        const responseBody = deps.asApiItem(role, actor.requestId);
+        await completeCreateRoleIdempotency(deps, {
+          actor,
+          idempotencyKey: idempotencyKey.key,
+          status: 'COMPLETED',
+          responseStatus: 201,
+          responseBody,
+        });
+        return deps.jsonResponse(201, responseBody);
+      } catch (error) {
+        deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
+        const failureResponse = deps.buildRoleSyncFailure({
+          error,
+          requestId: actor.requestId,
+          fallbackMessage: 'Rolle konnte nicht erstellt werden.',
+        });
+        await completeCreateRoleIdempotency(deps, {
+          actor,
+          idempotencyKey: idempotencyKey.key,
+          status: 'FAILED',
+          responseStatus: failureResponse.status,
+          responseBody: await failureResponse.clone().json(),
+        });
+        return failureResponse;
+      }
+    }
+
     const identityProvider = await deps.requireRoleIdentityProvider(actor.instanceId, actor.requestId);
     if (identityProvider instanceof Response) {
       const responseBody = buildCreateRoleUnavailableBody(actor.requestId);
@@ -247,9 +294,6 @@ export const createCreateRoleHandlerInternal =
       return deps.jsonResponse(503, responseBody);
     }
 
-    const roleKey = parsed.data.roleName;
-    const displayName = parsed.data.displayName?.trim() || roleKey;
-    const externalRoleName = roleKey;
     let createdInIdentityProvider = false;
 
     try {

--- a/packages/iam-admin/src/role-create-sync-failures.ts
+++ b/packages/iam-admin/src/role-create-sync-failures.ts
@@ -1,0 +1,239 @@
+import type { ApiErrorResponse } from '@sva/core';
+
+import type {
+  CreateRoleHandlerDeps,
+  CreateRoleIdentityProvider,
+  CreateRolePayloadShape,
+} from './role-create-handler.js';
+import type { PreparedRoleCreate } from './role-create-sync.js';
+
+export const CREATE_ROLE_ENDPOINT = 'POST:/api/v1/iam/roles';
+
+const buildCreateRoleUnavailableBody = (requestId?: string): ApiErrorResponse => ({
+  error: {
+    code: 'keycloak_unavailable',
+    message: 'Keycloak Admin API ist nicht konfiguriert.',
+    details: {
+      syncState: 'failed',
+      syncError: { code: 'IDP_UNAVAILABLE' },
+    },
+  },
+  ...(requestId ? { requestId } : {}),
+});
+
+const buildCreateRoleDbWriteFailureBody = (requestId?: string): ApiErrorResponse => ({
+  error: {
+    code: 'conflict',
+    message: 'Rolle konnte nicht erstellt werden.',
+    details: {
+      syncState: 'failed',
+      syncError: { code: 'DB_WRITE_FAILED' },
+    },
+  },
+  ...(requestId ? { requestId } : {}),
+});
+
+export const completeCreateRoleIdempotency = async (
+  deps: Pick<CreateRoleHandlerDeps, 'completeIdempotency'>,
+  input: {
+    readonly actor: PreparedRoleCreate<CreateRolePayloadShape>['actor'];
+    readonly idempotencyKey: string;
+    readonly status: 'COMPLETED' | 'FAILED';
+    readonly responseStatus: number;
+    readonly responseBody: unknown;
+  }
+) => {
+  await deps.completeIdempotency({
+    instanceId: input.actor.instanceId,
+    actorAccountId: input.actor.actorAccountId,
+    endpoint: CREATE_ROLE_ENDPOINT,
+    idempotencyKey: input.idempotencyKey,
+    status: input.status,
+    responseStatus: input.responseStatus,
+    responseBody: input.responseBody,
+  });
+};
+
+const recordCreateRoleOperationFailure = <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>
+) => {
+  deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
+};
+
+const logCreateRoleDatabaseWriteFailure = <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown,
+  message: string
+) => {
+  deps.logger.error(message, {
+    operation: 'create_role',
+    instance_id: input.actor.instanceId,
+    request_id: input.actor.requestId,
+    trace_id: input.actor.traceId,
+    role_key: input.roleKey,
+    external_role_name: input.externalRoleName,
+    error_code: 'DB_WRITE_FAILED',
+    error: deps.sanitizeRoleErrorMessage(error),
+  });
+};
+
+export const failCreateRoleUnavailable = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>
+): Promise<Response> => {
+  const responseBody = buildCreateRoleUnavailableBody(input.actor.requestId);
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: 503,
+    responseBody,
+  });
+  return deps.jsonResponse(503, responseBody);
+};
+
+export const failCreatedRole = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown
+): Promise<Response> => {
+  recordCreateRoleOperationFailure(deps);
+  const failureResponse = deps.buildRoleSyncFailure({
+    error,
+    requestId: input.actor.requestId,
+    fallbackMessage: 'Rolle konnte nicht erstellt werden.',
+  });
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: failureResponse.status,
+    responseBody: await failureResponse.clone().json(),
+  });
+  return failureResponse;
+};
+
+const failLocalRoleDatabaseWrite = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>
+): Promise<Response> => {
+  const responseBody = buildCreateRoleDbWriteFailureBody(input.actor.requestId);
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: 409,
+    responseBody,
+  });
+  return deps.jsonResponse(409, responseBody);
+};
+
+export const failLocalRoleCreateDatabaseWrite = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown
+): Promise<Response> => {
+  recordCreateRoleOperationFailure(deps);
+  logCreateRoleDatabaseWriteFailure(deps, input, error, 'Role create database write failed');
+  return failLocalRoleDatabaseWrite(deps, input);
+};
+
+export const failCreateCompensation = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  compensationError: unknown
+): Promise<Response> => {
+  deps.iamRoleSyncCounter.add(1, {
+    operation: 'create',
+    result: 'failure',
+    error_code: 'COMPENSATION_FAILED',
+  });
+  deps.logger.error('Role create compensation failed', {
+    operation: 'create_role_compensation',
+    instance_id: input.actor.instanceId,
+    request_id: input.actor.requestId,
+    trace_id: input.actor.traceId,
+    role_key: input.roleKey,
+    external_role_name: input.externalRoleName,
+    error_code: 'COMPENSATION_FAILED',
+    error: deps.sanitizeRoleErrorMessage(compensationError),
+  });
+  const responseBody = deps.createApiError(
+    500,
+    'internal_error',
+    'Rolle konnte nicht konsistent erstellt werden.',
+    input.actor.requestId,
+    {
+      syncState: 'failed',
+      syncError: { code: 'COMPENSATION_FAILED' },
+    }
+  );
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: 500,
+    responseBody: await responseBody.clone().json(),
+  });
+  return responseBody;
+};
+
+export const failTechnicalRoleDatabaseWrite = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown
+): Promise<Response> => {
+  deps.iamRoleSyncCounter.add(1, {
+    operation: 'create',
+    result: 'failure',
+    error_code: 'DB_WRITE_FAILED',
+  });
+  logCreateRoleDatabaseWriteFailure(
+    deps,
+    input,
+    error,
+    'Role create database write failed after successful Keycloak create'
+  );
+  return failLocalRoleDatabaseWrite(deps, input);
+};

--- a/packages/iam-admin/src/role-create-sync.ts
+++ b/packages/iam-admin/src/role-create-sync.ts
@@ -1,11 +1,18 @@
-import type { ApiErrorResponse } from '@sva/core';
-
 import type {
   CreateRoleActor,
   CreateRoleHandlerDeps,
   CreateRoleIdentityProvider,
   CreateRolePayloadShape,
 } from './role-create-handler.js';
+import {
+  completeCreateRoleIdempotency,
+  CREATE_ROLE_ENDPOINT,
+  failCreatedRole,
+  failCreateCompensation,
+  failCreateRoleUnavailable,
+  failLocalRoleCreateDatabaseWrite,
+  failTechnicalRoleDatabaseWrite,
+} from './role-create-sync-failures.js';
 
 export type PreparedRoleCreate<TPayload extends CreateRolePayloadShape> = {
   readonly actor: CreateRoleActor;
@@ -14,53 +21,6 @@ export type PreparedRoleCreate<TPayload extends CreateRolePayloadShape> = {
   readonly externalRoleName: string;
   readonly idempotencyKey: string;
   readonly roleKey: string;
-};
-
-const CREATE_ROLE_ENDPOINT = 'POST:/api/v1/iam/roles';
-
-const buildCreateRoleUnavailableBody = (requestId?: string): ApiErrorResponse => ({
-  error: {
-    code: 'keycloak_unavailable',
-    message: 'Keycloak Admin API ist nicht konfiguriert.',
-    details: {
-      syncState: 'failed',
-      syncError: { code: 'IDP_UNAVAILABLE' },
-    },
-  },
-  ...(requestId ? { requestId } : {}),
-});
-
-const buildCreateRoleDbWriteFailureBody = (requestId?: string): ApiErrorResponse => ({
-  error: {
-    code: 'conflict',
-    message: 'Rolle konnte nicht erstellt werden.',
-    details: {
-      syncState: 'failed',
-      syncError: { code: 'DB_WRITE_FAILED' },
-    },
-  },
-  ...(requestId ? { requestId } : {}),
-});
-
-const completeCreateRoleIdempotency = async (
-  deps: Pick<CreateRoleHandlerDeps, 'completeIdempotency'>,
-  input: {
-    readonly actor: CreateRoleActor;
-    readonly idempotencyKey: string;
-    readonly status: 'COMPLETED' | 'FAILED';
-    readonly responseStatus: number;
-    readonly responseBody: unknown;
-  }
-) => {
-  await deps.completeIdempotency({
-    instanceId: input.actor.instanceId,
-    actorAccountId: input.actor.actorAccountId,
-    endpoint: CREATE_ROLE_ENDPOINT,
-    idempotencyKey: input.idempotencyKey,
-    status: input.status,
-    responseStatus: input.responseStatus,
-    responseBody: input.responseBody,
-  });
 };
 
 const persistPreparedRole = async <
@@ -83,40 +43,6 @@ const persistPreparedRole = async <
     permissionAssignments: input.data.permissionAssignments,
   });
 
-const recordCreateRoleOperationFailure = <
-  TPayload extends CreateRolePayloadShape,
-  TAttributes,
-  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
-  TRole,
->(
-  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>
-) => {
-  deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
-};
-
-const logCreateRoleDatabaseWriteFailure = <
-  TPayload extends CreateRolePayloadShape,
-  TAttributes,
-  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
-  TRole,
->(
-  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
-  input: PreparedRoleCreate<TPayload>,
-  error: unknown,
-  message: string
-) => {
-  deps.logger.error(message, {
-    operation: 'create_role',
-    instance_id: input.actor.instanceId,
-    request_id: input.actor.requestId,
-    trace_id: input.actor.traceId,
-    role_key: input.roleKey,
-    external_role_name: input.externalRoleName,
-    error_code: 'DB_WRITE_FAILED',
-    error: deps.sanitizeRoleErrorMessage(error),
-  });
-};
-
 const finishCreatedRole = async <
   TPayload extends CreateRolePayloadShape,
   TAttributes,
@@ -137,136 +63,6 @@ const finishCreatedRole = async <
     responseBody,
   });
   return deps.jsonResponse(201, responseBody);
-};
-
-const failCreatedRole = async <
-  TPayload extends CreateRolePayloadShape,
-  TAttributes,
-  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
-  TRole,
->(
-  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
-  input: PreparedRoleCreate<TPayload>,
-  error: unknown
-): Promise<Response> => {
-  recordCreateRoleOperationFailure(deps);
-  const failureResponse = deps.buildRoleSyncFailure({
-    error,
-    requestId: input.actor.requestId,
-    fallbackMessage: 'Rolle konnte nicht erstellt werden.',
-  });
-  await completeCreateRoleIdempotency(deps, {
-    actor: input.actor,
-    idempotencyKey: input.idempotencyKey,
-    status: 'FAILED',
-    responseStatus: failureResponse.status,
-    responseBody: await failureResponse.clone().json(),
-  });
-  return failureResponse;
-};
-
-const failLocalRoleDatabaseWrite = async <
-  TPayload extends CreateRolePayloadShape,
-  TAttributes,
-  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
-  TRole,
->(
-  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
-  input: PreparedRoleCreate<TPayload>
-): Promise<Response> => {
-  const responseBody = buildCreateRoleDbWriteFailureBody(input.actor.requestId);
-  await completeCreateRoleIdempotency(deps, {
-    actor: input.actor,
-    idempotencyKey: input.idempotencyKey,
-    status: 'FAILED',
-    responseStatus: 409,
-    responseBody,
-  });
-  return deps.jsonResponse(409, responseBody);
-};
-
-const failLocalRoleCreateDatabaseWrite = async <
-  TPayload extends CreateRolePayloadShape,
-  TAttributes,
-  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
-  TRole,
->(
-  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
-  input: PreparedRoleCreate<TPayload>,
-  error: unknown
-): Promise<Response> => {
-  recordCreateRoleOperationFailure(deps);
-  logCreateRoleDatabaseWriteFailure(deps, input, error, 'Role create database write failed');
-  return failLocalRoleDatabaseWrite(deps, input);
-};
-
-const failCreateCompensation = async <
-  TPayload extends CreateRolePayloadShape,
-  TAttributes,
-  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
-  TRole,
->(
-  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
-  input: PreparedRoleCreate<TPayload>,
-  compensationError: unknown
-): Promise<Response> => {
-  deps.iamRoleSyncCounter.add(1, {
-    operation: 'create',
-    result: 'failure',
-    error_code: 'COMPENSATION_FAILED',
-  });
-  deps.logger.error('Role create compensation failed', {
-    operation: 'create_role_compensation',
-    instance_id: input.actor.instanceId,
-    request_id: input.actor.requestId,
-    trace_id: input.actor.traceId,
-    role_key: input.roleKey,
-    external_role_name: input.externalRoleName,
-    error_code: 'COMPENSATION_FAILED',
-    error: deps.sanitizeRoleErrorMessage(compensationError),
-  });
-  const responseBody = deps.createApiError(
-    500,
-    'internal_error',
-    'Rolle konnte nicht konsistent erstellt werden.',
-    input.actor.requestId,
-    {
-      syncState: 'failed',
-      syncError: { code: 'COMPENSATION_FAILED' },
-    }
-  );
-  await completeCreateRoleIdempotency(deps, {
-    actor: input.actor,
-    idempotencyKey: input.idempotencyKey,
-    status: 'FAILED',
-    responseStatus: 500,
-    responseBody: await responseBody.clone().json(),
-  });
-  return responseBody;
-};
-
-const failTechnicalRoleDatabaseWrite = async <
-  TPayload extends CreateRolePayloadShape,
-  TAttributes,
-  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
-  TRole,
->(
-  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
-  input: PreparedRoleCreate<TPayload>,
-  error: unknown
-): Promise<Response> => {
-  deps.iamRoleSyncCounter.add(1, {
-    operation: 'create',
-    result: 'failure',
-    error_code: 'DB_WRITE_FAILED',
-  });
-  logCreateRoleDatabaseWriteFailure(
-    deps,
-    input,
-    error,
-    'Role create database write failed after successful Keycloak create'
-  );
-  return failLocalRoleDatabaseWrite(deps, input);
 };
 
 export const reserveCreateRoleIdempotency = async <
@@ -330,15 +126,7 @@ export const syncTechnicalRoleCreate = async <
 ): Promise<Response> => {
   const identityProvider = await deps.requireRoleIdentityProvider(input.actor.instanceId, input.actor.requestId);
   if (identityProvider instanceof Response) {
-    const responseBody = buildCreateRoleUnavailableBody(input.actor.requestId);
-    await completeCreateRoleIdempotency(deps, {
-      actor: input.actor,
-      idempotencyKey: input.idempotencyKey,
-      status: 'FAILED',
-      responseStatus: 503,
-      responseBody,
-    });
-    return deps.jsonResponse(503, responseBody);
+    return failCreateRoleUnavailable(deps, input);
   }
 
   try {

--- a/packages/iam-admin/src/role-create-sync.ts
+++ b/packages/iam-admin/src/role-create-sync.ts
@@ -83,6 +83,40 @@ const persistPreparedRole = async <
     permissionAssignments: input.data.permissionAssignments,
   });
 
+const recordCreateRoleOperationFailure = <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>
+) => {
+  deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
+};
+
+const logCreateRoleDatabaseWriteFailure = <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown,
+  message: string
+) => {
+  deps.logger.error(message, {
+    operation: 'create_role',
+    instance_id: input.actor.instanceId,
+    request_id: input.actor.requestId,
+    trace_id: input.actor.traceId,
+    role_key: input.roleKey,
+    external_role_name: input.externalRoleName,
+    error_code: 'DB_WRITE_FAILED',
+    error: deps.sanitizeRoleErrorMessage(error),
+  });
+};
+
 const finishCreatedRole = async <
   TPayload extends CreateRolePayloadShape,
   TAttributes,
@@ -115,7 +149,7 @@ const failCreatedRole = async <
   input: PreparedRoleCreate<TPayload>,
   error: unknown
 ): Promise<Response> => {
-  deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
+  recordCreateRoleOperationFailure(deps);
   const failureResponse = deps.buildRoleSyncFailure({
     error,
     requestId: input.actor.requestId,
@@ -129,6 +163,41 @@ const failCreatedRole = async <
     responseBody: await failureResponse.clone().json(),
   });
   return failureResponse;
+};
+
+const failLocalRoleDatabaseWrite = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>
+): Promise<Response> => {
+  const responseBody = buildCreateRoleDbWriteFailureBody(input.actor.requestId);
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: 409,
+    responseBody,
+  });
+  return deps.jsonResponse(409, responseBody);
+};
+
+const failLocalRoleCreateDatabaseWrite = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown
+): Promise<Response> => {
+  recordCreateRoleOperationFailure(deps);
+  logCreateRoleDatabaseWriteFailure(deps, input, error, 'Role create database write failed');
+  return failLocalRoleDatabaseWrite(deps, input);
 };
 
 const failCreateCompensation = async <
@@ -183,22 +252,21 @@ const failTechnicalRoleDatabaseWrite = async <
   TRole,
 >(
   deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
-  input: PreparedRoleCreate<TPayload>
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown
 ): Promise<Response> => {
   deps.iamRoleSyncCounter.add(1, {
     operation: 'create',
     result: 'failure',
     error_code: 'DB_WRITE_FAILED',
   });
-  const responseBody = buildCreateRoleDbWriteFailureBody(input.actor.requestId);
-  await completeCreateRoleIdempotency(deps, {
-    actor: input.actor,
-    idempotencyKey: input.idempotencyKey,
-    status: 'FAILED',
-    responseStatus: 409,
-    responseBody,
-  });
-  return deps.jsonResponse(409, responseBody);
+  logCreateRoleDatabaseWriteFailure(
+    deps,
+    input,
+    error,
+    'Role create database write failed after successful Keycloak create'
+  );
+  return failLocalRoleDatabaseWrite(deps, input);
 };
 
 export const reserveCreateRoleIdempotency = async <
@@ -247,7 +315,7 @@ export const persistLocalRoleCreate = async <
   try {
     return await finishCreatedRole(deps, input, await persistPreparedRole(deps, input));
   } catch (error) {
-    return failCreatedRole(deps, input, error);
+    return failLocalRoleCreateDatabaseWrite(deps, input, error);
   }
 };
 
@@ -306,6 +374,6 @@ export const syncTechnicalRoleCreate = async <
     } catch (compensationError) {
       return failCreateCompensation(deps, input, compensationError);
     }
-    return failTechnicalRoleDatabaseWrite(deps, input);
+    return failTechnicalRoleDatabaseWrite(deps, input, error);
   }
 };

--- a/packages/iam-admin/src/role-create-sync.ts
+++ b/packages/iam-admin/src/role-create-sync.ts
@@ -1,0 +1,311 @@
+import type { ApiErrorResponse } from '@sva/core';
+
+import type {
+  CreateRoleActor,
+  CreateRoleHandlerDeps,
+  CreateRoleIdentityProvider,
+  CreateRolePayloadShape,
+} from './role-create-handler.js';
+
+export type PreparedRoleCreate<TPayload extends CreateRolePayloadShape> = {
+  readonly actor: CreateRoleActor;
+  readonly data: TPayload;
+  readonly displayName: string;
+  readonly externalRoleName: string;
+  readonly idempotencyKey: string;
+  readonly roleKey: string;
+};
+
+const CREATE_ROLE_ENDPOINT = 'POST:/api/v1/iam/roles';
+
+const buildCreateRoleUnavailableBody = (requestId?: string): ApiErrorResponse => ({
+  error: {
+    code: 'keycloak_unavailable',
+    message: 'Keycloak Admin API ist nicht konfiguriert.',
+    details: {
+      syncState: 'failed',
+      syncError: { code: 'IDP_UNAVAILABLE' },
+    },
+  },
+  ...(requestId ? { requestId } : {}),
+});
+
+const buildCreateRoleDbWriteFailureBody = (requestId?: string): ApiErrorResponse => ({
+  error: {
+    code: 'conflict',
+    message: 'Rolle konnte nicht erstellt werden.',
+    details: {
+      syncState: 'failed',
+      syncError: { code: 'DB_WRITE_FAILED' },
+    },
+  },
+  ...(requestId ? { requestId } : {}),
+});
+
+const completeCreateRoleIdempotency = async (
+  deps: Pick<CreateRoleHandlerDeps, 'completeIdempotency'>,
+  input: {
+    readonly actor: CreateRoleActor;
+    readonly idempotencyKey: string;
+    readonly status: 'COMPLETED' | 'FAILED';
+    readonly responseStatus: number;
+    readonly responseBody: unknown;
+  }
+) => {
+  await deps.completeIdempotency({
+    instanceId: input.actor.instanceId,
+    actorAccountId: input.actor.actorAccountId,
+    endpoint: CREATE_ROLE_ENDPOINT,
+    idempotencyKey: input.idempotencyKey,
+    status: input.status,
+    responseStatus: input.responseStatus,
+    responseBody: input.responseBody,
+  });
+};
+
+const persistPreparedRole = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>
+): Promise<TRole> =>
+  deps.persistCreatedRole({
+    actor: input.actor,
+    roleKey: input.roleKey,
+    displayName: input.displayName,
+    externalRoleName: input.externalRoleName,
+    description: input.data.description ?? undefined,
+    roleLevel: input.data.roleLevel,
+    permissionIds: input.data.permissionIds,
+    permissionAssignments: input.data.permissionAssignments,
+  });
+
+const finishCreatedRole = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  role: TRole
+): Promise<Response> => {
+  deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'success' });
+  const responseBody = deps.asApiItem(role, input.actor.requestId);
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'COMPLETED',
+    responseStatus: 201,
+    responseBody,
+  });
+  return deps.jsonResponse(201, responseBody);
+};
+
+const failCreatedRole = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  error: unknown
+): Promise<Response> => {
+  deps.iamUserOperationsCounter.add(1, { action: 'create_role', result: 'failure' });
+  const failureResponse = deps.buildRoleSyncFailure({
+    error,
+    requestId: input.actor.requestId,
+    fallbackMessage: 'Rolle konnte nicht erstellt werden.',
+  });
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: failureResponse.status,
+    responseBody: await failureResponse.clone().json(),
+  });
+  return failureResponse;
+};
+
+const failCreateCompensation = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>,
+  compensationError: unknown
+): Promise<Response> => {
+  deps.iamRoleSyncCounter.add(1, {
+    operation: 'create',
+    result: 'failure',
+    error_code: 'COMPENSATION_FAILED',
+  });
+  deps.logger.error('Role create compensation failed', {
+    operation: 'create_role_compensation',
+    instance_id: input.actor.instanceId,
+    request_id: input.actor.requestId,
+    trace_id: input.actor.traceId,
+    role_key: input.roleKey,
+    external_role_name: input.externalRoleName,
+    error_code: 'COMPENSATION_FAILED',
+    error: deps.sanitizeRoleErrorMessage(compensationError),
+  });
+  const responseBody = deps.createApiError(
+    500,
+    'internal_error',
+    'Rolle konnte nicht konsistent erstellt werden.',
+    input.actor.requestId,
+    {
+      syncState: 'failed',
+      syncError: { code: 'COMPENSATION_FAILED' },
+    }
+  );
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: 500,
+    responseBody: await responseBody.clone().json(),
+  });
+  return responseBody;
+};
+
+const failTechnicalRoleDatabaseWrite = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>
+): Promise<Response> => {
+  deps.iamRoleSyncCounter.add(1, {
+    operation: 'create',
+    result: 'failure',
+    error_code: 'DB_WRITE_FAILED',
+  });
+  const responseBody = buildCreateRoleDbWriteFailureBody(input.actor.requestId);
+  await completeCreateRoleIdempotency(deps, {
+    actor: input.actor,
+    idempotencyKey: input.idempotencyKey,
+    status: 'FAILED',
+    responseStatus: 409,
+    responseBody,
+  });
+  return deps.jsonResponse(409, responseBody);
+};
+
+export const reserveCreateRoleIdempotency = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: {
+    readonly actor: CreateRoleActor;
+    readonly idempotencyKey: string;
+    readonly rawBody: string;
+  }
+): Promise<Response | null> => {
+  const { actor } = input;
+  const idempotencyReservation = await deps.reserveIdempotency(
+    {
+      actorAccountId: actor.actorAccountId,
+      endpoint: CREATE_ROLE_ENDPOINT,
+      idempotencyKey: input.idempotencyKey,
+      instanceId: actor.instanceId,
+      payloadHash: deps.toPayloadHash(input.rawBody),
+    }
+  );
+
+  switch (idempotencyReservation.status) {
+    case 'conflict':
+      return deps.createApiError(409, 'idempotency_key_reuse', idempotencyReservation.message, actor.requestId);
+    case 'replay':
+      return deps.jsonResponse(idempotencyReservation.responseStatus, idempotencyReservation.responseBody);
+    case 'reserved':
+      return null;
+  }
+};
+
+export const persistLocalRoleCreate = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>
+): Promise<Response> => {
+  try {
+    return await finishCreatedRole(deps, input, await persistPreparedRole(deps, input));
+  } catch (error) {
+    return failCreatedRole(deps, input, error);
+  }
+};
+
+export const syncTechnicalRoleCreate = async <
+  TPayload extends CreateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends CreateRoleIdentityProvider<TAttributes>,
+  TRole,
+>(
+  deps: CreateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole>,
+  input: PreparedRoleCreate<TPayload>
+): Promise<Response> => {
+  const identityProvider = await deps.requireRoleIdentityProvider(input.actor.instanceId, input.actor.requestId);
+  if (identityProvider instanceof Response) {
+    const responseBody = buildCreateRoleUnavailableBody(input.actor.requestId);
+    await completeCreateRoleIdempotency(deps, {
+      actor: input.actor,
+      idempotencyKey: input.idempotencyKey,
+      status: 'FAILED',
+      responseStatus: 503,
+      responseBody,
+    });
+    return deps.jsonResponse(503, responseBody);
+  }
+
+  try {
+    await deps.trackKeycloakCall('create_role', () =>
+      identityProvider.provider.createRole({
+        externalName: input.externalRoleName,
+        description: input.data.description ?? undefined,
+        attributes: deps.buildRoleAttributes({
+          instanceId: input.actor.instanceId,
+          roleKey: input.roleKey,
+          displayName: input.displayName,
+        }),
+      })
+    );
+  } catch (error) {
+    deps.iamRoleSyncCounter.add(1, {
+      operation: 'create',
+      result: 'failure',
+      error_code: deps.mapRoleSyncErrorCode(error),
+    });
+    return failCreatedRole(deps, input, error);
+  }
+
+  try {
+    const response = await finishCreatedRole(deps, input, await persistPreparedRole(deps, input));
+    deps.iamRoleSyncCounter.add(1, { operation: 'create', result: 'success', error_code: 'none' });
+    return response;
+  } catch (error) {
+    try {
+      await deps.trackKeycloakCall('delete_role_compensation', () =>
+        identityProvider.provider.deleteRole(input.externalRoleName)
+      );
+    } catch (compensationError) {
+      return failCreateCompensation(deps, input, compensationError);
+    }
+    return failTechnicalRoleDatabaseWrite(deps, input);
+  }
+};

--- a/packages/iam-admin/src/role-delete-handler.test.ts
+++ b/packages/iam-admin/src/role-delete-handler.test.ts
@@ -206,6 +206,26 @@ describe('createDeleteRoleHandlerInternal', () => {
     });
   });
 
+  it('deletes technical roles in Keycloak by canonical role key when legacy aliases exist', async () => {
+    const deps = createDeps({
+      resolveDeletableRole: vi.fn(async () => ({
+        ...systemAdminRole,
+        external_role_name: 'legacy-system-admin',
+      })),
+    });
+
+    const response = await runDeleteRoleRequest(deps);
+
+    expect(response.status).toBe(200);
+    expect(identityProvider.provider.deleteRole).toHaveBeenCalledWith('system_admin');
+    expect(deps.deleteRoleFromDatabase).toHaveBeenCalledWith({
+      actor,
+      roleId: 'role-1',
+      roleKey: 'system_admin',
+      externalRoleName: 'system_admin',
+    });
+  });
+
   it('recreates the role in Keycloak when local deletion fails', async () => {
     const deps = createDeps({
       resolveDeletableRole: vi.fn(async () => systemAdminRole),

--- a/packages/iam-admin/src/role-delete-handler.test.ts
+++ b/packages/iam-admin/src/role-delete-handler.test.ts
@@ -29,6 +29,16 @@ const existingRole = {
   role_level: 20,
 };
 
+const systemAdminRole = {
+  ...existingRole,
+  role_key: 'system_admin',
+  role_name: 'system_admin',
+  display_name: 'System Admin',
+  external_role_name: 'system_admin',
+  is_system_role: true,
+  role_level: 90,
+};
+
 const identityProvider = {
   provider: {
     assignRealmRoles: vi.fn(async () => undefined),
@@ -167,15 +177,7 @@ describe('createDeleteRoleHandlerInternal', () => {
 
   it('recreates the role in Keycloak when local deletion fails', async () => {
     const deps = createDeps({
-      resolveDeletableRole: vi.fn(async () => ({
-        ...existingRole,
-        role_key: 'system_admin',
-        role_name: 'system_admin',
-        display_name: 'System Admin',
-        external_role_name: 'system_admin',
-        is_system_role: true,
-        role_level: 90,
-      })),
+      resolveDeletableRole: vi.fn(async () => systemAdminRole),
       deleteRoleFromDatabase: vi.fn(async () => {
         throw new Error('db write failed');
       }),
@@ -199,15 +201,7 @@ describe('createDeleteRoleHandlerInternal', () => {
 
   it('replays direct user role mappings when compensation recreates a deleted role', async () => {
     const deps = createDeps({
-      resolveDeletableRole: vi.fn(async () => ({
-        ...existingRole,
-        role_key: 'system_admin',
-        role_name: 'system_admin',
-        display_name: 'System Admin',
-        external_role_name: 'system_admin',
-        is_system_role: true,
-        role_level: 90,
-      })),
+      resolveDeletableRole: vi.fn(async () => systemAdminRole),
       deleteRoleFromDatabase: vi.fn(async () => {
         throw new Error('db write failed');
       }),

--- a/packages/iam-admin/src/role-delete-handler.test.ts
+++ b/packages/iam-admin/src/role-delete-handler.test.ts
@@ -217,6 +217,12 @@ describe('createDeleteRoleHandlerInternal', () => {
     const response = await runDeleteRoleRequest(deps);
 
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        roleKey: 'system_admin',
+        externalRoleName: 'system_admin',
+      },
+    });
     expect(identityProvider.provider.deleteRole).toHaveBeenCalledWith('system_admin');
     expect(deps.deleteRoleFromDatabase).toHaveBeenCalledWith({
       actor,

--- a/packages/iam-admin/src/role-delete-handler.test.ts
+++ b/packages/iam-admin/src/role-delete-handler.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { dbWriteFailedErrorBody } from './handler-test-helpers.js';
 import { createDeleteRoleHandlerInternal, type DeleteRoleHandlerDeps } from './role-delete-handler.js';
 
 const actor = {
@@ -55,6 +56,10 @@ const buildAttributes = (input: { readonly instanceId: string; readonly roleKey:
   ...input,
 });
 
+const rejectDbWrite = async () => {
+  throw new Error('db write failed');
+};
+
 const createDeps = (
   overrides: Partial<DeleteRoleHandlerDeps<ReturnType<typeof buildAttributes>, typeof identityProvider, typeof existingRole>> = {}
 ) =>
@@ -85,6 +90,13 @@ const createDeps = (
     ...overrides,
   }) satisfies DeleteRoleHandlerDeps<ReturnType<typeof buildAttributes>, typeof identityProvider, typeof existingRole>;
 
+const runDeleteRoleRequest = (
+  deps: DeleteRoleHandlerDeps<ReturnType<typeof buildAttributes>, typeof identityProvider, typeof existingRole>
+) => {
+  const handler = createDeleteRoleHandlerInternal(deps);
+  return handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'DELETE' }), ctx);
+};
+
 describe('createDeleteRoleHandlerInternal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -95,9 +107,8 @@ describe('createDeleteRoleHandlerInternal', () => {
 
   it('deletes tenant roles locally without deleting Keycloak roles', async () => {
     const deps = createDeps();
-    const handler = createDeleteRoleHandlerInternal(deps);
 
-    const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'DELETE' }), ctx);
+    const response = await runDeleteRoleRequest(deps);
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
@@ -131,13 +142,34 @@ describe('createDeleteRoleHandlerInternal', () => {
         return work();
       }),
     });
-    const handler = createDeleteRoleHandlerInternal(deps);
 
-    const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'DELETE' }), ctx);
+    const response = await runDeleteRoleRequest(deps);
 
     expect(response.status).toBe(200);
     expect(deps.deleteRoleFromDatabase).toHaveBeenCalled();
     expect(identityProvider.provider.deleteRole).not.toHaveBeenCalled();
+  });
+
+  it('returns DB_WRITE_FAILED without Keycloak compensation when local deletion fails', async () => {
+    const deps = createDeps({
+      deleteRoleFromDatabase: vi.fn(rejectDbWrite),
+    });
+
+    const response = await runDeleteRoleRequest(deps);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject(dbWriteFailedErrorBody('internal_error', 'req-delete-role'));
+    expect(deps.requireRoleIdentityProvider).not.toHaveBeenCalled();
+    expect(identityProvider.provider.deleteRole).not.toHaveBeenCalled();
+    expect(identityProvider.provider.createRole).not.toHaveBeenCalled();
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Role delete database write failed',
+      expect.objectContaining({
+        operation: 'delete_role',
+        error_code: 'DB_WRITE_FAILED',
+        error: 'db write failed',
+      })
+    );
   });
 
   it('marks sync failure when Keycloak deletion fails with a non-404 error', async () => {
@@ -158,9 +190,8 @@ describe('createDeleteRoleHandlerInternal', () => {
         return work();
       }),
     });
-    const handler = createDeleteRoleHandlerInternal(deps);
 
-    const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'DELETE' }), ctx);
+    const response = await runDeleteRoleRequest(deps);
 
     expect(response.status).toBe(503);
     expect(deps.markDeleteRoleSyncState).toHaveBeenCalledWith({
@@ -178,13 +209,10 @@ describe('createDeleteRoleHandlerInternal', () => {
   it('recreates the role in Keycloak when local deletion fails', async () => {
     const deps = createDeps({
       resolveDeletableRole: vi.fn(async () => systemAdminRole),
-      deleteRoleFromDatabase: vi.fn(async () => {
-        throw new Error('db write failed');
-      }),
+      deleteRoleFromDatabase: vi.fn(rejectDbWrite),
     });
-    const handler = createDeleteRoleHandlerInternal(deps);
 
-    const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'DELETE' }), ctx);
+    const response = await runDeleteRoleRequest(deps);
 
     expect(response.status).toBe(500);
     expect(identityProvider.provider.createRole).toHaveBeenCalledWith({
@@ -202,14 +230,11 @@ describe('createDeleteRoleHandlerInternal', () => {
   it('replays direct user role mappings when compensation recreates a deleted role', async () => {
     const deps = createDeps({
       resolveDeletableRole: vi.fn(async () => systemAdminRole),
-      deleteRoleFromDatabase: vi.fn(async () => {
-        throw new Error('db write failed');
-      }),
+      deleteRoleFromDatabase: vi.fn(rejectDbWrite),
       listDirectRoleAssignmentSubjects: vi.fn(async () => ['kc-user-1', 'kc-user-2']),
     });
-    const handler = createDeleteRoleHandlerInternal(deps);
 
-    const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'DELETE' }), ctx);
+    const response = await runDeleteRoleRequest(deps);
 
     expect(response.status).toBe(500);
     expect(identityProvider.provider.createRole).toHaveBeenCalledOnce();

--- a/packages/iam-admin/src/role-delete-handler.test.ts
+++ b/packages/iam-admin/src/role-delete-handler.test.ts
@@ -83,7 +83,7 @@ describe('createDeleteRoleHandlerInternal', () => {
     identityProvider.provider.deleteRole.mockClear();
   });
 
-  it('deletes the role in Keycloak and locally, then returns the deleted role summary', async () => {
+  it('deletes tenant roles locally without deleting Keycloak roles', async () => {
     const deps = createDeps();
     const handler = createDeleteRoleHandlerInternal(deps);
 
@@ -100,7 +100,8 @@ describe('createDeleteRoleHandlerInternal', () => {
       },
       requestId: 'req-delete-role',
     });
-    expect(identityProvider.provider.deleteRole).toHaveBeenCalledWith('editor');
+    expect(deps.requireRoleIdentityProvider).not.toHaveBeenCalled();
+    expect(identityProvider.provider.deleteRole).not.toHaveBeenCalled();
     expect(deps.deleteRoleFromDatabase).toHaveBeenCalledWith({
       actor,
       roleId: 'role-1',
@@ -109,7 +110,7 @@ describe('createDeleteRoleHandlerInternal', () => {
     });
   });
 
-  it('treats identity-provider 404 as already deleted and still removes local state', async () => {
+  it('does not require Keycloak for local role deletion', async () => {
     const missingRoleError = new Error('missing role');
     const deps = createDeps({
       isIdentityRoleNotFoundError: vi.fn((error) => error === missingRoleError),
@@ -126,10 +127,20 @@ describe('createDeleteRoleHandlerInternal', () => {
 
     expect(response.status).toBe(200);
     expect(deps.deleteRoleFromDatabase).toHaveBeenCalled();
+    expect(identityProvider.provider.deleteRole).not.toHaveBeenCalled();
   });
 
   it('marks sync failure when Keycloak deletion fails with a non-404 error', async () => {
     const deps = createDeps({
+      resolveDeletableRole: vi.fn(async () => ({
+        ...existingRole,
+        role_key: 'system_admin',
+        role_name: 'system_admin',
+        display_name: 'System Admin',
+        external_role_name: 'system_admin',
+        is_system_role: true,
+        role_level: 90,
+      })),
       trackKeycloakCall: vi.fn(async (operation, work) => {
         if (operation === 'delete_role') {
           throw new Error('keycloak down');
@@ -145,8 +156,8 @@ describe('createDeleteRoleHandlerInternal', () => {
     expect(deps.markDeleteRoleSyncState).toHaveBeenCalledWith({
       actor,
       roleId: 'role-1',
-      roleKey: 'editor',
-      externalRoleName: 'editor',
+      roleKey: 'system_admin',
+      externalRoleName: 'system_admin',
       result: 'failure',
       eventType: 'role.sync_failed',
       errorCode: 'IDP_UNAVAILABLE',
@@ -156,6 +167,15 @@ describe('createDeleteRoleHandlerInternal', () => {
 
   it('recreates the role in Keycloak when local deletion fails', async () => {
     const deps = createDeps({
+      resolveDeletableRole: vi.fn(async () => ({
+        ...existingRole,
+        role_key: 'system_admin',
+        role_name: 'system_admin',
+        display_name: 'System Admin',
+        external_role_name: 'system_admin',
+        is_system_role: true,
+        role_level: 90,
+      })),
       deleteRoleFromDatabase: vi.fn(async () => {
         throw new Error('db write failed');
       }),
@@ -166,19 +186,28 @@ describe('createDeleteRoleHandlerInternal', () => {
 
     expect(response.status).toBe(500);
     expect(identityProvider.provider.createRole).toHaveBeenCalledWith({
-      externalName: 'editor',
+      externalName: 'system_admin',
       description: 'Can edit content',
       attributes: {
         managedBy: 'studio',
         instanceId: 'de-musterhausen',
-        roleKey: 'editor',
-        displayName: 'Editor',
+        roleKey: 'system_admin',
+        displayName: 'System Admin',
       },
     });
   });
 
   it('replays direct user role mappings when compensation recreates a deleted role', async () => {
     const deps = createDeps({
+      resolveDeletableRole: vi.fn(async () => ({
+        ...existingRole,
+        role_key: 'system_admin',
+        role_name: 'system_admin',
+        display_name: 'System Admin',
+        external_role_name: 'system_admin',
+        is_system_role: true,
+        role_level: 90,
+      })),
       deleteRoleFromDatabase: vi.fn(async () => {
         throw new Error('db write failed');
       }),
@@ -191,7 +220,7 @@ describe('createDeleteRoleHandlerInternal', () => {
     expect(response.status).toBe(500);
     expect(identityProvider.provider.createRole).toHaveBeenCalledOnce();
     expect(identityProvider.provider.assignRealmRoles).toHaveBeenCalledTimes(2);
-    expect(identityProvider.provider.assignRealmRoles).toHaveBeenNthCalledWith(1, 'kc-user-1', ['editor']);
-    expect(identityProvider.provider.assignRealmRoles).toHaveBeenNthCalledWith(2, 'kc-user-2', ['editor']);
+    expect(identityProvider.provider.assignRealmRoles).toHaveBeenNthCalledWith(1, 'kc-user-1', ['system_admin']);
+    expect(identityProvider.provider.assignRealmRoles).toHaveBeenNthCalledWith(2, 'kc-user-2', ['system_admin']);
   });
 });

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -101,6 +101,9 @@ const resolveDeleteRoleRequest = async <
   return roleId instanceof Response ? roleId : { actor: resolvedActor.actor, roleId };
 };
 
+const getKeycloakRoleNameForDelete = (role: MutableRoleShape): string =>
+  isTenantTechnicalKeycloakRole(role) ? role.role_key : getRoleExternalName(role);
+
 export const createDeleteRoleHandlerInternal =
   <
     TAttributes,
@@ -123,7 +126,7 @@ export const createDeleteRoleHandlerInternal =
         return existing;
       }
 
-      const externalRoleName = getRoleExternalName(existing);
+      const externalRoleName = getKeycloakRoleNameForDelete(existing);
       const shouldSyncIdentityRole = isTenantTechnicalKeycloakRole(existing);
       if (!shouldSyncIdentityRole) {
         try {

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -1,4 +1,5 @@
 import { getRoleDisplayName, getRoleExternalName } from './role-audit.js';
+import { isTenantTechnicalKeycloakRole } from './role-governance.js';
 import type { MutableRoleShape, UpdateRoleActor, UpdateRoleAuthenticatedRequestContext } from './role-update-handler.js';
 
 export type DeleteRoleAuthenticatedRequestContext = UpdateRoleAuthenticatedRequestContext;
@@ -101,11 +102,6 @@ export const createDeleteRoleHandlerInternal =
       return roleId;
     }
 
-    const identityProvider = await deps.requireRoleIdentityProvider(actor.instanceId, actor.requestId);
-    if (identityProvider instanceof Response) {
-      return identityProvider;
-    }
-
     try {
       const existing = await deps.resolveDeletableRole(actor, roleId);
       if (existing instanceof Response) {
@@ -113,6 +109,34 @@ export const createDeleteRoleHandlerInternal =
       }
 
       const externalRoleName = getRoleExternalName(existing);
+      const shouldSyncIdentityRole = isTenantTechnicalKeycloakRole(existing);
+      if (!shouldSyncIdentityRole) {
+        await deps.deleteRoleFromDatabase({
+          actor,
+          roleId,
+          roleKey: existing.role_key,
+          externalRoleName,
+        });
+        return deps.jsonResponse(
+          200,
+          deps.asApiItem(
+            {
+              id: roleId,
+              roleKey: existing.role_key,
+              roleName: getRoleDisplayName(existing),
+              externalRoleName,
+              syncState: 'synced' as const,
+            },
+            actor.requestId
+          )
+        );
+      }
+
+      const identityProvider = await deps.requireRoleIdentityProvider(actor.instanceId, actor.requestId);
+      if (identityProvider instanceof Response) {
+        return identityProvider;
+      }
+
       const directAssignmentSubjects = await deps.listDirectRoleAssignmentSubjects({
         instanceId: actor.instanceId,
         roleId,

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -141,7 +141,7 @@ export const createDeleteRoleHandlerInternal =
         }
         return deps.jsonResponse(
           200,
-          deps.asApiItem(buildDeletedRolePayloadFromRole(roleId, existing), actor.requestId)
+          deps.asApiItem(buildDeletedRolePayloadFromRole(roleId, existing, externalRoleName), actor.requestId)
         );
       }
 
@@ -264,7 +264,7 @@ export const createDeleteRoleHandlerInternal =
       deps.iamRoleSyncCounter.add(1, { operation: 'delete', result: 'success', error_code: 'none' });
       return deps.jsonResponse(
         200,
-        deps.asApiItem(buildDeletedRolePayloadFromRole(roleId, existing), actor.requestId)
+        deps.asApiItem(buildDeletedRolePayloadFromRole(roleId, existing, externalRoleName), actor.requestId)
       );
     } catch {
       return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht gelöscht werden.', actor.requestId);

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -82,6 +82,24 @@ export type DeleteRoleHandlerDeps<
   ) => Promise<T>;
 };
 
+const resolveDeleteRoleRequest = async <
+  TAttributes,
+  TIdentityProvider extends DeleteRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+>(
+  deps: DeleteRoleHandlerDeps<TAttributes, TIdentityProvider, TRole>,
+  request: Request,
+  ctx: DeleteRoleAuthenticatedRequestContext
+): Promise<{ readonly actor: DeleteRoleActor; readonly roleId: string } | Response> => {
+  const resolvedActor = await deps.resolveRoleMutationActor(request, ctx);
+  if ('response' in resolvedActor) {
+    return resolvedActor.response;
+  }
+
+  const roleId = deps.requireRoleId(request, resolvedActor.actor.requestId);
+  return roleId instanceof Response ? roleId : { actor: resolvedActor.actor, roleId };
+};
+
 export const createDeleteRoleHandlerInternal =
   <
     TAttributes,
@@ -91,16 +109,12 @@ export const createDeleteRoleHandlerInternal =
     deps: DeleteRoleHandlerDeps<TAttributes, TIdentityProvider, TRole>
   ) =>
   async (request: Request, ctx: DeleteRoleAuthenticatedRequestContext): Promise<Response> => {
-    const resolvedActor = await deps.resolveRoleMutationActor(request, ctx);
-    if ('response' in resolvedActor) {
-      return resolvedActor.response;
+    const resolvedRequest = await resolveDeleteRoleRequest(deps, request, ctx);
+    if (resolvedRequest instanceof Response) {
+      return resolvedRequest;
     }
 
-    const { actor } = resolvedActor;
-    const roleId = deps.requireRoleId(request, actor.requestId);
-    if (roleId instanceof Response) {
-      return roleId;
-    }
+    const { actor, roleId } = resolvedRequest;
 
     try {
       const existing = await deps.resolveDeletableRole(actor, roleId);

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -1,4 +1,5 @@
 import { getRoleDisplayName, getRoleExternalName } from './role-audit.js';
+import { buildDeletedRolePayloadFromRole, failLocalRoleDeleteDatabaseWrite } from './role-delete-support.js';
 import { isTenantTechnicalKeycloakRole } from './role-governance.js';
 import type { MutableRoleShape, UpdateRoleActor, UpdateRoleAuthenticatedRequestContext } from './role-update-handler.js';
 
@@ -100,50 +101,6 @@ const resolveDeleteRoleRequest = async <
   return roleId instanceof Response ? roleId : { actor: resolvedActor.actor, roleId };
 };
 
-const buildDeletedRolePayload = (input: {
-  readonly roleId: string;
-  readonly roleKey: string;
-  readonly roleName: string;
-  readonly externalRoleName: string;
-}) => ({
-  id: input.roleId,
-  roleKey: input.roleKey,
-  roleName: input.roleName,
-  externalRoleName: input.externalRoleName,
-  syncState: 'synced' as const,
-});
-
-const failLocalRoleDeleteDatabaseWrite = <
-  TAttributes,
-  TIdentityProvider extends DeleteRoleIdentityProvider<TAttributes>,
-  TRole extends MutableRoleShape,
->(
-  deps: DeleteRoleHandlerDeps<TAttributes, TIdentityProvider, TRole>,
-  input: {
-    readonly actor: DeleteRoleActor;
-    readonly roleId: string;
-    readonly existing: TRole;
-    readonly externalRoleName: string;
-    readonly error: unknown;
-  }
-): Response => {
-  deps.logger.error('Role delete database write failed', {
-    operation: 'delete_role',
-    instance_id: input.actor.instanceId,
-    request_id: input.actor.requestId,
-    trace_id: input.actor.traceId,
-    role_id: input.roleId,
-    role_key: input.existing.role_key,
-    external_role_name: input.externalRoleName,
-    error_code: 'DB_WRITE_FAILED',
-    error: deps.sanitizeRoleErrorMessage(input.error),
-  });
-  return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht gelöscht werden.', input.actor.requestId, {
-    syncState: 'failed',
-    syncError: { code: 'DB_WRITE_FAILED' },
-  });
-};
-
 export const createDeleteRoleHandlerInternal =
   <
     TAttributes,
@@ -181,15 +138,7 @@ export const createDeleteRoleHandlerInternal =
         }
         return deps.jsonResponse(
           200,
-          deps.asApiItem(
-            buildDeletedRolePayload({
-              roleId,
-              roleKey: existing.role_key,
-              roleName: getRoleDisplayName(existing),
-              externalRoleName,
-            }),
-            actor.requestId
-          )
+          deps.asApiItem(buildDeletedRolePayloadFromRole(roleId, existing), actor.requestId)
         );
       }
 
@@ -312,15 +261,7 @@ export const createDeleteRoleHandlerInternal =
       deps.iamRoleSyncCounter.add(1, { operation: 'delete', result: 'success', error_code: 'none' });
       return deps.jsonResponse(
         200,
-        deps.asApiItem(
-          buildDeletedRolePayload({
-            roleId,
-            roleKey: existing.role_key,
-            roleName: getRoleDisplayName(existing),
-            externalRoleName,
-          }),
-          actor.requestId
-        )
+        deps.asApiItem(buildDeletedRolePayloadFromRole(roleId, existing), actor.requestId)
       );
     } catch {
       return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht gelöscht werden.', actor.requestId);

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -100,6 +100,50 @@ const resolveDeleteRoleRequest = async <
   return roleId instanceof Response ? roleId : { actor: resolvedActor.actor, roleId };
 };
 
+const buildDeletedRolePayload = (input: {
+  readonly roleId: string;
+  readonly roleKey: string;
+  readonly roleName: string;
+  readonly externalRoleName: string;
+}) => ({
+  id: input.roleId,
+  roleKey: input.roleKey,
+  roleName: input.roleName,
+  externalRoleName: input.externalRoleName,
+  syncState: 'synced' as const,
+});
+
+const failLocalRoleDeleteDatabaseWrite = <
+  TAttributes,
+  TIdentityProvider extends DeleteRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+>(
+  deps: DeleteRoleHandlerDeps<TAttributes, TIdentityProvider, TRole>,
+  input: {
+    readonly actor: DeleteRoleActor;
+    readonly roleId: string;
+    readonly existing: TRole;
+    readonly externalRoleName: string;
+    readonly error: unknown;
+  }
+): Response => {
+  deps.logger.error('Role delete database write failed', {
+    operation: 'delete_role',
+    instance_id: input.actor.instanceId,
+    request_id: input.actor.requestId,
+    trace_id: input.actor.traceId,
+    role_id: input.roleId,
+    role_key: input.existing.role_key,
+    external_role_name: input.externalRoleName,
+    error_code: 'DB_WRITE_FAILED',
+    error: deps.sanitizeRoleErrorMessage(input.error),
+  });
+  return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht gelöscht werden.', input.actor.requestId, {
+    syncState: 'failed',
+    syncError: { code: 'DB_WRITE_FAILED' },
+  });
+};
+
 export const createDeleteRoleHandlerInternal =
   <
     TAttributes,
@@ -125,22 +169,25 @@ export const createDeleteRoleHandlerInternal =
       const externalRoleName = getRoleExternalName(existing);
       const shouldSyncIdentityRole = isTenantTechnicalKeycloakRole(existing);
       if (!shouldSyncIdentityRole) {
-        await deps.deleteRoleFromDatabase({
-          actor,
-          roleId,
-          roleKey: existing.role_key,
-          externalRoleName,
-        });
+        try {
+          await deps.deleteRoleFromDatabase({
+            actor,
+            roleId,
+            roleKey: existing.role_key,
+            externalRoleName,
+          });
+        } catch (error) {
+          return failLocalRoleDeleteDatabaseWrite(deps, { actor, roleId, existing, externalRoleName, error });
+        }
         return deps.jsonResponse(
           200,
           deps.asApiItem(
-            {
-              id: roleId,
+            buildDeletedRolePayload({
+              roleId,
               roleKey: existing.role_key,
               roleName: getRoleDisplayName(existing),
               externalRoleName,
-              syncState: 'synced' as const,
-            },
+            }),
             actor.requestId
           )
         );
@@ -266,13 +313,12 @@ export const createDeleteRoleHandlerInternal =
       return deps.jsonResponse(
         200,
         deps.asApiItem(
-          {
-            id: roleId,
+          buildDeletedRolePayload({
+            roleId,
             roleKey: existing.role_key,
             roleName: getRoleDisplayName(existing),
             externalRoleName,
-            syncState: 'synced' as const,
-          },
+          }),
           actor.requestId
         )
       );

--- a/packages/iam-admin/src/role-delete-support.ts
+++ b/packages/iam-admin/src/role-delete-support.ts
@@ -1,0 +1,55 @@
+import { getRoleDisplayName, getRoleExternalName } from './role-audit.js';
+import type { DeleteRoleActor, DeleteRoleHandlerDeps, DeleteRoleIdentityProvider } from './role-delete-handler.js';
+import type { MutableRoleShape } from './role-update-handler.js';
+
+const buildDeletedRolePayload = (input: {
+  readonly roleId: string;
+  readonly roleKey: string;
+  readonly roleName: string;
+  readonly externalRoleName: string;
+}) => ({
+  id: input.roleId,
+  roleKey: input.roleKey,
+  roleName: input.roleName,
+  externalRoleName: input.externalRoleName,
+  syncState: 'synced' as const,
+});
+
+export const buildDeletedRolePayloadFromRole = (roleId: string, existing: MutableRoleShape) =>
+  buildDeletedRolePayload({
+    roleId,
+    roleKey: existing.role_key,
+    roleName: getRoleDisplayName(existing),
+    externalRoleName: getRoleExternalName(existing),
+  });
+
+export const failLocalRoleDeleteDatabaseWrite = <
+  TAttributes,
+  TIdentityProvider extends DeleteRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+>(
+  deps: DeleteRoleHandlerDeps<TAttributes, TIdentityProvider, TRole>,
+  input: {
+    readonly actor: DeleteRoleActor;
+    readonly roleId: string;
+    readonly existing: TRole;
+    readonly externalRoleName: string;
+    readonly error: unknown;
+  }
+): Response => {
+  deps.logger.error('Role delete database write failed', {
+    operation: 'delete_role',
+    instance_id: input.actor.instanceId,
+    request_id: input.actor.requestId,
+    trace_id: input.actor.traceId,
+    role_id: input.roleId,
+    role_key: input.existing.role_key,
+    external_role_name: input.externalRoleName,
+    error_code: 'DB_WRITE_FAILED',
+    error: deps.sanitizeRoleErrorMessage(input.error),
+  });
+  return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht gelöscht werden.', input.actor.requestId, {
+    syncState: 'failed',
+    syncError: { code: 'DB_WRITE_FAILED' },
+  });
+};

--- a/packages/iam-admin/src/role-delete-support.ts
+++ b/packages/iam-admin/src/role-delete-support.ts
@@ -15,12 +15,16 @@ const buildDeletedRolePayload = (input: {
   syncState: 'synced' as const,
 });
 
-export const buildDeletedRolePayloadFromRole = (roleId: string, existing: MutableRoleShape) =>
+export const buildDeletedRolePayloadFromRole = (
+  roleId: string,
+  existing: MutableRoleShape,
+  externalRoleName = getRoleExternalName(existing)
+) =>
   buildDeletedRolePayload({
     roleId,
     roleKey: existing.role_key,
     roleName: getRoleDisplayName(existing),
-    externalRoleName: getRoleExternalName(existing),
+    externalRoleName,
   });
 
 export const failLocalRoleDeleteDatabaseWrite = <

--- a/packages/iam-admin/src/role-governance.ts
+++ b/packages/iam-admin/src/role-governance.ts
@@ -40,9 +40,6 @@ export const isTenantManageableRole = (role: RoleIdentity): boolean =>
 export const isTenantTechnicalKeycloakRole = (role: RoleIdentity): boolean =>
   collectRoleIdentifiers(role).some((identifier) => TENANT_TECHNICAL_KEYCLOAK_ROLE_SET.has(identifier));
 
-export const isPlatformTechnicalKeycloakRoleName = (roleName: string): boolean =>
-  PLATFORM_TECHNICAL_KEYCLOAK_ROLE_SET.has(roleName);
-
 export const filterTenantTechnicalKeycloakRoleNames = (roleNames: readonly string[]): readonly string[] =>
   [...new Set(roleNames.filter((roleName) => TENANT_TECHNICAL_KEYCLOAK_ROLE_SET.has(roleName)))];
 

--- a/packages/iam-admin/src/role-governance.ts
+++ b/packages/iam-admin/src/role-governance.ts
@@ -43,5 +43,14 @@ export const isTenantTechnicalKeycloakRole = (role: RoleIdentity): boolean =>
 export const filterTenantTechnicalKeycloakRoleNames = (roleNames: readonly string[]): readonly string[] =>
   [...new Set(roleNames.filter((roleName) => TENANT_TECHNICAL_KEYCLOAK_ROLE_SET.has(roleName)))];
 
+export const resolveTenantTechnicalKeycloakRoleNames = (roles: readonly RoleIdentity[]): readonly string[] =>
+  [
+    ...new Set(
+      roles.flatMap((role) =>
+        isTenantTechnicalKeycloakRole(role) ? TENANT_TECHNICAL_KEYCLOAK_ROLE_NAMES : []
+      )
+    ),
+  ];
+
 export const filterPlatformTechnicalKeycloakRoleNames = (roleNames: readonly string[]): readonly string[] =>
   [...new Set(roleNames.filter((roleName) => PLATFORM_TECHNICAL_KEYCLOAK_ROLE_SET.has(roleName)))];

--- a/packages/iam-admin/src/role-governance.ts
+++ b/packages/iam-admin/src/role-governance.ts
@@ -47,7 +47,9 @@ export const resolveTenantTechnicalKeycloakRoleNames = (roles: readonly RoleIden
   [
     ...new Set(
       roles.flatMap((role) =>
-        isTenantTechnicalKeycloakRole(role) ? TENANT_TECHNICAL_KEYCLOAK_ROLE_NAMES : []
+        collectRoleIdentifiers(role).filter((identifier) =>
+          TENANT_TECHNICAL_KEYCLOAK_ROLE_SET.has(identifier)
+        )
       )
     ),
   ];

--- a/packages/iam-admin/src/role-governance.ts
+++ b/packages/iam-admin/src/role-governance.ts
@@ -7,6 +7,12 @@ type RoleIdentity = Readonly<{
 const SYSTEM_ADMIN_ROLE_KEY = 'system_admin';
 const ROOT_ONLY_ROLE_KEY = 'instance_registry_admin';
 
+export const TENANT_TECHNICAL_KEYCLOAK_ROLE_NAMES = [SYSTEM_ADMIN_ROLE_KEY] as const;
+export const PLATFORM_TECHNICAL_KEYCLOAK_ROLE_NAMES = [ROOT_ONLY_ROLE_KEY] as const;
+
+const TENANT_TECHNICAL_KEYCLOAK_ROLE_SET = new Set<string>(TENANT_TECHNICAL_KEYCLOAK_ROLE_NAMES);
+const PLATFORM_TECHNICAL_KEYCLOAK_ROLE_SET = new Set<string>(PLATFORM_TECHNICAL_KEYCLOAK_ROLE_NAMES);
+
 const normalizeRoleIdentifier = (value: string | null | undefined): string | null => {
   const normalized = value?.trim();
   return normalized ? normalized : null;
@@ -30,3 +36,15 @@ export const isRootOnlyRole = (role: RoleIdentity): boolean =>
 
 export const isTenantManageableRole = (role: RoleIdentity): boolean =>
   !isRootOnlyRole(role);
+
+export const isTenantTechnicalKeycloakRole = (role: RoleIdentity): boolean =>
+  collectRoleIdentifiers(role).some((identifier) => TENANT_TECHNICAL_KEYCLOAK_ROLE_SET.has(identifier));
+
+export const isPlatformTechnicalKeycloakRoleName = (roleName: string): boolean =>
+  PLATFORM_TECHNICAL_KEYCLOAK_ROLE_SET.has(roleName);
+
+export const filterTenantTechnicalKeycloakRoleNames = (roleNames: readonly string[]): readonly string[] =>
+  [...new Set(roleNames.filter((roleName) => TENANT_TECHNICAL_KEYCLOAK_ROLE_SET.has(roleName)))];
+
+export const filterPlatformTechnicalKeycloakRoleNames = (roleNames: readonly string[]): readonly string[] =>
+  [...new Set(roleNames.filter((roleName) => PLATFORM_TECHNICAL_KEYCLOAK_ROLE_SET.has(roleName)))];

--- a/packages/iam-admin/src/role-update-handler.test.ts
+++ b/packages/iam-admin/src/role-update-handler.test.ts
@@ -171,6 +171,33 @@ describe('createUpdateRoleHandlerInternal', () => {
     });
   });
 
+  it('updates technical roles in Keycloak by canonical role key when legacy aliases exist', async () => {
+    const deps = createDeps({
+      resolveMutableRole: vi.fn(async () => ({
+        ...systemAdminRole,
+        external_role_name: 'legacy-system-admin',
+      })),
+    });
+    const handler = createUpdateRoleHandlerInternal(deps);
+
+    const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'PATCH' }), ctx);
+
+    expect(response.status).toBe(200);
+    expect(identityProvider.provider.updateRole).toHaveBeenCalledWith(
+      'system_admin',
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          roleKey: 'system_admin',
+        }),
+      })
+    );
+    expect(deps.persistUpdatedRole).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalRoleName: 'system_admin',
+      })
+    );
+  });
+
   it('rejects retry sync for non-technical tenant roles', async () => {
     const keycloakError = new Error('keycloak down');
     const deps = createDeps({

--- a/packages/iam-admin/src/role-update-handler.test.ts
+++ b/packages/iam-admin/src/role-update-handler.test.ts
@@ -102,7 +102,7 @@ describe('createUpdateRoleHandlerInternal', () => {
     identityProvider.provider.updateRole.mockClear();
   });
 
-  it('updates the role in Keycloak, persists it locally and returns the API item', async () => {
+  it('updates tenant roles locally without updating Keycloak', async () => {
     const deps = createDeps();
     const handler = createUpdateRoleHandlerInternal(deps);
 
@@ -113,15 +113,9 @@ describe('createUpdateRoleHandlerInternal', () => {
       data: roleItem,
       requestId: 'req-update-role',
     });
-    expect(identityProvider.provider.updateRole).toHaveBeenCalledWith('editor', {
-      description: 'Can edit more content',
-      attributes: {
-        managedBy: 'studio',
-        instanceId: 'de-musterhausen',
-        roleKey: 'editor',
-        displayName: 'Editor Plus',
-      },
-    });
+    expect(deps.requireRoleIdentityProvider).not.toHaveBeenCalled();
+    expect(identityProvider.provider.updateRole).not.toHaveBeenCalled();
+    expect(deps.markRoleSyncState).not.toHaveBeenCalled();
     expect(deps.persistUpdatedRole).toHaveBeenCalledWith({
       actor,
       roleId: 'role-1',
@@ -135,40 +129,21 @@ describe('createUpdateRoleHandlerInternal', () => {
     });
   });
 
-  it('marks sync failure and returns the injected Keycloak failure response', async () => {
+  it('rejects retry sync for non-technical tenant roles', async () => {
     const keycloakError = new Error('keycloak down');
     const deps = createDeps({
-      trackKeycloakCall: vi.fn(async (operation, work) => {
-        if (operation === 'update_role') {
-          throw keycloakError;
-        }
-        return work();
-      }),
+      parseUpdateRoleBody: vi.fn(async () => ({ ok: true, data: { ...payload, retrySync: true }, rawBody: '{}' })),
     });
     const handler = createUpdateRoleHandlerInternal(deps);
 
     const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'PATCH' }), ctx);
 
-    expect(response.status).toBe(503);
-    expect(deps.markRoleSyncState).toHaveBeenCalledWith({
-      actor,
-      roleId: 'role-1',
-      operation: 'update',
-      result: 'failure',
-      roleKey: 'editor',
-      externalRoleName: 'editor',
-      errorCode: 'IDP_UNAVAILABLE',
-      syncState: 'failed',
-    });
-    expect(deps.buildRoleSyncFailure).toHaveBeenCalledWith({
-      error: keycloakError,
-      requestId: 'req-update-role',
-      fallbackMessage: 'Rolle konnte nicht mit Keycloak synchronisiert werden.',
-      roleId: 'role-1',
-    });
+    expect(response.status).toBe(400);
+    expect(identityProvider.provider.updateRole).not.toHaveBeenCalled();
+    expect(keycloakError).toBeInstanceOf(Error);
   });
 
-  it('compensates Keycloak when local persistence fails after the external update', async () => {
+  it('returns a local failure without Keycloak compensation for tenant role persistence errors', async () => {
     const deps = createDeps({
       persistUpdatedRole: vi.fn(async () => {
         throw new Error('db write failed');
@@ -179,23 +154,7 @@ describe('createUpdateRoleHandlerInternal', () => {
     const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'PATCH' }), ctx);
 
     expect(response.status).toBe(500);
-    expect(identityProvider.provider.updateRole).toHaveBeenCalledTimes(2);
-    expect(identityProvider.provider.updateRole).toHaveBeenLastCalledWith('editor', {
-      description: 'Can edit content',
-      attributes: {
-        managedBy: 'studio',
-        instanceId: 'de-musterhausen',
-        roleKey: 'editor',
-        displayName: 'Editor',
-      },
-    });
-    expect(deps.logger.error).toHaveBeenCalledWith(
-      'Role update database write failed after successful Keycloak update',
-      expect.objectContaining({
-        error: 'db write failed',
-        role_key: 'editor',
-      })
-    );
+    expect(identityProvider.provider.updateRole).not.toHaveBeenCalled();
   });
 
   it('returns precondition responses before mutation work', async () => {

--- a/packages/iam-admin/src/role-update-handler.test.ts
+++ b/packages/iam-admin/src/role-update-handler.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createJsonResponse, createTestDepsBuilder } from './handler-test-helpers.js';
+import { createJsonResponse, createTestDepsBuilder, dbWriteFailedErrorBody } from './handler-test-helpers.js';
 import { createUpdateRoleHandlerInternal, type UpdateRoleHandlerDeps } from './role-update-handler.js';
+import { syncTechnicalRoleUpdate, type PreparedRoleUpdate } from './role-update-sync.js';
 
 const actor = {
   instanceId: 'de-musterhausen',
@@ -35,6 +36,17 @@ const existingRole = {
   is_system_role: false,
   managed_by: 'studio',
   role_level: 20,
+};
+
+const systemAdminRole = {
+  ...existingRole,
+  role_key: 'system_admin',
+  role_name: 'system_admin',
+  display_name: 'System Admin',
+  external_role_name: 'system_admin',
+  description: 'System administration',
+  is_system_role: true,
+  role_level: 100,
 };
 
 const roleItem = {
@@ -92,6 +104,36 @@ const createDeps = createTestDepsBuilder<
     typeof roleItem
   >;
 
+const preparedRetryUpdate = {
+  actor,
+  roleId: 'role-system-admin',
+  existing: systemAdminRole,
+  data: payload,
+  operation: 'retry',
+  displayName: 'System Admin',
+  description: 'System administration',
+  roleLevel: 100,
+  externalRoleName: 'system_admin',
+} satisfies PreparedRoleUpdate<typeof payload, typeof existingRole>;
+
+const expectRetrySyncFailureMarked = (
+  deps: UpdateRoleHandlerDeps<typeof payload, ReturnType<typeof buildAttributes>, typeof identityProvider, typeof existingRole, typeof roleItem>,
+  errorCode: 'COMPENSATION_FAILED' | 'DB_WRITE_FAILED'
+) => {
+  expect(deps.markRoleSyncState).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      operation: 'retry',
+      result: 'failure',
+      errorCode,
+    })
+  );
+  expect(deps.iamRoleSyncCounter.add).toHaveBeenLastCalledWith(1, {
+    operation: 'retry',
+    result: 'failure',
+    error_code: errorCode,
+  });
+};
+
 function buildAttributes(input: { readonly instanceId: string; readonly roleKey: string; readonly displayName: string }) {
   return { managedBy: 'studio' as const, ...input };
 }
@@ -139,11 +181,22 @@ describe('createUpdateRoleHandlerInternal', () => {
     const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'PATCH' }), ctx);
 
     expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'invalid_request',
+        details: {
+          syncState: 'pending',
+          syncAction: 'reconcile_roles',
+        },
+      },
+      requestId: 'req-update-role',
+    });
+    expect(deps.resolveMutableRole).not.toHaveBeenCalled();
     expect(identityProvider.provider.updateRole).not.toHaveBeenCalled();
     expect(keycloakError).toBeInstanceOf(Error);
   });
 
-  it('returns a local failure without Keycloak compensation for tenant role persistence errors', async () => {
+  it('returns DB_WRITE_FAILED without Keycloak compensation for tenant role persistence errors', async () => {
     const deps = createDeps({
       persistUpdatedRole: vi.fn(async () => {
         throw new Error('db write failed');
@@ -154,7 +207,16 @@ describe('createUpdateRoleHandlerInternal', () => {
     const response = await handler(new Request('http://localhost/api/v1/iam/roles/role-1', { method: 'PATCH' }), ctx);
 
     expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject(dbWriteFailedErrorBody('internal_error', 'req-update-role'));
     expect(identityProvider.provider.updateRole).not.toHaveBeenCalled();
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      'Role update database write failed',
+      expect.objectContaining({
+        operation: 'update_role',
+        error_code: 'DB_WRITE_FAILED',
+        error: 'db write failed',
+      })
+    );
   });
 
   it('returns precondition responses before mutation work', async () => {
@@ -187,5 +249,37 @@ describe('createUpdateRoleHandlerInternal', () => {
     expect(deps.requireRoleIdentityProvider).not.toHaveBeenCalled();
     expect(identityProvider.provider.updateRole).not.toHaveBeenCalled();
     expect(deps.persistUpdatedRole).not.toHaveBeenCalled();
+  });
+
+  it('marks retry DB write failures as retry failures', async () => {
+    const deps = createDeps({
+      persistUpdatedRole: vi.fn(async () => {
+        throw new Error('db write failed');
+      }),
+    });
+
+    const response = await syncTechnicalRoleUpdate(deps, preparedRetryUpdate);
+
+    expect(response.status).toBe(500);
+    expectRetrySyncFailureMarked(deps, 'DB_WRITE_FAILED');
+  });
+
+  it('marks retry compensation failures as retry failures', async () => {
+    const deps = createDeps({
+      persistUpdatedRole: vi.fn(async () => {
+        throw new Error('db write failed');
+      }),
+      trackKeycloakCall: vi.fn(async (operation, work) => {
+        if (operation === 'update_role_compensation') {
+          throw new Error('compensation failed');
+        }
+        return work();
+      }),
+    });
+
+    const response = await syncTechnicalRoleUpdate(deps, preparedRetryUpdate);
+
+    expect(response.status).toBe(500);
+    expectRetrySyncFailureMarked(deps, 'COMPENSATION_FAILED');
   });
 });

--- a/packages/iam-admin/src/role-update-handler.ts
+++ b/packages/iam-admin/src/role-update-handler.ts
@@ -56,6 +56,9 @@ export type UpdateRoleIdentityProvider<TAttributes = unknown> = {
   };
 };
 
+const getKeycloakRoleNameForMutation = (role: MutableRoleShape): string =>
+  isTenantTechnicalKeycloakRole(role) ? role.role_key : getRoleExternalName(role);
+
 export type ParsedUpdateRoleBody<TPayload extends UpdateRolePayloadShape> =
   | { readonly ok: true; readonly data: TPayload; readonly rawBody: string }
   | { readonly ok: false };
@@ -191,7 +194,7 @@ export const createUpdateRoleHandlerInternal =
         displayName: parsed.data.displayName?.trim() || getRoleDisplayName(existing),
         description: parsed.data.description ?? existing.description ?? undefined,
         roleLevel: parsed.data.roleLevel ?? existing.role_level,
-        externalRoleName: getRoleExternalName(existing),
+        externalRoleName: getKeycloakRoleNameForMutation(existing),
       } satisfies PreparedRoleUpdate<TPayload, TRole>;
 
       if (!isTenantTechnicalKeycloakRole(existing)) {

--- a/packages/iam-admin/src/role-update-handler.ts
+++ b/packages/iam-admin/src/role-update-handler.ts
@@ -1,7 +1,12 @@
 import type { IamRolePermissionAssignmentScope } from '@sva/core';
 import { getRoleDisplayName, getRoleExternalName } from './role-audit.js';
 import { isTenantTechnicalKeycloakRole } from './role-governance.js';
-import { persistLocalRoleUpdate, syncTechnicalRoleUpdate, type PreparedRoleUpdate } from './role-update-sync.js';
+import {
+  persistLocalRoleUpdate,
+  redirectRoleSyncRetryToReconcile,
+  syncTechnicalRoleUpdate,
+  type PreparedRoleUpdate,
+} from './role-update-sync.js';
 
 export type UpdateRoleAuthenticatedRequestContext = {
   readonly sessionId: string;
@@ -158,6 +163,9 @@ export const createUpdateRoleHandlerInternal =
     if (!parsed.ok) {
       return deps.createApiError(400, 'invalid_request', 'Ungültiger Payload.', actor.requestId);
     }
+    if (parsed.data.retrySync) {
+      return redirectRoleSyncRetryToReconcile(deps, actor.requestId);
+    }
 
     const permissionValidationResponse = await deps.validateRequestedPermissions?.({
       actor,
@@ -179,7 +187,7 @@ export const createUpdateRoleHandlerInternal =
         roleId,
         existing,
         data: parsed.data,
-        operation: parsed.data.retrySync ? 'retry' : 'update',
+        operation: 'update',
         displayName: parsed.data.displayName?.trim() || getRoleDisplayName(existing),
         description: parsed.data.description ?? existing.description ?? undefined,
         roleLevel: parsed.data.roleLevel ?? existing.role_level,
@@ -187,14 +195,6 @@ export const createUpdateRoleHandlerInternal =
       } satisfies PreparedRoleUpdate<TPayload, TRole>;
 
       if (!isTenantTechnicalKeycloakRole(existing)) {
-        if (parsed.data.retrySync) {
-          return deps.createApiError(
-            400,
-            'invalid_request',
-            'Rollenabgleich ist nur für technische Sonderrollen verfügbar.',
-            actor.requestId
-          );
-        }
         return await persistLocalRoleUpdate(deps, preparedUpdate);
       }
       return await syncTechnicalRoleUpdate(deps, preparedUpdate);

--- a/packages/iam-admin/src/role-update-handler.ts
+++ b/packages/iam-admin/src/role-update-handler.ts
@@ -1,5 +1,6 @@
 import type { IamRolePermissionAssignmentScope } from '@sva/core';
 import { getRoleDisplayName, getRoleExternalName } from './role-audit.js';
+import { isTenantTechnicalKeycloakRole } from './role-governance.js';
 
 export type UpdateRoleAuthenticatedRequestContext = {
   readonly sessionId: string;
@@ -166,11 +167,6 @@ export const createUpdateRoleHandlerInternal =
       return permissionValidationResponse;
     }
 
-    const identityProvider = await deps.requireRoleIdentityProvider(actor.instanceId, actor.requestId);
-    if (identityProvider instanceof Response) {
-      return identityProvider;
-    }
-
     try {
       const existing = await deps.resolveMutableRole(actor, roleId);
       if (existing instanceof Response) {
@@ -182,6 +178,37 @@ export const createUpdateRoleHandlerInternal =
       const nextDescription = parsed.data.description ?? existing.description ?? undefined;
       const nextRoleLevel = parsed.data.roleLevel ?? existing.role_level;
       const externalRoleName = getRoleExternalName(existing);
+      const shouldSyncIdentityRole = isTenantTechnicalKeycloakRole(existing);
+
+      if (!shouldSyncIdentityRole) {
+        if (parsed.data.retrySync) {
+          return deps.createApiError(
+            400,
+            'invalid_request',
+            'Rollenabgleich ist nur für technische Sonderrollen verfügbar.',
+            actor.requestId
+          );
+        }
+
+        const roleItem = await deps.persistUpdatedRole({
+          actor,
+          roleId,
+          existing,
+          displayName: nextDisplayName,
+          description: nextDescription,
+          roleLevel: nextRoleLevel,
+          externalRoleName,
+          permissionIds: parsed.data.permissionIds,
+          permissionAssignments: parsed.data.permissionAssignments,
+          operation,
+        });
+        return deps.jsonResponse(200, deps.asApiItem(roleItem, actor.requestId));
+      }
+
+      const identityProvider = await deps.requireRoleIdentityProvider(actor.instanceId, actor.requestId);
+      if (identityProvider instanceof Response) {
+        return identityProvider;
+      }
 
       await deps.markRoleSyncState({
         actor,

--- a/packages/iam-admin/src/role-update-handler.ts
+++ b/packages/iam-admin/src/role-update-handler.ts
@@ -1,6 +1,7 @@
 import type { IamRolePermissionAssignmentScope } from '@sva/core';
 import { getRoleDisplayName, getRoleExternalName } from './role-audit.js';
 import { isTenantTechnicalKeycloakRole } from './role-governance.js';
+import { persistLocalRoleUpdate, syncTechnicalRoleUpdate, type PreparedRoleUpdate } from './role-update-sync.js';
 
 export type UpdateRoleAuthenticatedRequestContext = {
   readonly sessionId: string;
@@ -173,14 +174,19 @@ export const createUpdateRoleHandlerInternal =
         return existing;
       }
 
-      const operation = parsed.data.retrySync ? 'retry' : 'update';
-      const nextDisplayName = parsed.data.displayName?.trim() || getRoleDisplayName(existing);
-      const nextDescription = parsed.data.description ?? existing.description ?? undefined;
-      const nextRoleLevel = parsed.data.roleLevel ?? existing.role_level;
-      const externalRoleName = getRoleExternalName(existing);
-      const shouldSyncIdentityRole = isTenantTechnicalKeycloakRole(existing);
+      const preparedUpdate = {
+        actor,
+        roleId,
+        existing,
+        data: parsed.data,
+        operation: parsed.data.retrySync ? 'retry' : 'update',
+        displayName: parsed.data.displayName?.trim() || getRoleDisplayName(existing),
+        description: parsed.data.description ?? existing.description ?? undefined,
+        roleLevel: parsed.data.roleLevel ?? existing.role_level,
+        externalRoleName: getRoleExternalName(existing),
+      } satisfies PreparedRoleUpdate<TPayload, TRole>;
 
-      if (!shouldSyncIdentityRole) {
+      if (!isTenantTechnicalKeycloakRole(existing)) {
         if (parsed.data.retrySync) {
           return deps.createApiError(
             400,
@@ -189,153 +195,9 @@ export const createUpdateRoleHandlerInternal =
             actor.requestId
           );
         }
-
-        const roleItem = await deps.persistUpdatedRole({
-          actor,
-          roleId,
-          existing,
-          displayName: nextDisplayName,
-          description: nextDescription,
-          roleLevel: nextRoleLevel,
-          externalRoleName,
-          permissionIds: parsed.data.permissionIds,
-          permissionAssignments: parsed.data.permissionAssignments,
-          operation,
-        });
-        return deps.jsonResponse(200, deps.asApiItem(roleItem, actor.requestId));
+        return await persistLocalRoleUpdate(deps, preparedUpdate);
       }
-
-      const identityProvider = await deps.requireRoleIdentityProvider(actor.instanceId, actor.requestId);
-      if (identityProvider instanceof Response) {
-        return identityProvider;
-      }
-
-      await deps.markRoleSyncState({
-        actor,
-        roleId,
-        operation,
-        result: 'success',
-        roleKey: existing.role_key,
-        externalRoleName,
-        syncState: 'pending',
-      });
-
-      try {
-        await deps.trackKeycloakCall('update_role', () =>
-          identityProvider.provider.updateRole(externalRoleName, {
-            description: nextDescription,
-            attributes: deps.buildRoleAttributes({
-              instanceId: actor.instanceId,
-              roleKey: existing.role_key,
-              displayName: nextDisplayName,
-            }),
-          })
-        );
-      } catch (error) {
-        const errorCode = deps.mapRoleSyncErrorCode(error);
-        deps.iamRoleSyncCounter.add(1, { operation, result: 'failure', error_code: errorCode });
-        await deps.markRoleSyncState({
-          actor,
-          roleId,
-          operation,
-          result: 'failure',
-          roleKey: existing.role_key,
-          externalRoleName,
-          errorCode,
-          syncState: 'failed',
-        });
-        return deps.buildRoleSyncFailure({
-          error,
-          requestId: actor.requestId,
-          fallbackMessage: 'Rolle konnte nicht mit Keycloak synchronisiert werden.',
-          roleId,
-        });
-      }
-
-      try {
-        const roleItem = await deps.persistUpdatedRole({
-          actor,
-          roleId,
-          existing,
-          displayName: nextDisplayName,
-          description: nextDescription,
-          roleLevel: nextRoleLevel,
-          externalRoleName,
-          permissionIds: parsed.data.permissionIds,
-          permissionAssignments: parsed.data.permissionAssignments,
-          operation,
-        });
-        deps.iamRoleSyncCounter.add(1, { operation, result: 'success', error_code: 'none' });
-        return deps.jsonResponse(200, deps.asApiItem(roleItem, actor.requestId));
-      } catch (error) {
-        try {
-          await deps.trackKeycloakCall('update_role_compensation', () =>
-            identityProvider.provider.updateRole(externalRoleName, {
-              description: existing.description ?? undefined,
-              attributes: deps.buildRoleAttributes({
-                instanceId: actor.instanceId,
-                roleKey: existing.role_key,
-                displayName: getRoleDisplayName(existing),
-              }),
-            })
-          );
-        } catch {
-          await deps.markRoleSyncState({
-            actor,
-            roleId,
-            operation: 'update',
-            result: 'failure',
-            roleKey: existing.role_key,
-            externalRoleName,
-            errorCode: 'COMPENSATION_FAILED',
-            syncState: 'failed',
-          });
-          deps.iamRoleSyncCounter.add(1, {
-            operation: 'update',
-            result: 'failure',
-            error_code: 'COMPENSATION_FAILED',
-          });
-          return deps.createApiError(
-            500,
-            'internal_error',
-            'Rolle konnte nicht konsistent aktualisiert werden.',
-            actor.requestId,
-            {
-              syncState: 'failed',
-              syncError: { code: 'COMPENSATION_FAILED' },
-            }
-          );
-        }
-
-        await deps.markRoleSyncState({
-          actor,
-          roleId,
-          operation: 'update',
-          result: 'failure',
-          roleKey: existing.role_key,
-          externalRoleName,
-          errorCode: 'DB_WRITE_FAILED',
-          syncState: 'failed',
-        });
-        deps.iamRoleSyncCounter.add(1, {
-          operation: 'update',
-          result: 'failure',
-          error_code: 'DB_WRITE_FAILED',
-        });
-        deps.logger.error('Role update database write failed after successful Keycloak update', {
-          operation: 'update_role',
-          instance_id: actor.instanceId,
-          request_id: actor.requestId,
-          trace_id: actor.traceId,
-          role_id: roleId,
-          role_key: existing.role_key,
-          error: deps.sanitizeRoleErrorMessage(error),
-        });
-        return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht aktualisiert werden.', actor.requestId, {
-          syncState: 'failed',
-          syncError: { code: 'DB_WRITE_FAILED' },
-        });
-      }
+      return await syncTechnicalRoleUpdate(deps, preparedUpdate);
     } catch {
       return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht aktualisiert werden.', actor.requestId);
     }

--- a/packages/iam-admin/src/role-update-sync.ts
+++ b/packages/iam-admin/src/role-update-sync.ts
@@ -1,0 +1,190 @@
+import { getRoleDisplayName } from './role-audit.js';
+import type {
+  MutableRoleShape,
+  UpdateRoleHandlerDeps,
+  UpdateRoleIdentityProvider,
+  UpdateRolePayloadShape,
+  UpdateRoleActor,
+} from './role-update-handler.js';
+
+export type PreparedRoleUpdate<TPayload extends UpdateRolePayloadShape, TRole extends MutableRoleShape> = {
+  readonly actor: UpdateRoleActor;
+  readonly roleId: string;
+  readonly existing: TRole;
+  readonly data: TPayload;
+  readonly operation: 'update' | 'retry';
+  readonly displayName: string;
+  readonly description?: string;
+  readonly roleLevel: number;
+  readonly externalRoleName: string;
+};
+
+export const persistLocalRoleUpdate = async <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  input: PreparedRoleUpdate<TPayload, TRole>
+): Promise<Response> => {
+  const roleItem = await deps.persistUpdatedRole({
+    actor: input.actor,
+    roleId: input.roleId,
+    existing: input.existing,
+    displayName: input.displayName,
+    description: input.description,
+    roleLevel: input.roleLevel,
+    externalRoleName: input.externalRoleName,
+    permissionIds: input.data.permissionIds,
+    permissionAssignments: input.data.permissionAssignments,
+    operation: input.operation,
+  });
+  return deps.jsonResponse(200, deps.asApiItem(roleItem, input.actor.requestId));
+};
+
+const failTechnicalRoleCompensation = async <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  input: PreparedRoleUpdate<TPayload, TRole>
+) => {
+  await deps.markRoleSyncState({
+    actor: input.actor,
+    roleId: input.roleId,
+    operation: 'update',
+    result: 'failure',
+    roleKey: input.existing.role_key,
+    externalRoleName: input.externalRoleName,
+    errorCode: 'COMPENSATION_FAILED',
+    syncState: 'failed',
+  });
+  deps.iamRoleSyncCounter.add(1, { operation: 'update', result: 'failure', error_code: 'COMPENSATION_FAILED' });
+  return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht konsistent aktualisiert werden.', input.actor.requestId, {
+    syncState: 'failed',
+    syncError: { code: 'COMPENSATION_FAILED' },
+  });
+};
+
+const persistTechnicalRoleUpdate = async <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  input: PreparedRoleUpdate<TPayload, TRole>,
+  identityProvider: TIdentityProvider
+): Promise<Response> => {
+  try {
+    const response = await persistLocalRoleUpdate(deps, input);
+    deps.iamRoleSyncCounter.add(1, { operation: input.operation, result: 'success', error_code: 'none' });
+    return response;
+  } catch (error) {
+    try {
+      await deps.trackKeycloakCall('update_role_compensation', () =>
+        identityProvider.provider.updateRole(input.externalRoleName, {
+          description: input.existing.description ?? undefined,
+          attributes: deps.buildRoleAttributes({
+            instanceId: input.actor.instanceId,
+            roleKey: input.existing.role_key,
+            displayName: getRoleDisplayName(input.existing),
+          }),
+        })
+      );
+    } catch {
+      return failTechnicalRoleCompensation(deps, input);
+    }
+
+    await deps.markRoleSyncState({
+      actor: input.actor,
+      roleId: input.roleId,
+      operation: 'update',
+      result: 'failure',
+      roleKey: input.existing.role_key,
+      externalRoleName: input.externalRoleName,
+      errorCode: 'DB_WRITE_FAILED',
+      syncState: 'failed',
+    });
+    deps.iamRoleSyncCounter.add(1, { operation: 'update', result: 'failure', error_code: 'DB_WRITE_FAILED' });
+    deps.logger.error('Role update database write failed after successful Keycloak update', {
+      operation: 'update_role',
+      instance_id: input.actor.instanceId,
+      request_id: input.actor.requestId,
+      trace_id: input.actor.traceId,
+      role_id: input.roleId,
+      role_key: input.existing.role_key,
+      error: deps.sanitizeRoleErrorMessage(error),
+    });
+    return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht aktualisiert werden.', input.actor.requestId, {
+      syncState: 'failed',
+      syncError: { code: 'DB_WRITE_FAILED' },
+    });
+  }
+};
+
+export const syncTechnicalRoleUpdate = async <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  input: PreparedRoleUpdate<TPayload, TRole>
+): Promise<Response> => {
+  const identityProvider = await deps.requireRoleIdentityProvider(input.actor.instanceId, input.actor.requestId);
+  if (identityProvider instanceof Response) {
+    return identityProvider;
+  }
+
+  await deps.markRoleSyncState({
+    actor: input.actor,
+    roleId: input.roleId,
+    operation: input.operation,
+    result: 'success',
+    roleKey: input.existing.role_key,
+    externalRoleName: input.externalRoleName,
+    syncState: 'pending',
+  });
+
+  try {
+    await deps.trackKeycloakCall('update_role', () =>
+      identityProvider.provider.updateRole(input.externalRoleName, {
+        description: input.description,
+        attributes: deps.buildRoleAttributes({
+          instanceId: input.actor.instanceId,
+          roleKey: input.existing.role_key,
+          displayName: input.displayName,
+        }),
+      })
+    );
+  } catch (error) {
+    const errorCode = deps.mapRoleSyncErrorCode(error);
+    deps.iamRoleSyncCounter.add(1, { operation: input.operation, result: 'failure', error_code: errorCode });
+    await deps.markRoleSyncState({
+      actor: input.actor,
+      roleId: input.roleId,
+      operation: input.operation,
+      result: 'failure',
+      roleKey: input.existing.role_key,
+      externalRoleName: input.externalRoleName,
+      errorCode,
+      syncState: 'failed',
+    });
+    return deps.buildRoleSyncFailure({
+      error,
+      requestId: input.actor.requestId,
+      fallbackMessage: 'Rolle konnte nicht mit Keycloak synchronisiert werden.',
+      roleId: input.roleId,
+    });
+  }
+
+  return persistTechnicalRoleUpdate(deps, input, identityProvider);
+};

--- a/packages/iam-admin/src/role-update-sync.ts
+++ b/packages/iam-admin/src/role-update-sync.ts
@@ -19,7 +19,7 @@ export type PreparedRoleUpdate<TPayload extends UpdateRolePayloadShape, TRole ex
   readonly externalRoleName: string;
 };
 
-export const persistLocalRoleUpdate = async <
+const persistPreparedRoleUpdate = async <
   TPayload extends UpdateRolePayloadShape,
   TAttributes,
   TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
@@ -28,8 +28,8 @@ export const persistLocalRoleUpdate = async <
 >(
   deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
   input: PreparedRoleUpdate<TPayload, TRole>
-): Promise<Response> => {
-  const roleItem = await deps.persistUpdatedRole({
+): Promise<TRoleItem> =>
+  deps.persistUpdatedRole({
     actor: input.actor,
     roleId: input.roleId,
     existing: input.existing,
@@ -41,8 +41,92 @@ export const persistLocalRoleUpdate = async <
     permissionAssignments: input.data.permissionAssignments,
     operation: input.operation,
   });
-  return deps.jsonResponse(200, deps.asApiItem(roleItem, input.actor.requestId));
+
+const buildUpdatedRoleResponse = <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  input: PreparedRoleUpdate<TPayload, TRole>,
+  roleItem: TRoleItem
+): Response => deps.jsonResponse(200, deps.asApiItem(roleItem, input.actor.requestId));
+
+const failLocalRoleDatabaseWrite = <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  input: PreparedRoleUpdate<TPayload, TRole>,
+  error: unknown
+): Response => {
+  deps.logger.error('Role update database write failed', {
+    operation: 'update_role',
+    instance_id: input.actor.instanceId,
+    request_id: input.actor.requestId,
+    trace_id: input.actor.traceId,
+    role_id: input.roleId,
+    role_key: input.existing.role_key,
+    external_role_name: input.externalRoleName,
+    error_code: 'DB_WRITE_FAILED',
+    error: deps.sanitizeRoleErrorMessage(error),
+  });
+  return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht aktualisiert werden.', input.actor.requestId, {
+    syncState: 'failed',
+    syncError: { code: 'DB_WRITE_FAILED' },
+  });
 };
+
+export const persistLocalRoleUpdate = async <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  input: PreparedRoleUpdate<TPayload, TRole>
+): Promise<Response> => {
+  try {
+    return buildUpdatedRoleResponse(deps, input, await persistPreparedRoleUpdate(deps, input));
+  } catch (error) {
+    return failLocalRoleDatabaseWrite(deps, input, error);
+  }
+};
+
+const failRoleSyncRetryViaReconcile = <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  requestId?: string
+): Response =>
+  deps.createApiError(
+    400,
+    'invalid_request',
+    'Rollenabgleich wird über den Reconcile-Lauf ausgeführt.',
+    requestId,
+    { syncState: 'pending', syncAction: 'reconcile_roles' }
+  );
+
+export const redirectRoleSyncRetryToReconcile = <
+  TPayload extends UpdateRolePayloadShape,
+  TAttributes,
+  TIdentityProvider extends UpdateRoleIdentityProvider<TAttributes>,
+  TRole extends MutableRoleShape,
+  TRoleItem,
+>(
+  deps: UpdateRoleHandlerDeps<TPayload, TAttributes, TIdentityProvider, TRole, TRoleItem>,
+  requestId?: string
+): Response => failRoleSyncRetryViaReconcile(deps, requestId);
 
 const failTechnicalRoleCompensation = async <
   TPayload extends UpdateRolePayloadShape,
@@ -57,14 +141,18 @@ const failTechnicalRoleCompensation = async <
   await deps.markRoleSyncState({
     actor: input.actor,
     roleId: input.roleId,
-    operation: 'update',
+    operation: input.operation,
     result: 'failure',
     roleKey: input.existing.role_key,
     externalRoleName: input.externalRoleName,
     errorCode: 'COMPENSATION_FAILED',
     syncState: 'failed',
   });
-  deps.iamRoleSyncCounter.add(1, { operation: 'update', result: 'failure', error_code: 'COMPENSATION_FAILED' });
+  deps.iamRoleSyncCounter.add(1, {
+    operation: input.operation,
+    result: 'failure',
+    error_code: 'COMPENSATION_FAILED',
+  });
   return deps.createApiError(500, 'internal_error', 'Rolle konnte nicht konsistent aktualisiert werden.', input.actor.requestId, {
     syncState: 'failed',
     syncError: { code: 'COMPENSATION_FAILED' },
@@ -83,7 +171,7 @@ const persistTechnicalRoleUpdate = async <
   identityProvider: TIdentityProvider
 ): Promise<Response> => {
   try {
-    const response = await persistLocalRoleUpdate(deps, input);
+    const response = buildUpdatedRoleResponse(deps, input, await persistPreparedRoleUpdate(deps, input));
     deps.iamRoleSyncCounter.add(1, { operation: input.operation, result: 'success', error_code: 'none' });
     return response;
   } catch (error) {
@@ -105,14 +193,18 @@ const persistTechnicalRoleUpdate = async <
     await deps.markRoleSyncState({
       actor: input.actor,
       roleId: input.roleId,
-      operation: 'update',
+      operation: input.operation,
       result: 'failure',
       roleKey: input.existing.role_key,
       externalRoleName: input.externalRoleName,
       errorCode: 'DB_WRITE_FAILED',
       syncState: 'failed',
     });
-    deps.iamRoleSyncCounter.add(1, { operation: 'update', result: 'failure', error_code: 'DB_WRITE_FAILED' });
+    deps.iamRoleSyncCounter.add(1, {
+      operation: input.operation,
+      result: 'failure',
+      error_code: 'DB_WRITE_FAILED',
+    });
     deps.logger.error('Role update database write failed after successful Keycloak update', {
       operation: 'update_role',
       instance_id: input.actor.instanceId,

--- a/packages/iam-admin/src/user-create-persistence-support.ts
+++ b/packages/iam-admin/src/user-create-persistence-support.ts
@@ -1,6 +1,7 @@
 import type { IamUserDetail } from '@sva/core';
 
 import { getRoleExternalName } from './role-audit.js';
+import { resolveTenantTechnicalKeycloakRoleNames } from './role-governance.js';
 import type { QueryClient } from './query-client.js';
 import type { IamGroupRow, IamRoleRow } from './types.js';
 import { mapRoles } from './user-mapping.js';
@@ -167,5 +168,8 @@ export const buildCreatedUserResult = (
     roles: mapRoles(assignedRoleRows),
     mainserverUserApplicationSecretSet: false,
   },
-  roleNames: assignedRoleRows.map((entry) => getRoleExternalName(entry)),
+  roleNames: [...new Set([
+    ...assignedRoleRows.map((entry) => getRoleExternalName(entry)),
+    ...resolveTenantTechnicalKeycloakRoleNames(assignedRoleRows),
+  ])],
 });

--- a/packages/iam-admin/src/user-create-persistence.test.ts
+++ b/packages/iam-admin/src/user-create-persistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createUserCreatePersistence } from './user-create-persistence.js';
+import type { CreateUserPersistenceActor, CreateUserPersistencePayload } from './user-create-persistence.js';
 import type { QueryClient } from './query-client.js';
 
 const roleRow = {
@@ -11,6 +12,15 @@ const roleRow = {
   external_role_name: 'Editor',
   role_level: 20,
   is_system_role: false,
+};
+
+const systemAdminAliasRoleRow = {
+  ...roleRow,
+  role_key: 'system_admin',
+  role_name: 'system_admin',
+  display_name: 'System Admin',
+  external_role_name: 'legacy-system-admin',
+  is_system_role: true,
 };
 
 const createDeps = () => ({
@@ -34,35 +44,74 @@ const createDeps = () => ({
   resolveRolesByIds: vi.fn(async () => [roleRow]),
 });
 
+const createInsertClient = (accountId: string): QueryClient => ({
+  query: vi.fn(async (text: string) => {
+    if (text.includes('RETURNING id')) {
+      return { rowCount: 1, rows: [{ id: accountId }] };
+    }
+    return { rowCount: 1, rows: [] };
+  }),
+});
+
+type UserCreatePersistence = ReturnType<typeof createUserCreatePersistence>;
+type UserCreatePersistenceDeps = Parameters<typeof createUserCreatePersistence>[0];
+
+const persistCreatedTestUser = (
+  persistence: UserCreatePersistence,
+  client: QueryClient,
+  overrides: {
+    readonly actor?: Partial<CreateUserPersistenceActor>;
+    readonly externalId?: string;
+    readonly payload?: Partial<CreateUserPersistencePayload>;
+  } = {}
+) =>
+  persistence.persistCreatedUser(client, {
+    actor: {
+      instanceId: 'inst-1',
+      actorAccountId: 'actor-1',
+      actorRoles: ['admin'],
+      ...overrides.actor,
+    },
+    actorSubject: 'subject-actor',
+    externalId: overrides.externalId ?? 'subject-new',
+    payload: {
+      email: 'user@example.test',
+      roleIds: ['role-1'],
+      ...overrides.payload,
+    },
+  });
+
+const createNoWriteClient = (): QueryClient => ({
+  query: vi.fn(async () => ({ rowCount: 0, rows: [] })),
+});
+
+const expectCreateToRejectBeforeWrite = async (
+  deps: UserCreatePersistenceDeps,
+  message: string,
+  overrides?: Parameters<typeof persistCreatedTestUser>[2]
+) => {
+  const client = createNoWriteClient();
+  const persistence = createUserCreatePersistence(deps);
+
+  await expect(persistCreatedTestUser(persistence, client, overrides)).rejects.toThrow(message);
+  expect(client.query).not.toHaveBeenCalled();
+};
+
 describe('user-create-persistence', () => {
   it('persists a created user with membership, groups, roles, activity log and invalidation', async () => {
     const deps = createDeps();
-    const client: QueryClient = {
-      query: vi.fn(async (text: string) => {
-        if (text.includes('RETURNING id')) {
-          return { rowCount: 1, rows: [{ id: 'account-1' }] };
-        }
-        return { rowCount: 1, rows: [] };
-      }),
-    };
+    const client = createInsertClient('account-1');
     const persistence = createUserCreatePersistence(deps);
 
     await expect(
-      persistence.persistCreatedUser(client, {
+      persistCreatedTestUser(persistence, client, {
         actor: {
-          instanceId: 'inst-1',
-          actorAccountId: 'actor-1',
-          actorRoles: ['admin'],
           requestId: 'req-1',
           traceId: 'trace-1',
         },
-        actorSubject: 'subject-actor',
-        externalId: 'subject-new',
         payload: {
-          email: 'user@example.test',
           firstName: 'Ada',
           lastName: 'Lovelace',
-          roleIds: ['role-1'],
           groupIds: ['group-1'],
         },
       })
@@ -140,6 +189,29 @@ describe('user-create-persistence', () => {
     });
   });
 
+  it('includes canonical system_admin for aliased technical role rows', async () => {
+    const deps = {
+      ...createDeps(),
+      ensureRoleAssignmentWithinActorLevel: vi.fn(async () => ({
+        ok: true as const,
+        roles: [systemAdminAliasRoleRow],
+      })),
+      resolveRolesByIds: vi.fn(async () => [systemAdminAliasRoleRow]),
+    };
+    const client = createInsertClient('account-1');
+    const persistence = createUserCreatePersistence(deps);
+
+    await expect(
+      persistCreatedTestUser(persistence, client, {
+        payload: {
+          roleIds: ['role-admin'],
+        },
+      })
+    ).resolves.toMatchObject({
+      roleNames: ['legacy-system-admin', 'system_admin'],
+    });
+  });
+
   it('rejects role assignments above the actor level before writing the account', async () => {
     const deps = {
       ...createDeps(),
@@ -149,24 +221,9 @@ describe('user-create-persistence', () => {
         message: 'denied',
       })),
     };
-    const client: QueryClient = {
-      query: vi.fn(async () => ({ rowCount: 0, rows: [] })),
-    };
-    const persistence = createUserCreatePersistence(deps);
-
-    await expect(
-      persistence.persistCreatedUser(client, {
-        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1' },
-        actorSubject: 'subject-actor',
-        externalId: 'subject-new',
-        payload: {
-          email: 'user@example.test',
-          roleIds: ['role-1'],
-        },
-      })
-    ).rejects.toThrow('forbidden:denied');
-
-    expect(client.query).not.toHaveBeenCalled();
+    await expectCreateToRejectBeforeWrite(deps, 'forbidden:denied', {
+      actor: { actorRoles: undefined },
+    });
   });
 
   it('rejects unknown groups before writing the account', async () => {
@@ -174,25 +231,12 @@ describe('user-create-persistence', () => {
       ...createDeps(),
       resolveGroupsByIds: vi.fn(async () => []),
     };
-    const client: QueryClient = {
-      query: vi.fn(async () => ({ rowCount: 0, rows: [] })),
-    };
-    const persistence = createUserCreatePersistence(deps);
-
-    await expect(
-      persistence.persistCreatedUser(client, {
-        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
-        actorSubject: 'subject-actor',
-        externalId: 'subject-new',
-        payload: {
-          email: 'user@example.test',
-          roleIds: [],
-          groupIds: ['missing-group'],
-        },
-      })
-    ).rejects.toThrow('invalid_request:Mindestens eine aktive Gruppe existiert nicht.');
-
-    expect(client.query).not.toHaveBeenCalled();
+    await expectCreateToRejectBeforeWrite(deps, 'invalid_request:Mindestens eine aktive Gruppe existiert nicht.', {
+      payload: {
+        roleIds: [],
+        groupIds: ['missing-group'],
+      },
+    });
   });
 
   it('skips bundled group role validation when the selected groups do not add direct roles', async () => {
@@ -200,23 +244,12 @@ describe('user-create-persistence', () => {
       ...createDeps(),
       resolveRoleIdsForGroups: vi.fn(async () => []),
     };
-    const client: QueryClient = {
-      query: vi.fn(async (text: string) => {
-        if (text.includes('RETURNING id')) {
-          return { rowCount: 1, rows: [{ id: 'account-1' }] };
-        }
-        return { rowCount: 1, rows: [] };
-      }),
-    };
+    const client = createInsertClient('account-1');
     const persistence = createUserCreatePersistence(deps);
 
     await expect(
-      persistence.persistCreatedUser(client, {
-        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
-        actorSubject: 'subject-actor',
-        externalId: 'subject-new',
+      persistCreatedTestUser(persistence, client, {
         payload: {
-          email: 'user@example.test',
           roleIds: [],
           groupIds: ['group-1'],
         },
@@ -237,24 +270,12 @@ describe('user-create-persistence', () => {
       ...createDeps(),
       resolveRoleIdsForGroups: vi.fn(async () => ['role-1', 'role-1']),
     };
-    const client: QueryClient = {
-      query: vi.fn(async (text: string) => {
-        if (text.includes('RETURNING id')) {
-          return { rowCount: 1, rows: [{ id: 'account-3' }] };
-        }
-        return { rowCount: 1, rows: [] };
-      }),
-    };
+    const client = createInsertClient('account-3');
     const persistence = createUserCreatePersistence(deps);
 
     await expect(
-      persistence.persistCreatedUser(client, {
-        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
-        actorSubject: 'subject-actor',
-        externalId: 'subject-new',
+      persistCreatedTestUser(persistence, client, {
         payload: {
-          email: 'user@example.test',
-          roleIds: ['role-1'],
           groupIds: ['group-1'],
         },
       })
@@ -280,52 +301,22 @@ describe('user-create-persistence', () => {
           message: 'group bundle denied',
         }),
     };
-    const client: QueryClient = {
-      query: vi.fn(async () => ({ rowCount: 0, rows: [] })),
-    };
-    const persistence = createUserCreatePersistence(deps);
-
-    await expect(
-      persistence.persistCreatedUser(client, {
-        actor: { instanceId: 'inst-1', actorAccountId: 'actor-1', actorRoles: ['admin'] },
-        actorSubject: 'subject-actor',
-        externalId: 'subject-new',
-        payload: {
-          email: 'user@example.test',
-          roleIds: ['role-1'],
-          groupIds: ['group-1'],
-        },
-      })
-    ).rejects.toThrow('forbidden:group bundle denied');
-
-    expect(client.query).not.toHaveBeenCalled();
+    await expectCreateToRejectBeforeWrite(deps, 'forbidden:group bundle denied', {
+      payload: {
+        groupIds: ['group-1'],
+      },
+    });
   });
 
   it('persists users without groups and keeps explicit display names', async () => {
     const deps = createDeps();
-    const client: QueryClient = {
-      query: vi.fn(async (text: string) => {
-        if (text.includes('RETURNING id')) {
-          return { rowCount: 1, rows: [{ id: 'account-2' }] };
-        }
-        return { rowCount: 1, rows: [] };
-      }),
-    };
+    const client = createInsertClient('account-2');
     const persistence = createUserCreatePersistence(deps);
 
     await expect(
-      persistence.persistCreatedUser(client, {
-        actor: {
-          instanceId: 'inst-1',
-          actorAccountId: 'actor-1',
-          actorRoles: ['admin'],
-        },
-        actorSubject: 'subject-actor',
-        externalId: 'subject-new',
+      persistCreatedTestUser(persistence, client, {
         payload: {
-          email: 'user@example.test',
           displayName: 'Ada Display',
-          roleIds: ['role-1'],
         },
       })
     ).resolves.toMatchObject({

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -4,13 +4,18 @@ import { createJsonResponse, createTestDepsBuilder } from './handler-test-helper
 import {
   createUpdateUserHandlerInternal,
   RoleMutationCapabilityUnavailableError,
+  shouldUpdateUserIdentityAttributes,
+  shouldUpdateUserIdentityPayload,
   type UpdateUserHandlerDeps,
 } from './user-update-handler.js';
 
 type TestPayload = {
+  readonly displayName?: string;
   readonly email?: string;
   readonly firstName?: string;
   readonly lastName?: string;
+  readonly mainserverUserApplicationId?: string;
+  readonly mainserverUserApplicationSecret?: string;
   readonly status?: 'active' | 'inactive' | 'pending';
   readonly roleIds?: readonly string[];
 };
@@ -429,5 +434,24 @@ describe('createUpdateUserHandlerInternal', () => {
       action: 'update_user',
       result: 'failure',
     });
+  });
+});
+
+describe('user update identity predicates', () => {
+  it('keeps attribute updates as a subset of identity-provider updates', () => {
+    const attributePayloads: readonly TestPayload[] = [
+      { displayName: 'Alice' },
+      { mainserverUserApplicationId: 'app-1' },
+      { mainserverUserApplicationSecret: 'secret-1' },
+    ];
+
+    for (const payload of attributePayloads) {
+      expect(shouldUpdateUserIdentityAttributes(payload)).toBe(true);
+      expect(shouldUpdateUserIdentityPayload(payload)).toBe(true);
+    }
+
+    expect(shouldUpdateUserIdentityAttributes({ email: 'alice@example.test' })).toBe(false);
+    expect(shouldUpdateUserIdentityPayload({ email: 'alice@example.test' })).toBe(true);
+    expect(shouldUpdateUserIdentityPayload({ roleIds: ['role-editor'] })).toBe(false);
   });
 });

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -73,6 +73,8 @@ const identityProvider = {
   provider: {
     updateUser: vi.fn(async () => undefined),
     syncRoles: vi.fn(async () => undefined),
+    assignRealmRoles: vi.fn(async () => undefined),
+    removeRealmRoles: vi.fn(async () => undefined),
   },
 };
 
@@ -119,9 +121,11 @@ describe('createUpdateUserHandlerInternal', () => {
     vi.clearAllMocks();
     identityProvider.provider.updateUser.mockClear();
     identityProvider.provider.syncRoles.mockClear();
+    identityProvider.provider.assignRealmRoles.mockClear();
+    identityProvider.provider.removeRealmRoles.mockClear();
   });
 
-  it('updates identity, syncs roles, persists detail and returns the API item', async () => {
+  it('updates identity, assigns added technical roles, persists detail and returns the API item', async () => {
     const deps = createDeps();
     const handler = createUpdateUserHandlerInternal(deps);
 
@@ -157,7 +161,8 @@ describe('createUpdateUserHandlerInternal', () => {
       requestId: 'req-update',
       traceId: 'trace-update',
     });
-    expect(identityProvider.provider.syncRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin']);
+    expect(identityProvider.provider.assignRealmRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin']);
+    expect(identityProvider.provider.syncRoles).not.toHaveBeenCalled();
     expect(deps.persistUpdatedUserDetail).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       requestId: 'req-update',
@@ -172,6 +177,27 @@ describe('createUpdateUserHandlerInternal', () => {
       action: 'update_user',
       result: 'success',
     });
+  });
+
+  it('removes system_admin on demotion without broad role replacement or legacy role deletion', async () => {
+    const deps = createDeps({
+      resolveUserUpdatePlan: vi.fn(async () => ({
+        existing: {
+          keycloakSubject: 'kc-user-1',
+        },
+        previousRoleNames: ['system_admin', 'legacy_keycloak_editor'],
+        nextRoleNames: ['editor'],
+      })),
+    });
+    const handler = createUpdateUserHandlerInternal(deps);
+
+    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+
+    expect(response.status).toBe(200);
+    expect(deps.ensureManagedRealmRolesExist).not.toHaveBeenCalled();
+    expect(identityProvider.provider.removeRealmRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin']);
+    expect(identityProvider.provider.assignRealmRoles).not.toHaveBeenCalled();
+    expect(identityProvider.provider.syncRoles).not.toHaveBeenCalled();
   });
 
   it('returns the precondition response without update work', async () => {

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -18,6 +18,8 @@ type TestPayload = {
 type TestPlan = {
   readonly existing: {
     readonly keycloakSubject: string;
+    readonly mainserverUserApplicationId?: string;
+    readonly mainserverUserApplicationSecretSet?: boolean;
   };
   readonly previousRoleNames: readonly string[];
   readonly nextRoleNames?: readonly string[];
@@ -264,6 +266,11 @@ describe('createUpdateUserHandlerInternal', () => {
         userId: updatedDetail.id,
       })),
       ...createPlanOnlyUpdateDeps({
+        existing: {
+          keycloakSubject: 'kc-user-1',
+          mainserverUserApplicationId: 'existing-app',
+          mainserverUserApplicationSecretSet: true,
+        },
         previousRoleNames: [],
         nextRoleNames: [],
       }),
@@ -285,6 +292,14 @@ describe('createUpdateUserHandlerInternal', () => {
     });
     expect(identityProvider.provider.updateUser).not.toHaveBeenCalled();
     expect(deps.ensureManagedRealmRolesExist).not.toHaveBeenCalled();
+    expect(deps.persistUpdatedUserDetail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        existingMainserverCredentialState: {
+          mainserverUserApplicationId: 'existing-app',
+          mainserverUserApplicationSecretSet: true,
+        },
+      })
+    );
   });
 
   it('fails through the Keycloak error mapping when a technical role delta needs missing capabilities', async () => {

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -98,6 +98,11 @@ const createLegacyIdentityProvider = () => ({
   },
 });
 
+const createPlanOnlyUpdateDeps = (planOverrides: Partial<TestPlan>) => ({
+  resolveUserUpdatePlan: vi.fn(async () => createPlan(planOverrides)),
+  resolveUpdatedIdentityState: vi.fn(async () => ({})),
+});
+
 const createDeps = createTestDepsBuilder<UpdateUserHandlerDeps<TestPayload, TestPlan, TestIdentityState>>(() => ({
   asApiItem: vi.fn((data, requestId) => ({ data, ...(requestId ? { requestId } : {}) })),
   compensateUserIdentityUpdate: vi.fn(async () => undefined),
@@ -228,11 +233,10 @@ describe('createUpdateUserHandlerInternal', () => {
         },
         userId: updatedDetail.id,
       })),
-      resolveUserUpdatePlan: vi.fn(async () => createPlan({
+      ...createPlanOnlyUpdateDeps({
         previousRoleNames: ['system_admin'],
         nextRoleNames: undefined,
-      })),
-      resolveUpdatedIdentityState: vi.fn(async () => ({})),
+      }),
     });
     const handler = createUpdateUserHandlerInternal(deps);
 
@@ -244,6 +248,42 @@ describe('createUpdateUserHandlerInternal', () => {
       expect.objectContaining({ firstName: 'Alice' })
     );
     expect(legacyIdentityProvider.provider.syncRoles).not.toHaveBeenCalled();
+    expect(deps.ensureManagedRealmRolesExist).not.toHaveBeenCalled();
+  });
+
+  it('persists db-only role updates without resolving an identity provider', async () => {
+    const deps = createDeps({
+      resolveUpdateRequestContext: vi.fn(async () => ({
+        actor,
+        payload: {
+          roleIds: ['role-editor'],
+        },
+        resolveIdentityProvider: vi.fn(async () => {
+          throw new Error('identity provider should not be resolved');
+        }),
+        userId: updatedDetail.id,
+      })),
+      ...createPlanOnlyUpdateDeps({
+        previousRoleNames: [],
+        nextRoleNames: [],
+      }),
+    });
+    const handler = createUpdateUserHandlerInternal(deps);
+
+    const response = await handler(createUserUpdateRequest(), ctx);
+
+    expect(response.status).toBe(200);
+    expect(deps.resolveUpdatedIdentityState).toHaveBeenCalledWith({
+      plan: expect.objectContaining({
+        previousRoleNames: [],
+        nextRoleNames: [],
+      }),
+      payload: {
+        roleIds: ['role-editor'],
+      },
+      identityProvider: undefined,
+    });
+    expect(identityProvider.provider.updateUser).not.toHaveBeenCalled();
     expect(deps.ensureManagedRealmRolesExist).not.toHaveBeenCalled();
   });
 
@@ -281,7 +321,7 @@ describe('createUpdateUserHandlerInternal', () => {
     expect(deps.compensateUserIdentityUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         identityProvider: partialIdentityProvider,
-        restoreRoles: true,
+        restoreRoles: false,
       })
     );
     expect(deps.persistUpdatedUserDetail).not.toHaveBeenCalled();

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -249,11 +249,17 @@ describe('createUpdateUserHandlerInternal', () => {
 
   it('fails through the Keycloak error mapping when a technical role delta needs missing capabilities', async () => {
     const mappedResponse = createJsonResponse(503, { error: { code: 'keycloak_unavailable' } });
-    const legacyIdentityProvider = createLegacyIdentityProvider();
+    const assignRealmRoles = vi.fn(async () => undefined);
+    const partialIdentityProvider = {
+      provider: {
+        ...createLegacyIdentityProvider().provider,
+        assignRealmRoles,
+      },
+    };
     const deps = createDeps({
       resolveUpdateRequestContext: vi.fn(async () => ({
         actor,
-        identityProvider: legacyIdentityProvider,
+        identityProvider: partialIdentityProvider,
         payload,
         userId: updatedDetail.id,
       })),
@@ -267,10 +273,17 @@ describe('createUpdateUserHandlerInternal', () => {
     const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response).toBe(mappedResponse);
+    expect(assignRealmRoles).not.toHaveBeenCalled();
     expect(deps.handleKeycloakUpdateError).toHaveBeenCalledWith({
       error: expect.any(RoleMutationCapabilityUnavailableError),
       requestId: 'req-update',
     });
+    expect(deps.compensateUserIdentityUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identityProvider: partialIdentityProvider,
+        restoreRoles: true,
+      })
+    );
     expect(deps.persistUpdatedUserDetail).not.toHaveBeenCalled();
   });
 

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -176,7 +176,7 @@ describe('createUpdateUserHandlerInternal', () => {
     expect(deps.ensureManagedRealmRolesExist).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       identityProvider,
-      externalRoleNames: ['system_admin'],
+      roleKeys: ['system_admin'],
       actorAccountId: 'actor-account-1',
       requestId: 'req-update',
       traceId: 'trace-update',

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createJsonResponse, createTestDepsBuilder } from './handler-test-helpers.js';
 import {
   createUpdateUserHandlerInternal,
+  RoleMutationCapabilityUnavailableError,
   type UpdateUserHandlerDeps,
 } from './user-update-handler.js';
 
@@ -69,6 +70,18 @@ const updatedDetail = {
   status: 'active',
 };
 
+const userUpdateRequestUrl = `http://localhost/api/v1/iam/users/${updatedDetail.id}`;
+
+const createUserUpdateRequest = () => new Request(userUpdateRequestUrl);
+
+const createPlan = (overrides: Partial<TestPlan> = {}): TestPlan => ({
+  existing: {
+    keycloakSubject: 'kc-user-1',
+  },
+  previousRoleNames: [],
+  ...overrides,
+});
+
 const identityProvider = {
   provider: {
     updateUser: vi.fn(async () => undefined),
@@ -77,6 +90,13 @@ const identityProvider = {
     removeRealmRoles: vi.fn(async () => undefined),
   },
 };
+
+const createLegacyIdentityProvider = () => ({
+  provider: {
+    updateUser: vi.fn(async () => undefined),
+    syncRoles: vi.fn(async () => undefined),
+  },
+});
 
 const createDeps = createTestDepsBuilder<UpdateUserHandlerDeps<TestPayload, TestPlan, TestIdentityState>>(() => ({
   asApiItem: vi.fn((data, requestId) => ({ data, ...(requestId ? { requestId } : {}) })),
@@ -129,7 +149,7 @@ describe('createUpdateUserHandlerInternal', () => {
     const deps = createDeps();
     const handler = createUpdateUserHandlerInternal(deps);
 
-    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+    const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
@@ -181,23 +201,77 @@ describe('createUpdateUserHandlerInternal', () => {
 
   it('removes system_admin on demotion without broad role replacement or legacy role deletion', async () => {
     const deps = createDeps({
-      resolveUserUpdatePlan: vi.fn(async () => ({
-        existing: {
-          keycloakSubject: 'kc-user-1',
-        },
+      resolveUserUpdatePlan: vi.fn(async () => createPlan({
         previousRoleNames: ['system_admin', 'legacy_keycloak_editor'],
         nextRoleNames: ['editor'],
       })),
     });
     const handler = createUpdateUserHandlerInternal(deps);
 
-    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+    const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response.status).toBe(200);
     expect(deps.ensureManagedRealmRolesExist).not.toHaveBeenCalled();
     expect(identityProvider.provider.removeRealmRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin']);
     expect(identityProvider.provider.assignRealmRoles).not.toHaveBeenCalled();
     expect(identityProvider.provider.syncRoles).not.toHaveBeenCalled();
+  });
+
+  it('does not require role mutation capabilities when no technical role delta exists', async () => {
+    const legacyIdentityProvider = createLegacyIdentityProvider();
+    const deps = createDeps({
+      resolveUpdateRequestContext: vi.fn(async () => ({
+        actor,
+        identityProvider: legacyIdentityProvider,
+        payload: {
+          firstName: 'Alice',
+        },
+        userId: updatedDetail.id,
+      })),
+      resolveUserUpdatePlan: vi.fn(async () => createPlan({
+        previousRoleNames: ['system_admin'],
+        nextRoleNames: undefined,
+      })),
+      resolveUpdatedIdentityState: vi.fn(async () => ({})),
+    });
+    const handler = createUpdateUserHandlerInternal(deps);
+
+    const response = await handler(createUserUpdateRequest(), ctx);
+
+    expect(response.status).toBe(200);
+    expect(legacyIdentityProvider.provider.updateUser).toHaveBeenCalledWith(
+      'kc-user-1',
+      expect.objectContaining({ firstName: 'Alice' })
+    );
+    expect(legacyIdentityProvider.provider.syncRoles).not.toHaveBeenCalled();
+    expect(deps.ensureManagedRealmRolesExist).not.toHaveBeenCalled();
+  });
+
+  it('fails through the Keycloak error mapping when a technical role delta needs missing capabilities', async () => {
+    const mappedResponse = createJsonResponse(503, { error: { code: 'keycloak_unavailable' } });
+    const legacyIdentityProvider = createLegacyIdentityProvider();
+    const deps = createDeps({
+      resolveUpdateRequestContext: vi.fn(async () => ({
+        actor,
+        identityProvider: legacyIdentityProvider,
+        payload,
+        userId: updatedDetail.id,
+      })),
+      handleKeycloakUpdateError: vi.fn(({ error }) =>
+        error instanceof RoleMutationCapabilityUnavailableError ? mappedResponse : null
+      ),
+      resolveUpdatedIdentityState: vi.fn(async () => ({})),
+    });
+    const handler = createUpdateUserHandlerInternal(deps);
+
+    const response = await handler(createUserUpdateRequest(), ctx);
+
+    expect(response).toBe(mappedResponse);
+    expect(deps.handleKeycloakUpdateError).toHaveBeenCalledWith({
+      error: expect.any(RoleMutationCapabilityUnavailableError),
+      requestId: 'req-update',
+    });
+    expect(deps.persistUpdatedUserDetail).not.toHaveBeenCalled();
   });
 
   it('returns the precondition response without update work', async () => {
@@ -207,7 +281,7 @@ describe('createUpdateUserHandlerInternal', () => {
     });
     const handler = createUpdateUserHandlerInternal(deps);
 
-    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+    const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response).toBe(preconditionResponse);
     expect(deps.withInstanceScopedDb).not.toHaveBeenCalled();
@@ -219,7 +293,7 @@ describe('createUpdateUserHandlerInternal', () => {
     });
     const handler = createUpdateUserHandlerInternal(deps);
 
-    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+    const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response.status).toBe(404);
     expect(deps.notFoundResponse).toHaveBeenCalledWith('req-update');
@@ -234,7 +308,7 @@ describe('createUpdateUserHandlerInternal', () => {
     });
     const handler = createUpdateUserHandlerInternal(deps);
 
-    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+    const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response.status).toBe(500);
     expect(deps.compensateUserIdentityUpdate).toHaveBeenCalledWith({
@@ -260,7 +334,7 @@ describe('createUpdateUserHandlerInternal', () => {
     });
     const handler = createUpdateUserHandlerInternal(deps);
 
-    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+    const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response).toBe(mappedResponse);
     expect(deps.createUserMutationErrorResponse).not.toHaveBeenCalled();
@@ -274,7 +348,7 @@ describe('createUpdateUserHandlerInternal', () => {
     });
     const handler = createUpdateUserHandlerInternal(deps);
 
-    const response = await handler(new Request(`http://localhost/api/v1/iam/users/${updatedDetail.id}`), ctx);
+    const response = await handler(createUserUpdateRequest(), ctx);
 
     expect(response.status).toBe(500);
     expect(deps.logger.error).toHaveBeenCalledWith(

--- a/packages/iam-admin/src/user-update-handler.test.ts
+++ b/packages/iam-admin/src/user-update-handler.test.ts
@@ -59,7 +59,7 @@ const plan = {
     keycloakSubject: 'kc-user-1',
   },
   previousRoleNames: ['viewer'],
-  nextRoleNames: ['editor'],
+  nextRoleNames: ['system_admin', 'editor'],
 } satisfies TestPlan;
 
 const updatedDetail = {
@@ -152,12 +152,12 @@ describe('createUpdateUserHandlerInternal', () => {
     expect(deps.ensureManagedRealmRolesExist).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       identityProvider,
-      externalRoleNames: ['editor'],
+      externalRoleNames: ['system_admin'],
       actorAccountId: 'actor-account-1',
       requestId: 'req-update',
       traceId: 'trace-update',
     });
-    expect(identityProvider.provider.syncRoles).toHaveBeenCalledWith('kc-user-1', ['editor']);
+    expect(identityProvider.provider.syncRoles).toHaveBeenCalledWith('kc-user-1', ['system_admin']);
     expect(deps.persistUpdatedUserDetail).toHaveBeenCalledWith({
       instanceId: 'de-musterhausen',
       requestId: 'req-update',

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -394,14 +394,12 @@ const syncUpdatedIdentityAndRoles = async <
     input.shouldRestoreIdentityRef.current = true;
   }
 
-  if (await syncUpdatedTechnicalRoles(deps, {
+  await syncUpdatedTechnicalRoles(deps, {
     ...input,
     beforeRoleMutation: () => {
       input.shouldRestoreRolesRef.current = true;
     },
-  })) {
-    input.shouldRestoreRolesRef.current = true;
-  }
+  });
 };
 
 const executeUserUpdate = async <

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -57,6 +57,8 @@ export type UpdateUserPayloadShape = {
 export type UserUpdatePlanShape = {
   readonly existing: {
     readonly keycloakSubject: string;
+    readonly mainserverUserApplicationId?: string;
+    readonly mainserverUserApplicationSecretSet?: boolean;
     readonly roles?: readonly { readonly roleId: string }[];
     readonly groups?: readonly { readonly groupId: string }[];
   };
@@ -68,6 +70,11 @@ export type UpdatedIdentityStateShape = {
   readonly existingIdentityAttributes?: UpdateIdentityAttributes;
   readonly nextIdentityAttributes?: UpdateIdentityAttributes;
   readonly nextMainserverCredentialState?: unknown;
+};
+
+type UserMainserverCredentialStateShape = {
+  readonly mainserverUserApplicationId?: string;
+  readonly mainserverUserApplicationSecretSet: boolean;
 };
 
 export type UpdateRequestContext<
@@ -129,6 +136,7 @@ export type UpdateUserHandlerDeps<
     readonly existingRoleIds?: readonly string[];
     readonly existingGroupIds?: readonly string[];
     readonly payload: TPayload;
+    readonly existingMainserverCredentialState?: UserMainserverCredentialStateShape;
     readonly nextMainserverCredentialState: TIdentityState['nextMainserverCredentialState'];
   }) => Promise<unknown | undefined>;
   readonly compensateUserIdentityUpdate: (input: {
@@ -212,6 +220,16 @@ const shouldResolveIdentityProvider = (input: {
   readonly payload: UpdateUserPayloadShape;
   readonly plan: UserUpdatePlanShape;
 }): boolean => shouldUpdateIdentityPayload(input.payload) || hasTechnicalRoleDelta(input.plan);
+
+const resolveExistingMainserverCredentialState = (
+  existing: UserUpdatePlanShape['existing']
+): UserMainserverCredentialStateShape | undefined =>
+  existing.mainserverUserApplicationSecretSet === undefined
+    ? undefined
+    : {
+        mainserverUserApplicationId: existing.mainserverUserApplicationId,
+        mainserverUserApplicationSecretSet: existing.mainserverUserApplicationSecretSet,
+      };
 
 const requireRoleMutationCapability = (
   identityProvider: UpdateIdentityProvider,
@@ -457,6 +475,7 @@ const executeUserUpdate = async <
       existingRoleIds: plan.existing.roles?.map((role) => role.roleId),
       existingGroupIds: plan.existing.groups?.map((group) => group.groupId),
       payload: input.payload,
+      existingMainserverCredentialState: resolveExistingMainserverCredentialState(plan.existing),
       nextMainserverCredentialState: resolvedIdentityState.nextMainserverCredentialState,
     });
 

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -31,11 +31,18 @@ export type UpdateIdentityProvider = {
         readonly attributes?: UpdateIdentityAttributes;
       }
     ) => Promise<void>;
-    readonly assignRealmRoles: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
-    readonly removeRealmRoles: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
+    readonly assignRealmRoles?: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
+    readonly removeRealmRoles?: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
     readonly syncRoles: (keycloakSubject: string, roleNames: string[]) => Promise<void>;
   };
 };
+
+export class RoleMutationCapabilityUnavailableError extends Error {
+  constructor(readonly capability: 'assignRealmRoles' | 'removeRealmRoles') {
+    super(`${capability} provider capability unavailable`);
+    this.name = 'RoleMutationCapabilityUnavailableError';
+  }
+}
 
 export type UpdateUserPayloadShape = {
   readonly email?: string;
@@ -229,6 +236,9 @@ const assignTechnicalRoles = async <
   if (input.roleNames.length === 0) {
     return;
   }
+  if (!input.identityProvider.provider.assignRealmRoles) {
+    throw new RoleMutationCapabilityUnavailableError('assignRealmRoles');
+  }
   await deps.ensureManagedRealmRolesExist({
     instanceId: input.actor.instanceId,
     identityProvider: input.identityProvider,
@@ -238,7 +248,7 @@ const assignTechnicalRoles = async <
     traceId: input.actor.traceId,
   });
   await deps.trackKeycloakCall('assign_realm_roles', () =>
-    input.identityProvider.provider.assignRealmRoles(input.keycloakSubject, input.roleNames)
+    input.identityProvider.provider.assignRealmRoles!(input.keycloakSubject, input.roleNames)
   );
 };
 
@@ -258,8 +268,11 @@ const removeTechnicalRoles = async <
   if (input.roleNames.length === 0) {
     return;
   }
+  if (!input.identityProvider.provider.removeRealmRoles) {
+    throw new RoleMutationCapabilityUnavailableError('removeRealmRoles');
+  }
   await deps.trackKeycloakCall('remove_realm_roles', () =>
-    input.identityProvider.provider.removeRealmRoles(input.keycloakSubject, input.roleNames)
+    input.identityProvider.provider.removeRealmRoles!(input.keycloakSubject, input.roleNames)
   );
 };
 

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -32,6 +32,8 @@ export type UpdateIdentityProvider = {
       }
     ) => Promise<void>;
     readonly syncRoles: (keycloakSubject: string, roleNames: string[]) => Promise<void>;
+    readonly assignRealmRoles?: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
+    readonly removeRealmRoles?: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
   };
 };
 
@@ -158,6 +160,22 @@ export type UpdateUserHandlerDeps<
   ) => Promise<T>;
 };
 
+const resolveTechnicalRoleDelta = (input: {
+  readonly previousRoleNames: readonly string[];
+  readonly nextRoleNames: readonly string[];
+}): {
+  readonly addedRoleNames: readonly string[];
+  readonly removedRoleNames: readonly string[];
+} => {
+  const previousRoleNames = new Set(filterTenantTechnicalKeycloakRoleNames(input.previousRoleNames));
+  const nextRoleNames = new Set(filterTenantTechnicalKeycloakRoleNames(input.nextRoleNames));
+
+  return {
+    addedRoleNames: [...nextRoleNames].filter((roleName) => !previousRoleNames.has(roleName)),
+    removedRoleNames: [...previousRoleNames].filter((roleName) => !nextRoleNames.has(roleName)),
+  };
+};
+
 const syncUpdatedIdentityAndRoles = async <
   TPayload extends UpdateUserPayloadShape,
   TPlan extends UserUpdatePlanShape,
@@ -195,22 +213,39 @@ const syncUpdatedIdentityAndRoles = async <
   }
 
   if (input.plan.nextRoleNames) {
-    const nextRoleNames = filterTenantTechnicalKeycloakRoleNames(input.plan.nextRoleNames);
-    if (nextRoleNames.length === 0) {
+    const { addedRoleNames, removedRoleNames } = resolveTechnicalRoleDelta({
+      previousRoleNames: input.plan.previousRoleNames,
+      nextRoleNames: input.plan.nextRoleNames,
+    });
+    if (addedRoleNames.length === 0 && removedRoleNames.length === 0) {
       return;
     }
-    await deps.ensureManagedRealmRolesExist({
-      instanceId: input.actor.instanceId,
-      identityProvider: input.identityProvider,
-      externalRoleNames: nextRoleNames,
-      actorAccountId: input.actor.actorAccountId,
-      requestId: input.actor.requestId,
-      traceId: input.actor.traceId,
-    });
-    await deps.trackKeycloakCall('sync_roles', () =>
-      input.identityProvider.provider.syncRoles(input.plan.existing.keycloakSubject, [...nextRoleNames])
-    );
-    input.shouldRestoreRolesRef.current = true;
+    if (addedRoleNames.length > 0) {
+      if (!input.identityProvider.provider.assignRealmRoles) {
+        throw new Error('assignRealmRoles provider capability unavailable');
+      }
+      await deps.ensureManagedRealmRolesExist({
+        instanceId: input.actor.instanceId,
+        identityProvider: input.identityProvider,
+        externalRoleNames: addedRoleNames,
+        actorAccountId: input.actor.actorAccountId,
+        requestId: input.actor.requestId,
+        traceId: input.actor.traceId,
+      });
+      await deps.trackKeycloakCall('sync_roles', () =>
+        input.identityProvider.provider.assignRealmRoles!(input.plan.existing.keycloakSubject, addedRoleNames)
+      );
+      input.shouldRestoreRolesRef.current = true;
+    }
+    if (removedRoleNames.length > 0) {
+      if (!input.identityProvider.provider.removeRealmRoles) {
+        throw new Error('removeRealmRoles provider capability unavailable');
+      }
+      await deps.trackKeycloakCall('sync_roles', () =>
+        input.identityProvider.provider.removeRealmRoles!(input.plan.existing.keycloakSubject, removedRoleNames)
+      );
+      input.shouldRestoreRolesRef.current = true;
+    }
   }
 };
 

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -98,7 +98,7 @@ export type UpdateUserHandlerDeps<
   readonly ensureManagedRealmRolesExist: (input: {
     readonly instanceId: string;
     readonly identityProvider: TIdentityProvider;
-    readonly externalRoleNames: readonly string[];
+    readonly roleKeys: readonly string[];
     readonly actorAccountId?: string;
     readonly requestId?: string;
     readonly traceId?: string;
@@ -242,7 +242,7 @@ const assignTechnicalRoles = async <
   await deps.ensureManagedRealmRolesExist({
     instanceId: input.actor.instanceId,
     identityProvider: input.identityProvider,
-    externalRoleNames: input.roleNames,
+    roleKeys: input.roleNames,
     actorAccountId: input.actor.actorAccountId,
     requestId: input.actor.requestId,
     traceId: input.actor.traceId,

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -176,6 +176,135 @@ const resolveTechnicalRoleDelta = (input: {
   };
 };
 
+const syncUpdatedIdentity = async <
+  TPayload extends UpdateUserPayloadShape,
+  TPlan extends UserUpdatePlanShape,
+  TIdentityState extends UpdatedIdentityStateShape,
+  TIdentityProvider extends UpdateIdentityProvider,
+>(
+  deps: UpdateUserHandlerDeps<TPayload, TPlan, TIdentityState, TIdentityProvider>,
+  input: {
+    readonly identityProvider: TIdentityProvider;
+    readonly plan: TPlan;
+    readonly payload: TPayload;
+    readonly nextIdentityAttributes?: TIdentityState['nextIdentityAttributes'];
+  }
+): Promise<boolean> => {
+  const shouldUpdateIdentity =
+    input.nextIdentityAttributes ||
+    input.payload.email !== undefined ||
+    input.payload.firstName !== undefined ||
+    input.payload.lastName !== undefined ||
+    input.payload.status !== undefined;
+  if (!shouldUpdateIdentity) {
+    return false;
+  }
+
+  await deps.trackKeycloakCall('update_user', () =>
+    input.identityProvider.provider.updateUser(input.plan.existing.keycloakSubject, {
+      email: input.payload.email,
+      firstName: input.payload.firstName,
+      lastName: input.payload.lastName,
+      enabled: input.payload.status ? input.payload.status !== 'inactive' : undefined,
+      attributes: input.nextIdentityAttributes,
+    })
+  );
+  return true;
+};
+
+const assignTechnicalRoles = async <
+  TPayload extends UpdateUserPayloadShape,
+  TPlan extends UserUpdatePlanShape,
+  TIdentityState extends UpdatedIdentityStateShape,
+  TIdentityProvider extends UpdateIdentityProvider,
+>(
+  deps: UpdateUserHandlerDeps<TPayload, TPlan, TIdentityState, TIdentityProvider>,
+  input: {
+    readonly actor: UpdateActor;
+    readonly identityProvider: TIdentityProvider;
+    readonly keycloakSubject: string;
+    readonly roleNames: readonly string[];
+  }
+): Promise<void> => {
+  if (input.roleNames.length === 0) {
+    return;
+  }
+  if (!input.identityProvider.provider.assignRealmRoles) {
+    throw new Error('assignRealmRoles provider capability unavailable');
+  }
+  await deps.ensureManagedRealmRolesExist({
+    instanceId: input.actor.instanceId,
+    identityProvider: input.identityProvider,
+    externalRoleNames: input.roleNames,
+    actorAccountId: input.actor.actorAccountId,
+    requestId: input.actor.requestId,
+    traceId: input.actor.traceId,
+  });
+  await deps.trackKeycloakCall('sync_roles', () =>
+    input.identityProvider.provider.assignRealmRoles!(input.keycloakSubject, input.roleNames)
+  );
+};
+
+const removeTechnicalRoles = async <
+  TPayload extends UpdateUserPayloadShape,
+  TPlan extends UserUpdatePlanShape,
+  TIdentityState extends UpdatedIdentityStateShape,
+  TIdentityProvider extends UpdateIdentityProvider,
+>(
+  deps: UpdateUserHandlerDeps<TPayload, TPlan, TIdentityState, TIdentityProvider>,
+  input: {
+    readonly identityProvider: TIdentityProvider;
+    readonly keycloakSubject: string;
+    readonly roleNames: readonly string[];
+  }
+): Promise<void> => {
+  if (input.roleNames.length === 0) {
+    return;
+  }
+  if (!input.identityProvider.provider.removeRealmRoles) {
+    throw new Error('removeRealmRoles provider capability unavailable');
+  }
+  await deps.trackKeycloakCall('sync_roles', () =>
+    input.identityProvider.provider.removeRealmRoles!(input.keycloakSubject, input.roleNames)
+  );
+};
+
+const syncUpdatedTechnicalRoles = async <
+  TPayload extends UpdateUserPayloadShape,
+  TPlan extends UserUpdatePlanShape,
+  TIdentityState extends UpdatedIdentityStateShape,
+  TIdentityProvider extends UpdateIdentityProvider,
+>(
+  deps: UpdateUserHandlerDeps<TPayload, TPlan, TIdentityState, TIdentityProvider>,
+  input: {
+    readonly actor: UpdateActor;
+    readonly identityProvider: TIdentityProvider;
+    readonly plan: TPlan;
+  }
+): Promise<boolean> => {
+  if (!input.plan.nextRoleNames) {
+    return false;
+  }
+  const { addedRoleNames, removedRoleNames } = resolveTechnicalRoleDelta({
+    previousRoleNames: input.plan.previousRoleNames,
+    nextRoleNames: input.plan.nextRoleNames,
+  });
+
+  await assignTechnicalRoles(deps, {
+    actor: input.actor,
+    identityProvider: input.identityProvider,
+    keycloakSubject: input.plan.existing.keycloakSubject,
+    roleNames: addedRoleNames,
+  });
+  await removeTechnicalRoles(deps, {
+    identityProvider: input.identityProvider,
+    keycloakSubject: input.plan.existing.keycloakSubject,
+    roleNames: removedRoleNames,
+  });
+
+  return addedRoleNames.length > 0 || removedRoleNames.length > 0;
+};
+
 const syncUpdatedIdentityAndRoles = async <
   TPayload extends UpdateUserPayloadShape,
   TPlan extends UserUpdatePlanShape,
@@ -193,59 +322,12 @@ const syncUpdatedIdentityAndRoles = async <
     readonly shouldRestoreRolesRef: { current: boolean };
   }
 ) => {
-  if (
-    input.nextIdentityAttributes ||
-    input.payload.email !== undefined ||
-    input.payload.firstName !== undefined ||
-    input.payload.lastName !== undefined ||
-    input.payload.status !== undefined
-  ) {
-    await deps.trackKeycloakCall('update_user', () =>
-      input.identityProvider.provider.updateUser(input.plan.existing.keycloakSubject, {
-        email: input.payload.email,
-        firstName: input.payload.firstName,
-        lastName: input.payload.lastName,
-        enabled: input.payload.status ? input.payload.status !== 'inactive' : undefined,
-        attributes: input.nextIdentityAttributes,
-      })
-    );
+  if (await syncUpdatedIdentity(deps, input)) {
     input.shouldRestoreIdentityRef.current = true;
   }
 
-  if (input.plan.nextRoleNames) {
-    const { addedRoleNames, removedRoleNames } = resolveTechnicalRoleDelta({
-      previousRoleNames: input.plan.previousRoleNames,
-      nextRoleNames: input.plan.nextRoleNames,
-    });
-    if (addedRoleNames.length === 0 && removedRoleNames.length === 0) {
-      return;
-    }
-    if (addedRoleNames.length > 0) {
-      if (!input.identityProvider.provider.assignRealmRoles) {
-        throw new Error('assignRealmRoles provider capability unavailable');
-      }
-      await deps.ensureManagedRealmRolesExist({
-        instanceId: input.actor.instanceId,
-        identityProvider: input.identityProvider,
-        externalRoleNames: addedRoleNames,
-        actorAccountId: input.actor.actorAccountId,
-        requestId: input.actor.requestId,
-        traceId: input.actor.traceId,
-      });
-      await deps.trackKeycloakCall('sync_roles', () =>
-        input.identityProvider.provider.assignRealmRoles!(input.plan.existing.keycloakSubject, addedRoleNames)
-      );
-      input.shouldRestoreRolesRef.current = true;
-    }
-    if (removedRoleNames.length > 0) {
-      if (!input.identityProvider.provider.removeRealmRoles) {
-        throw new Error('removeRealmRoles provider capability unavailable');
-      }
-      await deps.trackKeycloakCall('sync_roles', () =>
-        input.identityProvider.provider.removeRealmRoles!(input.plan.existing.keycloakSubject, removedRoleNames)
-      );
-      input.shouldRestoreRolesRef.current = true;
-    }
+  if (await syncUpdatedTechnicalRoles(deps, input)) {
+    input.shouldRestoreRolesRef.current = true;
   }
 };
 

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -45,9 +45,12 @@ export class RoleMutationCapabilityUnavailableError extends Error {
 }
 
 export type UpdateUserPayloadShape = {
+  readonly displayName?: string;
   readonly email?: string;
   readonly firstName?: string;
   readonly lastName?: string;
+  readonly mainserverUserApplicationId?: string;
+  readonly mainserverUserApplicationSecret?: string;
   readonly status?: 'active' | 'inactive' | 'pending';
 };
 
@@ -74,8 +77,9 @@ export type UpdateRequestContext<
   | Response
   | {
       readonly actor: UpdateActor;
-      readonly identityProvider: TIdentityProvider;
+      readonly identityProvider?: TIdentityProvider;
       readonly payload: TPayload;
+      readonly resolveIdentityProvider?: () => Promise<TIdentityProvider | Response>;
       readonly userId: string;
     };
 
@@ -136,7 +140,7 @@ export type UpdateUserHandlerDeps<
     readonly restoreIdentity: boolean;
     readonly restoreRoles: boolean;
     readonly restoreIdentityAttributes?: TIdentityState['existingIdentityAttributes'];
-    readonly identityProvider: TIdentityProvider;
+    readonly identityProvider?: TIdentityProvider;
   }) => Promise<void>;
   readonly resolveUpdateRequestContext: (
     request: Request,
@@ -145,7 +149,7 @@ export type UpdateUserHandlerDeps<
   readonly resolveUpdatedIdentityState: (input: {
     readonly plan: TPlan;
     readonly payload: TPayload;
-    readonly identityProvider: TIdentityProvider;
+    readonly identityProvider?: TIdentityProvider;
   }) => Promise<TIdentityState>;
   readonly resolveUserUpdatePlan: (
     client: QueryClient,
@@ -194,6 +198,20 @@ const hasTechnicalRoleDelta = (plan: UserUpdatePlanShape): boolean => {
   });
   return addedRoleNames.length > 0 || removedRoleNames.length > 0;
 };
+
+const shouldUpdateIdentityPayload = (payload: UpdateUserPayloadShape): boolean =>
+  payload.displayName !== undefined ||
+  payload.email !== undefined ||
+  payload.firstName !== undefined ||
+  payload.lastName !== undefined ||
+  payload.mainserverUserApplicationId !== undefined ||
+  payload.mainserverUserApplicationSecret !== undefined ||
+  payload.status !== undefined;
+
+const shouldResolveIdentityProvider = (input: {
+  readonly payload: UpdateUserPayloadShape;
+  readonly plan: UserUpdatePlanShape;
+}): boolean => shouldUpdateIdentityPayload(input.payload) || hasTechnicalRoleDelta(input.plan);
 
 const requireRoleMutationCapability = (
   identityProvider: UpdateIdentityProvider,
@@ -302,6 +320,7 @@ const syncUpdatedTechnicalRoles = async <
     readonly actor: UpdateActor;
     readonly identityProvider: TIdentityProvider;
     readonly plan: TPlan;
+    readonly beforeRoleMutation: () => void;
   }
 ): Promise<boolean> => {
   if (!input.plan.nextRoleNames) {
@@ -316,6 +335,7 @@ const syncUpdatedTechnicalRoles = async <
   }
   requireRoleMutationCapability(input.identityProvider, 'assignRealmRoles');
   requireRoleMutationCapability(input.identityProvider, 'removeRealmRoles');
+  input.beforeRoleMutation();
 
   await assignTechnicalRoles(deps, {
     actor: input.actor,
@@ -353,10 +373,12 @@ const syncUpdatedIdentityAndRoles = async <
     input.shouldRestoreIdentityRef.current = true;
   }
 
-  if (hasTechnicalRoleDelta(input.plan)) {
-    input.shouldRestoreRolesRef.current = true;
-  }
-  if (await syncUpdatedTechnicalRoles(deps, input)) {
+  if (await syncUpdatedTechnicalRoles(deps, {
+    ...input,
+    beforeRoleMutation: () => {
+      input.shouldRestoreRolesRef.current = true;
+    },
+  })) {
     input.shouldRestoreRolesRef.current = true;
   }
 };
@@ -371,8 +393,9 @@ const executeUserUpdate = async <
   input: {
     readonly actor: UpdateActor;
     readonly ctx: UpdateAuthenticatedRequestContext;
-    readonly identityProvider: TIdentityProvider;
+    readonly identityProvider?: TIdentityProvider;
     readonly payload: TPayload;
+    readonly resolveIdentityProvider?: () => Promise<TIdentityProvider | Response>;
     readonly userId: string;
   }
 ): Promise<Response> => {
@@ -390,25 +413,39 @@ const executeUserUpdate = async <
     return deps.notFoundResponse(input.actor.requestId);
   }
 
+  let identityProvider = input.identityProvider;
+  if (!identityProvider && shouldResolveIdentityProvider({ payload: input.payload, plan })) {
+    if (!input.resolveIdentityProvider) {
+      throw new Error('identity_provider_resolution_unavailable');
+    }
+    const resolvedIdentityProvider = await input.resolveIdentityProvider();
+    if (resolvedIdentityProvider instanceof Response) {
+      return resolvedIdentityProvider;
+    }
+    identityProvider = resolvedIdentityProvider;
+  }
+
   const resolvedIdentityState = await deps.resolveUpdatedIdentityState({
     plan,
     payload: input.payload,
-    identityProvider: input.identityProvider,
+    identityProvider,
   });
 
   const shouldRestoreIdentityRef = { current: false };
   const shouldRestoreRolesRef = { current: false };
 
   try {
-    await syncUpdatedIdentityAndRoles(deps, {
-      actor: input.actor,
-      identityProvider: input.identityProvider,
-      plan,
-      payload: input.payload,
-      nextIdentityAttributes: resolvedIdentityState.nextIdentityAttributes,
-      shouldRestoreIdentityRef,
-      shouldRestoreRolesRef,
-    });
+    if (identityProvider) {
+      await syncUpdatedIdentityAndRoles(deps, {
+        actor: input.actor,
+        identityProvider,
+        plan,
+        payload: input.payload,
+        nextIdentityAttributes: resolvedIdentityState.nextIdentityAttributes,
+        shouldRestoreIdentityRef,
+        shouldRestoreRolesRef,
+      });
+    }
 
     const detail = await deps.persistUpdatedUserDetail({
       instanceId: input.actor.instanceId,
@@ -439,7 +476,7 @@ const executeUserUpdate = async <
       restoreIdentity: shouldRestoreIdentityRef.current,
       restoreRoles: shouldRestoreRolesRef.current,
       restoreIdentityAttributes: resolvedIdentityState.existingIdentityAttributes,
-      identityProvider: input.identityProvider,
+      identityProvider,
     });
     throw error;
   }

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -31,9 +31,9 @@ export type UpdateIdentityProvider = {
         readonly attributes?: UpdateIdentityAttributes;
       }
     ) => Promise<void>;
+    readonly assignRealmRoles: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
+    readonly removeRealmRoles: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
     readonly syncRoles: (keycloakSubject: string, roleNames: string[]) => Promise<void>;
-    readonly assignRealmRoles?: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
-    readonly removeRealmRoles?: (keycloakSubject: string, roleNames: readonly string[]) => Promise<void>;
   };
 };
 
@@ -151,7 +151,7 @@ export type UpdateUserHandlerDeps<
     }
   ) => Promise<TPlan | undefined>;
   readonly trackKeycloakCall: <T>(
-    operation: 'update_user' | 'sync_roles',
+    operation: 'assign_realm_roles' | 'remove_realm_roles' | 'update_user',
     work: () => Promise<T>
   ) => Promise<T>;
   readonly withInstanceScopedDb: <T>(
@@ -229,9 +229,6 @@ const assignTechnicalRoles = async <
   if (input.roleNames.length === 0) {
     return;
   }
-  if (!input.identityProvider.provider.assignRealmRoles) {
-    throw new Error('assignRealmRoles provider capability unavailable');
-  }
   await deps.ensureManagedRealmRolesExist({
     instanceId: input.actor.instanceId,
     identityProvider: input.identityProvider,
@@ -240,8 +237,8 @@ const assignTechnicalRoles = async <
     requestId: input.actor.requestId,
     traceId: input.actor.traceId,
   });
-  await deps.trackKeycloakCall('sync_roles', () =>
-    input.identityProvider.provider.assignRealmRoles!(input.keycloakSubject, input.roleNames)
+  await deps.trackKeycloakCall('assign_realm_roles', () =>
+    input.identityProvider.provider.assignRealmRoles(input.keycloakSubject, input.roleNames)
   );
 };
 
@@ -261,11 +258,8 @@ const removeTechnicalRoles = async <
   if (input.roleNames.length === 0) {
     return;
   }
-  if (!input.identityProvider.provider.removeRealmRoles) {
-    throw new Error('removeRealmRoles provider capability unavailable');
-  }
-  await deps.trackKeycloakCall('sync_roles', () =>
-    input.identityProvider.provider.removeRealmRoles!(input.keycloakSubject, input.roleNames)
+  await deps.trackKeycloakCall('remove_realm_roles', () =>
+    input.identityProvider.provider.removeRealmRoles(input.keycloakSubject, input.roleNames)
   );
 };
 

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -207,19 +207,22 @@ const hasTechnicalRoleDelta = (plan: UserUpdatePlanShape): boolean => {
   return addedRoleNames.length > 0 || removedRoleNames.length > 0;
 };
 
-const shouldUpdateIdentityPayload = (payload: UpdateUserPayloadShape): boolean =>
+export const shouldUpdateUserIdentityAttributes = (payload: UpdateUserPayloadShape): boolean =>
   payload.displayName !== undefined ||
+  payload.mainserverUserApplicationId !== undefined ||
+  payload.mainserverUserApplicationSecret !== undefined;
+
+export const shouldUpdateUserIdentityPayload = (payload: UpdateUserPayloadShape): boolean =>
   payload.email !== undefined ||
   payload.firstName !== undefined ||
   payload.lastName !== undefined ||
-  payload.mainserverUserApplicationId !== undefined ||
-  payload.mainserverUserApplicationSecret !== undefined ||
+  shouldUpdateUserIdentityAttributes(payload) ||
   payload.status !== undefined;
 
 const shouldResolveIdentityProvider = (input: {
   readonly payload: UpdateUserPayloadShape;
   readonly plan: UserUpdatePlanShape;
-}): boolean => shouldUpdateIdentityPayload(input.payload) || hasTechnicalRoleDelta(input.plan);
+}): boolean => shouldUpdateUserIdentityPayload(input.payload) || hasTechnicalRoleDelta(input.plan);
 
 const resolveExistingMainserverCredentialState = (
   existing: UserUpdatePlanShape['existing']

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from './query-client.js';
+import { filterTenantTechnicalKeycloakRoleNames } from './role-governance.js';
 
 export type UpdateAuthenticatedRequestContext = {
   readonly sessionId: string;
@@ -194,7 +195,10 @@ const syncUpdatedIdentityAndRoles = async <
   }
 
   if (input.plan.nextRoleNames) {
-    const nextRoleNames = input.plan.nextRoleNames;
+    const nextRoleNames = filterTenantTechnicalKeycloakRoleNames(input.plan.nextRoleNames);
+    if (nextRoleNames.length === 0) {
+      return;
+    }
     await deps.ensureManagedRealmRolesExist({
       instanceId: input.actor.instanceId,
       identityProvider: input.identityProvider,

--- a/packages/iam-admin/src/user-update-handler.ts
+++ b/packages/iam-admin/src/user-update-handler.ts
@@ -183,6 +183,27 @@ const resolveTechnicalRoleDelta = (input: {
   };
 };
 
+const hasTechnicalRoleDelta = (plan: UserUpdatePlanShape): boolean => {
+  if (!plan.nextRoleNames) {
+    return false;
+  }
+
+  const { addedRoleNames, removedRoleNames } = resolveTechnicalRoleDelta({
+    previousRoleNames: plan.previousRoleNames,
+    nextRoleNames: plan.nextRoleNames,
+  });
+  return addedRoleNames.length > 0 || removedRoleNames.length > 0;
+};
+
+const requireRoleMutationCapability = (
+  identityProvider: UpdateIdentityProvider,
+  capability: 'assignRealmRoles' | 'removeRealmRoles'
+): void => {
+  if (!identityProvider.provider[capability]) {
+    throw new RoleMutationCapabilityUnavailableError(capability);
+  }
+};
+
 const syncUpdatedIdentity = async <
   TPayload extends UpdateUserPayloadShape,
   TPlan extends UserUpdatePlanShape,
@@ -236,9 +257,6 @@ const assignTechnicalRoles = async <
   if (input.roleNames.length === 0) {
     return;
   }
-  if (!input.identityProvider.provider.assignRealmRoles) {
-    throw new RoleMutationCapabilityUnavailableError('assignRealmRoles');
-  }
   await deps.ensureManagedRealmRolesExist({
     instanceId: input.actor.instanceId,
     identityProvider: input.identityProvider,
@@ -268,9 +286,6 @@ const removeTechnicalRoles = async <
   if (input.roleNames.length === 0) {
     return;
   }
-  if (!input.identityProvider.provider.removeRealmRoles) {
-    throw new RoleMutationCapabilityUnavailableError('removeRealmRoles');
-  }
   await deps.trackKeycloakCall('remove_realm_roles', () =>
     input.identityProvider.provider.removeRealmRoles!(input.keycloakSubject, input.roleNames)
   );
@@ -296,6 +311,11 @@ const syncUpdatedTechnicalRoles = async <
     previousRoleNames: input.plan.previousRoleNames,
     nextRoleNames: input.plan.nextRoleNames,
   });
+  if (addedRoleNames.length === 0 && removedRoleNames.length === 0) {
+    return false;
+  }
+  requireRoleMutationCapability(input.identityProvider, 'assignRealmRoles');
+  requireRoleMutationCapability(input.identityProvider, 'removeRealmRoles');
 
   await assignTechnicalRoles(deps, {
     actor: input.actor,
@@ -309,7 +329,7 @@ const syncUpdatedTechnicalRoles = async <
     roleNames: removedRoleNames,
   });
 
-  return addedRoleNames.length > 0 || removedRoleNames.length > 0;
+  return true;
 };
 
 const syncUpdatedIdentityAndRoles = async <
@@ -333,6 +353,9 @@ const syncUpdatedIdentityAndRoles = async <
     input.shouldRestoreIdentityRef.current = true;
   }
 
+  if (hasTechnicalRoleDelta(input.plan)) {
+    input.shouldRestoreRolesRef.current = true;
+  }
   if (await syncUpdatedTechnicalRoles(deps, input)) {
     input.shouldRestoreRolesRef.current = true;
   }

--- a/packages/iam-admin/src/user-update-persistence.test.ts
+++ b/packages/iam-admin/src/user-update-persistence.test.ts
@@ -33,6 +33,19 @@ const createDeps = (client: QueryClient) => ({
   ),
 });
 
+const createPersistenceTestContext = () => {
+  const client: QueryClient = {
+    query: vi.fn(async () => ({ rowCount: 1, rows: [] })),
+  };
+  const deps = createDeps(client);
+
+  return {
+    client,
+    deps,
+    persistence: createUserUpdatePersistence(deps),
+  };
+};
+
 describe('user-update-persistence', () => {
   it('builds encrypted update params and keeps optional fields nullable', () => {
     expect(
@@ -62,11 +75,7 @@ describe('user-update-persistence', () => {
   });
 
   it('persists user updates, assignments, activity and invalidations', async () => {
-    const client: QueryClient = {
-      query: vi.fn(async () => ({ rowCount: 1, rows: [] })),
-    };
-    const deps = createDeps(client);
-    const persistence = createUserUpdatePersistence(deps);
+    const { client, deps, persistence } = createPersistenceTestContext();
 
     await expect(
       persistence.persistUpdatedUserDetail({
@@ -173,6 +182,31 @@ describe('user-update-persistence', () => {
         },
       })
     ).resolves.toBeUndefined();
+  });
+
+  it('preserves existing mainserver credential state when identity state was not reloaded', async () => {
+    const { persistence } = createPersistenceTestContext();
+
+    await expect(
+      persistence.persistUpdatedUserDetail({
+        instanceId: 'inst-1',
+        actorAccountId: 'actor-1',
+        userId: 'user-1',
+        keycloakSubject: 'kc-1',
+        existingRoleIds: ['role-0'],
+        payload: {
+          roleIds: ['role-1'],
+        },
+        existingMainserverCredentialState: {
+          mainserverUserApplicationId: 'existing-app',
+          mainserverUserApplicationSecretSet: true,
+        },
+      })
+    ).resolves.toEqual({
+      ...detail,
+      mainserverUserApplicationId: 'existing-app',
+      mainserverUserApplicationSecretSet: true,
+    });
   });
 
   it('revokes existing sessions when a user update deactivates the account', async () => {

--- a/packages/iam-admin/src/user-update-persistence.ts
+++ b/packages/iam-admin/src/user-update-persistence.ts
@@ -220,7 +220,7 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
     readonly existingRoleIds?: readonly string[];
     readonly existingGroupIds?: readonly string[];
     readonly payload: UpdateUserPersistencePayload;
-    readonly nextMainserverCredentialState: UserMainserverCredentialState;
+    readonly nextMainserverCredentialState?: UserMainserverCredentialState;
   }) => {
     const persisted = await deps.withInstanceScopedDb(input.instanceId, async (client) => {
       if (input.payload.roleIds) {
@@ -278,11 +278,13 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
       }
 
       return {
-        detail: {
-          ...detail,
-          mainserverUserApplicationId: input.nextMainserverCredentialState.mainserverUserApplicationId,
-          mainserverUserApplicationSecretSet: input.nextMainserverCredentialState.mainserverUserApplicationSecretSet,
-        },
+        detail: input.nextMainserverCredentialState
+          ? {
+              ...detail,
+              mainserverUserApplicationId: input.nextMainserverCredentialState.mainserverUserApplicationId,
+              mainserverUserApplicationSecretSet: input.nextMainserverCredentialState.mainserverUserApplicationSecretSet,
+            }
+          : detail,
         sessionAction,
       };
     });

--- a/packages/iam-admin/src/user-update-persistence.ts
+++ b/packages/iam-admin/src/user-update-persistence.ts
@@ -220,6 +220,7 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
     readonly existingRoleIds?: readonly string[];
     readonly existingGroupIds?: readonly string[];
     readonly payload: UpdateUserPersistencePayload;
+    readonly existingMainserverCredentialState?: UserMainserverCredentialState;
     readonly nextMainserverCredentialState?: UserMainserverCredentialState;
   }) => {
     const persisted = await deps.withInstanceScopedDb(input.instanceId, async (client) => {
@@ -277,12 +278,15 @@ export const createUserUpdatePersistence = (deps: UserUpdatePersistenceDeps) => 
         };
       }
 
+      const mainserverCredentialState =
+        input.nextMainserverCredentialState ?? input.existingMainserverCredentialState;
+
       return {
-        detail: input.nextMainserverCredentialState
+        detail: mainserverCredentialState
           ? {
               ...detail,
-              mainserverUserApplicationId: input.nextMainserverCredentialState.mainserverUserApplicationId,
-              mainserverUserApplicationSecretSet: input.nextMainserverCredentialState.mainserverUserApplicationSecretSet,
+              mainserverUserApplicationId: mainserverCredentialState.mainserverUserApplicationId,
+              mainserverUserApplicationSecretSet: mainserverCredentialState.mainserverUserApplicationSecretSet,
             }
           : detail,
         sessionAction,

--- a/packages/routing/src/protected.routes.ts
+++ b/packages/routing/src/protected.routes.ts
@@ -5,6 +5,7 @@ import { emitRoutingDiagnostic, type RoutingDiagnosticsHook } from './diagnostic
 export type RouteGuardUser = {
   readonly instanceId?: string;
   readonly roles: readonly string[];
+  readonly keycloakRoles?: readonly string[];
   readonly permissionActions?: readonly string[];
   readonly assignedModules?: readonly string[];
   readonly permissionStatus?: 'ok' | 'degraded';

--- a/packages/routing/src/protected.routes.ts
+++ b/packages/routing/src/protected.routes.ts
@@ -254,7 +254,4 @@ export const createProtectedRoute = <TContext extends RouteGuardContext = RouteG
 
 export const createAdminRoute = <TContext extends RouteGuardContext = RouteGuardContext>(
   options: ProtectedRouteOptions = {}
-) =>
-  createProtectedRoute<TContext>({
-    ...options,
-  });
+) => createProtectedRoute<TContext>({ ...options });

--- a/packages/routing/src/protected.routes.ts
+++ b/packages/routing/src/protected.routes.ts
@@ -4,7 +4,8 @@ import { emitRoutingDiagnostic, type RoutingDiagnosticsHook } from './diagnostic
 
 export type RouteGuardUser = {
   readonly instanceId?: string;
-  readonly roles: readonly string[]; readonly keycloakRoles?: readonly string[];
+  readonly roles: readonly string[];
+  readonly keycloakRoles?: readonly string[];
   readonly permissionActions?: readonly string[];
   readonly assignedModules?: readonly string[];
   readonly permissionStatus?: 'ok' | 'degraded';

--- a/packages/routing/src/protected.routes.ts
+++ b/packages/routing/src/protected.routes.ts
@@ -4,8 +4,7 @@ import { emitRoutingDiagnostic, type RoutingDiagnosticsHook } from './diagnostic
 
 export type RouteGuardUser = {
   readonly instanceId?: string;
-  readonly roles: readonly string[];
-  readonly keycloakRoles?: readonly string[];
+  readonly roles: readonly string[]; readonly keycloakRoles?: readonly string[];
   readonly permissionActions?: readonly string[];
   readonly assignedModules?: readonly string[];
   readonly permissionStatus?: 'ok' | 'degraded';


### PR DESCRIPTION
## Summary
- trennt kanonische IAM-Rollen von rohen Keycloak-Rollen über `keycloakRoles`
- begrenzt Keycloak-Rollenabgleich auf `system_admin` und `instance_registry_admin`
- stellt normale Tenant-Rollen-CRUD-Pfade auf DB-only um
- passt User-Create/-Update, Reconcile, Projektionen, UI, OpenSpec und Betriebsdoku an

## Verification
- `openspec validate refactor-keycloak-role-sync-boundary --strict`
- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx affected --target=test:types --base=origin/main`
- `pnpm check:server-runtime`
- `pnpm check:file-placement`
- `git diff --check`

## Rollout bleibt offen
- Drift-Berichte pro aktivem Tenant ausführen und dokumentieren
- Pilot-Tenant smoke-testen
- Legacy-Keycloak-Rollen tenantweise freigeben oder bereinigen
- stufenweise Aktivierung mit Monitoring für `manual_review`, `IDP_FORBIDDEN`, `IDP_UNAVAILABLE` und Drift-Backlog