### PR TITLE
fix(iam): delete user cleanup must use keycloak subject

### DIFF
--- a/packages/iam-admin/src/user-delete-handler.ts
+++ b/packages/iam-admin/src/user-delete-handler.ts
@@ -79,6 +79,7 @@ export type DeleteUserDeps = {
     input: {
       readonly instanceId: string;
       readonly accountId: string;
+      readonly keycloakSubject: string;
     }
   ) => Promise<void>;
   readonly resolveActorMaxRoleLevel: (
@@ -205,6 +206,7 @@ export const deleteUser = async (deps: DeleteUserDeps, input: DeleteUserInput): 
     await deps.reconcileOwnedContentForAccountDelete(client, {
       instanceId: input.actor.instanceId,
       accountId: input.userId,
+      keycloakSubject: prepared.keycloakSubject,
     });
     await deps.purgeAccountHardDeleteBlockers(client, {
       instanceId: input.actor.instanceId,

--- a/packages/iam-admin/src/user-delete-persistence.test.ts
+++ b/packages/iam-admin/src/user-delete-persistence.test.ts
@@ -24,12 +24,13 @@ describe('reconcileOwnedContentForAccountDelete', () => {
     await reconcileOwnedContentForAccountDelete({ query }, {
       instanceId: 'de-musterhausen',
       accountId: '11111111-1111-4111-8111-111111111111',
+      keycloakSubject: 'kc-user-1',
     });
 
     expect(String(query.mock.calls[0]?.[0])).toContain('account_deletion_content_preferences');
     expect(query.mock.calls[1]).toEqual([
       expect.stringContaining('UPDATE iam.contents'),
-      ['de-musterhausen', '11111111-1111-4111-8111-111111111111', IAM_DELETED_CONTENT_AUTHOR_TOKEN],
+      ['de-musterhausen', '11111111-1111-4111-8111-111111111111', IAM_DELETED_CONTENT_AUTHOR_TOKEN, 'kc-user-1'],
     ]);
     expect(String(query.mock.calls[1]?.[0])).toContain('WHEN author_account_id = $2::uuid THEN $3');
     expect(String(query.mock.calls[1]?.[0])).toContain('ELSE author_display_name');
@@ -38,6 +39,8 @@ describe('reconcileOwnedContentForAccountDelete', () => {
     expect(String(query.mock.calls[1]?.[0])).toContain('updater_account_id = CASE');
     expect(String(query.mock.calls[1]?.[0])).toContain('owner_subject_id = CASE');
     expect(String(query.mock.calls[1]?.[0])).toContain('owner_user_id = CASE');
+    expect(String(query.mock.calls[1]?.[0])).toContain('WHEN owner_subject_id = $4 THEN NULL');
+    expect(String(query.mock.calls[1]?.[0])).toContain('OR owner_subject_id = $4');
     expect(String(query.mock.calls[1]?.[0])).not.toContain("deletion_lifecycle_state = 'deleted'");
   });
 
@@ -56,20 +59,22 @@ describe('reconcileOwnedContentForAccountDelete', () => {
     await reconcileOwnedContentForAccountDelete({ query }, {
       instanceId: 'de-musterhausen',
       accountId: '22222222-2222-4222-8222-222222222222',
+      keycloakSubject: 'kc-user-2',
     });
 
     expect(query.mock.calls[1]).toEqual([
       expect.stringContaining('UPDATE iam.contents'),
-      ['de-musterhausen', '22222222-2222-4222-8222-222222222222', IAM_DELETED_CONTENT_AUTHOR_TOKEN],
+      ['de-musterhausen', '22222222-2222-4222-8222-222222222222', 'kc-user-2', IAM_DELETED_CONTENT_AUTHOR_TOKEN],
     ]);
     expect(String(query.mock.calls[1]?.[0])).toContain("deletion_lifecycle_state = 'deleted'");
     expect(String(query.mock.calls[1]?.[0])).toContain('deletion_lifecycle_changed_at = NOW()');
-    expect(String(query.mock.calls[1]?.[0])).toContain('WHEN author_account_id = $2::uuid THEN $3');
+    expect(String(query.mock.calls[1]?.[0])).toContain('WHEN author_account_id = $2::uuid THEN $4');
     expect(String(query.mock.calls[1]?.[0])).not.toContain("deletion_lifecycle_state IS DISTINCT FROM 'deleted'");
     expect(String(query.mock.calls[1]?.[0])).toContain('author_account_id = $2::uuid');
     expect(String(query.mock.calls[1]?.[0])).toContain('owner_subject_id = CASE');
     expect(String(query.mock.calls[1]?.[0])).toContain('owner_user_id = CASE');
-    expect(String(query.mock.calls[1]?.[0])).toContain('OR owner_subject_id = $2');
+    expect(String(query.mock.calls[1]?.[0])).toContain('WHEN owner_subject_id = $3 THEN NULL');
+    expect(String(query.mock.calls[1]?.[0])).toContain('OR owner_subject_id = $3');
     expect(String(query.mock.calls[1]?.[0])).toContain('OR owner_user_id = $2::uuid');
   });
 });

--- a/packages/iam-admin/src/user-delete-persistence.ts
+++ b/packages/iam-admin/src/user-delete-persistence.ts
@@ -114,7 +114,7 @@ const executeAccountDeleteBlockerStatements = async (
 
 export const anonymizeRetainedOwnedContent = async (
   client: QueryClient,
-  input: { instanceId: string; accountId: string; deletedLabel?: string }
+  input: { instanceId: string; accountId: string; keycloakSubject: string; deletedLabel?: string }
 ): Promise<void> => {
   await client.query(
     `
@@ -137,7 +137,7 @@ SET
     ELSE updater_account_id
   END,
   owner_subject_id = CASE
-    WHEN owner_subject_id = $2 THEN NULL
+    WHEN owner_subject_id = $4 THEN NULL
     ELSE owner_subject_id
   END,
   owner_user_id = CASE
@@ -150,17 +150,17 @@ WHERE instance_id = $1
     author_account_id = $2::uuid
     OR creator_account_id = $2::uuid
     OR updater_account_id = $2::uuid
-    OR owner_subject_id = $2
+    OR owner_subject_id = $4
     OR owner_user_id = $2::uuid
   );
 `,
-    [input.instanceId, input.accountId, input.deletedLabel ?? IAM_DELETED_CONTENT_AUTHOR_TOKEN]
+    [input.instanceId, input.accountId, input.deletedLabel ?? IAM_DELETED_CONTENT_AUTHOR_TOKEN, input.keycloakSubject]
   );
 };
 
 export const markOwnedContentDeletedForAccountRemoval = async (
   client: QueryClient,
-  input: { instanceId: string; accountId: string; deletedLabel?: string }
+  input: { instanceId: string; accountId: string; keycloakSubject: string; deletedLabel?: string }
 ): Promise<void> => {
   await client.query(
     `
@@ -170,11 +170,11 @@ SET
   deletion_lifecycle_changed_at = NOW(),
   updated_at = NOW(),
   author_display_name = CASE
-    WHEN author_account_id = $2::uuid THEN $3
+    WHEN author_account_id = $2::uuid THEN $4
     ELSE author_display_name
   END,
   owner_subject_id = CASE
-    WHEN owner_subject_id = $2 THEN NULL
+    WHEN owner_subject_id = $3 THEN NULL
     ELSE owner_subject_id
   END,
   owner_user_id = CASE
@@ -184,17 +184,17 @@ SET
 WHERE instance_id = $1
   AND (
     author_account_id = $2::uuid
-    OR owner_subject_id = $2
+    OR owner_subject_id = $3
     OR owner_user_id = $2::uuid
   );
 `,
-    [input.instanceId, input.accountId, input.deletedLabel ?? IAM_DELETED_CONTENT_AUTHOR_TOKEN]
+    [input.instanceId, input.accountId, input.keycloakSubject, input.deletedLabel ?? IAM_DELETED_CONTENT_AUTHOR_TOKEN]
   );
 };
 
 export const reconcileOwnedContentForAccountDelete = async (
   client: QueryClient,
-  input: { instanceId: string; accountId: string }
+  input: { instanceId: string; accountId: string; keycloakSubject: string }
 ): Promise<void> => {
   const effectiveContentStrategy = await readEffectiveAccountDeletionContentStrategy(client, input);
 


### PR DESCRIPTION
## Summary
- fix account delete content cleanup to compare `owner_subject_id` against the deleted user's Keycloak subject instead of the account UUID
- separate SQL parameters so Postgres no longer infers a conflicting `uuid` type for `owner_subject_id`
- extend the delete cleanup tests for both retain and lifecycle-managed content paths

## Verification
- `pnpm nx run iam-admin:test:unit --testFiles=src/user-delete-persistence.test.ts`
- `pnpm nx run iam-admin:test:types`

## Context
Grafana logs for request `60e8a3a3-33c0-4e50-9b7d-a0cad372a127` showed `IAM delete user failed` with `operator does not exist: text = uuid` during the delete flow.