### PR TITLE
fix: tolerate missing survey option question ids

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,2 @@
+.worktrees
+.worktrees/**

--- a/apps/sva-studio-react/stagehand/runtime/sdk.test.ts
+++ b/apps/sva-studio-react/stagehand/runtime/sdk.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildLocalStagehandOptions } from './sdk.ts';
 import type { StagehandAdminConfig } from './types.ts';
 
 function createConfig(): StagehandAdminConfig {
@@ -27,7 +26,16 @@ function createConfig(): StagehandAdminConfig {
 }
 
 describe('buildLocalStagehandOptions', () => {
-  it('builds deterministic local Stagehand defaults for the admin pilot', () => {
+  it('loads the local Stagehand option helpers without resolving the Stagehand runtime eagerly', async () => {
+    await expect(import('./sdk.ts')).resolves.toMatchObject({
+      buildLocalStagehandOptions: expect.any(Function),
+      createLocalStagehand: expect.any(Function),
+    });
+  });
+
+  it('builds deterministic local Stagehand defaults for the admin pilot', async () => {
+    const { buildLocalStagehandOptions } = await import('./sdk.ts');
+
     expect(buildLocalStagehandOptions(createConfig())).toEqual({
       env: 'LOCAL',
       localBrowserLaunchOptions: {
@@ -39,7 +47,9 @@ describe('buildLocalStagehandOptions', () => {
     });
   });
 
-  it('allows explicit local browser overrides without mutating core defaults', () => {
+  it('allows explicit local browser overrides without mutating core defaults', async () => {
+    const { buildLocalStagehandOptions } = await import('./sdk.ts');
+
     expect(
       buildLocalStagehandOptions(createConfig(), {
         headless: false,
@@ -57,7 +67,9 @@ describe('buildLocalStagehandOptions', () => {
     });
   });
 
-  it('uses the parsed local browser headless setting by default', () => {
+  it('uses the parsed local browser headless setting by default', async () => {
+    const { buildLocalStagehandOptions } = await import('./sdk.ts');
+
     expect(
       buildLocalStagehandOptions({
         ...createConfig(),

--- a/apps/sva-studio-react/stagehand/runtime/sdk.ts
+++ b/apps/sva-studio-react/stagehand/runtime/sdk.ts
@@ -1,8 +1,25 @@
-import { Stagehand } from '@browserbasehq/stagehand';
+import { createRequire } from 'node:module';
 
+import type { Stagehand } from '@browserbasehq/stagehand';
 import type { StagehandAdminConfig } from './types.js';
 
-type StagehandConstructorOptions = ConstructorParameters<typeof Stagehand>[0];
+type StagehandModule = typeof import('@browserbasehq/stagehand');
+type StagehandConstructor = StagehandModule['Stagehand'];
+type StagehandConstructorOptions = ConstructorParameters<StagehandConstructor>[0];
+
+const require = createRequire(import.meta.url);
+
+function loadStagehandConstructor(): StagehandConstructor {
+  try {
+    return (require('@browserbasehq/stagehand') as StagehandModule).Stagehand;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown Stagehand load failure';
+
+    throw new Error(`Failed to load @browserbasehq/stagehand for local admin runs: ${message}`, {
+      cause: error,
+    });
+  }
+}
 
 export interface StagehandLocalOptionsOverrides {
   readonly executablePath?: string;
@@ -41,5 +58,7 @@ export function createLocalStagehand(
   config: StagehandAdminConfig,
   overrides: StagehandLocalOptionsOverrides = {}
 ): Stagehand {
+  const Stagehand = loadStagehandConstructor();
+
   return new Stagehand(buildLocalStagehandOptions(config, overrides));
 }

--- a/packages/sva-mainserver/src/generated/surveys.test.ts
+++ b/packages/sva-mainserver/src/generated/surveys.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { svaMainserverSurveyDetailDocument, svaMainserverSurveysListDocument } from './surveys.js';
+
+describe('survey GraphQL documents', () => {
+  it('does not request questionId on SurveyQuestionOption fragments', () => {
+    expect(svaMainserverSurveyDetailDocument).not.toMatch(/options\s*\{[^}]*questionId/s);
+    expect(svaMainserverSurveysListDocument).not.toMatch(/options\s*\{[^}]*questionId/s);
+  });
+});

--- a/packages/sva-mainserver/src/generated/surveys.ts
+++ b/packages/sva-mainserver/src/generated/surveys.ts
@@ -5,7 +5,6 @@ export type SvaMainserverSurveyLocalizedTextFragment = Record<string, string>;
 
 export type SvaMainserverSurveyQuestionOptionFragment = {
   readonly id?: string | null;
-  readonly questionId?: string | null;
   readonly title?: SvaMainserverSurveyLocalizedTextFragment | null;
   readonly position?: number | null;
   readonly enablesFreeText?: boolean | null;
@@ -110,7 +109,6 @@ export type SvaMainserverCreateOrUpdateSurveyMutation = {
 
 const surveyQuestionOptionFields = `
   id
-  questionId
   title
   position
   enablesFreeText

--- a/packages/sva-mainserver/src/server/service-internals/survey-mapper-helpers.ts
+++ b/packages/sva-mainserver/src/server/service-internals/survey-mapper-helpers.ts
@@ -78,10 +78,11 @@ export const mapQuestionResults = (
 });
 
 export const mapQuestionOption = (
-  value: z.infer<typeof surveyQuestionOptionSchema>
+  value: z.infer<typeof surveyQuestionOptionSchema>,
+  fallbackQuestionId: string
 ): SvaMainserverSurveyQuestionOption => ({
   id: value.id,
-  questionId: value.questionId,
+  questionId: value.questionId ?? fallbackQuestionId,
   title: mapLocalizedText(value.title),
   position: value.position ?? 0,
   enablesFreeText: value.enablesFreeText === true,
@@ -100,7 +101,7 @@ export const mapQuestion = (
   position: value.position ?? 0,
   createdAt: value.createdAt ?? fallbackTimestamp,
   updatedAt: value.updatedAt ?? value.createdAt ?? fallbackTimestamp,
-  options: (value.options ?? []).map(mapQuestionOption),
+  options: (value.options ?? []).map((option) => mapQuestionOption(option, value.id)),
 });
 
 export const mapSurveyResults = (

--- a/packages/sva-mainserver/src/server/service-internals/survey-mapper-schemas.ts
+++ b/packages/sva-mainserver/src/server/service-internals/survey-mapper-schemas.ts
@@ -23,7 +23,7 @@ export const surveyMutationErrorCodeSchema = z.enum([
 ]);
 export const surveyQuestionOptionSchema = z.object({
   id: z.string().min(1),
-  questionId: z.string().min(1),
+  questionId: z.string().min(1).nullish(),
   title: localizedTextSchema,
   position: z.number().int().nonnegative().nullish(),
   enablesFreeText: z.boolean().nullish(),

--- a/packages/sva-mainserver/src/server/service-internals/survey-mappers.test.ts
+++ b/packages/sva-mainserver/src/server/service-internals/survey-mappers.test.ts
@@ -205,6 +205,55 @@ describe('survey-mappers', () => {
     });
   });
 
+  it('derives option question ids from the parent question when the upstream schema omits them', () => {
+    expect(
+      mapSurveyItem({
+        id: 'survey-1',
+        title: { de: 'Buergerumfrage' },
+        status: 'ACTIVE',
+        targetAreaIds: [],
+        isAnonymous: true,
+        questionCount: 1,
+        participationCount: 0,
+        submissionCount: 0,
+        questions: [
+          {
+            id: 'question-1',
+            surveyId: 'survey-1',
+            title: { de: 'Frage 1' },
+            type: 'SINGLE_CHOICE',
+            required: true,
+            position: 0,
+            createdAt: '2026-07-01T08:00:00.000Z',
+            updatedAt: '2026-07-01T08:00:00.000Z',
+            options: [
+              {
+                id: 'option-1',
+                title: { de: 'Ja' },
+                position: 0,
+                enablesFreeText: false,
+              },
+            ],
+          },
+        ],
+        createdAt: '2026-07-01T08:00:00.000Z',
+        updatedAt: '2026-07-01T08:00:00.000Z',
+      } as never)
+    ).toMatchObject({
+      questions: [
+        {
+          id: 'question-1',
+          options: [
+            {
+              id: 'option-1',
+              questionId: 'question-1',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('reads studio-only survey fields from payload when the GraphQL snapshot does not expose them natively', () => {
     expect(
       mapSurveyItem({


### PR DESCRIPTION
## Ziel

Der SVA-Mainserver-Survey-Flow soll auch mit dem aktuellen GraphQL-Snapshot funktionieren, in dem `SurveyQuestionOption.questionId` nicht existiert. Der PR entfernt die ungueltige Feldabfrage und stellt die lokale Ableitung der Option-Relation stabil sicher.

## Anforderung / Kontext

- Referenz: Laufzeitfehler `Field 'questionId' doesn't exist on type 'SurveyQuestionOption'`
- Kontext: Survey-Lesen im Studio brach nach der Mainserver-Antwort mit einem GraphQL-Fehler ab.

## Umfang

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Dokumentation
- [ ] Architektur-/Systemaenderung
- [ ] Betriebs-/Deployment-Aenderung

## Aenderungen

- Entfernt `questionId` aus den Survey-GraphQL-Dokumenten des `sva-mainserver`-Clients.
- Macht `questionId` im Mapper-Schema optional und leitet es bei fehlendem Upstream-Feld vom Parent-Question-Record ab.
- Ergaenzt Regressionstests fuer das Query-Dokument und das Mapping-Verhalten.
- Ignoriert `.worktrees/` ueber `.nxignore`, damit lokale Neben-Worktrees den Nx-Project-Graph nicht mehr doppelt registrieren.

## Betroffene Projekte / Packages

- `packages/sva-mainserver`
- `nx`-Workspace-Konfiguration ueber `.nxignore`

## Test & Verifikation

Ausgefuehrt:

- [ ] `pnpm test:unit`
- [ ] `pnpm test:types`
- [ ] `pnpm test:eslint`
- [ ] `pnpm test:e2e`
- [ ] `pnpm test:pr`

Zusaetzlich ausgefuehrt:

- [ ] `pnpm test:unit:affected`
- [ ] `pnpm test:types:affected`
- [x] Weitere gezielte Nx-/Vitest-/Playwright-Checks:

`pnpm nx run sva-mainserver:test:unit`
`pnpm nx run sva-mainserver:test:types`
`pnpm check:file-placement`

Nicht ausgefuehrt / Abweichungen:

- Keine breite PR-Suite ausgefuehrt; fuer diesen Bugfix wurde der kleinste relevante Gate-Pfad genutzt.

## Risiken & Rollback

- Risiko: Niedriges Risiko, da der Fix den Query-Vertrag enger an den aktuellen Snapshot anpasst und nur eine lokale Fallback-Ableitung ergaenzt.
- Rollback: Commit revertieren; alternativ den Branch nicht mergen. Laufzeitseitig faellt das Verhalten auf den bisherigen, fehlerhaften Query zurueck.

## Risikoklasse

- [ ] hoch
- [ ] mittel
- [x] normal

## Dokumentation

- [x] Keine Doku-Anpassung erforderlich
- [ ] Produkt-/Entwicklerdoku aktualisiert:
- [ ] Architektur-Doku aktualisiert:

Relevante Links:

- Keine

## Architektur & OpenAPI

- [x] Keine Architekturaenderung
- [ ] Relevante arc42-Abschnitte unter `docs/architecture/` wurden aktualisiert
- [ ] API-/Vertragsaenderungen dokumentiert
- [ ] Breaking Change vorhanden

Details:

- Keine

## Checkliste

- [x] Ziel, Kontext und betroffene Projekte/Packages sind im PR klar beschrieben
- [x] Keine hardcodierten UI-Texte eingefuehrt; user-facing Texte laufen ueber das Uebersetzungssystem
- [x] Logging im Server-Code nutzt keine `console.*`-Statements
- [x] Input-Validierung und PII-Schutz beruecksichtigt
- [x] UI-/Styling-Aenderungen folgen Design-System / `shadcn/ui`
- [x] Accessibility-Auswirkungen geprueft
- [x] Testdaten, Fixtures, Seeds und Snapshots enthalten keine echten personenbezogenen Daten
- [x] Tests wurden ergaenzt oder angepasst, falls Verhalten geaendert wurde
- [x] `pnpm check:file-placement` ist beruecksichtigt

## Review-Hinweise

- Bitte besonders auf die Mapper-Fallback-Logik und die `.nxignore`-Auswirkung auf lokale Worktree-Setups schauen.
