### PR TITLE
fix: scope instance registry mutations to tenant context

### DIFF
--- a/packages/auth-runtime/src/iam-instance-registry/core-mutations.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/core-mutations.test.ts
@@ -26,6 +26,7 @@ const state = vi.hoisted(() => {
     requireFreshReauth: vi.fn(),
     parseRegistryRequestBody: vi.fn(),
     withRegistryService: vi.fn(),
+    withScopedRegistryService: vi.fn(),
   };
 });
 
@@ -63,6 +64,7 @@ vi.mock('./request-parsing.js', () => ({
 
 vi.mock('./repository.js', () => ({
   withRegistryService: state.withRegistryService,
+  withScopedRegistryService: state.withScopedRegistryService,
 }));
 
 describe('iam-instance-registry core mutations', () => {
@@ -84,6 +86,7 @@ describe('iam-instance-registry core mutations', () => {
     expect(config.validateCsrf).toBe(state.validateCsrf);
     expect(config.requireFreshReauth).toBe(state.requireFreshReauth);
     expect(config.withRegistryService).toBe(state.withRegistryService);
+    expect(config.withScopedRegistryService).toBe(state.withScopedRegistryService);
     expect(subject.mapInstanceMutationError).toBe('mapped-error');
     expect(state.createInstanceMutationErrorMapper).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/auth-runtime/src/iam-instance-registry/core-mutations.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/core-mutations.ts
@@ -13,7 +13,7 @@ import {
   requireFreshReauth,
 } from './http.js';
 import { parseRegistryRequestBody } from './request-parsing.js';
-import { withRegistryService } from './repository.js';
+import { withRegistryService, withScopedRegistryService } from './repository.js';
 
 const getRequestId = (): string | undefined => getWorkspaceContext().requestId;
 
@@ -30,6 +30,7 @@ const mutationHandlers = createInstanceRegistryMutationHttpHandlers<Authenticate
   validateCsrf,
   requireFreshReauth,
   withRegistryService,
+  withScopedRegistryService,
 });
 
 export const mapInstanceMutationError = createInstanceMutationErrorMapper({

--- a/packages/auth-runtime/src/iam-instance-registry/repository.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/repository.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 const createInstanceRegistryRuntimeMock = vi.fn(() => ({
   withRegistryRepository: vi.fn(),
+  withScopedRegistryRepository: vi.fn(),
   withRegistryService: vi.fn(),
+  withScopedRegistryService: vi.fn(),
   withRegistryProvisioningWorkerService: vi.fn(),
   withRegistryProvisioningWorkerDeps: vi.fn(),
 }));

--- a/packages/auth-runtime/src/iam-instance-registry/repository.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/repository.ts
@@ -205,7 +205,9 @@ const registryRuntime = createInstanceRegistryRuntime({
 
 export const {
   withRegistryRepository,
+  withScopedRegistryRepository,
   withRegistryService,
+  withScopedRegistryService,
   withRegistryProvisioningWorkerService,
   withRegistryProvisioningWorkerDeps,
 } = registryRuntime;

--- a/packages/instance-registry/src/http-mutation-actions.ts
+++ b/packages/instance-registry/src/http-mutation-actions.ts
@@ -8,6 +8,7 @@ import {
   readInstanceIdOrError,
   requireIdempotencyKeyOrError,
   requireMutationGuards,
+  withScopedRegistryMutation,
 } from './http-mutation-shared.js';
 import {
   buildExecuteInstanceKeycloakProvisioningInput,
@@ -42,7 +43,7 @@ export const createReconcileInstanceKeycloakHandler =
     }
 
     try {
-      const status = await deps.withRegistryService((service) =>
+      const status = await withScopedRegistryMutation(deps, instanceId, (service) =>
         service.reconcileKeycloak(buildReconcileInstanceKeycloakInput(instanceId, payloadResult.data, {
           idempotencyKey,
           actorId: deps.getActor(ctx).id,
@@ -85,7 +86,7 @@ export const createExecuteInstanceKeycloakProvisioningHandler =
     }
 
     try {
-      const run = await deps.withRegistryService((service) =>
+      const run = await withScopedRegistryMutation(deps, instanceId, (service) =>
         service.executeKeycloakProvisioning(buildExecuteInstanceKeycloakProvisioningInput(instanceId, payloadResult.data, {
           idempotencyKey,
           actorId: deps.getActor(ctx).id,
@@ -125,7 +126,7 @@ export const createProbeTenantIamAccessHandler =
     }
 
     try {
-      const status = await deps.withRegistryService((service) =>
+      const status = await withScopedRegistryMutation(deps, instanceId, (service) =>
         service.probeTenantIamAccess(
           buildProbeTenantIamAccessInput(instanceId, {
             idempotencyKey,

--- a/packages/instance-registry/src/http-mutation-handlers.test.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.test.ts
@@ -37,6 +37,23 @@ const createDeps = (): InstanceRegistryMutationHttpDeps<TestContext> => ({
   ensurePlatformAccess: vi.fn(() => null),
   validateCsrf: vi.fn(() => null),
   requireFreshReauth: vi.fn(() => null),
+  withScopedRegistryService: vi.fn(async (_instanceId, work) =>
+    work({
+      reconcileKeycloak: vi.fn(async () => ({ realmExists: true })),
+      executeKeycloakProvisioning: vi.fn(async () => ({ id: 'run-1' })),
+      assignModule: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: ['news'] } })),
+      bootstrapAdminStructure: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: ['news'] } })),
+      revokeModule: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: [] } })),
+      seedIamBaseline: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: ['news'] } })),
+      probeTenantIamAccess: vi.fn(async () => ({
+        access: { status: 'ready', summary: 'ok', source: 'access_probe' },
+        overall: { status: 'unknown', summary: 'unknown', source: 'registry' },
+        configuration: { status: 'unknown', summary: 'unknown', source: 'registry' },
+        reconcile: { status: 'unknown', summary: 'unknown', source: 'role_reconcile' },
+      })),
+      changeStatus: vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', status: 'active' } })),
+    } as never)
+  ),
   withRegistryService: vi.fn(async (work) =>
     work({
       reconcileKeycloak: vi.fn(async () => ({ realmExists: true })),
@@ -90,7 +107,7 @@ describe('http mutation handlers', () => {
   });
 
   it('reconcileInstanceKeycloak returns not_found when the service has no instance', async () => {
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({ reconcileKeycloak: vi.fn(async () => null) } as never)
     );
     const handlers = createInstanceRegistryMutationHttpHandlers(deps);
@@ -109,9 +126,9 @@ describe('http mutation handlers', () => {
     const reconcileKeycloak = vi.fn(async () => ({ realmExists: true }));
     const executeKeycloakProvisioning = vi.fn(async () => ({ id: 'run-1' }));
     vi.mocked(deps.requireIdempotencyKey).mockReturnValue({ key: 'idem-keycloak-1' });
-    vi.mocked(deps.withRegistryService)
-      .mockImplementationOnce(async (work) => work({ reconcileKeycloak } as never))
-      .mockImplementationOnce(async (work) => work({ executeKeycloakProvisioning } as never));
+    vi.mocked(deps.withScopedRegistryService)
+      .mockImplementationOnce(async (_instanceId, work) => work({ reconcileKeycloak } as never))
+      .mockImplementationOnce(async (_instanceId, work) => work({ executeKeycloakProvisioning } as never));
     const handlers = createInstanceRegistryMutationHttpHandlers(deps);
 
     await handlers.reconcileInstanceKeycloak(
@@ -130,7 +147,7 @@ describe('http mutation handlers', () => {
   });
 
   it('executeInstanceKeycloakProvisioning maps thrown registry errors', async () => {
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async () => {
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async () => {
       throw new Error('tenant_admin_client_secret_missing');
     });
     const handlers = createInstanceRegistryMutationHttpHandlers(deps);
@@ -152,7 +169,7 @@ describe('http mutation handlers', () => {
       configuration: { status: 'ready', summary: 'ok', source: 'registry' },
       reconcile: { status: 'unknown', summary: 'unknown', source: 'role_reconcile' },
     }));
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({
         probeTenantIamAccess,
       } as never)
@@ -182,8 +199,8 @@ describe('http mutation handlers', () => {
 
   it('probeTenantIamAccess maps not_found and thrown registry errors', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValue({ ok: true, data: {} });
-    vi.mocked(deps.withRegistryService)
-      .mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService)
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           probeTenantIamAccess: vi.fn(async () => null),
         } as never)
@@ -259,7 +276,7 @@ describe('http mutation handlers', () => {
 
   it('assignModule returns invalid_request for unknown modules', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleId: 'unknown' } });
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({
         assignModule: vi.fn(async () => ({ ok: false, reason: 'unknown_module' })),
       } as never)
@@ -278,13 +295,13 @@ describe('http mutation handlers', () => {
 
   it('assignModule maps not_found and conflict results', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValue({ ok: true, data: { moduleId: 'news' } });
-    vi.mocked(deps.withRegistryService)
-      .mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService)
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           assignModule: vi.fn(async () => ({ ok: false, reason: 'not_found' })),
         } as never)
       )
-      .mockImplementationOnce(async (work) =>
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           assignModule: vi.fn(async () => ({ ok: false, reason: 'conflict' })),
         } as never)
@@ -320,13 +337,31 @@ describe('http mutation handlers', () => {
     expect(deps.requireFreshReauth).not.toHaveBeenCalled();
   });
 
+  it('assignModule uses the scoped registry service and maps thrown database errors', async () => {
+    vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleId: 'news' } });
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, _work) => {
+      throw new Error('new row violates row-level security policy for table "permissions"');
+    });
+    const handlers = createInstanceRegistryMutationHttpHandlers(deps);
+
+    const response = await handlers.assignModule(
+      new Request('http://localhost/api/instances/inst-1/modules/assign', { method: 'POST' }),
+      { userId: 'u-1' }
+    );
+    const body = await readBody(response);
+
+    expect(deps.withScopedRegistryService).toHaveBeenCalledWith('inst-1', expect.any(Function));
+    expect(response.status).toBe(503);
+    expect(body.code).toBe('database_unavailable');
+  });
+
   it('revokeModule returns the refreshed instance detail on success', async () => {
     const revokeModule = vi.fn(async () => ({ ok: true, instance: { instanceId: 'inst-1', assignedModules: [] } }));
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({
       ok: true,
       data: { moduleId: 'news', confirmation: 'REVOKE' },
     });
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({
         revokeModule,
       } as never)
@@ -355,18 +390,18 @@ describe('http mutation handlers', () => {
 
   it('revokeModule maps not_found, unknown_module and conflict results', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValue({ ok: true, data: { moduleId: 'news', confirmation: 'REVOKE' } });
-    vi.mocked(deps.withRegistryService)
-      .mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService)
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           revokeModule: vi.fn(async () => ({ ok: false, reason: 'not_found' })),
         } as never)
       )
-      .mockImplementationOnce(async (work) =>
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           revokeModule: vi.fn(async () => ({ ok: false, reason: 'unknown_module' })),
         } as never)
       )
-      .mockImplementationOnce(async (work) =>
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           revokeModule: vi.fn(async () => ({ ok: false, reason: 'conflict' })),
         } as never)
@@ -417,7 +452,7 @@ describe('http mutation handlers', () => {
       instance: { instanceId: 'inst-1', assignedModules: ['news'] },
     }));
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleIds: ['news'] } });
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({
         bootstrapAdminStructure,
       } as never)
@@ -445,7 +480,7 @@ describe('http mutation handlers', () => {
 
   it('seedIamBaseline requires an existing instance', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: {} });
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({
         seedIamBaseline: vi.fn(async () => ({ ok: false, reason: 'not_found' })),
       } as never)
@@ -478,7 +513,7 @@ describe('http mutation handlers', () => {
 
   it('bootstrapAdminStructure returns invalid_request for unknown modules', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { moduleIds: ['unknown'] } });
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({
         bootstrapAdminStructure: vi.fn(async () => ({ ok: false, reason: 'unknown_module' })),
       } as never)
@@ -497,13 +532,13 @@ describe('http mutation handlers', () => {
 
   it('bootstrapAdminStructure maps not_found and conflict results', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValue({ ok: true, data: { moduleIds: ['news'] } });
-    vi.mocked(deps.withRegistryService)
-      .mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService)
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           bootstrapAdminStructure: vi.fn(async () => ({ ok: false, reason: 'not_found' })),
         } as never)
       )
-      .mockImplementationOnce(async (work) =>
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           bootstrapAdminStructure: vi.fn(async () => ({ ok: false, reason: 'conflict' })),
         } as never)
@@ -577,7 +612,7 @@ describe('http mutation handlers', () => {
 
   it('mutateInstanceStatus returns the changed instance on success', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValueOnce({ ok: true, data: { status: 'suspended' } });
-    vi.mocked(deps.withRegistryService).mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService).mockImplementationOnce(async (_instanceId, work) =>
       work({
         changeStatus: vi.fn(async () => ({
           ok: true,
@@ -600,13 +635,13 @@ describe('http mutation handlers', () => {
 
   it('mutateInstanceStatus maps not_found and conflict service responses', async () => {
     vi.mocked(deps.parseRequestBody).mockResolvedValue({ ok: true, data: { status: 'active' } });
-    vi.mocked(deps.withRegistryService)
-      .mockImplementationOnce(async (work) =>
+    vi.mocked(deps.withScopedRegistryService)
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           changeStatus: vi.fn(async () => ({ ok: false, reason: 'not_found' })),
         } as never)
       )
-      .mockImplementationOnce(async (work) =>
+      .mockImplementationOnce(async (_instanceId, work) =>
         work({
           changeStatus: vi.fn(async () => ({ ok: false, reason: 'conflict' })),
         } as never)

--- a/packages/instance-registry/src/http-mutation-handlers.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.ts
@@ -24,16 +24,16 @@ export const createInstanceRegistryMutationHttpHandlers = <TContext>(
   deps: InstanceRegistryMutationHttpDeps<TContext>
 ) => {
   const mapMutationError = createInstanceMutationErrorMapper(deps);
-  const mutateInstanceStatus = createMutateInstanceStatusHandler(deps);
+  const mutateInstanceStatus = createMutateInstanceStatusHandler(deps, mapMutationError);
 
   return {
     reconcileInstanceKeycloak: createReconcileInstanceKeycloakHandler(deps, mapMutationError),
     executeInstanceKeycloakProvisioning: createExecuteInstanceKeycloakProvisioningHandler(deps, mapMutationError),
     probeTenantIamAccess: createProbeTenantIamAccessHandler(deps, mapMutationError),
-    assignModule: createAssignModuleHandler(deps),
-    bootstrapAdminStructure: createBootstrapAdminStructureHandler(deps),
-    revokeModule: createRevokeModuleHandler(deps),
-    seedIamBaseline: createSeedIamBaselineHandler(deps),
+    assignModule: createAssignModuleHandler(deps, mapMutationError),
+    bootstrapAdminStructure: createBootstrapAdminStructureHandler(deps, mapMutationError),
+    revokeModule: createRevokeModuleHandler(deps, mapMutationError),
+    seedIamBaseline: createSeedIamBaselineHandler(deps, mapMutationError),
     mutateInstanceStatus: (
       request: Request,
       ctx: TContext,

--- a/packages/instance-registry/src/http-mutation-module-actions.ts
+++ b/packages/instance-registry/src/http-mutation-module-actions.ts
@@ -12,6 +12,7 @@ import {
   readInstanceIdOrError,
   requireIdempotencyKeyOrError,
   requireMutationGuards,
+  withScopedRegistryMutation,
 } from './http-mutation-shared.js';
 import {
   buildAssignInstanceModuleInput,
@@ -25,7 +26,10 @@ import {
 } from './mutation-input-builders.js';
 
 export const createAssignModuleHandler =
-  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>) =>
+  <TContext>(
+    deps: InstanceRegistryMutationHttpDeps<TContext>,
+    mapMutationError: (error: unknown) => Response
+  ) =>
   async (request: Request, ctx: TContext): Promise<Response> => {
     const guardError = requireMutationGuards(deps, request, ctx);
     if (guardError) {
@@ -47,15 +51,20 @@ export const createAssignModuleHandler =
       return deps.createApiError(400, 'invalid_request', payloadResult.message, deps.getRequestId());
     }
 
-    const result = await deps.withRegistryService((service) =>
-      service.assignModule(
-        buildAssignInstanceModuleInput(instanceId, payloadResult.data, {
-          idempotencyKey,
-          actorId: deps.getActor(ctx).id,
-          requestId: deps.getRequestId(),
-        })
-      )
-    );
+    let result;
+    try {
+      result = await withScopedRegistryMutation(deps, instanceId, (service) =>
+        service.assignModule(
+          buildAssignInstanceModuleInput(instanceId, payloadResult.data, {
+            idempotencyKey,
+            actorId: deps.getActor(ctx).id,
+            requestId: deps.getRequestId(),
+          })
+        )
+      );
+    } catch (error) {
+      return mapMutationError(error);
+    }
 
     if (!result.ok) {
       if (result.reason === 'not_found') {
@@ -71,7 +80,10 @@ export const createAssignModuleHandler =
   };
 
 export const createBootstrapAdminStructureHandler =
-  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>) =>
+  <TContext>(
+    deps: InstanceRegistryMutationHttpDeps<TContext>,
+    mapMutationError: (error: unknown) => Response
+  ) =>
   async (request: Request, ctx: TContext): Promise<Response> => {
     const guardError = requireMutationGuards(deps, request, ctx);
     if (guardError) {
@@ -93,15 +105,20 @@ export const createBootstrapAdminStructureHandler =
       return deps.createApiError(400, 'invalid_request', payloadResult.message, deps.getRequestId());
     }
 
-    const result = await deps.withRegistryService((service) =>
-      service.bootstrapAdminStructure(
-        buildBootstrapAdminStructureInput(instanceId, payloadResult.data, {
-          idempotencyKey,
-          actorId: deps.getActor(ctx).id,
-          requestId: deps.getRequestId(),
-        })
-      )
-    );
+    let result;
+    try {
+      result = await withScopedRegistryMutation(deps, instanceId, (service) =>
+        service.bootstrapAdminStructure(
+          buildBootstrapAdminStructureInput(instanceId, payloadResult.data, {
+            idempotencyKey,
+            actorId: deps.getActor(ctx).id,
+            requestId: deps.getRequestId(),
+          })
+        )
+      );
+    } catch (error) {
+      return mapMutationError(error);
+    }
 
     if (!result.ok) {
       if (result.reason === 'not_found') {
@@ -117,7 +134,10 @@ export const createBootstrapAdminStructureHandler =
   };
 
 export const createRevokeModuleHandler =
-  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>) =>
+  <TContext>(
+    deps: InstanceRegistryMutationHttpDeps<TContext>,
+    mapMutationError: (error: unknown) => Response
+  ) =>
   async (request: Request, ctx: TContext): Promise<Response> => {
     const guardError = requireMutationGuards(deps, request, ctx);
     if (guardError) {
@@ -139,15 +159,20 @@ export const createRevokeModuleHandler =
       return deps.createApiError(400, 'invalid_request', payloadResult.message, deps.getRequestId());
     }
 
-    const result = await deps.withRegistryService((service) =>
-      service.revokeModule(
-        buildRevokeInstanceModuleInput(instanceId, payloadResult.data, {
-          idempotencyKey,
-          actorId: deps.getActor(ctx).id,
-          requestId: deps.getRequestId(),
-        })
-      )
-    );
+    let result;
+    try {
+      result = await withScopedRegistryMutation(deps, instanceId, (service) =>
+        service.revokeModule(
+          buildRevokeInstanceModuleInput(instanceId, payloadResult.data, {
+            idempotencyKey,
+            actorId: deps.getActor(ctx).id,
+            requestId: deps.getRequestId(),
+          })
+        )
+      );
+    } catch (error) {
+      return mapMutationError(error);
+    }
 
     if (!result.ok) {
       if (result.reason === 'not_found') {
@@ -163,7 +188,10 @@ export const createRevokeModuleHandler =
   };
 
 export const createSeedIamBaselineHandler =
-  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>) =>
+  <TContext>(
+    deps: InstanceRegistryMutationHttpDeps<TContext>,
+    mapMutationError: (error: unknown) => Response
+  ) =>
   async (request: Request, ctx: TContext): Promise<Response> => {
     const guardError = requireMutationGuards(deps, request, ctx);
     if (guardError) {
@@ -185,15 +213,20 @@ export const createSeedIamBaselineHandler =
       return deps.createApiError(400, 'invalid_request', payloadResult.message, deps.getRequestId());
     }
 
-    const result = await deps.withRegistryService((service) =>
-      service.seedIamBaseline(
-        buildSeedInstanceIamBaselineInput(instanceId, {
-          idempotencyKey,
-          actorId: deps.getActor(ctx).id,
-          requestId: deps.getRequestId(),
-        })
-      )
-    );
+    let result;
+    try {
+      result = await withScopedRegistryMutation(deps, instanceId, (service) =>
+        service.seedIamBaseline(
+          buildSeedInstanceIamBaselineInput(instanceId, {
+            idempotencyKey,
+            actorId: deps.getActor(ctx).id,
+            requestId: deps.getRequestId(),
+          })
+        )
+      );
+    } catch (error) {
+      return mapMutationError(error);
+    }
 
     if (!result.ok) {
       return deps.createApiError(404, 'not_found', 'Instanz wurde nicht gefunden.', deps.getRequestId());
@@ -203,7 +236,10 @@ export const createSeedIamBaselineHandler =
   };
 
 export const createMutateInstanceStatusHandler =
-  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>) =>
+  <TContext>(
+    deps: InstanceRegistryMutationHttpDeps<TContext>,
+    mapMutationError: (error: unknown) => Response
+  ) =>
   async (
     request: Request,
     ctx: TContext,
@@ -235,13 +271,18 @@ export const createMutateInstanceStatusHandler =
       return instanceId;
     }
 
-    const result = await deps.withRegistryService((service) =>
-      service.changeStatus(buildChangeInstanceStatusInput(instanceId, nextStatus, {
-        idempotencyKey,
-        actorId: deps.getActor(ctx).id,
-        requestId: deps.getRequestId(),
-      }))
-    );
+    let result;
+    try {
+      result = await withScopedRegistryMutation(deps, instanceId, (service) =>
+        service.changeStatus(buildChangeInstanceStatusInput(instanceId, nextStatus, {
+          idempotencyKey,
+          actorId: deps.getActor(ctx).id,
+          requestId: deps.getRequestId(),
+        }))
+      );
+    } catch (error) {
+      return mapMutationError(error);
+    }
 
     if (!result.ok) {
       if (result.reason === 'not_found') {

--- a/packages/instance-registry/src/http-mutation-shared.ts
+++ b/packages/instance-registry/src/http-mutation-shared.ts
@@ -39,6 +39,10 @@ export type InstanceRegistryMutationHttpDeps<TContext> = {
   readonly validateCsrf: (request: Request, requestId?: string) => Response | null;
   readonly requireFreshReauth: (request: Request, ctx: TContext) => Response | null;
   readonly withRegistryService: <T>(work: (service: InstanceRegistryService) => Promise<T>) => Promise<T>;
+  readonly withScopedRegistryService: <T>(
+    instanceId: string,
+    work: (service: InstanceRegistryService) => Promise<T>
+  ) => Promise<T>;
 };
 
 const mutationErrorMessages: Record<InstanceMutationErrorCode, string> = {
@@ -50,6 +54,8 @@ const mutationErrorMessages: Record<InstanceMutationErrorCode, string> = {
     'Für diese Instanz ist noch kein Tenant-Client-Secret hinterlegt.',
   idempotency_key_reuse:
     'Idempotency-Key wurde bereits mit anderem Payload verwendet.',
+  database_unavailable:
+    'Die Instanzverwaltung konnte wegen eines Datenbank- oder Schemafehlers nicht abgeschlossen werden.',
   encryption_not_configured:
     'Die Feldverschlüsselung für Tenant-Secrets ist nicht konfiguriert.',
   keycloak_unavailable:
@@ -68,6 +74,12 @@ export const createInstanceMutationErrorMapper = (
     classification.details
   );
 };
+
+export const withScopedRegistryMutation = <TContext, TResult>(
+  deps: InstanceRegistryMutationHttpDeps<TContext>,
+  instanceId: string,
+  work: (service: InstanceRegistryService) => Promise<TResult>
+): Promise<TResult> => deps.withScopedRegistryService(instanceId, work);
 
 export const requireMutationGuards = <TContext>(
   deps: InstanceRegistryMutationHttpDeps<TContext>,

--- a/packages/instance-registry/src/mutation-errors.test.ts
+++ b/packages/instance-registry/src/mutation-errors.test.ts
@@ -46,6 +46,17 @@ describe('mutation-errors', () => {
     });
   });
 
+  it('classifies tenant RLS and schema write failures as database failures', () => {
+    expect(
+      classifyInstanceMutationError(
+        new Error('new row violates row-level security policy for table "permissions"')
+      )
+    ).toEqual({
+      status: 503,
+      code: 'database_unavailable',
+    });
+  });
+
   it('classifies unknown failures as keycloak dependency failures', () => {
     expect(classifyInstanceMutationError(new Error('boom'))).toEqual({
       status: 502,

--- a/packages/instance-registry/src/mutation-errors.ts
+++ b/packages/instance-registry/src/mutation-errors.ts
@@ -6,6 +6,7 @@ export type BlockedDriftErrorCode =
 export type InstanceMutationErrorCode =
   | BlockedDriftErrorCode
   | 'idempotency_key_reuse'
+  | 'database_unavailable'
   | 'encryption_not_configured'
   | 'keycloak_unavailable';
 
@@ -78,6 +79,18 @@ export const classifyInstanceMutationError = (error: unknown): InstanceMutationE
     return {
       status: 503,
       code: 'encryption_not_configured',
+    };
+  }
+  if (
+    message.includes('row-level security policy') ||
+    message.includes('does not exist') ||
+    message.includes('relation "') ||
+    message.includes('undefined_table') ||
+    message.includes('database_unavailable')
+  ) {
+    return {
+      status: 503,
+      code: 'database_unavailable',
     };
   }
   return {

--- a/packages/instance-registry/src/runtime-wiring.test.ts
+++ b/packages/instance-registry/src/runtime-wiring.test.ts
@@ -65,4 +65,32 @@ describe('runtime wiring', () => {
     expect(deps.repository).toBe(repository);
     expect(deps.protectSecret?.('secret', 'aad')).toBe('secret');
   });
+
+  it('creates scoped repositories inside an instance transaction boundary', async () => {
+    const client = createClient();
+    const repository = { marker: 'repository' } as unknown as InstanceRegistryRepository;
+    let capturedExecutor: SqlExecutor | undefined;
+    const runtime = createInstanceRegistryRuntime({
+      resolvePool: () => ({ connect: async () => client }),
+      createRepository: (executor) => {
+        capturedExecutor = executor;
+        return repository;
+      },
+      serviceDeps: {
+        invalidateHost: vi.fn(),
+      },
+    });
+
+    const result = await runtime.withScopedRegistryRepository('tenant-a', async (resolvedRepository) => {
+      await capturedExecutor?.execute({ text: 'select 1', values: ['demo'] });
+      return resolvedRepository;
+    });
+
+    expect(result).toBe(repository);
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(client.query).toHaveBeenNthCalledWith(2, 'SELECT set_config($1, $2, true);', ['app.instance_id', 'tenant-a']);
+    expect(client.query).toHaveBeenNthCalledWith(3, 'select 1', ['demo']);
+    expect(client.query).toHaveBeenNthCalledWith(4, 'COMMIT');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/instance-registry/src/runtime-wiring.ts
+++ b/packages/instance-registry/src/runtime-wiring.ts
@@ -33,6 +33,30 @@ const createExecutor = (client: InstanceRegistryQueryClient): SqlExecutor => ({
 });
 
 export const createInstanceRegistryRuntime = (deps: InstanceRegistryRuntimeDeps) => {
+  const withScopedClient = async <T>(
+    instanceId: string,
+    work: (client: InstanceRegistryQueryClient) => Promise<T>
+  ): Promise<T> => {
+    const pool = deps.resolvePool();
+    if (!pool) {
+      throw new Error('IAM database not configured');
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query('SELECT set_config($1, $2, true);', ['app.instance_id', instanceId]);
+      const result = await work(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+
   const withRegistryRepository = async <T>(
     work: (repository: InstanceRegistryRepository) => Promise<T>
   ): Promise<T> => {
@@ -49,6 +73,12 @@ export const createInstanceRegistryRuntime = (deps: InstanceRegistryRuntimeDeps)
     }
   };
 
+  const withScopedRegistryRepository = async <T>(
+    instanceId: string,
+    work: (repository: InstanceRegistryRepository) => Promise<T>
+  ): Promise<T> =>
+    withScopedClient(instanceId, (client) => work(deps.createRepository(createExecutor(client))));
+
   const createService = (
     repository: InstanceRegistryRepository,
     serviceDeps: Omit<InstanceRegistryServiceDeps, 'repository'>
@@ -62,6 +92,12 @@ export const createInstanceRegistryRuntime = (deps: InstanceRegistryRuntimeDeps)
     work: (service: InstanceRegistryService) => Promise<T>
   ): Promise<T> =>
     withRegistryRepository((repository) => work(createService(repository, deps.serviceDeps)));
+
+  const withScopedRegistryService = async <T>(
+    instanceId: string,
+    work: (service: InstanceRegistryService) => Promise<T>
+  ): Promise<T> =>
+    withScopedRegistryRepository(instanceId, (repository) => work(createService(repository, deps.serviceDeps)));
 
   const getProvisioningWorkerServiceDeps = (
     repository: InstanceRegistryRepository
@@ -84,7 +120,9 @@ export const createInstanceRegistryRuntime = (deps: InstanceRegistryRuntimeDeps)
 
   return {
     withRegistryRepository,
+    withScopedRegistryRepository,
     withRegistryService,
+    withScopedRegistryService,
     withRegistryProvisioningWorkerService,
     withRegistryProvisioningWorkerDeps,
   };


### PR DESCRIPTION
## Summary
- scope instance-registry mutation writes to the target tenant via `app.instance_id` before hitting RLS-protected IAM tables
- route instance registry mutation handlers through the scoped service path and map tenant RLS/schema failures to `database_unavailable`
- add regression tests for scoped runtime wiring and mutation error handling in `instance-registry` and `auth-runtime`

## Test Plan
- `pnpm nx run instance-registry:test:unit --testFiles=src/runtime-wiring.test.ts --testFiles=src/mutation-errors.test.ts --testFiles=src/http-mutation-handlers.test.ts`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/iam-instance-registry/core-mutations.test.ts --testFiles=src/iam-instance-registry/repository.test.ts`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run instance-registry:check:runtime`
- `pnpm nx run auth-runtime:check:runtime`
