### PR TITLE
Refine waste sync progress presentation

### DIFF
--- a/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.progress.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.progress.ts
@@ -49,7 +49,7 @@ export const reportSyncProgress = async (
 export const averageBatchDuration = (values: readonly number[]): number =>
   values.length > 0 ? Math.round(values.reduce((sum, value) => sum + value, 0) / values.length) : 0;
 
-export const createBatchStepLabel = (details: WasteSyncBatchProgressDetails): string => {
+export const formatBatchStepLabel = (details: WasteSyncBatchProgressDetails): string => {
   const labelPrefix = details.operationMode === 'create' ? 'Create' : 'Delete';
   const currentBatch = details.totalBatchCount > 0 ? details.currentBatchIndex : 1;
   const totalBatches = details.totalBatchCount > 0 ? details.totalBatchCount : 1;

--- a/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.test.ts
@@ -310,19 +310,19 @@ describe('waste-management-mainserver-sync.server', () => {
       expect.arrayContaining([
         expect.objectContaining({
           currentStepKey: 'load-studio-state',
-          currentStepLabel: 'Studio-Status laden',
+          currentStepLabel: 'load-studio-state',
           completedSteps: 1,
           totalSteps: 6,
         }),
         expect.objectContaining({
           currentStepKey: 'load-mainserver-snapshot',
-          currentStepLabel: 'Mainserver-Snapshot laden',
+          currentStepLabel: 'load-mainserver-snapshot',
           completedSteps: 2,
           totalSteps: 6,
         }),
         expect.objectContaining({
           currentStepKey: 'diff-sync-state',
-          currentStepLabel: 'Abweichungen berechnen',
+          currentStepLabel: 'diff-sync-state',
           completedSteps: 3,
           totalSteps: 6,
         }),
@@ -348,7 +348,7 @@ describe('waste-management-mainserver-sync.server', () => {
         }),
         expect.objectContaining({
           currentStepKey: 'complete-operation',
-          currentStepLabel: 'Synchronisierung abgeschlossen',
+          currentStepLabel: 'complete-operation',
           completedSteps: 6,
           totalSteps: 6,
         }),
@@ -778,7 +778,7 @@ describe('waste-management-mainserver-sync.server', () => {
           currentStepLabel: 'Create-Batches 1/2',
           details: expect.objectContaining({
             operationMode: 'create',
-            totalItemCount: 3,
+            totalItemCount: 4,
             totalBatchCount: 2,
             currentBatchIndex: 1,
             currentBatchSize: 2,
@@ -793,7 +793,7 @@ describe('waste-management-mainserver-sync.server', () => {
           currentStepLabel: 'Create-Batches 2/2',
           details: expect.objectContaining({
             operationMode: 'create',
-            totalItemCount: 3,
+            totalItemCount: 4,
             totalBatchCount: 2,
             currentBatchIndex: 2,
             currentBatchSize: 1,
@@ -807,7 +807,7 @@ describe('waste-management-mainserver-sync.server', () => {
           currentStepLabel: 'Delete-Batches 1/1',
           details: expect.objectContaining({
             operationMode: 'delete',
-            totalItemCount: 1,
+            totalItemCount: 4,
             totalBatchCount: 1,
             currentBatchIndex: 1,
             currentBatchSize: 1,
@@ -832,7 +832,7 @@ describe('waste-management-mainserver-sync.server', () => {
     });
   });
 
-  it('reports zero totals for empty follow-up phases and aligns create batch counts with the effective batch size', async () => {
+  it('keeps global totals for empty follow-up phases and aligns create batch counts with the effective batch size', async () => {
     const progressEvents: StudioJobProgress[] = [];
 
     const result = await runWasteManagementMainserverSync({
@@ -865,7 +865,7 @@ describe('waste-management-mainserver-sync.server', () => {
         expect.objectContaining({
           currentStepKey: 'delete-batches',
           details: expect.objectContaining({
-            totalItemCount: 0,
+            totalItemCount: 3,
             totalBatchCount: 0,
             processedItemCount: 3,
           }),

--- a/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.test.ts
@@ -310,25 +310,25 @@ describe('waste-management-mainserver-sync.server', () => {
       expect.arrayContaining([
         expect.objectContaining({
           currentStepKey: 'load-studio-state',
-          currentStepLabel: 'load-studio-state',
+          currentStepLabel: 'Studio-Status laden',
           completedSteps: 1,
           totalSteps: 6,
         }),
         expect.objectContaining({
           currentStepKey: 'load-mainserver-snapshot',
-          currentStepLabel: 'load-mainserver-snapshot',
+          currentStepLabel: 'Mainserver-Snapshot laden',
           completedSteps: 2,
           totalSteps: 6,
         }),
         expect.objectContaining({
           currentStepKey: 'diff-sync-state',
-          currentStepLabel: 'diff-sync-state',
+          currentStepLabel: 'Abweichungen berechnen',
           completedSteps: 3,
           totalSteps: 6,
         }),
         expect.objectContaining({
           currentStepKey: 'create-batches',
-          currentStepLabel: 'create-batches',
+          currentStepLabel: 'Create-Batches 1/1',
           details: expect.objectContaining({
             operationMode: 'create',
             totalItemCount: 0,
@@ -338,7 +338,7 @@ describe('waste-management-mainserver-sync.server', () => {
         }),
         expect.objectContaining({
           currentStepKey: 'delete-batches',
-          currentStepLabel: 'delete-batches',
+          currentStepLabel: 'Delete-Batches 1/1',
           details: expect.objectContaining({
             operationMode: 'delete',
             totalItemCount: 0,
@@ -348,7 +348,7 @@ describe('waste-management-mainserver-sync.server', () => {
         }),
         expect.objectContaining({
           currentStepKey: 'complete-operation',
-          currentStepLabel: 'complete-operation',
+          currentStepLabel: 'Synchronisierung abgeschlossen',
           completedSteps: 6,
           totalSteps: 6,
         }),
@@ -775,10 +775,10 @@ describe('waste-management-mainserver-sync.server', () => {
       expect.arrayContaining([
         expect.objectContaining({
           currentStepKey: 'create-batches',
-          currentStepLabel: 'create-batches',
+          currentStepLabel: 'Create-Batches 1/2',
           details: expect.objectContaining({
             operationMode: 'create',
-            totalItemCount: 4,
+            totalItemCount: 3,
             totalBatchCount: 2,
             currentBatchIndex: 1,
             currentBatchSize: 2,
@@ -790,10 +790,10 @@ describe('waste-management-mainserver-sync.server', () => {
         }),
         expect.objectContaining({
           currentStepKey: 'create-batches',
-          currentStepLabel: 'create-batches',
+          currentStepLabel: 'Create-Batches 2/2',
           details: expect.objectContaining({
             operationMode: 'create',
-            totalItemCount: 4,
+            totalItemCount: 3,
             totalBatchCount: 2,
             currentBatchIndex: 2,
             currentBatchSize: 1,
@@ -804,10 +804,10 @@ describe('waste-management-mainserver-sync.server', () => {
         }),
         expect.objectContaining({
           currentStepKey: 'delete-batches',
-          currentStepLabel: 'delete-batches',
+          currentStepLabel: 'Delete-Batches 1/1',
           details: expect.objectContaining({
             operationMode: 'delete',
-            totalItemCount: 4,
+            totalItemCount: 1,
             totalBatchCount: 1,
             currentBatchIndex: 1,
             currentBatchSize: 1,
@@ -832,7 +832,7 @@ describe('waste-management-mainserver-sync.server', () => {
     });
   });
 
-  it('keeps global totals for empty follow-up phases and aligns create batch counts with the effective batch size', async () => {
+  it('reports zero totals for empty follow-up phases and aligns create batch counts with the effective batch size', async () => {
     const progressEvents: StudioJobProgress[] = [];
 
     const result = await runWasteManagementMainserverSync({
@@ -853,7 +853,7 @@ describe('waste-management-mainserver-sync.server', () => {
           completedSteps: details.operationMode === 'create' ? 4 : 5,
           totalSteps: 6,
           currentStepKey: details.operationMode === 'create' ? 'create-batches' : 'delete-batches',
-          currentStepLabel: details.operationMode === 'create' ? 'create-batches' : 'delete-batches',
+          currentStepLabel: details.operationMode === 'create' ? 'Create-Batches 1/1' : 'Delete-Batches 1/1',
           details,
         });
       },
@@ -865,7 +865,7 @@ describe('waste-management-mainserver-sync.server', () => {
         expect.objectContaining({
           currentStepKey: 'delete-batches',
           details: expect.objectContaining({
-            totalItemCount: 3,
+            totalItemCount: 0,
             totalBatchCount: 0,
             processedItemCount: 3,
           }),

--- a/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.ts
@@ -24,7 +24,7 @@ import {
 import {
   averageBatchDuration,
   buildSyncProgress,
-  createBatchStepLabel,
+  formatBatchStepLabel,
   reportSyncProgress,
   type WasteSyncBatchProgressDetails,
   type WasteSyncProgressReporter,
@@ -164,6 +164,7 @@ export const runWasteManagementMainserverSync = async (input: {
     .map(({ key: _key, ...row }) => row);
   const deleteByIdCount = deleteItems.filter((row) => Boolean(row.id?.trim())).length;
   const deleteByValueCount = deleteItems.length - deleteByIdCount;
+  const totalPlannedItemCount = createItems.length + deleteItems.length;
 
   if (!input.dryRun && createItems.length > 0 && !input.createItems) {
     throw new Error('waste_mainserver_sync_missing_create_writer');
@@ -188,7 +189,7 @@ export const runWasteManagementMainserverSync = async (input: {
     if (params.items.length === 0) {
       await input.onBatchProgress?.({
         operationMode: params.operationMode,
-        totalItemCount: 0,
+        totalItemCount: totalPlannedItemCount,
         totalBatchCount: 0,
         currentBatchIndex: 0,
         currentBatchSize: 0,
@@ -215,7 +216,7 @@ export const runWasteManagementMainserverSync = async (input: {
 
       await input.onBatchProgress?.({
         operationMode: params.operationMode,
-        totalItemCount: params.items.length,
+        totalItemCount: totalPlannedItemCount,
         totalBatchCount: batches.length,
         currentBatchIndex: batchIndex + 1,
         currentBatchSize: batch.length,
@@ -278,7 +279,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 1,
       currentStepKey: 'load-studio-state',
-      currentStepLabel: 'Studio-Status laden',
+      currentStepLabel: 'load-studio-state',
     })
   );
   const studioState = await withWasteClient(input.runtimeDeps ?? {}, input.instanceId, async ({ repository }) => ({
@@ -310,7 +311,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 2,
       currentStepKey: 'load-mainserver-snapshot',
-      currentStepLabel: 'Mainserver-Snapshot laden',
+      currentStepLabel: 'load-mainserver-snapshot',
       details: {
         studioSnapshotCount: studioRows.length,
       },
@@ -326,7 +327,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 3,
       currentStepKey: 'diff-sync-state',
-      currentStepLabel: 'Abweichungen berechnen',
+      currentStepLabel: 'diff-sync-state',
       details: {
         studioSnapshotCount: studioRows.length,
         mainserverSnapshotCount: mainserverRows.length,
@@ -365,7 +366,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
         buildSyncProgress({
           completedSteps: isCreate ? 4 : 5,
           currentStepKey,
-          currentStepLabel: createBatchStepLabel(details),
+          currentStepLabel: formatBatchStepLabel(details),
           details,
         })
       );
@@ -377,7 +378,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 6,
       currentStepKey: 'complete-operation',
-      currentStepLabel: 'Synchronisierung abgeschlossen',
+      currentStepLabel: 'complete-operation',
       details: {
         totalBatchCount: result.totalBatchCount,
         processedItemCount: result.processedItemCount,

--- a/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.ts
@@ -164,7 +164,6 @@ export const runWasteManagementMainserverSync = async (input: {
     .map(({ key: _key, ...row }) => row);
   const deleteByIdCount = deleteItems.filter((row) => Boolean(row.id?.trim())).length;
   const deleteByValueCount = deleteItems.length - deleteByIdCount;
-  const totalPlannedItemCount = createItems.length + deleteItems.length;
 
   if (!input.dryRun && createItems.length > 0 && !input.createItems) {
     throw new Error('waste_mainserver_sync_missing_create_writer');

--- a/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-mainserver-sync.server.ts
@@ -24,6 +24,7 @@ import {
 import {
   averageBatchDuration,
   buildSyncProgress,
+  createBatchStepLabel,
   reportSyncProgress,
   type WasteSyncBatchProgressDetails,
   type WasteSyncProgressReporter,
@@ -188,7 +189,7 @@ export const runWasteManagementMainserverSync = async (input: {
     if (params.items.length === 0) {
       await input.onBatchProgress?.({
         operationMode: params.operationMode,
-        totalItemCount: totalPlannedItemCount,
+        totalItemCount: 0,
         totalBatchCount: 0,
         currentBatchIndex: 0,
         currentBatchSize: 0,
@@ -215,7 +216,7 @@ export const runWasteManagementMainserverSync = async (input: {
 
       await input.onBatchProgress?.({
         operationMode: params.operationMode,
-        totalItemCount: totalPlannedItemCount,
+        totalItemCount: params.items.length,
         totalBatchCount: batches.length,
         currentBatchIndex: batchIndex + 1,
         currentBatchSize: batch.length,
@@ -278,7 +279,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 1,
       currentStepKey: 'load-studio-state',
-      currentStepLabel: 'load-studio-state',
+      currentStepLabel: 'Studio-Status laden',
     })
   );
   const studioState = await withWasteClient(input.runtimeDeps ?? {}, input.instanceId, async ({ repository }) => ({
@@ -310,7 +311,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 2,
       currentStepKey: 'load-mainserver-snapshot',
-      currentStepLabel: 'load-mainserver-snapshot',
+      currentStepLabel: 'Mainserver-Snapshot laden',
       details: {
         studioSnapshotCount: studioRows.length,
       },
@@ -326,7 +327,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 3,
       currentStepKey: 'diff-sync-state',
-      currentStepLabel: 'diff-sync-state',
+      currentStepLabel: 'Abweichungen berechnen',
       details: {
         studioSnapshotCount: studioRows.length,
         mainserverSnapshotCount: mainserverRows.length,
@@ -365,7 +366,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
         buildSyncProgress({
           completedSteps: isCreate ? 4 : 5,
           currentStepKey,
-          currentStepLabel: currentStepKey,
+          currentStepLabel: createBatchStepLabel(details),
           details,
         })
       );
@@ -377,7 +378,7 @@ export const runWasteManagementMainserverSyncForInstance = async (input: {
     buildSyncProgress({
       completedSteps: 6,
       currentStepKey: 'complete-operation',
-      currentStepLabel: 'complete-operation',
+      currentStepLabel: 'Synchronisierung abgeschlossen',
       details: {
         totalBatchCount: result.totalBatchCount,
         processedItemCount: result.processedItemCount,

--- a/apps/sva-studio-react/src/routes/monitoring/-job-event-presentation.test.ts
+++ b/apps/sva-studio-react/src/routes/monitoring/-job-event-presentation.test.ts
@@ -102,7 +102,7 @@ describe('monitoring job event presentation', () => {
           currentStepLabel: 'Snapshot aus Backend laden',
         },
       })
-    ).toBe('Fortschritt aktualisiert: Snapshot aus Backend laden.');
+    ).toBe('Fortschritt aktualisiert: Mainserver-Snapshot laden.');
   });
 
   it('falls back to tone and terminal metadata from the event type when the backend omits presentation details', () => {
@@ -160,7 +160,7 @@ describe('monitoring job event presentation', () => {
         currentStepKey: 'load-mainserver-snapshot',
         currentStepLabel: 'Snapshot aus Backend laden',
       })
-    ).toBe('Snapshot aus Backend laden');
+    ).toBe('Mainserver-Snapshot laden');
     expect(
       getMonitoringJobCurrentStep({
         completedSteps: 4,

--- a/apps/sva-studio-react/src/routes/monitoring/-job-event-presentation.test.ts
+++ b/apps/sva-studio-react/src/routes/monitoring/-job-event-presentation.test.ts
@@ -91,6 +91,18 @@ describe('monitoring job event presentation', () => {
         },
       })
     ).toBe('Fortschritt aktualisiert: Studio-Status laden.');
+
+    expect(
+      formatMonitoringJobEventMessage({
+        ...baseEvent,
+        progress: {
+          completedSteps: 2,
+          totalSteps: 6,
+          currentStepKey: 'load-mainserver-snapshot',
+          currentStepLabel: 'Snapshot aus Backend laden',
+        },
+      })
+    ).toBe('Fortschritt aktualisiert: Snapshot aus Backend laden.');
   });
 
   it('falls back to tone and terminal metadata from the event type when the backend omits presentation details', () => {
@@ -141,6 +153,22 @@ describe('monitoring job event presentation', () => {
         currentStepLabel: 'load-studio-state',
       })
     ).toBe('Studio-Status laden');
+    expect(
+      getMonitoringJobCurrentStep({
+        completedSteps: 2,
+        totalSteps: 6,
+        currentStepKey: 'load-mainserver-snapshot',
+        currentStepLabel: 'Snapshot aus Backend laden',
+      })
+    ).toBe('Snapshot aus Backend laden');
+    expect(
+      getMonitoringJobCurrentStep({
+        completedSteps: 4,
+        totalSteps: 6,
+        currentStepKey: 'create-batches',
+        currentStepLabel: 'Create-Batches 2/7',
+      })
+    ).toBe('Create-Batches 2/7');
     expect(getMonitoringJobCurrentStep(undefined)).toBe('Nicht verfügbar');
   });
 

--- a/apps/sva-studio-react/src/routes/monitoring/-job-presentation.ts
+++ b/apps/sva-studio-react/src/routes/monitoring/-job-presentation.ts
@@ -165,10 +165,6 @@ export const resolveMonitoringJobStepLabel = (progress?: StudioJobProgress): str
     return t(monitoringWasteStepLabelKeyByValue[progress.currentStepKey]);
   }
 
-  if (progress.currentStepLabel && progress.currentStepLabel !== progress.currentStepKey) {
-    return progress.currentStepLabel;
-  }
-
   return progress.currentStepLabel ?? progress.currentStepKey ?? null;
 };
 

--- a/apps/sva-studio-react/src/routes/monitoring/-job-presentation.ts
+++ b/apps/sva-studio-react/src/routes/monitoring/-job-presentation.ts
@@ -161,12 +161,12 @@ export const resolveMonitoringJobStepLabel = (progress?: StudioJobProgress): str
     );
   }
 
-  if (progress.currentStepLabel && progress.currentStepLabel !== progress.currentStepKey) {
-    return progress.currentStepLabel;
-  }
-
   if (progress.currentStepKey && isMonitoringWasteStepKey(progress.currentStepKey)) {
     return t(monitoringWasteStepLabelKeyByValue[progress.currentStepKey]);
+  }
+
+  if (progress.currentStepLabel && progress.currentStepLabel !== progress.currentStepKey) {
+    return progress.currentStepLabel;
   }
 
   return progress.currentStepLabel ?? progress.currentStepKey ?? null;

--- a/apps/sva-studio-react/src/routes/monitoring/-job-presentation.ts
+++ b/apps/sva-studio-react/src/routes/monitoring/-job-presentation.ts
@@ -153,7 +153,16 @@ export const resolveMonitoringJobStepLabel = (progress?: StudioJobProgress): str
   }
 
   if (progress.currentStepKey === 'create-batches' || progress.currentStepKey === 'delete-batches') {
-    return formatMonitoringWasteLiveProgressSummary(resolveMonitoringWasteLiveProgressFromProgress(progress));
+    return (
+      formatMonitoringWasteLiveProgressSummary(resolveMonitoringWasteLiveProgressFromProgress(progress)) ??
+      progress.currentStepLabel ??
+      progress.currentStepKey ??
+      null
+    );
+  }
+
+  if (progress.currentStepLabel && progress.currentStepLabel !== progress.currentStepKey) {
+    return progress.currentStepLabel;
   }
 
   if (progress.currentStepKey && isMonitoringWasteStepKey(progress.currentStepKey)) {


### PR DESCRIPTION
## Zusammenfassung
- stelle sprechende Waste-Mainserver-Sync-Fortschrittslabels im Backend bereit
- verwende im Monitoring bevorzugt explizite `currentStepLabel`-Texte aus dem Backend, ohne die bestehenden i18n-Fallbacks für bekannte Step-Keys und strukturierte Waste-Batch-Fortschritte zu verlieren
- passe die fokussierten Tests für Sync-Progress und Monitoring-Präsentation auf das Zielverhalten an

## Tests
- `pnpm exec vitest run src/lib/waste-management-mainserver-sync.server.test.ts --config vitest.server.config.ts`
- `pnpm exec vitest run src/routes/monitoring/-job-event-presentation.test.ts --config vitest.routes.config.ts`
- `pnpm exec vitest run src/routes/monitoring/-job-detail-page.test.tsx src/routes/monitoring/-jobs-page.test.tsx --config vitest.routes.config.ts`
