### PR TITLE
fix: harden mainserver content projection refresh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 .git
+.worktrees
 .nx
 .pnpm-store
 .tmp

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -1384,6 +1384,65 @@ describe('content list projection', () => {
     ]);
   });
 
+  it('deduplicates duplicate mainserver projection rows before insert', async () => {
+    state.listSvaMainserverEvents.mockResolvedValue({
+      data: [
+        {
+          id: 'event-duplicate-1',
+          title: 'Doppelte Veranstaltung',
+          contentType: 'events.event-record',
+          status: 'published',
+          dates: [],
+          recurringWeekdays: [],
+          categories: [],
+          addresses: [],
+          contacts: [],
+          urls: [],
+          mediaContents: [],
+          priceInformations: [],
+          tags: [],
+          visible: true,
+          createdAt: '2026-06-20T10:00:00.000Z',
+          updatedAt: '2026-06-21T10:00:00.000Z',
+        },
+        {
+          id: 'event-duplicate-1',
+          title: 'Doppelte Veranstaltung',
+          contentType: 'events.event-record',
+          status: 'published',
+          dates: [],
+          recurringWeekdays: [],
+          categories: [],
+          addresses: [],
+          contacts: [],
+          urls: [],
+          mediaContents: [],
+          priceInformations: [],
+          tags: [],
+          visible: true,
+          createdAt: '2026-06-20T10:00:00.000Z',
+          updatedAt: '2026-06-21T10:00:00.000Z',
+        },
+      ],
+      pagination: { page: 1, pageSize: 100, hasNextPage: false },
+    });
+
+    const response = await refreshProjectedContents(ctx, {
+      visibleTypes: ['events.event-record'],
+      force: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(projectionInsertArgs).toHaveLength(1);
+    expect(JSON.parse(String(projectionInsertArgs?.[0] ?? '[]'))).toHaveLength(1);
+    expect(projectionRows).toEqual([
+      expect.objectContaining({
+        content_type: 'events.event-record',
+        source_entity_id: 'event-duplicate-1',
+      }),
+    ]);
+  });
+
   it('returns deterministic refresh errors for missing instances, permission backend failures, and forbidden types', async () => {
     const missingInstanceResponse = await refreshProjectedContents(
       {

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -84,6 +84,28 @@ describe('content list projection', () => {
     }
   >;
   let projectionInsertArgs: readonly unknown[] | null;
+  let projectionInsertSql: string | null;
+  let simulateConcurrentProjectionConflict: boolean;
+
+  const buildScopeKey = (
+    row: Pick<
+      ProjectionRow,
+      | 'instance_id'
+      | 'source_system'
+      | 'source_entity_type'
+      | 'source_entity_id'
+      | 'organization_id'
+      | 'owner_subject_id'
+    >
+  ): string =>
+    [
+      row.instance_id,
+      row.source_system,
+      row.source_entity_type,
+      row.source_entity_id,
+      row.organization_id ?? '',
+      row.owner_subject_id ?? '',
+    ].join('::');
 
   const applyProjectionFilters = (text: string, values: readonly unknown[] | undefined): ProjectionRow[] => {
     const scopedInstanceId = String(values?.[0] ?? '');
@@ -144,6 +166,8 @@ describe('content list projection', () => {
     projectionRows = [];
     syncStates = new Map();
     projectionInsertArgs = null;
+    projectionInsertSql = null;
+    simulateConcurrentProjectionConflict = false;
     state.authorizeContentPrimitiveForUser.mockReset();
     state.resolveActorAccountId.mockReset();
     state.resolveEffectivePermissions.mockReset();
@@ -292,9 +316,9 @@ describe('content list projection', () => {
 
           if (text.includes('INSERT INTO iam.content_list_projection')) {
             projectionInsertArgs = values ?? null;
+            projectionInsertSql = text;
             const rows = JSON.parse(String(values?.[0] ?? '[]')) as Array<Record<string, unknown>>;
-            projectionRows.push(
-              ...(rows.map((row) => ({
+            const mappedRows = rows.map((row) => ({
                 id: String(row.id),
                 instance_id: String(row.instance_id),
                 organization_id: (row.organization_id as string | null) ?? null,
@@ -318,9 +342,42 @@ describe('content list projection', () => {
                 source_system: 'mainserver',
                 source_entity_type: String(row.source_entity_type),
                 source_entity_id: String(row.source_entity_id),
-              })) satisfies ProjectionRow[])
-            );
-            return { rows: [], rowCount: rows.length };
+              })) satisfies ProjectionRow[];
+
+            if (simulateConcurrentProjectionConflict && mappedRows.length > 0) {
+              projectionRows.push({
+                ...mappedRows[0],
+                id: 'concurrent-row',
+              });
+              simulateConcurrentProjectionConflict = false;
+            }
+
+            for (const row of mappedRows) {
+              const existingIndex = projectionRows.findIndex(
+                (candidate) => buildScopeKey(candidate) === buildScopeKey(row)
+              );
+
+              if (existingIndex >= 0) {
+                if (
+                  !text.includes(
+                    'ON CONFLICT ON CONSTRAINT content_list_projection_scope_key DO UPDATE'
+                  )
+                ) {
+                  const error = new Error(
+                    'duplicate key value violates unique constraint "content_list_projection_scope_key"'
+                  ) as Error & { code?: string };
+                  error.code = '23505';
+                  throw error;
+                }
+
+                projectionRows[existingIndex] = row;
+                continue;
+              }
+
+              projectionRows.push(row);
+            }
+
+            return { rows: [], rowCount: mappedRows.length };
           }
 
           if (text.includes('SELECT COUNT(*)::int AS total')) {
@@ -1439,6 +1496,50 @@ describe('content list projection', () => {
       expect.objectContaining({
         content_type: 'events.event-record',
         source_entity_id: 'event-duplicate-1',
+      }),
+    ]);
+  });
+
+  it('upserts mainserver projection rows when a concurrent write recreates the same scope', async () => {
+    simulateConcurrentProjectionConflict = true;
+    state.listSvaMainserverEvents.mockResolvedValue({
+      data: [
+        {
+          id: 'event-concurrent-1',
+          title: 'Konkurrierende Veranstaltung',
+          contentType: 'events.event-record',
+          status: 'published',
+          dates: [],
+          recurringWeekdays: [],
+          categories: [],
+          addresses: [],
+          contacts: [],
+          urls: [],
+          mediaContents: [],
+          priceInformations: [],
+          tags: [],
+          visible: true,
+          createdAt: '2026-06-20T10:00:00.000Z',
+          updatedAt: '2026-06-21T10:00:00.000Z',
+        },
+      ],
+      pagination: { page: 1, pageSize: 100, hasNextPage: false },
+    });
+
+    const response = await refreshProjectedContents(ctx, {
+      visibleTypes: ['events.event-record'],
+      force: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(projectionInsertSql).toContain(
+      'ON CONFLICT ON CONSTRAINT content_list_projection_scope_key'
+    );
+    expect(projectionRows).toEqual([
+      expect.objectContaining({
+        content_type: 'events.event-record',
+        organization_id: 'org-1',
+        source_entity_id: 'event-concurrent-1',
       }),
     ]);
   });

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -128,6 +128,32 @@ type MainserverProjectionRowInput = Pick<
     sourceEntityId: string;
   }>;
 
+const buildProjectionScopeKey = (
+  row: MainserverProjectionRowInput,
+  fallbackOwnerSubjectId: string
+): string =>
+  [
+    row.instanceId,
+    row.contentType,
+    row.sourceEntityType,
+    row.sourceEntityId,
+    row.organizationId ?? '',
+    row.ownerSubjectId ?? (row.organizationId ? '' : fallbackOwnerSubjectId),
+  ].join('::');
+
+const dedupeProjectionRows = (
+  rows: readonly MainserverProjectionRowInput[],
+  fallbackOwnerSubjectId: string
+): readonly MainserverProjectionRowInput[] => {
+  const deduped = new Map<string, MainserverProjectionRowInput>();
+
+  for (const row of rows) {
+    deduped.set(buildProjectionScopeKey(row, fallbackOwnerSubjectId), row);
+  }
+
+  return [...deduped.values()];
+};
+
 const mapProjectionRow = (row: ProjectionRow): IamContentListItem => ({
   id: row.id,
   instanceId: row.instance_id,
@@ -344,6 +370,8 @@ const replaceMainserverProjectionRows = async (
   organizationId: string | undefined,
   rows: readonly MainserverProjectionRowInput[]
 ): Promise<void> => {
+  const dedupedRows = dedupeProjectionRows(rows, keycloakSubject);
+
   await withInstanceScopedDb(instanceId, async (client) => {
     await client.query(
       `
@@ -366,7 +394,7 @@ WHERE instance_id = $1
       [instanceId, contentType, organizationId ?? null, keycloakSubject]
     );
 
-    if (rows.length > 0) {
+    if (dedupedRows.length > 0) {
       await client.query(
         `
 INSERT INTO iam.content_list_projection (
@@ -447,7 +475,7 @@ FROM jsonb_to_recordset($1::jsonb) AS item(
         `,
         [
           JSON.stringify(
-            rows.map((row) => ({
+            dedupedRows.map((row) => ({
               id: row.id,
               instance_id: row.instanceId,
               organization_id: row.organizationId ?? null,
@@ -501,7 +529,7 @@ DO UPDATE SET
   projected_count = EXCLUDED.projected_count,
   updated_at = NOW();
       `,
-      [instanceId, contentType, rows.length]
+      [instanceId, contentType, dedupedRows.length]
     );
   });
 };

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -471,7 +471,26 @@ FROM jsonb_to_recordset($1::jsonb) AS item(
   last_audit_event_ref text,
   source_entity_type text,
   source_entity_id text
-);
+)
+ON CONFLICT ON CONSTRAINT content_list_projection_scope_key
+DO UPDATE SET
+  id = EXCLUDED.id,
+  title = EXCLUDED.title,
+  published_at = EXCLUDED.published_at,
+  publish_from = EXCLUDED.publish_from,
+  publish_until = EXCLUDED.publish_until,
+  created_at = EXCLUDED.created_at,
+  created_by = EXCLUDED.created_by,
+  updated_at = EXCLUDED.updated_at,
+  updated_by = EXCLUDED.updated_by,
+  author_display_name = EXCLUDED.author_display_name,
+  payload_json = EXCLUDED.payload_json,
+  status = EXCLUDED.status,
+  validation_state = EXCLUDED.validation_state,
+  history_ref = EXCLUDED.history_ref,
+  current_revision_ref = EXCLUDED.current_revision_ref,
+  last_audit_event_ref = EXCLUDED.last_audit_event_ref,
+  projection_updated_at = NOW();
         `,
         [
           JSON.stringify(

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -124,9 +124,13 @@ type MainserverProjectionRowInput = Pick<
   | 'lastAuditEventRef'
 > &
   Readonly<{
-    sourceEntityType: string;
-    sourceEntityId: string;
-  }>;
+  sourceEntityType: string;
+  sourceEntityId: string;
+}>;
+
+type ProjectionDbClient = Readonly<{
+  query: (text: string, values?: readonly unknown[]) => Promise<unknown>;
+}>;
 
 const buildProjectionScopeKey = (
   row: MainserverProjectionRowInput,
@@ -363,18 +367,15 @@ DO UPDATE SET
   });
 };
 
-const replaceMainserverProjectionRows = async (
+const deleteMainserverProjectionRows = async (
+  client: ProjectionDbClient,
   instanceId: string,
   contentType: string,
-  keycloakSubject: string,
   organizationId: string | undefined,
-  rows: readonly MainserverProjectionRowInput[]
+  keycloakSubject: string
 ): Promise<void> => {
-  const dedupedRows = dedupeProjectionRows(rows, keycloakSubject);
-
-  await withInstanceScopedDb(instanceId, async (client) => {
-    await client.query(
-      `
+  await client.query(
+    `
 DELETE FROM iam.content_list_projection
 WHERE instance_id = $1
   AND source_system = 'mainserver'
@@ -390,13 +391,48 @@ WHERE instance_id = $1
       )
     )
   );
-      `,
-      [instanceId, contentType, organizationId ?? null, keycloakSubject]
-    );
+    `,
+    [instanceId, contentType, organizationId ?? null, keycloakSubject]
+  );
+};
 
-    if (dedupedRows.length > 0) {
-      await client.query(
-        `
+const buildMainserverProjectionPayloadJson = (
+  rows: readonly MainserverProjectionRowInput[],
+  keycloakSubject: string
+): string =>
+  JSON.stringify(
+    rows.map((row) => ({
+      id: row.id,
+      instance_id: row.instanceId,
+      organization_id: row.organizationId ?? null,
+      owner_subject_id: row.ownerSubjectId ?? (row.organizationId ? null : keycloakSubject),
+      content_type: row.contentType,
+      title: row.title,
+      published_at: row.publishedAt ?? null,
+      publish_from: row.publishFrom ?? null,
+      publish_until: row.publishUntil ?? null,
+      created_at: row.createdAt,
+      created_by: row.createdBy,
+      updated_at: row.updatedAt,
+      updated_by: row.updatedBy,
+      author_display_name: row.author,
+      payload_json: row.payload,
+      status: row.status,
+      validation_state: row.validationState,
+      history_ref: row.historyRef,
+      current_revision_ref: row.currentRevisionRef ?? '',
+      last_audit_event_ref: row.lastAuditEventRef ?? '',
+      source_entity_type: row.sourceEntityType,
+      source_entity_id: row.sourceEntityId,
+    }))
+  );
+
+const upsertMainserverProjectionRows = async (
+  client: ProjectionDbClient,
+  payloadJson: string
+): Promise<void> => {
+  await client.query(
+    `
 INSERT INTO iam.content_list_projection (
   id,
   instance_id,
@@ -491,41 +527,19 @@ DO UPDATE SET
   current_revision_ref = EXCLUDED.current_revision_ref,
   last_audit_event_ref = EXCLUDED.last_audit_event_ref,
   projection_updated_at = NOW();
-        `,
-        [
-          JSON.stringify(
-            dedupedRows.map((row) => ({
-              id: row.id,
-              instance_id: row.instanceId,
-              organization_id: row.organizationId ?? null,
-              owner_subject_id:
-                row.ownerSubjectId ?? (row.organizationId ? null : keycloakSubject),
-              content_type: row.contentType,
-              title: row.title,
-              published_at: row.publishedAt ?? null,
-              publish_from: row.publishFrom ?? null,
-              publish_until: row.publishUntil ?? null,
-              created_at: row.createdAt,
-              created_by: row.createdBy,
-              updated_at: row.updatedAt,
-              updated_by: row.updatedBy,
-              author_display_name: row.author,
-              payload_json: row.payload,
-              status: row.status,
-              validation_state: row.validationState,
-              history_ref: row.historyRef,
-              current_revision_ref: row.currentRevisionRef ?? '',
-              last_audit_event_ref: row.lastAuditEventRef ?? '',
-              source_entity_type: row.sourceEntityType,
-              source_entity_id: row.sourceEntityId,
-            }))
-          ),
-        ]
-      );
-    }
+    `,
+    [payloadJson]
+  );
+};
 
-    await client.query(
-      `
+const markMainserverProjectionSyncSucceeded = async (
+  client: ProjectionDbClient,
+  instanceId: string,
+  contentType: string,
+  projectedCount: number
+): Promise<void> => {
+  await client.query(
+    `
 INSERT INTO iam.content_list_projection_sync_state (
   instance_id,
   source_system,
@@ -547,8 +561,39 @@ DO UPDATE SET
   last_error_message = NULL,
   projected_count = EXCLUDED.projected_count,
   updated_at = NOW();
-      `,
-      [instanceId, contentType, dedupedRows.length]
+    `,
+    [instanceId, contentType, projectedCount]
+  );
+};
+
+const replaceMainserverProjectionRows = async (
+  instanceId: string,
+  contentType: string,
+  keycloakSubject: string,
+  organizationId: string | undefined,
+  rows: readonly MainserverProjectionRowInput[]
+): Promise<void> => {
+  const dedupedRows = dedupeProjectionRows(rows, keycloakSubject);
+  const projectionPayloadJson = buildMainserverProjectionPayloadJson(dedupedRows, keycloakSubject);
+
+  await withInstanceScopedDb(instanceId, async (client) => {
+    await deleteMainserverProjectionRows(
+      client,
+      instanceId,
+      contentType,
+      organizationId,
+      keycloakSubject
+    );
+
+    if (dedupedRows.length > 0) {
+      await upsertMainserverProjectionRows(client, projectionPayloadJson);
+    }
+
+    await markMainserverProjectionSyncSucceeded(
+      client,
+      instanceId,
+      contentType,
+      dedupedRows.length
     );
   });
 };


### PR DESCRIPTION
## Ziel

Behebt den Fehler im Mainserver-Projection-Refresh, bei dem konkurrierende Refreshes auf `iam.content_list_projection` mit `content_list_projection_scope_key` kollidieren und die Inhaltsliste im Admin ausfallen lassen.

## Anforderung / Kontext

- Beobachtet in `de-studio-sandbox` und `bb-guben` nach Deploys und auch im stabil laufenden neuen Container.
- Die Logs zeigten `duplicate key value violates unique constraint "content_list_projection_scope_key"` im Mainserver-Projektionspfad.
- Ursache war nicht nur doppelte Payload innerhalb eines Batches, sondern vor allem `DELETE` + plain `INSERT` ohne DB-seitige Konfliktbehandlung.

## Umfang

- [ ] Feature
- [x] Bugfix
- [ ] Refactoring
- [ ] Dokumentation
- [ ] Architektur-/Systemänderung
- [x] Betriebs-/Deployment-Änderung

## Änderungen

- Dedupliziert Mainserver-Projektionszeilen vor dem Persistieren anhand des fachlichen Scopes.
- Stellt den Mainserver-Insert auf `ON CONFLICT ON CONSTRAINT content_list_projection_scope_key DO UPDATE` um.
- Ergänzt einen Regressionstest für den Race-Fall, in dem ein konkurrierender Write denselben Scope zwischen `DELETE` und `INSERT` erneut anlegt.
- Ergänzt `.worktrees` in `.dockerignore`, damit lokale Git-Worktrees nicht in Docker-Kontexte geraten.

## Betroffene Projekte / Packages

- `apps/sva-studio-react`
- Root-Konfiguration: `.dockerignore`

## Test & Verifikation

Ausgeführt:

- [ ] `pnpm test:unit`
- [ ] `pnpm test:types`
- [ ] `pnpm test:eslint`
- [ ] `pnpm test:e2e`
- [ ] `pnpm test:pr`

Zusätzlich ausgeführt:

- [x] `cd apps/sva-studio-react && pnpm exec vitest run src/lib/iam-content-list-projection.server.test.ts --config vitest.server.config.ts`
- [x] `pnpm nx run sva-studio-react:test:unit --testFiles=apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts`

Nicht ausgeführt / Abweichungen:

- Statt der Vollsuite lief der kleinste relevante Gate-Pfad für den betroffenen Server-Projektionspfad.

## Risiken & Rollback

- Risiko: Niedrig bis mittel im Mainserver-Refresh-Pfad, weil Konflikte jetzt als Upsert behandelt werden statt als Abbruch.
- Bekannte Restunsicherheit: Der Triggerpfad feuert offenbar weiterhin häufig; dieser PR macht den Persistenzpfad robust, reduziert aber nicht die Anzahl der Refresh-Anstöße.
- Rollback: PR revertieren; keine Migrationen oder persistente Schemaänderungen.

## Risikoklasse

- [ ] hoch
- [x] mittel
- [ ] normal

## Dokumentation

- [x] Keine Doku-Anpassung erforderlich
- [ ] Produkt-/Entwicklerdoku aktualisiert:
- [ ] Architektur-Doku aktualisiert:

## Architektur & OpenAPI

- [x] Keine Architekturänderung
- [ ] Relevante arc42-Abschnitte unter `docs/architecture/` wurden aktualisiert
- [ ] API-/Vertragsänderungen dokumentiert
- [ ] Breaking Change vorhanden

Details:

- Keine API- oder Architekturänderung.

## Checkliste

- [x] Ziel, Kontext und betroffene Projekte/Packages sind im PR klar beschrieben
- [x] Keine hardcodierten UI-Texte eingeführt; user-facing Texte laufen über das Übersetzungssystem
- [x] Logging im Server-Code nutzt keine `console.*`-Statements
- [x] Input-Validierung und PII-Schutz berücksichtigt
- [x] UI-/Styling-Änderungen folgen Design-System / `shadcn/ui`
- [x] Accessibility-Auswirkungen geprüft
- [x] Testdaten, Fixtures, Seeds und Snapshots enthalten keine echten personenbezogenen Daten
- [x] Tests wurden ergänzt oder angepasst, falls Verhalten geändert wurde
- [x] `pnpm check:file-placement` ist berücksichtigt

## Review-Hinweise

- Bitte speziell auf den Mainserver-Upsert entlang von `content_list_projection_scope_key` schauen.
- Der PR behebt bewusst die Persistenz-Race-Condition; eine spätere Folgearbeit kann den Refresh-Triggerpfad selbst noch drosseln oder serialisieren.
