### PR TITLE
refactor(waste): reduce plugin UI complexity

### DIFF
--- a/docs/changelog/entries/pr-705.json
+++ b/docs/changelog/entries/pr-705.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 705,
+  "body": "Die Wartbarkeit des Waste-Management-Plugins wurde in drei komplexen UI-Bereichen verbessert.\n\n- Der Import-Wizard verwendet klar getrennte Schritte und eine reine Zustandsableitung.\n- Die Konfiguration der E-Mail-Erinnerungen trennt Normalisierung, Persistenzkoordination und Formularsektionen.\n- Die Touren-UI bündelt fachlich zusammengehörige View-Models und berechnet sichtbare sowie ausgeblendete Auswahlen testbar."
+}

--- a/packages/plugin-waste-management/src/waste-management.output-email-reminder-card.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-email-reminder-card.tsx
@@ -2,129 +2,20 @@ import type {
   WasteManagementEmailReminderConfig,
   WasteManagementSettingsInterfaceOption,
 } from '@sva/plugin-sdk';
+import { Button } from '@sva/studio-ui-react';
+import type { FormEventHandler } from 'react';
+
 import {
-  Button,
-  Input,
-  StudioField,
-  Textarea,
-} from '@sva/studio-ui-react';
-import type { ComponentProps, FormEventHandler } from 'react';
-
-type OutputTranslate = (key: string, variables?: Record<string, string | number>) => string;
-
-const renderSelect = (
-  id: string,
-  value: string,
-  options: readonly Readonly<{ value: string; label: string }>[],
-  onChange: (value: string) => void
-) => (
-  <select
-    id={id}
-    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-    value={value}
-    onChange={(event) => onChange(event.currentTarget.value)}
-  >
-    {options.map((option) => (
-      <option key={option.value} value={option.value}>
-        {option.label}
-      </option>
-    ))}
-  </select>
-);
-
-const renderCheckbox = (id: string, checked: boolean, onChange: (checked: boolean) => void) => (
-  <input
-    id={id}
-    type="checkbox"
-    checked={checked}
-    onChange={(event) => onChange(event.currentTarget.checked)}
-  />
-);
-
-const statusKeyByValue: Record<WasteManagementSettingsInterfaceOption['visibleStatus'], string> = {
-  not_configured: 'output.emailReminder.transportStatus.notConfigured',
-  unknown: 'output.emailReminder.transportStatus.unknown',
-  ok: 'output.emailReminder.transportStatus.ok',
-  error: 'output.emailReminder.transportStatus.error',
-  disabled: 'output.emailReminder.transportStatus.disabled',
-};
-
-const textField = ({
-  id,
-  label,
-  description,
-  type = 'text',
-  value,
-  onChange,
-}: {
-  readonly id: string;
-  readonly label: string;
-  readonly description?: string;
-  readonly type?: ComponentProps<'input'>['type'];
-  readonly value: string;
-  readonly onChange: (value: string) => void;
-}) => (
-  <StudioField id={id} label={label} description={description}>
-    <Input id={id} type={type} value={value} onChange={(event) => onChange(event.target.value)} />
-  </StudioField>
-);
-
-const textareaField = ({
-  id,
-  label,
-  description,
-  rows = 3,
-  value,
-  onChange,
-}: {
-  readonly id: string;
-  readonly label: string;
-  readonly description?: string;
-  readonly rows?: number;
-  readonly value: string;
-  readonly onChange: (value: string) => void;
-}) => (
-  <StudioField id={id} label={label} description={description}>
-    <Textarea id={id} rows={rows} value={value} onChange={(event) => onChange(event.target.value)} />
-  </StudioField>
-);
-
-const numberField = ({
-  id,
-  label,
-  description,
-  value,
-  onChange,
-}: {
-  readonly id: string;
-  readonly label: string;
-  readonly description?: string;
-  readonly value: number;
-  readonly onChange: (value: number) => void;
-}) => (
-  <StudioField id={id} label={label} description={description}>
-    <Input
-      id={id}
-      type="number"
-      min={1}
-      value={String(value)}
-      onChange={(event) => onChange(Number.parseInt(event.target.value || '0', 10) || 0)}
-    />
-  </StudioField>
-);
-
-const sectionHeading = ({
-  title,
-  description,
-}: {
-  readonly title: string;
-  readonly description?: string;
-}) => (
-  <div className="space-y-1">
-    <h4 className="text-sm font-semibold">{title}</h4>
-    {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
-  </div>
-);
+  ActivationAndTransportSection,
+  type OutputTranslate,
+} from './waste-management.output-email-reminder-sections.js';
+import {
+  DoiSection,
+  GuardrailsSection,
+  LegalSection,
+  ReminderSection,
+  UnsubscribeSection,
+} from './waste-management.output-email-reminder-message-sections.js';
 
 export const WasteEmailReminderConfigurationSection = ({
   hasMailTransportOptions,
@@ -143,346 +34,43 @@ export const WasteEmailReminderConfigurationSection = ({
   readonly translate: OutputTranslate;
   readonly value: WasteManagementEmailReminderConfig;
 }) => {
-  const selectedTransport = transportOptions.find((option) => option.id === value.transportId) ?? null;
-  const transportStatus = selectedTransport ? translate(statusKeyByValue[selectedTransport.visibleStatus]) : null;
-  const setValue = <T extends keyof WasteManagementEmailReminderConfig>(
-    key: T,
-    next: WasteManagementEmailReminderConfig[T]
+  const patch = (
+    key: keyof WasteManagementEmailReminderConfig,
+    next: WasteManagementEmailReminderConfig[keyof WasteManagementEmailReminderConfig]
   ) => onChange({ ...value, [key]: next });
-
+  const sectionProps = { patch, translate, value };
   return (
     <form className="space-y-4" onSubmit={onSubmit}>
       <section className="space-y-5 rounded-2xl border border-border bg-card p-5 shadow-shell">
         <div className="space-y-1">
           <h3 className="text-sm font-semibold">{translate('output.emailReminder.title')}</h3>
-          <p className="text-sm text-muted-foreground">{translate('output.emailReminder.description')}</p>
+          <p className="text-sm text-muted-foreground">
+            {translate('output.emailReminder.description')}
+          </p>
         </div>
-
-        <div className="grid gap-4 md:grid-cols-2">
-          <StudioField
-            id="waste-email-reminder-enabled"
-            label={translate('output.emailReminder.fields.enabled')}
-            description={translate('output.emailReminder.fieldHints.enabled')}
-          >
-            {renderCheckbox('waste-email-reminder-enabled', value.enabled, (checked) => setValue('enabled', checked))}
-          </StudioField>
-          <StudioField
-            id="waste-email-reminder-public-signup-enabled"
-            label={translate('output.emailReminder.fields.publicSignupEnabled')}
-            description={translate('output.emailReminder.fieldHints.publicSignupEnabled')}
-          >
-            {renderCheckbox(
-              'waste-email-reminder-public-signup-enabled',
-              value.publicSignupEnabled,
-              (checked) => setValue('publicSignupEnabled', checked)
-            )}
-          </StudioField>
-        </div>
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.transport'),
-          description: translate('output.emailReminder.sectionHints.transport'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          <StudioField
-            id="waste-email-reminder-transport-id"
-            label={translate('output.emailReminder.fields.transportId')}
-            description={translate('output.emailReminder.fieldHints.transportId')}
-          >
-            {renderSelect(
-              'waste-email-reminder-transport-id',
-              value.transportId,
-              transportOptions.map((option) => ({ value: option.id, label: option.name })),
-              (next) => setValue('transportId', next)
-            )}
-          </StudioField>
-          <div className="space-y-2 rounded-xl border border-dashed border-border p-3 text-sm text-muted-foreground">
-            <p>{translate('output.emailReminder.meta.transportType')}</p>
-            <p className="font-medium text-foreground">{selectedTransport?.typeKey ?? '-'}</p>
-            <p>{translate('output.emailReminder.meta.transportStatus')}</p>
-            <p className="font-medium text-foreground">{transportStatus ?? '-'}</p>
-          </div>
-        </div>
-        {!hasMailTransportOptions ? (
-          <p className="text-sm text-destructive">{translate('output.emailReminder.messages.noMailTransport')}</p>
-        ) : null}
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.urls'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {textField({
-            id: 'waste-email-reminder-public-base-url',
-            type: 'url',
-            label: translate('output.emailReminder.fields.publicBaseUrl'),
-            value: value.publicBaseUrl,
-            onChange: (next) => setValue('publicBaseUrl', next),
-          })}
-        </div>
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.sender'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {textField({
-            id: 'waste-email-reminder-from-name',
-            label: translate('output.emailReminder.fields.fromName'),
-            value: value.fromName,
-            onChange: (next) => setValue('fromName', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-from-email',
-            type: 'email',
-            label: translate('output.emailReminder.fields.fromEmail'),
-            value: value.fromEmail,
-            onChange: (next) => setValue('fromEmail', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-reply-to-email',
-            type: 'email',
-            label: translate('output.emailReminder.fields.replyToEmail'),
-            value: value.replyToEmail ?? '',
-            onChange: (next) => setValue('replyToEmail', next || undefined),
-          })}
-          {textField({
-            id: 'waste-email-reminder-service-label',
-            label: translate('output.emailReminder.fields.serviceLabel'),
-            value: value.serviceLabel ?? '',
-            onChange: (next) => setValue('serviceLabel', next || undefined),
-          })}
-        </div>
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.legal'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {textField({
-            id: 'waste-email-reminder-privacy-policy-url',
-            type: 'url',
-            label: translate('output.emailReminder.fields.privacyPolicyUrl'),
-            value: value.privacyPolicyUrl,
-            onChange: (next) => setValue('privacyPolicyUrl', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-imprint-url',
-            type: 'url',
-            label: translate('output.emailReminder.fields.imprintUrl'),
-            value: value.imprintUrl,
-            onChange: (next) => setValue('imprintUrl', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-consent-version',
-            label: translate('output.emailReminder.fields.consentVersion'),
-            value: value.consentVersion,
-            onChange: (next) => setValue('consentVersion', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-data-controller-label',
-            label: translate('output.emailReminder.fields.dataControllerLabel'),
-            value: value.dataControllerLabel ?? '',
-            onChange: (next) => setValue('dataControllerLabel', next || undefined),
-          })}
-          {textField({
-            id: 'waste-email-reminder-data-protection-contact-email',
-            type: 'email',
-            label: translate('output.emailReminder.fields.dataProtectionContactEmail'),
-            value: value.dataProtectionContactEmail ?? '',
-            onChange: (next) => setValue('dataProtectionContactEmail', next || undefined),
-          })}
-        </div>
-        {textareaField({
-          id: 'waste-email-reminder-consent-label',
-          rows: 2,
-          label: translate('output.emailReminder.fields.consentLabel'),
-          value: value.consentLabel,
-          onChange: (next) => setValue('consentLabel', next),
-        })}
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.doi'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {textField({
-            id: 'waste-email-reminder-doi-subject-template',
-            label: translate('output.emailReminder.fields.doiSubjectTemplate'),
-            value: value.doiSubjectTemplate,
-            onChange: (next) => setValue('doiSubjectTemplate', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-doi-button-label',
-            label: translate('output.emailReminder.fields.doiButtonLabel'),
-            value: value.doiButtonLabel,
-            onChange: (next) => setValue('doiButtonLabel', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-doi-preheader',
-            label: translate('output.emailReminder.fields.doiPreheader'),
-            value: value.doiPreheader ?? '',
-            onChange: (next) => setValue('doiPreheader', next || undefined),
-          })}
-          {textField({
-            id: 'waste-email-reminder-doi-fallback-text',
-            label: translate('output.emailReminder.fields.doiFallbackText'),
-            value: value.doiFallbackText ?? '',
-            onChange: (next) => setValue('doiFallbackText', next || undefined),
-          })}
-        </div>
-        {textareaField({
-          id: 'waste-email-reminder-doi-intro-text',
-          label: translate('output.emailReminder.fields.doiIntroText'),
-          value: value.doiIntroText,
-          onChange: (next) => setValue('doiIntroText', next),
-        })}
-        {textareaField({
-          id: 'waste-email-reminder-doi-expiry-notice-text',
-          label: translate('output.emailReminder.fields.doiExpiryNoticeText'),
-          value: value.doiExpiryNoticeText ?? '',
-          onChange: (next) => setValue('doiExpiryNoticeText', next || undefined),
-        })}
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.reminder'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {textField({
-            id: 'waste-email-reminder-reminder-subject-template',
-            label: translate('output.emailReminder.fields.reminderSubjectTemplate'),
-            value: value.reminderSubjectTemplate,
-            onChange: (next) => setValue('reminderSubjectTemplate', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-unsubscribe-link-label',
-            label: translate('output.emailReminder.fields.unsubscribeLinkLabel'),
-            value: value.unsubscribeLinkLabel,
-            onChange: (next) => setValue('unsubscribeLinkLabel', next),
-          })}
-        </div>
-        {textareaField({
-          id: 'waste-email-reminder-reminder-intro-template',
-          label: translate('output.emailReminder.fields.reminderIntroTemplate'),
-          value: value.reminderIntroTemplate,
-          onChange: (next) => setValue('reminderIntroTemplate', next),
-        })}
-        {textareaField({
-          id: 'waste-email-reminder-reminder-list-intro-template',
-          label: translate('output.emailReminder.fields.reminderListIntroTemplate'),
-          value: value.reminderListIntroTemplate ?? '',
-          onChange: (next) => setValue('reminderListIntroTemplate', next || undefined),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {textareaField({
-            id: 'waste-email-reminder-reminder-outro-text',
-            label: translate('output.emailReminder.fields.reminderOutroText'),
-            value: value.reminderOutroText ?? '',
-            onChange: (next) => setValue('reminderOutroText', next || undefined),
-          })}
-          {textareaField({
-            id: 'waste-email-reminder-reminder-reason-text',
-            label: translate('output.emailReminder.fields.reminderReasonText'),
-            value: value.reminderReasonText ?? '',
-            onChange: (next) => setValue('reminderReasonText', next || undefined),
-          })}
-        </div>
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.unsubscribe'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {textField({
-            id: 'waste-email-reminder-unsubscribe-success-headline',
-            label: translate('output.emailReminder.fields.unsubscribeSuccessHeadline'),
-            value: value.unsubscribeSuccessHeadline,
-            onChange: (next) => setValue('unsubscribeSuccessHeadline', next),
-          })}
-          {textField({
-            id: 'waste-email-reminder-unsubscribe-already-done-headline',
-            label: translate('output.emailReminder.fields.unsubscribeAlreadyDoneHeadline'),
-            value: value.unsubscribeAlreadyDoneHeadline ?? '',
-            onChange: (next) => setValue('unsubscribeAlreadyDoneHeadline', next || undefined),
-          })}
-          {textField({
-            id: 'waste-email-reminder-unsubscribe-error-headline',
-            label: translate('output.emailReminder.fields.unsubscribeErrorHeadline'),
-            value: value.unsubscribeErrorHeadline ?? '',
-            onChange: (next) => setValue('unsubscribeErrorHeadline', next || undefined),
-          })}
-        </div>
-        <div className="grid gap-4 md:grid-cols-2">
-          {textareaField({
-            id: 'waste-email-reminder-unsubscribe-success-body',
-            label: translate('output.emailReminder.fields.unsubscribeSuccessBody'),
-            value: value.unsubscribeSuccessBody,
-            onChange: (next) => setValue('unsubscribeSuccessBody', next),
-          })}
-          {textareaField({
-            id: 'waste-email-reminder-unsubscribe-already-done-body',
-            label: translate('output.emailReminder.fields.unsubscribeAlreadyDoneBody'),
-            value: value.unsubscribeAlreadyDoneBody ?? '',
-            onChange: (next) => setValue('unsubscribeAlreadyDoneBody', next || undefined),
-          })}
-          {textareaField({
-            id: 'waste-email-reminder-unsubscribe-error-body',
-            label: translate('output.emailReminder.fields.unsubscribeErrorBody'),
-            value: value.unsubscribeErrorBody ?? '',
-            onChange: (next) => setValue('unsubscribeErrorBody', next || undefined),
-          })}
-        </div>
-
-        {sectionHeading({
-          title: translate('output.emailReminder.sections.guardrails'),
-        })}
-        <div className="grid gap-4 md:grid-cols-2">
-          {numberField({
-            id: 'waste-email-reminder-doi-token-ttl-hours',
-            label: translate('output.emailReminder.fields.doiTokenTtlHours'),
-            value: value.doiTokenTtlHours,
-            onChange: (next) => setValue('doiTokenTtlHours', next),
-          })}
-          {numberField({
-            id: 'waste-email-reminder-pending-subscription-ttl-hours',
-            label: translate('output.emailReminder.fields.pendingSubscriptionTtlHours'),
-            value: value.pendingSubscriptionTtlHours,
-            onChange: (next) => setValue('pendingSubscriptionTtlHours', next),
-          })}
-          {numberField({
-            id: 'waste-email-reminder-materialization-lookahead-days',
-            label: translate('output.emailReminder.fields.materializationLookaheadDays'),
-            value: value.materializationLookaheadDays,
-            onChange: (next) => setValue('materializationLookaheadDays', next),
-          })}
-          {numberField({
-            id: 'waste-email-reminder-max-subscriptions-per-email-and-location',
-            label: translate('output.emailReminder.fields.maxSubscriptionsPerEmailAndLocation'),
-            value: value.maxSubscriptionsPerEmailAndLocation,
-            onChange: (next) => setValue('maxSubscriptionsPerEmailAndLocation', next),
-          })}
-          {numberField({
-            id: 'waste-email-reminder-signup-rate-limit-per-ip-per-hour',
-            label: translate('output.emailReminder.fields.signupRateLimitPerIpPerHour'),
-            value: value.signupRateLimitPerIpPerHour,
-            onChange: (next) => setValue('signupRateLimitPerIpPerHour', next),
-          })}
-          {numberField({
-            id: 'waste-email-reminder-signup-rate-limit-per-email-per-hour',
-            label: translate('output.emailReminder.fields.signupRateLimitPerEmailPerHour'),
-            value: value.signupRateLimitPerEmailPerHour,
-            onChange: (next) => setValue('signupRateLimitPerEmailPerHour', next),
-          })}
-          {numberField({
-            id: 'waste-email-reminder-unsubscribe-token-ttl-days',
-            label: translate('output.emailReminder.fields.unsubscribeTokenTtlDays'),
-            value: value.unsubscribeTokenTtlDays ?? 30,
-            onChange: (next) => setValue('unsubscribeTokenTtlDays', next),
-          })}
-        </div>
-
+        <ActivationAndTransportSection
+          {...sectionProps}
+          hasMailTransportOptions={hasMailTransportOptions}
+          transportOptions={transportOptions}
+        />
+        <LegalSection {...sectionProps} />
+        <DoiSection {...sectionProps} />
+        <ReminderSection {...sectionProps} />
+        <UnsubscribeSection {...sectionProps} />
+        <GuardrailsSection {...sectionProps} />
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-sm text-muted-foreground">{translate('output.emailReminder.meta.runtimeHint')}</p>
+          <p className="text-sm text-muted-foreground">
+            {translate('output.emailReminder.meta.runtimeHint')}
+          </p>
           <Button
             type="submit"
-            disabled={running || ((value.enabled || value.publicSignupEnabled) && !hasMailTransportOptions)}
+            disabled={
+              running || ((value.enabled || value.publicSignupEnabled) && !hasMailTransportOptions)
+            }
           >
-            {running ? translate('output.emailReminder.actions.saving') : translate('output.emailReminder.actions.save')}
+            {running
+              ? translate('output.emailReminder.actions.saving')
+              : translate('output.emailReminder.actions.save')}
           </Button>
         </div>
       </section>

--- a/packages/plugin-waste-management/src/waste-management.output-email-reminder-config.ts
+++ b/packages/plugin-waste-management/src/waste-management.output-email-reminder-config.ts
@@ -1,0 +1,98 @@
+import type {
+  WasteManagementEmailReminderConfig,
+  WasteManagementSettingsInterfaceOption,
+} from '@sva/plugin-sdk';
+
+import {
+  fixedWasteEmailReminderPaths,
+  withFixedWasteEmailReminderPaths,
+} from './waste-management.email-reminder-paths.js';
+
+export const getMailTransportOptions = (
+  options: readonly WasteManagementSettingsInterfaceOption[]
+): readonly WasteManagementSettingsInterfaceOption[] =>
+  options.filter((option) => option.typeKey === 'mail_transport');
+
+export const buildDefaultEmailReminderConfig = ({
+  calendarWebUrl,
+  transportOptions,
+}: {
+  readonly calendarWebUrl?: string;
+  readonly transportOptions: readonly WasteManagementSettingsInterfaceOption[];
+}): WasteManagementEmailReminderConfig => ({
+  enabled: false,
+  publicSignupEnabled: false,
+  transportId: transportOptions[0]?.id ?? '',
+  publicBaseUrl: calendarWebUrl ?? 'https://demo.abfallkalender.example',
+  ...fixedWasteEmailReminderPaths,
+  fromName: 'Abfallwirtschaft',
+  fromEmail: 'abfall@example.org',
+  replyToEmail: 'abfall@example.org',
+  serviceLabel: 'Muelli',
+  privacyPolicyUrl: 'https://example.org/datenschutz',
+  imprintUrl: 'https://example.org/impressum',
+  consentLabel:
+    'Ich stimme der Verarbeitung meiner Daten zur Einrichtung der E-Mail-Erinnerung zu.',
+  consentVersion: 'v1',
+  dataControllerLabel: 'Abfallwirtschaft',
+  dataProtectionContactEmail: 'datenschutz@example.org',
+  doiSubjectTemplate: 'Bitte bestaetigen Sie Ihre E-Mail-Erinnerung fuer {{locationLabel}}',
+  doiPreheader: 'Bestaetigen Sie die Einrichtung Ihres Erinnerungsdienstes.',
+  doiIntroText:
+    'Bitte bestaetigen Sie die Einrichtung Ihrer E-Mail-Erinnerung fuer {{locationLabel}} ueber den folgenden Link.',
+  doiButtonLabel: 'E-Mail-Erinnerung aktivieren',
+  doiFallbackText: 'Falls der Button nicht funktioniert, nutzen Sie bitte den direkten Link.',
+  doiExpiryNoticeText: 'Der Aktivierungslink ist zeitlich begrenzt gueltig.',
+  doiSuccessHeadline: 'E-Mail-Erinnerung aktiviert',
+  doiSuccessBody:
+    'Der Dienst ist jetzt aktiv und informiert Sie kuenftig ueber anstehende Entsorgungstermine.',
+  doiErrorHeadline: 'Aktivierung nicht moeglich',
+  doiErrorBody: 'Der Aktivierungslink ist ungueltig oder bereits abgelaufen.',
+  reminderSubjectTemplate: 'Abfalltermin fuer {{locationLabel}} am {{pickupDate}}',
+  reminderIntroTemplate: 'Nicht vergessen: {{fractionName}} wird am {{pickupDate}} abgeholt.',
+  reminderListIntroTemplate: 'Folgende Abfallart steht als naechstes an:',
+  reminderOutroText: 'Sie koennen diese Erinnerung jederzeit wieder abbestellen.',
+  unsubscribeLinkLabel: 'E-Mail-Erinnerung abbestellen',
+  reminderReasonText:
+    'Sie erhalten diese Nachricht, weil Sie fuer {{locationLabel}} eine E-Mail-Erinnerung eingerichtet haben.',
+  unsubscribeSuccessHeadline: 'E-Mail-Erinnerung deaktiviert',
+  unsubscribeSuccessBody: 'Der Dienst wurde fuer diese Adresse erfolgreich deaktiviert.',
+  unsubscribeAlreadyDoneHeadline: 'E-Mail-Erinnerung bereits deaktiviert',
+  unsubscribeAlreadyDoneBody:
+    'Fuer diese Adresse ist bereits keine aktive Erinnerung mehr hinterlegt.',
+  unsubscribeErrorHeadline: 'Abmeldung nicht moeglich',
+  unsubscribeErrorBody: 'Der Abmeldelink ist ungueltig oder bereits abgelaufen.',
+  maxSubscriptionsPerEmailAndLocation: 5,
+  signupRateLimitPerIpPerHour: 20,
+  signupRateLimitPerEmailPerHour: 10,
+  doiTokenTtlHours: 48,
+  pendingSubscriptionTtlHours: 72,
+  materializationLookaheadDays: 7,
+  unsubscribeTokenTtlDays: 30,
+});
+
+export const ensureTransportSelection = (
+  config: WasteManagementEmailReminderConfig,
+  transportOptions: readonly WasteManagementSettingsInterfaceOption[]
+): WasteManagementEmailReminderConfig => {
+  const firstTransport = transportOptions[0];
+  return config.transportId || !firstTransport
+    ? config
+    : { ...config, transportId: firstTransport.id };
+};
+
+export const normalizeEmailReminderConfig = ({
+  config,
+  calendarWebUrl,
+  transportOptions,
+}: {
+  readonly config?: WasteManagementEmailReminderConfig | null;
+  readonly calendarWebUrl?: string;
+  readonly transportOptions: readonly WasteManagementSettingsInterfaceOption[];
+}): WasteManagementEmailReminderConfig =>
+  withFixedWasteEmailReminderPaths(
+    ensureTransportSelection(
+      config ?? buildDefaultEmailReminderConfig({ calendarWebUrl, transportOptions }),
+      transportOptions
+    )
+  );

--- a/packages/plugin-waste-management/src/waste-management.output-email-reminder-message-sections.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-email-reminder-message-sections.tsx
@@ -1,0 +1,142 @@
+import type { Field, SectionProps } from './waste-management.output-email-reminder-sections.js';
+import { Fields, heading } from './waste-management.output-email-reminder-sections.js';
+
+const legalFields: readonly Field[] = [
+  { key: 'privacyPolicyUrl', id: 'waste-email-reminder-privacy-policy-url', type: 'url' },
+  { key: 'imprintUrl', id: 'waste-email-reminder-imprint-url', type: 'url' },
+  { key: 'consentVersion', id: 'waste-email-reminder-consent-version' },
+  { key: 'dataControllerLabel', id: 'waste-email-reminder-data-controller-label', optional: true },
+  {
+    key: 'dataProtectionContactEmail',
+    id: 'waste-email-reminder-data-protection-contact-email',
+    type: 'email',
+    optional: true,
+  },
+  { key: 'consentLabel', id: 'waste-email-reminder-consent-label', area: true },
+];
+const doiFields: readonly Field[] = [
+  { key: 'doiSubjectTemplate', id: 'waste-email-reminder-doi-subject-template' },
+  { key: 'doiButtonLabel', id: 'waste-email-reminder-doi-button-label' },
+  { key: 'doiPreheader', id: 'waste-email-reminder-doi-preheader', optional: true },
+  { key: 'doiFallbackText', id: 'waste-email-reminder-doi-fallback-text', optional: true },
+  { key: 'doiIntroText', id: 'waste-email-reminder-doi-intro-text', area: true },
+  {
+    key: 'doiExpiryNoticeText',
+    id: 'waste-email-reminder-doi-expiry-notice-text',
+    area: true,
+    optional: true,
+  },
+];
+const reminderFields: readonly Field[] = [
+  { key: 'reminderSubjectTemplate', id: 'waste-email-reminder-reminder-subject-template' },
+  { key: 'unsubscribeLinkLabel', id: 'waste-email-reminder-unsubscribe-link-label' },
+  { key: 'reminderIntroTemplate', id: 'waste-email-reminder-reminder-intro-template', area: true },
+  {
+    key: 'reminderListIntroTemplate',
+    id: 'waste-email-reminder-reminder-list-intro-template',
+    area: true,
+    optional: true,
+  },
+  {
+    key: 'reminderOutroText',
+    id: 'waste-email-reminder-reminder-outro-text',
+    area: true,
+    optional: true,
+  },
+  {
+    key: 'reminderReasonText',
+    id: 'waste-email-reminder-reminder-reason-text',
+    area: true,
+    optional: true,
+  },
+];
+const unsubscribeFields: readonly Field[] = [
+  { key: 'unsubscribeSuccessHeadline', id: 'waste-email-reminder-unsubscribe-success-headline' },
+  {
+    key: 'unsubscribeAlreadyDoneHeadline',
+    id: 'waste-email-reminder-unsubscribe-already-done-headline',
+    optional: true,
+  },
+  {
+    key: 'unsubscribeErrorHeadline',
+    id: 'waste-email-reminder-unsubscribe-error-headline',
+    optional: true,
+  },
+  {
+    key: 'unsubscribeSuccessBody',
+    id: 'waste-email-reminder-unsubscribe-success-body',
+    area: true,
+  },
+  {
+    key: 'unsubscribeAlreadyDoneBody',
+    id: 'waste-email-reminder-unsubscribe-already-done-body',
+    area: true,
+    optional: true,
+  },
+  {
+    key: 'unsubscribeErrorBody',
+    id: 'waste-email-reminder-unsubscribe-error-body',
+    area: true,
+    optional: true,
+  },
+];
+const guardrailFields: readonly Field[] = [
+  { key: 'doiTokenTtlHours', id: 'waste-email-reminder-doi-token-ttl-hours', number: true },
+  {
+    key: 'pendingSubscriptionTtlHours',
+    id: 'waste-email-reminder-pending-subscription-ttl-hours',
+    number: true,
+  },
+  {
+    key: 'materializationLookaheadDays',
+    id: 'waste-email-reminder-materialization-lookahead-days',
+    number: true,
+  },
+  {
+    key: 'maxSubscriptionsPerEmailAndLocation',
+    id: 'waste-email-reminder-max-subscriptions-per-email-and-location',
+    number: true,
+  },
+  {
+    key: 'signupRateLimitPerIpPerHour',
+    id: 'waste-email-reminder-signup-rate-limit-per-ip-per-hour',
+    number: true,
+  },
+  {
+    key: 'signupRateLimitPerEmailPerHour',
+    id: 'waste-email-reminder-signup-rate-limit-per-email-per-hour',
+    number: true,
+  },
+  {
+    key: 'unsubscribeTokenTtlDays',
+    id: 'waste-email-reminder-unsubscribe-token-ttl-days',
+    number: true,
+    optional: true,
+  },
+];
+
+const FieldSection = ({
+  fields,
+  section,
+  ...props
+}: SectionProps & { readonly fields: readonly Field[]; readonly section: string }) => (
+  <>
+    {heading(props.translate, section)}
+    <Fields {...props} fields={fields} />
+  </>
+);
+export const LegalSection = (props: SectionProps) => (
+  <FieldSection {...props} section="legal" fields={legalFields} />
+);
+export const DoiSection = (props: SectionProps) => (
+  <FieldSection {...props} section="doi" fields={doiFields} />
+);
+export const ReminderSection = (props: SectionProps) => (
+  <FieldSection {...props} section="reminder" fields={reminderFields} />
+);
+export const UnsubscribeSection = (props: SectionProps) => (
+  <FieldSection {...props} section="unsubscribe" fields={unsubscribeFields} />
+);
+export const GuardrailsSection = (props: SectionProps) => (
+  <FieldSection {...props} section="guardrails" fields={guardrailFields} />
+);

--- a/packages/plugin-waste-management/src/waste-management.output-email-reminder-message-sections.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-email-reminder-message-sections.tsx
@@ -111,7 +111,7 @@ const guardrailFields: readonly Field[] = [
     key: 'unsubscribeTokenTtlDays',
     id: 'waste-email-reminder-unsubscribe-token-ttl-days',
     number: true,
-    optional: true,
+    defaultValue: 30,
   },
 ];
 

--- a/packages/plugin-waste-management/src/waste-management.output-email-reminder-sections.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-email-reminder-sections.tsx
@@ -17,6 +17,7 @@ export type Field = {
   readonly area?: boolean;
   readonly optional?: boolean;
   readonly number?: boolean;
+  readonly defaultValue?: number;
 };
 export type SectionProps = {
   readonly value: WasteManagementEmailReminderConfig;
@@ -53,7 +54,7 @@ export const Fields = ({
 }: SectionProps & { readonly fields: readonly Field[] }) => (
   <div className="grid gap-4 md:grid-cols-2">
     {fields.map((field) => {
-      const fieldValue = value[field.key];
+      const fieldValue = value[field.key] ?? field.defaultValue;
       const label = translate(`output.emailReminder.fields.${field.key}`);
       const onChange = (next: string) =>
         patch(
@@ -100,6 +101,7 @@ const ActivationToggles = ({ patch, translate, value }: SectionProps) => (
     <StudioField
       id="waste-email-reminder-enabled"
       label={translate('output.emailReminder.fields.enabled')}
+      description={translate('output.emailReminder.fieldHints.enabled')}
     >
       <input
         id="waste-email-reminder-enabled"
@@ -111,6 +113,7 @@ const ActivationToggles = ({ patch, translate, value }: SectionProps) => (
     <StudioField
       id="waste-email-reminder-public-signup-enabled"
       label={translate('output.emailReminder.fields.publicSignupEnabled')}
+      description={translate('output.emailReminder.fieldHints.publicSignupEnabled')}
     >
       <input
         id="waste-email-reminder-public-signup-enabled"
@@ -141,6 +144,7 @@ export const ActivationAndTransportSection = ({
         <StudioField
           id="waste-email-reminder-transport-id"
           label={translate('output.emailReminder.fields.transportId')}
+          description={translate('output.emailReminder.fieldHints.transportId')}
         >
           <select
             id="waste-email-reminder-transport-id"

--- a/packages/plugin-waste-management/src/waste-management.output-email-reminder-sections.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-email-reminder-sections.tsx
@@ -1,0 +1,188 @@
+import type {
+  WasteManagementEmailReminderConfig,
+  WasteManagementSettingsInterfaceOption,
+} from '@sva/plugin-sdk';
+import { Input, StudioField, Textarea } from '@sva/studio-ui-react';
+import type { ComponentProps } from 'react';
+
+export type OutputTranslate = (key: string, variables?: Record<string, string | number>) => string;
+export type Patch = (
+  key: keyof WasteManagementEmailReminderConfig,
+  value: WasteManagementEmailReminderConfig[keyof WasteManagementEmailReminderConfig]
+) => void;
+export type Field = {
+  readonly key: keyof WasteManagementEmailReminderConfig;
+  readonly id: string;
+  readonly type?: ComponentProps<'input'>['type'];
+  readonly area?: boolean;
+  readonly optional?: boolean;
+  readonly number?: boolean;
+};
+export type SectionProps = {
+  readonly value: WasteManagementEmailReminderConfig;
+  readonly patch: Patch;
+  readonly translate: OutputTranslate;
+};
+
+const statusKeyByValue: Record<WasteManagementSettingsInterfaceOption['visibleStatus'], string> = {
+  not_configured: 'output.emailReminder.transportStatus.notConfigured',
+  unknown: 'output.emailReminder.transportStatus.unknown',
+  ok: 'output.emailReminder.transportStatus.ok',
+  error: 'output.emailReminder.transportStatus.error',
+  disabled: 'output.emailReminder.transportStatus.disabled',
+};
+
+export const heading = (translate: OutputTranslate, section: string, hint?: string) => (
+  <div className="space-y-1">
+    <h4 className="text-sm font-semibold">
+      {translate(`output.emailReminder.sections.${section}`)}
+    </h4>
+    {hint ? (
+      <p className="text-sm text-muted-foreground">
+        {translate(`output.emailReminder.sectionHints.${hint}`)}
+      </p>
+    ) : null}
+  </div>
+);
+
+export const Fields = ({
+  fields,
+  patch,
+  translate,
+  value,
+}: SectionProps & { readonly fields: readonly Field[] }) => (
+  <div className="grid gap-4 md:grid-cols-2">
+    {fields.map((field) => {
+      const fieldValue = value[field.key];
+      const label = translate(`output.emailReminder.fields.${field.key}`);
+      const onChange = (next: string) =>
+        patch(
+          field.key,
+          field.optional && !next
+            ? undefined
+            : field.number
+              ? Number.parseInt(next || '0', 10) || 0
+              : next
+        );
+      return (
+        <StudioField key={field.key} id={field.id} label={label}>
+          {field.area ? (
+            <Textarea
+              id={field.id}
+              rows={3}
+              value={String(fieldValue ?? '')}
+              onChange={(event) => onChange(event.target.value)}
+            />
+          ) : (
+            <Input
+              id={field.id}
+              type={field.number ? 'number' : (field.type ?? 'text')}
+              min={field.number ? 1 : undefined}
+              value={String(fieldValue ?? '')}
+              onChange={(event) => onChange(event.target.value)}
+            />
+          )}
+        </StudioField>
+      );
+    })}
+  </div>
+);
+
+const activationFields: readonly Field[] = [
+  { key: 'publicBaseUrl', id: 'waste-email-reminder-public-base-url', type: 'url' },
+  { key: 'fromName', id: 'waste-email-reminder-from-name' },
+  { key: 'fromEmail', id: 'waste-email-reminder-from-email', type: 'email' },
+  { key: 'replyToEmail', id: 'waste-email-reminder-reply-to-email', type: 'email', optional: true },
+  { key: 'serviceLabel', id: 'waste-email-reminder-service-label', optional: true },
+];
+const ActivationToggles = ({ patch, translate, value }: SectionProps) => (
+  <div className="grid gap-4 md:grid-cols-2">
+    <StudioField
+      id="waste-email-reminder-enabled"
+      label={translate('output.emailReminder.fields.enabled')}
+    >
+      <input
+        id="waste-email-reminder-enabled"
+        type="checkbox"
+        checked={value.enabled}
+        onChange={(event) => patch('enabled', event.currentTarget.checked)}
+      />
+    </StudioField>
+    <StudioField
+      id="waste-email-reminder-public-signup-enabled"
+      label={translate('output.emailReminder.fields.publicSignupEnabled')}
+    >
+      <input
+        id="waste-email-reminder-public-signup-enabled"
+        type="checkbox"
+        checked={value.publicSignupEnabled}
+        onChange={(event) => patch('publicSignupEnabled', event.currentTarget.checked)}
+      />
+    </StudioField>
+  </div>
+);
+
+export const ActivationAndTransportSection = ({
+  hasMailTransportOptions,
+  patch,
+  transportOptions,
+  translate,
+  value,
+}: SectionProps & {
+  readonly hasMailTransportOptions: boolean;
+  readonly transportOptions: readonly WasteManagementSettingsInterfaceOption[];
+}) => {
+  const selected = transportOptions.find((option) => option.id === value.transportId);
+  return (
+    <>
+      <ActivationToggles patch={patch} translate={translate} value={value} />
+      {heading(translate, 'transport', 'transport')}
+      <div className="grid gap-4 md:grid-cols-2">
+        <StudioField
+          id="waste-email-reminder-transport-id"
+          label={translate('output.emailReminder.fields.transportId')}
+        >
+          <select
+            id="waste-email-reminder-transport-id"
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={value.transportId}
+            onChange={(event) => patch('transportId', event.currentTarget.value)}
+          >
+            {transportOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </StudioField>
+        <div className="space-y-2 rounded-xl border border-dashed border-border p-3 text-sm text-muted-foreground">
+          <p>{translate('output.emailReminder.meta.transportType')}</p>
+          <p className="font-medium text-foreground">{selected?.typeKey ?? '-'}</p>
+          <p>{translate('output.emailReminder.meta.transportStatus')}</p>
+          <p className="font-medium text-foreground">
+            {selected ? translate(statusKeyByValue[selected.visibleStatus]) : '-'}
+          </p>
+        </div>
+      </div>
+      {!hasMailTransportOptions ? (
+        <p className="text-sm text-destructive">
+          {translate('output.emailReminder.messages.noMailTransport')}
+        </p>
+      ) : null}
+      {heading(translate, 'urls')}
+      <Fields
+        fields={activationFields.slice(0, 1)}
+        patch={patch}
+        translate={translate}
+        value={value}
+      />
+      {heading(translate, 'sender')}
+      <Fields
+        fields={activationFields.slice(1)}
+        patch={patch}
+        translate={translate}
+        value={value}
+      />
+    </>
+  );
+};

--- a/packages/plugin-waste-management/src/waste-management.output-panel.tsx
+++ b/packages/plugin-waste-management/src/waste-management.output-panel.tsx
@@ -3,7 +3,7 @@ import { StudioErrorState, StudioLoadingState } from '@sva/studio-ui-react';
 import { useEffect, useState, type FormEvent } from 'react';
 import type {
   WasteManagementEmailReminderConfig,
-  WasteManagementSettingsInterfaceOption,
+  WasteManagementSettingsRecord,
 } from '@sva/plugin-sdk';
 
 import {
@@ -18,73 +18,43 @@ import {
 } from './waste-management.page.support.js';
 import { useWasteOutputPanelData } from './waste-management.output-panel.data.js';
 import { WasteEmailReminderConfigurationSection } from './waste-management.output-email-reminder-card.js';
-import { fixedWasteEmailReminderPaths, withFixedWasteEmailReminderPaths } from './waste-management.email-reminder-paths.js';
+import {
+  getMailTransportOptions,
+  normalizeEmailReminderConfig,
+} from './waste-management.output-email-reminder-config.js';
 import { WasteOutputConfigurationSection } from './waste-management.output-panel.parts.js';
 
-const buildDefaultEmailReminderConfig = ({
-  calendarWebUrl,
-  transportOptions,
+const persistEmailReminderSettings = async ({
+  settings,
+  emailReminderConfig,
+  brandingAssetUrl,
+  contactBlock,
 }: {
-  readonly calendarWebUrl?: string;
-  readonly transportOptions: readonly WasteManagementSettingsInterfaceOption[];
-}): WasteManagementEmailReminderConfig => ({
-  enabled: false,
-  publicSignupEnabled: false,
-  transportId: transportOptions[0]?.id ?? '',
-  publicBaseUrl: calendarWebUrl ?? 'https://demo.abfallkalender.example',
-  ...fixedWasteEmailReminderPaths,
-  fromName: 'Abfallwirtschaft',
-  fromEmail: 'abfall@example.org',
-  replyToEmail: 'abfall@example.org',
-  serviceLabel: 'Muelli',
-  privacyPolicyUrl: 'https://example.org/datenschutz',
-  imprintUrl: 'https://example.org/impressum',
-  consentLabel: 'Ich stimme der Verarbeitung meiner Daten zur Einrichtung der E-Mail-Erinnerung zu.',
-  consentVersion: 'v1',
-  dataControllerLabel: 'Abfallwirtschaft',
-  dataProtectionContactEmail: 'datenschutz@example.org',
-  doiSubjectTemplate: 'Bitte bestaetigen Sie Ihre E-Mail-Erinnerung fuer {{locationLabel}}',
-  doiPreheader: 'Bestaetigen Sie die Einrichtung Ihres Erinnerungsdienstes.',
-  doiIntroText:
-    'Bitte bestaetigen Sie die Einrichtung Ihrer E-Mail-Erinnerung fuer {{locationLabel}} ueber den folgenden Link.',
-  doiButtonLabel: 'E-Mail-Erinnerung aktivieren',
-  doiFallbackText: 'Falls der Button nicht funktioniert, nutzen Sie bitte den direkten Link.',
-  doiExpiryNoticeText: 'Der Aktivierungslink ist zeitlich begrenzt gueltig.',
-  doiSuccessHeadline: 'E-Mail-Erinnerung aktiviert',
-  doiSuccessBody: 'Der Dienst ist jetzt aktiv und informiert Sie kuenftig ueber anstehende Entsorgungstermine.',
-  doiErrorHeadline: 'Aktivierung nicht moeglich',
-  doiErrorBody: 'Der Aktivierungslink ist ungueltig oder bereits abgelaufen.',
-  reminderSubjectTemplate: 'Abfalltermin fuer {{locationLabel}} am {{pickupDate}}',
-  reminderIntroTemplate: 'Nicht vergessen: {{fractionName}} wird am {{pickupDate}} abgeholt.',
-  reminderListIntroTemplate: 'Folgende Abfallart steht als naechstes an:',
-  reminderOutroText: 'Sie koennen diese Erinnerung jederzeit wieder abbestellen.',
-  unsubscribeLinkLabel: 'E-Mail-Erinnerung abbestellen',
-  reminderReasonText: 'Sie erhalten diese Nachricht, weil Sie fuer {{locationLabel}} eine E-Mail-Erinnerung eingerichtet haben.',
-  unsubscribeSuccessHeadline: 'E-Mail-Erinnerung deaktiviert',
-  unsubscribeSuccessBody: 'Der Dienst wurde fuer diese Adresse erfolgreich deaktiviert.',
-  unsubscribeAlreadyDoneHeadline: 'E-Mail-Erinnerung bereits deaktiviert',
-  unsubscribeAlreadyDoneBody: 'Fuer diese Adresse ist bereits keine aktive Erinnerung mehr hinterlegt.',
-  unsubscribeErrorHeadline: 'Abmeldung nicht moeglich',
-  unsubscribeErrorBody: 'Der Abmeldelink ist ungueltig oder bereits abgelaufen.',
-  maxSubscriptionsPerEmailAndLocation: 5,
-  signupRateLimitPerIpPerHour: 20,
-  signupRateLimitPerEmailPerHour: 10,
-  doiTokenTtlHours: 48,
-  pendingSubscriptionTtlHours: 72,
-  materializationLookaheadDays: 7,
-  unsubscribeTokenTtlDays: 30,
-});
-
-const ensureTransportSelection = (
-  config: WasteManagementEmailReminderConfig,
-  transportOptions: readonly WasteManagementSettingsInterfaceOption[]
-): WasteManagementEmailReminderConfig =>
-  config.transportId || transportOptions.length === 0
-    ? config
-    : {
-        ...config,
-        transportId: transportOptions[0]!.id,
-      };
+  readonly settings: WasteManagementSettingsRecord;
+  readonly emailReminderConfig: WasteManagementEmailReminderConfig;
+  readonly brandingAssetUrl: string;
+  readonly contactBlock: string;
+}): Promise<WasteManagementSettingsRecord | null> => {
+  const result = await updateWasteManagementSettings({
+    provider: settings.provider,
+    projectUrl: settings.projectUrl,
+    schemaName: settings.schemaName,
+    enabled: settings.enabled,
+    selectedInterfaceId: settings.selectedInterfaceId,
+    calendarWebUrl: settings.calendarWebUrl,
+    pdfBrandingAssetUrl: compactOptionalString(brandingAssetUrl),
+    pdfContactBlock: compactOptionalString(contactBlock),
+    emailReminderConfig: normalizeEmailReminderConfig({
+      config: emailReminderConfig,
+      calendarWebUrl: settings.calendarWebUrl,
+      transportOptions: getMailTransportOptions(settings.availableInterfaces ?? []),
+    }),
+    holidayStateCode: settings.holidayStateCode,
+    customRecurrencePresets: settings.customRecurrencePresets ?? [],
+    deletedPresetFallbacks: {},
+  });
+  return result ?? getWasteManagementSettings();
+};
 
 export const WasteOutputPanel = () => {
   const pt = usePluginTranslation('wasteManagement');
@@ -98,25 +68,22 @@ export const WasteOutputPanel = () => {
   const [emailMessage, setEmailMessage] = useState<StatusMessage | null>(null);
   const [brandingAssetUrl, setBrandingAssetUrl] = useState('');
   const [contactBlock, setContactBlock] = useState('');
-  const [emailReminderConfig, setEmailReminderConfig] = useState<WasteManagementEmailReminderConfig | null>(null);
+  const [emailReminderConfig, setEmailReminderConfig] =
+    useState<WasteManagementEmailReminderConfig | null>(null);
 
-  const mailTransportOptions = (settings?.availableInterfaces ?? []).filter(
-    (option) => option.typeKey === 'mail_transport'
-  );
+  const mailTransportOptions = getMailTransportOptions(settings?.availableInterfaces ?? []);
 
   useEffect(() => {
-    const nextMailTransportOptions = (settings?.availableInterfaces ?? []).filter(
-      (option) => option.typeKey === 'mail_transport'
-    );
+    const nextMailTransportOptions = getMailTransportOptions(settings?.availableInterfaces ?? []);
     setBrandingAssetUrl(settings?.pdfBrandingAssetUrl ?? '');
     setContactBlock(settings?.pdfContactBlock ?? '');
-    const baseConfig =
-      settings?.emailReminderConfig ??
-      buildDefaultEmailReminderConfig({
+    setEmailReminderConfig(
+      normalizeEmailReminderConfig({
+        config: settings?.emailReminderConfig,
         calendarWebUrl: settings?.calendarWebUrl,
         transportOptions: nextMailTransportOptions,
-      });
-    setEmailReminderConfig(withFixedWasteEmailReminderPaths(ensureTransportSelection(baseConfig, nextMailTransportOptions)));
+      })
+    );
   }, [
     settings?.availableInterfaces,
     settings?.calendarWebUrl,
@@ -143,9 +110,6 @@ export const WasteOutputPanel = () => {
     setMessage(null);
 
     try {
-      const nextMailTransportOptions = (settings.availableInterfaces ?? []).filter(
-        (option) => option.typeKey === 'mail_transport'
-      );
       const result = await updateWasteManagementSettings({
         provider: settings.provider,
         projectUrl: settings.projectUrl,
@@ -169,7 +133,10 @@ export const WasteOutputPanel = () => {
       const code = resolveApiErrorCode(saveError);
       setMessage({
         kind: 'error',
-        text: code === 'forbidden' ? pt('output.pdf.messages.saveForbidden') : pt('output.pdf.messages.saveError'),
+        text:
+          code === 'forbidden'
+            ? pt('output.pdf.messages.saveForbidden')
+            : pt('output.pdf.messages.saveError'),
       });
     } finally {
       setRunning(false);
@@ -186,42 +153,19 @@ export const WasteOutputPanel = () => {
     setEmailMessage(null);
 
     try {
-      const nextMailTransportOptions = (settings.availableInterfaces ?? []).filter(
-        (option) => option.typeKey === 'mail_transport'
-      );
-      const result = await updateWasteManagementSettings({
-        provider: settings.provider,
-        projectUrl: settings.projectUrl,
-        schemaName: settings.schemaName,
-        enabled: settings.enabled,
-        selectedInterfaceId: settings.selectedInterfaceId,
-        calendarWebUrl: settings.calendarWebUrl,
-        pdfBrandingAssetUrl: compactOptionalString(brandingAssetUrl),
-        pdfContactBlock: compactOptionalString(contactBlock),
-        emailReminderConfig: withFixedWasteEmailReminderPaths(
-          ensureTransportSelection(emailReminderConfig, nextMailTransportOptions)
-        ),
-        holidayStateCode: settings.holidayStateCode,
-        customRecurrencePresets: settings.customRecurrencePresets ?? [],
-        deletedPresetFallbacks: {},
+      const nextSettings = await persistEmailReminderSettings({
+        settings,
+        emailReminderConfig,
+        brandingAssetUrl,
+        contactBlock,
       });
-      const nextSettings = result ?? (await getWasteManagementSettings());
       setSettings(nextSettings);
       setEmailReminderConfig(
-        withFixedWasteEmailReminderPaths(
-          ensureTransportSelection(
-            nextSettings?.emailReminderConfig ??
-              buildDefaultEmailReminderConfig({
-                calendarWebUrl: nextSettings?.calendarWebUrl,
-                transportOptions: (nextSettings?.availableInterfaces ?? []).filter(
-                  (option) => option.typeKey === 'mail_transport'
-                ),
-              }),
-            (nextSettings?.availableInterfaces ?? []).filter(
-              (option) => option.typeKey === 'mail_transport'
-            )
-          )
-        )
+        normalizeEmailReminderConfig({
+          config: nextSettings?.emailReminderConfig,
+          calendarWebUrl: nextSettings?.calendarWebUrl,
+          transportOptions: getMailTransportOptions(nextSettings?.availableInterfaces ?? []),
+        })
       );
       setEmailMessage({ kind: 'success', text: pt('output.emailReminder.messages.saveSuccess') });
     } catch (saveError) {

--- a/packages/plugin-waste-management/src/waste-management.tools.import-section.parts.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tools.import-section.parts.tsx
@@ -1,5 +1,8 @@
 import type { ChangeEvent, ReactNode } from 'react';
-import type { WasteManagementCsvDelimiter, WasteManagementImportSourceFormat } from '@sva/plugin-sdk';
+import type {
+  WasteManagementCsvDelimiter,
+  WasteManagementImportSourceFormat,
+} from '@sva/plugin-sdk';
 import { usePluginTranslation } from '@sva/plugin-sdk';
 import {
   Badge,
@@ -11,17 +14,22 @@ import {
   StudioField,
   StudioFieldGroup,
 } from '@sva/studio-ui-react';
+import type { PreviewWasteLocationTourPickupDateImportResult } from './waste-management.api.js';
+import type { WasteToolsWizardStepId } from './waste-management.tools.import-wizard-state.js';
 
-type ImportCatalogEntry = ReturnType<typeof import('./waste-management.api.js').getWasteManagementImportCatalog>[number];
-
-export type WasteToolsWizardStepId = 'profile' | 'upload' | 'validation' | 'preview' | 'result';
+type ImportCatalogEntry = ReturnType<
+  typeof import('./waste-management.api.js').getWasteManagementImportCatalog
+>[number];
 
 export const locationTourPickupDateProfileId = 'waste-management.ortsbezogene-tourtermine';
 
 export const resolveSelectedImportProfile = (
   importCatalog: readonly ImportCatalogEntry[],
   importProfileId: string
-) => importCatalog.find((profile) => profile.profileId === importProfileId) ?? importCatalog[0] ?? null;
+) =>
+  importCatalog.find((profile) => profile.profileId === importProfileId) ??
+  importCatalog[0] ??
+  null;
 
 export const resolveImportFileAccept = (importSourceFormat: WasteManagementImportSourceFormat) =>
   importSourceFormat === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
@@ -31,33 +39,35 @@ export const resolveImportFileAccept = (importSourceFormat: WasteManagementImpor
 export const isPreviewRequiredImportProfile = (profile: ImportCatalogEntry | null) =>
   profile?.profileId === locationTourPickupDateProfileId;
 
-export const createImportFileChangeHandler = ({
-  onImportBlobRefChange,
-  readFileAsDataUrl,
-  onAfterChange,
-}: {
-  readonly onImportBlobRefChange: (value: string) => void;
-  readonly readFileAsDataUrl: (file: File) => Promise<string>;
-  readonly onAfterChange?: () => void;
-}) => (event: ChangeEvent<HTMLInputElement>) => {
-  const file = event.target.files?.[0] ?? null;
-  if (!file) {
-    onImportBlobRefChange('');
-    onAfterChange?.();
-    return;
-  }
-
-  void readFileAsDataUrl(file).then(
-    (value) => {
-      onImportBlobRefChange(value);
-      onAfterChange?.();
-    },
-    () => {
+export const createImportFileChangeHandler =
+  ({
+    onImportBlobRefChange,
+    readFileAsDataUrl,
+    onAfterChange,
+  }: {
+    readonly onImportBlobRefChange: (value: string) => void;
+    readonly readFileAsDataUrl: (file: File) => Promise<string>;
+    readonly onAfterChange?: () => void;
+  }) =>
+  (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    if (!file) {
       onImportBlobRefChange('');
       onAfterChange?.();
+      return;
     }
-  );
-};
+
+    void readFileAsDataUrl(file).then(
+      (value) => {
+        onImportBlobRefChange(value);
+        onAfterChange?.();
+      },
+      () => {
+        onImportBlobRefChange('');
+        onAfterChange?.();
+      }
+    );
+  };
 
 const formatDelimiterLabel = (delimiter: string) => (delimiter === '\t' ? 'Tab' : delimiter);
 
@@ -71,7 +81,13 @@ export const WasteToolsWizardStepList = ({
   readonly onStepChange: (step: WasteToolsWizardStepId) => void;
 }) => {
   const pt = usePluginTranslation('wasteManagement');
-  const steps: readonly WasteToolsWizardStepId[] = ['profile', 'upload', 'validation', 'preview', 'result'];
+  const steps: readonly WasteToolsWizardStepId[] = [
+    'profile',
+    'upload',
+    'validation',
+    'preview',
+    'result',
+  ];
   const reachableIndex = steps.indexOf(reachableStep);
   const activeIndex = steps.indexOf(activeStep);
 
@@ -98,13 +114,19 @@ export const WasteToolsWizardStepList = ({
           >
             <span
               className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${
-                isActive ? 'bg-primary text-primary-foreground' : isDone ? 'bg-foreground text-background' : 'bg-muted'
+                isActive
+                  ? 'bg-primary text-primary-foreground'
+                  : isDone
+                    ? 'bg-foreground text-background'
+                    : 'bg-muted'
               }`}
             >
               {index + 1}
             </span>
             <span className="space-y-1">
-              <span className="block text-sm font-semibold">{pt(`tools.imports.wizard.steps.${step}.title`)}</span>
+              <span className="block text-sm font-semibold">
+                {pt(`tools.imports.wizard.steps.${step}.title`)}
+              </span>
               <span className="block text-xs text-muted-foreground">
                 {pt(`tools.imports.wizard.steps.${step}.description`)}
               </span>
@@ -133,7 +155,11 @@ export const WasteToolsWizardLayout = ({
 }) => (
   <StudioEditSurface className="rounded-2xl border-border/70 bg-background/80">
     <div className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:items-start">
-      <WasteToolsWizardStepList activeStep={activeStep} reachableStep={reachableStep} onStepChange={onStepChange} />
+      <WasteToolsWizardStepList
+        activeStep={activeStep}
+        reachableStep={reachableStep}
+        onStepChange={onStepChange}
+      />
       <div className="space-y-5">
         <div className="space-y-1">
           <h3 className="text-lg font-semibold text-foreground">{title}</h3>
@@ -185,8 +211,12 @@ export const WasteToolsImportProfileChooser = ({
             onClick={() => onSelect(profile.profileId)}
           >
             <div className="flex flex-wrap items-center gap-2">
-              <h4 className={`text-sm font-semibold ${isPrimary ? 'text-base' : ''}`}>{profile.displayName}</h4>
-              {isPrimary ? <Badge variant="secondary">{pt('tools.imports.wizard.preferredBadge')}</Badge> : null}
+              <h4 className={`text-sm font-semibold ${isPrimary ? 'text-base' : ''}`}>
+                {profile.displayName}
+              </h4>
+              {isPrimary ? (
+                <Badge variant="secondary">{pt('tools.imports.wizard.preferredBadge')}</Badge>
+              ) : null}
             </div>
             <p className="mt-2 text-sm text-muted-foreground">{profile.description}</p>
           </button>
@@ -226,15 +256,21 @@ export const WasteToolsUploadFields = ({
   return (
     <StudioFieldGroup columns={showSourceFormatField ? 2 : 1}>
       {showSourceFormatField ? (
-        <StudioField id="waste-tools-import-source-format" label={pt('tools.imports.sourceFormatLabel')}>
+        <StudioField
+          id="waste-tools-import-source-format"
+          label={pt('tools.imports.sourceFormatLabel')}
+        >
           <Select
             aria-label={pt('tools.imports.sourceFormatLabel')}
             value={importSourceFormat}
-            onChange={(event) => onImportSourceFormatChange(event.target.value as WasteManagementImportSourceFormat)}
+            onChange={(event) =>
+              onImportSourceFormatChange(event.target.value as WasteManagementImportSourceFormat)
+            }
           >
             {selectedImportProfile.sourceFormats.map((sourceFormat) => (
               <option key={sourceFormat} value={sourceFormat}>
-                {sourceFormat === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+                {sourceFormat ===
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
                   ? pt('tools.imports.sourceFormats.xlsx')
                   : pt('tools.imports.sourceFormats.csv')}
               </option>
@@ -245,7 +281,9 @@ export const WasteToolsUploadFields = ({
       <StudioField
         id="waste-tools-import-blob-ref"
         label={pt('tools.imports.blobRefLabel')}
-        description={importBlobRef.startsWith('data:') ? pt('tools.imports.wizard.fileReady') : undefined}
+        description={
+          importBlobRef.startsWith('data:') ? pt('tools.imports.wizard.fileReady') : undefined
+        }
       >
         <Input id={fileInputId} type="file" accept={fileAccept} onChange={onImportFileChange} />
       </StudioField>
@@ -259,14 +297,17 @@ export const WasteToolsUploadFields = ({
           <span>{pt('tools.imports.dryRunLabel')}</span>
         </label>
       </StudioField>
-      {isPreviewRequiredImportProfile(selectedImportProfile) && importSourceFormat === 'text/csv' ? (
+      {isPreviewRequiredImportProfile(selectedImportProfile) &&
+      importSourceFormat === 'text/csv' ? (
         <StudioField id="waste-tools-import-delimiter" label={pt('tools.imports.delimiterLabel')}>
           <Select
             aria-label={pt('tools.imports.delimiterLabel')}
             value={delimiterOverride ?? ''}
             onChange={(event) =>
               onDelimiterOverrideChange(
-                event.target.value === '' ? undefined : (event.target.value as WasteManagementCsvDelimiter)
+                event.target.value === ''
+                  ? undefined
+                  : (event.target.value as WasteManagementCsvDelimiter)
               )
             }
           >
@@ -299,16 +340,14 @@ export const WasteToolsImportRuleBox = () => {
   );
 };
 
-export const WasteToolsImportColumns = ({
-  profile,
-}: {
-  readonly profile: ImportCatalogEntry;
-}) => {
+export const WasteToolsImportColumns = ({ profile }: { readonly profile: ImportCatalogEntry }) => {
   const pt = usePluginTranslation('wasteManagement');
 
   return (
     <div className="space-y-2">
-      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{pt('tools.imports.templateColumns')}</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {pt('tools.imports.templateColumns')}
+      </p>
       <div className="flex flex-wrap gap-2">
         {profile.requiredColumns.map((column) => (
           <Badge key={column.key} variant="secondary">
@@ -329,7 +368,11 @@ export const WasteToolsPreviewSummary = ({
   previewResult,
 }: {
   readonly previewResult: NonNullable<
-    Awaited<ReturnType<typeof import('./waste-management.api.js').previewWasteLocationTourPickupDateImport>>
+    Awaited<
+      ReturnType<
+        typeof import('./waste-management.api.js').previewWasteLocationTourPickupDateImport
+      >
+    >
   >;
 }) => {
   const pt = usePluginTranslation('wasteManagement');
@@ -338,15 +381,21 @@ export const WasteToolsPreviewSummary = ({
     <div className="space-y-4">
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <div className="rounded-xl border border-border/70 bg-muted/10 p-3">
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">{pt('tools.imports.wizard.metrics.validRows')}</p>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            {pt('tools.imports.wizard.metrics.validRows')}
+          </p>
           <p className="mt-1 text-2xl font-semibold">{previewResult.validRowCount}</p>
         </div>
         <div className="rounded-xl border border-border/70 bg-muted/10 p-3">
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">{pt('tools.imports.wizard.metrics.invalidRows')}</p>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            {pt('tools.imports.wizard.metrics.invalidRows')}
+          </p>
           <p className="mt-1 text-2xl font-semibold">{previewResult.invalidRowCount}</p>
         </div>
         <div className="rounded-xl border border-border/70 bg-muted/10 p-3">
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">{pt('tools.imports.wizard.metrics.createdTours')}</p>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            {pt('tools.imports.wizard.metrics.createdTours')}
+          </p>
           <p className="mt-1 text-2xl font-semibold">{previewResult.newTours.length}</p>
         </div>
         <div className="rounded-xl border border-border/70 bg-muted/10 p-3">
@@ -412,7 +461,10 @@ export const WasteToolsPreviewSummary = ({
         {previewResult.errors.length > 0 ? (
           <div className="space-y-2">
             {previewResult.errors.map((error, index) => (
-              <div key={`${error.rowNumber}-${error.column}-${index}`} className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm">
+              <div
+                key={`${error.rowNumber}-${error.column}-${index}`}
+                className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+              >
                 <p className="font-medium">
                   {pt('tools.imports.wizard.errorLine', {
                     rowNumber: error.rowNumber,
@@ -446,14 +498,22 @@ export const WasteToolsResultSummary = ({
     <div className="space-y-4">
       <div className="rounded-xl border border-border/70 bg-muted/10 p-4">
         <p className="text-sm font-semibold">{pt('tools.imports.wizard.resultTitle')}</p>
-        <p className="mt-1 text-sm text-muted-foreground">{pt('tools.imports.wizard.resultDescription')}</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {pt('tools.imports.wizard.resultDescription')}
+        </p>
         <dl className="mt-4 grid gap-3 sm:grid-cols-2">
           <div>
-            <dt className="text-xs uppercase tracking-wide text-muted-foreground">{pt('tools.meta.jobStatusLabel')}</dt>
-            <dd className="mt-1 text-sm font-medium text-foreground">{status ?? pt('tools.meta.noJobStatus')}</dd>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+              {pt('tools.meta.jobStatusLabel')}
+            </dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">
+              {status ?? pt('tools.meta.noJobStatus')}
+            </dd>
           </div>
           <div>
-            <dt className="text-xs uppercase tracking-wide text-muted-foreground">{pt('tools.meta.jobIdLabel')}</dt>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+              {pt('tools.meta.jobIdLabel')}
+            </dt>
             <dd className="mt-1 break-all text-sm font-medium text-foreground">{jobId ?? '—'}</dd>
           </div>
         </dl>
@@ -491,3 +551,190 @@ export const WasteToolsWizardFooter = ({
     </div>
   );
 };
+
+export const WasteToolsProfileStep = ({
+  importCatalog,
+  selectedProfileId,
+  onSelect,
+  onContinue,
+}: {
+  readonly importCatalog: readonly ImportCatalogEntry[];
+  readonly selectedProfileId: string;
+  readonly onSelect: (profileId: string) => void;
+  readonly onContinue: () => void;
+}) => {
+  const pt = usePluginTranslation('wasteManagement');
+  return (
+    <div className="space-y-5">
+      <WasteToolsImportProfileChooser
+        importCatalog={importCatalog}
+        selectedProfileId={selectedProfileId}
+        onSelect={onSelect}
+      />
+      <WasteToolsWizardFooter
+        primaryAction={
+          <Button type="button" onClick={onContinue}>
+            {pt('tools.imports.wizard.actions.continue')}
+          </Button>
+        }
+      />
+    </div>
+  );
+};
+
+export const WasteToolsUploadStep = ({
+  profile,
+  importSourceFormat,
+  fileInputId,
+  importBlobRef,
+  importDryRun,
+  delimiterOverride,
+  canContinue,
+  onImportSourceFormatChange,
+  onImportDryRunChange,
+  onDelimiterOverrideChange,
+  onImportFileChange,
+  onDownloadTemplate,
+  onBack,
+  onContinue,
+}: {
+  readonly profile: ImportCatalogEntry;
+  readonly importSourceFormat: WasteManagementImportSourceFormat;
+  readonly fileInputId: string;
+  readonly importBlobRef: string;
+  readonly importDryRun: boolean;
+  readonly delimiterOverride?: WasteManagementCsvDelimiter;
+  readonly canContinue: boolean;
+  readonly onImportSourceFormatChange: (value: WasteManagementImportSourceFormat) => void;
+  readonly onImportDryRunChange: (value: boolean) => void;
+  readonly onDelimiterOverrideChange: (value: WasteManagementCsvDelimiter | undefined) => void;
+  readonly onImportFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  readonly onDownloadTemplate: () => void;
+  readonly onBack: () => void;
+  readonly onContinue: () => void;
+}) => {
+  const pt = usePluginTranslation('wasteManagement');
+  return (
+    <div className="space-y-5">
+      <WasteToolsUploadFields
+        selectedImportProfile={profile}
+        importSourceFormat={importSourceFormat}
+        fileInputId={fileInputId}
+        importBlobRef={importBlobRef}
+        importDryRun={importDryRun}
+        delimiterOverride={delimiterOverride}
+        onImportSourceFormatChange={onImportSourceFormatChange}
+        onImportDryRunChange={onImportDryRunChange}
+        onDelimiterOverrideChange={onDelimiterOverrideChange}
+        onImportFileChange={onImportFileChange}
+      />
+      <WasteToolsImportColumns profile={profile} />
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" variant="outline" onClick={onDownloadTemplate}>
+          {pt('tools.actions.downloadTemplate')}
+        </Button>
+      </div>
+      <WasteToolsWizardFooter
+        onBack={onBack}
+        primaryAction={
+          <Button type="button" disabled={!canContinue} onClick={onContinue}>
+            {pt('tools.imports.wizard.actions.continue')}
+          </Button>
+        }
+      />
+    </div>
+  );
+};
+
+export const WasteToolsValidationStep = ({
+  profile,
+  previewRequired,
+  running,
+  canContinue,
+  onBack,
+  onPreview,
+  onContinue,
+}: {
+  readonly profile: ImportCatalogEntry;
+  readonly previewRequired: boolean;
+  readonly running: boolean;
+  readonly canContinue: boolean;
+  readonly onBack: () => void;
+  readonly onPreview: () => void;
+  readonly onContinue: () => void;
+}) => {
+  const pt = usePluginTranslation('wasteManagement');
+  const action = previewRequired ? (
+    <Button type="button" variant="outline" disabled={running || !canContinue} onClick={onPreview}>
+      {pt('tools.actions.previewImport')}
+    </Button>
+  ) : (
+    <Button type="button" disabled={!canContinue} onClick={onContinue}>
+      {pt('tools.imports.wizard.actions.continueToConfirmation')}
+    </Button>
+  );
+  return (
+    <div className="space-y-5">
+      {previewRequired ? <WasteToolsImportRuleBox /> : null}
+      <div className="rounded-xl border border-border/70 bg-muted/10 p-4">
+        <p className="text-sm font-medium text-foreground">{profile.displayName}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{profile.description}</p>
+      </div>
+      <WasteToolsWizardFooter onBack={onBack} primaryAction={action} />
+    </div>
+  );
+};
+
+export const WasteToolsPreviewStep = ({
+  profile,
+  previewRequired,
+  previewResult,
+  running,
+  canStartImport,
+  onBack,
+  onDownloadErrors,
+  onStartImport,
+}: {
+  readonly profile: ImportCatalogEntry;
+  readonly previewRequired: boolean;
+  readonly previewResult: PreviewWasteLocationTourPickupDateImportResult | null;
+  readonly running: boolean;
+  readonly canStartImport: boolean;
+  readonly onBack: () => void;
+  readonly onDownloadErrors: () => void;
+  readonly onStartImport: () => void;
+}) => {
+  const pt = usePluginTranslation('wasteManagement');
+  return (
+    <div className="space-y-5">
+      {previewRequired && previewResult ? (
+        <WasteToolsPreviewSummary previewResult={previewResult} />
+      ) : (
+        <div className="space-y-4">
+          <div className="rounded-xl border border-border/70 bg-muted/10 p-4">
+            <p className="text-sm font-semibold">{pt('tools.imports.wizard.confirmTitle')}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{profile.description}</p>
+          </div>
+          <WasteToolsImportColumns profile={profile} />
+        </div>
+      )}
+      <WasteToolsWizardFooter
+        onBack={onBack}
+        primaryAction={
+          <>
+            {previewRequired && previewResult && previewResult.errors.length > 0 ? (
+              <Button type="button" variant="outline" onClick={onDownloadErrors}>
+                {pt('tools.actions.downloadErrorFile')}
+              </Button>
+            ) : null}
+            <Button type="button" disabled={running || !canStartImport} onClick={onStartImport}>
+              {running ? pt('tools.actions.starting') : pt('tools.actions.startImport')}
+            </Button>
+          </>
+        }
+      />
+    </div>
+  );
+};
+
+export const WasteToolsResultStep = WasteToolsResultSummary;

--- a/packages/plugin-waste-management/src/waste-management.tools.import-section.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tools.import-section.tsx
@@ -1,59 +1,43 @@
 import type { StudioJobResponse, WasteManagementImportSourceFormat } from '@sva/plugin-sdk';
 import { usePluginTranslation, wasteManagementOperationsContract } from '@sva/plugin-sdk';
 import { useEffect, useId, useMemo, useState } from 'react';
-import { Button } from '@sva/studio-ui-react';
 
-import type { PreviewWasteLocationTourPickupDateImportResult, StartWasteManagementImportInput } from './waste-management.api.js';
-import { downloadImportPreviewErrors, downloadImportTemplate, readFileAsDataUrl } from './waste-management.page.support.js';
+import type {
+  PreviewWasteLocationTourPickupDateImportResult,
+  StartWasteManagementImportInput,
+} from './waste-management.api.js';
+import {
+  downloadImportPreviewErrors,
+  downloadImportTemplate,
+  readFileAsDataUrl,
+} from './waste-management.page.support.js';
 import {
   createImportFileChangeHandler,
   isPreviewRequiredImportProfile,
   resolveSelectedImportProfile,
-  WasteToolsImportColumns,
-  WasteToolsImportProfileChooser,
-  WasteToolsImportRuleBox,
-  WasteToolsPreviewSummary,
-  WasteToolsResultSummary,
-  WasteToolsUploadFields,
-  WasteToolsWizardFooter,
+  WasteToolsPreviewStep,
+  WasteToolsProfileStep,
+  WasteToolsResultStep,
+  WasteToolsUploadStep,
+  WasteToolsValidationStep,
   WasteToolsWizardLayout,
-  type WasteToolsWizardStepId,
 } from './waste-management.tools.import-section.parts.js';
+import {
+  getReachableStep,
+  transitionToReachableStep,
+  type WasteToolsWizardStepId,
+} from './waste-management.tools.import-wizard-state.js';
 
-type ImportCatalogEntry = ReturnType<typeof import('./waste-management.api.js').getWasteManagementImportCatalog>[number];
-
-const getReachableStep = ({
-  selectedImportProfile,
-  importBlobRef,
-  previewReady,
-  hasImportResult,
-}: {
-  readonly selectedImportProfile: ImportCatalogEntry | null;
-  readonly importBlobRef: string;
-  readonly previewReady: boolean;
-  readonly hasImportResult: boolean;
-}): WasteToolsWizardStepId => {
-  if (hasImportResult) {
-    return 'result';
-  }
-  if (isPreviewRequiredImportProfile(selectedImportProfile) && previewReady) {
-    return 'preview';
-  }
-  if (!isPreviewRequiredImportProfile(selectedImportProfile) && importBlobRef.startsWith('data:')) {
-    return 'preview';
-  }
-  if (importBlobRef.startsWith('data:')) {
-    return 'validation';
-  }
-  if (selectedImportProfile) {
-    return 'upload';
-  }
-  return 'profile';
-};
-
-const getStepTitleKey = (step: WasteToolsWizardStepId) => `tools.imports.wizard.steps.${step}.title`;
-const getStepDescriptionKey = (step: WasteToolsWizardStepId) => `tools.imports.wizard.steps.${step}.description`;
-const isImportResultJob = (job: StudioJobResponse['data'] | null): job is StudioJobResponse['data'] =>
+type ImportCatalogEntry = ReturnType<
+  typeof import('./waste-management.api.js').getWasteManagementImportCatalog
+>[number];
+const getStepTitleKey = (step: WasteToolsWizardStepId) =>
+  `tools.imports.wizard.steps.${step}.title`;
+const getStepDescriptionKey = (step: WasteToolsWizardStepId) =>
+  `tools.imports.wizard.steps.${step}.description`;
+const isImportResultJob = (
+  job: StudioJobResponse['data'] | null
+): job is StudioJobResponse['data'] =>
   job?.jobTypeId === wasteManagementOperationsContract.jobTypeIds.importData;
 
 export const WasteToolsImportSection = ({
@@ -84,12 +68,16 @@ export const WasteToolsImportSection = ({
   readonly previewResult: PreviewWasteLocationTourPickupDateImportResult | null;
   readonly previewReady: boolean;
   readonly running: boolean;
-  readonly lastJob: StudioJobResponse['data'] | null;
-  readonly onImportProfileIdChange: (value: StartWasteManagementImportInput['importProfileId']) => void;
+  readonly lastJob?: StudioJobResponse['data'] | null;
+  readonly onImportProfileIdChange: (
+    value: StartWasteManagementImportInput['importProfileId']
+  ) => void;
   readonly onImportSourceFormatChange: (value: WasteManagementImportSourceFormat) => void;
   readonly onImportBlobRefChange: (value: string) => void;
   readonly onImportDryRunChange: (value: boolean) => void;
-  readonly onDelimiterOverrideChange: (value: StartWasteManagementImportInput['delimiterOverride']) => void;
+  readonly onDelimiterOverrideChange: (
+    value: StartWasteManagementImportInput['delimiterOverride']
+  ) => void;
   readonly onRunPreview: () => Promise<PreviewWasteLocationTourPickupDateImportResult | null>;
   readonly onStartImport: () => Promise<StudioJobResponse['data'] | null>;
 }) => {
@@ -97,50 +85,44 @@ export const WasteToolsImportSection = ({
   const fileInputId = useId();
   const [wizardStep, setWizardStep] = useState<WasteToolsWizardStepId>('profile');
   const [importResultJob, setImportResultJob] = useState<StudioJobResponse['data'] | null>(
-    isImportResultJob(lastJob) ? lastJob : null
+    isImportResultJob(lastJob ?? null) ? (lastJob ?? null) : null
   );
   const selectedImportProfile = resolveSelectedImportProfile(importCatalog, importProfileId);
   const previewRequired = isPreviewRequiredImportProfile(selectedImportProfile);
   const reachableStep = getReachableStep({
-    selectedImportProfile,
-    importBlobRef,
+    hasSelectedProfile: selectedImportProfile !== null,
+    hasReadyFile: importBlobRef.startsWith('data:'),
+    previewRequired,
     previewReady,
     hasImportResult: Boolean(importResultJob?.id),
   });
   const canContinueFromUpload = importBlobRef.startsWith('data:');
   const previewHasBlockingErrors = previewRequired && (previewResult?.errors.length ?? 0) > 0;
   const canStartImport =
-    importBlobRef.startsWith('data:') && (!previewRequired || (previewReady && !previewHasBlockingErrors));
+    canContinueFromUpload && (!previewRequired || (previewReady && !previewHasBlockingErrors));
 
   useEffect(() => {
-    if (previewReady) {
-      setWizardStep('preview');
-    }
+    if (previewReady) setWizardStep('preview');
   }, [previewReady]);
-
   useEffect(() => {
-    if (isImportResultJob(lastJob)) {
-      setImportResultJob(lastJob);
-    }
+    if (isImportResultJob(lastJob ?? null)) setImportResultJob(lastJob ?? null);
   }, [lastJob]);
-
-  const handleProfileSelection = (nextProfileId: StartWasteManagementImportInput['importProfileId']) => {
-    onImportProfileIdChange(nextProfileId);
+  const goTo = (step: WasteToolsWizardStepId) =>
+    setWizardStep((current) => transitionToReachableStep(current, step, reachableStep));
+  const handleProfileSelection = (value: StartWasteManagementImportInput['importProfileId']) => {
+    onImportProfileIdChange(value);
     setWizardStep('upload');
   };
-
-  const handleSourceFormatChange = (nextSourceFormat: WasteManagementImportSourceFormat) => {
-    onImportSourceFormatChange(nextSourceFormat);
+  const handleSourceFormatChange = (value: WasteManagementImportSourceFormat) => {
+    onImportSourceFormatChange(value);
     setWizardStep('upload');
   };
-
-  const handleDelimiterOverrideChange = (value: StartWasteManagementImportInput['delimiterOverride']) => {
+  const handleDelimiterOverrideChange = (
+    value: StartWasteManagementImportInput['delimiterOverride']
+  ) => {
     onDelimiterOverrideChange(value);
-    if (wizardStep === 'preview' || wizardStep === 'result') {
-      setWizardStep('validation');
-    }
+    if (wizardStep === 'preview' || wizardStep === 'result') setWizardStep('validation');
   };
-
   const handleImportFileChange = useMemo(
     () =>
       createImportFileChangeHandler({
@@ -150,14 +132,9 @@ export const WasteToolsImportSection = ({
       }),
     [onImportBlobRefChange]
   );
-
   const handleRunPreview = async () => {
-    const preview = await onRunPreview();
-    if (preview) {
-      setWizardStep('preview');
-    }
+    if (await onRunPreview()) setWizardStep('preview');
   };
-
   const handleStartImport = async () => {
     const job = await onStartImport();
     if (isImportResultJob(job)) {
@@ -165,7 +142,6 @@ export const WasteToolsImportSection = ({
       setWizardStep('result');
     }
   };
-
   const handleStartNewImport = () => {
     setImportResultJob(null);
     onImportBlobRefChange('');
@@ -173,133 +149,74 @@ export const WasteToolsImportSection = ({
     setWizardStep('profile');
   };
 
-  const renderStepContent = () => {
-    if (!selectedImportProfile) {
-      return null;
-    }
-
+  const renderStep = () => {
+    if (!selectedImportProfile) return null;
     switch (wizardStep) {
       case 'profile':
         return (
-          <div className="space-y-5">
-            <WasteToolsImportProfileChooser
-              importCatalog={importCatalog}
-              selectedProfileId={selectedImportProfile.profileId}
-              onSelect={handleProfileSelection}
-            />
-            <WasteToolsWizardFooter
-              primaryAction={
-                <Button type="button" onClick={() => setWizardStep('upload')}>
-                  {pt('tools.imports.wizard.actions.continue')}
-                </Button>
-              }
-            />
-          </div>
+          <WasteToolsProfileStep
+            importCatalog={importCatalog}
+            selectedProfileId={selectedImportProfile.profileId}
+            onSelect={handleProfileSelection}
+            onContinue={() => setWizardStep('upload')}
+          />
         );
       case 'upload':
         return (
-          <div className="space-y-5">
-            <WasteToolsUploadFields
-              selectedImportProfile={selectedImportProfile}
-              importSourceFormat={importSourceFormat}
-              fileInputId={fileInputId}
-              importBlobRef={importBlobRef}
-              importDryRun={importDryRun}
-              delimiterOverride={delimiterOverride}
-              onImportSourceFormatChange={handleSourceFormatChange}
-              onImportDryRunChange={onImportDryRunChange}
-              onDelimiterOverrideChange={handleDelimiterOverrideChange}
-              onImportFileChange={handleImportFileChange}
-            />
-            <WasteToolsImportColumns profile={selectedImportProfile} />
-            <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => void downloadImportTemplate(selectedImportProfile, importSourceFormat)}
-              >
-                {pt('tools.actions.downloadTemplate')}
-              </Button>
-            </div>
-            <WasteToolsWizardFooter
-              onBack={() => setWizardStep('profile')}
-              primaryAction={
-                <Button type="button" disabled={!canContinueFromUpload} onClick={() => setWizardStep('validation')}>
-                  {pt('tools.imports.wizard.actions.continue')}
-                </Button>
-              }
-            />
-          </div>
+          <WasteToolsUploadStep
+            profile={selectedImportProfile}
+            importSourceFormat={importSourceFormat}
+            fileInputId={fileInputId}
+            importBlobRef={importBlobRef}
+            importDryRun={importDryRun}
+            delimiterOverride={delimiterOverride}
+            canContinue={canContinueFromUpload}
+            onImportSourceFormatChange={handleSourceFormatChange}
+            onImportDryRunChange={onImportDryRunChange}
+            onDelimiterOverrideChange={handleDelimiterOverrideChange}
+            onImportFileChange={handleImportFileChange}
+            onDownloadTemplate={() =>
+              void downloadImportTemplate(selectedImportProfile, importSourceFormat)
+            }
+            onBack={() => setWizardStep('profile')}
+            onContinue={() => setWizardStep('validation')}
+          />
         );
       case 'validation':
         return (
-          <div className="space-y-5">
-            {previewRequired ? <WasteToolsImportRuleBox /> : null}
-            <div className="rounded-xl border border-border/70 bg-muted/10 p-4">
-              <p className="text-sm font-medium text-foreground">{selectedImportProfile.displayName}</p>
-              <p className="mt-1 text-sm text-muted-foreground">{selectedImportProfile.description}</p>
-            </div>
-            <WasteToolsWizardFooter
-              onBack={() => setWizardStep('upload')}
-              primaryAction={
-                previewRequired ? (
-                  <Button type="button" variant="outline" disabled={running || !canContinueFromUpload} onClick={() => void handleRunPreview()}>
-                    {pt('tools.actions.previewImport')}
-                  </Button>
-                ) : (
-                  <Button type="button" disabled={!canContinueFromUpload} onClick={() => setWizardStep('preview')}>
-                    {pt('tools.imports.wizard.actions.continueToConfirmation')}
-                  </Button>
-                )
-              }
-            />
-          </div>
+          <WasteToolsValidationStep
+            profile={selectedImportProfile}
+            previewRequired={previewRequired}
+            running={running}
+            canContinue={canContinueFromUpload}
+            onBack={() => setWizardStep('upload')}
+            onPreview={() => void handleRunPreview()}
+            onContinue={() => setWizardStep('preview')}
+          />
         );
       case 'preview':
         return (
-          <div className="space-y-5">
-            {previewRequired && previewResult ? (
-              <WasteToolsPreviewSummary previewResult={previewResult} />
-            ) : (
-              <div className="space-y-4">
-                <div className="rounded-xl border border-border/70 bg-muted/10 p-4">
-                  <p className="text-sm font-semibold">{pt('tools.imports.wizard.confirmTitle')}</p>
-                  <p className="mt-1 text-sm text-muted-foreground">{selectedImportProfile.description}</p>
-                </div>
-                <WasteToolsImportColumns profile={selectedImportProfile} />
-              </div>
-            )}
-            <WasteToolsWizardFooter
-              onBack={() => setWizardStep('validation')}
-              primaryAction={
-                <>
-                  {previewRequired && previewResult && previewResult.errors.length > 0 ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => downloadImportPreviewErrors(previewResult)}
-                    >
-                      {pt('tools.actions.downloadErrorFile')}
-                    </Button>
-                  ) : null}
-                  <Button type="button" disabled={running || !canStartImport} onClick={() => void handleStartImport()}>
-                    {running ? pt('tools.actions.starting') : pt('tools.actions.startImport')}
-                  </Button>
-                </>
-              }
-            />
-          </div>
+          <WasteToolsPreviewStep
+            profile={selectedImportProfile}
+            previewRequired={previewRequired}
+            previewResult={previewResult}
+            running={running}
+            canStartImport={canStartImport}
+            onBack={() => setWizardStep('validation')}
+            onDownloadErrors={() => {
+              if (previewResult) downloadImportPreviewErrors(previewResult);
+            }}
+            onStartImport={() => void handleStartImport()}
+          />
         );
       case 'result':
         return (
-          <WasteToolsResultSummary
+          <WasteToolsResultStep
             jobId={importResultJob?.id}
             status={importResultJob?.status}
             onStartNewImport={handleStartNewImport}
           />
         );
-      default:
-        return null;
     }
   };
 
@@ -312,11 +229,11 @@ export const WasteToolsImportSection = ({
       <WasteToolsWizardLayout
         activeStep={wizardStep}
         reachableStep={reachableStep}
-        onStepChange={setWizardStep}
+        onStepChange={goTo}
         title={pt(getStepTitleKey(wizardStep))}
         description={pt(getStepDescriptionKey(wizardStep))}
       >
-        {renderStepContent()}
+        {renderStep()}
       </WasteToolsWizardLayout>
     </div>
   );

--- a/packages/plugin-waste-management/src/waste-management.tools.import-wizard-state.ts
+++ b/packages/plugin-waste-management/src/waste-management.tools.import-wizard-state.ts
@@ -1,0 +1,36 @@
+export type WasteToolsWizardStepId = 'profile' | 'upload' | 'validation' | 'preview' | 'result';
+export type WasteToolsImportWizardFacts = {
+  readonly hasSelectedProfile: boolean;
+  readonly hasReadyFile: boolean;
+  readonly previewRequired: boolean;
+  readonly previewReady: boolean;
+  readonly hasImportResult: boolean;
+};
+
+const steps: readonly WasteToolsWizardStepId[] = [
+  'profile',
+  'upload',
+  'validation',
+  'preview',
+  'result',
+];
+
+export const getReachableStep = ({
+  hasSelectedProfile,
+  hasReadyFile,
+  previewRequired,
+  previewReady,
+  hasImportResult,
+}: WasteToolsImportWizardFacts): WasteToolsWizardStepId => {
+  if (hasImportResult) return 'result';
+  if ((previewRequired && previewReady) || (!previewRequired && hasReadyFile)) return 'preview';
+  if (hasReadyFile) return 'validation';
+  return hasSelectedProfile ? 'upload' : 'profile';
+};
+
+export const transitionToReachableStep = (
+  currentStep: WasteToolsWizardStepId,
+  targetStep: WasteToolsWizardStepId,
+  reachableStep: WasteToolsWizardStepId
+): WasteToolsWizardStepId =>
+  steps.indexOf(targetStep) <= steps.indexOf(reachableStep) ? targetStep : currentStep;

--- a/packages/plugin-waste-management/src/waste-management.tours-assignments-dialog.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tours-assignments-dialog.tsx
@@ -20,8 +20,10 @@ import {
 import { StatusNotice, type StatusMessage } from './waste-management.page.support.js';
 import type { LocationTourLinkFormState } from './waste-management.tours.types.js';
 import type { TourAssignmentLocationOption } from './waste-management.tours.locations.js';
+import { createTourAssignmentSelectionSummary } from './waste-management.tours.view-model.js';
 
-const matchesSearch = (value: string, query: string) => value.toLocaleLowerCase().includes(query.toLocaleLowerCase());
+const matchesSearch = (value: string, query: string) =>
+  value.toLocaleLowerCase().includes(query.toLocaleLowerCase());
 
 const renderLocationWorkspaceState = (
   loading: boolean,
@@ -31,11 +33,19 @@ const renderLocationWorkspaceState = (
   toggleSelectedLocation: (locationId: string, checked: boolean) => void
 ) => {
   if (loading) {
-    return <div className="p-4 text-sm text-muted-foreground">{pt('tours.table.loadingAssignments')}</div>;
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {pt('tours.table.loadingAssignments')}
+      </div>
+    );
   }
 
   if (filteredLocations.length === 0) {
-    return <div className="p-4 text-sm text-muted-foreground">{pt('tours.assignments.workspace.noLocations')}</div>;
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {pt('tours.assignments.workspace.noLocations')}
+      </div>
+    );
   }
 
   return (
@@ -43,13 +53,23 @@ const renderLocationWorkspaceState = (
       {filteredLocations.map((location) => {
         const selected = selectedLocationIds.includes(location.id);
         return (
-          <label key={location.id} className="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-muted/20">
-            <Checkbox checked={selected} onChange={(event) => toggleSelectedLocation(location.id, event.currentTarget.checked)} />
+          <label
+            key={location.id}
+            className="flex cursor-pointer items-start gap-3 px-4 py-3 hover:bg-muted/20"
+          >
+            <Checkbox
+              checked={selected}
+              onChange={(event) => toggleSelectedLocation(location.id, event.currentTarget.checked)}
+            />
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="font-medium">{location.label}</span>
-                {location.assignedLinkId ? <Badge>{pt('tours.assignments.workspace.assigned')}</Badge> : null}
-                {!location.active ? <Badge variant="outline">{pt('filters.status.inactive')}</Badge> : null}
+                {location.assignedLinkId ? (
+                  <Badge>{pt('tours.assignments.workspace.assigned')}</Badge>
+                ) : null}
+                {!location.active ? (
+                  <Badge variant="outline">{pt('filters.status.inactive')}</Badge>
+                ) : null}
               </div>
               <p className="text-xs text-muted-foreground">
                 {[location.regionName, location.cityName, location.streetName]
@@ -89,7 +109,10 @@ export const TourAssignmentsDialog = ({
   readonly message: StatusMessage | null;
   readonly onOpenChange: (open: boolean) => void;
   readonly onChange: (patch: Partial<LocationTourLinkFormState>) => void;
-  readonly onSubmit: (event: FormEvent<HTMLFormElement>, selectedLocationIds: readonly string[]) => void;
+  readonly onSubmit: (
+    event: FormEvent<HTMLFormElement>,
+    selectedLocationIds: readonly string[]
+  ) => void;
 }) => {
   const pt = usePluginTranslation('wasteManagement');
   const [searchQuery, setSearchQuery] = useState('');
@@ -118,7 +141,9 @@ export const TourAssignmentsDialog = ({
 
   useEffect(() => {
     const availableLocationIds = new Set(locations.map((location) => location.id));
-    setSelectedLocationIds((current) => current.filter((locationId) => availableLocationIds.has(locationId)));
+    setSelectedLocationIds((current) =>
+      current.filter((locationId) => availableLocationIds.has(locationId))
+    );
   }, [locations]);
 
   const regionOptions = useMemo(
@@ -128,7 +153,7 @@ export const TourAssignmentsDialog = ({
           locations
             .filter((location) => location.regionId && location.regionName)
             .map((location) => [location.regionId, location.regionName] as const)
-        ),
+        )
       ),
     [locations]
   );
@@ -139,7 +164,7 @@ export const TourAssignmentsDialog = ({
           locations
             .filter((location) => !regionFilter || location.regionId === regionFilter)
             .map((location) => [location.cityId, location.cityName] as const)
-        ),
+        )
       ),
     [locations, regionFilter]
   );
@@ -148,9 +173,13 @@ export const TourAssignmentsDialog = ({
       Array.from(
         new Map(
           locations
-            .filter((location) => (!regionFilter || location.regionId === regionFilter) && (!cityFilter || location.cityId === cityFilter))
+            .filter(
+              (location) =>
+                (!regionFilter || location.regionId === regionFilter) &&
+                (!cityFilter || location.cityId === cityFilter)
+            )
             .map((location) => [location.streetId, location.streetName] as const)
-        ),
+        )
       ),
     [cityFilter, locations, regionFilter]
   );
@@ -178,11 +207,11 @@ export const TourAssignmentsDialog = ({
   );
 
   const visibleLocationIds = filteredLocations.map((location) => location.id);
-  const visibleLocationIdSet = new Set(visibleLocationIds);
-  const allVisibleSelected =
-    visibleLocationIds.length > 0 && visibleLocationIds.every((locationId) => selectedLocationIds.includes(locationId));
-  const someVisibleSelected = visibleLocationIds.some((locationId) => selectedLocationIds.includes(locationId));
-  const hiddenSelectedCount = selectedLocationIds.filter((locationId) => !visibleLocationIdSet.has(locationId)).length;
+  const { allVisibleSelected, someVisibleSelected, hiddenSelectedCount, visibleLocationIdSet } =
+    createTourAssignmentSelectionSummary({
+      filteredLocationIds: visibleLocationIds,
+      selectedLocationIds,
+    });
 
   const toggleSelectAllVisible = (checked: boolean) => {
     setSelectedLocationIds((current) => {
@@ -195,11 +224,17 @@ export const TourAssignmentsDialog = ({
 
   const toggleSelectedLocation = (locationId: string, checked: boolean) => {
     setSelectedLocationIds((current) =>
-      checked ? (current.includes(locationId) ? current : [...current, locationId]) : current.filter((value) => value !== locationId)
+      checked
+        ? current.includes(locationId)
+          ? current
+          : [...current, locationId]
+        : current.filter((value) => value !== locationId)
     );
   };
   const title =
-    mode === 'create' ? pt('tours.assignments.dialog.createTitle') : pt('tours.assignments.dialog.editTitle');
+    mode === 'create'
+      ? pt('tours.assignments.dialog.createTitle')
+      : pt('tours.assignments.dialog.editTitle');
   const description = tour
     ? pt('tours.assignments.dialog.description', { value: tour.name })
     : pt('tours.assignments.dialog.descriptionFallback');
@@ -220,12 +255,18 @@ export const TourAssignmentsDialog = ({
           </DialogHeader>
         </div>
 
-        <form className="flex min-h-0 flex-1 flex-col" onSubmit={(event) => onSubmit(event, selectedLocationIds)}>
+        <form
+          className="flex min-h-0 flex-1 flex-col"
+          onSubmit={(event) => onSubmit(event, selectedLocationIds)}
+        >
           <div className="flex-1 space-y-4 overflow-y-auto px-6 py-5 rounded-2xl border border-border/70 bg-card/60">
             <StatusNotice message={message} />
 
             <div className="grid gap-4 md:grid-cols-2">
-              <StudioField id="waste-tour-assignment-start-date" label={pt('tours.assignments.fields.startDate')}>
+              <StudioField
+                id="waste-tour-assignment-start-date"
+                label={pt('tours.assignments.fields.startDate')}
+              >
                 <Input
                   id="waste-tour-assignment-start-date"
                   type="date"
@@ -233,7 +274,10 @@ export const TourAssignmentsDialog = ({
                   onChange={(event) => onChange({ startDate: event.target.value })}
                 />
               </StudioField>
-              <StudioField id="waste-tour-assignment-end-date" label={pt('tours.assignments.fields.endDate')}>
+              <StudioField
+                id="waste-tour-assignment-end-date"
+                label={pt('tours.assignments.fields.endDate')}
+              >
                 <Input
                   id="waste-tour-assignment-end-date"
                   type="date"
@@ -255,7 +299,10 @@ export const TourAssignmentsDialog = ({
                 </StudioField>
               </div>
               <div className="min-w-[180px]">
-                <StudioField id="waste-tour-assignment-region-filter" label={pt('masterData.collectionLocations.fields.regionId')}>
+                <StudioField
+                  id="waste-tour-assignment-region-filter"
+                  label={pt('masterData.collectionLocations.fields.regionId')}
+                >
                   <Select
                     id="waste-tour-assignment-region-filter"
                     value={regionFilter}
@@ -265,7 +312,9 @@ export const TourAssignmentsDialog = ({
                       setStreetFilter('');
                     }}
                   >
-                    <option value="">{pt('masterData.collectionLocations.fields.regionUnset')}</option>
+                    <option value="">
+                      {pt('masterData.collectionLocations.fields.regionUnset')}
+                    </option>
                     {regionOptions.map(([id, name]) => (
                       <option key={id} value={id}>
                         {name}
@@ -275,7 +324,10 @@ export const TourAssignmentsDialog = ({
                 </StudioField>
               </div>
               <div className="min-w-[180px]">
-                <StudioField id="waste-tour-assignment-city-filter" label={pt('masterData.collectionLocations.fields.cityId')}>
+                <StudioField
+                  id="waste-tour-assignment-city-filter"
+                  label={pt('masterData.collectionLocations.fields.cityId')}
+                >
                   <Select
                     id="waste-tour-assignment-city-filter"
                     value={cityFilter}
@@ -284,7 +336,9 @@ export const TourAssignmentsDialog = ({
                       setStreetFilter('');
                     }}
                   >
-                    <option value="">{pt('masterData.collectionLocations.fields.cityUnset')}</option>
+                    <option value="">
+                      {pt('masterData.collectionLocations.fields.cityUnset')}
+                    </option>
                     {cityOptions.map(([id, name]) => (
                       <option key={id} value={id}>
                         {name}
@@ -294,9 +348,18 @@ export const TourAssignmentsDialog = ({
                 </StudioField>
               </div>
               <div className="min-w-[180px]">
-                <StudioField id="waste-tour-assignment-street-filter" label={pt('masterData.collectionLocations.fields.streetId')}>
-                  <Select id="waste-tour-assignment-street-filter" value={streetFilter} onChange={(event) => setStreetFilter(event.target.value)}>
-                    <option value="">{pt('masterData.collectionLocations.fields.streetUnset')}</option>
+                <StudioField
+                  id="waste-tour-assignment-street-filter"
+                  label={pt('masterData.collectionLocations.fields.streetId')}
+                >
+                  <Select
+                    id="waste-tour-assignment-street-filter"
+                    value={streetFilter}
+                    onChange={(event) => setStreetFilter(event.target.value)}
+                  >
+                    <option value="">
+                      {pt('masterData.collectionLocations.fields.streetUnset')}
+                    </option>
                     {streetOptions.map(([id, name]) => (
                       <option key={id} value={id}>
                         {name}
@@ -310,24 +373,42 @@ export const TourAssignmentsDialog = ({
             <div className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-background/70 p-4">
               <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                 <div className="space-y-1">
-                  <p className="text-sm font-medium">{pt('tours.assignments.workspace.availableTitle')}</p>
+                  <p className="text-sm font-medium">
+                    {pt('tours.assignments.workspace.availableTitle')}
+                  </p>
                   <div className="flex flex-wrap gap-2">
-                    <Badge variant="outline">{pt('tours.assignments.workspace.selectedCount', { value: selectedLocationIds.length })}</Badge>
-                    <Badge variant="outline">{pt('tours.assignments.workspace.visibleCount', { value: filteredLocations.length })}</Badge>
+                    <Badge variant="outline">
+                      {pt('tours.assignments.workspace.selectedCount', {
+                        value: selectedLocationIds.length,
+                      })}
+                    </Badge>
+                    <Badge variant="outline">
+                      {pt('tours.assignments.workspace.visibleCount', {
+                        value: filteredLocations.length,
+                      })}
+                    </Badge>
                     {hiddenSelectedCount > 0 ? (
-                      <Badge variant="outline">{pt('tours.assignments.workspace.hiddenSelectedCount', { value: hiddenSelectedCount })}</Badge>
+                      <Badge variant="outline">
+                        {pt('tours.assignments.workspace.hiddenSelectedCount', {
+                          value: hiddenSelectedCount,
+                        })}
+                      </Badge>
                     ) : null}
                   </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-3">
                   <label className="flex items-center gap-2 text-sm">
                     <Checkbox
-                      aria-label={pt('masterData.collectionLocations.bulk.actions.selectAllFiltered')}
+                      aria-label={pt(
+                        'masterData.collectionLocations.bulk.actions.selectAllFiltered'
+                      )}
                       checked={allVisibleSelected}
                       indeterminate={!allVisibleSelected && someVisibleSelected}
                       onChange={(event) => toggleSelectAllVisible(event.currentTarget.checked)}
                     />
-                    <span>{pt('masterData.collectionLocations.bulk.actions.selectAllFiltered')}</span>
+                    <span>
+                      {pt('masterData.collectionLocations.bulk.actions.selectAllFiltered')}
+                    </span>
                   </label>
                   <Button
                     type="button"
@@ -360,7 +441,10 @@ export const TourAssignmentsDialog = ({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               {pt('tours.assignments.actions.cancel')}
             </Button>
-            <Button type="submit" disabled={saving || (!selectedLocationIds.length && assignedLocationIds.length === 0)}>
+            <Button
+              type="submit"
+              disabled={saving || (!selectedLocationIds.length && assignedLocationIds.length === 0)}
+            >
               {submitLabel}
             </Button>
           </DialogFooter>

--- a/packages/plugin-waste-management/src/waste-management.tours.content.body.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tours.content.body.tsx
@@ -1,28 +1,20 @@
 import type { Dispatch, SetStateAction } from 'react';
 import type { WasteTourRecord } from '@sva/plugin-sdk';
 
-import type { WasteManagementMasterDataOverview, WasteManagementSchedulingOverview } from './waste-management.api.js';
+import type {
+  WasteManagementMasterDataOverview,
+  WasteManagementSchedulingOverview,
+} from './waste-management.api.js';
 import { WastePanelTableTopBar } from './waste-management.table-frame.js';
-import type { WasteToursSortDirection, WasteToursSortField } from './waste-management.tours.table.parts.js';
+import type {
+  WasteToursSortDirection,
+  WasteToursSortField,
+} from './waste-management.tours.table.parts.js';
 import { WasteToursTable } from './waste-management.tours.table.js';
 import { WasteToursToolbar } from './waste-management.tours.toolbar.js';
 
-type WasteToursContentBodyProps = {
+export type WasteToursFilterViewModel = {
   readonly filterDialogOpen: boolean;
-  readonly selectedTourIds: readonly string[];
-  readonly setBulkDeleteOpen: Dispatch<SetStateAction<boolean>>;
-  readonly tours: readonly WasteTourRecord[];
-  readonly fractions: readonly { readonly id: string; readonly name: string }[];
-  readonly masterDataOverview: WasteManagementMasterDataOverview | null;
-  readonly schedulingOverview: WasteManagementSchedulingOverview | null;
-  readonly assignmentContextLoading: boolean;
-  readonly allVisibleSelected: boolean;
-  readonly someVisibleSelected: boolean;
-  readonly saving: boolean;
-  readonly sortField: WasteToursSortField | null;
-  readonly sortDirection: WasteToursSortDirection;
-  readonly page: number;
-  readonly pageSize: number;
   readonly query: string;
   readonly status: 'all' | 'active' | 'inactive';
   readonly tourWasteFractionId: string | undefined;
@@ -38,13 +30,8 @@ type WasteToursContentBodyProps = {
   readonly draftEndDateFrom: string | undefined;
   readonly draftEndDateTo: string | undefined;
   readonly hasActiveFilters: boolean;
-  readonly onOpenCreateDialog: () => void;
   readonly onOpenFilterDialog: () => void;
   readonly onFilterDialogOpenChange: (open: boolean) => void;
-  readonly onPageChange: (page: number) => void;
-  readonly onSyncPageChange?: (page: number) => void;
-  readonly onPageSizeChange: (pageSize: number) => void;
-  readonly onSortChange: (field: WasteToursSortField) => void;
   readonly onDraftQueryChange: (value: string) => void;
   readonly onDraftStatusChange: (value: 'all' | 'active' | 'inactive') => void;
   readonly onDraftTourWasteFractionIdChange: (value: string | undefined) => void;
@@ -54,6 +41,25 @@ type WasteToursContentBodyProps = {
   readonly onDraftEndDateToChange: (value: string | undefined) => void;
   readonly onApplyFilters: () => void;
   readonly onResetFilters: () => void;
+};
+
+export type WasteToursTableViewModel = {
+  readonly selectedTourIds: readonly string[];
+  readonly tours: readonly WasteTourRecord[];
+  readonly masterDataOverview: WasteManagementMasterDataOverview | null;
+  readonly schedulingOverview: WasteManagementSchedulingOverview | null;
+  readonly assignmentContextLoading: boolean;
+  readonly allVisibleSelected: boolean;
+  readonly someVisibleSelected: boolean;
+  readonly saving: boolean;
+  readonly sortField: WasteToursSortField | null;
+  readonly sortDirection: WasteToursSortDirection;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly onPageChange: (page: number) => void;
+  readonly onSyncPageChange?: (page: number) => void;
+  readonly onPageSizeChange: (pageSize: number) => void;
+  readonly onSortChange: (field: WasteToursSortField) => void;
   readonly toggleSelectAllVisible: (checked: boolean) => void;
   readonly toggleSelectedTour: (tourId: string, checked: boolean) => void;
   readonly onOpenCalendar: (tour: WasteTourRecord) => void;
@@ -66,71 +72,67 @@ type WasteToursContentBodyProps = {
   readonly setTourPendingDelete: Dispatch<SetStateAction<WasteTourRecord | null>>;
 };
 
-export const WasteToursContentBody = (props: WasteToursContentBodyProps) => (
+type WasteToursContentBodyProps = {
+  readonly fractions: readonly { readonly id: string; readonly name: string }[];
+  readonly onOpenCreateDialog: () => void;
+  readonly setBulkDeleteOpen: Dispatch<SetStateAction<boolean>>;
+  readonly filters: WasteToursFilterViewModel;
+  readonly table: WasteToursTableViewModel;
+  /** Transitional compatibility for focused body consumers; production uses `table`. */
+  readonly tours?: readonly WasteTourRecord[];
+  readonly onSortChange?: (field: WasteToursSortField) => void;
+  readonly setTourPendingDelete?: Dispatch<SetStateAction<WasteTourRecord | null>>;
+};
+
+export const WasteToursContentBody = ({
+  fractions,
+  onOpenCreateDialog,
+  setBulkDeleteOpen,
+  filters,
+  table,
+}: WasteToursContentBodyProps) => (
   <section className="overflow-hidden rounded-none border-y border-border bg-card shadow-shell">
     <WastePanelTableTopBar>
       <WasteToursToolbar
-        filterDialogOpen={props.filterDialogOpen}
-        selectedCount={props.selectedTourIds.length}
-        query={props.query}
-        status={props.status}
-        fractions={props.fractions}
-        tourWasteFractionId={props.tourWasteFractionId}
-        firstDateFrom={props.firstDateFrom}
-        firstDateTo={props.firstDateTo}
-        endDateFrom={props.endDateFrom}
-        endDateTo={props.endDateTo}
-        draftQuery={props.draftQuery}
-        draftStatus={props.draftStatus}
-        draftTourWasteFractionId={props.draftTourWasteFractionId}
-        draftFirstDateFrom={props.draftFirstDateFrom}
-        draftFirstDateTo={props.draftFirstDateTo}
-        draftEndDateFrom={props.draftEndDateFrom}
-        draftEndDateTo={props.draftEndDateTo}
-        hasActiveFilters={props.hasActiveFilters}
-        onOpenCreateDialog={props.onOpenCreateDialog}
-        onOpenFilterDialog={props.onOpenFilterDialog}
-        onFilterDialogOpenChange={props.onFilterDialogOpenChange}
-        onOpenBulkDelete={() => props.setBulkDeleteOpen(true)}
-        onDraftQueryChange={props.onDraftQueryChange}
-        onDraftStatusChange={props.onDraftStatusChange}
-        onDraftTourWasteFractionIdChange={props.onDraftTourWasteFractionIdChange}
-        onDraftFirstDateFromChange={props.onDraftFirstDateFromChange}
-        onDraftFirstDateToChange={props.onDraftFirstDateToChange}
-        onDraftEndDateFromChange={props.onDraftEndDateFromChange}
-        onDraftEndDateToChange={props.onDraftEndDateToChange}
-        onApplyFilters={props.onApplyFilters}
-        onResetFilters={props.onResetFilters}
+        filterDialogOpen={filters.filterDialogOpen}
+        selectedCount={table.selectedTourIds.length}
+        query={filters.query}
+        status={filters.status}
+        fractions={fractions}
+        tourWasteFractionId={filters.tourWasteFractionId}
+        firstDateFrom={filters.firstDateFrom}
+        firstDateTo={filters.firstDateTo}
+        endDateFrom={filters.endDateFrom}
+        endDateTo={filters.endDateTo}
+        draftQuery={filters.draftQuery}
+        draftStatus={filters.draftStatus}
+        draftTourWasteFractionId={filters.draftTourWasteFractionId}
+        draftFirstDateFrom={filters.draftFirstDateFrom}
+        draftFirstDateTo={filters.draftFirstDateTo}
+        draftEndDateFrom={filters.draftEndDateFrom}
+        draftEndDateTo={filters.draftEndDateTo}
+        hasActiveFilters={filters.hasActiveFilters}
+        onOpenCreateDialog={onOpenCreateDialog}
+        onOpenFilterDialog={filters.onOpenFilterDialog}
+        onFilterDialogOpenChange={filters.onFilterDialogOpenChange}
+        onOpenBulkDelete={() => setBulkDeleteOpen(true)}
+        onDraftQueryChange={filters.onDraftQueryChange}
+        onDraftStatusChange={filters.onDraftStatusChange}
+        onDraftTourWasteFractionIdChange={filters.onDraftTourWasteFractionIdChange}
+        onDraftFirstDateFromChange={filters.onDraftFirstDateFromChange}
+        onDraftFirstDateToChange={filters.onDraftFirstDateToChange}
+        onDraftEndDateFromChange={filters.onDraftEndDateFromChange}
+        onDraftEndDateToChange={filters.onDraftEndDateToChange}
+        onApplyFilters={filters.onApplyFilters}
+        onResetFilters={filters.onResetFilters}
       />
     </WastePanelTableTopBar>
     <WasteToursTable
-      tours={props.tours}
-      fractions={props.fractions}
-      masterDataOverview={props.masterDataOverview}
-      schedulingOverview={props.schedulingOverview}
-      assignmentContextLoading={props.assignmentContextLoading}
-      selectedTourIds={props.selectedTourIds}
-      allVisibleSelected={props.allVisibleSelected}
-      someVisibleSelected={props.someVisibleSelected}
-      saving={props.saving}
-      sortField={props.sortField}
-      sortDirection={props.sortDirection}
-      page={props.page}
-      pageSize={props.pageSize}
-      onPageChange={props.onPageChange}
-      onSyncPageChange={props.onSyncPageChange}
-      onPageSizeChange={props.onPageSizeChange}
-      onSortChange={props.onSortChange}
-      onToggleSelectAllVisible={props.toggleSelectAllVisible}
-      onToggleSelectedTour={props.toggleSelectedTour}
-      onOpenCalendar={props.onOpenCalendar}
-      onOpenEditDialog={props.onOpenEditDialog}
-      onOpenDuplicateDialog={props.onOpenDuplicateDialog}
-      onOpenCreateAssignmentsDialog={props.onOpenCreateAssignmentsDialog}
-      onOpenEditAssignmentsDialog={props.onOpenEditAssignmentsDialog}
-      canDuplicateTour={props.canDuplicateTour}
-      onToggleTourStatus={props.onToggleTourStatus}
-      onRequestDeleteTour={props.setTourPendingDelete}
+      {...table}
+      fractions={fractions}
+      onToggleSelectAllVisible={table.toggleSelectAllVisible}
+      onToggleSelectedTour={table.toggleSelectedTour}
+      onRequestDeleteTour={table.setTourPendingDelete}
     />
   </section>
 );

--- a/packages/plugin-waste-management/src/waste-management.tours.content.body.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tours.content.body.tsx
@@ -78,10 +78,6 @@ type WasteToursContentBodyProps = {
   readonly setBulkDeleteOpen: Dispatch<SetStateAction<boolean>>;
   readonly filters: WasteToursFilterViewModel;
   readonly table: WasteToursTableViewModel;
-  /** Transitional compatibility for focused body consumers; production uses `table`. */
-  readonly tours?: readonly WasteTourRecord[];
-  readonly onSortChange?: (field: WasteToursSortField) => void;
-  readonly setTourPendingDelete?: Dispatch<SetStateAction<WasteTourRecord | null>>;
 };
 
 export const WasteToursContentBody = ({

--- a/packages/plugin-waste-management/src/waste-management.tours.content.parts.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tours.content.parts.tsx
@@ -3,7 +3,6 @@ import type { WasteTourRecord } from '@sva/plugin-sdk';
 import { usePluginTranslation } from '@sva/plugin-sdk';
 import { StudioConfirmDialog } from '@sva/studio-ui-react';
 
-import type { WasteManagementMasterDataOverview, WasteManagementSchedulingOverview } from './waste-management.api.js';
 import {
   type WasteToursFilterDate,
   type WasteToursFilterFraction,
@@ -11,48 +10,7 @@ import {
   useWasteToursDraftFiltersState,
 } from './waste-management.tours.filter-state.js';
 
-export type WasteToursContentProps = {
-  readonly assignmentContextLoading: boolean;
-  readonly message: import('./waste-management.page.support.js').StatusMessage | null;
-  readonly tours: readonly WasteTourRecord[];
-  readonly fractions: readonly { readonly id: string; readonly name: string }[];
-  readonly masterDataOverview: WasteManagementMasterDataOverview | null;
-  readonly schedulingOverview: WasteManagementSchedulingOverview | null;
-  readonly onOpenCreateDialog: () => void;
-  readonly onOpenEditDialog: (tour: WasteTourRecord) => void;
-  readonly onOpenDuplicateDialog: (tour: WasteTourRecord) => void;
-  readonly onOpenCreateAssignmentsDialog: (tour: WasteTourRecord) => void;
-  readonly onOpenEditAssignmentsDialog: (tour: WasteTourRecord, linkId: string) => void;
-  readonly onOpenCalendar: (tour: WasteTourRecord) => void;
-  readonly onToggleTourStatus: (tour: WasteTourRecord, nextActive: boolean) => Promise<void>;
-  readonly onDeleteTour: (tour: WasteTourRecord) => Promise<void>;
-  readonly onDeleteTours: (tourIds: readonly string[]) => Promise<void>;
-  readonly canDuplicateTour?: boolean;
-  readonly saving?: boolean;
-  readonly page: number;
-  readonly pageSize: number;
-  readonly query: string;
-  readonly status: WasteToursFilterStatus;
-  readonly tourWasteFractionId: WasteToursFilterFraction;
-  readonly firstDateFrom: WasteToursFilterDate;
-  readonly firstDateTo: WasteToursFilterDate;
-  readonly endDateFrom: WasteToursFilterDate;
-  readonly endDateTo: WasteToursFilterDate;
-  readonly onPageChange: (page: number) => void;
-  readonly onSyncPageChange?: (page: number) => void;
-  readonly onPageSizeChange: (pageSize: number) => void;
-  readonly onQueryChange: (value: string) => void;
-  readonly onStatusChange: (value: WasteToursFilterStatus) => void;
-  readonly onFiltersChange?: (
-    query: string,
-    status: WasteToursFilterStatus,
-    tourWasteFractionId: WasteToursFilterFraction,
-    firstDateFrom: WasteToursFilterDate,
-    firstDateTo: WasteToursFilterDate,
-    endDateFrom: WasteToursFilterDate,
-    endDateTo: WasteToursFilterDate,
-  ) => void;
-};
+export type { WasteToursContentProps } from './waste-management.tours.view-model.js';
 
 type UseWasteToursSelectionStateArgs = {
   readonly tours: readonly WasteTourRecord[];
@@ -75,9 +33,10 @@ const useWasteToursVisibleSelectionState = ({
   const [selectedTourIds, setSelectedTourIds] = useState<readonly string[]>([]);
   const visibleTourIds = useMemo(
     () => tours.slice((page - 1) * pageSize, page * pageSize).map((tour) => tour.id),
-    [page, pageSize, tours],
+    [page, pageSize, tours]
   );
-  const allVisibleSelected = visibleTourIds.length > 0 && visibleTourIds.every((tourId) => selectedTourIds.includes(tourId));
+  const allVisibleSelected =
+    visibleTourIds.length > 0 && visibleTourIds.every((tourId) => selectedTourIds.includes(tourId));
   const someVisibleSelected = visibleTourIds.some((tourId) => selectedTourIds.includes(tourId));
 
   useEffect(() => {
@@ -100,7 +59,11 @@ const useWasteToursVisibleSelectionState = ({
       }),
     toggleSelectedTour: (tourId: string, checked: boolean) =>
       setSelectedTourIds((current) =>
-        checked ? (current.includes(tourId) ? current : [...current, tourId]) : current.filter((value) => value !== tourId),
+        checked
+          ? current.includes(tourId)
+            ? current
+            : [...current, tourId]
+          : current.filter((value) => value !== tourId)
       ),
   };
 };

--- a/packages/plugin-waste-management/src/waste-management.tours.content.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tours.content.tsx
@@ -3,10 +3,13 @@ import { usePluginTranslation } from '@sva/plugin-sdk';
 
 import { StatusNotice } from './waste-management.page.support.js';
 import { useWasteTabPanelActions } from './waste-management.tab-panel-actions.js';
-import { WasteToursContentBody } from './waste-management.tours.content.body.js';
+import {
+  WasteToursContentBody,
+  type WasteToursFilterViewModel,
+  type WasteToursTableViewModel,
+} from './waste-management.tours.content.body.js';
 import {
   WasteToursDeleteDialogs,
-  type WasteToursContentProps,
   useWasteToursSelectionState,
 } from './waste-management.tours.content.parts.js';
 import { WasteToursEmptyState } from './waste-management.tours.empty-state.js';
@@ -17,44 +20,49 @@ import {
   sortWasteTours,
   updateWasteToursSorting,
 } from './waste-management.tours.content.helpers.js';
-import type { WasteToursSortDirection, WasteToursSortField } from './waste-management.tours.table.parts.js';
+import type {
+  WasteToursSortDirection,
+  WasteToursSortField,
+} from './waste-management.tours.table.parts.js';
+import type { WasteToursContentProps } from './waste-management.tours.view-model.js';
 
 export { WasteToursEmptyState };
 
-export const WasteToursContent = ({
-  assignmentContextLoading,
-  message,
-  tours,
-  fractions,
-  masterDataOverview,
-  schedulingOverview,
-  onOpenCreateDialog,
-  onOpenEditDialog,
-  onOpenDuplicateDialog,
-  onOpenCreateAssignmentsDialog,
-  onOpenEditAssignmentsDialog,
-  onOpenCalendar,
-  onToggleTourStatus,
-  onDeleteTour,
-  onDeleteTours,
-  canDuplicateTour = false,
-  saving = false,
-  page,
-  pageSize,
-  query,
-  status,
-  tourWasteFractionId,
-  firstDateFrom,
-  firstDateTo,
-  endDateFrom,
-  endDateTo,
-  onPageChange,
-  onSyncPageChange,
-  onPageSizeChange,
-  onQueryChange,
-  onStatusChange,
-  onFiltersChange,
-}: WasteToursContentProps) => {
+export const WasteToursContent = (props: WasteToursContentProps) => {
+  const {
+    assignmentContextLoading,
+    message,
+    tours,
+    fractions,
+    masterDataOverview,
+    schedulingOverview,
+    onOpenCreateDialog,
+    onOpenEditDialog,
+    onOpenDuplicateDialog,
+    onOpenCreateAssignmentsDialog,
+    onOpenEditAssignmentsDialog,
+    onOpenCalendar,
+    onToggleTourStatus,
+    onDeleteTour,
+    onDeleteTours,
+    canDuplicateTour = false,
+    saving = false,
+    page,
+    pageSize,
+    query,
+    status,
+    tourWasteFractionId,
+    firstDateFrom,
+    firstDateTo,
+    endDateFrom,
+    endDateTo,
+    onPageChange,
+    onSyncPageChange,
+    onPageSizeChange,
+    onQueryChange,
+    onStatusChange,
+    onFiltersChange,
+  } = props;
   const pt = usePluginTranslation('wasteManagement');
   const [sortField, setSortField] = useState<WasteToursSortField | null>(null);
   const [sortDirection, setSortDirection] = useState<WasteToursSortDirection>('asc');
@@ -64,11 +72,11 @@ export const WasteToursContent = ({
   } | null>(null);
   const locationCountByTourId = useMemo(
     () => createLocationCountByTourId(masterDataOverview?.locationTourLinks),
-    [masterDataOverview?.locationTourLinks],
+    [masterDataOverview?.locationTourLinks]
   );
   const sortedTours = useMemo(
     () => sortWasteTours({ tours, sortField, sortDirection, locationCountByTourId, pt }),
-    [locationCountByTourId, pt, sortDirection, sortField, tours],
+    [locationCountByTourId, pt, sortDirection, sortField, tours]
   );
   const {
     selectedTourIds,
@@ -114,85 +122,97 @@ export const WasteToursContent = ({
 
   useWasteTabPanelActions(null);
 
+  const filters: WasteToursFilterViewModel = {
+    filterDialogOpen,
+    query,
+    status,
+    tourWasteFractionId,
+    firstDateFrom,
+    firstDateTo,
+    endDateFrom,
+    endDateTo,
+    draftQuery,
+    draftStatus,
+    draftTourWasteFractionId,
+    draftFirstDateFrom,
+    draftFirstDateTo,
+    draftEndDateFrom,
+    draftEndDateTo,
+    hasActiveFilters,
+    onOpenFilterDialog: () => {
+      syncDraftFilters();
+      setFilterDialogOpen(true);
+    },
+    onFilterDialogOpenChange: setFilterDialogOpen,
+    onDraftQueryChange: setDraftQuery,
+    onDraftStatusChange: setDraftStatus,
+    onDraftTourWasteFractionIdChange: setDraftTourWasteFractionId,
+    onDraftFirstDateFromChange: setDraftFirstDateFrom,
+    onDraftFirstDateToChange: setDraftFirstDateTo,
+    onDraftEndDateFromChange: setDraftEndDateFrom,
+    onDraftEndDateToChange: setDraftEndDateTo,
+    onApplyFilters: () =>
+      applyWasteToursFilters({
+        onFiltersChange,
+        onQueryChange,
+        onStatusChange,
+        setFilterDialogOpen,
+        draftQuery,
+        draftStatus,
+        draftTourWasteFractionId,
+        draftFirstDateFrom,
+        draftFirstDateTo,
+        draftEndDateFrom,
+        draftEndDateTo,
+      }),
+    onResetFilters: () =>
+      resetWasteToursFilters({ onFiltersChange, onQueryChange, onStatusChange }),
+  };
+  const table: WasteToursTableViewModel = {
+    selectedTourIds,
+    tours: sortedTours,
+    masterDataOverview,
+    schedulingOverview,
+    assignmentContextLoading,
+    allVisibleSelected,
+    someVisibleSelected,
+    saving,
+    sortField,
+    sortDirection,
+    page,
+    pageSize,
+    onPageChange,
+    onSyncPageChange,
+    onPageSizeChange,
+    onSortChange: (field) =>
+      updateWasteToursSorting({ field, sortField, setSortField, setSortDirection }),
+    toggleSelectAllVisible,
+    toggleSelectedTour,
+    onOpenCalendar,
+    onOpenEditDialog,
+    onOpenDuplicateDialog,
+    onOpenCreateAssignmentsDialog,
+    onOpenEditAssignmentsDialog,
+    canDuplicateTour,
+    onToggleTourStatus: (tour, nextActive) => {
+      setTourPendingStatusChange({ tour, nextActive });
+      return Promise.resolve();
+    },
+    setTourPendingDelete,
+  };
+
   return (
     <div className="space-y-4">
       <StatusNotice message={message} />
       <WasteToursContentBody
-        filterDialogOpen={filterDialogOpen}
         setBulkDeleteOpen={setBulkDeleteOpen}
-        tours={sortedTours}
         fractions={fractions}
-        masterDataOverview={masterDataOverview}
-        schedulingOverview={schedulingOverview}
-        assignmentContextLoading={assignmentContextLoading}
-        selectedTourIds={selectedTourIds}
-        allVisibleSelected={allVisibleSelected}
-        someVisibleSelected={someVisibleSelected}
-        saving={saving}
-        sortField={sortField}
-        sortDirection={sortDirection}
-        page={page}
-        pageSize={pageSize}
-        query={query}
-        status={status}
-        tourWasteFractionId={tourWasteFractionId}
-        firstDateFrom={firstDateFrom}
-        firstDateTo={firstDateTo}
-        endDateFrom={endDateFrom}
-        endDateTo={endDateTo}
-        draftQuery={draftQuery}
-        draftStatus={draftStatus}
-        draftTourWasteFractionId={draftTourWasteFractionId}
-        draftFirstDateFrom={draftFirstDateFrom}
-        draftFirstDateTo={draftFirstDateTo}
-        draftEndDateFrom={draftEndDateFrom}
-        draftEndDateTo={draftEndDateTo}
-        hasActiveFilters={hasActiveFilters}
         onOpenCreateDialog={onOpenCreateDialog}
-        onOpenFilterDialog={() => {
-          syncDraftFilters();
-          setFilterDialogOpen(true);
-        }}
-        onFilterDialogOpenChange={setFilterDialogOpen}
-        onPageChange={onPageChange}
-        onSyncPageChange={onSyncPageChange}
-        onPageSizeChange={onPageSizeChange}
-        onSortChange={(field) => updateWasteToursSorting({ field, sortField, setSortField, setSortDirection })}
-        onDraftQueryChange={setDraftQuery}
-        onDraftStatusChange={setDraftStatus}
-        onDraftTourWasteFractionIdChange={setDraftTourWasteFractionId}
-        onDraftFirstDateFromChange={setDraftFirstDateFrom}
-        onDraftFirstDateToChange={setDraftFirstDateTo}
-        onDraftEndDateFromChange={setDraftEndDateFrom}
-        onDraftEndDateToChange={setDraftEndDateTo}
-        onApplyFilters={() =>
-          applyWasteToursFilters({
-            onFiltersChange,
-            onQueryChange,
-            onStatusChange,
-            setFilterDialogOpen,
-            draftQuery,
-            draftStatus,
-            draftTourWasteFractionId,
-            draftFirstDateFrom,
-            draftFirstDateTo,
-            draftEndDateFrom,
-            draftEndDateTo,
-          })}
-        onResetFilters={() => resetWasteToursFilters({ onFiltersChange, onQueryChange, onStatusChange })}
-        toggleSelectAllVisible={toggleSelectAllVisible}
-        toggleSelectedTour={toggleSelectedTour}
-        onOpenCalendar={onOpenCalendar}
-        onOpenEditDialog={onOpenEditDialog}
-        onOpenDuplicateDialog={onOpenDuplicateDialog}
-        onOpenCreateAssignmentsDialog={onOpenCreateAssignmentsDialog}
-        onOpenEditAssignmentsDialog={onOpenEditAssignmentsDialog}
-        canDuplicateTour={canDuplicateTour}
-        onToggleTourStatus={(tour, nextActive) => {
-          setTourPendingStatusChange({ tour, nextActive });
-          return Promise.resolve();
-        }}
-        setTourPendingDelete={setTourPendingDelete}
+        filters={filters}
+        table={table}
+        tours={table.tours}
+        onSortChange={table.onSortChange}
+        setTourPendingDelete={table.setTourPendingDelete}
       />
       <WasteToursDeleteDialogs
         tourPendingDelete={tourPendingDelete}
@@ -208,9 +228,9 @@ export const WasteToursContent = ({
             return Promise.resolve();
           }
 
-          return Promise.resolve(onToggleTourStatus(tourPendingStatusChange.tour, tourPendingStatusChange.nextActive)).finally(
-            () => setTourPendingStatusChange(null)
-          );
+          return Promise.resolve(
+            onToggleTourStatus(tourPendingStatusChange.tour, tourPendingStatusChange.nextActive)
+          ).finally(() => setTourPendingStatusChange(null));
         }}
         onDeleteTours={onDeleteTours}
         onAfterBulkDelete={() => {

--- a/packages/plugin-waste-management/src/waste-management.tours.content.tsx
+++ b/packages/plugin-waste-management/src/waste-management.tours.content.tsx
@@ -210,9 +210,6 @@ export const WasteToursContent = (props: WasteToursContentProps) => {
         onOpenCreateDialog={onOpenCreateDialog}
         filters={filters}
         table={table}
-        tours={table.tours}
-        onSortChange={table.onSortChange}
-        setTourPendingDelete={table.setTourPendingDelete}
       />
       <WasteToursDeleteDialogs
         tourPendingDelete={tourPendingDelete}

--- a/packages/plugin-waste-management/src/waste-management.tours.view-model.ts
+++ b/packages/plugin-waste-management/src/waste-management.tours.view-model.ts
@@ -6,8 +6,9 @@ export const createTourAssignmentSelectionSummary = ({
   readonly selectedLocationIds: readonly string[];
 }) => {
   const visibleLocationIdSet = new Set(filteredLocationIds);
+  const selectedLocationIdSet = new Set(selectedLocationIds);
   const selectedVisibleCount = filteredLocationIds.filter((locationId) =>
-    selectedLocationIds.includes(locationId)
+    selectedLocationIdSet.has(locationId)
   ).length;
 
   return {

--- a/packages/plugin-waste-management/src/waste-management.tours.view-model.ts
+++ b/packages/plugin-waste-management/src/waste-management.tours.view-model.ts
@@ -1,0 +1,90 @@
+export const createTourAssignmentSelectionSummary = ({
+  filteredLocationIds,
+  selectedLocationIds,
+}: {
+  readonly filteredLocationIds: readonly string[];
+  readonly selectedLocationIds: readonly string[];
+}) => {
+  const visibleLocationIdSet = new Set(filteredLocationIds);
+  const selectedVisibleCount = filteredLocationIds.filter((locationId) =>
+    selectedLocationIds.includes(locationId)
+  ).length;
+
+  return {
+    allVisibleSelected:
+      filteredLocationIds.length > 0 && selectedVisibleCount === filteredLocationIds.length,
+    someVisibleSelected: selectedVisibleCount > 0,
+    hiddenSelectedCount: selectedLocationIds.filter(
+      (locationId) => !visibleLocationIdSet.has(locationId)
+    ).length,
+    visibleLocationIdSet,
+  };
+};
+import type { WasteTourRecord } from '@sva/plugin-sdk';
+
+import type {
+  WasteManagementMasterDataOverview,
+  WasteManagementSchedulingOverview,
+} from './waste-management.api.js';
+import type {
+  WasteToursFilterDate,
+  WasteToursFilterFraction,
+  WasteToursFilterStatus,
+} from './waste-management.tours.filter-state.js';
+
+export type WasteToursDataProps = {
+  readonly assignmentContextLoading: boolean;
+  readonly message: import('./waste-management.page.support.js').StatusMessage | null;
+  readonly tours: readonly WasteTourRecord[];
+  readonly fractions: readonly { readonly id: string; readonly name: string }[];
+  readonly masterDataOverview: WasteManagementMasterDataOverview | null;
+  readonly schedulingOverview: WasteManagementSchedulingOverview | null;
+};
+
+export type WasteToursActionsProps = {
+  readonly onOpenCreateDialog: () => void;
+  readonly onOpenEditDialog: (tour: WasteTourRecord) => void;
+  readonly onOpenDuplicateDialog: (tour: WasteTourRecord) => void;
+  readonly onOpenCreateAssignmentsDialog: (tour: WasteTourRecord) => void;
+  readonly onOpenEditAssignmentsDialog: (tour: WasteTourRecord, linkId: string) => void;
+  readonly onOpenCalendar: (tour: WasteTourRecord) => void;
+  readonly onToggleTourStatus: (tour: WasteTourRecord, nextActive: boolean) => Promise<void>;
+  readonly onDeleteTour: (tour: WasteTourRecord) => Promise<void>;
+  readonly onDeleteTours: (tourIds: readonly string[]) => Promise<void>;
+};
+
+export type WasteToursCapabilitiesProps = {
+  readonly canDuplicateTour?: boolean;
+  readonly saving?: boolean;
+};
+
+export type WasteToursQueryProps = {
+  readonly page: number;
+  readonly pageSize: number;
+  readonly query: string;
+  readonly status: WasteToursFilterStatus;
+  readonly tourWasteFractionId: WasteToursFilterFraction;
+  readonly firstDateFrom: WasteToursFilterDate;
+  readonly firstDateTo: WasteToursFilterDate;
+  readonly endDateFrom: WasteToursFilterDate;
+  readonly endDateTo: WasteToursFilterDate;
+  readonly onPageChange: (page: number) => void;
+  readonly onSyncPageChange?: (page: number) => void;
+  readonly onPageSizeChange: (pageSize: number) => void;
+  readonly onQueryChange: (value: string) => void;
+  readonly onStatusChange: (value: WasteToursFilterStatus) => void;
+  readonly onFiltersChange?: (
+    query: string,
+    status: WasteToursFilterStatus,
+    tourWasteFractionId: WasteToursFilterFraction,
+    firstDateFrom: WasteToursFilterDate,
+    firstDateTo: WasteToursFilterDate,
+    endDateFrom: WasteToursFilterDate,
+    endDateTo: WasteToursFilterDate
+  ) => void;
+};
+
+export type WasteToursContentProps = WasteToursDataProps &
+  WasteToursActionsProps &
+  WasteToursCapabilitiesProps &
+  WasteToursQueryProps;

--- a/packages/plugin-waste-management/tests/waste-management.output-panel.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.output-panel.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WasteOutputPanel } from '../src/waste-management.output-panel.js';
 import { WasteEmailReminderConfigurationSection } from '../src/waste-management.output-email-reminder-card.js';
+import {
+  buildDefaultEmailReminderConfig,
+  ensureTransportSelection,
+  getMailTransportOptions,
+  normalizeEmailReminderConfig,
+} from '../src/waste-management.output-email-reminder-config.js';
 
 const apiMocks = vi.hoisted(() => ({
   getWasteManagementSettings: vi.fn(),
@@ -20,7 +26,9 @@ vi.mock('@sva/studio-ui-react', () => ({
   Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
   Textarea: (props: React.ComponentProps<'textarea'>) => <textarea {...props} />,
   StudioErrorState: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
-  StudioLoadingState: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  StudioLoadingState: ({ children }: { readonly children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   StudioField: ({
     id,
     label,
@@ -41,7 +49,9 @@ vi.mock('@sva/studio-ui-react', () => ({
 }));
 
 vi.mock('../src/waste-management.api.js', async () => {
-  const actual = await vi.importActual<typeof import('../src/waste-management.api.js')>('../src/waste-management.api.js');
+  const actual = await vi.importActual<typeof import('../src/waste-management.api.js')>(
+    '../src/waste-management.api.js'
+  );
   return {
     ...actual,
     ...apiMocks,
@@ -337,9 +347,12 @@ describe('WasteOutputPanel', () => {
     fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeLinkLabel'), {
       target: { value: 'Abmelden' },
     });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessHeadline'), {
-      target: { value: 'Abgemeldet' },
-    });
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessHeadline'),
+      {
+        target: { value: 'Abgemeldet' },
+      }
+    );
     fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessBody'), {
       target: { value: 'Sie wurden abgemeldet.' },
     });
@@ -430,30 +443,37 @@ describe('WasteOutputPanel', () => {
           serviceLabel: 'Muelli',
           privacyPolicyUrl: 'https://example.org/datenschutz',
           imprintUrl: 'https://example.org/impressum',
-          consentLabel: 'Ich stimme der Verarbeitung meiner Daten zur Einrichtung der E-Mail-Erinnerung zu.',
+          consentLabel:
+            'Ich stimme der Verarbeitung meiner Daten zur Einrichtung der E-Mail-Erinnerung zu.',
           consentVersion: 'v1',
           dataControllerLabel: 'Abfallwirtschaft',
           dataProtectionContactEmail: 'datenschutz@example.org',
           doiSubjectTemplate: 'Bitte bestaetigen Sie Ihre E-Mail-Erinnerung fuer {{locationLabel}}',
           doiPreheader: 'Bestaetigen Sie die Einrichtung Ihres Erinnerungsdienstes.',
-          doiIntroText: 'Bitte bestaetigen Sie die Einrichtung Ihrer E-Mail-Erinnerung fuer {{locationLabel}} ueber den folgenden Link.',
+          doiIntroText:
+            'Bitte bestaetigen Sie die Einrichtung Ihrer E-Mail-Erinnerung fuer {{locationLabel}} ueber den folgenden Link.',
           doiButtonLabel: 'E-Mail-Erinnerung aktivieren',
-          doiFallbackText: 'Falls der Button nicht funktioniert, nutzen Sie bitte den direkten Link.',
+          doiFallbackText:
+            'Falls der Button nicht funktioniert, nutzen Sie bitte den direkten Link.',
           doiExpiryNoticeText: 'Der Aktivierungslink ist zeitlich begrenzt gueltig.',
           doiSuccessHeadline: 'E-Mail-Erinnerung aktiviert',
-          doiSuccessBody: 'Der Dienst ist jetzt aktiv und informiert Sie kuenftig ueber anstehende Entsorgungstermine.',
+          doiSuccessBody:
+            'Der Dienst ist jetzt aktiv und informiert Sie kuenftig ueber anstehende Entsorgungstermine.',
           doiErrorHeadline: 'Aktivierung nicht moeglich',
           doiErrorBody: 'Der Aktivierungslink ist ungueltig oder bereits abgelaufen.',
           reminderSubjectTemplate: 'Abfalltermin fuer {{locationLabel}} am {{pickupDate}}',
-          reminderIntroTemplate: 'Nicht vergessen: {{fractionName}} wird am {{pickupDate}} abgeholt.',
+          reminderIntroTemplate:
+            'Nicht vergessen: {{fractionName}} wird am {{pickupDate}} abgeholt.',
           reminderListIntroTemplate: 'Folgende Abfallart steht als naechstes an:',
           reminderOutroText: 'Sie koennen diese Erinnerung jederzeit wieder abbestellen.',
           unsubscribeLinkLabel: 'E-Mail-Erinnerung abbestellen',
-          reminderReasonText: 'Sie erhalten diese Nachricht, weil Sie fuer {{locationLabel}} eine E-Mail-Erinnerung eingerichtet haben.',
+          reminderReasonText:
+            'Sie erhalten diese Nachricht, weil Sie fuer {{locationLabel}} eine E-Mail-Erinnerung eingerichtet haben.',
           unsubscribeSuccessHeadline: 'E-Mail-Erinnerung deaktiviert',
           unsubscribeSuccessBody: 'Der Dienst wurde fuer diese Adresse erfolgreich deaktiviert.',
           unsubscribeAlreadyDoneHeadline: 'E-Mail-Erinnerung bereits deaktiviert',
-          unsubscribeAlreadyDoneBody: 'Fuer diese Adresse ist bereits keine aktive Erinnerung mehr hinterlegt.',
+          unsubscribeAlreadyDoneBody:
+            'Fuer diese Adresse ist bereits keine aktive Erinnerung mehr hinterlegt.',
           unsubscribeErrorHeadline: 'Abmeldung nicht moeglich',
           unsubscribeErrorBody: 'Der Abmeldelink ist ungueltig oder bereits abgelaufen.',
           maxSubscriptionsPerEmailAndLocation: 5,
@@ -474,9 +494,12 @@ describe('WasteOutputPanel', () => {
     render(<WasteOutputPanel />);
 
     expect(await screen.findByText('output.emailReminder.messages.noMailTransport')).toBeTruthy();
-    expect(String((screen.getByLabelText('output.emailReminder.fields.publicBaseUrl') as HTMLInputElement).value)).toContain(
-      'https://'
-    );
+    expect(
+      String(
+        (screen.getByLabelText('output.emailReminder.fields.publicBaseUrl') as HTMLInputElement)
+          .value
+      )
+    ).toContain('https://');
     fireEvent.click(screen.getByRole('button', { name: 'output.pdf.actions.save' }));
 
     await waitFor(() => {
@@ -485,7 +508,9 @@ describe('WasteOutputPanel', () => {
   });
 
   it('maps forbidden and generic save failures for pdf and email reminder settings', async () => {
-    apiMocks.updateWasteManagementSettings.mockRejectedValueOnce(new Error('forbidden')).mockRejectedValueOnce(new Error('boom'));
+    apiMocks.updateWasteManagementSettings
+      .mockRejectedValueOnce(new Error('forbidden'))
+      .mockRejectedValueOnce(new Error('boom'));
 
     render(<WasteOutputPanel />);
 
@@ -586,44 +611,131 @@ describe('WasteOutputPanel', () => {
 
     fireEvent.click(screen.getByLabelText('output.emailReminder.fields.enabled'));
     fireEvent.click(screen.getByLabelText('output.emailReminder.fields.publicSignupEnabled'));
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.transportId'), { target: { value: 'mail-transport-2' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.publicBaseUrl'), { target: { value: 'https://public.example.org' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.fromName'), { target: { value: 'Landkreis' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.fromEmail'), { target: { value: 'noreply@example.org' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.replyToEmail'), { target: { value: 'service@example.org' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.serviceLabel'), { target: { value: 'Service' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.privacyPolicyUrl'), { target: { value: 'https://example.org/ds' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.imprintUrl'), { target: { value: 'https://example.org/imprint-new' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.consentVersion'), { target: { value: 'v2' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.dataControllerLabel'), { target: { value: 'Controller' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.dataProtectionContactEmail'), { target: { value: 'privacy@example.org' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.consentLabel'), { target: { value: 'Neue Einwilligung' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiSubjectTemplate'), { target: { value: 'DOI Betreff' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiButtonLabel'), { target: { value: 'Bestaetigen' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiPreheader'), { target: { value: 'DOI Preheader' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiFallbackText'), { target: { value: 'DOI Fallback' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiIntroText'), { target: { value: 'DOI Intro' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiExpiryNoticeText'), { target: { value: '24h' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderSubjectTemplate'), { target: { value: 'Reminder Betreff' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeLinkLabel'), { target: { value: 'Jetzt abmelden' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderIntroTemplate'), { target: { value: 'Reminder Intro' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderListIntroTemplate'), { target: { value: 'Reminder Liste' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderOutroText'), { target: { value: 'Reminder Outro' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderReasonText'), { target: { value: 'Reminder Grund' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessHeadline'), { target: { value: 'Success Headline' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeAlreadyDoneHeadline'), { target: { value: 'Already Headline' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeErrorHeadline'), { target: { value: 'Error Headline' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessBody'), { target: { value: 'Success Body' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeAlreadyDoneBody'), { target: { value: 'Already Body' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeErrorBody'), { target: { value: 'Error Body' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiTokenTtlHours'), { target: { value: '12' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.pendingSubscriptionTtlHours'), { target: { value: '36' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.materializationLookaheadDays'), { target: { value: '5' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.maxSubscriptionsPerEmailAndLocation'), { target: { value: '3' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.signupRateLimitPerIpPerHour'), { target: { value: '8' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.signupRateLimitPerEmailPerHour'), { target: { value: '4' } });
-    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeTokenTtlDays'), { target: { value: '90' } });
-    fireEvent.submit(screen.getByRole('button', { name: 'output.emailReminder.actions.save' }).closest('form')!);
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.transportId'), {
+      target: { value: 'mail-transport-2' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.publicBaseUrl'), {
+      target: { value: 'https://public.example.org' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.fromName'), {
+      target: { value: 'Landkreis' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.fromEmail'), {
+      target: { value: 'noreply@example.org' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.replyToEmail'), {
+      target: { value: 'service@example.org' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.serviceLabel'), {
+      target: { value: 'Service' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.privacyPolicyUrl'), {
+      target: { value: 'https://example.org/ds' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.imprintUrl'), {
+      target: { value: 'https://example.org/imprint-new' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.consentVersion'), {
+      target: { value: 'v2' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.dataControllerLabel'), {
+      target: { value: 'Controller' },
+    });
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.dataProtectionContactEmail'),
+      { target: { value: 'privacy@example.org' } }
+    );
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.consentLabel'), {
+      target: { value: 'Neue Einwilligung' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiSubjectTemplate'), {
+      target: { value: 'DOI Betreff' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiButtonLabel'), {
+      target: { value: 'Bestaetigen' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiPreheader'), {
+      target: { value: 'DOI Preheader' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiFallbackText'), {
+      target: { value: 'DOI Fallback' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiIntroText'), {
+      target: { value: 'DOI Intro' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiExpiryNoticeText'), {
+      target: { value: '24h' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderSubjectTemplate'), {
+      target: { value: 'Reminder Betreff' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeLinkLabel'), {
+      target: { value: 'Jetzt abmelden' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderIntroTemplate'), {
+      target: { value: 'Reminder Intro' },
+    });
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.reminderListIntroTemplate'),
+      { target: { value: 'Reminder Liste' } }
+    );
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderOutroText'), {
+      target: { value: 'Reminder Outro' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.reminderReasonText'), {
+      target: { value: 'Reminder Grund' },
+    });
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessHeadline'),
+      { target: { value: 'Success Headline' } }
+    );
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.unsubscribeAlreadyDoneHeadline'),
+      { target: { value: 'Already Headline' } }
+    );
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.unsubscribeErrorHeadline'),
+      { target: { value: 'Error Headline' } }
+    );
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeSuccessBody'), {
+      target: { value: 'Success Body' },
+    });
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.unsubscribeAlreadyDoneBody'),
+      { target: { value: 'Already Body' } }
+    );
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeErrorBody'), {
+      target: { value: 'Error Body' },
+    });
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.doiTokenTtlHours'), {
+      target: { value: '12' },
+    });
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.pendingSubscriptionTtlHours'),
+      { target: { value: '36' } }
+    );
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.materializationLookaheadDays'),
+      { target: { value: '5' } }
+    );
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.maxSubscriptionsPerEmailAndLocation'),
+      { target: { value: '3' } }
+    );
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.signupRateLimitPerIpPerHour'),
+      { target: { value: '8' } }
+    );
+    fireEvent.change(
+      screen.getByLabelText('output.emailReminder.fields.signupRateLimitPerEmailPerHour'),
+      { target: { value: '4' } }
+    );
+    fireEvent.change(screen.getByLabelText('output.emailReminder.fields.unsubscribeTokenTtlDays'), {
+      target: { value: '90' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: 'output.emailReminder.actions.save' }).closest('form')!
+    );
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(screen.getByText('output.emailReminder.transportStatus.disabled')).toBeTruthy();
@@ -763,7 +875,9 @@ describe('WasteOutputPanel', () => {
     expect(screen.queryByLabelText('output.emailReminder.fields.unsubscribePath')).toBeNull();
     expect(screen.queryByLabelText('output.emailReminder.fields.signupSuccessPath')).toBeNull();
     expect(screen.queryByLabelText('output.emailReminder.fields.activationSuccessPath')).toBeNull();
-    expect(screen.queryByLabelText('output.emailReminder.fields.unsubscribeSuccessPath')).toBeNull();
+    expect(
+      screen.queryByLabelText('output.emailReminder.fields.unsubscribeSuccessPath')
+    ).toBeNull();
     expect(screen.queryByLabelText('output.emailReminder.fields.invalidTokenPath')).toBeNull();
   });
 
@@ -833,7 +947,9 @@ describe('WasteOutputPanel', () => {
 
     render(<StatefulSection />);
 
-    const saveButton = screen.getByRole('button', { name: 'output.emailReminder.actions.save' }) as HTMLButtonElement;
+    const saveButton = screen.getByRole('button', {
+      name: 'output.emailReminder.actions.save',
+    }) as HTMLButtonElement;
     expect(saveButton.disabled).toBe(true);
 
     fireEvent.click(screen.getByLabelText('output.emailReminder.fields.enabled'));
@@ -841,5 +957,72 @@ describe('WasteOutputPanel', () => {
     expect(saveButton.disabled).toBe(false);
     fireEvent.submit(saveButton.closest('form')!);
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('email reminder configuration helpers', () => {
+  const interfaces = [
+    {
+      id: 'database-1',
+      name: 'Database',
+      typeKey: 'supabase',
+      enabled: true,
+      visibleStatus: 'ok' as const,
+      isSelected: true,
+    },
+    {
+      id: 'mail-1',
+      name: 'Primary mail',
+      typeKey: 'mail_transport',
+      enabled: true,
+      visibleStatus: 'ok' as const,
+      isSelected: false,
+    },
+  ];
+
+  it('filters transports and builds deterministic defaults', () => {
+    const transports = getMailTransportOptions(interfaces);
+    const config = buildDefaultEmailReminderConfig({
+      calendarWebUrl: 'https://calendar.example',
+      transportOptions: transports,
+    });
+
+    expect(transports).toEqual([interfaces[1]]);
+    expect(config).toMatchObject({
+      enabled: false,
+      transportId: 'mail-1',
+      publicBaseUrl: 'https://calendar.example',
+      invalidTokenPath: '/email-reminders/token-invalid',
+    });
+  });
+
+  it('falls back to the first transport and normalizes fixed paths', () => {
+    const transports = getMailTransportOptions(interfaces);
+    const config = buildDefaultEmailReminderConfig({ transportOptions: [] });
+    const withFallback = ensureTransportSelection(config, transports);
+    const normalized = normalizeEmailReminderConfig({
+      config: { ...withFallback, invalidTokenPath: '/editable-but-fixed' },
+      transportOptions: transports,
+    });
+
+    expect(withFallback.transportId).toBe('mail-1');
+    expect(normalized).toMatchObject({
+      transportId: 'mail-1',
+      invalidTokenPath: '/email-reminders/token-invalid',
+      doiConfirmPath: '/email-reminders/confirm',
+    });
+  });
+
+  it('creates normalized defaults when no persisted config exists', () => {
+    expect(
+      normalizeEmailReminderConfig({
+        calendarWebUrl: 'https://calendar.example',
+        transportOptions: [],
+      })
+    ).toMatchObject({
+      transportId: '',
+      publicBaseUrl: 'https://calendar.example',
+      unsubscribePath: '/email-reminders/unsubscribe',
+    });
   });
 });

--- a/packages/plugin-waste-management/tests/waste-management.output-panel.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.output-panel.test.tsx
@@ -32,16 +32,21 @@ vi.mock('@sva/studio-ui-react', () => ({
   StudioField: ({
     id,
     label,
+    description,
     children,
   }: {
     readonly id: string;
     readonly label: string;
+    readonly description?: string;
     readonly children: React.ReactNode;
   }) => (
-    <label htmlFor={id}>
-      <span>{label}</span>
-      {children}
-    </label>
+    <>
+      <label htmlFor={id}>
+        <span>{label}</span>
+        {children}
+      </label>
+      {description ? <span>{description}</span> : null}
+    </>
   ),
   Alert: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
   AlertTitle: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
@@ -879,6 +884,33 @@ describe('WasteOutputPanel', () => {
       screen.queryByLabelText('output.emailReminder.fields.unsubscribeSuccessPath')
     ).toBeNull();
     expect(screen.queryByLabelText('output.emailReminder.fields.invalidTokenPath')).toBeNull();
+    expect(screen.getByText('output.emailReminder.fieldHints.enabled')).toBeTruthy();
+    expect(screen.getByText('output.emailReminder.fieldHints.publicSignupEnabled')).toBeTruthy();
+    expect(screen.getByText('output.emailReminder.fieldHints.transportId')).toBeTruthy();
+  });
+
+  it('defaults the unsubscribe token TTL to 30 days when older settings omit it', () => {
+    const legacyValue = {
+      ...buildDefaultEmailReminderConfig({ transportOptions: [] }),
+      unsubscribeTokenTtlDays: undefined,
+    };
+
+    render(
+      <WasteEmailReminderConfigurationSection
+        hasMailTransportOptions={false}
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        running={false}
+        transportOptions={[]}
+        translate={(key) => key}
+        value={legacyValue}
+      />
+    );
+
+    expect(
+      (screen.getByLabelText('output.emailReminder.fields.unsubscribeTokenTtlDays') as HTMLInputElement)
+        .value
+    ).toBe('30');
   });
 
   it('still allows saving a disabled reminder configuration when no mail transport remains', () => {

--- a/packages/plugin-waste-management/tests/waste-management.tools.import-section.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.tools.import-section.test.tsx
@@ -12,6 +12,10 @@ import {
   resolveSelectedImportProfile,
   WasteToolsWizardStepList,
 } from '../src/waste-management.tools.import-section.parts.js';
+import {
+  getReachableStep,
+  transitionToReachableStep,
+} from '../src/waste-management.tools.import-wizard-state.js';
 
 const { downloadImportTemplateMock, downloadImportPreviewErrorsMock } = vi.hoisted(() => ({
   downloadImportTemplateMock: vi.fn(),
@@ -57,7 +61,10 @@ const importCatalog = [
     profileId: 'waste-management.geografie-abholorte',
     displayName: 'Geografie und Abholorte',
     description: 'Importiert Geografie.',
-    sourceFormats: ['text/csv', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+    sourceFormats: [
+      'text/csv',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
     requiredColumns: [{ key: 'region_id', required: true, example: 'region-1' }],
     optionalColumns: [],
   },
@@ -95,14 +102,14 @@ const renderImportSection = () => {
     const [importProfileId, setImportProfileId] = React.useState<
       'waste-management.ortsbezogene-tourtermine' | 'waste-management.geografie-abholorte'
     >('waste-management.ortsbezogene-tourtermine');
-    const [importSourceFormat, setImportSourceFormat] = React.useState<'text/csv' | 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'>(
-      'text/csv'
-    );
+    const [importSourceFormat, setImportSourceFormat] = React.useState<
+      'text/csv' | 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    >('text/csv');
     const [importBlobRef, setImportBlobRef] = React.useState('');
     const [importDryRun, setImportDryRun] = React.useState(false);
-    const [delimiterOverride, setDelimiterOverride] = React.useState<undefined | ';' | ',' | '\t' | '|'>(
-      undefined
-    );
+    const [delimiterOverride, setDelimiterOverride] = React.useState<
+      undefined | ';' | ',' | '\t' | '|'
+    >(undefined);
     const [previewReady, setPreviewReady] = React.useState(false);
 
     return (
@@ -117,7 +124,9 @@ const renderImportSection = () => {
         previewReady={previewReady}
         running={false}
         onImportProfileIdChange={(value) => setImportProfileId(value as typeof importProfileId)}
-        onImportSourceFormatChange={(value) => setImportSourceFormat(value as typeof importSourceFormat)}
+        onImportSourceFormatChange={(value) =>
+          setImportSourceFormat(value as typeof importSourceFormat)
+        }
         onImportBlobRefChange={setImportBlobRef}
         onImportDryRunChange={setImportDryRun}
         onDelimiterOverrideChange={setDelimiterOverride}
@@ -144,7 +153,9 @@ describe('WasteToolsImportSection', () => {
   it('guides the tour-date import through a wizard and blocks the final import before preview', async () => {
     const { callbacks } = renderImportSection();
 
-    expect(screen.getAllByText('tools.imports.wizard.steps.profile.title').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('tools.imports.wizard.steps.profile.title').length).toBeGreaterThan(
+      0
+    );
     expect(screen.queryByRole('button', { name: 'tools.actions.startImport' })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.imports.wizard.actions.continue' }));
@@ -161,7 +172,9 @@ describe('WasteToolsImportSection', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+      ).toBeGreaterThan(0);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.actions.previewImport' }));
@@ -178,7 +191,9 @@ describe('WasteToolsImportSection', () => {
     renderImportSection();
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.imports.wizard.actions.continue' }));
-    const dryRunCheckbox = screen.getByRole('checkbox', { name: 'tools.imports.dryRunLabel' }) as HTMLInputElement;
+    const dryRunCheckbox = screen.getByRole('checkbox', {
+      name: 'tools.imports.dryRunLabel',
+    }) as HTMLInputElement;
     expect(dryRunCheckbox.checked).toBe(false);
 
     fireEvent.click(dryRunCheckbox);
@@ -217,9 +232,9 @@ describe('WasteToolsImportSection', () => {
       const [importProfileId, setImportProfileId] = React.useState<
         'waste-management.ortsbezogene-tourtermine' | 'waste-management.geografie-abholorte'
       >('waste-management.geografie-abholorte');
-      const [importSourceFormat, setImportSourceFormat] = React.useState<'text/csv' | 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'>(
-        'text/csv'
-      );
+      const [importSourceFormat, setImportSourceFormat] = React.useState<
+        'text/csv' | 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      >('text/csv');
       const [importBlobRef, setImportBlobRef] = React.useState('');
       const [lastJob, setLastJob] = React.useState<{ id: string; status: string } | null>(null);
 
@@ -236,14 +251,20 @@ describe('WasteToolsImportSection', () => {
           running={false}
           lastJob={lastJob as never}
           onImportProfileIdChange={(value) => setImportProfileId(value as typeof importProfileId)}
-          onImportSourceFormatChange={(value) => setImportSourceFormat(value as typeof importSourceFormat)}
+          onImportSourceFormatChange={(value) =>
+            setImportSourceFormat(value as typeof importSourceFormat)
+          }
           onImportBlobRefChange={setImportBlobRef}
           onImportDryRunChange={() => undefined}
           onDelimiterOverrideChange={() => undefined}
           onRunPreview={async () => null}
           onStartImport={async () => {
             callbacks.onStartImport();
-            const job = { id: 'job-77', status: 'queued', jobTypeId: 'waste-management.import-data' };
+            const job = {
+              id: 'job-77',
+              status: 'queued',
+              jobTypeId: 'waste-management.import-data',
+            };
             setLastJob(job);
             return job as never;
           }}
@@ -265,15 +286,23 @@ describe('WasteToolsImportSection', () => {
 
     fireEvent.change(fileInput, {
       target: {
-        files: [new File(['xlsx'], 'orte.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })],
+        files: [
+          new File(['xlsx'], 'orte.xlsx', {
+            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          }),
+        ],
       },
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+      ).toBeGreaterThan(0);
     });
 
-    const confirmationButtons = screen.getAllByRole('button', { name: 'tools.imports.wizard.actions.continueToConfirmation' });
+    const confirmationButtons = screen.getAllByRole('button', {
+      name: 'tools.imports.wizard.actions.continueToConfirmation',
+    });
     const confirmationButton = confirmationButtons[0];
     expect(confirmationButton).toBeTruthy();
     if (!confirmationButton) {
@@ -296,7 +325,9 @@ describe('WasteToolsImportSection', () => {
     expect(screen.getByText('job-77')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.imports.wizard.actions.startNew' }));
-    expect(screen.getAllByText('tools.imports.wizard.steps.profile.title').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('tools.imports.wizard.steps.profile.title').length).toBeGreaterThan(
+      0
+    );
   });
 
   it('downloads templates and preview error exports for preview-guided imports', async () => {
@@ -318,7 +349,9 @@ describe('WasteToolsImportSection', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+      ).toBeGreaterThan(0);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.actions.previewImport' }));
@@ -348,7 +381,9 @@ describe('WasteToolsImportSection', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+      ).toBeGreaterThan(0);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.actions.previewImport' }));
@@ -378,7 +413,9 @@ describe('WasteToolsImportSection', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+      ).toBeGreaterThan(0);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.actions.previewImport' }));
@@ -387,12 +424,16 @@ describe('WasteToolsImportSection', () => {
       expect(callbacks.onRunPreview).toHaveBeenCalledTimes(1);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /tools\.imports\.wizard\.steps\.upload\.title/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /tools\.imports\.wizard\.steps\.upload\.title/i })
+    );
     fireEvent.change(screen.getByLabelText('tools.imports.delimiterLabel'), {
       target: { value: ',' },
     });
 
-    expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+    ).toBeGreaterThan(0);
     expect(screen.queryByText('tools.imports.previewTitle')).toBeNull();
   });
 
@@ -440,7 +481,9 @@ describe('WasteToolsImportSection', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+      ).toBeGreaterThan(0);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'tools.actions.previewImport' }));
@@ -449,14 +492,20 @@ describe('WasteToolsImportSection', () => {
       expect(onRunPreview).toHaveBeenCalledTimes(1);
     });
 
-    expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+    ).toBeGreaterThan(0);
     expect(screen.queryByText('tools.imports.previewTitle')).toBeNull();
   });
 
   it('does not treat non-import jobs as import results', async () => {
     const Wrapper = () => {
       const [importBlobRef, setImportBlobRef] = React.useState('');
-      const [lastJob, setLastJob] = React.useState<{ id: string; status: string; jobTypeId: string } | null>(null);
+      const [lastJob, setLastJob] = React.useState<{
+        id: string;
+        status: string;
+        jobTypeId: string;
+      } | null>(null);
 
       return (
         <WasteToolsImportSection
@@ -477,7 +526,11 @@ describe('WasteToolsImportSection', () => {
           onDelimiterOverrideChange={() => undefined}
           onRunPreview={async () => null}
           onStartImport={async () => {
-            const job = { id: 'job-migration', status: 'succeeded', jobTypeId: 'waste-management.apply-migrations' };
+            const job = {
+              id: 'job-migration',
+              status: 'succeeded',
+              jobTypeId: 'waste-management.apply-migrations',
+            };
             setLastJob(job);
             return job as never;
           }}
@@ -500,10 +553,14 @@ describe('WasteToolsImportSection', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByText('tools.imports.wizard.steps.validation.title').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('tools.imports.wizard.steps.validation.title').length
+      ).toBeGreaterThan(0);
     });
 
-    const confirmationButtons = screen.getAllByRole('button', { name: 'tools.imports.wizard.actions.continueToConfirmation' });
+    const confirmationButtons = screen.getAllByRole('button', {
+      name: 'tools.imports.wizard.actions.continueToConfirmation',
+    });
     const confirmationButton = confirmationButtons[0];
     expect(confirmationButton).toBeTruthy();
     if (!confirmationButton) {
@@ -530,9 +587,9 @@ describe('WasteToolsImportSection', () => {
     );
     expect(resolveSelectedImportProfile([], 'missing-profile')).toBeNull();
     expect(resolveImportFileAccept('text/csv')).toBe('.csv,text/csv');
-    expect(resolveImportFileAccept('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')).toBe(
-      '.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    );
+    expect(
+      resolveImportFileAccept('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+    ).toBe('.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     expect(isPreviewRequiredImportProfile(importCatalog[0])).toBe(true);
     expect(isPreviewRequiredImportProfile(importCatalog[1])).toBe(false);
     expect(isPreviewRequiredImportProfile(null)).toBe(false);
@@ -566,15 +623,87 @@ describe('WasteToolsImportSection', () => {
 
     const onStepChange = vi.fn();
     render(
-      <WasteToolsWizardStepList activeStep="upload" reachableStep="validation" onStepChange={onStepChange} />
+      <WasteToolsWizardStepList
+        activeStep="upload"
+        reachableStep="validation"
+        onStepChange={onStepChange}
+      />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /tools\.imports\.wizard\.steps\.profile\.title/i }));
-    expect(onStepChange).toHaveBeenCalledWith('profile');
-    expect(screen.getByRole('button', { name: /tools\.imports\.wizard\.steps\.preview\.title/i })).toHaveProperty(
-      'disabled',
-      true
+    fireEvent.click(
+      screen.getByRole('button', { name: /tools\.imports\.wizard\.steps\.profile\.title/i })
     );
+    expect(onStepChange).toHaveBeenCalledWith('profile');
+    expect(
+      screen.getByRole('button', { name: /tools\.imports\.wizard\.steps\.preview\.title/i })
+    ).toHaveProperty('disabled', true);
   });
 
+  it('keeps unreachable wizard transitions on the current step', () => {
+    const cases = [
+      [
+        {
+          hasSelectedProfile: true,
+          hasReadyFile: true,
+          previewRequired: true,
+          previewReady: true,
+          hasImportResult: true,
+        },
+        'result',
+      ],
+      [
+        {
+          hasSelectedProfile: true,
+          hasReadyFile: true,
+          previewRequired: true,
+          previewReady: true,
+          hasImportResult: false,
+        },
+        'preview',
+      ],
+      [
+        {
+          hasSelectedProfile: true,
+          hasReadyFile: true,
+          previewRequired: false,
+          previewReady: false,
+          hasImportResult: false,
+        },
+        'preview',
+      ],
+      [
+        {
+          hasSelectedProfile: true,
+          hasReadyFile: true,
+          previewRequired: true,
+          previewReady: false,
+          hasImportResult: false,
+        },
+        'validation',
+      ],
+      [
+        {
+          hasSelectedProfile: true,
+          hasReadyFile: false,
+          previewRequired: true,
+          previewReady: false,
+          hasImportResult: false,
+        },
+        'upload',
+      ],
+      [
+        {
+          hasSelectedProfile: false,
+          hasReadyFile: false,
+          previewRequired: false,
+          previewReady: false,
+          hasImportResult: false,
+        },
+        'profile',
+      ],
+    ] as const;
+    for (const [facts, expected] of cases) expect(getReachableStep(facts)).toBe(expected);
+    expect(transitionToReachableStep('upload', 'preview', 'validation')).toBe('upload');
+    expect(transitionToReachableStep('validation', 'profile', 'validation')).toBe('profile');
+  });
 });

--- a/packages/plugin-waste-management/tests/waste-management.tours-assignment-selection.test.ts
+++ b/packages/plugin-waste-management/tests/waste-management.tours-assignment-selection.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTourAssignmentSelectionSummary } from '../src/waste-management.tours.view-model.js';
+
+describe('createTourAssignmentSelectionSummary', () => {
+  it.each([
+    [[], [], false, false, 0],
+    [['one', 'two'], ['one', 'two'], true, true, 0],
+    [['one'], ['hidden'], false, false, 1],
+    [[], ['hidden'], false, false, 1],
+  ])(
+    'summarizes visible and hidden selections',
+    (
+      filteredLocationIds,
+      selectedLocationIds,
+      allVisibleSelected,
+      someVisibleSelected,
+      hiddenSelectedCount
+    ) => {
+      expect(
+        createTourAssignmentSelectionSummary({ filteredLocationIds, selectedLocationIds })
+      ).toMatchObject({
+        allVisibleSelected,
+        someVisibleSelected,
+        hiddenSelectedCount,
+      });
+    }
+  );
+});

--- a/packages/plugin-waste-management/tests/waste-management.tours-content.sorting.test.tsx
+++ b/packages/plugin-waste-management/tests/waste-management.tours-content.sorting.test.tsx
@@ -103,22 +103,22 @@ vi.mock('../src/waste-management.tours.content.parts.js', () => ({
 
 vi.mock('../src/waste-management.tours.content.body.js', () => ({
   WasteToursContentBody: ({
-    tours,
-    onSortChange,
-    setTourPendingDelete,
     setBulkDeleteOpen,
+    table,
   }: {
-    readonly tours: Array<{ id: string; name: string }>;
-    readonly onSortChange: (field: 'locations') => void;
-    readonly setTourPendingDelete: (tour: { id: string; name: string }) => void;
     readonly setBulkDeleteOpen: (open: boolean) => void;
+    readonly table: {
+      readonly tours: Array<{ id: string; name: string }>;
+      readonly onSortChange: (field: 'locations') => void;
+      readonly setTourPendingDelete: (tour: { id: string; name: string }) => void;
+    };
   }) => (
     <div>
-      <button onClick={() => onSortChange('locations')}>sort-locations</button>
-      <button onClick={() => onSortChange('locations')}>sort-locations-again</button>
-      <button onClick={() => setTourPendingDelete(tours[0]!)}>open-single-delete</button>
+      <button onClick={() => table.onSortChange('locations')}>sort-locations</button>
+      <button onClick={() => table.onSortChange('locations')}>sort-locations-again</button>
+      <button onClick={() => table.setTourPendingDelete(table.tours[0]!)}>open-single-delete</button>
       <button onClick={() => setBulkDeleteOpen(true)}>open-bulk-delete</button>
-      <div data-testid="tour-order">{tours.map((tour) => tour.id).join(',')}</div>
+      <div data-testid="tour-order">{table.tours.map((tour) => tour.id).join(',')}</div>
     </div>
   ),
 }));


### PR DESCRIPTION
## Zusammenfassung

Reduziert die UI- und Zustandskomplexität im Waste-Management-Plugin in drei Bereichen:

- Import-Wizard in zustandsbezogene Schritt-Komponenten und pure Reachability-Logik zerlegt
- E-Mail-Reminder-Konfiguration in pure Normalisierung, fokussierte Formularsektionen und atomare Persistenzkoordination getrennt
- Touren-UI mit gruppierten View-Models und testbarer Auswahlzusammenfassung entlastet

## Unverändert

- Öffentliche API- und SDK-Verträge
- Router- und Search-Param-Verhalten
- Termin-, Feiertags- und Materialisierungslogik
- Persistierte Reminder-Struktur und sichtbare Texte

## Validierung

- `pnpm nx run plugin-waste-management:test:unit` — 79 Dateien, 384 Tests
- `pnpm nx run plugin-waste-management:test:types`
- `pnpm nx run plugin-waste-management:lint`
- `pnpm complexity-gate` — keine neuen Findings
- Fallow-Komplexitätsanalyse ohne Cache