### PR TITLE
Fix studio app network placement

### DIFF
--- a/deploy/portainer/docker-compose.studio.yml
+++ b/deploy/portainer/docker-compose.studio.yml
@@ -58,7 +58,7 @@ services:
       com.sva-studio.component: 'app'
       com.sva-studio.environment: 'production'
     networks:
-      - public
+      - network-node-005
       - internal
     deploy:
       replicas: 1
@@ -318,6 +318,8 @@ services:
 
 networks:
   public:
+    external: true
+  network-node-005:
     external: true
   internal:
     driver: overlay


### PR DESCRIPTION
## Summary
- route the `studio_app` service through the existing `network-node-005` external overlay network
- declare `network-node-005` in the Studio compose file while leaving the internal network unchanged

## Context
During the Studio rollout recovery, `studio_app` stayed unscheduled while attached to the previous external network. Switching the app service to the node-specific external network restored scheduling and external health.

## Test Plan
- [x] `docker compose -f deploy/portainer/docker-compose.studio.yml config --quiet` with Studio runtime placeholders
- [ ] Local unit/type/e2e tests skipped at operator request
