### PR TITLE
fix(plugin-events): use date-only fields for event dates

### DIFF
--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -71,7 +71,7 @@ test.describe('events and POI plugins', () => {
     await page.getByRole('button', { name: /Rathaus\s*poi-1/ }).click();
     await page.getByRole('tab', { name: /Inhalt|events\.detailTabs\.content\.title/ }).click();
     await page.locator('#event-description').fill('Sommerfest in der Innenstadt');
-    await page.locator('#event-date-start').fill('2026-04-14T09:30');
+    await page.locator('#event-date-start').fill('2026-04-14');
     await page.locator('#event-street').fill('Marktplatz');
     await page.locator('#event-city').fill('Musterhausen');
     await page.locator('#event-contact-email').fill('events@example.com');

--- a/packages/plugin-events/src/events.date-only.ts
+++ b/packages/plugin-events/src/events.date-only.ts
@@ -1,0 +1,73 @@
+const dateOnlyPattern = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/;
+
+const editorDateFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Europe/Berlin',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const formatDateOnlyParts = (date: Date): string => {
+  const parts = editorDateFormatter.formatToParts(date);
+  const readPart = (type: Intl.DateTimeFormatPartTypes) => parts.find((part) => part.type === type)?.value ?? '';
+
+  return `${readPart('year')}-${readPart('month')}-${readPart('day')}`;
+};
+
+const isValidDateOnlyParts = (year: number, month: number, day: number): boolean => {
+  if (
+    [year, month, day].some((entry) => Number.isInteger(entry) === false) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    return false;
+  }
+
+  const candidate = new Date(Date.UTC(year, month - 1, day));
+  return (
+    candidate.getUTCFullYear() === year &&
+    candidate.getUTCMonth() === month - 1 &&
+    candidate.getUTCDate() === day
+  );
+};
+
+export const fromDateOnlyInputValue = (value: string): string => {
+  if (value.length === 0) {
+    return '';
+  }
+
+  const match = dateOnlyPattern.exec(value);
+  if (!match?.groups) {
+    return '';
+  }
+
+  const year = Number(match.groups.year);
+  const month = Number(match.groups.month);
+  const day = Number(match.groups.day);
+
+  return isValidDateOnlyParts(year, month, day) ? value : '';
+};
+
+export const isValidDateOnlyValue = (value?: string): boolean => {
+  if (!value) {
+    return true;
+  }
+
+  return fromDateOnlyInputValue(value).length > 0;
+};
+
+export const toDateOnlyInputValue = (value?: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  const normalizedDateOnly = fromDateOnlyInputValue(value);
+  if (normalizedDateOnly) {
+    return normalizedDateOnly;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? '' : formatDateOnlyParts(parsed);
+};

--- a/packages/plugin-events/src/events.date-only.ts
+++ b/packages/plugin-events/src/events.date-only.ts
@@ -1,4 +1,6 @@
 const dateOnlyPattern = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/;
+const isoDatePrefixPattern = /^(?<date>\d{4}-\d{2}-\d{2})(?:T|$)/;
+const defaultEditorLocale = 'de-DE';
 
 const editorDateFormatter = new Intl.DateTimeFormat('en-CA', {
   timeZone: 'Europe/Berlin',
@@ -31,6 +33,21 @@ const isValidDateOnlyParts = (year: number, month: number, day: number): boolean
     candidate.getUTCMonth() === month - 1 &&
     candidate.getUTCDate() === day
   );
+};
+
+const resolveDateOnlyLocale = (locale?: string): string => {
+  const candidate = locale?.trim() || globalThis.document?.documentElement.lang?.trim() || defaultEditorLocale;
+
+  try {
+    return Intl.DateTimeFormat.supportedLocalesOf(candidate)[0] ?? defaultEditorLocale;
+  } catch {
+    return defaultEditorLocale;
+  }
+};
+
+const extractIsoDatePrefix = (value: string): string => {
+  const match = isoDatePrefixPattern.exec(value);
+  return match?.groups?.date ?? '';
 };
 
 export const fromDateOnlyInputValue = (value: string): string => {
@@ -68,6 +85,27 @@ export const toDateOnlyInputValue = (value?: string): string => {
     return normalizedDateOnly;
   }
 
+  const normalizedIsoDatePrefix = fromDateOnlyInputValue(extractIsoDatePrefix(value));
+  if (normalizedIsoDatePrefix) {
+    return normalizedIsoDatePrefix;
+  }
+
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? '' : formatDateOnlyParts(parsed);
+};
+
+export const formatDateOnlyForEditor = (value?: string, locale?: string): string | undefined => {
+  const normalizedDateOnly = value ? fromDateOnlyInputValue(value) : '';
+  if (!normalizedDateOnly) {
+    return value;
+  }
+
+  const [year, month, day] = normalizedDateOnly.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return new Intl.DateTimeFormat(resolveDateOnlyLocale(locale), {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
 };

--- a/packages/plugin-events/src/events.detail-content-tab.tsx
+++ b/packages/plugin-events/src/events.detail-content-tab.tsx
@@ -167,7 +167,7 @@ export function EventsDetailContentTab({
               <StudioField id={index === 0 ? 'event-date-start' : `event-date-start-${index}`} label={pt('fields.dateStart')}>
                 <Input
                   id={index === 0 ? 'event-date-start' : `event-date-start-${index}`}
-                  type="datetime-local"
+                  type="date"
                   aria-invalid={index === 0 && dateInputsInvalid.dateStart ? true : undefined}
                   value={index === 0 ? dateStartInput : date.dateStart ?? ''}
                   onChange={(event) => {
@@ -182,7 +182,7 @@ export function EventsDetailContentTab({
               <StudioField id={index === 0 ? 'event-date-end' : `event-date-end-${index}`} label={pt('fields.dateEnd')}>
                 <Input
                   id={index === 0 ? 'event-date-end' : `event-date-end-${index}`}
-                  type="datetime-local"
+                  type="date"
                   aria-invalid={index === 0 && dateInputsInvalid.dateEnd ? true : undefined}
                   value={index === 0 ? dateEndInput : date.dateEnd ?? ''}
                   onChange={(event) => {

--- a/packages/plugin-events/src/events.detail-form.ts
+++ b/packages/plugin-events/src/events.detail-form.ts
@@ -8,6 +8,7 @@ import type {
   EventPriceInformation,
   EventWebUrl,
 } from './events.types.js';
+import { toDateOnlyInputValue } from './events.date-only.js';
 
 export type EventsFormGeoLocationValue = Readonly<{
   latitude: string;
@@ -166,7 +167,13 @@ export const mapEventItemToDetailFormValues = (item: EventContentItem): EventsDe
   },
   content: {
     description: item.description ?? '',
-    dates: item.dates?.length ? item.dates : [createDefaultDate()],
+    dates: item.dates?.length
+      ? item.dates.map((entry) => ({
+          ...entry,
+          dateStart: toDateOnlyInputValue(entry.dateStart),
+          dateEnd: toDateOnlyInputValue(entry.dateEnd),
+        }))
+      : [createDefaultDate()],
     addresses: item.addresses?.length ? item.addresses.map(mapAddressToFormValue) : [createDefaultAddress()],
     urls: item.urls?.length ? item.urls : [createDefaultUrl()],
     contacts: item.contacts?.length ? item.contacts : [createDefaultContact()],

--- a/packages/plugin-events/src/events.detail-page.tsx
+++ b/packages/plugin-events/src/events.detail-page.tsx
@@ -3,11 +3,9 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { Link, useNavigate } from '@tanstack/react-router';
 import {
   findHostMediaReferenceAssetId,
-  fromDatetimeLocalValue,
   listHostMediaAssets,
   listHostMediaReferencesByTarget,
   replaceHostMediaReferences,
-  toDatetimeLocalValue,
   toHostMediaFieldOptions,
   usePluginTranslation,
 } from '@sva/plugin-sdk';
@@ -43,6 +41,7 @@ import { EventsDetailContentTab } from './events.detail-content-tab.js';
 import { EventsDetailHistoryTab } from './events.detail-history-tab.js';
 import { EventsDetailSettingsTab } from './events.detail-settings-tab.js';
 import { createEventsDetailTabDefinitions, type EventsDetailTabId } from './events.detail-tabs.js';
+import { fromDateOnlyInputValue, toDateOnlyInputValue } from './events.date-only.js';
 import { pluginEventsMediaPickers } from './plugin.js';
 import type { EventCategoryOption, EventContentItem } from './events.types.js';
 import type { PoiSelectItem } from './events.types.js';
@@ -99,12 +98,12 @@ const eventsTabIconMap = {
 const errorMessage = (pt: ReturnType<typeof usePluginTranslation>, error: unknown, fallbackKey: string) =>
   error instanceof EventsApiError ? error.message : pt(fallbackKey);
 
-const parseDatetimeLocalInput = (value: string, referenceValue?: string) => {
+const parseDateOnlyInput = (value: string) => {
   if (value.trim().length === 0) {
     return { isInvalid: false, normalizedValue: '' };
   }
 
-  const normalizedValue = fromDatetimeLocalValue(value, referenceValue);
+  const normalizedValue = fromDateOnlyInputValue(value);
   return {
     isInvalid: normalizedValue.length === 0,
     normalizedValue,
@@ -197,8 +196,8 @@ export function EventsDetailPage({
         const nextValues = mapEventItemToDetailFormValues(item);
         reset(nextValues);
         setLoadedItem(item);
-        setDateStartInput(toDatetimeLocalValue(nextValues.content.dates?.[0]?.dateStart));
-        setDateEndInput(toDatetimeLocalValue(nextValues.content.dates?.[0]?.dateEnd));
+        setDateStartInput(toDateOnlyInputValue(nextValues.content.dates?.[0]?.dateStart));
+        setDateEndInput(toDateOnlyInputValue(nextValues.content.dates?.[0]?.dateEnd));
         setInvalidDateInputs({ dateStart: false, dateEnd: false });
         setLoading(false);
         void listHostMediaReferencesByTarget({
@@ -249,8 +248,7 @@ export function EventsDetailPage({
   const updateDateField = React.useCallback(
     (field: 'dateStart' | 'dateEnd', nextValue: string) => {
       const currentDate = methods.getValues('content.dates.0') ?? {};
-      const referenceValue = currentDate[field];
-      const { isInvalid, normalizedValue } = parseDatetimeLocalInput(nextValue, referenceValue);
+      const { isInvalid, normalizedValue } = parseDateOnlyInput(nextValue);
       methods.setValue(
         'content.dates',
         [{ ...currentDate, [field]: normalizedValue }],

--- a/packages/plugin-events/src/events.pages.tsx
+++ b/packages/plugin-events/src/events.pages.tsx
@@ -11,6 +11,7 @@ import {
 } from '@sva/studio-ui-react';
 
 import { listEvents } from './events.api.js';
+import { formatDateOnlyForEditor, isValidDateOnlyValue } from './events.date-only.js';
 import { EventsDetailPage } from './events.detail-page.js';
 import { normalizeListSearch } from './list-pagination.js';
 import type { EventContentItem, EventListResult } from './events.types.js';
@@ -28,6 +29,9 @@ const updateListSearchPage = (
   page,
   pageSize,
 });
+
+const formatEventStartDate = (value?: string): string | undefined =>
+  isValidDateOnlyValue(value) ? formatDateOnlyForEditor(value) : formatDateTimeInEditorTimeZone(value);
 
 export function EventsListPage() {
   const pt = usePluginTranslation('events');
@@ -111,8 +115,7 @@ export function EventsListPage() {
               {
                 id: 'dateStart',
                 header: pt('fields.dateStart'),
-                cell: (item: EventContentItem) =>
-                  item.dates?.[0]?.dateStart ? formatDateTimeInEditorTimeZone(item.dates[0].dateStart) : '—',
+                cell: (item: EventContentItem) => (item.dates?.[0]?.dateStart ? formatEventStartDate(item.dates[0].dateStart) : '—'),
               },
             ]}
             rowActions={(item) => (

--- a/packages/plugin-events/src/events.validation.ts
+++ b/packages/plugin-events/src/events.validation.ts
@@ -1,4 +1,5 @@
 import type { EventFormInput } from './events.types.js';
+import { isValidDateOnlyValue } from './events.date-only.js';
 
 const isHttpsUrl = (value: string): boolean => {
   try {
@@ -7,8 +8,6 @@ const isHttpsUrl = (value: string): boolean => {
     return false;
   }
 };
-
-const isValidDate = (value: string): boolean => Number.isNaN(new Date(value).getTime()) === false;
 
 const hasInvalidUrl = (value: string | undefined): boolean => value !== undefined && value.trim().length > 0 && isHttpsUrl(value) === false;
 
@@ -37,7 +36,7 @@ export const validateEventForm = (input: EventFormInput): readonly string[] => {
     errors.push('title');
   }
 
-  if ((input.dates ?? []).some((date) => date.dateStart && isValidDate(date.dateStart) === false)) {
+  if ((input.dates ?? []).some((date) => isValidDateOnlyValue(date.dateStart) === false || isValidDateOnlyValue(date.dateEnd) === false)) {
     errors.push('dates');
   }
 

--- a/packages/plugin-events/tests/events.detail-content-tab.test.tsx
+++ b/packages/plugin-events/tests/events.detail-content-tab.test.tsx
@@ -218,8 +218,8 @@ describe('EventsDetailContentTab', () => {
     await screen.findAllByRole('button', { name: 'Kartenpunkt setzen' });
 
     fireEvent.change(screen.getByTestId('rich-text-editor'), { target: { value: '<p>Eventbeschreibung</p>' } });
-    fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-06-12T10:15' } });
-    fireEvent.change(screen.getByLabelText('Enddatum'), { target: { value: '2026-06-12T12:30' } });
+    fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-06-12' } });
+    fireEvent.change(screen.getByLabelText('Enddatum'), { target: { value: '2026-06-12' } });
     fireEvent.change(screen.getByLabelText('Startzeit'), { target: { value: '10:15' } });
     fireEvent.change(screen.getByLabelText('Endzeit'), { target: { value: '12:30' } });
     fireEvent.change(screen.getByLabelText('Institution/Firma'), { target: { value: 'Stadtwerke' } });
@@ -238,8 +238,8 @@ describe('EventsDetailContentTab', () => {
     fireEvent.change(screen.getByLabelText('Preis'), { target: { value: '12' } });
     fireEvent.change(screen.getByLabelText('Barrierefreiheitsbeschreibung'), { target: { value: 'Stufenlos' } });
 
-    expect(onDateStartInputChange).toHaveBeenCalledWith('2026-06-12T10:15');
-    expect(onDateEndInputChange).toHaveBeenCalledWith('2026-06-12T12:30');
+    expect(onDateStartInputChange).toHaveBeenCalledWith('2026-06-12');
+    expect(onDateEndInputChange).toHaveBeenCalledWith('2026-06-12');
     expect(getValues().content.description).toBe('<p>Eventbeschreibung</p>');
     expect(getValues().content.dates?.[0]).toMatchObject({ timeStart: '10:15', timeEnd: '12:30' });
     expect(getValues().content.addresses?.[0]).toMatchObject({ street: 'Marktplatz 1', city: 'Musterstadt' });
@@ -329,10 +329,10 @@ describe('EventsDetailContentTab', () => {
     await screen.findAllByRole('button', { name: 'Kartenpunkt setzen' });
 
     fireEvent.change(screen.getByLabelText('Startdatum', { selector: '#event-date-start-1' }), {
-      target: { value: '2026-09-01T08:00' },
+      target: { value: '2026-09-01' },
     });
     fireEvent.change(screen.getByLabelText('Enddatum', { selector: '#event-date-end-1' }), {
-      target: { value: '2026-09-01T09:00' },
+      target: { value: '2026-09-01' },
     });
     fireEvent.click(screen.getByLabelText('Nur Zeit-Hinweis verwenden', { selector: '#event-only-time-description-0' }));
     fireEvent.change(screen.getByLabelText('Straße', { selector: '#event-street-1' }), {
@@ -354,8 +354,8 @@ describe('EventsDetailContentTab', () => {
     expect(onDateStartInputChange).not.toHaveBeenCalled();
     expect(onDateEndInputChange).not.toHaveBeenCalled();
     expect(getValues().content.dates?.[1]).toMatchObject({
-      dateStart: '2026-09-01T08:00',
-      dateEnd: '2026-09-01T09:00',
+      dateStart: '2026-09-01',
+      dateEnd: '2026-09-01',
     });
     expect(getValues().content.dates?.[0]?.useOnlyTimeDescription).toBe(true);
     expect(getValues().content.addresses?.[1]?.street).toBe('Zweite Straße 2');
@@ -386,6 +386,14 @@ describe('EventsDetailContentTab', () => {
 
     expect(screen.getByLabelText('Startdatum').getAttribute('aria-invalid')).toBe('true');
     expect(screen.getByLabelText('Enddatum').getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('renders date-only inputs for event dates', async () => {
+    renderTab();
+    await screen.findAllByRole('button', { name: 'Kartenpunkt setzen' });
+
+    expect(screen.getByLabelText('Startdatum').getAttribute('type')).toBe('date');
+    expect(screen.getByLabelText('Enddatum').getAttribute('type')).toBe('date');
   });
 
   it('renders fallback values when optional arrays are initially missing', async () => {

--- a/packages/plugin-events/tests/events.detail-form.test.ts
+++ b/packages/plugin-events/tests/events.detail-form.test.ts
@@ -52,6 +52,7 @@ describe('events.detail-form', () => {
         recurringWeekdays: ['MO'],
       },
       content: {
+        dates: [{ dateStart: '2026-06-11', timeDescription: 'ab 10 Uhr', weekday: 'Mittwoch' }],
         description: 'Innenstadt',
         addresses: [
           {

--- a/packages/plugin-events/tests/events.detail-form.test.ts
+++ b/packages/plugin-events/tests/events.detail-form.test.ts
@@ -368,6 +368,25 @@ describe('events.detail-form', () => {
     });
   });
 
+  it('keeps the stored calendar day when legacy ISO timestamps are normalized to date-only values', () => {
+    expect(
+      mapEventItemToDetailFormValues({
+        id: 'event-legacy-late',
+        contentType: 'events.event-record',
+        status: 'published',
+        createdAt: '2026-06-11T10:00:00.000Z',
+        updatedAt: '2026-06-11T10:00:00.000Z',
+        title: 'Spättermin',
+        dates: [{ dateStart: '2026-06-11T23:30:00.000Z', dateEnd: '2026-06-12T23:45:00.000Z' }],
+      } satisfies EventContentItem).content.dates
+    ).toEqual([
+      expect.objectContaining({
+        dateStart: '2026-06-11',
+        dateEnd: '2026-06-12',
+      }),
+    ]);
+  });
+
   it('serializes defensively when optional collections are absent at runtime', () => {
     expect(
       mapEventsDetailFormValuesToInput({

--- a/packages/plugin-events/tests/events.detail-page.test.tsx
+++ b/packages/plugin-events/tests/events.detail-page.test.tsx
@@ -118,6 +118,7 @@ describe('EventsDetailPage', () => {
         'events.fields.categoriesSearchPlaceholder': 'Kategorie suchen oder auswählen',
         'events.fields.url': 'URL',
         'events.fields.dateStart': 'Startdatum',
+        'events.fields.dateEnd': 'Enddatum',
         'events.fields.repeat': 'Wiederholung',
         'events.fields.visible': 'Sichtbar',
         'events.fields.pushNotification': 'Push-Benachrichtigung',
@@ -239,6 +240,24 @@ describe('EventsDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('Stadtfest')).toBeTruthy();
     });
+  });
+
+  it('normalizes loaded event dates to date-only inputs in edit mode', async () => {
+    vi.mocked(getEvent).mockResolvedValueOnce({
+      id: 'event-1944005',
+      title: 'Sommerfest',
+      dates: [{ dateStart: '2026-06-11T10:00:00.000Z', dateEnd: '2026-06-12T18:00:00.000Z' }],
+    } as never);
+
+    render(<EventsDetailPage mode="edit" contentId="1944005" />);
+
+    fireEvent.click(await screen.findByRole('tab', { name: 'Inhalt' }));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Startdatum') as HTMLInputElement).value).toBe('2026-06-11');
+    });
+
+    expect((screen.getByLabelText('Enddatum') as HTMLInputElement).value).toBe('2026-06-12');
   });
 
   it('blocks submission on invalid title, invalid date input, and non-https links', async () => {

--- a/packages/plugin-events/tests/events.pages.test.tsx
+++ b/packages/plugin-events/tests/events.pages.test.tsx
@@ -225,7 +225,7 @@ describe('EventsListPage', () => {
     });
 
     fireEvent.change(screen.getByLabelText('Beschreibung'), { target: { value: 'Live im Stadtpark' } });
-    fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-04-14' } });
     fireEvent.change(screen.getByLabelText('Web-URL'), { target: { value: 'https://example.com/events' } });
     fireEvent.click(screen.getByRole('tab', { name: 'Einstellungen' }));
     await waitFor(() => {
@@ -239,6 +239,7 @@ describe('EventsListPage', () => {
         expect.objectContaining({
           title: 'Konzertabend',
           description: 'Live im Stadtpark',
+          dates: [{ dateStart: '2026-04-14' }],
           urls: [{ url: 'https://example.com/events' }],
         })
       );
@@ -252,7 +253,7 @@ describe('EventsListPage', () => {
     });
   });
 
-  it('keeps invalid DST-gap event dates visible and blocks submit', async () => {
+  it('ignores impossible date-only input values that browsers reject natively', async () => {
     render(<EventsCreatePage />);
 
     await waitFor(() => {
@@ -264,16 +265,20 @@ describe('EventsListPage', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Startdatum')).toBeTruthy();
     });
-    fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-03-29T02:30' } });
+    fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-03-40' } });
     fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Bitte korrigieren Sie die markierten Felder.')).toBeTruthy();
+      expect(createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Konzertabend',
+          dates: [],
+        })
+      );
     });
 
-    expect(screen.getByLabelText('Startdatum').getAttribute('value')).toBe('2026-03-29T02:30');
-    expect(screen.getByLabelText('Startdatum').getAttribute('aria-invalid')).toBe('true');
-    expect(createEvent).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Startdatum').getAttribute('value')).toBe('');
+    expect(screen.getByLabelText('Startdatum').getAttribute('aria-invalid')).toBeNull();
   });
 
   it('loads existing host media references on edit and keeps the update flow stable', async () => {

--- a/packages/plugin-events/tests/events.pages.test.tsx
+++ b/packages/plugin-events/tests/events.pages.test.tsx
@@ -210,6 +210,28 @@ describe('EventsListPage', () => {
     });
   });
 
+  it('renders stored date-only event values in the overview without an artificial time', async () => {
+    vi.mocked(listEvents).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'event-date-only',
+          title: 'Kalendereintrag',
+          categoryName: 'Kultur',
+          dates: [{ dateStart: '2026-04-14' }],
+        },
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+
+    render(<EventsListPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('14.04.2026').length).toBeGreaterThan(1);
+    });
+
+    expect(screen.queryByText('14.04.2026, 02:00')).toBeNull();
+  });
+
   it('creates host media references alongside the legacy event payload without leaking storage artifacts', async () => {
     render(<EventsCreatePage />);
 

--- a/packages/plugin-events/tests/events.validation.test.ts
+++ b/packages/plugin-events/tests/events.validation.test.ts
@@ -15,6 +15,15 @@ describe('validateEventForm', () => {
     expect(validateEventForm({ title: '', urls: [{ url: 'http://example.test' }] })).toEqual(['title', 'urls']);
   });
 
+  it('rejects non-date-only event date values', () => {
+    expect(
+      validateEventForm({
+        title: 'Stadtfest',
+        dates: [{ dateStart: '2026-06-11T10:00:00.000Z' }, { dateEnd: '2026-13-40' }],
+      })
+    ).toEqual(['dates']);
+  });
+
   it('rejects invalid nested contact urls and non-finite prices', () => {
     expect(
       validateEventForm({


### PR DESCRIPTION
## Summary
- switch event `Startdatum` and `Enddatum` inputs from `datetime-local` to date-only fields
- normalize loaded event date values to `YYYY-MM-DD` and validate only date-only payload values
- update plugin-events tests for the new editor behavior and date validation

## Test Plan
- [x] `pnpm nx run plugin-events:test:unit --testFiles=tests/events.detail-content-tab.test.tsx --testFiles=tests/events.detail-form.test.ts --testFiles=tests/events.detail-page.test.tsx --testFiles=tests/events.pages.test.tsx --testFiles=tests/events.validation.test.ts`
- [x] `pnpm nx run plugin-events:test:types`
