### PR TITLE
fix(iam): restore mainserver credential warnings

### DIFF
--- a/apps/sva-studio-react/src/i18n/resources/de/admin/users.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/admin/users.resources.ts
@@ -226,6 +226,8 @@ export const usersAdminDEResources = {
     resultCount: '{{count}} Nutzer gefunden.',
     statusSwitchLabel: 'Aktivstatus für {{name}}',
     mainserverCredentialsMissing: 'Mainserver-Daten fehlen',
+    mainserverApplicationIdMissing: 'Mainserver Application-ID fehlt',
+    mainserverApplicationSecretMissing: 'Mainserver Application-Secret fehlt',
     syncRunning: 'Synchronisierung läuft ...',
     syncEmpty: 'Keine neuen oder geänderten Benutzer gefunden. {{skippedCount}} übersprungen.',
     syncResult:

--- a/apps/sva-studio-react/src/i18n/resources/en/admin/users.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/admin/users.resources.ts
@@ -223,6 +223,8 @@ export const usersAdminENResources = {
     resultCount: '{{count}} users found.',
     statusSwitchLabel: 'Active status for {{name}}',
     mainserverCredentialsMissing: 'Mainserver data missing',
+    mainserverApplicationIdMissing: 'Mainserver application ID is missing',
+    mainserverApplicationSecretMissing: 'Mainserver application secret is missing',
     syncRunning: 'Synchronization in progress ...',
     syncEmpty: 'No new or changed users found. {{skippedCount}} skipped.',
     syncResult:

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
@@ -9,7 +9,11 @@ const isIamBulkEnabledMock = vi.fn();
 const useAuthMock = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ to, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+  Link: ({
+    to,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
     <a href={to} {...props}>
       {children}
     </a>
@@ -43,7 +47,9 @@ const createUsersApiState = (overrides: Record<string, unknown> = {}) => ({
       email: 'alice@example.com',
       status: 'active',
       lastLoginAt: '2026-03-04T10:00:00Z',
-      roles: [{ roleId: 'role-1', roleKey: 'system_admin', roleName: 'system_admin', roleLevel: 90 }],
+      roles: [
+        { roleId: 'role-1', roleKey: 'system_admin', roleName: 'system_admin', roleLevel: 90 },
+      ],
     },
   ],
   total: 1,
@@ -116,8 +122,12 @@ describe('UserListPage', () => {
     render(<UserListPage />);
 
     expect(screen.getByRole('heading', { name: 'Benutzerverwaltung' })).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Nutzer anlegen' }).getAttribute('href')).toBe('/admin/users/new');
-    expect(screen.getAllByRole('link', { name: 'Bearbeiten' })[0]!.getAttribute('href')).toBe('/admin/users/$userId');
+    expect(screen.getByRole('link', { name: 'Nutzer anlegen' }).getAttribute('href')).toBe(
+      '/admin/users/new'
+    );
+    expect(screen.getAllByRole('link', { name: 'Bearbeiten' })[0]!.getAttribute('href')).toBe(
+      '/admin/users/$userId'
+    );
     expect(screen.getAllByRole('button', { name: 'Löschen' }).length).toBeGreaterThan(0);
   });
 
@@ -133,7 +143,13 @@ describe('UserListPage', () => {
             status: 'active',
             mappingStatus: 'manual_review',
             editability: 'blocked',
-            diagnostics: [{ code: 'missing_instance_attribute', objectId: 'subject-unmapped', objectType: 'user' }],
+            diagnostics: [
+              {
+                code: 'missing_instance_attribute',
+                objectId: 'subject-unmapped',
+                objectType: 'user',
+              },
+            ],
             roles: [],
           },
         ],
@@ -157,6 +173,58 @@ describe('UserListPage', () => {
       .forEach((button) => expect(button.hasAttribute('disabled')).toBe(true));
   });
 
+  it.each([
+    ['missing_application_id', 'Mainserver Application-ID fehlt'],
+    ['missing_application_secret', 'Mainserver Application-Secret fehlt'],
+    ['missing_both', 'Mainserver-Daten fehlen'],
+  ] as const)(
+    'shows a precise warning for credential status %s',
+    (mainserverCredentialStatus, label) => {
+      useUsersMock.mockReturnValue(
+        createUsersApiState({
+          users: [
+            {
+              id: 'user-1',
+              keycloakSubject: 'subject-1',
+              displayName: 'Alice',
+              status: 'active',
+              roles: [],
+              mainserverCredentialStatus,
+            },
+          ],
+        })
+      );
+
+      render(<UserListPage />);
+
+      expect(screen.getAllByRole('img', { name: label }).length).toBeGreaterThan(0);
+    }
+  );
+
+  it.each(['complete', 'unknown'] as const)(
+    'does not show a credential warning for status %s',
+    (mainserverCredentialStatus) => {
+      useUsersMock.mockReturnValue(
+        createUsersApiState({
+          users: [
+            {
+              id: 'user-1',
+              keycloakSubject: 'subject-1',
+              displayName: 'Alice',
+              status: 'active',
+              roles: [],
+              mainserverCredentialStatus,
+            },
+          ],
+        })
+      );
+
+      render(<UserListPage />);
+
+      expect(screen.queryByRole('img')).toBeNull();
+    }
+  );
+
   it('updates filters and pagination controls', () => {
     const setSearch = vi.fn();
     const setStatus = vi.fn();
@@ -176,7 +244,9 @@ describe('UserListPage', () => {
 
     render(<UserListPage />);
 
-    fireEvent.change(screen.getByPlaceholderText('Nach Name oder E-Mail suchen'), { target: { value: 'bob' } });
+    fireEvent.change(screen.getByPlaceholderText('Nach Name oder E-Mail suchen'), {
+      target: { value: 'bob' },
+    });
     fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'inactive' } });
     fireEvent.click(screen.getByRole('button', { name: 'Zurück' }));
     fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
@@ -209,7 +279,9 @@ describe('UserListPage', () => {
           {
             keycloakSubject: 'subject-2',
             mappingStatus: 'manual_review',
-            diagnostics: [{ code: 'missing_instance_attribute', objectId: 'subject-2', objectType: 'user' }],
+            diagnostics: [
+              { code: 'missing_instance_attribute', objectId: 'subject-2', objectType: 'user' },
+            ],
           },
         ],
       },
@@ -230,13 +302,15 @@ describe('UserListPage', () => {
 
     expect(refetch).toHaveBeenCalledTimes(1);
     await waitFor(() => expect(syncUsersFromKeycloak).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(screen.getByText(/6 geprüft: 3 korrigiert, 1 manuell prüfen/i)).toBeTruthy());
     await waitFor(() =>
-      expect(
-        screen.getByText(/Realm de-musterhausen, Quelle Instanz-Realm\./i)
-      ).toBeTruthy()
+      expect(screen.getByText(/6 geprüft: 3 korrigiert, 1 manuell prüfen/i)).toBeTruthy()
     );
-    expect(screen.getByText('1 Benutzerobjekte mit Diagnose: missing_instance_attribute')).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByText(/Realm de-musterhausen, Quelle Instanz-Realm\./i)).toBeTruthy()
+    );
+    expect(
+      screen.getByText('1 Benutzerobjekte mit Diagnose: missing_instance_attribute')
+    ).toBeTruthy();
     expect(screen.getByText(/teilweisen Fehlern oder manuellem Nachlauf/i)).toBeTruthy();
   });
 
@@ -302,7 +376,13 @@ describe('UserListPage', () => {
   it('confirms bulk mainserver reprovision and shows summarized feedback', async () => {
     const bulkReprovisionMainserver = vi.fn().mockResolvedValue({
       successes: [{ id: 'user-1' }],
-      failures: [{ id: 'user-2', code: 'conflict', message: 'Für den Nutzer ist keine E-Mail-Adresse hinterlegt.' }],
+      failures: [
+        {
+          id: 'user-2',
+          code: 'conflict',
+          message: 'Für den Nutzer ist keine E-Mail-Adresse hinterlegt.',
+        },
+      ],
       successCount: 1,
       failureCount: 1,
     });
@@ -335,14 +415,24 @@ describe('UserListPage', () => {
 
     render(<UserListPage />);
 
-    fireEvent.click(screen.getAllByRole('checkbox', { name: 'Benutzertabelle: Zeile user-1 auswählen' })[0]!);
-    fireEvent.click(screen.getAllByRole('checkbox', { name: 'Benutzertabelle: Zeile user-2 auswählen' })[0]!);
+    fireEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Benutzertabelle: Zeile user-1 auswählen' })[0]!
+    );
+    fireEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Benutzertabelle: Zeile user-2 auswählen' })[0]!
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Mainserver-Daten aktualisieren' }));
 
     expect(screen.getByText(/maximal 50/i)).toBeTruthy();
-    fireEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Mainserver-Daten aktualisieren' }));
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Mainserver-Daten aktualisieren',
+      })
+    );
 
-    await waitFor(() => expect(bulkReprovisionMainserver).toHaveBeenCalledWith(['user-1', 'user-2']));
+    await waitFor(() =>
+      expect(bulkReprovisionMainserver).toHaveBeenCalledWith(['user-1', 'user-2'])
+    );
     expect(screen.getByText('1 Nutzer erfolgreich aktualisiert.')).toBeTruthy();
     expect(screen.getByText('1 Nutzer konnten nicht aktualisiert werden.')).toBeTruthy();
     expect(screen.getByText(/user-2/)).toBeTruthy();
@@ -375,7 +465,9 @@ describe('UserListPage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Löschen' })[0]!);
     expect(screen.getByText(/physisch in Studio und Keycloak gelöscht/i)).toBeTruthy();
 
-    fireEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Löschen' }));
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Löschen' })
+    );
 
     await waitFor(() => expect(deleteUser).toHaveBeenCalledWith('user-2'));
   });
@@ -432,7 +524,14 @@ describe('UserListPage', () => {
             email: 'alice@example.com',
             status: 'inactive',
             lastLoginAt: '2026-03-04T10:00:00Z',
-            roles: [{ roleId: 'role-1', roleKey: 'system_admin', roleName: 'system_admin', roleLevel: 90 }],
+            roles: [
+              {
+                roleId: 'role-1',
+                roleKey: 'system_admin',
+                roleName: 'system_admin',
+                roleLevel: 90,
+              },
+            ],
           },
         ],
       })
@@ -444,13 +543,17 @@ describe('UserListPage', () => {
 
     expect(screen.getByText('Die ausgewählte Person wird wieder aktiviert.')).toBeTruthy();
 
-    fireEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Aktivieren' }));
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Aktivieren' })
+    );
 
     await waitFor(() => expect(updateUser).toHaveBeenCalledWith('user-1', { status: 'active' }));
   });
 
   it('renders platform user management on root scope without tenant mutations', () => {
-    useAuthMock.mockReturnValue({ user: { id: 'platform-admin', roles: ['instance_registry_admin'] } });
+    useAuthMock.mockReturnValue({
+      user: { id: 'platform-admin', roles: ['instance_registry_admin'] },
+    });
     useUsersMock.mockReturnValue(createUsersApiState());
 
     render(<UserListPage />);

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.test.tsx
@@ -221,7 +221,9 @@ describe('UserListPage', () => {
 
       render(<UserListPage />);
 
-      expect(screen.queryByRole('img')).toBeNull();
+      expect(screen.queryByRole('img', { name: 'Mainserver Application-ID fehlt' })).toBeNull();
+      expect(screen.queryByRole('img', { name: 'Mainserver Application-Secret fehlt' })).toBeNull();
+      expect(screen.queryByRole('img', { name: 'Mainserver-Daten fehlen' })).toBeNull();
     }
   );
 

--- a/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-list-page.tsx
@@ -4,8 +4,12 @@ import type {
   IamKeycloakObjectEditability,
   IamUserImportSyncReport,
 } from '@sva/core';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
-import { StudioDataTable, StudioListPageTemplate, type StudioColumnDef } from '@sva/studio-ui-react';
+import { IconAlertTriangle, IconEdit, IconTrash } from '@tabler/icons-react';
+import {
+  StudioDataTable,
+  StudioListPageTemplate,
+  type StudioColumnDef,
+} from '@sva/studio-ui-react';
 import { Link } from '@tanstack/react-router';
 import React from 'react';
 
@@ -20,7 +24,11 @@ import { Label } from '../../../components/ui/label';
 import { Select } from '../../../components/ui/select';
 import { Switch } from '../../../components/ui/switch';
 import { useUsers } from '../../../hooks/use-users';
-import { hasPlatformInstanceAdminAccess, hasUserDeleteAccess, isIamBulkEnabled } from '../../../lib/iam-admin-access';
+import {
+  hasPlatformInstanceAdminAccess,
+  hasUserDeleteAccess,
+  isIamBulkEnabled,
+} from '../../../lib/iam-admin-access';
 import { IamHttpError } from '../../../lib/iam-api';
 import { useAuth } from '../../../providers/auth-provider';
 import { t } from '../../../i18n';
@@ -82,6 +90,41 @@ const renderDiagnosticCodes = (diagnostics: readonly IamKeycloakObjectDiagnostic
 
 type UserListUser = UsersApiState['users'][number];
 
+const mainserverCredentialWarningTranslationKey = {
+  missing_application_id: 'admin.users.messages.mainserverApplicationIdMissing',
+  missing_application_secret: 'admin.users.messages.mainserverApplicationSecretMissing',
+  missing_both: 'admin.users.messages.mainserverCredentialsMissing',
+} as const;
+
+const UserDisplayNameCell = ({ user }: { user: UserListUser }) => {
+  const status = user.mainserverCredentialStatus ?? 'unknown';
+  const warningTranslationKey =
+    status === 'missing_application_id' ||
+    status === 'missing_application_secret' ||
+    status === 'missing_both'
+      ? mainserverCredentialWarningTranslationKey[status]
+      : undefined;
+
+  if (!warningTranslationKey) {
+    return user.displayName;
+  }
+
+  const warningLabel = t(warningTranslationKey);
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span>{user.displayName}</span>
+      <span
+        role="img"
+        aria-label={warningLabel}
+        title={warningLabel}
+        className="inline-flex text-amber-600"
+      >
+        <IconAlertTriangle aria-hidden="true" className="h-4 w-4 stroke-current" />
+      </span>
+    </span>
+  );
+};
+
 const UserStatusCell = ({
   user,
   isAuthLoading,
@@ -136,12 +179,12 @@ const UserKeycloakCell = ({ user }: { user: UserListUser }) => {
 const buildUserColumns = (
   isAuthLoading: boolean,
   isPlatformScope: boolean,
-  onStatusAction: (action: 'activate' | 'deactivate', userId: string) => void,
+  onStatusAction: (action: 'activate' | 'deactivate', userId: string) => void
 ): readonly StudioColumnDef<UserListUser>[] => [
   {
     id: 'displayName',
     header: t('admin.users.table.headerName'),
-    cell: (user) => user.displayName,
+    cell: (user) => <UserDisplayNameCell user={user} />,
     sortable: true,
     sortValue: (user) => user.displayName.toLowerCase(),
   },
@@ -205,7 +248,9 @@ const UserListToolbarStart = ({ usersApi }: { usersApi: UsersApiState }) => (
       <Select
         id="users-status"
         value={usersApi.filters.status}
-        onChange={(event) => usersApi.setStatus(event.target.value as 'active' | 'inactive' | 'pending' | 'all')}
+        onChange={(event) =>
+          usersApi.setStatus(event.target.value as 'active' | 'inactive' | 'pending' | 'all')
+        }
       >
         <option value="all">{t('admin.users.filters.statusAll')}</option>
         <option value="active">{t('admin.users.filters.statusActive')}</option>
@@ -235,7 +280,9 @@ const UserListToolbarEnd = ({
       disabled={syncStatus === 'pending'}
       onClick={() => void onSyncUsers()}
     >
-      {syncStatus === 'pending' ? t('admin.users.actions.syncing') : t('admin.users.actions.syncKeycloak')}
+      {syncStatus === 'pending'
+        ? t('admin.users.actions.syncing')
+        : t('admin.users.actions.syncKeycloak')}
     </Button>
   </>
 );
@@ -375,7 +422,9 @@ const UserListBulkReprovisionFeedback = ({
     return null;
   }
 
-  const renderFailureMessage = (failure: NonNullable<BulkReprovisionFeedbackState>['failures'][number]) => {
+  const renderFailureMessage = (
+    failure: NonNullable<BulkReprovisionFeedbackState>['failures'][number]
+  ) => {
     const localizedMessage = userErrorMessage(
       new IamHttpError({
         status: failure.code === 'not_found' ? 404 : failure.code === 'forbidden' ? 403 : 409,
@@ -384,7 +433,8 @@ const UserListBulkReprovisionFeedback = ({
       }),
       'mutation'
     );
-    return localizedMessage === t('admin.users.messages.mutationError') && failure.message.trim().length > 0
+    return localizedMessage === t('admin.users.messages.mutationError') &&
+      failure.message.trim().length > 0
       ? failure.message
       : localizedMessage;
   };
@@ -392,10 +442,17 @@ const UserListBulkReprovisionFeedback = ({
   return (
     <Alert className="border-secondary/40 bg-secondary/10 text-secondary" role="status">
       <AlertDescription className="flex flex-col gap-2">
-        <span>{t('admin.users.messages.bulkReprovisionSuccessCount', { count: feedback.successCount })}</span>
-        <span>{t('admin.users.messages.bulkReprovisionFailureCount', { count: feedback.failureCount })}</span>
+        <span>
+          {t('admin.users.messages.bulkReprovisionSuccessCount', { count: feedback.successCount })}
+        </span>
+        <span>
+          {t('admin.users.messages.bulkReprovisionFailureCount', { count: feedback.failureCount })}
+        </span>
         {feedback.failures.length > 0 ? (
-          <ul className="list-disc pl-5 text-xs text-muted-foreground" aria-label={t('admin.users.messages.bulkReprovisionFailuresLabel')}>
+          <ul
+            className="list-disc pl-5 text-xs text-muted-foreground"
+            aria-label={t('admin.users.messages.bulkReprovisionFailuresLabel')}
+          >
             {feedback.failures.map((failure) => (
               <li key={failure.id}>
                 {t('admin.users.messages.bulkReprovisionFailureItem', {
@@ -461,7 +518,8 @@ const UserListRowActions = ({
   user: UserListUser;
 }) => {
   const editBlocked = user.editability === 'blocked';
-  const deleteBlocked = editBlocked || user.editability === 'read_only' || hasSystemAdminTargetRole(user);
+  const deleteBlocked =
+    editBlocked || user.editability === 'read_only' || hasSystemAdminTargetRole(user);
   const deleteDisabledReason = hasSystemAdminTargetRole(user)
     ? t('admin.users.confirm.deleteSystemAdminDisabled')
     : t('admin.users.actions.delete');
@@ -541,7 +599,9 @@ export const UserListPage = () => {
     <section className="space-y-5" aria-busy={usersApi.isLoading}>
       <StudioListPageTemplate
         title={t(isPlatformScope ? 'admin.users.page.platformTitle' : 'admin.users.page.title')}
-        description={t(isPlatformScope ? 'admin.users.page.platformSubtitle' : 'admin.users.page.subtitle')}
+        description={t(
+          isPlatformScope ? 'admin.users.page.platformSubtitle' : 'admin.users.page.subtitle'
+        )}
         primaryAction={
           isPlatformScope || isAuthLoading
             ? undefined
@@ -556,16 +616,23 @@ export const UserListPage = () => {
         }
       >
         <StudioDataTable
-          ariaLabel={t(isPlatformScope ? 'admin.users.table.platformAriaLabel' : 'admin.users.table.ariaLabel')}
+          ariaLabel={t(
+            isPlatformScope ? 'admin.users.table.platformAriaLabel' : 'admin.users.table.ariaLabel'
+          )}
           labels={studioDataTableLabels}
-          caption={t(isPlatformScope ? 'admin.users.table.platformCaption' : 'admin.users.table.caption')}
+          caption={t(
+            isPlatformScope ? 'admin.users.table.platformCaption' : 'admin.users.table.caption'
+          )}
           data={usersApi.users}
           columns={userColumns}
           getRowId={(user) => user.id}
           isLoading={usersApi.isLoading}
           loadingState={t('content.messages.loading')}
           emptyState={
-            <Card className="border-none p-0 text-sm text-muted-foreground shadow-none" role="status">
+            <Card
+              className="border-none p-0 text-sm text-muted-foreground shadow-none"
+              role="status"
+            >
               {t('admin.users.messages.emptyState')}
             </Card>
           }
@@ -576,7 +643,8 @@ export const UserListPage = () => {
                     id: 'bulk-deactivate',
                     label: t('admin.users.actions.bulkDeactivate'),
                     variant: 'destructive',
-                    onClick: ({ selectedRows }) => openBulkDeactivate(selectedRows.map((user) => user.id)),
+                    onClick: ({ selectedRows }) =>
+                      openBulkDeactivate(selectedRows.map((user) => user.id)),
                   },
                   {
                     id: 'bulk-reprovision-mainserver',
@@ -588,7 +656,13 @@ export const UserListPage = () => {
               : []
           }
           toolbarStart={<UserListToolbarStart usersApi={usersApi} />}
-          toolbarEnd={<UserListToolbarEnd syncStatus={syncStatus} total={usersApi.total} onSyncUsers={onSyncUsers} />}
+          toolbarEnd={
+            <UserListToolbarEnd
+              syncStatus={syncStatus}
+              total={usersApi.total}
+              onSyncUsers={onSyncUsers}
+            />
+          }
           rowActions={
             isPlatformScope || isAuthLoading
               ? undefined
@@ -614,7 +688,11 @@ export const UserListPage = () => {
 
       <UserListErrorAlert error={usersApi.error} onRetry={() => void usersApi.refetch()} />
 
-      <UserListPaginationFooter page={usersApi.page} pageCount={pageCount} setPage={usersApi.setPage} />
+      <UserListPaginationFooter
+        page={usersApi.page}
+        pageCount={pageCount}
+        setPage={usersApi.setPage}
+      />
 
       <ConfirmDialog
         open={Boolean(statusActionDialog)}

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -590,14 +590,15 @@ Fehlerpfad:
 2. Liste wird paginiert über `GET /api/v1/iam/users` geladen.
 3. Bearbeitung erfolgt in `/admin/users/$userId` per Tabs und `PATCH /api/v1/iam/users/$userId`.
 4. Von der Detailansicht aus können Admins zusätzlich Passwort-Einladungen erneut auslösen und Mainserver-Credentials über `POST /api/v1/iam/users/$userId/reprovision-mainserver` neu provisionieren.
-5. Rollen-Änderungen triggern Permission-Invalidierung über `pg_notify`.
-6. `system_admin` verwaltet Custom-Rollen auf `/admin/roles` mit `POST/PATCH/DELETE /api/v1/iam/roles`.
-7. Auf Tenant-Hosts löst der Backend-Service den Adminpfad strikt aus `iam.instances.authRealm` plus `tenantAdminClient.clientId` und tenantlokalem Admin-Secret auf und führt Rollen- und Nutzer-CRUD Keycloak-First innerhalb desselben Tenant-Realms aus.
-8. Root-/Plattform-Pfade verwenden einen separaten Plattform-Admin-Client nur für Instanz-Provisioning, Reconcile und explizites Break-Glass.
-9. Beim Löschen einer Custom-Rolle entfernt der Service nach erfolgreichem Tenant-Sync zuerst direkte Benutzer- und Gruppenzuordnungen der Rolle und danach das lokale IAM-Mapping.
-10. Die Admin-UI zeigt vor dem Bestätigen nur eine allgemeine Warnung an, dass damit auch bestehende Benutzer- und Gruppenzuordnungen entfernt werden.
-11. Bei Erfolg werden `role.sync_succeeded` und `role.created|updated|deleted` auditierbar protokolliert; der Löschpfad ergänzt dabei Zähler für entfernte Benutzer- und Gruppenzuordnungen.
-12. Bei Fehlern werden `sync_state`, `last_error_code`, Metriken und `role.sync_failed` aktualisiert.
+5. Die Benutzerliste leitet den technischen Mainserver-Credential-Status aus den Attributen der bereits geladenen Keycloak-Benutzerprojektion ab. Fehlende Application-ID, fehlendes Secret und vollständig fehlende Credentials werden getrennt ausgewiesen; ein nicht bestimmbarer Zustand bleibt neutral. Dadurch entstehen keine zusätzlichen Keycloak-Aufrufe pro Tabellenzeile und keine Credential-Werte gelangen in den Browser.
+6. Rollen-Änderungen triggern Permission-Invalidierung über `pg_notify`.
+7. `system_admin` verwaltet Custom-Rollen auf `/admin/roles` mit `POST/PATCH/DELETE /api/v1/iam/roles`.
+8. Auf Tenant-Hosts löst der Backend-Service den Adminpfad strikt aus `iam.instances.authRealm` plus `tenantAdminClient.clientId` und tenantlokalem Admin-Secret auf und führt Rollen- und Nutzer-CRUD Keycloak-First innerhalb desselben Tenant-Realms aus.
+9. Root-/Plattform-Pfade verwenden einen separaten Plattform-Admin-Client nur für Instanz-Provisioning, Reconcile und explizites Break-Glass.
+10. Beim Löschen einer Custom-Rolle entfernt der Service nach erfolgreichem Tenant-Sync zuerst direkte Benutzer- und Gruppenzuordnungen der Rolle und danach das lokale IAM-Mapping.
+11. Die Admin-UI zeigt vor dem Bestätigen nur eine allgemeine Warnung an, dass damit auch bestehende Benutzer- und Gruppenzuordnungen entfernt werden.
+12. Bei Erfolg werden `role.sync_succeeded` und `role.created|updated|deleted` auditierbar protokolliert; der Löschpfad ergänzt dabei Zähler für entfernte Benutzer- und Gruppenzuordnungen.
+13. Bei Fehlern werden `sync_state`, `last_error_code`, Metriken und `role.sync_failed` aktualisiert.
 
 Fehlerpfad:
 

--- a/docs/changelog/entries/pr-704.json
+++ b/docs/changelog/entries/pr-704.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 704,
+  "body": "Die Benutzerverwaltung zeigt unvollständige persönliche Mainserver-Zugangsdaten wieder direkt in der Nutzerliste an.\n\n- Fehlende Application-ID, fehlendes Application-Secret und vollständig fehlende Zugangsdaten werden mit einer passenden Warnung unterschieden.\n- Die Prüfung verwendet die bereits geladene Keycloak-Benutzerprojektion und erzeugt keine zusätzlichen Keycloak-Aufrufe pro Tabellenzeile.\n- Ein vorübergehend nicht bestimmbarer Status bleibt neutral, damit technische Ausfälle nicht fälschlich als fehlende Zugangsdaten erscheinen."
+}

--- a/openspec/specs/account-ui/spec.md
+++ b/openspec/specs/account-ui/spec.md
@@ -1,8 +1,11 @@
 # account-ui Specification
 
 ## Purpose
+
 TBD - created by archiving change add-account-user-management-ui. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Auth-State-Provider
 
 Das System MUST einen zentralen React-Context (`AuthProvider` in `sva-studio-react`) bereitstellen, der den Authentifizierungs-State anwendungsweit verfügbar macht, verteilte `/auth/me`-Aufrufe durch einen einheitlichen `useAuth()`-Hook ersetzt und Auth-Unterbrechungen strukturiert diagnostizierbar macht.
@@ -334,6 +337,14 @@ Das System MUST serverseitige API-Endpunkte unter `/api/v1/iam/` für User-CRUD,
 - **DANN** enthält die Antwort `mainserverUserApplicationId`, falls in Keycloak gesetzt
 - **UND** die Antwort enthält einen booleschen Status, ob `mainserverUserApplicationSecret` vorhanden ist
 - **UND** der Klartext des Secrets wird nie an den Browser übertragen
+
+#### Scenario: Benutzertabelle warnt bei unvollständigen Mainserver-Credentials
+
+- **WENN** die bereits geladene Keycloak-Benutzerprojektion eine fehlende Mainserver Application-ID, ein fehlendes Mainserver Application-Secret oder vollständig fehlende Mainserver-Credentials enthält
+- **DANN** zeigt die Benutzertabelle am betroffenen Konto eine zugängliche, ursachenspezifische Warnung
+- **UND** ein nicht bestimmbarer Credential-Status wird nicht als fehlende Credentials dargestellt
+- **UND** die Prüfung erzeugt keine zusätzlichen Keycloak-Aufrufe pro Tabellenzeile
+- **UND** weder Application-ID noch Secret werden dafür an den Browser übertragen
 
 ### Requirement: Gruppenverwaltung im Admin-Bereich
 
@@ -913,60 +924,72 @@ Die Account-UI SHALL Packages fuer Admin-Ressourcen nur deklarative UI-Beitraege
 The Studio admin UI SHALL allow authorized platform and tenant admins to use Studio as an alternative UI for Keycloak user and role administration.
 
 #### Scenario: Complete user list with edit affordances
+
 - **WHEN** ein Admin `/admin/users` öffnet
 - **THEN** zeigt die UI alle im aktiven Scope relevanten Keycloak-User mit Such-, Status-, Rollen- und Mapping-Filtern
 - **AND** zeigt pro User, ob Bearbeitung, Deaktivierung und Rollenzuordnung möglich, read-only oder blockiert ist
 
 #### Scenario: Complete role list with edit affordances
+
 - **WHEN** ein Admin `/admin/roles` öffnet
 - **THEN** zeigt die UI alle im aktiven Scope relevanten Keycloak-Rollen mit Such-, Typ- und Bearbeitbarkeitsfiltern
 - **AND** unterscheidet Built-in-, externe und Studio-managed Rollen sichtbar
 
 #### Scenario: Sync diagnostics are actionable
+
 - **WHEN** ein Sync oder Reconcile `partial_failure`, `blocked` oder `failed` meldet
 - **THEN** zeigt die UI Zähler, Diagnosecodes und betroffene User/Rollen
 - **AND** bietet nur Aktionen an, die im aktiven Scope und laut Bearbeitbarkeitsmatrix erlaubt sind
 
 ### Requirement: Shared Studio UI React Package
+
 The system SHALL provide `@sva/studio-ui-react` as the shared React UI package for host pages and plugin custom views.
 
 #### Scenario: Host page uses shared UI
+
 - **GIVEN** a host-owned overview or detail page is implemented
 - **WHEN** the page needs reusable Studio layout, controls, actions, or state components
 - **THEN** it imports them from `@sva/studio-ui-react`
 - **AND** it does not import reusable Studio UI from app-internal component paths
 
 #### Scenario: Plugin custom view uses shared UI
+
 - **GIVEN** a plugin provides a custom React view
 - **WHEN** the view renders Studio page structure, form controls, actions, or feedback states
 - **THEN** it uses `@sva/studio-ui-react` components
 - **AND** it does not define a parallel basis control system for buttons, inputs, tables, tabs, dialogs, or alerts
 
 #### Scenario: Plugin uses domain wrapper around shared UI
+
 - **GIVEN** a plugin needs a domain-specific field, action, or status component
 - **WHEN** the component is implemented
 - **THEN** it composes primitives from `@sva/studio-ui-react`
 - **AND** it does not redefine shared visual variants, focus behavior, ARIA semantics, or design tokens
 
 ### Requirement: Studio UI React Overview and Detail Templates
+
 The system SHALL provide reusable overview and detail templates that encode the Studio page standards for headings, resource identity, actions, navigation, work surfaces, and state handling.
 
 #### Scenario: Overview page renders with standard structure
+
 - **GIVEN** a host or plugin overview page uses `StudioOverviewPageTemplate`
 - **WHEN** the page is rendered
 - **THEN** the visible structure contains page heading, optional primary action, toolbar slot, content slot, and pagination or result-state slot
 - **AND** loading, empty, error, and forbidden states are rendered through shared Studio state components
 
 #### Scenario: Detail page renders with standard structure
+
 - **GIVEN** a host or plugin detail page uses `StudioDetailPageTemplate`
 - **WHEN** the page is rendered
 - **THEN** the visible structure contains return or breadcrumb context, page heading, primary action slot, resource header slot, detail navigation slot, and active work surface
 - **AND** resource identity, status badges, metadata, and destructive actions follow shared Studio patterns
 
 ### Requirement: Studio UI React Form Controls
+
 The system SHALL provide form composition primitives that standardize labels, required markers, descriptions, validation states, and accessible field relationships.
 
 #### Scenario: Field with validation error
+
 - **GIVEN** a Studio form field has a validation error
 - **WHEN** the field is rendered
 - **THEN** the control exposes `aria-invalid`
@@ -974,26 +997,31 @@ The system SHALL provide form composition primitives that standardize labels, re
 - **AND** the visual state is consistent across host and plugin forms
 
 #### Scenario: Plugin form uses specialized field
+
 - **GIVEN** a plugin needs a specialized editor such as upload, rich text, media, color, icon, rating, or geo selection
 - **WHEN** the specialized editor is implemented
 - **THEN** it is wrapped as a Studio component or composed from `@sva/studio-ui-react` primitives
 - **AND** it preserves label, description, validation, disabled, and read-only semantics
 
 ### Requirement: Plugin Custom Views Preserve Studio UX Contracts
+
 The system SHALL allow plugin custom views only when they preserve Studio shell, layout, accessibility, action, and state contracts through `@sva/studio-ui-react`.
 
 #### Scenario: Plugin custom view is accepted
+
 - **GIVEN** a plugin registers or exports a custom admin view
 - **WHEN** the host validates or reviews the view integration
 - **THEN** the view uses `@sva/studio-ui-react` for common layout, controls, actions, and states
 - **AND** any deviation from shared Studio UI is documented as an architecture decision
 
 #### Scenario: Plugin custom view imports app internals
+
 - **GIVEN** a plugin custom view imports from `apps/sva-studio-react/src/components`
 - **WHEN** lint, boundary, or CI checks run
 - **THEN** the check fails with a message that directs the plugin to `@sva/studio-ui-react`
 
 #### Scenario: Plugin defines duplicate basis control
+
 - **GIVEN** a plugin defines or exports a reusable basis control that duplicates an available Studio UI component
 - **WHEN** lint, CI, or review checks run
 - **THEN** the contribution is rejected or changed to compose `@sva/studio-ui-react`
@@ -1228,22 +1256,27 @@ Das System MUST in der Organisationsverwaltung eine abgesicherte Pflege organisa
 - **UND** die Oberfläche sendet keinen leeren oder `null`-basierten Secret-Wert als impliziten Revoke-Request
 
 ### Requirement: Rollen-Detailseite pflegt Assignment-Scopes fuer scope-faehige Rechte
+
 Das System SHALL in der Rollen-Detailseite fuer scope-faehige Datensatzrechte neben der Zuweisung auch den Assignment-Scope pflegbar machen.
 
 #### Scenario: Scope-Selector erscheint nur fuer geeignete Rechte
+
 - **WHEN** ein Administrator den Permissions-Tab einer editierbaren Rolle oeffnet
 - **THEN** zeigt die UI fuer scope-faehige Rechte einen Selector fuer `all`, `own` und `organization`
 - **AND** nicht scope-faehige Rechte bleiben binaer zuweisbar
 
 #### Scenario: Speichern sendet strukturierte Permission-Assignments
+
 - **WHEN** ein Administrator Rechte- oder Scope-Aenderungen speichert
 - **THEN** sendet die UI `permissionAssignments[]` mit `permissionId` und `accessScope`
 - **AND** neu zugewiesene scope-faehige Rechte erhalten standardmaessig `all`
 
 ### Requirement: Nutzeransicht zeigt effektive Permission-Scopes transparent an
+
 Das System SHALL in der Nutzer-Berechtigungsansicht den effektiven Assignment-Scope rollen- oder gruppenvermittelter Datensatzrechte sichtbar machen.
 
 #### Scenario: Effektiver Scope wird im Permission Trace dargestellt
+
 - **WHEN** ein Administrator den Tab `Berechtigungen` einer Nutzerdetailseite betrachtet
 - **THEN** enthalten effektive Permission-Trace-Eintraege den wirksamen Assignment-Scope
 - **AND** die Darstellung bleibt read-only
@@ -1273,35 +1306,43 @@ Das System SHALL innerhalb des IAM-Bereichs eigenständige Detailseiten für Gov
 - **UND** die Rückkehr bleibt ohne manuelles Neuwählen des Fachbereichs verständlich und erwartbar
 
 ### Requirement: Tenant-Rollenverwaltung zeigt keine Root-Plattformrolle als tenantlokales Artefakt
+
 Das System SHALL in tenantlokalen Rollen- und Benutzerverwaltungsansichten die Plattformrolle `instance_registry_admin` nicht als zuweisbare Tenant-Rolle darstellen.
 
 #### Scenario: Tenant-Rollenliste blendet Root-Plattformrolle aus
+
 - **WHEN** ein Administrator die tenantlokale Rollenverwaltung unter `/admin/roles` öffnet
 - **THEN** erscheint `instance_registry_admin` dort nicht als tenantseitig verwaltbare Rolle
 - **AND** die Ansicht bleibt auf tenantlokale Rollen des aktiven Tenant-Realm beschränkt
 
 #### Scenario: Tenant-Benutzerbearbeitung bietet keine Root-Plattformrolle an
+
 - **WHEN** ein Administrator im Tenant-Realm Rollen für einen Benutzer bearbeitet
 - **THEN** ist `instance_registry_admin` nicht als auswählbare Rollenzuweisung verfügbar
 - **AND** die UI behandelt tenantlokale und Root-Rollen nicht als gemeinsamen Katalog
 
 ### Requirement: Tenant-Rollenverwaltung erlaubt individuelle Rechtezuschnitte ohne Standardrollenpflicht
+
 Das System SHALL in der tenantlokalen Rollenverwaltung die Zuordnung von Rechten zu individuellen Rollen unterstützen, ohne kanonische Standardrollen als Primärmodell vorauszusetzen.
 
 #### Scenario: Individuelle Rolle erhält modulbezogene Rechte
+
 - **WHEN** ein Administrator eine editierbare tenantlokale Rolle erstellt oder bearbeitet
 - **THEN** kann er modulbezogene und tenantlokale Rechte direkt über die Rollenverwaltung zuweisen
 - **AND** die UI verlangt dafür keine Auswahl oder Kopplung an Rollen wie `editor`, `designer` oder `app_manager`
 
 ### Requirement: UI-Gates behandeln system_admin als vollständigen Tenant-Vollzugriff
+
 Das System SHALL tenantlokale Navigations-, Aktions- und Verwaltungs-Gates so auswerten, dass ein Benutzer mit `system_admin` die vollständigen vorgesehenen Tenant-Admin-Funktionen nutzen kann, ohne zusätzliche versteckte Rollen- oder Gruppenabhängigkeiten.
 
 #### Scenario: Sidebar und Admin-Funktionen bleiben für system_admin sichtbar
+
 - **WHEN** ein Benutzer im Tenant-Realm ausschließlich `system_admin` besitzt
 - **THEN** bleiben die für Tenant-Administratoren vorgesehenen Navigationspunkte, Verwaltungsseiten und Aktionen sichtbar und nutzbar
 - **AND** ihre Verfügbarkeit hängt nicht zusätzlich von Gruppen wie `admins` oder Rollen wie `core_admin` ab
 
 ### Requirement: GUI-gestuetzter Authorize-Performance-Lauf im Monitoring
+
 Das System MUST im bestehenden Monitoring-Bereich unter `/monitoring` einen bedienbaren Bereich fuer einen sessiongebundenen Authorize-Performance-Lauf bereitstellen.
 
 #### Scenario: Berechtigter Administrator findet den Lauf im Monitoring-Menue
@@ -1437,4 +1478,3 @@ Das System MUST in den Account-/Privacy-Oberflächen die tenantweiten Löschrege
 - **DANN** zeigt die UI die tenantweite Default-Inhaltsstrategie als wirksamen Zustand
 - **UND** erklärt, dass nur eigene Inhalte im Scope `iam.contents` betroffen sind
 - **UND** bleibt die Oberfläche tastaturbedienbar, screenreader-tauglich und mit klaren Leer-, Lade- und Fehlerzuständen ausgestattet
-

--- a/packages/auth-runtime/src/iam-account-management/tenant-keycloak-users.test.ts
+++ b/packages/auth-runtime/src/iam-account-management/tenant-keycloak-users.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   loadMappedUsersBySubject: vi.fn(),
   mapUnmappedKeycloakUser: vi.fn(),
   mergeMappedUserWithKeycloak: vi.fn(),
+  resolveMainserverCredentialStatus: vi.fn(),
 }));
 
 vi.mock('./shared-runtime.js', () => ({
@@ -18,6 +19,10 @@ vi.mock('./shared-runtime.js', () => ({
       listUserRoleNames: mocks.listUserRoleNames,
     },
   })),
+}));
+
+vi.mock('../mainserver-credentials.js', () => ({
+  resolveMainserverCredentialStatus: mocks.resolveMainserverCredentialStatus,
 }));
 
 vi.mock('@sva/iam-admin', () => ({
@@ -41,6 +46,7 @@ vi.mock('./shared-observability.js', () => ({
 describe('tenant keycloak users', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveMainserverCredentialStatus.mockReturnValue('unknown');
   });
 
   it('maps unmapped keycloak users without leaking the tenant instance id into the projection', async () => {
@@ -71,7 +77,11 @@ describe('tenant keycloak users', () => {
     });
 
     expect(result.users).toEqual([projectedUser]);
-    expect(mocks.mapUnmappedKeycloakUser).toHaveBeenCalledWith(keycloakUser, ['tenant_admin']);
+    expect(mocks.mapUnmappedKeycloakUser).toHaveBeenCalledWith(
+      keycloakUser,
+      ['tenant_admin'],
+      'unknown'
+    );
   });
 
   it('uses the local query path for role-filtered listings instead of scanning all keycloak users', async () => {

--- a/packages/auth-runtime/src/iam-account-management/tenant-keycloak-users.ts
+++ b/packages/auth-runtime/src/iam-account-management/tenant-keycloak-users.ts
@@ -1,6 +1,10 @@
 import type { IamUserListItem } from '@sva/core';
 
-import type { IdentityListedUser, IdentityProviderPort, IdentityUserListQuery } from '../identity-provider-port.js';
+import type {
+  IdentityListedUser,
+  IdentityProviderPort,
+  IdentityUserListQuery,
+} from '../identity-provider-port.js';
 import {
   KeycloakAdminRequestError,
   KeycloakAdminUnavailableError,
@@ -10,8 +14,12 @@ import type { QueryClient } from '../db.js';
 import { resolveIdentityProviderForInstance } from './shared-runtime.js';
 import { logger, trackKeycloakCall } from './shared-observability.js';
 import { loadMappedUsersBySubject } from './tenant-keycloak-user-query.js';
-import { mapUnmappedKeycloakUser, mergeMappedUserWithKeycloak } from './tenant-keycloak-user-projection.js';
+import {
+  mapUnmappedKeycloakUser,
+  mergeMappedUserWithKeycloak,
+} from './tenant-keycloak-user-projection.js';
 import type { UserStatus } from './types.js';
+import { resolveMainserverCredentialStatus } from '../mainserver-credentials.js';
 
 const TENANT_USER_ROLE_PROJECTION_CONCURRENCY = 5;
 
@@ -55,7 +63,11 @@ const resolveRoleNamesForUsers = async (input: {
   const workers = Array.from(
     { length: Math.min(TENANT_USER_ROLE_PROJECTION_CONCURRENCY, input.users.length) },
     async (_, workerIndex) => {
-      for (let index = workerIndex; index < input.users.length; index += TENANT_USER_ROLE_PROJECTION_CONCURRENCY) {
+      for (
+        let index = workerIndex;
+        index < input.users.length;
+        index += TENANT_USER_ROLE_PROJECTION_CONCURRENCY
+      ) {
         const user = input.users[index];
         if (!user) {
           continue;
@@ -63,10 +75,15 @@ const resolveRoleNamesForUsers = async (input: {
         try {
           roleNamesBySubject.set(
             user.externalId,
-            await trackKeycloakCall('list_tenant_user_roles', () => input.provider.listUserRoleNames(user.externalId))
+            await trackKeycloakCall('list_tenant_user_roles', () =>
+              input.provider.listUserRoleNames(user.externalId)
+            )
           );
         } catch (error) {
-          if (!(error instanceof KeycloakAdminRequestError) && !(error instanceof KeycloakAdminUnavailableError)) {
+          if (
+            !(error instanceof KeycloakAdminRequestError) &&
+            !(error instanceof KeycloakAdminUnavailableError)
+          ) {
             throw error;
           }
           logger.warn('Tenant user role projection degraded', {
@@ -108,15 +125,14 @@ export const resolveTenantKeycloakUsersWithPagination = async (
       users: localResult.users,
       total: localResult.total,
       keycloakRoleNamesBySubject: new Map(
-        localResult.users.map((user) => [
-          user.keycloakSubject,
-          null,
-        ] as const)
+        localResult.users.map((user) => [user.keycloakSubject, null] as const)
       ),
     };
   }
 
-  const identityProvider = await resolveIdentityProviderForInstance(input.instanceId, { executionMode: 'tenant_admin' });
+  const identityProvider = await resolveIdentityProviderForInstance(input.instanceId, {
+    executionMode: 'tenant_admin',
+  });
   if (!identityProvider) {
     throw new Error('tenant_admin_client_not_configured');
   }
@@ -143,15 +159,19 @@ export const resolveTenantKeycloakUsersWithPagination = async (
   const users = visibleUsers.map((user) => {
     const roleNames = roleNamesBySubject.get(user.externalId) ?? null;
     const mapped = mappedUsersBySubject.get(user.externalId);
+    const mainserverCredentialStatus = resolveMainserverCredentialStatus(user.attributes);
     return mapped
-      ? mergeMappedUserWithKeycloak(mapped, user, roleNames)
-      : mapUnmappedKeycloakUser(user, roleNames);
+      ? mergeMappedUserWithKeycloak(mapped, user, roleNames, mainserverCredentialStatus)
+      : mapUnmappedKeycloakUser(user, roleNames, mainserverCredentialStatus);
   });
 
   const total = (await identityProvider.provider.countUsers?.(query)) ?? users.length;
 
   const visibleRoleNamesBySubject = new Map(
-    users.map((user) => [user.keycloakSubject, roleNamesBySubject.get(user.keycloakSubject) ?? null] as const)
+    users.map(
+      (user) =>
+        [user.keycloakSubject, roleNamesBySubject.get(user.keycloakSubject) ?? null] as const
+    )
   );
 
   return { users, total, keycloakRoleNamesBySubject: visibleRoleNamesBySubject };

--- a/packages/auth-runtime/src/mainserver-credentials.test.ts
+++ b/packages/auth-runtime/src/mainserver-credentials.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 const state = vi.hoisted(() => ({
   resolveIdentityProvider: vi.fn(),
   resolveIdentityProviderForInstance: vi.fn(),
-  trackKeycloakCall: vi.fn(async (_operation: string, execute: () => Promise<unknown>) => execute()),
+  trackKeycloakCall: vi.fn(async (_operation: string, execute: () => Promise<unknown>) =>
+    execute()
+  ),
 }));
 
 vi.mock('./keycloak-user-attributes.js', () => ({
@@ -13,6 +15,25 @@ vi.mock('./keycloak-user-attributes.js', () => ({
 }));
 
 describe('readSvaMainserverCredentials', () => {
+  it('classifies complete, partial, missing and unavailable credential states', async () => {
+    const { resolveMainserverCredentialStatus } = await import('./mainserver-credentials.js');
+
+    expect(
+      resolveMainserverCredentialStatus({
+        mainserverUserApplicationId: ['app-id'],
+        mainserverUserApplicationSecret: ['secret'],
+      })
+    ).toBe('complete');
+    expect(resolveMainserverCredentialStatus({ mainserverUserApplicationSecret: ['secret'] })).toBe(
+      'missing_application_id'
+    );
+    expect(resolveMainserverCredentialStatus({ mainserverUserApplicationId: ['app-id'] })).toBe(
+      'missing_application_secret'
+    );
+    expect(resolveMainserverCredentialStatus({})).toBe('missing_both');
+    expect(resolveMainserverCredentialStatus(undefined)).toBe('unknown');
+  });
+
   it('returns credentials from the current keycloak attributes', async () => {
     state.resolveIdentityProvider.mockReturnValue({
       provider: {
@@ -125,9 +146,8 @@ describe('readSvaMainserverCredentials', () => {
       },
     });
 
-    const { readIdentityUserAttributes, resolveMainserverCredentialState } = await import(
-      './mainserver-credentials.js'
-    );
+    const { readIdentityUserAttributes, resolveMainserverCredentialState } =
+      await import('./mainserver-credentials.js');
 
     const attributes = await readIdentityUserAttributes({ keycloakSubject: 'subject-1' });
     expect(resolveMainserverCredentialState(attributes)).toEqual({

--- a/packages/auth-runtime/src/mainserver-credentials.test.ts
+++ b/packages/auth-runtime/src/mainserver-credentials.test.ts
@@ -31,7 +31,8 @@ describe('readSvaMainserverCredentials', () => {
       'missing_application_secret'
     );
     expect(resolveMainserverCredentialStatus({})).toBe('missing_both');
-    expect(resolveMainserverCredentialStatus(undefined)).toBe('unknown');
+    expect(resolveMainserverCredentialStatus(undefined)).toBe('missing_both');
+    expect(resolveMainserverCredentialStatus(null)).toBe('unknown');
   });
 
   it('returns credentials from the current keycloak attributes', async () => {

--- a/packages/auth-runtime/src/mainserver-credentials.test.ts
+++ b/packages/auth-runtime/src/mainserver-credentials.test.ts
@@ -31,7 +31,7 @@ describe('readSvaMainserverCredentials', () => {
       'missing_application_secret'
     );
     expect(resolveMainserverCredentialStatus({})).toBe('missing_both');
-    expect(resolveMainserverCredentialStatus(undefined)).toBe('missing_both');
+    expect(resolveMainserverCredentialStatus(undefined)).toBe('unknown');
     expect(resolveMainserverCredentialStatus(null)).toBe('unknown');
   });
 

--- a/packages/auth-runtime/src/mainserver-credentials.ts
+++ b/packages/auth-runtime/src/mainserver-credentials.ts
@@ -1,3 +1,5 @@
+import type { IamMainserverCredentialStatus } from '@sva/core';
+
 import type { IdentityUserAttributes } from './keycloak-user-attributes.js';
 import {
   resolveIdentityProvider,
@@ -81,13 +83,37 @@ const copyIdentityAttributes = (
 export const resolveMainserverCredentialState = (
   attributes: IdentityUserAttributes | null | undefined
 ): MainserverCredentialState => {
-  const applicationId = resolveAttributeFromCandidates(attributes, MAINSERVER_APPLICATION_ID_ATTRIBUTE_NAMES);
-  const applicationSecret = resolveAttributeFromCandidates(attributes, MAINSERVER_APPLICATION_SECRET_ATTRIBUTE_NAMES);
+  const applicationId = resolveAttributeFromCandidates(
+    attributes,
+    MAINSERVER_APPLICATION_ID_ATTRIBUTE_NAMES
+  );
+  const applicationSecret = resolveAttributeFromCandidates(
+    attributes,
+    MAINSERVER_APPLICATION_SECRET_ATTRIBUTE_NAMES
+  );
 
   return {
     mainserverUserApplicationId: applicationId ?? undefined,
     mainserverUserApplicationSecretSet: applicationSecret !== null,
   };
+};
+
+export const resolveMainserverCredentialStatus = (
+  attributes: IdentityUserAttributes | null | undefined
+): IamMainserverCredentialStatus => {
+  if (attributes === null || attributes === undefined) {
+    return 'unknown';
+  }
+
+  const state = resolveMainserverCredentialState(attributes);
+  const applicationIdSet = state.mainserverUserApplicationId !== undefined;
+  if (applicationIdSet && state.mainserverUserApplicationSecretSet) {
+    return 'complete';
+  }
+  if (!applicationIdSet && !state.mainserverUserApplicationSecretSet) {
+    return 'missing_both';
+  }
+  return applicationIdSet ? 'missing_application_secret' : 'missing_application_id';
 };
 
 export const buildMainserverIdentityAttributes = (input: {
@@ -97,7 +123,10 @@ export const buildMainserverIdentityAttributes = (input: {
 }): Record<string, readonly string[]> => {
   const attributes = copyIdentityAttributes(input.existingAttributes);
   const currentState = resolveMainserverCredentialState(attributes);
-  const preservedSecret = resolveAttributeFromCandidates(attributes, MAINSERVER_APPLICATION_SECRET_ATTRIBUTE_NAMES);
+  const preservedSecret = resolveAttributeFromCandidates(
+    attributes,
+    MAINSERVER_APPLICATION_SECRET_ATTRIBUTE_NAMES
+  );
 
   delete attributes[LEGACY_MAINSERVER_API_KEY_ATTRIBUTE];
   delete attributes[LEGACY_MAINSERVER_API_SECRET_ATTRIBUTE];
@@ -166,8 +195,14 @@ export const readSvaMainserverCredentialsWithStatus = async (
     };
   }
 
-  const apiKey = resolveAttributeFromCandidates(attributes, MAINSERVER_APPLICATION_ID_ATTRIBUTE_NAMES);
-  const apiSecret = resolveAttributeFromCandidates(attributes, MAINSERVER_APPLICATION_SECRET_ATTRIBUTE_NAMES);
+  const apiKey = resolveAttributeFromCandidates(
+    attributes,
+    MAINSERVER_APPLICATION_ID_ATTRIBUTE_NAMES
+  );
+  const apiSecret = resolveAttributeFromCandidates(
+    attributes,
+    MAINSERVER_APPLICATION_SECRET_ATTRIBUTE_NAMES
+  );
   if (!apiKey || !apiSecret) {
     return {
       status: 'missing_credentials',

--- a/packages/auth-runtime/src/mainserver-credentials.ts
+++ b/packages/auth-runtime/src/mainserver-credentials.ts
@@ -101,7 +101,7 @@ export const resolveMainserverCredentialState = (
 export const resolveMainserverCredentialStatus = (
   attributes: IdentityUserAttributes | null | undefined
 ): IamMainserverCredentialStatus => {
-  if (attributes === null || attributes === undefined) {
+  if (attributes === null) {
     return 'unknown';
   }
 

--- a/packages/auth-runtime/src/mainserver-credentials.ts
+++ b/packages/auth-runtime/src/mainserver-credentials.ts
@@ -101,7 +101,7 @@ export const resolveMainserverCredentialState = (
 export const resolveMainserverCredentialStatus = (
   attributes: IdentityUserAttributes | null | undefined
 ): IamMainserverCredentialStatus => {
-  if (attributes === null) {
+  if (attributes === null || attributes === undefined) {
     return 'unknown';
   }
 

--- a/packages/core/dist/iam/account-management-contract.d.ts
+++ b/packages/core/dist/iam/account-management-contract.d.ts
@@ -111,6 +111,7 @@ export type IamUserPermissionTraceItem = {
     readonly validFrom?: string;
     readonly validTo?: string;
 };
+export type IamMainserverCredentialStatus = 'complete' | 'missing_application_id' | 'missing_application_secret' | 'missing_both' | 'unknown';
 export type IamUserListItem = {
     readonly id: IamUuid;
     readonly keycloakSubject: string;
@@ -126,6 +127,7 @@ export type IamUserListItem = {
     readonly roles: readonly IamUserRoleAssignment[];
     readonly keycloakRoles?: readonly string[];
     readonly mainserverUserApplicationSecretSet: boolean;
+    readonly mainserverCredentialStatus?: IamMainserverCredentialStatus;
 };
 export type IamUserDetail = IamUserListItem & {
     readonly username?: string;

--- a/packages/core/src/iam/account-management-contract.ts
+++ b/packages/core/src/iam/account-management-contract.ts
@@ -102,13 +102,7 @@ export type IamRuntimeDiagnostics = {
 };
 
 export type InstanceStatus =
-  | 'requested'
-  | 'validated'
-  | 'provisioning'
-  | 'active'
-  | 'failed'
-  | 'suspended'
-  | 'archived';
+  'requested' | 'validated' | 'provisioning' | 'active' | 'failed' | 'suspended' | 'archived';
 
 export type InstanceRealmMode = 'new' | 'existing';
 
@@ -211,6 +205,9 @@ export type IamUserPermissionTraceItem = {
   readonly validTo?: string;
 };
 
+export type IamMainserverCredentialStatus =
+  'complete' | 'missing_application_id' | 'missing_application_secret' | 'missing_both' | 'unknown';
+
 export type IamUserListItem = {
   readonly id: IamUuid;
   readonly keycloakSubject: string;
@@ -226,6 +223,7 @@ export type IamUserListItem = {
   readonly roles: readonly IamUserRoleAssignment[];
   readonly keycloakRoles?: readonly string[];
   readonly mainserverUserApplicationSecretSet: boolean;
+  readonly mainserverCredentialStatus?: IamMainserverCredentialStatus;
 };
 
 export type IamUserDetail = IamUserListItem & {
@@ -420,12 +418,7 @@ export type IamPendingLegalTextItem = {
 };
 
 export type IamOrganizationType =
-  | 'county'
-  | 'municipality'
-  | 'district'
-  | 'company'
-  | 'agency'
-  | 'other';
+  'county' | 'municipality' | 'district' | 'company' | 'agency' | 'other';
 
 export type IamContentAuthorPolicy = 'org_only' | 'org_or_personal';
 
@@ -547,7 +540,13 @@ export const instanceAuditCheckStatuses = ['pass', 'fail', 'warn', 'skip'] as co
 
 export type InstanceAuditCheckStatus = (typeof instanceAuditCheckStatuses)[number];
 
-export const instanceAuditCheckScopes = ['instance', 'registry', 'keycloak', 'localIam', 'run'] as const;
+export const instanceAuditCheckScopes = [
+  'instance',
+  'registry',
+  'keycloak',
+  'localIam',
+  'run',
+] as const;
 
 export type InstanceAuditCheckScope = (typeof instanceAuditCheckScopes)[number];
 
@@ -623,10 +622,7 @@ export type IamInstanceKeycloakProvisioningRun = {
   readonly instanceId: string;
   readonly mode: InstanceRealmMode;
   readonly intent:
-    | 'provision'
-    | 'provision_admin_client'
-    | 'reset_tenant_admin'
-    | 'rotate_client_secret';
+    'provision' | 'provision_admin_client' | 'reset_tenant_admin' | 'rotate_client_secret';
   readonly overallStatus: 'planned' | 'running' | 'succeeded' | 'failed';
   readonly driftSummary: string;
   readonly requestId?: string;

--- a/packages/core/src/iam/index.ts
+++ b/packages/core/src/iam/index.ts
@@ -71,6 +71,7 @@ export type {
   IamRoleSyncState,
   InstanceStatus,
   IamCreateUserResult,
+  IamMainserverCredentialStatus,
   IamUserDetail,
   IamUserGroupAssignment,
   IamUserInvitationError,

--- a/packages/iam-admin/src/tenant-keycloak-user-projection.test.ts
+++ b/packages/iam-admin/src/tenant-keycloak-user-projection.test.ts
@@ -18,14 +18,16 @@ describe('tenant-keycloak-user-projection', () => {
           enabled: true,
           attributes: { displayName: ['Redaktion'], instanceId: ['de-musterhausen'] },
         },
-        []
+        [],
+        'complete'
       )
     ).toEqual({
       id: 'keycloak:kc-1',
       keycloakSubject: 'kc-1',
       displayName: 'Redaktion',
       email: 'm.mustermann@example.org',
-      mainserverUserApplicationSecretSet: false,
+      mainserverUserApplicationSecretSet: true,
+      mainserverCredentialStatus: 'complete',
       status: 'active',
       mappingStatus: 'unmapped',
       editability: 'blocked',
@@ -36,7 +38,7 @@ describe('tenant-keycloak-user-projection', () => {
 
   it('keeps unmapped users independent from deprecated instance attributes', () => {
     expect(
-      mapUnmappedKeycloakUser({ externalId: 'kc-1', attributes: {} }, null)
+      mapUnmappedKeycloakUser({ externalId: 'kc-1', attributes: {} }, null, 'missing_both')
     ).toEqual(
       expect.objectContaining({
         mappingStatus: 'unmapped',
@@ -50,7 +52,8 @@ describe('tenant-keycloak-user-projection', () => {
     expect(
       mapUnmappedKeycloakUser(
         { externalId: 'kc-2', attributes: { instanceId: ['de-altstadt'] } },
-        []
+        [],
+        'missing_both'
       )
     ).toEqual(
       expect.objectContaining({
@@ -81,7 +84,8 @@ describe('tenant-keycloak-user-projection', () => {
           email: 'max@example.org',
           enabled: false,
         },
-        null
+        null,
+        'unknown'
       )
     ).toEqual({
       ...mapped,
@@ -90,6 +94,8 @@ describe('tenant-keycloak-user-projection', () => {
       status: 'inactive',
       mappingStatus: 'manual_review',
       editability: 'blocked',
+      mainserverUserApplicationSecretSet: false,
+      mainserverCredentialStatus: 'unknown',
       diagnostics: [{ code: 'keycloak_projection_degraded', objectId: 'kc-1', objectType: 'user' }],
     });
   });

--- a/packages/iam-admin/src/tenant-keycloak-user-projection.ts
+++ b/packages/iam-admin/src/tenant-keycloak-user-projection.ts
@@ -1,4 +1,8 @@
-import type { IamKeycloakObjectDiagnostic, IamUserListItem } from '@sva/core';
+import type {
+  IamKeycloakObjectDiagnostic,
+  IamMainserverCredentialStatus,
+  IamUserListItem,
+} from '@sva/core';
 
 type IdentityListedUser = {
   readonly externalId: string;
@@ -34,16 +38,25 @@ const resolveDisplayName = (user: IdentityListedUser): string => {
   return fullName || user.username || user.email || user.externalId;
 };
 
-const mapKeycloakUserStatus = (user: IdentityListedUser): UserStatus => (user.enabled === false ? 'inactive' : 'active');
+const mapKeycloakUserStatus = (user: IdentityListedUser): UserStatus =>
+  user.enabled === false ? 'inactive' : 'active';
+
+const isMainserverApplicationSecretSet = (status: IamMainserverCredentialStatus): boolean =>
+  status === 'complete' || status === 'missing_application_id';
 
 export const mapUnmappedKeycloakUser = (
   user: IdentityListedUser,
-  roleNames: readonly string[] | null
+  roleNames: readonly string[] | null,
+  mainserverCredentialStatus: IamMainserverCredentialStatus
 ): IamUserListItem => {
   const diagnostics: IamKeycloakObjectDiagnostic[] = [];
   diagnostics.push({ code: 'mapping_missing', objectId: user.externalId, objectType: 'user' });
   if (roleNames === null) {
-    diagnostics.push({ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' });
+    diagnostics.push({
+      code: 'keycloak_projection_degraded',
+      objectId: user.externalId,
+      objectType: 'user',
+    });
   }
 
   return {
@@ -56,14 +69,18 @@ export const mapUnmappedKeycloakUser = (
     editability: 'blocked',
     diagnostics,
     roles: [],
-    mainserverUserApplicationSecretSet: false,
+    mainserverUserApplicationSecretSet: isMainserverApplicationSecretSet(
+      mainserverCredentialStatus
+    ),
+    mainserverCredentialStatus,
   };
 };
 
 export const mergeMappedUserWithKeycloak = (
   mapped: IamUserListItem,
   user: IdentityListedUser,
-  roleNames: readonly string[] | null
+  roleNames: readonly string[] | null,
+  mainserverCredentialStatus: IamMainserverCredentialStatus
 ): IamUserListItem => ({
   ...mapped,
   displayName: mapped.displayName || resolveDisplayName(user),
@@ -71,6 +88,8 @@ export const mergeMappedUserWithKeycloak = (
   status: mapKeycloakUserStatus(user),
   mappingStatus: roleNames === null ? 'manual_review' : 'mapped',
   editability: roleNames === null ? 'blocked' : 'editable',
+  mainserverUserApplicationSecretSet: isMainserverApplicationSecretSet(mainserverCredentialStatus),
+  mainserverCredentialStatus,
   diagnostics:
     roleNames === null
       ? [{ code: 'keycloak_projection_degraded', objectId: user.externalId, objectType: 'user' }]

--- a/packages/iam-admin/src/user-mapping.ts
+++ b/packages/iam-admin/src/user-mapping.ts
@@ -62,8 +62,14 @@ export const mapUserRowToListItem = (row: {
     row.display_name_ciphertext,
     `iam.accounts.display_name:${row.keycloak_subject}`
   );
-  const firstName = revealField(row.first_name_ciphertext, `iam.accounts.first_name:${row.keycloak_subject}`);
-  const lastName = revealField(row.last_name_ciphertext, `iam.accounts.last_name:${row.keycloak_subject}`);
+  const firstName = revealField(
+    row.first_name_ciphertext,
+    `iam.accounts.first_name:${row.keycloak_subject}`
+  );
+  const lastName = revealField(
+    row.last_name_ciphertext,
+    `iam.accounts.last_name:${row.keycloak_subject}`
+  );
   const displayName = resolveUserDisplayName({
     decryptedDisplayName,
     firstName,
@@ -84,5 +90,6 @@ export const mapUserRowToListItem = (row: {
     lastLoginAt: row.last_login_at ?? undefined,
     roles: mapRoles(row.roles),
     mainserverUserApplicationSecretSet: false,
+    mainserverCredentialStatus: 'unknown',
   };
 };


### PR DESCRIPTION
## Was ändert sich?

- stellt die Warnung für unvollständige persönliche Mainserver-Credentials in der Benutzertabelle wieder her
- unterscheidet fehlende Application-ID, fehlendes Application-Secret, vollständig fehlende Credentials und einen unbekannten Zustand
- leitet den Status aus den Attributen der bereits geladenen Keycloak-Benutzerprojektion ab
- ergänzt zugängliche deutsche und englische Warntexte sowie Unit-Tests
- aktualisiert Account-UI-Spezifikation und Runtime-Architekturdokumentation

## Warum?

Die frühere Warnung wurde in PR #702 entfernt, nachdem die Implementierung einen zusätzlichen Keycloak-Aufruf pro Benutzer erzeugte und temporäre Keycloak-Fehler fälschlich als fehlende Credentials darstellte. Seitdem konnte die Tabelle eine gelöschte Mainserver Application-ID nicht mehr anzeigen.

Die neue Projektion verwendet ausschließlich die Attribute des bestehenden `listUsers`-Responses. Dadurch entstehen keine zusätzlichen Keycloak-Aufrufe pro Tabellenzeile. Ein nicht bestimmbarer Status bleibt `unknown` und erzeugt keine irreführende Warnung. Credential-Werte werden nicht an den Browser übertragen.

## Validierung

- zielgerichtete Unit-Tests für `iam-admin`, `auth-runtime` und `sva-studio-react`
- Type-Gates für `iam-admin`, `auth-runtime` und `sva-studio-react`
- Server-Runtime-Gates für `iam-admin` und `auth-runtime`
- Lint für `core`, `iam-admin`, `auth-runtime` und `sva-studio-react`
- `sva-studio-react:check:i18n`
- `openspec validate account-ui --strict`
- `pnpm check:file-placement`
- Prettier- und `git diff --check`

Hinweis: Der bestehende Core-Lint meldet weiterhin ausschließlich bereits vorhandene Warnungen; alle Lint-Targets laufen ohne Fehler durch.
