### PR TITLE
fix: accept studio app node network in rollout checks

### DIFF
--- a/docs/development/studio-db-schema-final.sql
+++ b/docs/development/studio-db-schema-final.sql
@@ -926,6 +926,33 @@ ALTER TABLE ONLY iam.instance_external_interfaces FORCE ROW LEVEL SECURITY;
 
 
 --
+-- Name: instance_waste_data_sources; Type: TABLE; Schema: iam; Owner: -
+--
+
+CREATE TABLE iam.instance_waste_data_sources (
+    instance_id text NOT NULL,
+    provider_key text NOT NULL,
+    project_url text NOT NULL,
+    schema_name text NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    database_url_ciphertext text,
+    service_role_key_ciphertext text,
+    visible_status text DEFAULT 'unknown'::text NOT NULL,
+    last_checked_at timestamp with time zone,
+    last_check_status text,
+    last_check_error_code text,
+    last_check_error_message text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT instance_waste_data_sources_last_check_status_chk CHECK (((last_check_status IS NULL) OR (last_check_status = ANY (ARRAY['succeeded'::text, 'failed'::text])))),
+    CONSTRAINT instance_waste_data_sources_visible_status_chk CHECK ((visible_status = ANY (ARRAY['not_configured'::text, 'unknown'::text, 'ok'::text, 'error'::text, 'disabled'::text])))
+);
+
+
+ALTER TABLE ONLY iam.instance_waste_data_sources FORCE ROW LEVEL SECURITY;
+
+
+--
 -- Name: instance_hostnames; Type: TABLE; Schema: iam; Owner: -
 --
 
@@ -1902,6 +1929,14 @@ ALTER TABLE ONLY iam.instance_memberships
 
 ALTER TABLE ONLY iam.instance_modules
     ADD CONSTRAINT instance_modules_pkey PRIMARY KEY (instance_id, module_id);
+
+
+--
+-- Name: instance_waste_data_sources instance_waste_data_sources_pkey; Type: CONSTRAINT; Schema: iam; Owner: -
+--
+
+ALTER TABLE ONLY iam.instance_waste_data_sources
+    ADD CONSTRAINT instance_waste_data_sources_pkey PRIMARY KEY (instance_id);
 
 
 --
@@ -3383,6 +3418,14 @@ ALTER TABLE ONLY iam.instance_modules
 
 
 --
+-- Name: instance_waste_data_sources instance_waste_data_sources_instance_id_fkey; Type: FK CONSTRAINT; Schema: iam; Owner: -
+--
+
+ALTER TABLE ONLY iam.instance_waste_data_sources
+    ADD CONSTRAINT instance_waste_data_sources_instance_id_fkey FOREIGN KEY (instance_id) REFERENCES iam.instances(id) ON DELETE CASCADE;
+
+
+--
 -- Name: instance_provisioning_runs instance_provisioning_runs_instance_id_fkey; Type: FK CONSTRAINT; Schema: iam; Owner: -
 --
 
@@ -3877,10 +3920,22 @@ CREATE POLICY instance_deletion_rules_isolation_policy ON iam.instance_deletion_
 ALTER TABLE iam.instance_external_interfaces ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: instance_waste_data_sources; Type: ROW SECURITY; Schema: iam; Owner: -
+--
+
+ALTER TABLE iam.instance_waste_data_sources ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: instance_external_interfaces instance_external_interfaces_isolation_policy; Type: POLICY; Schema: iam; Owner: -
 --
 
 CREATE POLICY instance_external_interfaces_isolation_policy ON iam.instance_external_interfaces USING ((instance_id = iam.current_instance_id())) WITH CHECK ((instance_id = iam.current_instance_id()));
+
+--
+-- Name: instance_waste_data_sources instance_waste_data_sources_isolation_policy; Type: POLICY; Schema: iam; Owner: -
+--
+
+CREATE POLICY instance_waste_data_sources_isolation_policy ON iam.instance_waste_data_sources USING ((instance_id = iam.current_instance_id())) WITH CHECK ((instance_id = iam.current_instance_id()));
 
 
 --
@@ -4017,4 +4072,3 @@ CREATE POLICY roles_isolation_policy ON iam.roles USING ((instance_id = iam.curr
 --
 
 \unrestrict 1ugJP7BDXFaPR9YgsKK3TZzQTddLwXFiJjir05XJfqbmkpA6OidoP927HKFo5do
-

--- a/docs/development/studio-db-schema.md
+++ b/docs/development/studio-db-schema.md
@@ -168,6 +168,7 @@ Tabellen für Instanzkonfiguration, Hostnames und technische Provisionierung:
 - `iam.instance_integrations`
 - `iam.external_interface_types`
 - `iam.instance_external_interfaces`
+- `iam.instance_waste_data_sources`
 - `iam.instance_modules`
 - `iam.instance_hostnames`
 - `iam.instance_provisioning_runs`
@@ -179,6 +180,7 @@ Kernidee:
 
 - Diese Tabellen modellieren die technische Betriebs- und Provisioning-Ebene pro Instanz.
 - Externe Schnittstellen werden hostgeführt über einen zentralen Typkatalog und instanzbezogene Konfigurationsdatensätze mit verschlüsselten Secret-Blöcken verwaltet.
+- Die instanzspezifische Waste-Datenquelle bleibt als eigener technischer Datensatz im IAM-Schema modelliert und folgt demselben `instance_id`-basierten Isolationvertrag.
 - Keycloak-bezogene Zustände sind explizit persistiert und auditierbar.
 
 ### 6. Content-Management

--- a/packages/auth-runtime/src/iam-account-management/schema-guard.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/schema-guard.test.ts
@@ -10,7 +10,9 @@ describe('schema guard helpers', () => {
     } = await import('./schema-guard.js');
 
     expect(CRITICAL_IAM_SCHEMA_GUARD_FIELDS).toContain('groups_exists');
+    expect(CRITICAL_IAM_SCHEMA_GUARD_FIELDS).toContain('instance_waste_data_sources_exists');
     expect(CRITICAL_IAM_SCHEMA_GUARD_SQL).toContain("to_regclass('iam.groups')");
+    expect(CRITICAL_IAM_SCHEMA_GUARD_SQL).toContain("to_regclass('iam.instance_waste_data_sources')");
 
     const okRow = Object.fromEntries(CRITICAL_IAM_SCHEMA_GUARD_FIELDS.map((field) => [field, true]));
     const okReport = evaluateCriticalIamSchemaGuard(okRow);
@@ -29,6 +31,12 @@ describe('schema guard helpers', () => {
       ok: false,
       reasonCode: 'missing_table',
       expectedMigration: '0014_iam_groups.sql',
+    });
+    expect(
+      failedReport.checks.find((check) => check.schemaObject === 'iam.instance_waste_data_sources')
+    ).toMatchObject({
+      ok: false,
+      reasonCode: 'missing_table',
     });
     expect(summarizeSchemaGuardFailures(failedReport)).toContain('iam.groups');
   });

--- a/packages/auth-runtime/src/iam-account-management/schema-guard.ts
+++ b/packages/auth-runtime/src/iam-account-management/schema-guard.ts
@@ -32,6 +32,7 @@ type SchemaGuardRow = {
   groups_exists: boolean;
   instance_hostnames_exists: boolean;
   instance_hostnames_rls_disabled: boolean;
+  instance_waste_data_sources_exists: boolean;
   instances_auth_client_id_column_exists: boolean;
   instances_auth_client_secret_ciphertext_column_exists: boolean;
   instances_auth_issuer_url_column_exists: boolean;
@@ -63,6 +64,7 @@ export const CRITICAL_IAM_SCHEMA_GUARD_FIELDS = [
   'account_groups_origin_column_exists',
   'instance_hostnames_exists',
   'instance_hostnames_rls_disabled',
+  'instance_waste_data_sources_exists',
   'instances_primary_hostname_column_exists',
   'instances_rls_disabled',
   'instances_auth_realm_column_exists',
@@ -192,6 +194,14 @@ const REQUIRED_SCHEMA_CHECKS = [
     reasonCode: 'policy_mismatch',
     expectedMigration: '0023_iam_disable_rls.sql',
     message: 'iam.instance_hostnames darf fuer den Runtime-Lookup keine aktive RLS erzwingen.',
+  },
+  {
+    field: 'instance_waste_data_sources_exists',
+    kind: 'table',
+    schemaObject: 'iam.instance_waste_data_sources',
+    reasonCode: 'missing_table',
+    expectedMigration: '0065_iam_instance_waste_data_sources.sql',
+    message: 'Kritische IAM-Tabelle iam.instance_waste_data_sources fehlt.',
   },
   {
     field: 'instances_primary_hostname_column_exists',
@@ -389,6 +399,7 @@ SELECT
       AND c.relrowsecurity = false
       AND c.relforcerowsecurity = false
   ) AS instance_hostnames_rls_disabled,
+  to_regclass('iam.instance_waste_data_sources') IS NOT NULL AS instance_waste_data_sources_exists,
   EXISTS (
     SELECT 1
     FROM information_schema.columns

--- a/packages/auth-runtime/src/iam-instance-registry/repository.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/repository.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { KeycloakAdminRequestError } from '../keycloak-admin-client.js';
 
 const createInstanceRegistryRuntimeMock = vi.fn(() => ({
   withRegistryRepository: vi.fn(),
@@ -314,6 +315,46 @@ describe('iam instance registry repository wiring', () => {
         source: 'access_probe',
         errorCode: 'IDP_FORBIDDEN',
         requestId: 'req-probe-4',
+      })
+    );
+  });
+
+  it('classifies a structured keycloak 403 as forbidden without relying on message matching', async () => {
+    resolveIdentityProviderForInstanceMock.mockResolvedValueOnce({
+      provider: {
+        listRoles: vi.fn(async () => []),
+        listUsers: vi.fn(async () => {
+          throw new KeycloakAdminRequestError({
+            message: 'tenant admin access denied',
+            statusCode: 403,
+            code: 'http_403',
+            retryable: false,
+          });
+        }),
+        executeActionsEmail: vi.fn(async () => undefined),
+        getOidcClientByClientId: vi.fn(async () => ({ id: 'client-1', clientId: 'sva-studio' })),
+      },
+    });
+    resolveAuthConfigForInstanceMock.mockResolvedValueOnce({
+      clientId: 'sva-studio',
+    });
+    await import('./repository.js');
+
+    const runtimeConfig = createInstanceRegistryRuntimeMock.mock.calls.at(-1)?.[0];
+    expect(runtimeConfig).toBeDefined();
+
+    await expect(
+      runtimeConfig?.serviceDeps.probeTenantIamAccess({
+        instanceId: 'demo',
+        requestId: 'req-probe-structured-403',
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: 'blocked',
+        summary: 'Tenant-Admin-Client darf die erforderlichen IAM-Ressourcen nicht lesen.',
+        source: 'access_probe',
+        errorCode: 'IDP_FORBIDDEN',
+        requestId: 'req-probe-structured-403',
       })
     );
   });

--- a/packages/auth-runtime/src/iam-instance-registry/repository.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/repository.ts
@@ -23,6 +23,7 @@ import {
   isKeycloakIdentityProvider,
   resolveIdentityProviderForInstance,
 } from '../iam-account-management/shared-runtime.js';
+import { KeycloakAdminRequestError } from '../keycloak-admin-client.js';
 import { syncTenantAdminBootstrapAccount } from './tenant-admin-bootstrap-sync.js';
 
 const getWorkerKeycloakPreflight = async (input: Parameters<typeof getInstanceKeycloakPreflightViaProvisioner>[0]) =>
@@ -134,7 +135,9 @@ const probeTenantIamAccess = async (input: { instanceId: string; requestId?: str
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const errorCode =
-      message.includes('403') || message.toLowerCase().includes('forbidden')
+      (error instanceof KeycloakAdminRequestError && error.statusCode === 403) ||
+      message.includes('403') ||
+      message.toLowerCase().includes('forbidden')
         ? 'IDP_FORBIDDEN'
         : 'IDP_UNAVAILABLE';
 

--- a/packages/data/migrations/0065_iam_instance_waste_data_sources.sql
+++ b/packages/data/migrations/0065_iam_instance_waste_data_sources.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS iam.instance_waste_data_sources (
+  instance_id TEXT PRIMARY KEY REFERENCES iam.instances(id) ON DELETE CASCADE,
+  provider_key TEXT NOT NULL,
+  project_url TEXT NOT NULL,
+  schema_name TEXT NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  database_url_ciphertext TEXT,
+  service_role_key_ciphertext TEXT,
+  visible_status TEXT NOT NULL DEFAULT 'unknown',
+  last_checked_at TIMESTAMPTZ,
+  last_check_status TEXT,
+  last_check_error_code TEXT,
+  last_check_error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT instance_waste_data_sources_visible_status_chk CHECK (
+    visible_status IN ('not_configured', 'unknown', 'ok', 'error', 'disabled')
+  ),
+  CONSTRAINT instance_waste_data_sources_last_check_status_chk CHECK (
+    last_check_status IS NULL OR last_check_status IN ('succeeded', 'failed')
+  )
+);
+
+ALTER TABLE iam.instance_waste_data_sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE iam.instance_waste_data_sources FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS instance_waste_data_sources_isolation_policy ON iam.instance_waste_data_sources;
+CREATE POLICY instance_waste_data_sources_isolation_policy
+  ON iam.instance_waste_data_sources
+  USING (instance_id = iam.current_instance_id())
+  WITH CHECK (instance_id = iam.current_instance_id());
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP POLICY IF EXISTS instance_waste_data_sources_isolation_policy ON iam.instance_waste_data_sources;
+DROP TABLE IF EXISTS iam.instance_waste_data_sources;
+-- +goose StatementEnd

--- a/scripts/ops/runtime/acceptance-maintenance-report.test.ts
+++ b/scripts/ops/runtime/acceptance-maintenance-report.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 
 describe('renderQuantumDeployProject', () => {
   it('validates the rendered compose document against the compose app service key', () => {
-    const assertComposeServiceNetworks = vi.fn(() => ({ labels: {}, networks: ['internal', 'public'] }));
+    const assertComposeServiceNetworks = vi.fn(() => ({ labels: {}, networks: ['internal', 'network-node-005'] }));
     const assertComposeServiceIngressLabels = vi.fn();
 
     const project = renderQuantumDeployProject({
@@ -48,7 +48,11 @@ describe('renderQuantumDeployProject', () => {
       withoutDebugEnv: vi.fn(),
     }, { SVA_RUNTIME_PROFILE: 'studio' });
 
-    expect(assertComposeServiceNetworks).toHaveBeenCalledWith({ services: { app: {} } }, 'app', ['internal', 'public']);
+    expect(assertComposeServiceNetworks).toHaveBeenCalledWith(
+      { services: { app: {} } },
+      'app',
+      ['internal', 'network-node-005'],
+    );
     expect(assertComposeServiceIngressLabels).toHaveBeenCalledWith({ services: { app: {} } }, 'app');
 
     project.cleanup();

--- a/scripts/ops/runtime/acceptance-maintenance-report.ts
+++ b/scripts/ops/runtime/acceptance-maintenance-report.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 
 import type { AcceptanceDeployReport, AcceptanceReleaseManifest } from '../runtime-env.shared.ts';
 import { formatAcceptanceDeployReportMarkdown } from '../runtime-env.shared.ts';
-import type { ComposeDocument } from './deploy-project.ts';
+import { getExpectedRemoteAppNetworks, type ComposeDocument } from './deploy-project.ts';
 import type { AcceptanceMaintenanceDeps, BaseReportInput } from './acceptance-maintenance.types.ts';
 
 const writeJsonArtifact = (filePath: string, payload: unknown) => {
@@ -58,7 +58,11 @@ export const renderQuantumDeployProject = (deps: AcceptanceMaintenanceDeps, env:
   const runtimeProfile = env.SVA_RUNTIME_PROFILE?.trim() || 'studio';
   const renderedComposeDocument = renderRemoteComposeDocument(deps, env);
   const renderedComposeAppServiceName = 'app';
-  deps.assertComposeServiceNetworks(renderedComposeDocument, renderedComposeAppServiceName, ['internal', 'public']);
+  deps.assertComposeServiceNetworks(
+    renderedComposeDocument,
+    renderedComposeAppServiceName,
+    getExpectedRemoteAppNetworks(runtimeProfile),
+  );
   deps.assertComposeServiceIngressLabels(renderedComposeDocument, renderedComposeAppServiceName);
   const renderedCompose = JSON.stringify(deps.buildQuantumDeployComposeDocument(renderedComposeDocument), null, 2);
   const projectDir = mkdtempSync(resolve(tmpdir(), `sva-studio-${runtimeProfile}-deploy-`));

--- a/scripts/ops/runtime/acceptance-runtime-checks-live-spec.ts
+++ b/scripts/ops/runtime/acceptance-runtime-checks-live-spec.ts
@@ -1,6 +1,7 @@
 import type { RuntimeProfile } from '../../../packages/core/src/runtime-profile.ts';
 import type { AcceptanceDeployOptions, DoctorCheck } from '../runtime-env.shared.ts';
 import type { RemoteServiceContract } from './remote-service-spec.ts';
+import { getExpectedRemoteAppNetworks } from './deploy-project.ts';
 import {
   runtimeContractComparisonKeys,
   runtimeContractSecretPresenceKeys,
@@ -54,7 +55,11 @@ export const buildAcceptanceLiveSpecCheck = async (
   const renderedComposeAppServiceName = 'app';
   const stackName = deps.getConfiguredStackName(env);
   const liveServiceName = resolveRemoteShortServiceName(stackName, deps.getRemoteAppServiceName(env));
-  const expectedAppContract = deps.assertComposeServiceNetworks(renderedCompose, renderedComposeAppServiceName, ['internal', 'public']);
+  const expectedAppContract = deps.assertComposeServiceNetworks(
+    renderedCompose,
+    renderedComposeAppServiceName,
+    getExpectedRemoteAppNetworks(runtimeProfile),
+  );
   deps.assertComposeServiceIngressLabels(renderedCompose, renderedComposeAppServiceName);
   const expectedIngressLabels = Object.fromEntries(
     Object.entries(expectedAppContract.labels).filter(([key]) => key.startsWith('traefik.')),

--- a/scripts/ops/runtime/acceptance-runtime-checks.live-spec.test.ts
+++ b/scripts/ops/runtime/acceptance-runtime-checks.live-spec.test.ts
@@ -10,7 +10,7 @@ describe('acceptance runtime checks live spec and readiness', () => {
       labels: {
         'traefik.http.routers.app.rule': 'Host(`studio.smart-village.app`)',
       },
-      networks: ['internal', 'public'],
+      networks: ['internal', 'network-node-005'],
     }));
     const assertComposeServiceIngressLabels = vi.fn();
     const inspectRemoteServiceContract = vi.fn(async () => ({
@@ -74,7 +74,11 @@ describe('acceptance runtime checks live spec and readiness', () => {
 
     expect(check.status).toBe('warn');
     expect(check.code).toBe('live_spec_differs');
-    expect(assertComposeServiceNetworks).toHaveBeenCalledWith({ services: { app: {} } }, 'app', ['internal', 'public']);
+    expect(assertComposeServiceNetworks).toHaveBeenCalledWith(
+      { services: { app: {} } },
+      'app',
+      ['internal', 'network-node-005'],
+    );
     expect(assertComposeServiceIngressLabels).toHaveBeenCalledWith({ services: { app: {} } }, 'app');
     expect(inspectRemoteServiceContract).toHaveBeenCalledWith(
       expect.anything(),
@@ -84,7 +88,7 @@ describe('acceptance runtime checks live spec and readiness', () => {
       configDrift: ['APP_DB_USER'],
       liveImage: 'ghcr.io/smart-village/studio:old',
       missingIngressLabels: ['traefik.http.routers.app.rule'],
-      missingNetworks: ['public'],
+      missingNetworks: ['network-node-005'],
       missingSecretKeys: [
         'SVA_AUTH_CLIENT_SECRET',
         'SVA_AUTH_STATE_SECRET',
@@ -103,7 +107,7 @@ describe('acceptance runtime checks live spec and readiness', () => {
       labels: {
         'traefik.http.routers.app.rule': 'Host(`studio.smart-village.app`)',
       },
-      networks: ['internal', 'public'],
+      networks: ['internal', 'network-node-005'],
     }));
     const assertComposeServiceIngressLabels = vi.fn();
     const inspectRemoteServiceContract = vi.fn(async () => null);
@@ -124,7 +128,11 @@ describe('acceptance runtime checks live spec and readiness', () => {
       acceptanceOptions,
     );
 
-    expect(assertComposeServiceNetworks).toHaveBeenCalledWith({ services: { app: {} } }, 'app', ['internal', 'public']);
+    expect(assertComposeServiceNetworks).toHaveBeenCalledWith(
+      { services: { app: {} } },
+      'app',
+      ['internal', 'network-node-005'],
+    );
     expect(assertComposeServiceIngressLabels).toHaveBeenCalledWith({ services: { app: {} } }, 'app');
     expect(inspectRemoteServiceContract).toHaveBeenCalledWith(
       expect.anything(),

--- a/scripts/ops/runtime/acceptance-runtime-checks.test-helpers.ts
+++ b/scripts/ops/runtime/acceptance-runtime-checks.test-helpers.ts
@@ -23,7 +23,7 @@ export const createDeps = (overrides: Partial<AcceptanceRuntimeCheckDeps> = {}):
     labels: {
       'traefik.http.routers.app.rule': 'Host(`studio.smart-village.app`)',
     },
-    networks: ['internal', 'public'],
+    networks: ['internal', 'network-node-005'],
   })),
   checkHttpHealth: vi.fn(async () => ({
     payload: undefined,
@@ -68,7 +68,7 @@ export const createDeps = (overrides: Partial<AcceptanceRuntimeCheckDeps> = {}):
     labels: {
       'traefik.http.routers.app.rule': 'Host(`studio.smart-village.app`)',
     },
-    networkNames: ['internal', 'public'],
+    networkNames: ['internal', 'network-node-005'],
     serviceName: 'studio_app',
   })),
   readRemoteStackEvidence: vi.fn(async () => ({

--- a/scripts/ops/runtime/acceptance-runtime-facade.test.ts
+++ b/scripts/ops/runtime/acceptance-runtime-facade.test.ts
@@ -33,7 +33,7 @@ describe('createAcceptanceRuntimeCore', () => {
         runMigrationJobAgainstAcceptance: vi.fn(),
       },
       assertComposeServiceIngressLabels: vi.fn(),
-      assertComposeServiceNetworks: vi.fn(() => ({ env: {}, labels: {}, networks: ['internal', 'public'] })),
+      assertComposeServiceNetworks: vi.fn(() => ({ env: {}, labels: {}, networks: ['internal', 'network-node-005'] })),
       assertDeterministicRemoteMutationContext: vi.fn(),
       buildAcceptanceReportPaths: vi.fn(),
       buildInstanceHostnameMappingCheck: vi.fn(),

--- a/scripts/ops/runtime/deploy-project.ts
+++ b/scripts/ops/runtime/deploy-project.ts
@@ -16,6 +16,9 @@ export type ServiceContract = {
   networks: readonly string[];
 };
 
+export const getExpectedRemoteAppNetworks = (runtimeProfile: string): readonly string[] =>
+  runtimeProfile === 'studio' ? ['internal', 'network-node-005'] : ['internal', 'public'];
+
 const REQUIRED_INGRESS_LABELS = ['traefik.enable', 'traefik.docker.network'] as const;
 
 const toStringRecord = (value: JsonValue | undefined): Record<string, string> => {


### PR DESCRIPTION
## Summary
- derive expected remote app networks from the runtime profile
- accept `network-node-005` for the `studio` profile in rollout/live-spec checks
- update the affected runtime acceptance tests

## Verification
- `pnpm exec vitest --root tooling/testing run tests ../../scripts/ops/runtime/acceptance-maintenance-report.test.ts ../../scripts/ops/runtime/acceptance-runtime-checks.live-spec.test.ts ../../scripts/ops/runtime/acceptance-runtime-facade.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests`
- `pnpm env:precheck:studio -- --json --image-digest=sha256:57891f5f97bffe4c51b8be80df8a396b3d87b59c5505ca387b24037885770054 --image-tag=df3a9544401e`
- `pnpm env:smoke:studio -- --json`

----
## Summary by Gitar

- **Database schema:**
  - Added `iam.instance_waste_data_sources` table to track instance-specific waste data configurations.
  - Updated `studio-db-schema-final.sql` and `schema-guard` to include the new table.
- **IAM access probe:**
  - Improved `probeTenantIamAccess` to explicitly handle `KeycloakAdminRequestError` with `403` status codes.

<sub>This will update automatically on new commits.</sub>