### PR TITLE
Prepare Traefik v3 compose labels

### DIFF
--- a/deploy/portainer/docker-compose.public-waste.yml
+++ b/deploy/portainer/docker-compose.public-waste.yml
@@ -9,6 +9,7 @@ services:
       PUBLIC_WASTE_INSTANCE_ID: '${PUBLIC_WASTE_INSTANCE_ID}'
       PUBLIC_WASTE_DATABASE_URL: '${PUBLIC_WASTE_DATABASE_URL}'
       PUBLIC_WASTE_SCHEMA_NAME: '${PUBLIC_WASTE_SCHEMA_NAME}'
+      PUBLIC_WASTE_PDF_URL_TEMPLATE: '${PUBLIC_WASTE_PDF_URL_TEMPLATE}'
     labels:
       com.sva-studio.component: 'public-waste-app'
       com.sva-studio.environment: 'production'
@@ -22,10 +23,13 @@ services:
       update_config:
         parallelism: 1
         delay: 10s
-        order: stop-first
+        order: start-first
+        failure_action: rollback
+        monitor: 45s
       rollback_config:
         parallelism: 1
         order: stop-first
+        monitor: 45s
       restart_policy:
         condition: any
         delay: 5s
@@ -38,12 +42,20 @@ services:
           memory: 384M
           cpus: '0.50'
       labels:
-        - traefik.enable=true
-        - traefik.docker.network=public
-        - traefik.public-waste.frontend.rule=Host:${PUBLIC_WASTE_PUBLIC_HOST}
-        - traefik.public-waste.frontend.priority=220
-        - traefik.public-waste.frontend.passHostHeader=true
-        - traefik.public-waste.port=3002
+        - "traefik.enable=true"
+        - "traefik.docker.network=public"
+
+        #Traefik v1
+        - "traefik.public-waste.frontend.rule=Host:${PUBLIC_WASTE_PUBLIC_HOST}"
+        - "traefik.public-waste.frontend.priority=220"
+        - "traefik.public-waste.frontend.passHostHeader=true"
+        - "traefik.public-waste.port=3002"
+
+        #Traefik v3
+        - "traefik.http.routers.public-waste.rule=Host(`${PUBLIC_WASTE_PUBLIC_HOST}`)"
+        - "traefik.http.routers.public-waste.tls=true"
+        - "traefik.http.services.public-waste.loadbalancer.server.port=3002"
+
     healthcheck:
       test:
         - CMD-SHELL

--- a/deploy/portainer/docker-compose.public-waste.yml
+++ b/deploy/portainer/docker-compose.public-waste.yml
@@ -46,10 +46,10 @@ services:
         - "traefik.docker.network=public"
 
         #Traefik v1
-        - "traefik.public-waste.frontend.rule=Host:${PUBLIC_WASTE_PUBLIC_HOST}"
-        - "traefik.public-waste.frontend.priority=220"
-        - "traefik.public-waste.frontend.passHostHeader=true"
-        - "traefik.public-waste.port=3002"
+        - "traefik.frontend.rule=Host:${PUBLIC_WASTE_PUBLIC_HOST}"
+        - "traefik.frontend.priority=220"
+        - "traefik.frontend.passHostHeader=true"
+        - "traefik.port=3002"
 
         #Traefik v3
         - "traefik.http.routers.public-waste.rule=Host(`${PUBLIC_WASTE_PUBLIC_HOST}`)"

--- a/deploy/portainer/docker-compose.studio.yml
+++ b/deploy/portainer/docker-compose.studio.yml
@@ -84,36 +84,18 @@ services:
           memory: 512M
           cpus: '1.0'
       labels:
-        - traefik.enable=true
-        - traefik.docker.network=public
-        - traefik.main.frontend.rule=Host:${SVA_PUBLIC_HOST},${SVA_PARENT_DOMAIN}
-        - traefik.main.frontend.priority=200
-        - traefik.main.frontend.passHostHeader=true
-        - traefik.main.port=3000
-        - traefik.bb-guben.frontend.rule=Host:bb-guben.${SVA_PARENT_DOMAIN}
-        - traefik.bb-guben.frontend.priority=210
-        - traefik.bb-guben.frontend.passHostHeader=true
-        - traefik.bb-guben.port=3000
-        - traefik.de-musterhausen.frontend.rule=Host:de-musterhausen.${SVA_PARENT_DOMAIN}
-        - traefik.de-musterhausen.frontend.priority=210
-        - traefik.de-musterhausen.frontend.passHostHeader=true
-        - traefik.de-musterhausen.port=3000
-        - traefik.bb-bad-belzig.frontend.rule=Host:bb-bad-belzig.${SVA_PARENT_DOMAIN}
-        - traefik.bb-bad-belzig.frontend.priority=210
-        - traefik.bb-bad-belzig.frontend.passHostHeader=true
-        - traefik.bb-bad-belzig.port=3000
-        - traefik.de-studio-sandbox.frontend.rule=Host:de-studio-sandbox.${SVA_PARENT_DOMAIN}
-        - traefik.de-studio-sandbox.frontend.priority=210
-        - traefik.de-studio-sandbox.frontend.passHostHeader=true
-        - traefik.de-studio-sandbox.port=3000
-        - traefik.hb-meinquartier.frontend.rule=Host:hb-meinquartier.${SVA_PARENT_DOMAIN}
-        - traefik.hb-meinquartier.frontend.priority=210
-        - traefik.hb-meinquartier.frontend.passHostHeader=true
-        - traefik.hb-meinquartier.port=3000
-        - traefik.instance.frontend.rule=HostRegexp:{subdomain:[a-z0-9-]+}.${SVA_PARENT_DOMAIN}
-        - traefik.instance.frontend.priority=200
-        - traefik.instance.frontend.passHostHeader=true
-        - traefik.instance.port=3000
+        traefik.docker.network: "public"
+        traefik.enable: "true"
+        traefik.frontend.passHostHeader: "true"
+        traefik.frontend.rule: "Host:studio.smart-village.app,bb-bad-belzig.studio.smart-village.app,bb-guben.studio.smart-village.app,de-musterhausen.studio.smart-village.app,de-studio-sandbox.studio.smart-village.app,hb-meinquartier.studio.smart-village.app"
+        traefik.port: "3000"
+
+        # v3
+        traefik.http.routers.studio-app.rule: "Host(`studio.smart-village.app`) || Host(`bb-bad-belzig.studio.smart-village.app`) || Host(`bb-guben.studio.smart-village.app`) || Host(`de-musterhausen.studio.smart-village.app`) || Host(`de-studio-sandbox.studio.smart-village.app`) || Host(`hb-meinquartier.studio.smart-village.app`)"
+        traefik.http.routers.studio-app.tls: "true"
+        traefik.http.services.studio-app.loadbalancer.server.port: "3000"
+
+
     healthcheck:
       test:
         - CMD-SHELL


### PR DESCRIPTION
## Summary
- add Traefik v3 router/service labels alongside existing v1 labels for Portainer stacks
- keep public-waste v1 routing while adding v3 routing and rollout rollback monitors
- update studio ingress labels for the current explicit host set

## Test Plan
- [x] docker compose -f deploy/portainer/docker-compose.public-waste.yml config --quiet
- [x] docker compose -f deploy/portainer/docker-compose.studio.yml config --quiet
- [x] pnpm check:file-placement
- [x] NX_SKIP_NX_CACHE=true pnpm nx run tooling-testing:test:unit

## Notes
- The current studio host list is intentionally explicit for the transition window.