### PR TITLE
Fix redundant conditionals and Vitest file filters

### DIFF
--- a/apps/sva-studio-react/src/routes/__root.tsx
+++ b/apps/sva-studio-react/src/routes/__root.tsx
@@ -60,19 +60,12 @@ export const getRootHead = () => ({
       title: 'SVA Studio',
     },
   ],
-  links: import.meta.env.DEV
-    ? [
-        {
-          rel: 'stylesheet',
-          href: appCssHref,
-        },
-      ]
-    : [
-        {
-          rel: 'stylesheet',
-          href: appCssHref,
-        },
-      ],
+  links: [
+    {
+      rel: 'stylesheet',
+      href: appCssHref,
+    },
+  ],
 });
 
 export const Route = createRootRoute({

--- a/docs/changelog/entries/pr-700.json
+++ b/docs/changelog/entries/pr-700.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 700,
+  "body": "Mehrere redundante Bedingungen ohne Laufzeitnutzen wurden in Studio- und Serverpfaden entfernt.\n\n- Die Sonar-Hinweise in der Root-Route, im IAM-Rollen-Delete-Handler und in der Mainserver-Generic-Items-Route sind behoben.\n- Dateigefilterte Vitest-Läufe über den Nx-Wrapper greifen wieder präzise auf die angeforderten Testdateien, statt unnötig ganze Testsuiten auszuführen."
+}

--- a/packages/iam-admin/src/role-delete-handler.test.ts
+++ b/packages/iam-admin/src/role-delete-handler.test.ts
@@ -150,6 +150,22 @@ describe('createDeleteRoleHandlerInternal', () => {
     expect(identityProvider.provider.deleteRole).not.toHaveBeenCalled();
   });
 
+  it('returns actor resolution responses unchanged from prepare', async () => {
+    const unauthorizedResponse = createJsonResponse(403, {
+      error: { code: 'forbidden', message: 'Nicht erlaubt.' },
+      requestId: 'req-delete-role',
+    });
+    const deps = createDeps({
+      resolveRoleMutationActor: vi.fn(async () => ({ response: unauthorizedResponse })),
+    });
+
+    const response = await runDeleteRoleRequest(deps);
+
+    expect(response).toBe(unauthorizedResponse);
+    expect(deps.requireRoleId).not.toHaveBeenCalled();
+    expect(deps.resolveDeletableRole).not.toHaveBeenCalled();
+  });
+
   it('returns DB_WRITE_FAILED without Keycloak compensation when local deletion fails', async () => {
     const deps = createDeps({
       deleteRoleFromDatabase: vi.fn(rejectDbWrite),

--- a/packages/iam-admin/src/role-delete-handler.ts
+++ b/packages/iam-admin/src/role-delete-handler.ts
@@ -125,8 +125,7 @@ export const createDeleteRoleHandlerInternal =
     Response
   >({
     prepare: async ({ request, context }) => {
-      const resolvedRequest = await resolveDeleteRoleRequest(deps, request, context);
-      return resolvedRequest instanceof Response ? resolvedRequest : resolvedRequest;
+      return resolveDeleteRoleRequest(deps, request, context);
     },
     authorize: async () => ({}),
     parse: async () => undefined,

--- a/packages/sva-mainserver/src/server/generic-items-route.test.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route.test.ts
@@ -264,6 +264,23 @@ describe('dispatchSvaMainserverGenericItemsRequest', () => {
     expect(state.createSvaMainserverGenericItem).not.toHaveBeenCalled();
   });
 
+  it('returns invalid JSON request errors before calling the create service', async () => {
+    mockAuthorizedMutation();
+
+    const response = await dispatchSvaMainserverGenericItemsRequest(
+      createRequest('https://studio.test/api/v1/mainserver/generic-items', {
+        method: 'POST',
+        body: '{invalid-json',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    );
+
+    expect(response?.status).toBe(400);
+    expect(state.createSvaMainserverGenericItem).not.toHaveBeenCalled();
+  });
+
   it('rejects mutating requests when csrf validation fails', async () => {
     state.withAuthenticatedUser.mockImplementation((_request, handler) => handler(ctx));
     state.validateCsrf.mockReturnValue({ ok: false });

--- a/packages/sva-mainserver/src/server/generic-items-route.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route.ts
@@ -106,8 +106,7 @@ const authorizeMutation = async (
 };
 
 const parseGenericItemOrResponse = async (request: Request): Promise<SvaMainserverGenericItemInput | Response> => {
-  const genericItem = await parseGenericItemInput(request);
-  return isResponse(genericItem) ? genericItem : genericItem;
+  return parseGenericItemInput(request);
 };
 
 const handleListRequest = async (

--- a/scripts/ci/run-vitest-target.test.ts
+++ b/scripts/ci/run-vitest-target.test.ts
@@ -58,11 +58,10 @@ describe('run-vitest-target', () => {
     ]);
   });
 
-  it('protects test file filters from options with optional values', () => {
-    expect(normalizeVitestRunArgs(['--changed', '--testFiles=src/runtime-health.test.ts'])).toEqual([
-      '--changed',
-      'src/runtime-health.test.ts',
-    ]);
+  it('rejects combining test file filters with options that accept optional values', () => {
+    expect(() => normalizeVitestRunArgs(['--changed', '--testFiles=src/runtime-health.test.ts'])).toThrow(
+      '--changed kann nicht mit --testFiles kombiniert werden.'
+    );
   });
 
   it('keeps plain positional filters ahead of explicit test file filters', () => {

--- a/scripts/ci/run-vitest-target.test.ts
+++ b/scripts/ci/run-vitest-target.test.ts
@@ -17,7 +17,6 @@ describe('run-vitest-target', () => {
       '--config',
       'vitest.config.ts',
       '--passWithNoTests',
-      '--',
       'src/runtime-health.test.ts',
     ]);
   });
@@ -34,7 +33,6 @@ describe('run-vitest-target', () => {
     ).toEqual([
       '--config',
       'vitest.config.ts',
-      '--',
       'src/runtime-health.test.ts',
       'src/runtime-auth.test.ts',
     ]);
@@ -56,7 +54,6 @@ describe('run-vitest-target', () => {
       '--reporter=verbose',
       '--config',
       'vitest.config.ts',
-      '--',
       'tests/foo.test.ts',
     ]);
   });
@@ -64,7 +61,22 @@ describe('run-vitest-target', () => {
   it('protects test file filters from options with optional values', () => {
     expect(normalizeVitestRunArgs(['--changed', '--testFiles=src/runtime-health.test.ts'])).toEqual([
       '--changed',
-      '--',
+      'src/runtime-health.test.ts',
+    ]);
+  });
+
+  it('keeps plain positional filters ahead of explicit test file filters', () => {
+    expect(
+      normalizeVitestRunArgs([
+        'src/server',
+        '--config',
+        'vitest.config.ts',
+        '--testFiles=src/runtime-health.test.ts',
+      ])
+    ).toEqual([
+      'src/server',
+      '--config',
+      'vitest.config.ts',
       'src/runtime-health.test.ts',
     ]);
   });

--- a/scripts/ci/run-vitest-target.ts
+++ b/scripts/ci/run-vitest-target.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const TEST_FILES_FLAG = '--testFiles';
+const OPTIONAL_VALUE_FLAGS = new Set(['--changed']);
 
 export const normalizeVitestRunArgs = (args: readonly string[]): string[] => {
   const passthroughArgs: string[] = [];
@@ -39,6 +40,13 @@ export const normalizeVitestRunArgs = (args: readonly string[]): string[] => {
 
   if (testFileArgs.length === 0) {
     return passthroughArgs;
+  }
+
+  const conflictingOptionalValueFlag = passthroughArgs.find((argument) => OPTIONAL_VALUE_FLAGS.has(argument));
+  if (conflictingOptionalValueFlag) {
+    throw new Error(
+      `${conflictingOptionalValueFlag} kann nicht mit --testFiles kombiniert werden. Verwende stattdessen direkte Vitest-Dateifilter ohne ${conflictingOptionalValueFlag}.`
+    );
   }
 
   return [...passthroughArgs, ...testFileArgs];

--- a/scripts/ci/run-vitest-target.ts
+++ b/scripts/ci/run-vitest-target.ts
@@ -41,7 +41,7 @@ export const normalizeVitestRunArgs = (args: readonly string[]): string[] => {
     return passthroughArgs;
   }
 
-  return [...passthroughArgs, '--', ...testFileArgs];
+  return [...passthroughArgs, ...testFileArgs];
 };
 
 export const isRunVitestTargetEntrypoint = (


### PR DESCRIPTION
## Was wurde geändert?

Dieser PR behebt drei Sonar-Meldungen zu redundanten Bedingungen und korrigiert zusätzlich den lokalen Vitest-Wrapper für dateigefilterte Nx-Testläufe.

Konkret:
- entfernt identische `true/false`-Branches in der Root-Route von `sva-studio-react`
- entfernt identische Response-Rückgaben in `iam-admin` und `sva-mainserver`
- ergänzt gezielte Regressionstests für die beiden Serverpfade
- korrigiert `scripts/ci/run-vitest-target.ts`, damit `--testFiles` wieder als echter Vitest-Dateifilter statt als Vollsuite-Lauf verarbeitet wird

## Warum?

Die Sonar-Funde waren echte Redundanzen ohne semantischen Mehrwert.

Zusätzlich hat sich beim Verifizieren gezeigt, dass der aktuelle Nx/Vitest-Wrapper `--testFiles` zu `vitest run -- <datei>` umschreibt. Mit Vitest 4.1.9 führt diese Form nicht zu einem Dateifilter, sondern zur gesamten Suite. Das treibt lokale Testkosten hoch und zieht PR-fremde Timeouts in Validierungsläufe hinein.

## Auswirkung

- Sonar-Meldungen für die drei redundanten Bedingungen sind beseitigt.
- Dateigefilterte Nx-Vitest-Läufe werden wieder präzise auf die angeforderten Testdateien begrenzt.
- PR-fremde Langläufer werden bei gezielten Shift-left-Runs deutlich seltener mitgezogen.

## Validierung

- `pnpm exec vitest run src/routes/-__root.test.tsx --config vitest.routes.config.ts`
- `pnpm exec vitest run src/server/generic-items-route.test.ts --config vitest.config.ts`
- `pnpm nx run iam-admin:test:unit --testFiles=src/role-delete-handler.test.ts`
- `pnpm nx run iam-admin:test:types`
- `pnpm nx run sva-mainserver:test:types`
- `pnpm nx run sva-studio-react:test:types`
- `pnpm exec vitest run scripts/ci/run-vitest-target.test.ts`
- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/generic-items-route.test.ts`
