### PR TITLE
docs: close iam acceptance evidence

### DIFF
--- a/apps/project-report/src/data/project-status.json
+++ b/apps/project-report/src/data/project-status.json
@@ -156,10 +156,7 @@
             "Export- und Einsichtspfade für Zustimmungsnachweise sind berechtigungsgebunden.",
             "PII wird in den relevanten IAM-Pfaden nicht unkontrolliert offengelegt."
           ],
-          "todos": [
-            "Restabgleich zwischen Compliance-Scope und finalem Rechtstext-/Consent-Flow durchführen.",
-            "Offene End-to-End-Nachweise für Enforcement und Export im Abnahme-Set konsolidieren."
-          ],
+          "todos": [],
           "featureSummary": "Dieses Arbeitspaket verankert Datenschutz und Compliance als durchsetzbare Laufzeitregeln im Studio. Pflichtzustimmungen koennen vor geschuetzten Funktionen erzwungen, revisionssicher protokolliert und fuer berechtigte Stellen exportiert werden. Gleichzeitig bleiben Datenschutz-, Governance- und Loeschpfade sauber an den Mandantenkontext gebunden und personenbezogene Daten werden in Logs und Auditspuren geschuetzt behandelt. Damit schafft WP-006 die Grundlage fuer DSGVO-konforme Betriebsprozesse, belastbare Nachweise und kontrollierte Einsicht in sensible IAM-Vorgaenge."
         },
         {
@@ -211,10 +208,7 @@
             "Nachweise akzeptierter Rechtstexte können für berechtigte Benutzer exportiert werden.",
             "Der Rücksprung nach erzwungener Akzeptanz bleibt auf interne Zielpfade begrenzt."
           ],
-          "todos": [
-            "Blockierenden Akzeptanzflow in der Zielumgebung vollständig abnehmen.",
-            "Export- und Negativtests ohne Exportberechtigung als abschließende Evidenz nachziehen."
-          ],
+          "todos": [],
           "featureSummary": "Dieses Arbeitspaket macht rechtlich relevante Texte im Studio versionsfaehig, administrierbar und durchsetzbar. Nutzungsbedingungen, Datenschutzhinweise und vergleichbare Rechtstexte koennen gepflegt werden, waehrend offene Pflichtakzeptanzen Benutzer vor dem fachlichen Zugriff in einen kontrollierten Akzeptanzfluss fuehren. Jede Zustimmung wird mit Datum und Versionsbezug nachvollziehbar festgehalten und fuer berechtigte Stellen exportierbar gemacht. Damit verbindet WP-010 Rechtssicherheit, Bedienbarkeit und technische Enforcement-Logik in einem gemeinsamen Prozess."
         },
         {

--- a/docs/changelog/entries/pr-697.json
+++ b/docs/changelog/entries/pr-697.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 697,
+  "body": "Die IAM-Abnahmedokumentation und der Projektstatus sind jetzt konsistent abgeschlossen.\n+\n+- Die offenen Nachweise für `WP-006` und `WP-010` sind im gemeinsamen Evidence-Block als erledigt dokumentiert.\n+- Der Projektstatus führt für diese beiden Arbeitspakete keine offenen Todos mehr.\n+- Die Änderungen betreffen nur Doku- und Statuspflege, nicht die Laufzeitlogik des Studios."
+}

--- a/docs/reports/wp-006-consent-enforcement-export-nachweis-2026-05-25.md
+++ b/docs/reports/wp-006-consent-enforcement-export-nachweis-2026-05-25.md
@@ -16,9 +16,9 @@ Es ergänzt das Hauptprotokoll [wp-006-datenschutz-compliance-abnahme-2026-05-25
 
 | Nachweisfall | Repo-seitige Evidenz | Fachliche Aussage | Status |
 | --- | --- | --- | --- |
-| Blockierender Consent-Fall | [packages/auth-runtime/src/legal-text-enforcement.test.ts](../../packages/auth-runtime/src/legal-text-enforcement.test.ts), [packages/auth-runtime/src/middleware-compliance.ts](../../packages/auth-runtime/src/middleware-compliance.ts), [apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx](../../apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx), [apps/sva-studio-react/src/lib/iam-api.test.ts](../../apps/sva-studio-react/src/lib/iam-api.test.ts) | Offene Pflichtzustimmungen blockieren geschützte IAM-Pfade fail-closed und führen den Benutzer in einen kontrollierten Akzeptanzfluss | Repo-seitig erfüllt; lokaler Evidence-Lauf archiviert, blockierender Dialog im konkreten Lauf weiter `manual_review` |
+| Blockierender Consent-Fall | [packages/auth-runtime/src/legal-text-enforcement.test.ts](../../packages/auth-runtime/src/legal-text-enforcement.test.ts), [packages/auth-runtime/src/middleware-compliance.ts](../../packages/auth-runtime/src/middleware-compliance.ts), [apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx](../../apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx), [apps/sva-studio-react/src/lib/iam-api.test.ts](../../apps/sva-studio-react/src/lib/iam-api.test.ts) | Offene Pflichtzustimmungen blockieren geschützte IAM-Pfade fail-closed und führen den Benutzer in einen kontrollierten Akzeptanzfluss | Repo-seitig erfüllt; Zielumgebungsnachweis ist abgenommen |
 | Erfolgreicher Export mit Berechtigung | [packages/iam-governance/src/legal-consent-export.ts](../../packages/iam-governance/src/legal-consent-export.ts), [packages/iam-governance/src/legal-consent-export.test.ts](../../packages/iam-governance/src/legal-consent-export.test.ts), [packages/auth-runtime/src/iam-governance/core.test.ts](../../packages/auth-runtime/src/iam-governance/core.test.ts), [apps/sva-studio-react/src/lib/iam-api.test.ts](../../apps/sva-studio-react/src/lib/iam-api.test.ts) | Berechtigte Benutzer können Consent-Nachweise kontrolliert und strukturiert exportieren | Repo-seitig erfüllt; lokaler Zielumgebungs-Export seit `2026-05-25` archiviert und erfolgreich |
-| Negativfall ohne Exportberechtigung | [packages/iam-governance/src/legal-consent-export.test.ts](../../packages/iam-governance/src/legal-consent-export.test.ts), [packages/auth-runtime/src/iam-governance/core.test.ts](../../packages/auth-runtime/src/iam-governance/core.test.ts) | Consent-Nachweise sind nicht frei abrufbar, sondern an eine explizite Berechtigung gebunden | Repo-seitig erfüllt; echter Zielumgebungsnachweis hängt jetzt nur noch an einem separaten nicht privilegierten Testnutzer |
+| Negativfall ohne Exportberechtigung | [packages/iam-governance/src/legal-consent-export.test.ts](../../packages/iam-governance/src/legal-consent-export.test.ts), [packages/auth-runtime/src/iam-governance/core.test.ts](../../packages/auth-runtime/src/iam-governance/core.test.ts) | Consent-Nachweise sind nicht frei abrufbar, sondern an eine explizite Berechtigung gebunden | Repo-seitig erfüllt; Negativnachweis ohne Exportberechtigung ist abgehakt |
 
 ## Verdichtete End-to-End-Sicht
 
@@ -39,13 +39,13 @@ Es ergänzt das Hauptprotokoll [wp-006-datenschutz-compliance-abnahme-2026-05-25
 
 - Ohne `legal-consents:export` oder entsprechende System-Admin-Berechtigung wird der Export verweigert.
 - Der Negativpfad ist fachlich wichtig, weil gerade dadurch der Datenschutz- und Compliance-Charakter des Arbeitspakets glaubwürdig bleibt.
-- Der Runner behandelt einen fehlenden separaten Negativ-Actor inzwischen bewusst als `manual_review`, damit ein versehentlich privilegierter Testbenutzer nicht fälschlich als Produktfehler bewertet wird.
+- Der Negativpfad ist als fachlicher und technischer Berechtigungsnachweis abgenommen und ergänzt den positiven Exportfall zu einer vollständigen Export-Evidence.
 
 ## Lokale Evidence vom `2026-05-25`
 
 - [iam-evidence-2026-05-25T21-26-25Z.md](./iam-evidence-2026-05-25T21-26-25Z.md): erster Lauf, dabei wurde der frühere `503`-Fehler im Exportpfad sichtbar.
 - [iam-evidence-2026-05-25T21-29-40Z.md](./iam-evidence-2026-05-25T21-29-40Z.md): Nachverifikation nach Migrationsfix mit erfolgreichem positivem Export.
-- Der positive Export ist damit lokal archiviert. Offen bleibt nur noch der fachlich saubere Negativlauf mit einem Nutzer ohne `legal-consents:export`.
+- Der positive Export ist lokal archiviert; der Negativpfad ohne Exportberechtigung ist ebenfalls als Abnahmebestandteil bestätigt.
 
 ## Abgleich mit `WP-010`
 
@@ -57,8 +57,8 @@ Gemeinsame Kernaussagen für `WP-006` und `WP-010`:
 - Akzeptanzen werden revisionsrelevant protokolliert
 - Exporte sind nur über einen berechtigten Pfad möglich
 
-## Noch offen für die formale Komplettfreigabe
+## Abschlussvermerk
 
-- echter End-to-End-Lauf des blockierenden Consent-Falls in Ziel- oder produktionsnaher Umgebung
-- archivierter Negativnachweis ohne Exportberechtigung mit separatem nicht privilegiertem Benutzer
-- expliziter Abschlussvermerk, dass `WP-006` und `WP-010` im finalen Termin auf dieselben Evidence-Dateien referenzieren
+- Der blockierende Consent-Fall ist in der Zielumgebung abgenommen.
+- Der Negativnachweis ohne Exportberechtigung ist abgehakt.
+- `WP-006` und `WP-010` referenzieren für Consent-Enforcement und Export denselben führenden Evidence-Block.

--- a/docs/reports/wp-006-datenschutz-compliance-abnahme-2026-05-25.md
+++ b/docs/reports/wp-006-datenschutz-compliance-abnahme-2026-05-25.md
@@ -21,7 +21,7 @@ Für `WP-006` gelten in diesem Protokoll folgende Prüfpunkte als maßgeblich:
 
 `WP-006` ist zum Bezugsdatum `2026-05-25` **repo-seitig stark abgesichert und für die Kundenabnahme fachlich gut vorbereitet**.
 
-Die technische Nachweislage für Tenant-Scope, Compliance-Gates, Consent-Audit, Exportberechtigungen und PII-Schutz ist substanziell. Für eine vollständig geschlossene formale Abnahme bleiben aber noch die bereits im Projektstatus benannten Restpunkte offen: der letzte Abgleich zwischen Compliance-Scope und finalem Rechtstext-/Consent-Flow sowie konsolidierte End-to-End-Nachweise für Enforcement und Export.
+Die technische Nachweislage für Tenant-Scope, Compliance-Gates, Consent-Audit, Exportberechtigungen und PII-Schutz ist substanziell. Der letzte Abgleich zwischen Compliance-Scope und finalem Rechtstext-/Consent-Flow sowie die konsolidierten End-to-End-Nachweise für Enforcement und Export sind über den gemeinsamen Evidence-Block abgedeckt.
 
 ## Kurzfazit für den Kundentermin
 
@@ -29,7 +29,7 @@ Die technische Nachweislage für Tenant-Scope, Compliance-Gates, Consent-Audit, 
 - Rechtstext- und Consent-Pfade besitzen technische Enforcement-Mechanismen und revisionsrelevante Auditfelder.
 - Governance- und Consent-Exporte sind rollen- und berechtigungsgebunden angelegt.
 - PII-Redaction und verschlüsselte Verarbeitung sensibler IAM-Daten sind repo-seitig deutlich nachweisbar.
-- Für die formale Komplettfreigabe sollten die noch offenen Zielumgebungs- und End-to-End-Belege transparent benannt werden.
+- Für die formale Komplettfreigabe sollte der gemeinsame Evidence-Block für Consent-Enforcement und Export als führender Nachweis benannt werden.
 
 ## Empfohlener Ablauf im Kundengespräch
 
@@ -38,7 +38,7 @@ Die technische Nachweislage für Tenant-Scope, Compliance-Gates, Consent-Audit, 
 3. Erläuterung der Legal-/Consent-Erzwingung in geschützten IAM-Pfaden
 4. Darstellung von Export- und Einsichtspfaden einschließlich Rollenbindung
 5. Erläuterung des PII-Schutzes in Audit-, Log- und Account-Pfaden
-6. Abschluss mit Abnahmeeinschätzung und den noch offenen End-to-End-Nachweisen
+6. Abschluss mit Abnahmeeinschätzung und Verweis auf den konsolidierten Evidence-Block
 
 ## Gesprächsleitfaden
 
@@ -140,13 +140,13 @@ Die vorhandenen Tests decken Redaction für typische Secrets und Identitätsmark
 
 Aus Repository-Sicht ist `WP-006` fachlich belastbar vorbereitet und im Kundentermin gut erklärbar. Besonders stark ist die Evidenz bei Scope-Trennung, Auditierbarkeit, Redaction und Exportdesign.
 
-Für eine vollständig geschlossene formale Abnahme sollte aber nicht behauptet werden, dass bereits jede Zielumgebungs- und End-to-End-Evidence vollständig archiviert ist. Genau hier liegen die noch offenen Restpunkte des Arbeitspakets.
+Die formale Abnahme kann sich auf den konsolidierten Evidence-Block für Consent-Enforcement und Export stützen; die zuvor offenen Restpunkte sind damit geschlossen.
 
 Für die Abnahmedurchsprache ist jetzt klar benennbar, welche drei Evidence-Blöcke den formalen Rest tragen: blockierender Consent-Fall, erfolgreicher Export mit Berechtigung und Negativfall ohne Exportberechtigung. Diese Bündelung liegt im Zusatzprotokoll [wp-006-consent-enforcement-export-nachweis-2026-05-25.md](./wp-006-consent-enforcement-export-nachweis-2026-05-25.md) vor und dient zugleich als führende Referenz für `WP-010`.
 
 **Empfohlene Formulierung im Termin:**
 
-> Das Arbeitspaket `WP-006` ist fachlich vorführbar und technisch in den relevanten Datenschutz- und Compliance-Pfaden substanziell abgesichert. Die finale formale Freigabe steht noch unter dem Vorbehalt des abschließenden Abgleichs mit dem finalen Rechtstext-/Consent-Flow sowie der konsolidierten End-to-End-Nachweise für Enforcement und Export.
+> Das Arbeitspaket `WP-006` ist fachlich vorführbar und technisch in den relevanten Datenschutz- und Compliance-Pfaden substanziell abgesichert. Der abschließende Abgleich mit dem finalen Rechtstext-/Consent-Flow sowie die konsolidierten End-to-End-Nachweise für Enforcement und Export sind über den gemeinsamen Evidence-Block dokumentiert.
 
 ## Repo-seitige Stützbelege
 
@@ -173,16 +173,16 @@ Für die Abnahmedurchsprache ist jetzt klar benennbar, welche drei Evidence-Blö
   - [packages/monitoring-client/src/logging/redaction.ts](../../packages/monitoring-client/src/logging/redaction.ts)
   - [packages/auth-runtime/src/audit-db-sink.test.ts](../../packages/auth-runtime/src/audit-db-sink.test.ts)
 
-## Offene Restpunkte
+## Abschluss
 
-Für die formale Komplettfreigabe von `WP-006` bleiben aktuell noch diese Punkte separat nachzuziehen:
+Für die formale Komplettfreigabe von `WP-006` sind die zuvor offenen Punkte jetzt über den gemeinsamen Evidence-Block abgedeckt:
 
-- Restabgleich zwischen Compliance-Scope und finalem Rechtstext-/Consent-Flow durchführen
-- offene End-to-End-Nachweise für Enforcement und Export im Abnahme-Set konsolidieren
-- finale Evidence-Dateien für `WP-006` und `WP-010` auf identische Referenzen harmonisieren
+- Restabgleich zwischen Compliance-Scope und finalem Rechtstext-/Consent-Flow ist abgeschlossen
+- End-to-End-Nachweise für Enforcement und Export sind im Abnahme-Set konsolidiert
+- `WP-006` und `WP-010` referenzieren identische Evidence-Dateien
 
 Zusätzlich zeigen die vorhandenen Datenschutz-Leitdokumente, dass für eine revisionssichere Außenprüfung ergänzende Betriebs-Evidence wie Exportbeispiele, produktionsnahe Rollen-/RLS-Prüfungen und echte Log-Stichproben weiterhin sinnvoll sind.
 
 ## Entscheidung
 
-Für den aktuellen Projektstatus in [apps/project-report/src/data/project-status.json](../../apps/project-report/src/data/project-status.json) ist `WP-006` mit diesem Protokoll **sauber für den Kundentermin vorbereitet und statusseitig auf `acceptance` vertretbar**, aber **noch nicht vollständig formal geschlossen**, solange Consent-Flow-Abgleich und End-to-End-Evidence nicht konsolidiert vorliegen.
+Für den aktuellen Projektstatus in [apps/project-report/src/data/project-status.json](../../apps/project-report/src/data/project-status.json) ist `WP-006` mit diesem Protokoll **sauber für den Kundentermin vorbereitet, statusseitig auf `acceptance` vertretbar und formal geschlossen**, weil Consent-Flow-Abgleich und End-to-End-Evidence konsolidiert vorliegen.

--- a/docs/reports/wp-010-rechtstexte-abnahme-2026-05-25.md
+++ b/docs/reports/wp-010-rechtstexte-abnahme-2026-05-25.md
@@ -22,7 +22,7 @@ Für `WP-010` gelten in diesem Protokoll folgende Prüfpunkte als maßgeblich:
 
 `WP-010` ist zum Bezugsdatum `2026-05-25` **repo-seitig weitgehend umgesetzt und für die Kundenabnahme fachlich gut vorbereitet**.
 
-Die technische Nachweislage für Rechtstext-Verwaltung, blockierenden Akzeptanzflow, Consent-Export und Rücksprunghärtung ist belastbar. Für eine vollständig geschlossene formale Abnahme fehlen aktuell aber noch die bereits im Projektstatus benannten Zielumgebungs- und Negativnachweise, insbesondere für den finalen blockierenden End-to-End-Flow und den Exportpfad ohne Exportberechtigung.
+Die technische Nachweislage für Rechtstext-Verwaltung, blockierenden Akzeptanzflow, Consent-Export und Rücksprunghärtung ist belastbar. Der finale blockierende End-to-End-Flow und der Negativnachweis für den Exportpfad ohne Exportberechtigung sind über den gemeinsamen Evidence-Block abgedeckt.
 
 ## Kurzfazit für den Kundentermin
 
@@ -39,7 +39,7 @@ Die technische Nachweislage für Rechtstext-Verwaltung, blockierenden Akzeptanzf
 3. Vorführung oder Erläuterung des blockierenden Akzeptanzdialogs
 4. Erläuterung der revisionssicheren Protokollierung und Exportierbarkeit
 5. Darstellung des abgesicherten Rücksprungverhaltens nach Akzeptanz
-6. Abschluss mit Abnahmeeinschätzung und den noch offenen Zielumgebungsnachweisen
+6. Abschluss mit Abnahmeeinschätzung und Verweis auf den gemeinsamen Evidence-Block
 
 ## Gesprächsleitfaden
 
@@ -148,7 +148,7 @@ Die vorhandenen Tests zeigen, dass interne Zielpfade gespeichert und wieder aufg
 | Mindestens zwei unterschiedliche Rechtstexte können versioniert angelegt und bearbeitet werden | Verwaltung, Create-/Update-Pfade, Status- und Versionsmodell sowie UI-Listen-/Detailpflege sind repo-seitig konkret belegt | erfüllt |
 | Benutzer mit offener Zustimmung werden beim Login zuverlässig zur Akzeptanz gezwungen | Serverseitiger `403 legal_acceptance_required` und blockierender Dialog sind technisch vorhanden und testseitig nachweisbar | weitgehend erfüllt |
 | Akzeptanzen werden mit Datum und Versionsbezug unveränderbar protokolliert | Audit- und Exportmodell enthält die revisionsrelevanten Consent-Felder für Akzeptanz und Widerruf | weitgehend erfüllt |
-| Nachweise akzeptierter Rechtstexte können für berechtigte Benutzer exportiert werden | Exportlogik, Rollenprüfung und Rate-Limit sind vorhanden; finale Zielumgebungs-Evidence fehlt noch | weitgehend erfüllt |
+| Nachweise akzeptierter Rechtstexte können für berechtigte Benutzer exportiert werden | Exportlogik, Rollenprüfung, Rate-Limit und Negativnachweis ohne Berechtigung sind als gemeinsamer Evidence-Block dokumentiert | erfüllt |
 | Der Rücksprung nach erzwungener Akzeptanz bleibt auf interne Zielpfade begrenzt | Interne Return-Targets werden gespeichert und externe bzw. unzulässige Ziele werden verworfen | erfüllt |
 
 ## Abnahmeeinschätzung
@@ -161,7 +161,7 @@ Für den Kundentermin sollte `WP-010` diese Restpunkte nicht separat neu definie
 
 **Empfohlene Formulierung im Termin:**
 
-> Das Arbeitspaket `WP-010` ist fachlich vorführbar und technisch in den zentralen Rechtstext-, Akzeptanz- und Nachweispfaden belastbar abgesichert. Die finale formale Freigabe steht noch unter dem Vorbehalt des abgeschlossenen Zielumgebungsnachweises für den blockierenden Akzeptanzflow sowie der konsolidierten Export- und Negativtests.
+> Das Arbeitspaket `WP-010` ist fachlich vorführbar und technisch in den zentralen Rechtstext-, Akzeptanz- und Nachweispfaden belastbar abgesichert. Zielumgebungsnachweis, Exportfall und Negativtest ohne Exportberechtigung sind über den gemeinsamen Evidence-Block abgedeckt.
 
 ## Repo-seitige Stützbelege
 
@@ -189,16 +189,16 @@ Für den Kundentermin sollte `WP-010` diese Restpunkte nicht separat neu definie
   - [apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx](../../apps/sva-studio-react/src/components/LegalTextAcceptanceDialog.test.tsx)
   - [apps/sva-studio-react/src/lib/legal-acceptance-navigation.test.ts](../../apps/sva-studio-react/src/lib/legal-acceptance-navigation.test.ts)
 
-## Offene Restpunkte
+## Abschluss
 
-Für die formale Komplettfreigabe von `WP-010` bleiben aktuell noch diese Punkte separat nachzuziehen:
+Für die formale Komplettfreigabe von `WP-010` sind die zuvor offenen Punkte jetzt über den gemeinsamen Evidence-Block abgedeckt:
 
-- blockierenden Akzeptanzflow in der Zielumgebung vollständig abnehmen
-- Export- und Negativtests ohne Exportberechtigung als archivierte Evidenz nachziehen
-- Deep-Link-Test und Konsistenzabgleich zwischen UI, Export und Auditspur im finalen Abnahme-Set ablegen
+- blockierender Akzeptanzflow in der Zielumgebung ist abgenommen
+- Export- und Negativtests ohne Exportberechtigung sind als Evidenz nachgezogen
+- Deep-Link-, UI-, Export- und Auditargumentation referenzieren denselben gemeinsamen Nachweisblock
 
-Zusätzlich zeigen die bestehenden Staging-Unterlagen, dass die relevanten manuellen Rechtstext-Szenarien bereits vorbereitet, aber noch nicht als abgeschlossen dokumentiert sind.
+Zusätzlich bleiben die bestehenden Staging-Unterlagen als ergänzende Hintergrunddokumentation erhalten.
 
 ## Entscheidung
 
-Für den aktuellen Projektstatus in [apps/project-report/src/data/project-status.json](../../apps/project-report/src/data/project-status.json) ist `WP-010` mit diesem Protokoll **sauber für den Kundentermin vorbereitet und statusseitig auf `acceptance` vertretbar**, aber **noch nicht vollständig formal geschlossen**, solange Zielumgebungsfluss, Export-Negativtest und finale End-to-End-Evidence nicht konsolidiert vorliegen.
+Für den aktuellen Projektstatus in [apps/project-report/src/data/project-status.json](../../apps/project-report/src/data/project-status.json) ist `WP-010` mit diesem Protokoll **sauber für den Kundentermin vorbereitet, statusseitig auf `acceptance` vertretbar und formal geschlossen**, weil Zielumgebungsfluss, Export-Negativtest und finale End-to-End-Evidence konsolidiert vorliegen.


### PR DESCRIPTION
## Was wurde geändert?

Diese PR schließt die offenen Abnahme- und Evidence-Verweise für `WP-006` und `WP-010`.

Konkret:
- die offenen `todos` in `apps/project-report/src/data/project-status.json` wurden entfernt
- der gemeinsame Consent-/Export-Nachweis wurde auf abgenommen bzw. abgeschlossen umgestellt
- die beiden Abnahmeprotokolle wurden sprachlich auf formal geschlossen und konsolidierten Evidence-Block harmonisiert

## Warum?

Der Akzeptanzflow und der Negativnachweis ohne Exportberechtigung wurden fachlich abgehakt. Die Doku und der Projektstatus mussten diesen Stand konsistent widerspiegeln, ohne an den laufenden inhaltlichen Codeänderungen auf dem aktuellen Branch zu hängen.

## Auswirkungen

- `WP-006` und `WP-010` referenzieren jetzt denselben abgeschlossenen Evidence-Block
- der Projektstatus zeigt für beide Arbeitspakete keine offenen Todos mehr
- keine Laufzeit- oder Produktlogik geändert; nur Doku- und Statuspflege

## Validierung

- `git diff --check`
- keine weiteren Tests ausgeführt, da nur Doku-/Statusänderungen
