### PR TITLE
fix(studio): deduplicate projected mainserver content rows

### DIFF
--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -804,7 +804,7 @@ describe('content list projection', () => {
         publish_until: null,
         created_at: '2026-06-20T10:00:00.000Z',
         created_by: 'mainserver',
-        updated_at: '2026-06-21T10:00:00.000Z',
+        updated_at: '2026-06-22T10:00:00.000Z',
         updated_by: 'mainserver',
         author_display_name: 'Redaktion',
         payload_json: {},
@@ -884,6 +884,138 @@ describe('content list projection', () => {
 
     await expect(response.json()).resolves.toMatchObject({
       data: [expect.objectContaining({ id: 'poi-org-1', title: 'Haus der Familie e.V.' })],
+      pagination: {
+        page: 1,
+        pageSize: 25,
+        total: 1,
+      },
+      requestId: 'req-1',
+    });
+  });
+
+  it('deduplicates mainserver rows even when legacy scope variants disagree on content_type', async () => {
+    projectionRows = [
+      {
+        id: 'poi-org-legacy',
+        instance_id: 'de-musterhausen',
+        organization_id: 'org-1',
+        owner_subject_id: null,
+        owner_user_id: null,
+        owner_organization_id: 'org-1',
+        content_type: 'poi.point-of-interest',
+        title: 'Schule 123',
+        published_at: null,
+        publish_from: null,
+        publish_until: null,
+        created_at: '2026-06-20T10:00:00.000Z',
+        created_by: 'mainserver',
+        updated_at: '2026-06-21T10:00:00.000Z',
+        updated_by: 'mainserver',
+        author_display_name: 'Redaktion',
+        payload_json: {},
+        status: 'published',
+        validation_state: 'valid',
+        history_ref: 'history-poi-org-legacy',
+        current_revision_ref: null,
+        last_audit_event_ref: null,
+        source_system: 'mainserver',
+        source_entity_type: 'poi.point-of-interest',
+        source_entity_id: 'poi-shared-legacy',
+      },
+      {
+        id: 'poi-own-legacy',
+        instance_id: 'de-musterhausen',
+        organization_id: null,
+        owner_subject_id: null,
+        owner_user_id: 'account-1',
+        owner_organization_id: null,
+        content_type: 'poi.legacy-point-of-interest',
+        title: 'Schule 123',
+        published_at: null,
+        publish_from: null,
+        publish_until: null,
+        created_at: '2026-06-20T10:00:00.000Z',
+        created_by: 'mainserver',
+        updated_at: '2026-06-22T10:00:00.000Z',
+        updated_by: 'mainserver',
+        author_display_name: 'Redaktion',
+        payload_json: {},
+        status: 'published',
+        validation_state: 'valid',
+        history_ref: 'history-poi-own-legacy',
+        current_revision_ref: null,
+        last_audit_event_ref: null,
+        source_system: 'mainserver',
+        source_entity_type: 'poi.point-of-interest',
+        source_entity_id: 'poi-shared-legacy',
+      },
+    ];
+    syncStates.set('poi.point-of-interest', {
+      last_started_at: null,
+      last_succeeded_at: '2026-06-20T10:00:00.000Z',
+      last_failed_at: null,
+      last_error_code: null,
+      last_error_message: null,
+      projected_count: 2,
+    });
+    state.authorizeContentPrimitiveForUser.mockImplementation(
+      async ({ action }: { action: string }) =>
+        action === 'poi.read'
+          ? {
+              ok: true,
+              actor: {
+                instanceId: 'de-musterhausen',
+                keycloakSubject: 'kc-user-1',
+                organizationId: 'org-1',
+              },
+              permissions: [
+                {
+                  action,
+                  resourceType: 'poi',
+                  organizationId: 'org-1',
+                  accessScope: 'organization',
+                },
+                {
+                  action,
+                  resourceType: 'poi',
+                  accessScope: 'own',
+                },
+              ],
+            }
+          : {
+              ok: false,
+              status: 403,
+              error: 'forbidden',
+              message: 'forbidden',
+            }
+    );
+    state.resolveEffectivePermissions.mockResolvedValue({
+      ok: true,
+      permissions: [
+        {
+          action: 'poi.read',
+          resourceType: 'poi',
+          organizationId: 'org-1',
+          accessScope: 'organization',
+        },
+        {
+          action: 'poi.read',
+          resourceType: 'poi',
+          accessScope: 'own',
+        },
+      ],
+    });
+
+    const response = await listProjectedContents(ctx, {
+      page: 1,
+      pageSize: 25,
+      visibleTypes: ['poi.point-of-interest'],
+      sortBy: 'updatedAt',
+      sortDirection: 'desc',
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: [expect.objectContaining({ id: 'poi-org-legacy', title: 'Schule 123' })],
       pagination: {
         page: 1,
         pageSize: 25,

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -761,6 +761,138 @@ describe('content list projection', () => {
     });
   });
 
+  it('deduplicates mainserver rows that are visible through own and organization scopes', async () => {
+    projectionRows = [
+      {
+        id: 'poi-org-1',
+        instance_id: 'de-musterhausen',
+        organization_id: 'org-1',
+        owner_subject_id: null,
+        owner_user_id: null,
+        owner_organization_id: 'org-1',
+        content_type: 'poi.point-of-interest',
+        title: 'Haus der Familie e.V.',
+        published_at: null,
+        publish_from: null,
+        publish_until: null,
+        created_at: '2026-06-20T10:00:00.000Z',
+        created_by: 'mainserver',
+        updated_at: '2026-06-21T10:00:00.000Z',
+        updated_by: 'mainserver',
+        author_display_name: 'Redaktion',
+        payload_json: {},
+        status: 'published',
+        validation_state: 'valid',
+        history_ref: 'history-poi-org',
+        current_revision_ref: null,
+        last_audit_event_ref: null,
+        source_system: 'mainserver',
+        source_entity_type: 'poi.point-of-interest',
+        source_entity_id: 'poi-shared-1',
+      },
+      {
+        id: 'poi-own-1',
+        instance_id: 'de-musterhausen',
+        organization_id: null,
+        owner_subject_id: null,
+        owner_user_id: 'account-1',
+        owner_organization_id: null,
+        content_type: 'poi.point-of-interest',
+        title: 'Haus der Familie e.V.',
+        published_at: null,
+        publish_from: null,
+        publish_until: null,
+        created_at: '2026-06-20T10:00:00.000Z',
+        created_by: 'mainserver',
+        updated_at: '2026-06-21T10:00:00.000Z',
+        updated_by: 'mainserver',
+        author_display_name: 'Redaktion',
+        payload_json: {},
+        status: 'published',
+        validation_state: 'valid',
+        history_ref: 'history-poi-own',
+        current_revision_ref: null,
+        last_audit_event_ref: null,
+        source_system: 'mainserver',
+        source_entity_type: 'poi.point-of-interest',
+        source_entity_id: 'poi-shared-1',
+      },
+    ];
+    syncStates.set('poi.point-of-interest', {
+      last_started_at: null,
+      last_succeeded_at: '2026-06-20T10:00:00.000Z',
+      last_failed_at: null,
+      last_error_code: null,
+      last_error_message: null,
+      projected_count: 2,
+    });
+    state.authorizeContentPrimitiveForUser.mockImplementation(
+      async ({ action }: { action: string }) =>
+        action === 'poi.read'
+          ? {
+              ok: true,
+              actor: {
+                instanceId: 'de-musterhausen',
+                keycloakSubject: 'kc-user-1',
+                organizationId: 'org-1',
+              },
+              permissions: [
+                {
+                  action,
+                  resourceType: 'poi',
+                  organizationId: 'org-1',
+                  accessScope: 'organization',
+                },
+                {
+                  action,
+                  resourceType: 'poi',
+                  accessScope: 'own',
+                },
+              ],
+            }
+          : {
+              ok: false,
+              status: 403,
+              error: 'forbidden',
+              message: 'forbidden',
+            }
+    );
+    state.resolveEffectivePermissions.mockResolvedValue({
+      ok: true,
+      permissions: [
+        {
+          action: 'poi.read',
+          resourceType: 'poi',
+          organizationId: 'org-1',
+          accessScope: 'organization',
+        },
+        {
+          action: 'poi.read',
+          resourceType: 'poi',
+          accessScope: 'own',
+        },
+      ],
+    });
+
+    const response = await listProjectedContents(ctx, {
+      page: 1,
+      pageSize: 25,
+      visibleTypes: ['poi.point-of-interest'],
+      sortBy: 'updatedAt',
+      sortDirection: 'desc',
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: [expect.objectContaining({ id: 'poi-org-1', title: 'Haus der Familie e.V.' })],
+      pagination: {
+        page: 1,
+        pageSize: 25,
+        total: 1,
+      },
+      requestId: 'req-1',
+    });
+  });
+
   it('finds projected rows when the search term appears only in payload_json', async () => {
     projectionRows = [
       {

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -214,6 +214,62 @@ const mapProjectionRow = (row: ProjectionRow): IamContentListItem => ({
   historyRef: row.history_ref,
 });
 
+const projectionListCollator = new Intl.Collator('de', {
+  sensitivity: 'base',
+  numeric: true,
+});
+
+const resolveProjectionScopePriority = (row: ProjectionRow): number => {
+  if (row.organization_id || row.owner_organization_id) {
+    return 2;
+  }
+
+  if (row.owner_user_id) {
+    return 1;
+  }
+
+  return 0;
+};
+
+const buildProjectionDeduplicationKey = (row: ProjectionRow): string =>
+  row.source_system === 'mainserver'
+    ? ['mainserver', row.content_type, row.source_entity_type, row.source_entity_id].join('::')
+    : row.id;
+
+const compareProjectionRows = (
+  left: ProjectionRow,
+  right: ProjectionRow,
+  sortBy: IamContentListQuery['sortBy'],
+  sortDirection: IamContentListQuery['sortDirection']
+): number => {
+  const direction = sortDirection === 'asc' ? 1 : -1;
+
+  const primaryResult =
+    sortBy === 'contentType'
+      ? projectionListCollator.compare(left.content_type, right.content_type)
+      : sortBy === 'title'
+        ? projectionListCollator.compare(left.title, right.title)
+        : sortBy === 'status'
+          ? projectionListCollator.compare(left.status, right.status)
+          : projectionListCollator.compare(left.updated_at, right.updated_at);
+  if (primaryResult !== 0) {
+    return primaryResult * direction;
+  }
+
+  const scopePriorityResult =
+    resolveProjectionScopePriority(right) - resolveProjectionScopePriority(left);
+  if (scopePriorityResult !== 0) {
+    return scopePriorityResult;
+  }
+
+  const updatedAtResult = right.updated_at.localeCompare(left.updated_at);
+  if (updatedAtResult !== 0) {
+    return updatedAtResult;
+  }
+
+  return right.id.localeCompare(left.id);
+};
+
 const buildReadAction = (contentType: string): string =>
   isMainserverContentType(contentType)
     ? `${contentType.split('.')[0] ?? 'content'}.read`
@@ -1112,24 +1168,6 @@ const loadProjectionPage = async (
     );
 
     const whereClause = `WHERE ${conditions.join('\n  AND ')}`;
-    const orderByClause = `ORDER BY ${listSortColumnByField[query.sortBy]} ${
-      query.sortDirection === 'asc' ? 'ASC' : 'DESC'
-    }, projection.updated_at DESC, projection.id DESC`;
-
-    const totalResult = await client.query<{ total: string | number }>(
-      `
-SELECT COUNT(*)::int AS total
-FROM iam.content_list_projection AS projection
-${whereClause};
-      `,
-      params
-    );
-    const total = Number(totalResult.rows[0]?.total ?? 0);
-
-    params.push(query.pageSize);
-    const limitParam = `$${params.length}`;
-    params.push(Math.max(0, (query.page - 1) * query.pageSize));
-    const offsetParam = `$${params.length}`;
 
     const result = await client.query<ProjectionRow>(
       `
@@ -1163,17 +1201,28 @@ SELECT
   projection.source_entity_type,
   projection.source_entity_id
 FROM iam.content_list_projection AS projection
-${whereClause}
-${orderByClause}
-LIMIT ${limitParam}
-OFFSET ${offsetParam};
+${whereClause};
       `,
       params
     );
 
+    const sortedRows = [...result.rows].sort((left, right) =>
+      compareProjectionRows(left, right, query.sortBy, query.sortDirection)
+    );
+    const dedupedRows = new Map<string, ProjectionRow>();
+    for (const row of sortedRows) {
+      const deduplicationKey = buildProjectionDeduplicationKey(row);
+      if (!dedupedRows.has(deduplicationKey)) {
+        dedupedRows.set(deduplicationKey, row);
+      }
+    }
+    const filteredRows = [...dedupedRows.values()];
+    const offset = Math.max(0, (query.page - 1) * query.pageSize);
+    const paginatedRows = filteredRows.slice(offset, offset + query.pageSize);
+
     return {
-      items: result.rows.map(mapProjectionRow),
-      total,
+      items: paginatedRows.map(mapProjectionRow),
+      total: filteredRows.length,
     };
   });
 

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -1120,13 +1120,6 @@ const buildProjectionReadVisibilitySql = (
   return perTypeClauses.length > 0 ? `(${perTypeClauses.join(' OR ')})` : 'FALSE';
 };
 
-const listSortColumnByField = {
-  title: 'projection.title',
-  contentType: 'projection.content_type',
-  status: 'projection.status',
-  updatedAt: 'projection.updated_at',
-} as const satisfies Record<IamContentListQuery['sortBy'], string>;
-
 const loadProjectionPage = async (
   instanceId: string,
   query: IamContentListQuery,

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -233,8 +233,26 @@ const resolveProjectionScopePriority = (row: ProjectionRow): number => {
 
 const buildProjectionDeduplicationKey = (row: ProjectionRow): string =>
   row.source_system === 'mainserver'
-    ? ['mainserver', row.content_type, row.source_entity_type, row.source_entity_id].join('::')
+    ? ['mainserver', row.source_entity_type, row.source_entity_id].join('::')
     : row.id;
+
+const comparePreferredProjectionRows = (
+  left: ProjectionRow,
+  right: ProjectionRow
+): number => {
+  const scopePriorityResult =
+    resolveProjectionScopePriority(right) - resolveProjectionScopePriority(left);
+  if (scopePriorityResult !== 0) {
+    return scopePriorityResult;
+  }
+
+  const updatedAtResult = right.updated_at.localeCompare(left.updated_at);
+  if (updatedAtResult !== 0) {
+    return updatedAtResult;
+  }
+
+  return right.id.localeCompare(left.id);
+};
 
 const compareProjectionRows = (
   left: ProjectionRow,
@@ -256,18 +274,7 @@ const compareProjectionRows = (
     return primaryResult * direction;
   }
 
-  const scopePriorityResult =
-    resolveProjectionScopePriority(right) - resolveProjectionScopePriority(left);
-  if (scopePriorityResult !== 0) {
-    return scopePriorityResult;
-  }
-
-  const updatedAtResult = right.updated_at.localeCompare(left.updated_at);
-  if (updatedAtResult !== 0) {
-    return updatedAtResult;
-  }
-
-  return right.id.localeCompare(left.id);
+  return comparePreferredProjectionRows(left, right);
 };
 
 const buildReadAction = (contentType: string): string =>
@@ -1199,17 +1206,20 @@ ${whereClause};
       params
     );
 
-    const sortedRows = [...result.rows].sort((left, right) =>
-      compareProjectionRows(left, right, query.sortBy, query.sortDirection)
-    );
     const dedupedRows = new Map<string, ProjectionRow>();
-    for (const row of sortedRows) {
+    for (const row of result.rows) {
       const deduplicationKey = buildProjectionDeduplicationKey(row);
-      if (!dedupedRows.has(deduplicationKey)) {
+      const existingRow = dedupedRows.get(deduplicationKey);
+      if (
+        !existingRow ||
+        comparePreferredProjectionRows(row, existingRow) < 0
+      ) {
         dedupedRows.set(deduplicationKey, row);
       }
     }
-    const filteredRows = [...dedupedRows.values()];
+    const filteredRows = [...dedupedRows.values()].sort((left, right) =>
+      compareProjectionRows(left, right, query.sortBy, query.sortDirection)
+    );
     const offset = Math.max(0, (query.page - 1) * query.pageSize);
     const paginatedRows = filteredRows.slice(offset, offset + query.pageSize);
 


### PR DESCRIPTION
## Zusammenfassung
- dedupliziert Mainserver-Projektionszeilen scope-uebergreifend in der Content-Liste
- bevorzugt organisationsbezogene Projektionen bei mehrfach sichtbaren Zeilen
- deckt den Regressionsfall mit einem Server-Unit-Test ab

## Tests
- pnpm nx run sva-studio-react:test:unit:server --testFiles=apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts