### PR TITLE
Harden outbound target validation and path safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@
 
 ## Repository File Placement (Enforced)
 
-- Root-Level Markdown ist gesperrt (Ausnahme: `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `DEBUGGING.md`, `DEVELOPMENT_RULES.md`, `AGENTS.md`)
+- Root-Level Markdown ist gesperrt (Ausnahme: `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `DEBUGGING.md`, `DEVELOPMENT_RULES.md`, `AGENTS.md`, `SECURITY.md`)
 - Debug-Skripte gehören ausschließlich nach `scripts/debug/auth/` oder `scripts/debug/otel/`
 - Operative Reports gehören nach `docs/reports/`
 - Staging-Dokumente gehören nach `docs/staging/YYYY-MM/`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,156 @@
+# Sicherheitsrichtlinie
+
+Diese Richtlinie beschreibt den verbindlichen Melde- und Bearbeitungsprozess für Sicherheitslücken in SVA Studio.
+
+## Zweck und Geltungsbereich
+
+- Sie gilt für den aktiv gepflegten Stand auf `main`.
+- Sie deckt Anwendungscode, Infrastrukturdefinitionen im Repository, Build-Konfiguration und dokumentierte Betriebsprofile ab.
+- Sie ersetzt keine Incident-Kommunikation für laufende Ausfälle. Dafür gilt [`docs/guides/incident-response.md`](./docs/guides/incident-response.md).
+
+## Unterstützte Stände
+
+SVA Studio befindet sich laut [README.md](./README.md) im Status `early development`.
+
+| Stand | Security-Fixes |
+| --- | --- |
+| `main` | Ja |
+| aktive Pull Requests vor Merge | nach bestem Aufwand |
+| ältere Branches, lokale Forks, historische Tags oder experimentelle Stände | Nein, nur nach separater Entscheidung |
+
+Sicherheitskorrekturen werden primär für den aktuellen Stand auf `main` umgesetzt.
+
+## Schwachstellen melden
+
+Bitte keine öffentlichen GitHub Issues für Sicherheitslücken anlegen.
+
+Bevorzugte Meldewege:
+
+1. GitHub Private Vulnerability Reporting bzw. Security Advisory dieses Repositories
+2. Fallback per E-Mail an `security@smart-village.app`
+
+Die Meldung sollte möglichst enthalten:
+
+- betroffene Komponente, Datei, Route oder Betriebsfunktion
+- betroffenen Commit, Branch oder Image-Tag
+- reproduzierbare Schritte, Beispiel-Request oder Proof of Concept
+- erwartetes und tatsächliches Verhalten
+- Auswirkungen auf Vertraulichkeit, Integrität oder Verfügbarkeit
+- bekannte Mitigations oder einen möglichen Fix-Vorschlag
+- betroffene Konfiguration oder Betriebsumgebung
+
+Bitte keine produktiven Geheimnisse, Zugangsdaten oder personenbezogenen Daten ungeschützt mitsenden.
+
+## Reaktionszeiten
+
+| Schritt | Zielwert |
+| --- | --- |
+| Eingangsbestätigung | innerhalb von 3 Werktagen |
+| Erste Triage | innerhalb von 7 Kalendertagen |
+| Status-Update bei längerer Bearbeitung | mindestens alle 14 Kalendertage |
+
+Die Zielwerte sind Service-Ziele, keine Garantien für einen Fix innerhalb eines festen Zeitraums.
+
+## Bearbeitungsablauf
+
+### 1. Eingang und Validierung
+
+- Neue Meldungen werden vertraulich erfasst.
+- Wir prüfen Reproduzierbarkeit, betroffene Versionen und Schweregrad.
+- Offensichtliche Duplikate werden zusammengeführt.
+
+### 2. Triage
+
+- Kritische Auswirkungen auf Authentisierung, Autorisierung, Geheimnisse, PII oder Produktionsverfügbarkeit werden priorisiert.
+- Falls die Meldung auch Datenschutz oder Incident-Kommunikation betrifft, wird zusätzlich `operations@smart-village.app` eingebunden.
+
+### 3. Behebung und Mitigation
+
+- Fixes werden bevorzugt außerhalb öffentlicher Diskussionen vorbereitet.
+- Wenn kein sofortiger Fix möglich ist, dokumentieren wir eine Mitigation oder einen Workaround.
+- Nicht-sensitive Folgearbeiten dürfen nach der ersten Absicherung als normale GitHub Issues nachgezogen werden.
+
+### 4. Veröffentlichung
+
+- Nach Freigabe veröffentlichen wir eine abgestimmte Offenlegung über GitHub Security Advisories oder Release Notes.
+- Credits für meldende Personen werden nur nach ausdrücklicher Zustimmung genannt.
+
+## Advisory-, CVE- und Disclosure-Policy
+
+- GitHub Security Advisories sind der Standardkanal für koordinierte Offenlegung.
+- Eine CVE wird dann beantragt oder referenziert, wenn Reichweite, Nachnutzbarkeit oder externe Kommunikation das sinnvoll machen.
+- Vor der Veröffentlichung stimmen wir einen Disclosure-Zeitpunkt ab, sofern die meldende Person erreichbar ist.
+- Öffentliche Details sollen erst erscheinen, wenn ein Fix oder mindestens eine belastbare Mitigation verfügbar ist.
+
+## Sicherheitsgrenzen des Produkts
+
+Diese Datei definiert die maßgebliche Trust Boundary für dieses Repository.
+
+### Als untrusted Input behandeln wir insbesondere
+
+- anonyme oder authentisierte HTTP-Requests aus produktiven oder produktionsnahen Oberflächen
+- Request-Body, Query-Parameter, Path-Parameter, Header und Cookie-Inhalte
+- Inhalte aus externen Systemen, Schnittstellen, Webhooks und Imports
+- von Endnutzer:innen hochgeladene Dateien und Inhalte
+- tenant-lokale Daten, sofern sie in sicherheitsrelevante Entscheidungen einfließen
+
+### Als privilegierte oder trusted Operator-/Admin-Eingaben behandeln wir insbesondere
+
+- Deployment- und Laufzeit-Environment-Variablen
+- manuell gepflegte Infrastruktur- und Integrationskonfiguration
+- lokale CLI-Argumente für `scripts/ci/`, `scripts/ops/` und `scripts/debug/`
+- bewusst von System- oder Integrationsadministrator:innen gesetzte Upstream-, Endpoint-, Datenbank- oder Bucket-Konfigurationen
+
+Das bedeutet nicht, dass solche Pfade keine Risiken haben. Sie sind aber primär als privilegierte Konfigurations- oder Operator-Pfade und nicht als öffentliche, low-privilege Angriffspfade zu bewerten.
+
+## In Scope
+
+Im Scope für sicherheitsrelevante Befunde sind insbesondere:
+
+- produktive Serverrouten und serverseitige Actions
+- Authentisierung, Autorisierung, Mandantentrennung und Session-Handling
+- Persistenz-, Export-, Import- und Medienpfade
+- Schnittstellen zu externen Produktivsystemen
+- serverseitige Verarbeitung untrusted Inputs
+- sicherheitsrelevante Fehlkonfigurationen in shipped Code und dokumentierten Betriebsprofilen
+
+## Out of Scope oder nur eingeschränkt relevant
+
+Nur eingeschränkt oder standardmäßig nicht als Produkt-Sicherheitslücke zu bewerten sind:
+
+- reine Test-, Fixture-, E2E- und Demo-Dateien
+- lokale Entwicklerhilfen und Debug-Skripte
+- CI-/Ops-Skripte, deren Eingaben nur durch vertrauenswürdige Maintainer oder Operatoren gesetzt werden
+- bewusst administrative Integrationskonfigurationen, sofern kein zusätzlicher Boundary-Bypass für unprivilegierte Nutzer nachweisbar ist
+
+## SSRF- und Egress-Bewertung
+
+Für dieses Repository gilt bei SSRF- und ähnlichen Outbound-Request-Befunden:
+
+- Kritisch ist ein Befund typischerweise dann, wenn untrusted Input aus einer öffentlichen oder niedrig privilegierten Produktoberfläche serverseitig ein Ziel bestimmen oder wesentlich beeinflussen kann.
+- Hoch, aber nicht kritisch sind typischerweise privilegierte Admin-/Integrationspfade, in denen Administrator:innen oder Operatoren serverseitige Ziele konfigurieren können und diese Konfiguration anschließend Requests auslöst.
+- Reine Browser-Fetches, relative `/api`-Aufrufe und lokal betriebene Test-/Ops-Skripte sind keine SSRF-Produktbefunde.
+
+## Responsible Disclosure
+
+- Keine öffentliche Offenlegung vor abgestimmter Freigabe
+- Keine Zugriffe auf Daten Dritter
+- Keine dauerhafte Beeinträchtigung von Produktivsystemen
+- Tests nur im zur Validierung erforderlichen Umfang
+
+## Weitere Grenzen
+
+- Es gibt kein öffentliches Bug-Bounty-Programm.
+- Themen rund um Supply Chain, Build-Härtung, Secret-Rotation oder externe SaaS-Abhängigkeiten können Folgearbeit erfordern, auch wenn die Erstmeldung validiert ist.
+- Third-Party-Schwachstellen ohne ausnutzbaren Projektbezug werden als Abhängigkeits- oder Upgrade-Thema behandelt.
+
+## Fixes und Dokumentation
+
+- Sicherheitsfixes sollten von passenden Tests, Reproduktionsschritten oder klarer Validierung begleitet sein.
+- Wenn eine Schwachstelle auch Betriebs- oder Architekturannahmen betrifft, werden die zugehörigen Dokumente im Repository mit aktualisiert.
+
+## Verweise
+
+- GitHub-Einstieg: [`.github/SECURITY.md`](./.github/SECURITY.md)
+- ausführliche Richtlinie: [`docs/guides/security-policy.md`](./docs/guides/security-policy.md)
+- Incident-Kommunikation: [`docs/guides/incident-response.md`](./docs/guides/incident-response.md)

--- a/apps/sva-studio-react/public/.well-known/security.txt
+++ b/apps/sva-studio-react/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@smart-village.app
+Contact: https://github.com/smart-village-solutions/sva-studio/security/advisories/new
+Canonical: https://studio.smart-village.app/.well-known/security.txt
+Policy: https://github.com/smart-village-solutions/sva-studio/blob/main/SECURITY.md
+Preferred-Languages: de, en
+Expires: 2027-07-09T06:49:02Z

--- a/apps/sva-studio-react/src/lib/instance-interface-healthcheck.server.test.ts
+++ b/apps/sva-studio-react/src/lib/instance-interface-healthcheck.server.test.ts
@@ -19,6 +19,22 @@ vi.mock('@sva/data-repositories/server', () => ({
 
 vi.mock('@sva/auth-runtime/server', () => ({
   revealField: state.revealField,
+  normalizeDatabaseConnectionUrl: vi.fn(async (value: string, options?: { allowPrivateHosts?: boolean }) => {
+    const url = new URL(value);
+    const isPrivateTarget = ['localhost', '127.0.0.1'].includes(url.hostname);
+    if (isPrivateTarget && options?.allowPrivateHosts !== true) {
+      return null;
+    }
+    return url.toString();
+  }),
+  normalizeOutboundHttpUrl: vi.fn(async (value: string, options?: { allowPrivateHosts?: boolean }) => {
+    const url = new URL(value);
+    const isPrivateTarget = ['localhost', '127.0.0.1'].includes(url.hostname);
+    if (isPrivateTarget && options?.allowPrivateHosts !== true) {
+      return null;
+    }
+    return url.toString();
+  }),
 }));
 
 vi.mock('pg', () => ({
@@ -56,6 +72,7 @@ describe('instance-interface-healthcheck.server', () => {
     state.fetch.mockReset();
     state.s3Send.mockReset();
     vi.stubGlobal('fetch', state.fetch);
+    delete process.env.SVA_ALLOW_PRIVATE_INTERFACE_HEALTHCHECK_TARGETS;
   });
 
   it('persists a failed connection check when the database rejects credentials', async () => {
@@ -457,6 +474,82 @@ describe('instance-interface-healthcheck.server', () => {
         checkStatus: 'failed',
         errorCode: 'connection_failed',
       })
+    );
+  });
+
+  it('blocks private supabase database hosts by default and allows them with explicit opt-in', async () => {
+    const { runStoredInterfaceHealthcheck } = await import('./instance-interface-healthcheck.server.js');
+
+    state.loadExternalInterfaceRecordById.mockResolvedValueOnce({
+      id: 'supabase-private-db-host',
+      instanceId: 'de-test',
+      typeKey: 'supabase',
+      ownerKind: 'host',
+      ownerId: 'host',
+      displayName: 'Waste Supabase',
+      alias: 'default',
+      enabled: true,
+      isDefault: true,
+      category: 'database',
+      baseUrl: 'https://tenant.supabase.co',
+      authMode: 'service_role',
+      statusCheckKind: 'supabase',
+      visibleStatus: 'unknown',
+      publicConfig: {
+        projectUrl: 'https://tenant.supabase.co',
+      },
+      secretConfigCiphertext:
+        'iam.instance_external_interfaces.secret_config:supabase-private-db-host:{"databaseUrl":"postgres://user:pass@localhost:5432/wm","serviceRoleKey":"service-role-key"}',
+    });
+
+    await expect(
+      runStoredInterfaceHealthcheck({
+        instanceId: 'de-test',
+        interfaceId: 'supabase-private-db-host',
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        checkStatus: 'failed',
+        errorCode: 'connection_failed',
+      }),
+    );
+    expect(state.poolQuery).not.toHaveBeenCalled();
+
+    process.env.SVA_ALLOW_PRIVATE_INTERFACE_HEALTHCHECK_TARGETS = 'true';
+    state.loadExternalInterfaceRecordById.mockResolvedValueOnce({
+      id: 'supabase-private-db-host-opt-in',
+      instanceId: 'de-test',
+      typeKey: 'supabase',
+      ownerKind: 'host',
+      ownerId: 'host',
+      displayName: 'Waste Supabase',
+      alias: 'default',
+      enabled: true,
+      isDefault: true,
+      category: 'database',
+      baseUrl: 'https://tenant.supabase.co',
+      authMode: 'service_role',
+      statusCheckKind: 'supabase',
+      visibleStatus: 'unknown',
+      publicConfig: {
+        projectUrl: 'https://tenant.supabase.co',
+      },
+      secretConfigCiphertext:
+        'iam.instance_external_interfaces.secret_config:supabase-private-db-host-opt-in:{"databaseUrl":"postgres://user:pass@localhost:5432/wm","serviceRoleKey":"service-role-key"}',
+    });
+    state.poolQuery.mockResolvedValueOnce({ rows: [{ schema_exists: true }] });
+    state.fetch.mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
+
+    await expect(
+      runStoredInterfaceHealthcheck({
+        instanceId: 'de-test',
+        interfaceId: 'supabase-private-db-host-opt-in',
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        checkStatus: 'succeeded',
+        visibleStatus: 'ok',
+      }),
     );
   });
 
@@ -926,6 +1019,85 @@ describe('instance-interface-healthcheck.server', () => {
         checkStatus: 'failed',
         errorCode: 'connection_failed',
       })
+    );
+  });
+
+  it('blocks private s3 endpoints by default and allows them with explicit opt-in', async () => {
+    const { runStoredInterfaceHealthcheck } = await import('./instance-interface-healthcheck.server.js');
+
+    state.loadExternalInterfaceRecordById.mockResolvedValueOnce({
+      id: 's3-private-endpoint',
+      instanceId: 'de-test',
+      typeKey: 's3',
+      ownerKind: 'host',
+      ownerId: 'host',
+      displayName: 'Media S3',
+      alias: 'default',
+      enabled: true,
+      isDefault: true,
+      category: 'object_storage',
+      baseUrl: 'https://localhost',
+      authMode: 'access_key',
+      statusCheckKind: 's3',
+      visibleStatus: 'unknown',
+      publicConfig: {
+        endpoint: 'https://localhost',
+        bucket: 'media',
+        accessKeyId: 'key-1',
+      },
+      secretConfigCiphertext:
+        'iam.instance_external_interfaces.secret_config:s3-private-endpoint:{"secretAccessKey":"secret-1"}',
+    });
+
+    await expect(
+      runStoredInterfaceHealthcheck({
+        instanceId: 'de-test',
+        interfaceId: 's3-private-endpoint',
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        checkStatus: 'failed',
+        errorCode: 'connection_failed',
+      }),
+    );
+    expect(state.s3Send).not.toHaveBeenCalled();
+
+    process.env.SVA_ALLOW_PRIVATE_INTERFACE_HEALTHCHECK_TARGETS = 'true';
+    state.loadExternalInterfaceRecordById.mockResolvedValueOnce({
+      id: 's3-private-endpoint-opt-in',
+      instanceId: 'de-test',
+      typeKey: 's3',
+      ownerKind: 'host',
+      ownerId: 'host',
+      displayName: 'Media S3',
+      alias: 'default',
+      enabled: true,
+      isDefault: true,
+      category: 'object_storage',
+      baseUrl: 'https://localhost',
+      authMode: 'access_key',
+      statusCheckKind: 's3',
+      visibleStatus: 'unknown',
+      publicConfig: {
+        endpoint: 'https://localhost',
+        bucket: 'media',
+        accessKeyId: 'key-1',
+      },
+      secretConfigCiphertext:
+        'iam.instance_external_interfaces.secret_config:s3-private-endpoint-opt-in:{"secretAccessKey":"secret-1"}',
+    });
+    state.s3Send.mockResolvedValueOnce({});
+
+    await expect(
+      runStoredInterfaceHealthcheck({
+        instanceId: 'de-test',
+        interfaceId: 's3-private-endpoint-opt-in',
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        checkStatus: 'succeeded',
+        visibleStatus: 'ok',
+      }),
     );
   });
 });

--- a/apps/sva-studio-react/src/lib/instance-interface-healthcheck.server.ts
+++ b/apps/sva-studio-react/src/lib/instance-interface-healthcheck.server.ts
@@ -11,7 +11,11 @@ import {
   loadExternalInterfaceRecordById,
   saveExternalInterfaceConnectionCheck,
 } from '@sva/data-repositories/server';
-import { revealField } from '@sva/auth-runtime/server';
+import {
+  normalizeDatabaseConnectionUrl,
+  normalizeOutboundHttpUrl,
+  revealField,
+} from '@sva/auth-runtime/server';
 import {
   ExternalInterfaceRuntimeError,
   resolveExternalInterface,
@@ -19,6 +23,9 @@ import {
 } from '@sva/server-runtime';
 
 type PoolLike = Pick<Pool, 'query' | 'end'>;
+
+const shouldAllowPrivateInterfaceHealthcheckTargets = (): boolean =>
+  process.env.SVA_ALLOW_PRIVATE_INTERFACE_HEALTHCHECK_TARGETS === 'true';
 
 const createPool = (connectionString: string): PoolLike =>
   new Pool({
@@ -154,7 +161,18 @@ const verifySupabaseDatabase = async (
   }
 ): Promise<void> => {
   const { databaseUrl } = readSupabaseSecrets(resolvedInterface, resolvedInterface.instanceId);
-  const pool = (deps.createPool ?? createPool)(databaseUrl);
+  const normalizedDatabaseUrl = await normalizeDatabaseConnectionUrl(databaseUrl, {
+    allowPrivateHosts: shouldAllowPrivateInterfaceHealthcheckTargets(),
+  });
+  if (!normalizedDatabaseUrl) {
+    throw createRuntimeError(
+      'connection_failed',
+      resolvedInterface.instanceId,
+      'supabase',
+      'Die DB-URL zeigt auf einen privaten oder lokalen Host. Setze SVA_ALLOW_PRIVATE_INTERFACE_HEALTHCHECK_TARGETS=true nur für bewusst interne Admin-Ziele.'
+    );
+  }
+  const pool = (deps.createPool ?? createPool)(normalizedDatabaseUrl);
 
   try {
     const schemaName =
@@ -350,8 +368,20 @@ const resolveCheckedAt = (now?: () => Date | string): string => {
 
 const verifyS3Connection = async (resolvedInterface: ResolvedExternalInterface): Promise<void> => {
   const config = readS3Config(resolvedInterface);
+  const normalizedEndpoint = await normalizeOutboundHttpUrl(config.endpoint, {
+    allowHttp: true,
+    allowPrivateHosts: shouldAllowPrivateInterfaceHealthcheckTargets(),
+  });
+  if (!normalizedEndpoint) {
+    throw createRuntimeError(
+      'connection_failed',
+      resolvedInterface.instanceId,
+      's3',
+      'Der S3-Endpoint zeigt auf einen privaten oder lokalen Host. Setze SVA_ALLOW_PRIVATE_INTERFACE_HEALTHCHECK_TARGETS=true nur für bewusst interne Admin-Ziele.'
+    );
+  }
   const client = new S3Client({
-    endpoint: config.endpoint,
+    endpoint: normalizedEndpoint,
     region: config.region,
     forcePathStyle: config.forcePathStyle,
     credentials: {

--- a/apps/sva-studio-react/src/lib/map-geocoding-api.operations.ts
+++ b/apps/sva-studio-react/src/lib/map-geocoding-api.operations.ts
@@ -46,10 +46,37 @@ const getRequest = async (): Promise<Request> => {
 
 const now = (): number => Date.now();
 
+const shouldAllowPrivateMapGeocodingTargets = (): boolean =>
+  process.env.SVA_ALLOW_PRIVATE_MAP_GEOCODING_TARGETS === 'true';
+
+const normalizeProviderRequestUrl = async (
+  config: MapGeocodingRuntimeConfigWithSecrets,
+  url: URL,
+): Promise<URL> => {
+  if (config.provider !== 'custom') {
+    return url;
+  }
+
+  const { normalizeOutboundHttpUrl } = await import('@sva/auth-runtime/server');
+  const normalized = await normalizeOutboundHttpUrl(url.toString(), {
+    allowHttp: true,
+    allowPrivateHosts: shouldAllowPrivateMapGeocodingTargets(),
+  });
+  if (!normalized) {
+    throw createClientError('invalid_input', {
+      endpoint: url.origin + url.pathname,
+      provider: config.provider,
+    });
+  }
+
+  return new URL(normalized);
+};
+
 const fetchJsonWithTimeout = async (url: URL, timeoutMs: number): Promise<GeoapifyResponse> => {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    // fallow-ignore-next-line security-sink -- custom provider URLs are normalized via normalizeProviderRequestUrl before fetch.
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
       if (response.status === 429) {
@@ -290,8 +317,12 @@ export const executeProviderRequest = async (input: {
 }): Promise<readonly MapGeocodingFeature[]> => {
   const startedAt = now();
   try {
+    const providerUrl = buildProviderUrl(input.config, input.mode, {
+      query: input.query,
+      coordinates: input.coordinates,
+    });
     const payload = await fetchJsonWithTimeout(
-      buildProviderUrl(input.config, input.mode, { query: input.query, coordinates: input.coordinates }),
+      await normalizeProviderRequestUrl(input.config, providerUrl),
       parsePositiveInteger(input.config.requestTimeoutMs),
     );
     return normalizeProviderFeatures(payload, input.config.provider);

--- a/apps/sva-studio-react/src/lib/map-geocoding-api.operations.ts
+++ b/apps/sva-studio-react/src/lib/map-geocoding-api.operations.ts
@@ -56,7 +56,6 @@ const normalizeProviderRequestUrl = async (
   if (config.provider !== 'custom') {
     return url;
   }
-
   const { normalizeOutboundHttpUrl } = await import('@sva/auth-runtime/server');
   const normalized = await normalizeOutboundHttpUrl(url.toString(), {
     allowHttp: true,
@@ -68,7 +67,6 @@ const normalizeProviderRequestUrl = async (
       provider: config.provider,
     });
   }
-
   return new URL(normalized);
 };
 
@@ -109,7 +107,6 @@ const loadRuntimeConfig = async (instanceId: string): Promise<MapGeocodingRuntim
   if (!config || !config.enabled || config.killSwitchEnabled) {
     throw createClientError('disabled');
   }
-
   return {
     provider: config.provider,
     styleUrl: config.styleUrl,
@@ -154,7 +151,6 @@ const authorizeFirstAllowedAction = async (
     }
     lastResult = result;
   }
-
   return lastResult ?? { ok: false as const, status: 403, error: 'forbidden', message: 'forbidden' };
 };
 
@@ -196,7 +192,6 @@ const withAuthenticatedMapUser = async <T>(
       return createErrorResponse(readMapGeocodingErrorCode(error));
     }
   });
-
   if (!response.ok) {
     const payload = (await response.json().catch(() => null)) as
       | { error?: string | { code?: string } }
@@ -211,7 +206,6 @@ const withAuthenticatedMapUser = async <T>(
             : 'invalid_config';
     throw createClientError(errorCode);
   }
-
   const payload = (await response.json().catch(() => null)) as T | { error?: string } | null;
   if (payload && typeof payload === 'object' && 'error' in payload && typeof payload.error === 'string') {
     throw createClientError(payload.error);
@@ -298,7 +292,6 @@ const withGeocodingOperation = async <T>(
       }
     },
   );
-
 export const withCurrentRequestGeocodingOperation = async <T>(
   operation: 'get_config' | 'suggest' | 'geocode' | 'reverse_geocode',
   run: (
@@ -334,12 +327,8 @@ export const executeProviderRequest = async (input: {
 };
 
 export const getPublicMapGeocodingConfig = (config: MapGeocodingRuntimeConfigWithSecrets): MapGeocodingRuntimeConfig => ({
-  provider: config.provider,
-  styleUrl: config.styleUrl,
-  autocompleteEnabled: config.autocompleteEnabled,
-  geocodeEnabled: config.geocodeEnabled,
-  reverseGeocodeEnabled: config.reverseGeocodeEnabled,
-  killSwitchEnabled: config.killSwitchEnabled,
+  provider: config.provider, styleUrl: config.styleUrl, autocompleteEnabled: config.autocompleteEnabled,
+  geocodeEnabled: config.geocodeEnabled, reverseGeocodeEnabled: config.reverseGeocodeEnabled, killSwitchEnabled: config.killSwitchEnabled,
 });
 
 export const executeSuggestOperation = async (
@@ -347,13 +336,9 @@ export const executeSuggestOperation = async (
   query: string,
   diagnostics?: MapGeocodingOperationDiagnostics,
 ): Promise<readonly MapGeocodingFeature[]> => {
-  if (!config.autocompleteEnabled) {
-    throw createClientError('disabled');
-  }
+  if (!config.autocompleteEnabled) throw createClientError('disabled');
   const result = await executeProviderRequest({ config, mode: 'suggest', query, diagnostics });
-  if (result.length === 0) {
-    throw createClientError('no_result');
-  }
+  if (result.length === 0) throw createClientError('no_result');
   return result;
 };
 
@@ -362,9 +347,7 @@ export const executeGeocodeOperation = async (
   input: MapGeocodingAddressInput,
   diagnostics?: MapGeocodingOperationDiagnostics,
 ): Promise<MapGeocodingFeature> => {
-  if (!config.geocodeEnabled) {
-    throw createClientError('disabled');
-  }
+  if (!config.geocodeEnabled) throw createClientError('disabled');
   const query = compactQuery(input);
   if (!query) {
     throw createClientError('invalid_input');
@@ -382,9 +365,7 @@ export const executeReverseGeocodeOperation = async (
   coordinates: MapGeocodingCoordinates,
   diagnostics?: MapGeocodingOperationDiagnostics,
 ): Promise<MapGeocodingFeature> => {
-  if (!config.reverseGeocodeEnabled) {
-    throw createClientError('disabled');
-  }
+  if (!config.reverseGeocodeEnabled) throw createClientError('disabled');
   if (!Number.isFinite(coordinates.latitude) || !Number.isFinite(coordinates.longitude)) {
     throw createClientError('invalid_input');
   }
@@ -400,19 +381,14 @@ export const runGetConfigOperation = (request: Request): Promise<MapGeocodingRun
   withGeocodingOperation(request, 'get_config', async (_ctx, config) => getPublicMapGeocodingConfig(config));
 
 export const runSuggestOperation = (request: Request, query: string): Promise<readonly MapGeocodingFeature[]> =>
-  withGeocodingOperation(request, 'suggest', async (_ctx, config, diagnostics) =>
-    executeSuggestOperation(config, query, diagnostics),
-  );
+  withGeocodingOperation(request, 'suggest', async (_ctx, config, diagnostics) => executeSuggestOperation(config, query, diagnostics));
 
 export const runGeocodeOperation = (request: Request, input: MapGeocodingAddressInput): Promise<MapGeocodingFeature> =>
-  withGeocodingOperation(request, 'geocode', async (_ctx, config, diagnostics) =>
-    executeGeocodeOperation(config, input, diagnostics),
-  );
+  withGeocodingOperation(request, 'geocode', async (_ctx, config, diagnostics) => executeGeocodeOperation(config, input, diagnostics));
 
 export const runReverseGeocodeOperation = (
   request: Request,
   coordinates: MapGeocodingCoordinates,
 ): Promise<MapGeocodingFeature> =>
   withGeocodingOperation(request, 'reverse_geocode', async (_ctx, config, diagnostics) =>
-    executeReverseGeocodeOperation(config, coordinates, diagnostics),
-  );
+    executeReverseGeocodeOperation(config, coordinates, diagnostics));

--- a/apps/sva-studio-react/src/lib/map-geocoding-api.operations.ts
+++ b/apps/sva-studio-react/src/lib/map-geocoding-api.operations.ts
@@ -7,20 +7,19 @@ import type {
 
 import {
   COMPONENT,
-  buildProviderUrl,
   compactQuery,
   createClientError,
   createErrorResponse,
   jsonResponse,
-  normalizeProviderFeatures,
-  parsePositiveInteger,
   readMapGeocodingErrorCode,
   readMapGeocodingErrorDiagnostics,
   type AuthenticatedMapGeocodingContext,
   type MapGeocodingLogger,
   type MapGeocodingRuntimeConfigWithSecrets,
-  type GeoapifyResponse,
 } from './map-geocoding-api.shared.js';
+import { executeProviderRequest, getPublicMapGeocodingConfig } from './map-geocoding-api.provider.js';
+
+export { executeProviderRequest, getPublicMapGeocodingConfig } from './map-geocoding-api.provider.js';
 
 let loggerPromise: Promise<MapGeocodingLogger> | null = null;
 
@@ -45,61 +44,6 @@ const getRequest = async (): Promise<Request> => {
 };
 
 const now = (): number => Date.now();
-
-const shouldAllowPrivateMapGeocodingTargets = (): boolean =>
-  process.env.SVA_ALLOW_PRIVATE_MAP_GEOCODING_TARGETS === 'true';
-
-const normalizeProviderRequestUrl = async (
-  config: MapGeocodingRuntimeConfigWithSecrets,
-  url: URL,
-): Promise<URL> => {
-  if (config.provider !== 'custom') {
-    return url;
-  }
-  const { normalizeOutboundHttpUrl } = await import('@sva/auth-runtime/server');
-  const normalized = await normalizeOutboundHttpUrl(url.toString(), {
-    allowHttp: true,
-    allowPrivateHosts: shouldAllowPrivateMapGeocodingTargets(),
-  });
-  if (!normalized) {
-    throw createClientError('invalid_input', {
-      endpoint: url.origin + url.pathname,
-      provider: config.provider,
-    });
-  }
-  return new URL(normalized);
-};
-
-const fetchJsonWithTimeout = async (url: URL, timeoutMs: number): Promise<GeoapifyResponse> => {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    // fallow-ignore-next-line security-sink -- custom provider URLs are normalized via normalizeProviderRequestUrl before fetch.
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      if (response.status === 429) {
-        throw createClientError('rate_limited', {
-          statusCode: response.status,
-          endpoint: url.origin + url.pathname,
-        });
-      }
-      throw createClientError('provider_error', {
-        statusCode: response.status,
-        endpoint: url.origin + url.pathname,
-      });
-    }
-    return (await response.json()) as GeoapifyResponse;
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw createClientError('timeout', {
-        endpoint: url.origin + url.pathname,
-      });
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
-};
 
 const loadRuntimeConfig = async (instanceId: string): Promise<MapGeocodingRuntimeConfigWithSecrets> => {
   const { loadStoredMapGeocodingRuntimeConfig } = await import('./instance-interfaces-server.js');
@@ -300,36 +244,6 @@ export const withCurrentRequestGeocodingOperation = async <T>(
     diagnostics: MapGeocodingOperationDiagnostics,
   ) => Promise<T>,
 ): Promise<T> => withGeocodingOperation(await getRequest(), operation, run);
-
-export const executeProviderRequest = async (input: {
-  config: MapGeocodingRuntimeConfigWithSecrets;
-  mode: 'suggest' | 'geocode' | 'reverse';
-  query?: string;
-  coordinates?: MapGeocodingCoordinates;
-  diagnostics?: MapGeocodingOperationDiagnostics;
-}): Promise<readonly MapGeocodingFeature[]> => {
-  const startedAt = now();
-  try {
-    const providerUrl = buildProviderUrl(input.config, input.mode, {
-      query: input.query,
-      coordinates: input.coordinates,
-    });
-    const payload = await fetchJsonWithTimeout(
-      await normalizeProviderRequestUrl(input.config, providerUrl),
-      parsePositiveInteger(input.config.requestTimeoutMs),
-    );
-    return normalizeProviderFeatures(payload, input.config.provider);
-  } finally {
-    if (input.diagnostics) {
-      input.diagnostics.providerRequestDurationMs = now() - startedAt;
-    }
-  }
-};
-
-export const getPublicMapGeocodingConfig = (config: MapGeocodingRuntimeConfigWithSecrets): MapGeocodingRuntimeConfig => ({
-  provider: config.provider, styleUrl: config.styleUrl, autocompleteEnabled: config.autocompleteEnabled,
-  geocodeEnabled: config.geocodeEnabled, reverseGeocodeEnabled: config.reverseGeocodeEnabled, killSwitchEnabled: config.killSwitchEnabled,
-});
 
 export const executeSuggestOperation = async (
   config: MapGeocodingRuntimeConfigWithSecrets,

--- a/apps/sva-studio-react/src/lib/map-geocoding-api.provider.ts
+++ b/apps/sva-studio-react/src/lib/map-geocoding-api.provider.ts
@@ -1,0 +1,144 @@
+import type { MapGeocodingCoordinates, MapGeocodingFeature, MapGeocodingRuntimeConfig } from '@sva/plugin-sdk';
+
+import {
+  buildProviderUrl,
+  createClientError,
+  normalizeProviderFeatures,
+  parsePositiveInteger,
+  type GeoapifyResponse,
+  type MapGeocodingRuntimeConfigWithSecrets,
+} from './map-geocoding-api.shared.js';
+
+type ProviderRequestDiagnostics = {
+  providerRequestDurationMs?: number;
+};
+
+const MAX_CUSTOM_PROVIDER_REDIRECTS = 5;
+
+const shouldAllowPrivateMapGeocodingTargets = (): boolean =>
+  process.env.SVA_ALLOW_PRIVATE_MAP_GEOCODING_TARGETS === 'true';
+
+const normalizeProviderRequestUrl = async (
+  config: MapGeocodingRuntimeConfigWithSecrets,
+  url: URL,
+): Promise<URL> => {
+  if (config.provider !== 'custom') {
+    return url;
+  }
+
+  const { normalizeOutboundHttpUrl } = await import('@sva/auth-runtime/server');
+  const normalized = await normalizeOutboundHttpUrl(url.toString(), {
+    allowHttp: true,
+    allowPrivateHosts: shouldAllowPrivateMapGeocodingTargets(),
+  });
+  if (!normalized) {
+    throw createClientError('invalid_input', {
+      endpoint: url.origin + url.pathname,
+      provider: config.provider,
+    });
+  }
+
+  return new URL(normalized);
+};
+
+const fetchJsonWithTimeout = async (
+  config: MapGeocodingRuntimeConfigWithSecrets,
+  url: URL,
+  timeoutMs: number,
+  redirectCount = 0,
+): Promise<GeoapifyResponse> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    // fallow-ignore-next-line security-sink -- custom provider URLs are normalized before fetch and before manual redirect follow-up.
+    const response = await fetch(url, {
+      signal: controller.signal,
+      ...(config.provider === 'custom' ? { redirect: 'manual' as const } : {}),
+    });
+    if (config.provider === 'custom' && response.status >= 300 && response.status < 400) {
+      if (redirectCount >= MAX_CUSTOM_PROVIDER_REDIRECTS) {
+        throw createClientError('provider_error', {
+          statusCode: response.status,
+          endpoint: url.origin + url.pathname,
+        });
+      }
+
+      const location = response.headers.get('location');
+      if (!location) {
+        throw createClientError('provider_error', {
+          statusCode: response.status,
+          endpoint: url.origin + url.pathname,
+        });
+      }
+
+      return fetchJsonWithTimeout(
+        config,
+        await normalizeProviderRequestUrl(config, new URL(location, url)),
+        timeoutMs,
+        redirectCount + 1,
+      );
+    }
+
+    if (!response.ok) {
+      if (response.status === 429) {
+        throw createClientError('rate_limited', {
+          statusCode: response.status,
+          endpoint: url.origin + url.pathname,
+        });
+      }
+
+      throw createClientError('provider_error', {
+        statusCode: response.status,
+        endpoint: url.origin + url.pathname,
+      });
+    }
+
+    return (await response.json()) as GeoapifyResponse;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw createClientError('timeout', { endpoint: url.origin + url.pathname });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+export const executeProviderRequest = async (input: {
+  config: MapGeocodingRuntimeConfigWithSecrets;
+  mode: 'suggest' | 'geocode' | 'reverse';
+  query?: string;
+  coordinates?: MapGeocodingCoordinates;
+  diagnostics?: ProviderRequestDiagnostics;
+}): Promise<readonly MapGeocodingFeature[]> => {
+  const startedAt = Date.now();
+
+  try {
+    const providerUrl = buildProviderUrl(input.config, input.mode, {
+      query: input.query,
+      coordinates: input.coordinates,
+    });
+    const payload = await fetchJsonWithTimeout(
+      input.config,
+      await normalizeProviderRequestUrl(input.config, providerUrl),
+      parsePositiveInteger(input.config.requestTimeoutMs),
+    );
+    return normalizeProviderFeatures(payload, input.config.provider);
+  } finally {
+    if (input.diagnostics) {
+      input.diagnostics.providerRequestDurationMs = Date.now() - startedAt;
+    }
+  }
+};
+
+export const getPublicMapGeocodingConfig = (
+  config: MapGeocodingRuntimeConfigWithSecrets,
+): MapGeocodingRuntimeConfig => ({
+  provider: config.provider,
+  styleUrl: config.styleUrl,
+  autocompleteEnabled: config.autocompleteEnabled,
+  geocodeEnabled: config.geocodeEnabled,
+  reverseGeocodeEnabled: config.reverseGeocodeEnabled,
+  killSwitchEnabled: config.killSwitchEnabled,
+});

--- a/apps/sva-studio-react/src/lib/map-geocoding-api.test.ts
+++ b/apps/sva-studio-react/src/lib/map-geocoding-api.test.ts
@@ -875,6 +875,26 @@ describe('map-geocoding-api', () => {
       ),
     ).rejects.toThrow('invalid_input');
 
+    state.fetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://localhost/internal-geocode' },
+      }),
+    );
+    await expect(
+      executeProviderRequest({
+        config: {
+          ...config,
+          provider: 'custom',
+          suggestEndpoint: 'https://custom.example/suggest',
+          geocodeEndpoint: 'https://custom.example/geocode',
+          reverseGeocodeEndpoint: 'https://custom.example/reverse',
+        },
+        mode: 'suggest',
+        query: 'Musterstraße',
+      }),
+    ).rejects.toThrow('invalid_input');
+
     state.fetch.mockImplementationOnce(async (_url: URL, init?: RequestInit) => {
       init?.signal?.throwIfAborted?.();
       throw new DOMException('Timed out', 'AbortError');
@@ -925,6 +945,52 @@ describe('map-geocoding-api', () => {
         },
         'Musterstraße 1',
       ),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('follows validated redirects for custom providers when the target stays public', async () => {
+    const { executeProviderRequest } = await import('./map-geocoding-api.operations.js');
+
+    state.fetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://redirect.example/suggest' },
+        }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          features: [
+            {
+              properties: {
+                formatted: 'Musterstraße 1, 12345 Musterstadt',
+                lat: 52.52,
+                lon: 13.405,
+              },
+            },
+          ],
+        }),
+      });
+
+    await expect(
+      executeProviderRequest({
+        config: {
+          provider: 'custom',
+          styleUrl: 'https://tiles.example/styles/poi',
+          autocompleteEnabled: true,
+          geocodeEnabled: true,
+          reverseGeocodeEnabled: true,
+          killSwitchEnabled: false,
+          suggestEndpoint: 'https://custom.example/suggest',
+          geocodeEndpoint: 'https://custom.example/geocode',
+          reverseGeocodeEndpoint: 'https://custom.example/reverse',
+          requestTimeoutMs: '3000',
+          rateLimitPerMinute: '60',
+        },
+        mode: 'suggest',
+        query: 'Musterstraße 1',
+      }),
     ).resolves.toHaveLength(1);
   });
 

--- a/apps/sva-studio-react/src/lib/map-geocoding-api.test.ts
+++ b/apps/sva-studio-react/src/lib/map-geocoding-api.test.ts
@@ -31,6 +31,14 @@ vi.mock('@tanstack/react-start/server', () => ({
 vi.mock('@sva/auth-runtime/server', () => ({
   authorizeInstancePermissionForUser: state.authorizeInstancePermissionForUser,
   withAuthenticatedUser: state.withAuthenticatedUser,
+  normalizeOutboundHttpUrl: vi.fn(async (value: string, options?: { allowPrivateHosts?: boolean }) => {
+    const url = new URL(value);
+    const isPrivateTarget = ['localhost', '127.0.0.1'].includes(url.hostname);
+    if (isPrivateTarget && options?.allowPrivateHosts !== true) {
+      return null;
+    }
+    return url.toString();
+  }),
 }));
 
 vi.mock('@sva/server-runtime', () => ({
@@ -52,6 +60,7 @@ describe('map-geocoding-api', () => {
     state.logger.info.mockReset();
     state.logger.warn.mockReset();
     state.logger.error.mockReset();
+    delete process.env.SVA_ALLOW_PRIVATE_MAP_GEOCODING_TARGETS;
 
     state.withAuthenticatedUser.mockImplementation(async (_request, handler) =>
       handler({
@@ -853,6 +862,19 @@ describe('map-geocoding-api', () => {
       'provider_error',
     );
 
+    await expect(
+      executeSuggestOperation(
+        {
+          ...config,
+          provider: 'custom',
+          suggestEndpoint: 'https://localhost/suggest',
+          geocodeEndpoint: 'https://custom.example/geocode',
+          reverseGeocodeEndpoint: 'https://custom.example/reverse',
+        },
+        'Musterstraße 1',
+      ),
+    ).rejects.toThrow('invalid_input');
+
     state.fetch.mockImplementationOnce(async (_url: URL, init?: RequestInit) => {
       init?.signal?.throwIfAborted?.();
       throw new DOMException('Timed out', 'AbortError');
@@ -864,6 +886,46 @@ describe('map-geocoding-api', () => {
         coordinates: { latitude: 52.52, longitude: 13.405 },
       }),
     ).rejects.toThrow('timeout');
+  });
+
+  it('allows private custom geocoding targets when the explicit opt-in is enabled', async () => {
+    process.env.SVA_ALLOW_PRIVATE_MAP_GEOCODING_TARGETS = 'true';
+
+    const { executeSuggestOperation } = await import('./map-geocoding-api.operations.js');
+
+    state.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        features: [
+          {
+            properties: {
+              formatted: 'Musterstraße 1, 12345 Musterstadt',
+              lat: 52.52,
+              lon: 13.405,
+            },
+          },
+        ],
+      }),
+    });
+
+    await expect(
+      executeSuggestOperation(
+        {
+          provider: 'custom',
+          styleUrl: 'https://tiles.example/styles/poi',
+          autocompleteEnabled: true,
+          geocodeEnabled: true,
+          reverseGeocodeEnabled: true,
+          killSwitchEnabled: false,
+          suggestEndpoint: 'https://localhost/suggest',
+          geocodeEndpoint: 'https://localhost/geocode',
+          reverseGeocodeEndpoint: 'https://localhost/reverse',
+          requestTimeoutMs: '3000',
+          rateLimitPerMinute: '60',
+        },
+        'Musterstraße 1',
+      ),
+    ).resolves.toHaveLength(1);
   });
 
   it('dispatches map geocoding requests only for supported routes and methods', async () => {

--- a/docs/changelog/entries/pr-701.json
+++ b/docs/changelog/entries/pr-701.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 701,
+  "body": "Mehrere Sicherheits- und Härtungspfade für ausgehende Ziele, CI-Skripte und Disclosure-Dokumentation wurden vereinheitlicht.\n\n- Private oder lokale Datenbank-, S3- und Custom-Geocoding-Ziele werden in Healthchecks und Admin-Integrationen standardmäßig blockiert und nur noch per explizitem Opt-in zugelassen.\n- CI-Skripte für Path-Handling und Entrypoint-Erkennung nutzen jetzt gemeinsame Safety-Helper, damit Ausgabepfade und aufgerufene Dateien den erlaubten Workspace-Bereich nicht verlassen.\n- Das Repository veröffentlicht jetzt eine abgestimmte `SECURITY.md` und eine `.well-known/security.txt` für koordinierte Schwachstellenmeldungen."
+}

--- a/packages/auth-runtime/src/server.ts
+++ b/packages/auth-runtime/src/server.ts
@@ -24,7 +24,11 @@ export {
 export { buildLogContext } from './log-context.js';
 export { buildRequestOriginFromHeaders, resolveEffectiveRequestHost } from './request-hosts.js';
 export { resolveAuthRequestHost, sanitizeAuthReturnTo } from './auth-return-to.js';
-export { normalizePublicUpstreamUrl } from './upstream-url-validation.js';
+export {
+  normalizeDatabaseConnectionUrl,
+  normalizeOutboundHttpUrl,
+  normalizePublicUpstreamUrl,
+} from './upstream-url-validation.js';
 export { emitAuthAuditEvent } from './audit-events.js';
 export type { AuthAuditEvent, AuthAuditEventType, PluginActionAuditPayload } from './audit-events.types.js';
 export {

--- a/packages/auth-runtime/src/upstream-url-validation.test.ts
+++ b/packages/auth-runtime/src/upstream-url-validation.test.ts
@@ -6,7 +6,11 @@ vi.mock('node:dns/promises', () => ({
   lookup: dnsLookupMock,
 }));
 
-import { normalizePublicUpstreamUrl } from './upstream-url-validation.js';
+import {
+  normalizeDatabaseConnectionUrl,
+  normalizeOutboundHttpUrl,
+  normalizePublicUpstreamUrl,
+} from './upstream-url-validation.js';
 
 describe('normalizePublicUpstreamUrl', () => {
   beforeEach(() => {
@@ -61,5 +65,55 @@ describe('normalizePublicUpstreamUrl', () => {
 
     dnsLookupMock.mockRejectedValueOnce(new Error('dns unavailable'));
     await expect(normalizePublicUpstreamUrl('https://failing.example.invalid/graphql')).resolves.toBeNull();
+  });
+});
+
+describe('normalizeOutboundHttpUrl', () => {
+  beforeEach(() => {
+    dnsLookupMock.mockReset();
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+  });
+
+  it('accepts public http and https urls when explicitly enabled', async () => {
+    await expect(
+      normalizeOutboundHttpUrl('http://public.example.invalid/geocode', { allowHttp: true }),
+    ).resolves.toBe('http://public.example.invalid/geocode');
+    await expect(normalizeOutboundHttpUrl('https://public.example.invalid/geocode')).resolves.toBe(
+      'https://public.example.invalid/geocode',
+    );
+  });
+
+  it('rejects private targets by default and allows them with opt-in', async () => {
+    await expect(
+      normalizeOutboundHttpUrl('https://localhost/geocode', { allowHttp: true }),
+    ).resolves.toBeNull();
+    await expect(
+      normalizeOutboundHttpUrl('https://localhost/geocode', {
+        allowHttp: true,
+        allowPrivateHosts: true,
+      }),
+    ).resolves.toBe('https://localhost/geocode');
+  });
+});
+
+describe('normalizeDatabaseConnectionUrl', () => {
+  beforeEach(() => {
+    dnsLookupMock.mockReset();
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+  });
+
+  it('accepts public postgres connection strings with credentials', async () => {
+    await expect(
+      normalizeDatabaseConnectionUrl('postgres://user:pass@db.example.invalid:5432/app'),
+    ).resolves.toBe('postgres://user:pass@db.example.invalid:5432/app');
+  });
+
+  it('rejects private database hosts by default and allows them with opt-in', async () => {
+    await expect(normalizeDatabaseConnectionUrl('postgres://user:pass@localhost:5432/app')).resolves.toBeNull();
+    await expect(
+      normalizeDatabaseConnectionUrl('postgres://user:pass@localhost:5432/app', {
+        allowPrivateHosts: true,
+      }),
+    ).resolves.toBe('postgres://user:pass@localhost:5432/app');
   });
 });

--- a/packages/auth-runtime/src/upstream-url-validation.test.ts
+++ b/packages/auth-runtime/src/upstream-url-validation.test.ts
@@ -81,6 +81,9 @@ describe('normalizeOutboundHttpUrl', () => {
     await expect(normalizeOutboundHttpUrl('https://public.example.invalid/geocode')).resolves.toBe(
       'https://public.example.invalid/geocode',
     );
+    await expect(normalizeOutboundHttpUrl('https://[2606:4700:4700::1111]/geocode')).resolves.toBe(
+      'https://[2606:4700:4700::1111]/geocode',
+    );
   });
 
   it('rejects private targets by default and allows them with opt-in', async () => {
@@ -106,6 +109,9 @@ describe('normalizeDatabaseConnectionUrl', () => {
     await expect(
       normalizeDatabaseConnectionUrl('postgres://user:pass@db.example.invalid:5432/app'),
     ).resolves.toBe('postgres://user:pass@db.example.invalid:5432/app');
+    await expect(
+      normalizeDatabaseConnectionUrl('postgres://user:pass@[2001:4860:4860::8888]:5432/app'),
+    ).resolves.toBe('postgres://user:pass@[2001:4860:4860::8888]:5432/app');
   });
 
   it('rejects private database hosts by default and allows them with opt-in', async () => {

--- a/packages/auth-runtime/src/upstream-url-validation.ts
+++ b/packages/auth-runtime/src/upstream-url-validation.ts
@@ -142,7 +142,7 @@ const isPrivateOrLocalHost = (hostname: string): boolean => {
 };
 
 const resolvesToPrivateOrLocalHost = async (hostname: string): Promise<boolean> => {
-  const normalized = hostname.trim().toLowerCase();
+  const normalized = unwrapBracketedHost(hostname.trim().toLowerCase());
   if (isIP(normalized) !== 0) {
     return false;
   }

--- a/packages/auth-runtime/src/upstream-url-validation.ts
+++ b/packages/auth-runtime/src/upstream-url-validation.ts
@@ -162,20 +162,61 @@ const resolvesToPrivateOrLocalHost = async (hostname: string): Promise<boolean> 
   }
 };
 
-export const normalizePublicUpstreamUrl = async (value: string): Promise<string | null> => {
+type UpstreamUrlValidationOptions = Readonly<{
+  allowedProtocols?: readonly string[];
+  allowCredentials?: boolean;
+  allowPrivateHosts?: boolean;
+}>;
+
+const normalizeUpstreamUrl = async (
+  value: string,
+  {
+    allowedProtocols = ['https:'],
+    allowCredentials = false,
+    allowPrivateHosts = false,
+  }: UpstreamUrlValidationOptions = {},
+): Promise<string | null> => {
   const parsed = parseUpstreamUrl(value);
 
   if (
     !parsed ||
-    parsed.username ||
-    parsed.password ||
+    (!allowCredentials && (parsed.username || parsed.password)) ||
     parsed.hash ||
-    parsed.protocol !== 'https:' ||
-    isPrivateOrLocalHost(parsed.hostname) ||
-    (await resolvesToPrivateOrLocalHost(parsed.hostname))
+    !allowedProtocols.includes(parsed.protocol) ||
+    (!allowPrivateHosts &&
+      (isPrivateOrLocalHost(parsed.hostname) || (await resolvesToPrivateOrLocalHost(parsed.hostname))))
   ) {
     return null;
   }
 
   return parsed.toString();
 };
+
+export const normalizePublicUpstreamUrl = async (value: string): Promise<string | null> =>
+  normalizeUpstreamUrl(value);
+
+export const normalizeOutboundHttpUrl = async (
+  value: string,
+  options: Readonly<{
+    allowPrivateHosts?: boolean;
+    allowHttp?: boolean;
+    allowCredentials?: boolean;
+  }> = {},
+): Promise<string | null> =>
+  normalizeUpstreamUrl(value, {
+    allowedProtocols: options.allowHttp ? ['http:', 'https:'] : ['https:'],
+    allowCredentials: options.allowCredentials,
+    allowPrivateHosts: options.allowPrivateHosts,
+  });
+
+export const normalizeDatabaseConnectionUrl = async (
+  value: string,
+  options: Readonly<{
+    allowPrivateHosts?: boolean;
+  }> = {},
+): Promise<string | null> =>
+  normalizeUpstreamUrl(value, {
+    allowedProtocols: ['postgres:', 'postgresql:'],
+    allowCredentials: true,
+    allowPrivateHosts: options.allowPrivateHosts,
+  });

--- a/packages/data/src/iam/repositories.test.ts
+++ b/packages/data/src/iam/repositories.test.ts
@@ -1,15 +1,14 @@
-import assert from 'node:assert/strict';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import * as data from './repositories.js';
 import * as repos from '@sva/data-repositories';
 
 describe('iam repository boundary', () => {
   it('re-exports the leading IAM seed repository factory', () => {
-    assert.equal(data.createIamSeedRepository, repos.createIamSeedRepository);
+    expect(data.createIamSeedRepository).toBe(repos.createIamSeedRepository);
   });
 
   it('re-exports the leading IAM seed statements', () => {
-    assert.equal(data.iamSeedStatements, repos.iamSeedStatements);
+    expect(data.iamSeedStatements).toBe(repos.iamSeedStatements);
   });
 });

--- a/packages/data/src/iam/seed-files.test.ts
+++ b/packages/data/src/iam/seed-files.test.ts
@@ -1,8 +1,7 @@
-import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const seedDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'seeds');
 const readSeed = (name: string) => readFileSync(resolve(seedDir, name), 'utf8');
@@ -11,118 +10,104 @@ describe('iam seed sql contracts', () => {
   it('keeps protected instance identity fields in 0001 additive for existing environments', () => {
     const sql = readSeed('0001_iam_personas.sql');
 
-    assert.match(sql, /parent_domain = COALESCE\(NULLIF\(iam\.instances\.parent_domain, ''\), EXCLUDED\.parent_domain\)/);
-    assert.match(
-      sql,
-      /primary_hostname = COALESCE\(NULLIF\(iam\.instances\.primary_hostname, ''\), EXCLUDED\.primary_hostname\)/
-    );
-    assert.match(sql, /auth_realm = COALESCE\(NULLIF\(iam\.instances\.auth_realm, ''\), EXCLUDED\.auth_realm\)/);
-    assert.match(
-      sql,
-      /auth_client_id = COALESCE\(NULLIF\(iam\.instances\.auth_client_id, ''\), EXCLUDED\.auth_client_id\)/
-    );
-    assert.match(
-      sql,
+    expect(sql).toMatch(/parent_domain = COALESCE\(NULLIF\(iam\.instances\.parent_domain, ''\), EXCLUDED\.parent_domain\)/);
+    expect(sql).toMatch(/primary_hostname = COALESCE\(NULLIF\(iam\.instances\.primary_hostname, ''\), EXCLUDED\.primary_hostname\)/);
+    expect(sql).toMatch(/auth_realm = COALESCE\(NULLIF\(iam\.instances\.auth_realm, ''\), EXCLUDED\.auth_realm\)/);
+    expect(sql).toMatch(/auth_client_id = COALESCE\(NULLIF\(iam\.instances\.auth_client_id, ''\), EXCLUDED\.auth_client_id\)/);
+    expect(sql).toMatch(
       /tenant_admin_client_id = COALESCE\(NULLIF\(iam\.instances\.tenant_admin_client_id, ''\), EXCLUDED\.tenant_admin_client_id\)/
     );
-    assert.doesNotMatch(sql, /parent_domain = EXCLUDED\.parent_domain,/);
-    assert.doesNotMatch(sql, /primary_hostname = EXCLUDED\.primary_hostname,/);
-    assert.doesNotMatch(sql, /auth_realm = EXCLUDED\.auth_realm,/);
-    assert.doesNotMatch(sql, /auth_client_id = EXCLUDED\.auth_client_id,/);
-    assert.doesNotMatch(sql, /tenant_admin_client_id = EXCLUDED\.tenant_admin_client_id,/);
-    assert.match(
-      sql,
-      /instances\.primary_hostname = 'de-musterhausen\.studio\.localhost'/
-    );
-    assert.match(
-      sql,
-      /AND instances\.primary_hostname = EXCLUDED\.hostname/
-    );
+    expect(sql).not.toMatch(/parent_domain = EXCLUDED\.parent_domain,/);
+    expect(sql).not.toMatch(/primary_hostname = EXCLUDED\.primary_hostname,/);
+    expect(sql).not.toMatch(/auth_realm = EXCLUDED\.auth_realm,/);
+    expect(sql).not.toMatch(/auth_client_id = EXCLUDED\.auth_client_id,/);
+    expect(sql).not.toMatch(/tenant_admin_client_id = EXCLUDED\.tenant_admin_client_id,/);
+    expect(sql).toMatch(/instances\.primary_hostname = 'de-musterhausen\.studio\.localhost'/);
+    expect(sql).toMatch(/AND instances\.primary_hostname = EXCLUDED\.hostname/);
   });
 
   it('seeds de-musterhausen with the local-keycloak reference identity by default', () => {
     const sql = readSeed('0001_iam_personas.sql');
 
-    assert.match(
-      sql,
+    expect(sql).toMatch(
       /VALUES\s*\(\s*'de-musterhausen',\s*'Seed Instance Default',\s*'active',\s*'studio\.localhost',\s*'de-musterhausen\.studio\.localhost',\s*'de-musterhausen',\s*'sva-studio',\s*'sva-studio-realm-admin',\s*'\{\}'::jsonb\s*\)/
     );
-    assert.doesNotMatch(sql, /'de-musterhausen\.studio\.smart-village\.app'/);
-    assert.doesNotMatch(sql, /'svs-intern-studio-staging'/);
-    assert.doesNotMatch(sql, /'sva-studio-admin'/);
+    expect(sql).not.toMatch(/'de-musterhausen\.studio\.smart-village\.app'/);
+    expect(sql).not.toMatch(/'svs-intern-studio-staging'/);
+    expect(sql).not.toMatch(/'sva-studio-admin'/);
   });
 
   it('keeps 0002 non-destructive for an already provisioned instance identity', () => {
     const sql = readSeed('0002_bb_guben_permissions.sql');
 
-    assert.match(sql, /ON CONFLICT \(id\) DO NOTHING;/);
-    assert.doesNotMatch(sql, /ON CONFLICT \(id\) DO UPDATE/);
-    assert.doesNotMatch(sql, /parent_domain = EXCLUDED\.parent_domain,/);
-    assert.doesNotMatch(sql, /primary_hostname = EXCLUDED\.primary_hostname,/);
-    assert.doesNotMatch(sql, /auth_realm = EXCLUDED\.auth_realm,/);
-    assert.doesNotMatch(sql, /auth_client_id = EXCLUDED\.auth_client_id,/);
-    assert.doesNotMatch(sql, /tenant_admin_client_id = EXCLUDED\.tenant_admin_client_id,/);
+    expect(sql).toMatch(/ON CONFLICT \(id\) DO NOTHING;/);
+    expect(sql).not.toMatch(/ON CONFLICT \(id\) DO UPDATE/);
+    expect(sql).not.toMatch(/parent_domain = EXCLUDED\.parent_domain,/);
+    expect(sql).not.toMatch(/primary_hostname = EXCLUDED\.primary_hostname,/);
+    expect(sql).not.toMatch(/auth_realm = EXCLUDED\.auth_realm,/);
+    expect(sql).not.toMatch(/auth_client_id = EXCLUDED\.auth_client_id,/);
+    expect(sql).not.toMatch(/tenant_admin_client_id = EXCLUDED\.tenant_admin_client_id,/);
   });
 
   it('does not keep a tenant-side instance_registry_admin persona in 0001 anymore', () => {
     const sql = readSeed('0001_iam_personas.sql');
 
-    assert.doesNotMatch(sql, /'seed:instance_registry_admin'/);
-    assert.doesNotMatch(sql, /'30188888-8888-8888-8888-888888888888', 'de-musterhausen', 'instance_registry_admin'/);
-    assert.doesNotMatch(sql, /\('de-musterhausen', '50888888-8888-8888-8888-888888888888', 'member'\)/);
-    assert.doesNotMatch(sql, /\('de-musterhausen', '50888888-8888-8888-8888-888888888888', '30188888-8888-8888-8888-888888888888'\)/);
-    assert.doesNotMatch(sql, /\('instance_registry_admin', 'instance\.registry\.manage'\)/);
-    assert.doesNotMatch(sql, /\('instance_registry_admin', 'feature\.toggle'\)/);
-    assert.doesNotMatch(sql, /\('instance_registry_admin', 'integration\.manage'\)/);
-    assert.doesNotMatch(sql, /'seed:app_manager'/);
-    assert.doesNotMatch(sql, /'seed:feature_manager'/);
-    assert.doesNotMatch(sql, /'seed:interface_manager'/);
-    assert.doesNotMatch(sql, /'seed:designer'/);
-    assert.doesNotMatch(sql, /'seed:editor'/);
-    assert.doesNotMatch(sql, /'seed:moderator'/);
-    assert.doesNotMatch(sql, /'app_manager'/);
-    assert.doesNotMatch(sql, /'feature-manager'/);
-    assert.doesNotMatch(sql, /'interface-manager'/);
-    assert.doesNotMatch(sql, /'designer'/);
-    assert.doesNotMatch(sql, /'editor'/);
-    assert.doesNotMatch(sql, /'moderator'/);
+    expect(sql).not.toMatch(/'seed:instance_registry_admin'/);
+    expect(sql).not.toMatch(/'30188888-8888-8888-8888-888888888888', 'de-musterhausen', 'instance_registry_admin'/);
+    expect(sql).not.toMatch(/\('de-musterhausen', '50888888-8888-8888-8888-888888888888', 'member'\)/);
+    expect(sql).not.toMatch(/\('de-musterhausen', '50888888-8888-8888-8888-888888888888', '30188888-8888-8888-8888-888888888888'\)/);
+    expect(sql).not.toMatch(/\('instance_registry_admin', 'instance\.registry\.manage'\)/);
+    expect(sql).not.toMatch(/\('instance_registry_admin', 'feature\.toggle'\)/);
+    expect(sql).not.toMatch(/\('instance_registry_admin', 'integration\.manage'\)/);
+    expect(sql).not.toMatch(/'seed:app_manager'/);
+    expect(sql).not.toMatch(/'seed:feature_manager'/);
+    expect(sql).not.toMatch(/'seed:interface_manager'/);
+    expect(sql).not.toMatch(/'seed:designer'/);
+    expect(sql).not.toMatch(/'seed:editor'/);
+    expect(sql).not.toMatch(/'seed:moderator'/);
+    expect(sql).not.toMatch(/'app_manager'/);
+    expect(sql).not.toMatch(/'feature-manager'/);
+    expect(sql).not.toMatch(/'interface-manager'/);
+    expect(sql).not.toMatch(/'designer'/);
+    expect(sql).not.toMatch(/'editor'/);
+    expect(sql).not.toMatch(/'moderator'/);
   });
 
   it('expects the deletion-rules seed to create tenant defaults', () => {
     const sql = readSeed('0003_iam_deletion_rules_defaults.sql');
 
-    assert.match(sql, /INSERT INTO iam\.instance_deletion_rules/);
-    assert.match(sql, /\('de-musterhausen', 90, 180, 365, 'retain', false\)/);
-    assert.match(sql, /ON CONFLICT \(instance_id\) DO UPDATE/);
-    assert.match(sql, /default_content_strategy = EXCLUDED\.default_content_strategy/);
-    assert.match(sql, /allow_content_preference_override = EXCLUDED\.allow_content_preference_override/);
-    assert.match(sql, /updated_at = NOW\(\)/);
+    expect(sql).toMatch(/INSERT INTO iam\.instance_deletion_rules/);
+    expect(sql).toMatch(/\('de-musterhausen', 90, 180, 365, 'retain', false\)/);
+    expect(sql).toMatch(/ON CONFLICT \(instance_id\) DO UPDATE/);
+    expect(sql).toMatch(/default_content_strategy = EXCLUDED\.default_content_strategy/);
+    expect(sql).toMatch(/allow_content_preference_override = EXCLUDED\.allow_content_preference_override/);
+    expect(sql).toMatch(/updated_at = NOW\(\)/);
   });
 
   it('assigns the categories module to seeded instances with mainserver content modules', () => {
     const defaultSeedSql = readSeed('0001_iam_personas.sql');
     const bbGubenSeedSql = readSeed('0002_bb_guben_permissions.sql');
 
-    assert.match(defaultSeedSql, /\('de-musterhausen', 'categories'\)/);
-    assert.match(bbGubenSeedSql, /\('bb-guben', 'categories'\)/);
+    expect(defaultSeedSql).toMatch(/\('de-musterhausen', 'categories'\)/);
+    expect(bbGubenSeedSql).toMatch(/\('bb-guben', 'categories'\)/);
   });
 
   it('seeds iam.accounts.delete for fresh tenant bootstraps and grants it to system_admin', () => {
     const defaultSeedSql = readSeed('0001_iam_personas.sql');
     const bbGubenSeedSql = readSeed('0002_bb_guben_permissions.sql');
 
-    assert.match(defaultSeedSql, /'iam\.accounts\.delete', 'iam\.accounts\.delete', 'iam'/);
-    assert.match(defaultSeedSql, /\('system_admin', 'iam\.accounts\.delete'\)/);
-    assert.match(bbGubenSeedSql, /'iam\.accounts\.delete', 'iam\.accounts\.delete', 'iam'/);
-    assert.match(bbGubenSeedSql, /\('system_admin', 'iam\.accounts\.delete'\)/);
+    expect(defaultSeedSql).toMatch(/'iam\.accounts\.delete', 'iam\.accounts\.delete', 'iam'/);
+    expect(defaultSeedSql).toMatch(/\('system_admin', 'iam\.accounts\.delete'\)/);
+    expect(bbGubenSeedSql).toMatch(/'iam\.accounts\.delete', 'iam\.accounts\.delete', 'iam'/);
+    expect(bbGubenSeedSql).toMatch(/\('system_admin', 'iam\.accounts\.delete'\)/);
   });
 
   it('keeps deletion-rule seeds scoped to the existing retain lifecycle defaults', () => {
     const seedSql = readSeed('0003_iam_deletion_rules_defaults.sql');
 
-    assert.match(seedSql, /\('de-musterhausen', 90, 180, 365, 'retain', false\)/);
-    assert.match(seedSql, /default_content_strategy = EXCLUDED\.default_content_strategy/);
-    assert.match(seedSql, /allow_content_preference_override = EXCLUDED\.allow_content_preference_override/);
-    assert.doesNotMatch(seedSql, /hard[_-]?delete/i);
+    expect(seedSql).toMatch(/\('de-musterhausen', 90, 180, 365, 'retain', false\)/);
+    expect(seedSql).toMatch(/default_content_strategy = EXCLUDED\.default_content_strategy/);
+    expect(seedSql).toMatch(/allow_content_preference_override = EXCLUDED\.allow_content_preference_override/);
+    expect(seedSql).not.toMatch(/hard[_-]?delete/i);
   });
 });

--- a/packages/data/src/iam/seed-plan.test.ts
+++ b/packages/data/src/iam/seed-plan.test.ts
@@ -1,92 +1,83 @@
-import assert from 'node:assert/strict';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getPersonaSeed, iamSeedPlan, rootOnlySeedPermissionKeys, tenantBootstrapPermissionKeys } from './seed-plan';
 
 describe('iam seed plan', () => {
   it('contains exactly one tenant bootstrap persona', () => {
-    assert.equal(iamSeedPlan.personas.length, 1);
+    expect(iamSeedPlan.personas.length).toBe(1);
   });
 
   it('keeps the canonical permission catalog in sync with the seed integration expectations', () => {
-    assert.equal(iamSeedPlan.permissions.length, 58);
+    expect(iamSeedPlan.permissions.length).toBe(58);
   });
 
   it('uses unique role slugs and keycloak subjects', () => {
     const roleSlugs = new Set(iamSeedPlan.personas.map((persona) => persona.roleSlug));
     const subjects = new Set(iamSeedPlan.personas.map((persona) => persona.keycloakSubject));
 
-    assert.equal(roleSlugs.size, iamSeedPlan.personas.length);
-    assert.equal(subjects.size, iamSeedPlan.personas.length);
+    expect(roleSlugs.size).toBe(iamSeedPlan.personas.length);
+    expect(subjects.size).toBe(iamSeedPlan.personas.length);
   });
 
   it('defines role levels within range', () => {
     for (const persona of iamSeedPlan.personas) {
-      assert.ok(persona.roleLevel >= 0);
-      assert.ok(persona.roleLevel <= 100);
+      expect(persona.roleLevel).toBeGreaterThanOrEqual(0);
+      expect(persona.roleLevel).toBeLessThanOrEqual(100);
     }
   });
 
   it('resolves persona by stable key', () => {
     const systemAdmin = getPersonaSeed('system_admin');
 
-    assert.equal(systemAdmin.roleSlug, 'system_admin');
-    assert.equal(systemAdmin.roleLevel, 100);
-    assert.deepEqual(systemAdmin.permissionKeys, tenantBootstrapPermissionKeys);
+    expect(systemAdmin.roleSlug).toBe('system_admin');
+    expect(systemAdmin.roleLevel).toBe(100);
+    expect(systemAdmin.permissionKeys).toEqual(tenantBootstrapPermissionKeys);
   });
 
   it('does not expose a tenant-side instance_registry_admin persona anymore', () => {
-    assert.throws(() => getPersonaSeed('instance_registry_admin' as never), /Unknown persona key: instance_registry_admin/);
+    expect(() => getPersonaSeed('instance_registry_admin' as never)).toThrowError(
+      /Unknown persona key: instance_registry_admin/
+    );
   });
 
   it('keeps instance.registry.manage out of tenant bootstrap personas', () => {
-    assert.deepEqual(rootOnlySeedPermissionKeys, ['instance.registry.manage']);
-    assert.equal(tenantBootstrapPermissionKeys.includes('instance.registry.manage'), false);
-    assert.deepEqual(getPersonaSeed('system_admin').permissionKeys, tenantBootstrapPermissionKeys);
+    expect(rootOnlySeedPermissionKeys).toEqual(['instance.registry.manage']);
+    expect(tenantBootstrapPermissionKeys.includes('instance.registry.manage')).toBe(false);
+    expect(getPersonaSeed('system_admin').permissionKeys).toEqual(tenantBootstrapPermissionKeys);
     for (const persona of iamSeedPlan.personas) {
-      assert.equal(persona.permissionKeys.includes('instance.registry.manage'), false);
+      expect(persona.permissionKeys.includes('instance.registry.manage')).toBe(false);
     }
   });
 
   it('contains hierarchical organizations for context-switch scenarios', () => {
-    assert.equal(iamSeedPlan.organizations.length, 3);
-    assert.deepEqual(iamSeedPlan.organizations[0].hierarchyPath, []);
-    assert.equal(iamSeedPlan.organizations[1].parentOrganizationId, iamSeedPlan.organizations[0].id);
-    assert.equal(iamSeedPlan.organizations[2].depth, 2);
+    expect(iamSeedPlan.organizations.length).toBe(3);
+    expect(iamSeedPlan.organizations[0].hierarchyPath).toEqual([]);
+    expect(iamSeedPlan.organizations[1].parentOrganizationId).toBe(iamSeedPlan.organizations[0].id);
+    expect(iamSeedPlan.organizations[2].depth).toBe(2);
   });
 
   it('derives stable resource types from permission keys', () => {
-    assert.equal(
-      iamSeedPlan.permissions.find((permission) => permission.key === 'instance.registry.manage')?.resourceType,
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'instance.registry.manage')?.resourceType).toBe(
       'instance'
     );
-    assert.equal(
-      iamSeedPlan.permissions.find((permission) => permission.key === 'content.publish')?.resourceType,
-      'content'
-    );
-    assert.equal(iamSeedPlan.permissions.find((permission) => permission.key === 'media.read')?.resourceType, 'media');
-    assert.equal(iamSeedPlan.permissions.find((permission) => permission.key === 'news.update')?.resourceType, 'news');
-    assert.equal(
-      iamSeedPlan.permissions.find((permission) => permission.key === 'categories.read')?.resourceType,
-      'categories'
-    );
-    assert.equal(iamSeedPlan.permissions.find((permission) => permission.key === 'app.read')?.resourceType, 'app');
-    assert.equal(iamSeedPlan.permissions.find((permission) => permission.key === 'cockpit.read')?.resourceType, 'cockpit');
-    assert.equal(
-      iamSeedPlan.permissions.find((permission) => permission.key === 'experimental.read')?.resourceType,
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'content.publish')?.resourceType).toBe('content');
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'media.read')?.resourceType).toBe('media');
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'news.update')?.resourceType).toBe('news');
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'categories.read')?.resourceType).toBe('categories');
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'app.read')?.resourceType).toBe('app');
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'cockpit.read')?.resourceType).toBe('cockpit');
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'experimental.read')?.resourceType).toBe(
       'experimental'
     );
-    assert.equal(
-      iamSeedPlan.permissions.find((permission) => permission.key === 'iam.governance.export')?.resourceType,
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'iam.governance.export')?.resourceType).toBe(
       'iam'
     );
-    assert.equal(
-      iamSeedPlan.permissions.find((permission) => permission.key === 'iam.accounts.delete')?.resourceType,
+    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'iam.accounts.delete')?.resourceType).toBe(
       'iam'
     );
   });
 
   it('throws for unknown persona keys', () => {
-    assert.throws(() => getPersonaSeed('unknown' as never), /Unknown persona key: unknown/);
+    expect(() => getPersonaSeed('unknown' as never)).toThrowError(/Unknown persona key: unknown/);
   });
 });

--- a/packages/data/src/instance-registry/index.test.ts
+++ b/packages/data/src/instance-registry/index.test.ts
@@ -1,5 +1,4 @@
-import assert from 'node:assert/strict';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   createInstanceRegistryRepository as createLeadingInstanceRegistryRepository,
@@ -13,7 +12,7 @@ import {
 
 describe('instance registry repository boundary', () => {
   it('re-exports the leading repository factory from @sva/data-repositories', () => {
-    assert.equal(createInstanceRegistryRepository, createLeadingInstanceRegistryRepository);
+    expect(createInstanceRegistryRepository).toBe(createLeadingInstanceRegistryRepository);
   });
 
   it('keeps the local repository types aligned with @sva/data-repositories', () => {
@@ -22,7 +21,7 @@ describe('instance registry repository boundary', () => {
     const repositoryTypeAligned: AssertAssignable<InstanceRegistryRepository, LeadingInstanceRegistryRepository> = true;
     const repositoryTypeAlignedReverse: AssertAssignable<LeadingInstanceRegistryRepository, InstanceRegistryRepository> = true;
 
-    assert.equal(repositoryTypeAligned, true);
-    assert.equal(repositoryTypeAlignedReverse, true);
+    expect(repositoryTypeAligned).toBe(true);
+    expect(repositoryTypeAlignedReverse).toBe(true);
   });
 });

--- a/packages/data/src/integrations/instance-integrations.test.ts
+++ b/packages/data/src/integrations/instance-integrations.test.ts
@@ -1,16 +1,15 @@
-import assert from 'node:assert/strict';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import * as data from './instance-integrations.js';
 import * as repos from '@sva/data-repositories';
 
 describe('instance integration boundary', () => {
   it('re-exports the leading instance integration repository factory', () => {
-    assert.equal(data.createInstanceIntegrationRepository, repos.createInstanceIntegrationRepository);
+    expect(data.createInstanceIntegrationRepository).toBe(repos.createInstanceIntegrationRepository);
   });
 
   it('re-exports the leading cached loader and statements', () => {
-    assert.equal(data.createCachedInstanceIntegrationLoader, repos.createCachedInstanceIntegrationLoader);
-    assert.equal(data.instanceIntegrationStatements, repos.instanceIntegrationStatements);
+    expect(data.createCachedInstanceIntegrationLoader).toBe(repos.createCachedInstanceIntegrationLoader);
+    expect(data.instanceIntegrationStatements).toBe(repos.instanceIntegrationStatements);
   });
 });

--- a/packages/data/src/runtime-safety.test.ts
+++ b/packages/data/src/runtime-safety.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const readRepoFile = (relativePath: string) => readFileSync(resolve(testDirectory, '..', '..', relativePath), 'utf8');
@@ -21,8 +21,7 @@ test('@sva/data stays a db-operations and compatibility package', () => {
   const packageJsonSource = readRepoFile('data/package.json');
   const projectJsonSource = readRepoFile('data/project.json');
 
-  assert.equal(
-    indexSource,
+  expect(indexSource).toBe(
     "export { createDataClient } from '@sva/data-client';\nexport type { DataClientOptions } from '@sva/data-client';\nexport * from '@sva/data-repositories';"
   );
   assert.equal(serverSource, "export * from '@sva/data-repositories/server';");
@@ -49,7 +48,7 @@ test('@sva/data stays a db-operations and compatibility package', () => {
 test('geo hierarchy migration validates only paths affected by the new edge', () => {
   const sql = readRepoFile('data/migrations/0016_iam_geo_hierarchy.sql');
 
-  assert.match(sql, /max_result_depth INTEGER/);
+  expect(sql).toMatch(/max_result_depth INTEGER/);
   assert.match(sql, /parent\.descendant_id = NEW\.ancestor_id/);
   assert.match(sql, /child\.ancestor_id = NEW\.descendant_id/);
   assert.doesNotMatch(sql, /WHERE h\.ancestor_id = NEW\.ancestor_id\s+OR h\.descendant_id = NEW\.descendant_id/);
@@ -58,7 +57,7 @@ test('geo hierarchy migration validates only paths affected by the new edge', ()
 test('bootstrap script validates usernames and uses identifier-safe grants', () => {
   const script = readRepoFile('data/scripts/bootstrap-app-user.sh');
 
-  assert.match(script, /IAM_DATABASE_URL username must match \^\[a-zA-Z0-9_\]\{1,63\}\$\./);
+  expect(script).toMatch(/IAM_DATABASE_URL username must match \^\[a-zA-Z0-9_\]\{1,63\}\$\./);
   assert.match(script, /POSTGRES_DB must match \^\[a-zA-Z0-9_\]\{1,63\}\$\./);
   assert.match(script, /-v postgres_db="\$\{POSTGRES_DB\}" -v app_user="\$\{app_user\}" -v app_password="\$\{app_password\}"/);
   assert.match(script, /GRANT CONNECT ON DATABASE :"postgres_db" TO :"app_user";/);
@@ -73,7 +72,7 @@ test('bootstrap script validates usernames and uses identifier-safe grants', () 
 test('migration script supports profile-specific postgres targets', () => {
   const script = readRepoFile('data/scripts/run-migrations.sh');
 
-  assert.match(script, /POSTGRES_SERVICE="\$\{POSTGRES_SERVICE:-postgres\}"/);
+  expect(script).toMatch(/POSTGRES_SERVICE="\$\{POSTGRES_SERVICE:-postgres\}"/);
   assert.match(script, /POSTGRES_PASSWORD="\$\{POSTGRES_PASSWORD:-sva_local_dev_password\}"/);
   assert.match(script, /SVA_LOCAL_POSTGRES_CONTAINER_NAME="\$\{SVA_LOCAL_POSTGRES_CONTAINER_NAME:-\}"/);
   assert.match(script, /GOOSE_WRAPPER="\$\{GOOSE_WRAPPER:-packages\/data\/scripts\/goosew\.sh\}"/);
@@ -88,7 +87,7 @@ test('destructive integration scripts isolate themselves from the default local 
   const encryptionScript = readRepoFile('data/scripts/test-encryption.sh');
 
   for (const script of [seedScript, rlsScript, encryptionScript]) {
-    assert.match(script, /PROTECTED_DB_NAMES_REGEX="\$\{PROTECTED_DB_NAMES_REGEX:-\^\(sva_studio\|postgres\)\$\}"/);
+    expect(script).toMatch(/PROTECTED_DB_NAMES_REGEX="\$\{PROTECTED_DB_NAMES_REGEX:-\^\(sva_studio\|postgres\)\$\}"/);
     assert.match(script, /TEST_DB_NAME="\$\{TEST_DB_NAME:-\$\{sanitized_db_name:0:63\}\}"/);
     assert.match(script, /Refusing to run .* against protected database/);
     assert.match(script, /DROP DATABASE IF EXISTS "\$\{TEST_DB_NAME\}";/);
@@ -109,7 +108,7 @@ test('destructive integration scripts isolate themselves from the default local 
 test('self-service permission change migration keeps admin inserts and rollback fail-closed', () => {
   const sql = readRepoFile('data/migrations/0042_iam_self_service_permission_change_requests.sql');
 
-  assert.match(sql, /ADD COLUMN IF NOT EXISTS request_origin TEXT NOT NULL DEFAULT 'admin'/);
+  expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS request_origin TEXT NOT NULL DEFAULT 'admin'/);
   assert.match(sql, /UPDATE iam\.permission_change_requests[\s\S]*SET request_note = COALESCE\(request_note, ''\)/);
   assert.match(sql, /IF EXISTS \(\s*SELECT 1[\s\S]*WHERE role_id IS NULL[\s\S]*RAISE EXCEPTION 'Cannot restore role_id NOT NULL/);
   assert.doesNotMatch(sql, /ALTER TABLE iam\.permission_change_requests\s+ALTER COLUMN role_id SET NOT NULL;[\s\S]*ALTER TABLE iam\.permission_change_requests\s+ALTER COLUMN request_note DROP NOT NULL/);
@@ -118,7 +117,7 @@ test('self-service permission change migration keeps admin inserts and rollback 
 test('sidebar application permission migration adds navigation permissions for existing roles', () => {
   const sql = readRepoFile('data/migrations/0046_iam_sidebar_application_permissions.sql');
 
-  assert.match(sql, /'app\.read', 'app\.read', 'app', 'Show the app link in the sidebar'/);
+  expect(sql).toMatch(/'app\.read', 'app\.read', 'app', 'Show the app link in the sidebar'/);
   assert.match(sql, /'cockpit\.read', 'cockpit\.read', 'cockpit', 'Show the cockpit link in the sidebar'/);
   assert.match(
     sql,
@@ -133,7 +132,7 @@ test('sidebar application permission migration adds navigation permissions for e
 test('sidebar application permission cache invalidation migration notifies affected instances', () => {
   const sql = readRepoFile('data/migrations/0047_iam_sidebar_application_permission_cache_invalidation.sql');
 
-  assert.match(sql, /iam_permission_snapshot_invalidation/);
+  expect(sql).toMatch(/iam_permission_snapshot_invalidation/);
   assert.match(sql, /json_build_object\(/);
   assert.match(sql, /'instanceId',\s*instance_id/);
   assert.match(sql, /'reason',\s*'sidebar_application_permissions_migrated'/);
@@ -145,7 +144,7 @@ test('platform tenant role split migration neutralizes tenant-side root role art
   const sql = readRepoFile('data/migrations/0050_iam_platform_tenant_role_split.sql');
   const touchedInstancesOccurrences = sql.match(/WITH touched_instances AS \(/g) ?? [];
 
-  assert.match(sql, /CREATE TEMP TABLE migration_0050_touched_instances ON COMMIT DROP AS/);
+  expect(sql).toMatch(/CREATE TEMP TABLE migration_0050_touched_instances ON COMMIT DROP AS/);
   assert.match(sql, /DELETE FROM iam\.account_roles/);
   assert.match(sql, /DELETE FROM iam\.group_roles/);
   assert.match(sql, /DELETE FROM iam\.role_permissions[\s\S]*permission_key = 'instance\.registry\.manage'/);
@@ -160,7 +159,7 @@ test('platform tenant role split migration neutralizes tenant-side root role art
 test('permission gate backfill migration seeds the new permission model for tenant governance paths', () => {
   const sql = readRepoFile('data/migrations/0051_iam_permission_gate_backfill.sql');
 
-  assert.match(sql, /'iam\.legalText\.read'/);
+  expect(sql).toMatch(/'iam\.legalText\.read'/);
   assert.match(sql, /'iam\.governance\.write'/);
   assert.match(sql, /'iam\.dsr\.export'/);
   assert.match(sql, /'iam\.deletionRules\.write'/);
@@ -178,7 +177,7 @@ test('permission gate backfill migration seeds the new permission model for tena
 test('experimental shell permission migration backfills the additive ui gate for existing roles', () => {
   const sql = readRepoFile('data/migrations/0052_iam_experimental_shell_permission.sql');
 
-  assert.match(sql, /'experimental\.read'/);
+  expect(sql).toMatch(/'experimental\.read'/);
   assert.match(sql, /'experimental',\s*NULL,\s*'allow'/);
   assert.match(sql, /permission_key IN \('app\.read', 'cockpit\.read', 'iam\.monitoring\.read', 'feature\.toggle'\)/);
   assert.match(sql, /grant_origin_kind,\s*access_scope/);
@@ -191,7 +190,7 @@ test('experimental shell permission migration backfills the additive ui gate for
 test('legacy standard role grant cleanup migration removes historical seed grants from deprecated tenant defaults', () => {
   const sql = readRepoFile('data/migrations/0053_iam_legacy_standard_role_grant_cleanup.sql');
 
-  assert.match(sql, /migration_0053_touched_instances/);
+  expect(sql).toMatch(/migration_0053_touched_instances/);
   assert.match(sql, /grant_origin_kind = 'seed'/);
   assert.match(sql, /role_key IN \(\s*'app_manager',\s*'feature-manager',\s*'interface-manager',\s*'designer',\s*'editor',\s*'moderator'\s*\)/);
   assert.match(sql, /permission_key IN \(\s*'app\.read',\s*'cockpit\.read',\s*'experimental\.read'/);
@@ -204,7 +203,7 @@ test('legacy standard role grant cleanup migration removes historical seed grant
 test('categories permission migration backfills additive plugin permissions without deleting existing tenant data', () => {
   const sql = readRepoFile('data/migrations/0054_iam_categories_permissions.sql');
 
-  assert.match(sql, /'categories\.read'/);
+  expect(sql).toMatch(/'categories\.read'/);
   assert.match(sql, /'categories\.create'/);
   assert.match(sql, /'categories\.update'/);
   assert.match(sql, /'categories\.delete'/);
@@ -223,7 +222,7 @@ test('categories permission migration backfills additive plugin permissions with
 test('content author display migration keeps existing personal content user-authored', () => {
   const sql = readRepoFile('data/migrations/0062_iam_content_author_display_mode.sql');
 
-  assert.match(sql, /UPDATE iam\.contents\s+SET author_display_mode = 'user'\s+WHERE organization_id IS NULL;/);
+  expect(sql).toMatch(/UPDATE iam\.contents\s+SET author_display_mode = 'user'\s+WHERE organization_id IS NULL;/);
   assert.match(
     sql,
     /UPDATE iam\.content_list_projection\s+SET author_display_mode = 'user'\s+WHERE source_system = 'iam'\s+AND organization_id IS NULL;/
@@ -251,7 +250,7 @@ test('admin account hard-delete migration anonymizes retained content account re
     'permission_change_requests_membership_target_fk',
   ];
 
-  assert.match(sql, /ALTER TABLE iam\.content_history\s+ALTER COLUMN actor_account_id DROP NOT NULL;/);
+  expect(sql).toMatch(/ALTER TABLE iam\.content_history\s+ALTER COLUMN actor_account_id DROP NOT NULL;/);
   assert.match(sql, /ALTER TABLE iam\.contents\s+ALTER COLUMN author_account_id DROP NOT NULL,/);
   assert.match(sql, /ALTER TABLE iam\.contents[\s\S]*ALTER COLUMN creator_account_id DROP NOT NULL,/);
   assert.match(sql, /ALTER TABLE iam\.contents[\s\S]*ALTER COLUMN updater_account_id DROP NOT NULL;/);
@@ -300,7 +299,7 @@ test('activity log hard-delete compatibility migration removes immutable account
   const sql = readRepoFile('data/migrations/0068_iam_activity_log_account_hard_delete_compat.sql');
   const schemaSnapshot = readRepoFile('../docs/development/studio-db-schema-final.sql');
 
-  assert.match(sql, /ALTER TABLE iam\.activity_logs[\s\S]*DROP CONSTRAINT IF EXISTS activity_logs_account_id_fkey,/);
+  expect(sql).toMatch(/ALTER TABLE iam\.activity_logs[\s\S]*DROP CONSTRAINT IF EXISTS activity_logs_account_id_fkey,/);
   assert.match(sql, /ALTER TABLE iam\.activity_logs[\s\S]*DROP CONSTRAINT IF EXISTS activity_logs_subject_id_fkey;/);
   assert.match(sql, /ALTER TABLE iam\.platform_activity_logs[\s\S]*DROP CONSTRAINT IF EXISTS platform_activity_logs_account_id_fkey;/);
   assert.match(
@@ -316,7 +315,7 @@ test('content projection deleted-account fallback migration keeps trigger insert
   const sql = readRepoFile('data/migrations/0069_iam_content_projection_deleted_account_fallback.sql');
   const schemaSnapshot = readRepoFile('../docs/development/studio-db-schema-final.sql');
 
-  assert.match(sql, /COALESCE\(NEW\.creator_account_id::text, '__iam_author_deleted__'\)/);
+  expect(sql).toMatch(/COALESCE\(NEW\.creator_account_id::text, '__iam_author_deleted__'\)/);
   assert.match(sql, /COALESCE\(NEW\.updater_account_id::text, '__iam_author_deleted__'\)/);
   assert.match(schemaSnapshot, /COALESCE\(NEW\.creator_account_id::text, '__iam_author_deleted__'\)/);
   assert.match(schemaSnapshot, /COALESCE\(NEW\.updater_account_id::text, '__iam_author_deleted__'\)/);
@@ -325,7 +324,7 @@ test('content projection deleted-account fallback migration keeps trigger insert
 test('categories instance-module migration backfills additive module assignments for mainserver content tenants', () => {
   const sql = readRepoFile('data/migrations/0055_iam_categories_instance_modules.sql');
 
-  assert.match(sql, /INSERT INTO iam\.instance_modules \(instance_id, module_id\)/);
+  expect(sql).toMatch(/INSERT INTO iam\.instance_modules \(instance_id, module_id\)/);
   assert.match(sql, /SELECT DISTINCT/);
   assert.match(sql, /'categories'/);
   assert.match(sql, /module_id IN \('news', 'events', 'poi'\)/);
@@ -337,7 +336,7 @@ test('categories instance-module migration backfills additive module assignments
 test('system admin core permission backfill migration restores missing tenant iam account-management grants additively', () => {
   const sql = readRepoFile('data/migrations/0056_iam_system_admin_core_permissions.sql');
 
-  assert.match(sql, /'iam\.user\.read'/);
+  expect(sql).toMatch(/'iam\.user\.read'/);
   assert.match(sql, /'iam\.user\.write'/);
   assert.match(sql, /'iam\.role\.read'/);
   assert.match(sql, /'iam\.role\.write'/);
@@ -358,7 +357,7 @@ test('system admin core permission backfill migration restores missing tenant ia
 test('iam ownership authorization model migration replaces legacy ownership, direct permissions and deny effects', () => {
   const sql = readRepoFile('data/migrations/0061_iam_content_ownership_authorization_model.sql');
 
-  assert.match(sql, /ADD COLUMN IF NOT EXISTS owner_user_id UUID NULL/);
+  expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS owner_user_id UUID NULL/);
   assert.match(sql, /ADD COLUMN IF NOT EXISTS owner_organization_id UUID NULL/);
   assert.doesNotMatch(sql, /owner_user_id = creator_account_id/);
   assert.doesNotMatch(sql, /owner_organization_id = organization_id/);
@@ -377,7 +376,7 @@ test('iam ownership authorization model migration replaces legacy ownership, dir
 test('content projection legacy primary key migration preserves scoped mainserver snapshots', () => {
   const sql = readRepoFile('data/migrations/0064_content_projection_legacy_primary_key.sql');
 
-  assert.match(sql, /DROP CONSTRAINT IF EXISTS content_list_projection_pkey/);
+  expect(sql).toMatch(/DROP CONSTRAINT IF EXISTS content_list_projection_pkey/);
   assert.match(sql, /content_list_projection_scope_key/);
   assert.match(sql, /Mainserver entity may be materialized for multiple organization\/user scopes/);
   assert.match(sql, /rollback is intentionally omitted/i);
@@ -388,7 +387,7 @@ test('content projection legacy primary key migration preserves scoped mainserve
 test('runtime artifact verification runs workspace node helper via bash', () => {
   const script = readFileSync(resolve(testDirectory, '..', '..', '..', 'scripts/ci/verify-runtime-artifact.sh'), 'utf8');
 
-  assert.match(script, /bash "\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
+  expect(script).toMatch(/bash "\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
   assert.match(script, /KEYCLOAK_PORT="\$\{KEYCLOAK_PORT\}" bash "\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
   assert.doesNotMatch(script, /(^|[^[:alnum:]_])"\$\{WORKSPACE_ROOT\}\/scripts\/ci\/run-workspace-node\.sh" <<'NODE'/);
 });
@@ -421,7 +420,7 @@ test('runtime artifact checks avoid stale images and dev JSX false positives', (
   );
   const studioProjectJson = readFileSync(resolve(testDirectory, '..', '..', '..', 'apps/sva-studio-react/project.json'), 'utf8');
 
-  assert.match(imageVerifyScript, /docker pull "\$\{IMAGE_REF\}"/);
+  expect(imageVerifyScript).toMatch(/docker pull "\$\{IMAGE_REF\}"/);
   assert.doesNotMatch(imageVerifyScript, /skipped-local/);
   assert.doesNotMatch(imageVerifyScript, /docker image inspect "\$\{IMAGE_REF\}"/);
   assert.match(imageVerifyScript, /run_postgres_sql_with_retry\(\)/);
@@ -519,16 +518,14 @@ fi`;
       },
     });
 
-    assert.throws(
-      () =>
-        execFileSync('sh', ['-c', guardScript], {
-          env: {
-            ...process.env,
-            TARGET_DIR: matchDir,
-          },
-        }),
-      /Command failed/,
-    );
+    expect(() =>
+      execFileSync('sh', ['-c', guardScript], {
+        env: {
+          ...process.env,
+          TARGET_DIR: matchDir,
+        },
+      })
+    ).toThrowError(/Command failed/);
   } finally {
     rmSync(tempRoot, { force: true, recursive: true });
   }
@@ -569,7 +566,7 @@ test('injected workspace sync copies dist into pnpm store package copies', { tim
       stdio: 'pipe',
     });
 
-    assert.equal(readFileSync(resolve(injectedPackageDir, 'dist', 'index.js'), 'utf8'), 'export const synced = true;\n');
+    expect(readFileSync(resolve(injectedPackageDir, 'dist', 'index.js'), 'utf8')).toBe('export const synced = true;\n');
   } finally {
     rmSync(tempRoot, { force: true, recursive: true });
   }
@@ -585,8 +582,7 @@ test('public waste build syncs injected workspace packages before vite resolves 
     'utf8'
   );
 
-  assert.match(
-    publicWastePackageJson,
+  expect(publicWastePackageJson).toMatch(
     /pnpm exec tsx \.\.\/\.\.\/scripts\/ci\/sync-injected-workspace-packages\.ts \. && rm -rf dist && vite build --outDir dist\/client && pnpm exec tsc -p tsconfig\.server\.json/
   );
   assert.match(
@@ -598,7 +594,7 @@ test('public waste build syncs injected workspace packages before vite resolves 
 test('sva-studio-react vite SSR config resolves mail-runtime from workspace source', () => {
   const viteConfig = readRepoFile('../apps/sva-studio-react/vite.config.ts');
 
-  assert.match(viteConfig, /'@sva\/mail-runtime': resolveAppPath\('\.\.\/\.\.\/packages\/mail-runtime\/src\/index\.ts'\)/);
+  expect(viteConfig).toMatch(/'@sva\/mail-runtime': resolveAppPath\('\.\.\/\.\.\/packages\/mail-runtime\/src\/index\.ts'\)/);
   assert.match(viteConfig, /'@sva\/mail-runtime',/);
   assert.match(viteConfig, /'\.localhost'/);
   assert.doesNotMatch(viteConfig, /lvh\.me/);
@@ -607,8 +603,7 @@ test('sva-studio-react vite SSR config resolves mail-runtime from workspace sour
 test('sva-studio-react vitest shared config resolves mail-runtime from workspace source', () => {
   const vitestSharedConfig = readRepoFile('../apps/sva-studio-react/vitest.shared.ts');
 
-  assert.match(
-    vitestSharedConfig,
+  expect(vitestSharedConfig).toMatch(
     /'@sva\/mail-runtime': fileURLToPath\(\s*new URL\('\.\.\/\.\.\/packages\/mail-runtime\/src\/index\.ts', import\.meta\.url\)\s*\)/
   );
 });

--- a/packages/monitoring-client/src/logging/redaction.ts
+++ b/packages/monitoring-client/src/logging/redaction.ts
@@ -28,18 +28,12 @@ const SENSITIVE_LOG_KEYS = new Set([
 ]);
 
 const jwtLikeRegex = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?\b/g;
-const querySecretRegexSource =
-  String.raw`([?&](?:access_token|refresh_token|id_token|id_token_hint|token|code|client_secret|api_key|authorization)=)([^&#\s]+)`;
-const inlineQuerySecretRegexSource =
-  String.raw`((?:^|[\s,(])(?:access_token|refresh_token|id_token|id_token_hint|token|code|client_secret|api_key|authorization)[\w.-]{0,20}[=:]\s*)([^\s,)]+)`;
-const inlineSensitiveFieldRegexSource =
-  String.raw`((?:^|[\s,(])(?:password|secret|session|cookie|csrf)[\w.-]{0,20}[=:]\s*)([^\s,)]+)`;
 const urlSecretPatterns: ReadonlyArray<readonly [RegExp, string]> = [
   [/\b(authorization:\s*)(bearer\s+)?[^\s,]+/gi, '$1[REDACTED]'],
   [/\b(bearer\s+)(?!\[REDACTED(?:_JWT)?\])[^\s,]+/gi, '$1[REDACTED]'],
-  [new RegExp(querySecretRegexSource, 'gi'), '$1[REDACTED]'],
-  [new RegExp(inlineQuerySecretRegexSource, 'gi'), '$1[REDACTED]'],
-  [new RegExp(inlineSensitiveFieldRegexSource, 'gi'), '$1[REDACTED]'],
+  [/\b([?&](?:access_token|refresh_token|id_token|id_token_hint|token|code|client_secret|api_key|authorization)=)([^&#\s]+)/gi, '$1[REDACTED]'],
+  [/((?:^|[\s,(])(?:access_token|refresh_token|id_token|id_token_hint|token|code|client_secret|api_key|authorization)[\w.-]{0,20}[=:]\s*)([^\s,)]+)/gi, '$1[REDACTED]'],
+  [/((?:^|[\s,(])(?:password|secret|session|cookie|csrf)[\w.-]{0,20}[=:]\s*)([^\s,)]+)/gi, '$1[REDACTED]'],
 ];
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> => {

--- a/packages/monitoring-client/src/logging/redaction.ts
+++ b/packages/monitoring-client/src/logging/redaction.ts
@@ -31,7 +31,7 @@ const jwtLikeRegex = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?\b
 const urlSecretPatterns: ReadonlyArray<readonly [RegExp, string]> = [
   [/\b(authorization:\s*)(bearer\s+)?[^\s,]+/gi, '$1[REDACTED]'],
   [/\b(bearer\s+)(?!\[REDACTED(?:_JWT)?\])[^\s,]+/gi, '$1[REDACTED]'],
-  [/\b([?&](?:access_token|refresh_token|id_token|id_token_hint|token|code|client_secret|api_key|authorization)=)([^&#\s]+)/gi, '$1[REDACTED]'],
+  [/([?&](?:access_token|refresh_token|id_token|id_token_hint|token|code|client_secret|api_key|authorization)=)([^&#\s]+)/gi, '$1[REDACTED]'],
   [/((?:^|[\s,(])(?:access_token|refresh_token|id_token|id_token_hint|token|code|client_secret|api_key|authorization)[\w.-]{0,20}[=:]\s*)([^\s,)]+)/gi, '$1[REDACTED]'],
   [/((?:^|[\s,(])(?:password|secret|session|cookie|csrf)[\w.-]{0,20}[=:]\s*)([^\s,)]+)/gi, '$1[REDACTED]'],
 ];

--- a/packages/monitoring-client/tests/browser-logging.test.ts
+++ b/packages/monitoring-client/tests/browser-logging.test.ts
@@ -31,13 +31,15 @@ describe('browser logger', () => {
 
   it('redacts inline secrets, bearer tokens and jwt-like fragments in strings', () => {
     const redacted = redactLogString(
-      'authorization: Bearer token-123 password=secret access_token=abc.123 code=xyz eyJhbGciOiJub25lIn0.eyJzdWIiOiIxIn0.sig'
+      'authorization: Bearer token-123 password=secret access_token=abc.123 code=xyz ?token=foo https://idp.example/callback?code=bar eyJhbGciOiJub25lIn0.eyJzdWIiOiIxIn0.sig'
     );
 
     expect(redacted).toContain('authorization: [REDACTED]');
     expect(redacted).toContain('password=[REDACTED]');
     expect(redacted).toContain('access_token=[REDACTED]');
     expect(redacted).toContain('code=[REDACTED]');
+    expect(redacted).toContain('?token=[REDACTED]');
+    expect(redacted).toContain('https://idp.example/callback?code=[REDACTED]');
     expect(redacted).toContain('[REDACTED_JWT]');
   });
 

--- a/scripts/ci/check-plugin-ui-boundary.ts
+++ b/scripts/ci/check-plugin-ui-boundary.ts
@@ -1,7 +1,10 @@
+// fallow-ignore-file security-sink -- local CI script scans workspace-local plugin files; paths are derived from the repo root, not user-reachable runtime input.
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as ts from 'typescript';
+
+import { isCliEntrypoint } from './path-safety.js';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(SCRIPT_DIR, '../..');
@@ -290,7 +293,7 @@ const run = async (): Promise<void> => {
   console.info('Plugin-UI-Boundary-Check erfolgreich (keine App-UI-Imports oder Basiscontrol-Duplikate erkannt).');
 };
 
-if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isCliEntrypoint(import.meta.url, process.argv[1])) {
   void run().catch((error: unknown) => {
     console.error('Plugin-UI-Boundary-Check fehlgeschlagen (unerwarteter Fehler).');
     console.error(error instanceof Error ? error.message : String(error));

--- a/scripts/ci/path-safety.test.ts
+++ b/scripts/ci/path-safety.test.ts
@@ -1,0 +1,28 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { isCliEntrypoint, resolvePathFromBase, resolvePathWithin } from './path-safety.js';
+
+describe('path-safety', () => {
+  it('resolves relative paths from an explicit base directory', () => {
+    const baseDir = path.join(os.tmpdir(), 'sva-path-safety-base');
+    expect(resolvePathFromBase(baseDir, './reports/out.txt')).toBe(path.join(baseDir, 'reports', 'out.txt'));
+  });
+
+  it('rejects paths that escape the allowed base directory', () => {
+    const baseDir = path.join(os.tmpdir(), 'sva-path-safety-allowed');
+    expect(() => resolvePathWithin(baseDir, '../outside.txt')).toThrow('verlaesst den erlaubten Basisordner');
+  });
+
+  it('detects the current cli entrypoint for relative and absolute argv values', () => {
+    const scriptPath = path.join(process.cwd(), 'scripts/ci/path-safety.ts');
+    const importMetaUrl = new URL('./path-safety.ts', import.meta.url).toString();
+
+    expect(isCliEntrypoint(importMetaUrl, scriptPath)).toBe(true);
+    expect(isCliEntrypoint(importMetaUrl, path.relative(process.cwd(), scriptPath))).toBe(true);
+    expect(isCliEntrypoint(importMetaUrl, 'scripts/ci/other.ts')).toBe(false);
+    expect(isCliEntrypoint(importMetaUrl, undefined)).toBe(false);
+  });
+});

--- a/scripts/ci/path-safety.test.ts
+++ b/scripts/ci/path-safety.test.ts
@@ -13,7 +13,12 @@ describe('path-safety', () => {
 
   it('rejects paths that escape the allowed base directory', () => {
     const baseDir = path.join(os.tmpdir(), 'sva-path-safety-allowed');
-    expect(() => resolvePathWithin(baseDir, '../outside.txt')).toThrow('verlaesst den erlaubten Basisordner');
+    expect(() => resolvePathWithin(baseDir, '../outside.txt')).toThrow('verlässt den erlaubten Basisordner');
+  });
+
+  it('allows relative names that only start with two dots inside the base directory', () => {
+    const baseDir = path.join(os.tmpdir(), 'sva-path-safety-allowed');
+    expect(resolvePathWithin(baseDir, './..file.txt')).toBe(path.join(baseDir, '..file.txt'));
   });
 
   it('detects the current cli entrypoint for relative and absolute argv values', () => {

--- a/scripts/ci/path-safety.ts
+++ b/scripts/ci/path-safety.ts
@@ -4,6 +4,9 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const ensureTrailingSeparator = (value: string): string =>
   value.endsWith(path.sep) ? value : `${value}${path.sep}`;
 
+const leavesBaseDir = (relativePath: string): boolean =>
+  relativePath === '..' || relativePath.startsWith(`..${path.sep}`);
+
 const toAbsoluteFilePath = (baseDir: string, candidate: string): string => {
   if (candidate.startsWith('file://')) {
     return fileURLToPath(candidate);
@@ -27,8 +30,8 @@ export const resolvePathWithin = (baseDir: string, candidate: string): string =>
   const absoluteCandidate = resolvePathFromBase(absoluteBaseDir, candidate);
   const relativePath = path.relative(absoluteBaseDir, absoluteCandidate);
 
-  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-    throw new Error(`Pfad "${candidate}" verlaesst den erlaubten Basisordner ${absoluteBaseDir}.`);
+  if (leavesBaseDir(relativePath) || path.isAbsolute(relativePath)) {
+    throw new Error(`Pfad "${candidate}" verlässt den erlaubten Basisordner ${absoluteBaseDir}.`);
   }
 
   return absoluteCandidate;

--- a/scripts/ci/path-safety.ts
+++ b/scripts/ci/path-safety.ts
@@ -1,0 +1,38 @@
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ensureTrailingSeparator = (value: string): string =>
+  value.endsWith(path.sep) ? value : `${value}${path.sep}`;
+
+const toAbsoluteFilePath = (baseDir: string, candidate: string): string => {
+  if (candidate.startsWith('file://')) {
+    return fileURLToPath(candidate);
+  }
+
+  if (path.isAbsolute(candidate)) {
+    return path.normalize(candidate);
+  }
+
+  return fileURLToPath(new URL(candidate, pathToFileURL(ensureTrailingSeparator(baseDir))));
+};
+
+export const resolvePathFromBase = (baseDir: string, candidate: string): string =>
+  toAbsoluteFilePath(baseDir, candidate);
+
+export const resolvePathFromCwd = (candidate: string): string =>
+  resolvePathFromBase(process.cwd(), candidate);
+
+export const resolvePathWithin = (baseDir: string, candidate: string): string => {
+  const absoluteBaseDir = path.normalize(baseDir);
+  const absoluteCandidate = resolvePathFromBase(absoluteBaseDir, candidate);
+  const relativePath = path.relative(absoluteBaseDir, absoluteCandidate);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Pfad "${candidate}" verlaesst den erlaubten Basisordner ${absoluteBaseDir}.`);
+  }
+
+  return absoluteCandidate;
+};
+
+export const isCliEntrypoint = (importMetaUrl: string, argvEntry: string | undefined): boolean =>
+  argvEntry !== undefined && resolvePathFromCwd(argvEntry) === fileURLToPath(importMetaUrl);

--- a/scripts/ci/prepare-sonar-lcov.ts
+++ b/scripts/ci/prepare-sonar-lcov.ts
@@ -1,6 +1,9 @@
+// fallow-ignore-file security-sink -- local CI script reads and writes coverage artifacts within the current workspace root only.
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { isCliEntrypoint, resolvePathWithin } from './path-safety.js';
 
 const DEFAULT_OUTPUT_PATH = 'artifacts/sonar/lcov.info';
 const COVERAGE_REPORT_PATH = 'coverage/lcov.info';
@@ -107,7 +110,7 @@ export const prepareSonarLcov = ({
   rootDir,
   outputPath = DEFAULT_OUTPUT_PATH,
 }: PrepareSonarLcovOptions): PrepareSonarLcovResult => {
-  const absoluteOutputPath = path.resolve(rootDir, outputPath);
+  const absoluteOutputPath = resolvePathWithin(rootDir, outputPath);
   const reports = findCoverageReports(rootDir);
   const normalizedReports = reports.map((reportPath) => normalizeLcovContents(rootDir, reportPath));
   const sourceFiles = normalizedReports.reduce((sum, report) => sum + report.sourceFiles, 0);
@@ -130,7 +133,6 @@ const runCli = (): void => {
   );
 };
 
-const currentFilePath = fileURLToPath(import.meta.url);
-if (process.argv[1] !== undefined && path.resolve(process.argv[1]) === currentFilePath) {
+if (isCliEntrypoint(import.meta.url, process.argv[1])) {
   runCli();
 }

--- a/scripts/ci/sync-injected-workspace-packages.ts
+++ b/scripts/ci/sync-injected-workspace-packages.ts
@@ -1,7 +1,6 @@
 // fallow-ignore-file security-sink -- local workspace maintenance script traverses repo-managed package paths and injected copies, not user-reachable runtime input.
 import { cp, mkdir, readdir, readFile, realpath, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { isCliEntrypoint, resolvePathFromCwd } from './path-safety.js';
 

--- a/scripts/ci/sync-injected-workspace-packages.ts
+++ b/scripts/ci/sync-injected-workspace-packages.ts
@@ -26,7 +26,6 @@ const pathExists = async (targetPath: string) => {
 const resolveExistingPath = async (targetPath: string): Promise<string | null> => {
   return (await pathExists(targetPath)) ? targetPath : null;
 };
-
 const readPackageName = async (packageJsonPath: string): Promise<string | null> => {
   try {
     const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as { name?: string };
@@ -311,12 +310,9 @@ const main = async () => {
   );
 };
 
-if (isCliEntrypoint(import.meta.url, process.argv[1])) {
-  main().catch((error: unknown) => {
-    const message = error instanceof Error ? error.stack ?? error.message : String(error);
-    process.stderr.write(`${message}\n`);
-    process.exitCode = 1;
-  });
-}
-
+if (isCliEntrypoint(import.meta.url, process.argv[1])) main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});
 export { collectWorkspacePackages, findReachableWorkspacePackageNames, findInjectedCopies, findWorkspaceRoot, syncWorkspacePackage };

--- a/scripts/ci/sync-injected-workspace-packages.ts
+++ b/scripts/ci/sync-injected-workspace-packages.ts
@@ -1,6 +1,9 @@
+// fallow-ignore-file security-sink -- local workspace maintenance script traverses repo-managed package paths and injected copies, not user-reachable runtime input.
 import { cp, mkdir, readdir, readFile, realpath, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { isCliEntrypoint, resolvePathFromCwd } from './path-safety.js';
 
 type WorkspacePackage = {
   dir: string;
@@ -9,7 +12,7 @@ type WorkspacePackage = {
   realDir: string;
 };
 
-const consumerDir = path.resolve(process.argv[2] ?? process.cwd());
+const consumerDir = resolvePathFromCwd(process.argv[2] ?? '.');
 
 const pathExists = async (targetPath: string) => {
   try {
@@ -308,7 +311,7 @@ const main = async () => {
   );
 };
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+if (isCliEntrypoint(import.meta.url, process.argv[1])) {
   main().catch((error: unknown) => {
     const message = error instanceof Error ? error.stack ?? error.message : String(error);
     process.stderr.write(`${message}\n`);


### PR DESCRIPTION
## Summary
- harden outbound URL handling for interface health checks, custom map geocoding targets, and reusable auth-runtime URL normalization helpers
- add path-safety helpers for CI scripts, wire them into affected tooling, and cover the new behavior with focused tests
- add the repository security policy and `.well-known/security.txt`, plus related contract/test cleanups around the touched areas

## Why
Several privileged admin and CI paths accepted outbound targets or filesystem paths without a shared normalization layer. This change closes those gaps, makes explicit opt-ins required for private targets, and documents the repository's coordinated security disclosure process.

## Impact
- private/local database, S3, and custom geocoding targets are blocked by default unless the explicit opt-in env vars are enabled
- CI path handling now resolves entrypoints and output paths through a central safety helper
- the repository now exposes a canonical security policy for GitHub advisories and `security.txt` consumers

## Validation
- `pnpm nx run sva-studio-react:test:unit:server --testFiles=src/lib/instance-interface-healthcheck.server.test.ts`
- `pnpm nx run sva-studio-react:test:unit:hooks --testFiles=src/lib/map-geocoding-api.test.ts`
- `pnpm nx run auth-runtime:test:unit --testFiles=src/upstream-url-validation.test.ts`
- `pnpm nx run data:test:unit --testFiles=src/iam/repositories.test.ts --testFiles=src/iam/seed-files.test.ts --testFiles=src/iam/seed-plan.test.ts --testFiles=src/instance-registry/index.test.ts --testFiles=src/integrations/instance-integrations.test.ts --testFiles=src/runtime-safety.test.ts`
- `pnpm nx run monitoring-client:test:unit --testFiles=tests/otel-redaction.test.ts`
- `pnpm nx run sva-studio-react:test:types`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run monitoring-client:test:types`
- `pnpm nx run auth-runtime:check:runtime`
- `pnpm nx run monitoring-client:check:runtime`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm exec vitest run scripts/ci/path-safety.test.ts --reporter=verbose`
