### PR TITLE
Fix system admin organization context handling

### DIFF
--- a/apps/sva-studio-react/e2e/studio-shell.helpers.ts
+++ b/apps/sva-studio-react/e2e/studio-shell.helpers.ts
@@ -1,14 +1,7 @@
 import { expect, type Page } from '@playwright/test';
+import { resolveUserInitials } from '@sva/core';
 
 const escapeForRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const resolveInitials = (value: string) =>
-  value
-    .split(/[\s._-]+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0]?.toUpperCase() ?? '')
-    .join('');
 
 export const gotoShellRoot = async (page: Page, attempts = 5) => {
   let lastError: unknown;
@@ -35,7 +28,7 @@ export const gotoHomeAsAuthenticatedUser = async (page: Page, expectedUserName =
     (response) => response.request().method() === 'GET' && response.url().includes('/auth/me') && response.status() === 200
   );
   const expectedTriggerPattern = new RegExp(
-    `${escapeForRegex(expectedUserName)}|${escapeForRegex(resolveInitials(expectedUserName))}`
+    `${escapeForRegex(expectedUserName)}|${escapeForRegex(resolveUserInitials(expectedUserName))}`
   );
 
   await gotoShellRoot(page);

--- a/apps/sva-studio-react/src/components/Header.test.tsx
+++ b/apps/sva-studio-react/src/components/Header.test.tsx
@@ -622,7 +622,7 @@ describe('Header auth actions', () => {
     });
   });
 
-  it('rendert keinen fuehrenden Separator vor Mein Konto, wenn nur Organisationsmitgliedschaften angezeigt werden', async () => {
+  it('rendert keinen führenden Separator vor Mein Konto, wenn nur Organisationsmitgliedschaften angezeigt werden', async () => {
     useOrganizationContextMock.mockReturnValue({
       context: {
         activeOrganizationId: 'org-1',

--- a/apps/sva-studio-react/src/components/Header.test.tsx
+++ b/apps/sva-studio-react/src/components/Header.test.tsx
@@ -11,7 +11,9 @@ const useLocaleMock = vi.fn();
 const useThemeMock = vi.fn();
 const useOrganizationContextMock = vi.fn();
 const organizationContextSwitcherMock = vi.fn(
-  (_props?: { variant?: 'inline' | 'menu' }) => <div data-testid="organization-context-switcher">Organization Context</div>
+  (_props?: { variant?: 'inline' | 'menu'; readOnly?: boolean }) => (
+    <div data-testid="organization-context-switcher">Organization Context</div>
+  )
 );
 const localStorageState = new Map<string, string>();
 const sessionStorageState = new Map<string, string>();
@@ -286,11 +288,82 @@ describe('Header auth actions', () => {
     expect(
       screen.getByTestId('organization-context-switcher').compareDocumentPosition(screen.getByRole('menuitem', { name: 'Mein Konto' }))
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(organizationContextSwitcherMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'menu',
+        readOnly: false,
+      })
+    );
 
     const logoutForm = document.querySelector('form[action="/auth/logout"]');
     const logoutIntent = logoutForm?.querySelector('input[name="logoutIntent"]');
     expect(logoutForm?.getAttribute('method')).toBe('post');
     expect(logoutIntent?.getAttribute('value')).toBe('user');
+  });
+
+  it('zeigt Organisationsmitgliedschaften auch für system_admin im Kontomenü als read-only Bereich', async () => {
+    useOrganizationContextMock.mockReturnValue({
+      context: {
+        activeOrganizationId: 'org-1',
+        organizations: [
+          {
+            organizationId: 'org-1',
+            organizationKey: 'alpha',
+            displayName: 'Alpha',
+            organizationType: 'county',
+            isActive: true,
+            isDefaultContext: true,
+          },
+        ],
+      },
+      isLoading: false,
+      isUpdating: false,
+      error: null,
+      refetch: vi.fn(),
+      switchOrganization: vi.fn(),
+    });
+    useAuthMock.mockReturnValue({
+      user: {
+        id: 'user-1',
+        name: 'Test User',
+        roles: ['system_admin'],
+        permissionActions: ['experimental.read'],
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      hasResolvedSession: true,
+      refetch: vi.fn(),
+      logout: vi.fn(),
+      invalidatePermissions: vi.fn(),
+    });
+    useThemeMock.mockReturnValue({
+      mode: 'dark',
+      themeName: 'sva-default',
+      themeLabel: 'SVA Studio',
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+    useLocaleMock.mockReturnValue({
+      locale: 'de',
+      setLocale: vi.fn(),
+    });
+
+    render(<Header />);
+
+    const accountTrigger = await screen.findByRole('button', { name: /Test User/ });
+    accountTrigger.click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('organization-context-switcher')).toBeTruthy();
+    });
+
+    expect(organizationContextSwitcherMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'menu',
+        readOnly: true,
+      })
+    );
   });
 
   it('räumt lokale Session-Marker vor dem Formular-Logout auf', async () => {
@@ -549,7 +622,7 @@ describe('Header auth actions', () => {
     });
   });
 
-  it('rendert keinen fuehrenden Separator, wenn der Organisationswechsler im Kontomenue ausfaellt', async () => {
+  it('rendert keinen fuehrenden Separator vor Mein Konto, wenn nur Organisationsmitgliedschaften angezeigt werden', async () => {
     useOrganizationContextMock.mockReturnValue({
       context: {
         activeOrganizationId: 'org-1',
@@ -606,8 +679,8 @@ describe('Header auth actions', () => {
       expect(screen.getByRole('menuitem', { name: 'Mein Konto' })).toBeTruthy();
     });
 
-    expect(screen.queryByTestId('organization-context-switcher')).toBeNull();
-    expect(screen.getAllByRole('separator')).toHaveLength(2);
+    expect(screen.getByTestId('organization-context-switcher')).toBeTruthy();
+    expect(screen.getAllByRole('separator')).toHaveLength(3);
     expect(screen.getByRole('menuitem', { name: 'Mein Konto' }).previousElementSibling?.getAttribute('role')).not.toBe(
       'separator'
     );

--- a/apps/sva-studio-react/src/components/Header.tsx
+++ b/apps/sva-studio-react/src/components/Header.tsx
@@ -7,6 +7,7 @@
 import { Bell, ChevronDown, Languages, Menu, MessageCircle, Moon, Search, SendHorizontal, Sun } from 'lucide-react';
 import React from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
+import { resolveOrganizationContextState, resolveUserDisplayName, resolveUserInitials } from '@sva/core';
 
 import { OrganizationContextSwitcher } from './OrganizationContextSwitcher';
 import { Button } from './ui/button';
@@ -15,7 +16,7 @@ import { t } from '../i18n';
 import { createAccountActionHref, createLoginHref, resolveCurrentReturnTo } from '../lib/auth-navigation';
 import { clearClientLogoutState } from '../lib/auth-session-state';
 import { useOrganizationContext } from '../hooks/use-organization-context';
-import { hasExperimentalAccess, hasProtectedTenantRole } from '../lib/iam-admin-access';
+import { hasExperimentalAccess } from '../lib/iam-admin-access';
 import { cn } from '../lib/utils';
 import { useAuth } from '../providers/auth-provider';
 import { useLocale } from '../providers/locale-provider';
@@ -59,19 +60,6 @@ type HeaderAuthActionProps = Readonly<{
   displayName: string;
   initials: string;
 }>;
-
-const resolveUserDisplayName = (user: { readonly id: string }) => {
-  const candidate = user as { readonly name?: string; readonly displayName?: string };
-  return candidate.displayName?.trim() || candidate.name?.trim() || user.id;
-};
-
-const resolveUserInitials = (value: string) =>
-  value
-    .split(/[\s._-]+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0]?.toUpperCase() ?? '')
-    .join('') || value.slice(0, 2).toUpperCase();
 
 const HeaderSectionDivider = () => <hr className="my-1 border-border" />;
 
@@ -246,58 +234,39 @@ const HeaderPromptField = ({
   </div>
 );
 
-const HeaderAuthAction = ({
-  isHydrated,
-  isLoading,
-  isAuthLoading,
-  isAuthenticated,
-  showOrganizationContext,
-  isSystemAdmin,
-  isDevAuthAvailable = false,
+const renderUnauthenticatedHeaderAction = ({
   hideAnonymousLoginAction,
+  isDevAuthAvailable,
   loginHref,
   loginWithDevAuth,
-  logout,
-  user,
-  displayName,
-  initials,
-}: HeaderAuthActionProps): React.ReactNode => {
-  if (!isHydrated || isLoading || isAuthLoading) {
-    return (
-      <>
-        <span role="status" aria-live="polite" className="sr-only">
-          {t('shell.header.authLoading')}
-        </span>
-        <span aria-hidden="true" className="h-9 w-28 animate-skeleton rounded-full" />
-      </>
-    );
+}: Pick<
+  HeaderAuthActionProps,
+  'hideAnonymousLoginAction' | 'isDevAuthAvailable' | 'loginHref' | 'loginWithDevAuth'
+>): React.ReactNode => {
+  if (hideAnonymousLoginAction) {
+    return null;
   }
 
-  if (!isAuthenticated) {
-    if (hideAnonymousLoginAction) {
-      return null;
-    }
-
-    if (isDevAuthAvailable) {
-      return (
-        <Button type="button" variant="secondary" onClick={() => void loginWithDevAuth?.()}>
-          {t('shell.header.login')}
-        </Button>
-      );
-    }
-
+  if (isDevAuthAvailable) {
     return (
-      <Button asChild variant="secondary">
-        <a href={loginHref}>{t('shell.header.login')}</a>
+      <Button type="button" variant="secondary" onClick={() => void loginWithDevAuth?.()}>
+        {t('shell.header.login')}
       </Button>
     );
   }
 
-  if (!user) {
-    return null;
-  }
+  return (
+    <Button asChild variant="secondary">
+      <a href={loginHref}>{t('shell.header.login')}</a>
+    </Button>
+  );
+};
 
-  const logoutItem: HeaderDropdownItem = isDevAuthAvailable
+const createLogoutMenuItem = ({
+  isDevAuthAvailable,
+  logout,
+}: Pick<HeaderAuthActionProps, 'isDevAuthAvailable' | 'logout'>): HeaderDropdownItem =>
+  isDevAuthAvailable
     ? {
         id: 'logout',
         label: t('shell.header.logout'),
@@ -324,46 +293,72 @@ const HeaderAuthAction = ({
         ),
       };
 
-  const accountMenuItems: readonly HeaderDropdownItem[] = [
-    ...(showOrganizationContext
-      ? ([
-          {
-            id: 'organization-context',
-            render: <OrganizationContextSwitcher variant="menu" readOnly={isSystemAdmin} />,
-          },
-          {
-            id: 'divider-organization-context',
-            render: <HeaderSectionDivider />,
-          },
-        ] satisfies readonly HeaderDropdownItem[])
-      : []),
-    { id: 'account', label: t('account.profile.title'), href: '/account' },
-    {
-      id: 'password',
-      label: t('shell.header.changePassword'),
-      href: createAccountActionHref('update-password'),
-      documentNavigation: true,
-    },
-    {
-      id: 'divider-privacy',
-      render: <HeaderSectionDivider />,
-    },
-    {
-      id: 'privacy',
-      label: t('account.privacy.navLabel'),
-      href: '/account/privacy',
-    },
-    {
-      id: 'rules',
-      label: t('account.rules.navLabel'),
-      href: '/account/rules',
-    },
-    {
-      id: 'divider-session',
-      render: <HeaderSectionDivider />,
-    },
+const createAccountMenuItems = ({
+  showOrganizationContext,
+  isSystemAdmin,
+  logoutItem,
+}: {
+  readonly showOrganizationContext: boolean;
+  readonly isSystemAdmin: boolean;
+  readonly logoutItem: HeaderDropdownItem;
+}): readonly HeaderDropdownItem[] => [
+  ...(showOrganizationContext
+    ? ([
+        {
+          id: 'organization-context',
+          render: <OrganizationContextSwitcher variant="menu" readOnly={isSystemAdmin} />,
+        },
+        {
+          id: 'divider-organization-context',
+          render: <HeaderSectionDivider />,
+        },
+      ] satisfies readonly HeaderDropdownItem[])
+    : []),
+  { id: 'account', label: t('account.profile.title'), href: '/account' },
+  {
+    id: 'password',
+    label: t('shell.header.changePassword'),
+    href: createAccountActionHref('update-password'),
+    documentNavigation: true,
+  },
+  {
+    id: 'divider-privacy',
+    render: <HeaderSectionDivider />,
+  },
+  {
+    id: 'privacy',
+    label: t('account.privacy.navLabel'),
+    href: '/account/privacy',
+  },
+  {
+    id: 'rules',
+    label: t('account.rules.navLabel'),
+    href: '/account/rules',
+  },
+  {
+    id: 'divider-session',
+    render: <HeaderSectionDivider />,
+  },
+  logoutItem,
+];
+
+const HeaderAuthenticatedAccountMenu = ({
+  showOrganizationContext,
+  isSystemAdmin,
+  isDevAuthAvailable = false,
+  logout,
+  displayName,
+  initials,
+}: Pick<
+  HeaderAuthActionProps,
+  'showOrganizationContext' | 'isSystemAdmin' | 'isDevAuthAvailable' | 'logout' | 'displayName' | 'initials'
+>) => {
+  const logoutItem = createLogoutMenuItem({ isDevAuthAvailable, logout });
+  const accountMenuItems = createAccountMenuItems({
+    showOrganizationContext,
+    isSystemAdmin,
     logoutItem,
-  ];
+  });
 
   return (
     <HeaderDropdownMenu
@@ -394,6 +389,58 @@ const HeaderAuthAction = ({
   );
 };
 
+const HeaderAuthAction = ({
+  isHydrated,
+  isLoading,
+  isAuthLoading,
+  isAuthenticated,
+  showOrganizationContext,
+  isSystemAdmin,
+  isDevAuthAvailable = false,
+  hideAnonymousLoginAction,
+  loginHref,
+  loginWithDevAuth,
+  logout,
+  user,
+  displayName,
+  initials,
+}: HeaderAuthActionProps): React.ReactNode => {
+  if (!isHydrated || isLoading || isAuthLoading) {
+    return (
+      <>
+        <span role="status" aria-live="polite" className="sr-only">
+          {t('shell.header.authLoading')}
+        </span>
+        <span aria-hidden="true" className="h-9 w-28 animate-skeleton rounded-full" />
+      </>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return renderUnauthenticatedHeaderAction({
+      hideAnonymousLoginAction,
+      isDevAuthAvailable,
+      loginHref,
+      loginWithDevAuth,
+    });
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <HeaderAuthenticatedAccountMenu
+      showOrganizationContext={showOrganizationContext}
+      isSystemAdmin={isSystemAdmin}
+      isDevAuthAvailable={isDevAuthAvailable}
+      logout={logout}
+      displayName={displayName}
+      initials={initials}
+    />
+  );
+};
+
 /**
  * Rendert die Kopfzeile mit globalen Aktionen.
  *
@@ -407,7 +454,12 @@ export default function Header({
 }: HeaderProps) {
   const { user, isAuthenticated, isLoading: isAuthLoading, isDevAuthAvailable, loginWithDevAuth, logout } = useAuth();
   const organizationContext = useOrganizationContext();
-  const isSystemAdmin = hasProtectedTenantRole(user);
+  const organizationContextState = resolveOrganizationContextState({
+    roleNames: user?.roles,
+    organizations: organizationContext.context?.organizations,
+    storedActiveOrganizationId: organizationContext.context?.activeOrganizationId,
+  });
+  const isSystemAdmin = organizationContextState.isReadOnly;
   const { locale, setLocale } = useLocale();
   const { mode, toggleMode } = useTheme();
   const currentPathname = useRouterState({
@@ -416,8 +468,6 @@ export default function Header({
   const [isHydrated, setIsHydrated] = React.useState(false);
   const resolvedMode = isHydrated ? mode : 'light';
   const loginHref = isHydrated ? createLoginHref(resolveCurrentReturnTo()) : '/auth/login';
-  const hasActiveOrganizations =
-    (organizationContext.context?.organizations.filter((organization) => organization.isActive).length ?? 0) > 0;
   const showOrganizationContext =
     isHydrated &&
     isAuthenticated &&
@@ -425,7 +475,7 @@ export default function Header({
     !isAuthLoading &&
     Boolean(user) &&
     !organizationContext.isLoading &&
-    hasActiveOrganizations;
+    organizationContextState.hasVisibleMemberships;
   const showAuthenticatedHeaderTools = isHydrated && isAuthenticated && !isLoading && !isAuthLoading;
   const showExperimentalHeaderTools = showAuthenticatedHeaderTools && hasExperimentalAccess(user);
   const hideAnonymousLoginAction = !isAuthenticated && currentPathname === '/';

--- a/apps/sva-studio-react/src/components/Header.tsx
+++ b/apps/sva-studio-react/src/components/Header.tsx
@@ -15,7 +15,7 @@ import { t } from '../i18n';
 import { createAccountActionHref, createLoginHref, resolveCurrentReturnTo } from '../lib/auth-navigation';
 import { clearClientLogoutState } from '../lib/auth-session-state';
 import { useOrganizationContext } from '../hooks/use-organization-context';
-import { hasExperimentalAccess } from '../lib/iam-admin-access';
+import { hasExperimentalAccess, hasProtectedTenantRole } from '../lib/iam-admin-access';
 import { cn } from '../lib/utils';
 import { useAuth } from '../providers/auth-provider';
 import { useLocale } from '../providers/locale-provider';
@@ -49,6 +49,7 @@ type HeaderAuthActionProps = Readonly<{
   isAuthLoading: boolean;
   isAuthenticated: boolean;
   showOrganizationContext: boolean;
+  isSystemAdmin: boolean;
   isDevAuthAvailable?: boolean;
   hideAnonymousLoginAction: boolean;
   loginHref: string;
@@ -251,6 +252,7 @@ const HeaderAuthAction = ({
   isAuthLoading,
   isAuthenticated,
   showOrganizationContext,
+  isSystemAdmin,
   isDevAuthAvailable = false,
   hideAnonymousLoginAction,
   loginHref,
@@ -327,7 +329,7 @@ const HeaderAuthAction = ({
       ? ([
           {
             id: 'organization-context',
-            render: <OrganizationContextSwitcher variant="menu" />,
+            render: <OrganizationContextSwitcher variant="menu" readOnly={isSystemAdmin} />,
           },
           {
             id: 'divider-organization-context',
@@ -405,6 +407,7 @@ export default function Header({
 }: HeaderProps) {
   const { user, isAuthenticated, isLoading: isAuthLoading, isDevAuthAvailable, loginWithDevAuth, logout } = useAuth();
   const organizationContext = useOrganizationContext();
+  const isSystemAdmin = hasProtectedTenantRole(user);
   const { locale, setLocale } = useLocale();
   const { mode, toggleMode } = useTheme();
   const currentPathname = useRouterState({
@@ -413,8 +416,8 @@ export default function Header({
   const [isHydrated, setIsHydrated] = React.useState(false);
   const resolvedMode = isHydrated ? mode : 'light';
   const loginHref = isHydrated ? createLoginHref(resolveCurrentReturnTo()) : '/auth/login';
-  const hasMultipleActiveOrganizations =
-    (organizationContext.context?.organizations.filter((organization) => organization.isActive).length ?? 0) > 1;
+  const hasActiveOrganizations =
+    (organizationContext.context?.organizations.filter((organization) => organization.isActive).length ?? 0) > 0;
   const showOrganizationContext =
     isHydrated &&
     isAuthenticated &&
@@ -422,7 +425,7 @@ export default function Header({
     !isAuthLoading &&
     Boolean(user) &&
     !organizationContext.isLoading &&
-    hasMultipleActiveOrganizations;
+    hasActiveOrganizations;
   const showAuthenticatedHeaderTools = isHydrated && isAuthenticated && !isLoading && !isAuthLoading;
   const showExperimentalHeaderTools = showAuthenticatedHeaderTools && hasExperimentalAccess(user);
   const hideAnonymousLoginAction = !isAuthenticated && currentPathname === '/';
@@ -548,6 +551,7 @@ export default function Header({
             isAuthLoading={isAuthLoading}
             isAuthenticated={isAuthenticated}
             showOrganizationContext={showOrganizationContext}
+            isSystemAdmin={isSystemAdmin}
             isDevAuthAvailable={isDevAuthAvailable}
             hideAnonymousLoginAction={hideAnonymousLoginAction}
             loginHref={loginHref}

--- a/apps/sva-studio-react/src/components/OrganizationContextSwitcher.test.tsx
+++ b/apps/sva-studio-react/src/components/OrganizationContextSwitcher.test.tsx
@@ -314,4 +314,71 @@ describe('OrganizationContextSwitcher', () => {
     expect(select.className).toContain('rounded-lg');
     expect(screen.queryByText('beta · municipality · Default-Kontext')).toBeNull();
   });
+
+  it('renders organization memberships in the menu even when only one active organization exists', () => {
+    useOrganizationContextMock.mockReturnValue({
+      context: {
+        activeOrganizationId: 'org-1',
+        organizations: [
+          {
+            organizationId: 'org-1',
+            organizationKey: 'alpha',
+            displayName: 'Alpha',
+            organizationType: 'county',
+            isActive: true,
+            isDefaultContext: true,
+          },
+        ],
+      },
+      isLoading: false,
+      isUpdating: false,
+      error: null,
+      refetch: vi.fn(),
+      switchOrganization: vi.fn(),
+    });
+
+    render(<OrganizationContextSwitcher variant="menu" />);
+
+    expect(screen.getByText('Organisationsmitgliedschaften')).toBeTruthy();
+    expect(screen.getByText('Alpha')).toBeTruthy();
+  });
+
+  it('renders system_admin memberships as read-only without a selector', () => {
+    useOrganizationContextMock.mockReturnValue({
+      context: {
+        activeOrganizationId: undefined,
+        organizations: [
+          {
+            organizationId: 'org-1',
+            organizationKey: 'alpha',
+            displayName: 'Alpha',
+            organizationType: 'county',
+            isActive: true,
+            isDefaultContext: true,
+          },
+          {
+            organizationId: 'org-2',
+            organizationKey: 'beta',
+            displayName: 'Beta',
+            organizationType: 'municipality',
+            isActive: true,
+            isDefaultContext: false,
+          },
+        ],
+      },
+      isLoading: false,
+      isUpdating: false,
+      error: null,
+      refetch: vi.fn(),
+      switchOrganization: vi.fn(),
+    });
+
+    render(<OrganizationContextSwitcher variant="menu" readOnly />);
+
+    expect(screen.queryByLabelText('Aktive Organisation')).toBeNull();
+    expect(screen.getByText('Organisationsmitgliedschaften')).toBeTruthy();
+    expect(screen.getByText('Als Systemadmin arbeiten Sie instanzweit; Organisationsmitgliedschaften schränken Ihre Rechte nicht ein.')).toBeTruthy();
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.getByText('Beta')).toBeTruthy();
+  });
 });

--- a/apps/sva-studio-react/src/components/OrganizationContextSwitcher.test.tsx
+++ b/apps/sva-studio-react/src/components/OrganizationContextSwitcher.test.tsx
@@ -381,4 +381,31 @@ describe('OrganizationContextSwitcher', () => {
     expect(screen.getByText('Alpha')).toBeTruthy();
     expect(screen.getByText('Beta')).toBeTruthy();
   });
+
+  it('does not announce a stale active organization in read-only mode', () => {
+    useOrganizationContextMock.mockReturnValue({
+      context: {
+        activeOrganizationId: 'org-1',
+        organizations: [
+          {
+            organizationId: 'org-1',
+            organizationKey: 'alpha',
+            displayName: 'Alpha',
+            organizationType: 'county',
+            isActive: true,
+            isDefaultContext: true,
+          },
+        ],
+      },
+      isLoading: false,
+      isUpdating: false,
+      error: null,
+      refetch: vi.fn(),
+      switchOrganization: vi.fn(),
+    });
+
+    render(<OrganizationContextSwitcher variant="menu" readOnly />);
+
+    expect(screen.getByRole('status').textContent).toBe('');
+  });
 });

--- a/apps/sva-studio-react/src/components/OrganizationContextSwitcher.tsx
+++ b/apps/sva-studio-react/src/components/OrganizationContextSwitcher.tsx
@@ -25,9 +25,13 @@ const organizationContextErrorMessage = (error: IamHttpError | null) => {
 
 type OrganizationContextSwitcherProps = Readonly<{
   variant?: 'inline' | 'menu';
+  readOnly?: boolean;
 }>;
 
-export const OrganizationContextSwitcher = ({ variant = 'inline' }: OrganizationContextSwitcherProps) => {
+export const OrganizationContextSwitcher = ({
+  variant = 'inline',
+  readOnly = false,
+}: OrganizationContextSwitcherProps) => {
   const organizationContext = useOrganizationContext();
   const options = organizationContext.context?.organizations.filter((organization) => organization.isActive) ?? [];
   const activeOrganization = options.find(
@@ -37,12 +41,14 @@ export const OrganizationContextSwitcher = ({ variant = 'inline' }: Organization
   const statusId = React.useId();
   const errorId = React.useId();
   const describedBy = [statusId, errorMessage ? errorId : null].filter(Boolean).join(' ') || undefined;
+  const isMenuVariant = variant === 'menu';
 
-  if (organizationContext.isLoading || options.length <= 1) {
+  const shouldRenderSelector = !readOnly && options.length > 1;
+  const shouldRenderMenuMemberships = isMenuVariant && options.length > 0;
+
+  if (organizationContext.isLoading || (!shouldRenderSelector && !shouldRenderMenuMemberships)) {
     return null;
   }
-
-  const isMenuVariant = variant === 'menu';
 
   return (
     <div
@@ -52,38 +58,59 @@ export const OrganizationContextSwitcher = ({ variant = 'inline' }: Organization
       )}
     >
       <div className={cn('field-group', isMenuVariant ? 'flex w-full flex-col gap-2' : 'flex items-center gap-2')}>
-        <Label
-          htmlFor="organization-context-switcher"
-          className={cn(isMenuVariant ? 'text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground' : undefined)}
-        >
-          {t('shell.header.organizationContext')}
-        </Label>
-        <Select
-          id="organization-context-switcher"
-          aria-label={t('shell.header.organizationContext')}
-          aria-describedby={describedBy}
-          value={organizationContext.context?.activeOrganizationId ?? ''}
-          onChange={(event) => {
-            if (!event.target.value) {
-              return;
-            }
-            void organizationContext.switchOrganization(event.target.value);
-          }}
-          className={cn(
-            'text-sm',
-            isMenuVariant
-              ? 'h-10 w-full rounded-lg border-border bg-background px-3 py-2 shadow-none'
-              : 'h-8 w-auto min-w-40 max-w-full px-2 py-1'
-          )}
-          disabled={organizationContext.isUpdating}
-        >
-          {options.map((organization) => (
-            <option key={organization.organizationId} value={organization.organizationId}>
-              {organization.displayName}
-            </option>
-          ))}
-        </Select>
+        {shouldRenderSelector ? (
+          <>
+            <Label
+              htmlFor="organization-context-switcher"
+              className={cn(isMenuVariant ? 'text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground' : undefined)}
+            >
+              {t('shell.header.organizationContext')}
+            </Label>
+            <Select
+              id="organization-context-switcher"
+              aria-label={t('shell.header.organizationContext')}
+              aria-describedby={describedBy}
+              value={organizationContext.context?.activeOrganizationId ?? ''}
+              onChange={(event) => {
+                if (!event.target.value) {
+                  return;
+                }
+                void organizationContext.switchOrganization(event.target.value);
+              }}
+              className={cn(
+                'text-sm',
+                isMenuVariant
+                  ? 'h-10 w-full rounded-lg border-border bg-background px-3 py-2 shadow-none'
+                  : 'h-8 w-auto min-w-40 max-w-full px-2 py-1'
+              )}
+              disabled={organizationContext.isUpdating}
+            >
+              {options.map((organization) => (
+                <option key={organization.organizationId} value={organization.organizationId}>
+                  {organization.displayName}
+                </option>
+              ))}
+            </Select>
+          </>
+        ) : null}
       </div>
+      {shouldRenderMenuMemberships ? (
+        <div className="flex w-full flex-col gap-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            {t('shell.header.organizationMemberships')}
+          </p>
+          {readOnly ? (
+            <p className="text-xs text-muted-foreground">
+              {t('shell.header.organizationMembershipsSystemAdminHint')}
+            </p>
+          ) : null}
+          <ul className="flex flex-col gap-1 text-sm text-foreground">
+            {options.map((organization) => (
+              <li key={organization.organizationId}>{organization.displayName}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
       <span id={statusId} role="status" aria-live="polite" className="sr-only">
         {organizationContext.isUpdating
           ? t('shell.header.organizationContextUpdating')

--- a/apps/sva-studio-react/src/components/OrganizationContextSwitcher.tsx
+++ b/apps/sva-studio-react/src/components/OrganizationContextSwitcher.tsx
@@ -39,9 +39,9 @@ export const OrganizationContextSwitcher = ({
     storedActiveOrganizationId: organizationContext.context?.activeOrganizationId,
   });
   const options = organizationContextState.activeOrganizations;
-  const activeOrganization = options.find(
-    (organization) => organization.organizationId === organizationContext.context?.activeOrganizationId
-  );
+  const activeOrganization = readOnly
+    ? undefined
+    : options.find((organization) => organization.organizationId === organizationContextState.activeOrganizationId);
   const errorMessage = organizationContextErrorMessage(organizationContext.error);
   const statusId = React.useId();
   const errorId = React.useId();
@@ -75,7 +75,7 @@ export const OrganizationContextSwitcher = ({
               id="organization-context-switcher"
               aria-label={t('shell.header.organizationContext')}
               aria-describedby={describedBy}
-              value={organizationContext.context?.activeOrganizationId ?? ''}
+              value={organizationContextState.activeOrganizationId ?? ''}
               onChange={(event) => {
                 if (!event.target.value) {
                   return;

--- a/apps/sva-studio-react/src/components/OrganizationContextSwitcher.tsx
+++ b/apps/sva-studio-react/src/components/OrganizationContextSwitcher.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { resolveOrganizationContextState } from '@sva/core';
 
 import type { IamHttpError } from '../lib/iam-api';
 import { t } from '../i18n';
@@ -33,7 +34,11 @@ export const OrganizationContextSwitcher = ({
   readOnly = false,
 }: OrganizationContextSwitcherProps) => {
   const organizationContext = useOrganizationContext();
-  const options = organizationContext.context?.organizations.filter((organization) => organization.isActive) ?? [];
+  const organizationContextState = resolveOrganizationContextState({
+    organizations: organizationContext.context?.organizations,
+    storedActiveOrganizationId: organizationContext.context?.activeOrganizationId,
+  });
+  const options = organizationContextState.activeOrganizations;
   const activeOrganization = options.find(
     (organization) => organization.organizationId === organizationContext.context?.activeOrganizationId
   );
@@ -43,8 +48,8 @@ export const OrganizationContextSwitcher = ({
   const describedBy = [statusId, errorMessage ? errorId : null].filter(Boolean).join(' ') || undefined;
   const isMenuVariant = variant === 'menu';
 
-  const shouldRenderSelector = !readOnly && options.length > 1;
-  const shouldRenderMenuMemberships = isMenuVariant && options.length > 0;
+  const shouldRenderSelector = !readOnly && organizationContextState.canSwitch;
+  const shouldRenderMenuMemberships = isMenuVariant && organizationContextState.hasVisibleMemberships;
 
   if (organizationContext.isLoading || (!shouldRenderSelector && !shouldRenderMenuMemberships)) {
     return null;

--- a/apps/sva-studio-react/src/i18n/resources/de/shell.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/shell.resources.ts
@@ -91,6 +91,9 @@ export const shellDEResources = {
     adminRoles: 'Rollen',
     adminGroups: 'Gruppen',
     organizationContext: 'Aktive Organisation',
+    organizationMemberships: 'Organisationsmitgliedschaften',
+    organizationMembershipsSystemAdminHint:
+      'Als Systemadmin arbeiten Sie instanzweit; Organisationsmitgliedschaften schränken Ihre Rechte nicht ein.',
     organizationContextStatus: 'Aktiver Organisationskontext: {{name}}',
     organizationContextUpdating: 'Organisationskontext wird aktualisiert.',
     organizationContextError: 'Organisationskontext konnte nicht gewechselt werden.',

--- a/apps/sva-studio-react/src/i18n/resources/en/shell.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/shell.resources.ts
@@ -90,6 +90,9 @@ export const shellENResources = {
     adminRoles: 'Roles',
     adminGroups: 'Groups',
     organizationContext: 'Active organization',
+    organizationMemberships: 'Organization memberships',
+    organizationMembershipsSystemAdminHint:
+      'As a system admin, you work instance-wide; organization memberships do not limit your permissions.',
     organizationContextStatus: 'Active organization context: {{name}}',
     organizationContextUpdating: 'Organization context is being updated.',
     organizationContextError: 'Organization context could not be changed.',

--- a/apps/sva-studio-react/src/lib/iam-admin-access.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-admin-access.test.ts
@@ -47,7 +47,7 @@ describe('iam-admin-access', () => {
     expect(access.hasMonitoringAccess(user)).toBe(true);
     expect(access.hasInterfacesAccess(user)).toBe(true);
     expect(access.hasExperimentalAccess(user)).toBe(true);
-    expect(access.hasProtectedTenantRole(user)).toBe(false);
+    expect(access.hasSystemAdminRole(user)).toBe(false);
     expect(access.hasPlatformInstanceAdminAccess(user)).toBe(true);
     expect(access.hasUserAdminAccess(null)).toBe(false);
   });

--- a/apps/sva-studio-react/src/lib/iam-admin-access.ts
+++ b/apps/sva-studio-react/src/lib/iam-admin-access.ts
@@ -1,3 +1,5 @@
+import { hasSystemAdminRole as hasCoreSystemAdminRole } from '@sva/core';
+
 type UserWithRoles = {
   roles?: readonly string[];
   permissionActions?: readonly string[];
@@ -16,7 +18,6 @@ const IAM_GOVERNANCE_PERMISSIONS = new Set([
   'iam.dsr.read',
   'iam.deletionRules.read',
 ]);
-const SYSTEM_ADMIN_ROLES = new Set(['system_admin']);
 const ROOT_ADMIN_ROLES = new Set(['instance_registry_admin']);
 
 const readFlag = (value: string | undefined, fallback: boolean) => {
@@ -57,8 +58,7 @@ export const hasExperimentalAccess = (user: UserWithRoles | null | undefined) =>
 export const hasMonitoringAccess = (user: UserWithRoles | null | undefined) =>
   user?.permissionActions?.includes(MONITORING_PERMISSION) === true;
 
-export const hasProtectedTenantRole = (user: UserWithRoles | null | undefined) =>
-  Boolean(user?.roles?.some((role) => SYSTEM_ADMIN_ROLES.has(role)));
+export const hasSystemAdminRole = (user: UserWithRoles | null | undefined) => hasCoreSystemAdminRole(user?.roles);
 
 export const hasPlatformInstanceAdminAccess = (user: UserWithRoles | null | undefined) =>
   Boolean(user?.roles?.some((role) => ROOT_ADMIN_ROLES.has(role)));

--- a/apps/sva-studio-react/src/routing/app-route-bindings.tsx
+++ b/apps/sva-studio-react/src/routing/app-route-bindings.tsx
@@ -1,5 +1,5 @@
 import { normalizeIamTab, normalizeRoleDetailTab, type AppRouteBindings as BaseAppRouteBindings } from '@sva/routing';
-import type { IamOrganizationContextOption, IamOrganizationDetail } from '@sva/core';
+import { resolveUserDisplayName, type IamOrganizationContextOption, type IamOrganizationDetail } from '@sva/core';
 import { CategoriesPage } from '@sva/plugin-categories';
 import { EventsCreatePage, EventsEditPage } from '@sva/plugin-events';
 import { NewsDetailPage, NewsEditPage, type NewsAuthorControl } from '@sva/plugin-news';
@@ -44,11 +44,6 @@ import { PlaceholderPage } from '../routes/-placeholder-page';
 
 const readStringParam = (value: unknown, fallback = ''): string => {
   return typeof value === 'string' ? value : fallback;
-};
-
-const resolveUserDisplayName = (user: { readonly id: string }) => {
-  const candidate = user as { readonly name?: string; readonly displayName?: string };
-  return candidate.displayName?.trim() || candidate.name?.trim() || user.id;
 };
 
 const EMPTY_ORGANIZATIONS: readonly IamOrganizationContextOption[] = [];

--- a/packages/auth-runtime/src/iam-contents/request-context.test.ts
+++ b/packages/auth-runtime/src/iam-contents/request-context.test.ts
@@ -331,4 +331,21 @@ describe('content request authorization context', () => {
     );
     expect('error' in missingAccount && missingAccount.error.status).toBe(403);
   });
+
+  it('clears stale session organization scope when the actor is system_admin', async () => {
+    getSessionMock.mockResolvedValueOnce({ activeOrganizationId: 'org-1' });
+
+    await expect(
+      resolveContentActor(new Request('https://example.test/content'), {
+        sessionId: 'session-1',
+        user: { id: 'subject-1', roles: ['system_admin'], instanceId: 'instance-1' },
+      } as never)
+    ).resolves.toMatchObject({
+      actor: {
+        instanceId: 'instance-1',
+        actorAccountId: 'account-1',
+        activeOrganizationId: undefined,
+      },
+    });
+  });
 });

--- a/packages/auth-runtime/src/iam-contents/request-context.ts
+++ b/packages/auth-runtime/src/iam-contents/request-context.ts
@@ -1,4 +1,5 @@
 import {
+  resolveSessionActiveOrganizationId,
   summarizeContentAccess,
   type IamContentAccessSummary, type IamContentDomainCapability, type IamContentPrimitiveAction,
 } from '@sva/core';
@@ -310,7 +311,10 @@ export const resolveContentActor = async (
       actorDisplayName: ctx.user.id,
       requestId: actorResolution.actor.requestId,
       traceId: actorResolution.actor.traceId,
-      activeOrganizationId: session?.activeOrganizationId,
+      activeOrganizationId: resolveSessionActiveOrganizationId({
+        roleNames: ctx.user.roles,
+        activeOrganizationId: session?.activeOrganizationId,
+      }),
     },
   };
 };

--- a/packages/auth-runtime/src/iam-contents/request-context.ts
+++ b/packages/auth-runtime/src/iam-contents/request-context.ts
@@ -5,7 +5,6 @@ import {
 } from '@sva/core';
 import { evaluateAuthorizeDecision, type AuthorizeRequest, type EffectivePermission } from '@sva/iam-core';
 import { getWorkspaceContext, toJsonErrorResponse, withRequestContext } from '@sva/server-runtime';
-
 import { createApiError } from '../iam-account-management/api-helpers.js';
 import { ensureFeature, getFeatureFlags } from '../iam-account-management/feature-flags.js';
 import { resolveEffectivePermissions } from '../iam-authorization/permission-store.js';

--- a/packages/auth-runtime/src/iam-contents/server-authorization.model.ts
+++ b/packages/auth-runtime/src/iam-contents/server-authorization.model.ts
@@ -1,3 +1,4 @@
+import { resolveSessionActiveOrganizationId } from '@sva/core';
 import {
   evaluateAuthorizeDecision,
   type AuthorizeRequest,
@@ -176,12 +177,16 @@ export const resolveOrganizationOptionalDecision = (
 export const resolveActiveOrganizationId = async (input: {
   readonly sessionId: string;
   readonly instanceId: string;
+  readonly roleNames?: readonly string[];
   readonly requestId?: string;
   readonly traceId?: string;
 }): Promise<string | undefined | ContentPrimitiveAuthorizationResult> => {
   try {
     const session = await getSession(input.sessionId);
-    return session?.activeOrganizationId;
+    return resolveSessionActiveOrganizationId({
+      roleNames: input.roleNames,
+      activeOrganizationId: session?.activeOrganizationId,
+    });
   } catch (error) {
     accountLogger.error('Content primitive authorization session lookup failed', {
       operation: 'content_primitive_authorize',

--- a/packages/auth-runtime/src/iam-contents/server-authorization.test.ts
+++ b/packages/auth-runtime/src/iam-contents/server-authorization.test.ts
@@ -246,6 +246,44 @@ describe('authorizeContentPrimitiveForUser', () => {
     );
   });
 
+  it('ignores stale session organization scope for system_admin users', async () => {
+    getSessionMock.mockResolvedValueOnce({
+      id: 'session-1',
+      userId: 'user-1',
+      createdAt: Date.now(),
+      activeOrganizationId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    await expect(
+      authorizeContentPrimitiveForUser({
+        ctx: {
+          ...createCtx(),
+          user: {
+            ...createCtx().user,
+            roles: ['system_admin'],
+          },
+        },
+        action: 'news.read',
+        resource: {
+          contentType: 'news.article',
+        },
+      })
+    ).resolves.toEqual({
+      ok: true,
+      actor: {
+        instanceId: 'instance-1',
+        keycloakSubject: 'subject-1',
+      },
+      permissions: [permission],
+    });
+
+    expect(resolveEffectivePermissionsMock).toHaveBeenCalledWith({
+      instanceId: 'instance-1',
+      keycloakSubject: 'subject-1',
+      organizationId: undefined,
+    });
+  });
+
   it('falls back to account-wide authorization when no organization context is available', async () => {
     resolveEffectivePermissionsMock.mockResolvedValueOnce({
       ok: true,

--- a/packages/auth-runtime/src/iam-contents/server-authorization.ts
+++ b/packages/auth-runtime/src/iam-contents/server-authorization.ts
@@ -50,6 +50,7 @@ export const authorizeContentPrimitiveForUser = async (input: {
     const activeOrganizationId = await resolveActiveOrganizationId({
       sessionId: input.ctx.sessionId,
       instanceId,
+      roleNames: input.ctx.user.roles,
       requestId: workspaceContext.requestId,
       traceId: workspaceContext.traceId,
     });

--- a/packages/auth-runtime/src/middleware.test.ts
+++ b/packages/auth-runtime/src/middleware.test.ts
@@ -229,15 +229,6 @@ describe('auth-runtime withAuthenticatedUser', () => {
     const request = new Request('http://localhost/auth/me', {
       headers: { cookie: 'sva_auth_session=session-2' },
     });
-    dbMocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolvePool, _instanceId, work) =>
-      work({
-        query: vi.fn(async () => ({
-          rowCount: 1,
-          rows: [{ role_key: 'system_admin' }],
-        })),
-      })
-    );
-
     const response = await withAuthenticatedUser(
       request,
       ({ sessionId, sessionExpiresAt, freshReauthAt, activeOrganizationId, user }) =>
@@ -258,13 +249,52 @@ describe('auth-runtime withAuthenticatedUser', () => {
       freshReauthAt: 1_700_000_000_000,
       activeOrganizationId: '11111111-1111-1111-8111-111111111111',
       userId: 'user-1',
-      roles: ['system_admin'],
+      roles: [],
     });
     expect(authServerMocks.resolveSessionUser).toHaveBeenCalledWith(
       request,
       expect.objectContaining({ id: 'user-1' })
     );
     expect(dbMocks.withResolvedInstanceDb).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears stale active organization scope for system_admin users in the authenticated context', async () => {
+    getSessionUserMock.mockResolvedValue({
+      kind: 'authenticated',
+      user: {
+        id: 'user-1',
+        name: 'Max',
+        roles: ['editor'],
+        instanceId: 'de-musterhausen',
+      },
+      activeOrganizationId: '11111111-1111-1111-8111-111111111111',
+    });
+    const request = new Request('http://localhost/auth/me', {
+      headers: { cookie: 'sva_auth_session=session-2' },
+    });
+    dbMocks.withResolvedInstanceDb.mockImplementationOnce(async (_resolvePool, _instanceId, work) =>
+      work({
+        query: vi.fn(async () => ({
+          rowCount: 1,
+          rows: [{ role_key: 'system_admin' }],
+        })),
+      })
+    );
+
+    const response = await withAuthenticatedUser(
+      request,
+      ({ activeOrganizationId, user }) =>
+        Response.json({
+          activeOrganizationId,
+          roles: user.roles,
+        })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      activeOrganizationId: undefined,
+      roles: ['system_admin'],
+    });
   });
 
   it('can skip effective role hydration for handlers that resolve permissions separately', async () => {

--- a/packages/auth-runtime/src/middleware.ts
+++ b/packages/auth-runtime/src/middleware.ts
@@ -1,4 +1,5 @@
 import { parse as parseCookie } from 'cookie-es';
+import { resolveSessionActiveOrganizationId } from '@sva/core';
 import { createSdkLogger } from '@sva/server-runtime';
 
 import { createApiError } from './api-error.js';
@@ -165,6 +166,10 @@ const createAuthenticatedContext = async (
     ? runtimeSessionUser
     : await enrichSessionUserWithEffectiveRoles(runtimeSessionUser);
   const runtimeSessionHydrationMs = performance.now() - runtimeSessionHydrationStartedAt;
+  const activeOrganizationId = resolveSessionActiveOrganizationId({
+    roleNames: effectiveSessionUser.roles,
+    activeOrganizationId: sessionResolution.activeOrganizationId,
+  });
 
   return {
     kind: 'authenticated',
@@ -172,7 +177,7 @@ const createAuthenticatedContext = async (
     storedSessionResolutionMs,
     runtimeSessionHydrationMs,
     freshReauthAt: sessionResolution.freshReauthAt,
-    activeOrganizationId: sessionResolution.activeOrganizationId,
+    activeOrganizationId,
     sessionId,
     sessionExpiresAt: sessionResolution.expiresAt,
     user: effectiveSessionUser,

--- a/packages/core/src/iam/index.ts
+++ b/packages/core/src/iam/index.ts
@@ -1,5 +1,7 @@
 export { extractRoles, resolveInstanceId, resolveUserName } from './claims.js';
+export { hasSystemAdminRole, resolveOrganizationContextState } from './organization-context-policy.js';
 export { parseJwtPayload } from './token.js';
+export { resolveUserDisplayName, resolveUserInitials } from './user-display.js';
 export type {
   IamAccountProfile,
   IamAccountStatus,

--- a/packages/core/src/iam/index.ts
+++ b/packages/core/src/iam/index.ts
@@ -1,5 +1,9 @@
 export { extractRoles, resolveInstanceId, resolveUserName } from './claims.js';
-export { hasSystemAdminRole, resolveOrganizationContextState } from './organization-context-policy.js';
+export {
+  hasSystemAdminRole,
+  resolveOrganizationContextState,
+  resolveSessionActiveOrganizationId,
+} from './organization-context-policy.js';
 export { parseJwtPayload } from './token.js';
 export { resolveUserDisplayName, resolveUserInitials } from './user-display.js';
 export type {

--- a/packages/core/src/iam/organization-context-policy.test.ts
+++ b/packages/core/src/iam/organization-context-policy.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { hasSystemAdminRole, resolveOrganizationContextState } from './organization-context-policy.js';
+import {
+  hasSystemAdminRole,
+  resolveOrganizationContextState,
+  resolveSessionActiveOrganizationId,
+} from './organization-context-policy.js';
 
 describe('organization context policy', () => {
   describe('hasSystemAdminRole', () => {
@@ -8,6 +12,23 @@ describe('organization context policy', () => {
       expect(hasSystemAdminRole(['editor', 'system_admin'])).toBe(true);
       expect(hasSystemAdminRole([' editor ', ' viewer '])).toBe(false);
       expect(hasSystemAdminRole(undefined)).toBe(false);
+    });
+  });
+
+  describe('resolveSessionActiveOrganizationId', () => {
+    it('clears active organization scope for system_admin users and keeps it for other roles', () => {
+      expect(
+        resolveSessionActiveOrganizationId({
+          roleNames: ['system_admin'],
+          activeOrganizationId: 'org-1',
+        })
+      ).toBeUndefined();
+      expect(
+        resolveSessionActiveOrganizationId({
+          roleNames: ['editor'],
+          activeOrganizationId: 'org-1',
+        })
+      ).toBe('org-1');
     });
   });
 

--- a/packages/core/src/iam/organization-context-policy.test.ts
+++ b/packages/core/src/iam/organization-context-policy.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasSystemAdminRole, resolveOrganizationContextState } from './organization-context-policy.js';
+
+describe('organization context policy', () => {
+  describe('hasSystemAdminRole', () => {
+    it('detects the canonical system_admin role from mixed role inputs', () => {
+      expect(hasSystemAdminRole(['editor', 'system_admin'])).toBe(true);
+      expect(hasSystemAdminRole([' editor ', ' viewer '])).toBe(false);
+      expect(hasSystemAdminRole(undefined)).toBe(false);
+    });
+  });
+
+  describe('resolveOrganizationContextState', () => {
+    const organizations = [
+      { organizationId: 'org-1', isActive: true },
+      { organizationId: 'org-2', isActive: false },
+      { organizationId: 'org-3', isActive: true },
+    ] as const;
+
+    it('returns a read-only membership view for system_admin users', () => {
+      const state = resolveOrganizationContextState({
+        roleNames: ['system_admin'],
+        organizations,
+        storedActiveOrganizationId: 'org-1',
+        chooseActiveOrganizationId: () => 'org-3',
+      });
+
+      expect(state).toEqual({
+        activeOrganizations: [
+          { organizationId: 'org-1', isActive: true },
+          { organizationId: 'org-3', isActive: true },
+        ],
+        activeOrganizationId: undefined,
+        canSwitch: false,
+        hasVisibleMemberships: true,
+        isReadOnly: true,
+      });
+    });
+
+    it('resolves the active organization for non-admin users through the injected chooser', () => {
+      const state = resolveOrganizationContextState({
+        roleNames: ['editor'],
+        organizations,
+        storedActiveOrganizationId: 'org-1',
+        chooseActiveOrganizationId: ({ storedActiveOrganizationId, activeOrganizations }) =>
+          storedActiveOrganizationId === 'org-1' ? activeOrganizations[1]?.organizationId : undefined,
+      });
+
+      expect(state).toEqual({
+        activeOrganizations: [
+          { organizationId: 'org-1', isActive: true },
+          { organizationId: 'org-3', isActive: true },
+        ],
+        activeOrganizationId: 'org-3',
+        canSwitch: true,
+        hasVisibleMemberships: true,
+        isReadOnly: false,
+      });
+    });
+
+    it('handles missing active organizations without exposing a visible context block', () => {
+      const state = resolveOrganizationContextState({
+        roleNames: ['editor'],
+        organizations: [{ organizationId: 'org-1', isActive: false }],
+        storedActiveOrganizationId: 'org-1',
+      });
+
+      expect(state).toEqual({
+        activeOrganizations: [],
+        activeOrganizationId: undefined,
+        canSwitch: false,
+        hasVisibleMemberships: false,
+        isReadOnly: false,
+      });
+    });
+  });
+});

--- a/packages/core/src/iam/organization-context-policy.test.ts
+++ b/packages/core/src/iam/organization-context-policy.test.ts
@@ -74,5 +74,25 @@ describe('organization context policy', () => {
         isReadOnly: false,
       });
     });
+
+    it('keeps a stored active organization when it still belongs to the active memberships', () => {
+      const state = resolveOrganizationContextState({
+        roleNames: ['editor'],
+        organizations,
+        storedActiveOrganizationId: 'org-3',
+      });
+
+      expect(state.activeOrganizationId).toBe('org-3');
+    });
+
+    it('falls back to the first active organization when no stored context matches', () => {
+      const state = resolveOrganizationContextState({
+        roleNames: ['editor'],
+        organizations,
+        storedActiveOrganizationId: 'org-2',
+      });
+
+      expect(state.activeOrganizationId).toBe('org-1');
+    });
   });
 });

--- a/packages/core/src/iam/organization-context-policy.ts
+++ b/packages/core/src/iam/organization-context-policy.ts
@@ -11,6 +11,11 @@ const normalizeRoleNames = (roleNames: readonly string[] | undefined): readonly 
 export const hasSystemAdminRole = (roleNames: readonly string[] | undefined): boolean =>
   normalizeRoleNames(roleNames).includes(SYSTEM_ADMIN_ROLE);
 
+export const resolveSessionActiveOrganizationId = (input: {
+  readonly roleNames?: readonly string[];
+  readonly activeOrganizationId?: string;
+}): string | undefined => (hasSystemAdminRole(input.roleNames) ? undefined : input.activeOrganizationId);
+
 const defaultChooseActiveOrganizationId = <T extends OrganizationContextOptionLike>(input: {
   readonly storedActiveOrganizationId?: string;
   readonly activeOrganizations: readonly T[];

--- a/packages/core/src/iam/organization-context-policy.ts
+++ b/packages/core/src/iam/organization-context-policy.ts
@@ -1,0 +1,53 @@
+const SYSTEM_ADMIN_ROLE = 'system_admin';
+
+type OrganizationContextOptionLike = {
+  readonly organizationId: string;
+  readonly isActive: boolean;
+};
+
+const normalizeRoleNames = (roleNames: readonly string[] | undefined): readonly string[] =>
+  [...new Set(roleNames?.map((roleName) => roleName.trim()).filter((roleName) => roleName.length > 0) ?? [])];
+
+export const hasSystemAdminRole = (roleNames: readonly string[] | undefined): boolean =>
+  normalizeRoleNames(roleNames).includes(SYSTEM_ADMIN_ROLE);
+
+const defaultChooseActiveOrganizationId = <T extends OrganizationContextOptionLike>(input: {
+  readonly storedActiveOrganizationId?: string;
+  readonly activeOrganizations: readonly T[];
+}): string | undefined => {
+  if (
+    input.storedActiveOrganizationId &&
+    input.activeOrganizations.some((organization) => organization.organizationId === input.storedActiveOrganizationId)
+  ) {
+    return input.storedActiveOrganizationId;
+  }
+
+  return input.activeOrganizations[0]?.organizationId;
+};
+
+export const resolveOrganizationContextState = <T extends OrganizationContextOptionLike>(input: {
+  readonly roleNames?: readonly string[];
+  readonly organizations?: readonly T[];
+  readonly storedActiveOrganizationId?: string;
+  readonly chooseActiveOrganizationId?: (input: {
+    readonly storedActiveOrganizationId?: string;
+    readonly activeOrganizations: readonly T[];
+  }) => string | undefined;
+}) => {
+  const activeOrganizations = (input.organizations ?? []).filter((organization) => organization.isActive);
+  const isReadOnly = hasSystemAdminRole(input.roleNames);
+  const activeOrganizationId = isReadOnly
+    ? undefined
+    : (input.chooseActiveOrganizationId ?? defaultChooseActiveOrganizationId)({
+        storedActiveOrganizationId: input.storedActiveOrganizationId,
+        activeOrganizations,
+      });
+
+  return {
+    activeOrganizations,
+    activeOrganizationId,
+    canSwitch: !isReadOnly && activeOrganizations.length > 1,
+    hasVisibleMemberships: activeOrganizations.length > 0,
+    isReadOnly,
+  };
+};

--- a/packages/core/src/iam/user-display.test.ts
+++ b/packages/core/src/iam/user-display.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveUserDisplayName, resolveUserInitials } from './user-display.js';
+
+describe('user display helpers', () => {
+  describe('resolveUserDisplayName', () => {
+    it('prefers displayName, then name, then the technical id', () => {
+      expect(
+        resolveUserDisplayName({
+          id: 'user-1',
+          displayName: 'Display Name',
+          name: 'Fallback Name',
+        })
+      ).toBe('Display Name');
+      expect(
+        resolveUserDisplayName({
+          id: 'user-2',
+          displayName: '   ',
+          name: 'Fallback Name',
+        })
+      ).toBe('Fallback Name');
+      expect(
+        resolveUserDisplayName({
+          id: 'user-3',
+          displayName: '   ',
+          name: '   ',
+        })
+      ).toBe('user-3');
+    });
+  });
+
+  describe('resolveUserInitials', () => {
+    it('derives initials from separated name parts and falls back to the raw value prefix', () => {
+      expect(resolveUserInitials('Ada Lovelace')).toBe('AL');
+      expect(resolveUserInitials('john_doe')).toBe('JD');
+      expect(resolveUserInitials('x')).toBe('X');
+      expect(resolveUserInitials('  ')).toBe('');
+    });
+  });
+});

--- a/packages/core/src/iam/user-display.test.ts
+++ b/packages/core/src/iam/user-display.test.ts
@@ -34,6 +34,7 @@ describe('user display helpers', () => {
       expect(resolveUserInitials('Ada Lovelace')).toBe('AL');
       expect(resolveUserInitials('john_doe')).toBe('JD');
       expect(resolveUserInitials('x')).toBe('X');
+      expect(resolveUserInitials('__')).toBe('__');
       expect(resolveUserInitials('  ')).toBe('');
     });
   });

--- a/packages/core/src/iam/user-display.ts
+++ b/packages/core/src/iam/user-display.ts
@@ -1,0 +1,24 @@
+type UserDisplayIdentity = {
+  readonly id: string;
+  readonly name?: string;
+  readonly displayName?: string;
+};
+
+export const resolveUserDisplayName = (user: UserDisplayIdentity): string =>
+  user.displayName?.trim() || user.name?.trim() || user.id;
+
+export const resolveUserInitials = (value: string): string => {
+  const normalizedValue = value.trim();
+  if (!normalizedValue) {
+    return '';
+  }
+
+  const initials = normalizedValue
+    .split(/[\s._-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+
+  return initials || normalizedValue.slice(0, 2).toUpperCase();
+};

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -322,6 +322,10 @@ test('runtime artifact checks avoid stale images and dev JSX false positives', (
     resolve(testDirectory, '..', '..', '..', 'scripts/ci/patch-runtime-artifact.ts'),
     'utf8'
   );
+  const checkServerPackageRuntime = readFileSync(
+    resolve(testDirectory, '..', '..', '..', 'scripts/ci/check-server-package-runtime.ts'),
+    'utf8'
+  );
   const syncInjectedWorkspacePackages = readFileSync(
     resolve(testDirectory, '..', '..', '..', 'scripts/ci/sync-injected-workspace-packages.ts'),
     'utf8'
@@ -371,6 +375,13 @@ test('runtime artifact checks avoid stale images and dev JSX false positives', (
   assert.match(syncInjectedWorkspacePackages, /await cp\(sourceDistDir, targetDistDir, \{ force: true, recursive: true \}\)/);
   assert.match(syncInjectedWorkspacePackages, /await replaceInjectedDist\(liveSourceDistDir, injectedCopy\.dir\)/);
   assert.match(syncInjectedWorkspacePackages, /if \(injectedCopy\.realDir === workspacePackage\.realDir\)/);
+
+  assert.match(checkServerPackageRuntime, /const replaceInjectedDist = \(sourceDistDir: string, injectedPackageDir: string\): void =>/);
+  assert.match(checkServerPackageRuntime, /const backupDistDir = path\.join\(injectedPackageDir, `\.dist-backup-\$\{swapSuffix\}`\);/);
+  assert.match(checkServerPackageRuntime, /fs\.renameSync\(targetDistDir, backupDistDir\)/);
+  assert.match(checkServerPackageRuntime, /fs\.renameSync\(stagedDistDir, targetDistDir\)/);
+  assert.match(checkServerPackageRuntime, /maxRetries: 5/);
+  assert.doesNotMatch(checkServerPackageRuntime, /fs\.rmSync\(targetDistDir, \{ recursive: true, force: true \}\)/);
 
   assert.match(
     studioProjectJson,

--- a/packages/iam-admin/src/actor-authorization.ts
+++ b/packages/iam-admin/src/actor-authorization.ts
@@ -1,4 +1,4 @@
-import type { ApiErrorCode } from '@sva/core';
+import { hasSystemAdminRole, type ApiErrorCode } from '@sva/core';
 
 import type { QueryClient } from './query-client.js';
 import { isRootOnlyRole } from './role-governance.js';
@@ -35,9 +35,6 @@ SELECT EXISTS (
 
 const normalizeRoleNames = (roleNames: readonly string[] | undefined): readonly string[] =>
   [...new Set(roleNames?.map((roleName) => roleName.trim()).filter((roleName) => roleName.length > 0) ?? [])];
-
-const hasSystemAdminRole = (roleNames: readonly string[] | undefined): boolean =>
-  normalizeRoleNames(roleNames).includes(SYSTEM_ADMIN_ROLE_KEY);
 
 export const resolveActorMaxRoleLevel = async (
   client: QueryClient,

--- a/packages/iam-admin/src/organization-mutation-handlers.test.ts
+++ b/packages/iam-admin/src/organization-mutation-handlers.test.ts
@@ -134,7 +134,7 @@ const ctx = {
   sessionId: 'session-1',
   user: {
     id: 'kc-1',
-    roles: ['system_admin'],
+    roles: ['editor'],
   },
 };
 
@@ -758,6 +758,28 @@ describe('organization mutation handlers', () => {
       expect.anything(),
       expect.objectContaining({ trigger: 'organization_context_switched' })
     );
+  });
+
+  it('keeps the organization context unset for system_admin actors', async () => {
+    const handlers = createOrganizationMutationHandlers(buildDeps());
+
+    const response = await handlers.updateMyOrganizationContextInternal(
+      new Request('http://localhost/api/v1/iam/me/organization-context', { method: 'PATCH' }),
+      {
+        ...ctx,
+        user: { ...ctx.user, roles: ['system_admin'] },
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateSession).toHaveBeenCalledWith('session-1', {
+      activeOrganizationId: undefined,
+    });
+    await expect(json(response)).resolves.toMatchObject({
+      data: {
+        organizations: [expect.objectContaining({ organizationId: '11111111-1111-1111-8111-111111111111' })],
+      },
+    });
   });
 
   it('rejects inactive organizations as new active context', async () => {

--- a/packages/iam-admin/src/organization-mutation-handlers.ts
+++ b/packages/iam-admin/src/organization-mutation-handlers.ts
@@ -1,4 +1,4 @@
-import type { ApiErrorCode } from '@sva/core';
+import { hasSystemAdminRole, type ApiErrorCode } from '@sva/core';
 import type { z } from 'zod';
 
 import type { OrganizationMainserverCredentialState } from './organization-mainserver-credentials.js';
@@ -54,11 +54,6 @@ type OrganizationRow = {
   readonly child_count: number;
   readonly membership_count: number;
 };
-
-const SYSTEM_ADMIN_ROLES = new Set(['system_admin']);
-
-const hasSystemAdminRole = (roles: readonly string[]): boolean =>
-  roles.some((role) => SYSTEM_ADMIN_ROLES.has(role));
 
 export type OrganizationMutationHandlerDeps<TFeatureFlags = unknown> = {
   readonly asApiItem: (data: unknown, requestId?: string) => unknown;

--- a/packages/iam-admin/src/organization-mutation-handlers.ts
+++ b/packages/iam-admin/src/organization-mutation-handlers.ts
@@ -55,6 +55,11 @@ type OrganizationRow = {
   readonly membership_count: number;
 };
 
+const SYSTEM_ADMIN_ROLES = new Set(['system_admin']);
+
+const hasSystemAdminRole = (roles: readonly string[]): boolean =>
+  roles.some((role) => SYSTEM_ADMIN_ROLES.has(role));
+
 export type OrganizationMutationHandlerDeps<TFeatureFlags = unknown> = {
   readonly asApiItem: (data: unknown, requestId?: string) => unknown;
   readonly completeIdempotency: (input: {
@@ -1006,6 +1011,20 @@ WHERE membership.instance_id = $1
       const organizations = await deps.withInstanceScopedDb(actor.instanceId, (client) =>
         deps.loadContextOptions(client, { instanceId: actor.instanceId, accountId: actor.actorAccountId })
       );
+      if (hasSystemAdminRole(ctx.user.roles)) {
+        await deps.updateSession(ctx.sessionId, { activeOrganizationId: undefined });
+
+        return deps.jsonResponse(
+          200,
+          deps.asApiItem(
+            {
+              activeOrganizationId: undefined,
+              organizations,
+            },
+            actor.requestId
+          )
+        );
+      }
       const target = organizations.find((organization) => organization.organizationId === parsed.data.organizationId);
       if (!target) {
         return deps.createApiError(400, 'invalid_organization_id', 'Organisation gehört nicht zum Benutzerkontext.', actor.requestId);

--- a/packages/iam-admin/src/organization-read-handlers.test.ts
+++ b/packages/iam-admin/src/organization-read-handlers.test.ts
@@ -108,7 +108,7 @@ const ctx = {
   sessionId: 'session-1',
   user: {
     id: 'kc-1',
-    roles: ['system_admin'],
+    roles: ['editor'],
   },
 };
 
@@ -163,6 +163,28 @@ describe('organization read handlers', () => {
       expect.objectContaining({ search: 'Alpha', page: 1, pageSize: 20 })
     );
     await expect(json(response)).resolves.toMatchObject({ pagination: { total: 1 }, requestId: 'req-org' });
+  });
+
+  it('returns no active organization context for system_admin users and clears stale session context', async () => {
+    const deps = buildDeps();
+    state.session = { activeOrganizationId: '11111111-1111-1111-8111-111111111111' };
+    const handlers = createOrganizationReadHandlers(deps);
+
+    const response = await handlers.getMyOrganizationContextInternal(
+      new Request('http://localhost/api/v1/iam/me/context'),
+      {
+        ...ctx,
+        user: { ...ctx.user, roles: ['system_admin'] },
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateSession).toHaveBeenCalledWith('session-1', { activeOrganizationId: undefined });
+    await expect(json(response)).resolves.toMatchObject({
+      data: {
+        organizations: [expect.objectContaining({ organizationId: '11111111-1111-1111-8111-111111111111' })],
+      },
+    });
   });
 
   it('supports a custom access authorizer for permission-based tenant organization access', async () => {

--- a/packages/iam-admin/src/organization-read-handlers.ts
+++ b/packages/iam-admin/src/organization-read-handlers.ts
@@ -107,6 +107,11 @@ export type OrganizationReadHandlerDeps<TFeatureFlags = unknown> = {
   ) => Promise<T>;
 };
 
+const SYSTEM_ADMIN_ROLES = new Set(['system_admin']);
+
+const hasSystemAdminRole = (roles: readonly string[]): boolean =>
+  roles.some((role) => SYSTEM_ADMIN_ROLES.has(role));
+
 const createMissingOrganizationReadAuthorizerResponse = <TFeatureFlags>(
   deps: OrganizationReadHandlerDeps<TFeatureFlags>,
   requestId?: string
@@ -260,10 +265,12 @@ export const createOrganizationReadHandlers = <TFeatureFlags>(
         })
       );
       const session = await deps.getSession(ctx.sessionId);
-      const activeOrganizationId = deps.chooseActiveOrganizationId({
-        storedActiveOrganizationId: session?.activeOrganizationId,
-        organizations,
-      });
+      const activeOrganizationId = hasSystemAdminRole(ctx.user.roles)
+        ? undefined
+        : deps.chooseActiveOrganizationId({
+            storedActiveOrganizationId: session?.activeOrganizationId,
+            organizations,
+          });
 
       if (session && session.activeOrganizationId !== activeOrganizationId) {
         await deps.updateSession(ctx.sessionId, { activeOrganizationId });

--- a/packages/iam-admin/src/organization-read-handlers.ts
+++ b/packages/iam-admin/src/organization-read-handlers.ts
@@ -1,11 +1,12 @@
-import type {
+import {
+  resolveOrganizationContextState,
   IamOrganizationContext,
   IamOrganizationContextOption,
   IamOrganizationDetail,
   IamOrganizationListItem,
   IamOrganizationType,
+  type ApiErrorCode,
 } from '@sva/core';
-import type { ApiErrorCode } from '@sva/core';
 
 import type { QueryClient } from './query-client.js';
 
@@ -106,11 +107,6 @@ export type OrganizationReadHandlerDeps<TFeatureFlags = unknown> = {
     work: (client: QueryClient) => Promise<T>
   ) => Promise<T>;
 };
-
-const SYSTEM_ADMIN_ROLES = new Set(['system_admin']);
-
-const hasSystemAdminRole = (roles: readonly string[]): boolean =>
-  roles.some((role) => SYSTEM_ADMIN_ROLES.has(role));
 
 const createMissingOrganizationReadAuthorizerResponse = <TFeatureFlags>(
   deps: OrganizationReadHandlerDeps<TFeatureFlags>,
@@ -265,12 +261,17 @@ export const createOrganizationReadHandlers = <TFeatureFlags>(
         })
       );
       const session = await deps.getSession(ctx.sessionId);
-      const activeOrganizationId = hasSystemAdminRole(ctx.user.roles)
-        ? undefined
-        : deps.chooseActiveOrganizationId({
-            storedActiveOrganizationId: session?.activeOrganizationId,
-            organizations,
-          });
+      const organizationContextState = resolveOrganizationContextState({
+        roleNames: ctx.user.roles,
+        organizations,
+        storedActiveOrganizationId: session?.activeOrganizationId,
+        chooseActiveOrganizationId: ({ storedActiveOrganizationId, activeOrganizations }) =>
+          deps.chooseActiveOrganizationId({
+            storedActiveOrganizationId,
+            organizations: activeOrganizations,
+          }),
+      });
+      const activeOrganizationId = organizationContextState.activeOrganizationId;
 
       if (session && session.activeOrganizationId !== activeOrganizationId) {
         await deps.updateSession(ctx.sessionId, { activeOrganizationId });

--- a/packages/iam-admin/src/organization-read-handlers.ts
+++ b/packages/iam-admin/src/organization-read-handlers.ts
@@ -1,11 +1,13 @@
 import {
   resolveOrganizationContextState,
+  type ApiErrorCode,
+} from '@sva/core';
+import type {
   IamOrganizationContext,
   IamOrganizationContextOption,
   IamOrganizationDetail,
   IamOrganizationListItem,
   IamOrganizationType,
-  type ApiErrorCode,
 } from '@sva/core';
 
 import type { QueryClient } from './query-client.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,6 @@ overrides:
   slow-redact: 0.3.1
   tmp: 0.2.7
   uuid: 11.1.1
-  '@ai-sdk/provider-utils': 5.0.2
   js-yaml: 4.2.0
   '@opentelemetry/core': 2.8.0
   '@actions/github>undici': 6.27.0
@@ -1298,19 +1297,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.2':
-    resolution: {integrity: sha512-EcmdjJb7yggsZPCbS3MFBpvAUnKaPW+QvanU5GzF00XCq0bqqAmvJ3MN19ejlmOETbW8sJNiq6qam48wTcbUNw==}
-    engines: {node: '>=22'}
+  '@ai-sdk/provider-utils@3.0.27':
+    resolution: {integrity: sha512-JFhJK5ynprll2FR3e+sHagJJIwvIagsNA0FLbLPq2Os4yLUK2/eiaCU0jXsADik73/hhvcPPLmD+Uo8eu5kFaQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.28':
+    resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider@2.0.3':
     resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
     engines: {node: '>=18'}
-
-  '@ai-sdk/provider@4.0.1':
-    resolution: {integrity: sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==}
-    engines: {node: '>=22'}
 
   '@ai-sdk/togetherai@1.0.44':
     resolution: {integrity: sha512-DnJ5afc/rSJCT22lYHjtjQ0WfRHwQPwa85sYeLE+fUR/yskb8NdOoaqYaOroVihyAb8Ankf14vHChyS3QuYNKg==}
@@ -5693,9 +5694,6 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@workflow/serde@4.1.0':
-    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
-
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
@@ -8894,7 +8892,7 @@ snapshots:
     dependencies:
       '@ai-sdk/anthropic': 2.0.83(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       '@smithy/eventstream-codec': 4.4.1
       '@smithy/util-utf8': 4.4.1
       aws4fetch: 1.0.20
@@ -8904,7 +8902,7 @@ snapshots:
   '@ai-sdk/anthropic@2.0.83(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
@@ -8913,7 +8911,7 @@ snapshots:
       '@ai-sdk/deepseek': 1.0.44(zod@3.25.76)
       '@ai-sdk/openai': 2.0.108(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
@@ -8921,21 +8919,21 @@ snapshots:
     dependencies:
       '@ai-sdk/openai-compatible': 1.0.41(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
   '@ai-sdk/deepseek@1.0.44(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
   '@ai-sdk/gateway@2.0.103(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
@@ -8945,7 +8943,7 @@ snapshots:
       '@ai-sdk/google': 2.0.76(zod@3.25.76)
       '@ai-sdk/openai-compatible': 1.0.41(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       google-auth-library: 10.7.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -8955,58 +8953,61 @@ snapshots:
   '@ai-sdk/google@2.0.76(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
   '@ai-sdk/groq@2.0.42(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
   '@ai-sdk/mistral@2.0.35(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
   '@ai-sdk/openai-compatible@1.0.41(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
   '@ai-sdk/openai@2.0.108(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
   '@ai-sdk/perplexity@2.0.32(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
-  '@ai-sdk/provider-utils@5.0.2(zod@3.25.76)':
+  '@ai-sdk/provider-utils@3.0.27(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.1
+      '@ai-sdk/provider': 2.0.3
       '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/provider@2.0.3':
+  '@ai-sdk/provider-utils@3.0.28(zod@3.25.76)':
     dependencies:
-      json-schema: 0.4.0
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 3.25.76
+    optional: true
 
-  '@ai-sdk/provider@4.0.1':
+  '@ai-sdk/provider@2.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -9014,7 +9015,7 @@ snapshots:
     dependencies:
       '@ai-sdk/openai-compatible': 1.0.41(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
@@ -9022,7 +9023,7 @@ snapshots:
     dependencies:
       '@ai-sdk/openai-compatible': 1.0.41(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
@@ -13976,8 +13977,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@workflow/serde@4.1.0': {}
-
   '@yarnpkg/lockfile@1.1.0': {}
 
   '@zkochan/js-yaml@0.0.7':
@@ -14021,7 +14020,7 @@ snapshots:
     dependencies:
       '@ai-sdk/gateway': 2.0.103(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.27(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
@@ -15905,7 +15904,7 @@ snapshots:
   ollama-ai-provider-v2@1.5.5(zod@3.25.76):
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 5.0.2(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.28(zod@3.25.76)
       zod: 3.25.76
     optional: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,8 @@ allowBuilds:
   protobufjs: false
   sharp: true
 overrides:
+  # Keep @ai-sdk/provider-utils unpinned here: Stagehand 3.6.0 still resolves against
+  # the AI SDK v2/v3 provider graph, and the old 5.0.2 override forced an incompatible tree.
   "@tanstack/react-router": "1.170.8"
   "@tanstack/router-core": "1.171.6"
   "@tanstack/start-plugin-core": "1.171.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,6 @@ overrides:
   slow-redact: "0.3.1"
   tmp: "0.2.7"
   uuid: "11.1.1"
-  "@ai-sdk/provider-utils": "5.0.2"
   js-yaml: "4.2.0"
   "@opentelemetry/core": "2.8.0"
   "@actions/github>undici": "6.27.0"

--- a/scripts/ci/check-server-package-runtime.ts
+++ b/scripts/ci/check-server-package-runtime.ts
@@ -60,9 +60,10 @@ const replaceInjectedDist = (sourceDistDir: string, injectedPackageDir: string):
 
   safeRemoveDirectory(stagedDistDir);
   safeRemoveDirectory(backupDistDir);
-  fs.cpSync(sourceDistDir, stagedDistDir, { force: true, recursive: true });
 
   try {
+    fs.cpSync(sourceDistDir, stagedDistDir, { force: true, recursive: true });
+
     if (fs.existsSync(targetDistDir)) {
       fs.renameSync(targetDistDir, backupDistDir);
     }

--- a/scripts/ci/check-server-package-runtime.ts
+++ b/scripts/ci/check-server-package-runtime.ts
@@ -35,6 +35,51 @@ const isDirectory = (filePath: string): boolean => {
   }
 };
 
+const safeRemoveDirectory = (targetDir: string): void => {
+  try {
+    fs.rmSync(targetDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 25,
+    });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+const replaceInjectedDist = (sourceDistDir: string, injectedPackageDir: string): void => {
+  fs.mkdirSync(injectedPackageDir, { recursive: true });
+
+  const targetDistDir = path.join(injectedPackageDir, 'dist');
+  const swapSuffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const stagedDistDir = path.join(injectedPackageDir, `.dist-sync-${swapSuffix}`);
+  const backupDistDir = path.join(injectedPackageDir, `.dist-backup-${swapSuffix}`);
+
+  safeRemoveDirectory(stagedDistDir);
+  safeRemoveDirectory(backupDistDir);
+  fs.cpSync(sourceDistDir, stagedDistDir, { force: true, recursive: true });
+
+  try {
+    if (fs.existsSync(targetDistDir)) {
+      fs.renameSync(targetDistDir, backupDistDir);
+    }
+    fs.renameSync(stagedDistDir, targetDistDir);
+  } catch (error) {
+    safeRemoveDirectory(stagedDistDir);
+
+    if (fs.existsSync(backupDistDir) && !fs.existsSync(targetDistDir)) {
+      fs.renameSync(backupDistDir, targetDistDir);
+    }
+
+    throw error;
+  }
+
+  safeRemoveDirectory(backupDistDir);
+};
+
 const walkFiles = (rootDir: string, predicate: (filePath: string) => boolean): string[] => {
   const results: string[] = [];
   const queue = [rootDir];
@@ -319,9 +364,7 @@ export const syncInjectedWorkspacePackageDists = (
         continue;
       }
 
-      const targetDistDir = path.join(injectedPackageDir, 'dist');
-      fs.rmSync(targetDistDir, { recursive: true, force: true });
-      fs.cpSync(sourceDistDir, targetDistDir, { force: true, recursive: true });
+      replaceInjectedDist(sourceDistDir, injectedPackageDir);
       updatedCopies += 1;
     }
   }


### PR DESCRIPTION
## Summary
- show organization memberships in the account menu even when only one active organization exists
- keep system admins instance-wide by clearing any active organization context while still showing memberships read-only
- add frontend and iam-admin regression coverage for the new system_admin and membership behavior

## Test Plan
- [x] `npx vitest run src/components/Header.test.tsx src/components/OrganizationContextSwitcher.test.tsx`
- [x] `pnpm nx run sva-studio-react:test:unit --testFiles=src/components/Header.test.tsx --testFiles=src/components/OrganizationContextSwitcher.test.tsx`
- [x] `pnpm nx run iam-admin:test:unit --testFiles=src/organization-read-handlers.test.ts --testFiles=src/organization-mutation-handlers.test.ts`
- [x] `pnpm test:pr`

## Notes
- `pnpm test:pr` reaches the frontend full Vitest step and currently fails in existing unrelated suites:
  - `apps/sva-studio-react/stagehand/cli.test.ts`
  - `apps/sva-studio-react/stagehand/runtime/sdk.test.ts`
- Failure: `SyntaxError: The requested module '@ai-sdk/provider-utils' does not provide an export named 'lazyValidator'`
