### PR TITLE
refactor: reduce verified Fallow technical debt

### DIFF
--- a/apps/sva-studio-react/src/hooks/use-runtime-health.ts
+++ b/apps/sva-studio-react/src/hooks/use-runtime-health.ts
@@ -24,7 +24,7 @@ const createUnknownServices = (): RuntimeHealthResponse['checks']['services'] =>
     ])
   ) as RuntimeHealthResponse['checks']['services'];
 
-export const createUnknownRuntimeHealth = (): RuntimeHealthResponse => ({
+const createUnknownRuntimeHealth = (): RuntimeHealthResponse => ({
   checks: {
     authorizationCache: {
       coldStart: false,

--- a/apps/sva-studio-react/src/lib/browser-operation-logging.ts
+++ b/apps/sva-studio-react/src/lib/browser-operation-logging.ts
@@ -22,7 +22,7 @@ type ErrorWithMeta = {
 export const createOperationLogger = (component: string, level: BrowserLogLevel = 'info'): BrowserLogger =>
   createBrowserLogger({ component, level });
 
-export const buildBrowserErrorMeta = (
+const buildBrowserErrorMeta = (
   error: unknown,
   meta: BrowserOperationLogMeta = {}
 ): BrowserOperationLogMeta => {

--- a/apps/sva-studio-react/src/lib/dev-auth.ts
+++ b/apps/sva-studio-react/src/lib/dev-auth.ts
@@ -2,7 +2,7 @@ import { isMockAuthRuntimeProfile, parseRuntimeProfile } from '@sva/core';
 
 export const DEV_AUTH_LOGIN_ENDPOINT = '/auth/dev-login';
 export const DEV_AUTH_LOGOUT_ENDPOINT = '/auth/dev-logout';
-export const DEV_AUTH_COOKIE_NAME = 'sva_dev_auth';
+const DEV_AUTH_COOKIE_NAME = 'sva_dev_auth';
 
 const readCookieValue = (cookieHeader: string, name: string): string | null => {
   const cookieName = `${encodeURIComponent(name)}=`;

--- a/apps/sva-studio-react/src/lib/error-message-utils.ts
+++ b/apps/sva-studio-react/src/lib/error-message-utils.ts
@@ -1,7 +1,7 @@
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
-export const extractMessageFromUnknown = (value: unknown): string | null => {
+const extractMessageFromUnknown = (value: unknown): string | null => {
   if (typeof value === 'string' && value.trim()) {
     return value;
   }

--- a/apps/sva-studio-react/src/lib/studio-changelog.shared.ts
+++ b/apps/sva-studio-react/src/lib/studio-changelog.shared.ts
@@ -2,7 +2,7 @@ export const STUDIO_CHANGELOG_ENTRY_DIRECTORY = 'docs/changelog/entries';
 export const STUDIO_CHANGELOG_ENTRY_PATTERN = /^docs\/changelog\/entries\/pr-(\d+)\.json$/u;
 export const STUDIO_CHANGELOG_ARTIFACT_RELATIVE_PATH = 'generated/studio-changelog.json';
 export const STUDIO_CHANGELOG_ENTRY_LIMIT = 20;
-export const STUDIO_CHANGELOG_RAW_HTML_PATTERN = /<\/?[a-z][\w-]*(?:\s[^<>]*)?\s*\/?>/iu;
+const STUDIO_CHANGELOG_RAW_HTML_PATTERN = /<\/?[a-z][\w-]*(?:\s[^<>]*)?\s*\/?>/iu;
 
 export type StudioChangelogEntry = {
   readonly prNumber: number;

--- a/apps/sva-studio-react/src/lib/theme.ts
+++ b/apps/sva-studio-react/src/lib/theme.ts
@@ -10,7 +10,7 @@ const INSTANCE_THEME_MAP: Readonly<Record<string, AppThemeName>> = {
   '11111111-1111-1111-8111-111111111111': 'sva-forest',
 };
 
-export const isThemeMode = (value: string | null | undefined): value is ThemeMode => value === 'light' || value === 'dark';
+const isThemeMode = (value: string | null | undefined): value is ThemeMode => value === 'light' || value === 'dark';
 
 export const resolveThemeName = (instanceId?: string): AppThemeName => {
   if (!instanceId) {

--- a/docs/changelog/entries/pr-706.json
+++ b/docs/changelog/entries/pr-706.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 706,
+  "body": "Die Wartbarkeit und Qualitätssicherung des Studios wurden weiter verbessert.\n\n- Nachweislich ungenutzte interne Exporte und eine nicht mehr verwendete Typdatei wurden entfernt.\n- Wiederholtes Kommandozeilen-Parsing in den CI-Prüfungen verwendet jetzt eine gemeinsame, getestete Implementierung.\n- Die statisch gemessene Code-Duplikation und die Zahl der Fallow-Qualitätsbefunde wurden reduziert."
+}

--- a/packages/auth-runtime/src/iam-instance-registry/http.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/http.ts
@@ -5,20 +5,6 @@ import { createInstanceRegistryHttpGuards } from '@sva/instance-registry/http-gu
 
 import type { AuthenticatedRequestContext } from '../middleware.js';
 import { resolveEffectiveRequestHost } from '../request-hosts.js';
-export {
-  assignModuleSchema,
-  createInstanceSchema,
-  executeKeycloakProvisioningSchema,
-  listQuerySchema,
-  readDetailInstanceId,
-  readKeycloakRunId,
-  reconcileKeycloakSchema,
-  revokeModuleSchema,
-  seedIamBaselineSchema,
-  statusMutationSchema,
-  updateInstanceSchema,
-} from '@sva/instance-registry/http-contracts';
-
 const isRootHostRequest = (request: Request): boolean => isCanonicalAuthHost(resolveEffectiveRequestHost(request));
 
 const httpGuards = createInstanceRegistryHttpGuards<AuthenticatedRequestContext>({

--- a/packages/data/src/iam/repositories/role-sync-types.ts
+++ b/packages/data/src/iam/repositories/role-sync-types.ts
@@ -1,2 +1,0 @@
-export type RoleManagedBy = 'studio' | 'external';
-export type RoleSyncState = 'synced' | 'pending' | 'failed';

--- a/packages/iam-admin/test-support/handler-test-helpers.ts
+++ b/packages/iam-admin/test-support/handler-test-helpers.ts
@@ -1,5 +1,3 @@
-// fallow-ignore-file unused-file
-
 export const createJsonResponse = (status: number, body: unknown): Response =>
   new Response(JSON.stringify(body), {
     status,

--- a/packages/routing/src/account-ui.routes.ts
+++ b/packages/routing/src/account-ui.routes.ts
@@ -42,7 +42,7 @@ type AccountUiRouteGuardDefinition = {
   readonly requiredAnyPermissions?: ProtectedRouteOptions['requiredAnyPermissions'];
 };
 
-export const accountUiRouteGuardDefinitions: Record<AccountUiRouteGuardKey, AccountUiRouteGuardDefinition> = {
+const accountUiRouteGuardDefinitions: Record<AccountUiRouteGuardKey, AccountUiRouteGuardDefinition> = {
   account: { kind: 'protected', route: uiRoutePaths.account },
   accountPrivacy: { kind: 'protected', route: uiRoutePaths.accountPrivacy },
   accountPrivacyDetail: { kind: 'protected', route: uiRoutePaths.accountPrivacyDetail },

--- a/packages/routing/src/admin-resource-route-aliases.ts
+++ b/packages/routing/src/admin-resource-route-aliases.ts
@@ -4,7 +4,7 @@ import { toAdminRoutePath } from './admin-resource-route-paths.js';
 
 export const LEGACY_CONTENT_ALIAS_PREFIX = '/content';
 
-export const coreContentAdminResource = {
+const coreContentAdminResource = {
   resourceId: 'content',
   basePath: 'content',
   titleKey: 'content.page.title',

--- a/packages/studio-ui-react/src/use-studio-media-picker-overlay.actions.ts
+++ b/packages/studio-ui-react/src/use-studio-media-picker-overlay.actions.ts
@@ -35,7 +35,7 @@ export type StudioMediaPickerOverlayOptions<TAssetDetail extends StudioMediaPick
   canAcceptAsset?: (asset: TAssetDetail) => boolean;
 }>;
 
-export const withPreviewUrlFallback = <TAssetDetail extends StudioMediaPickerAssetDetail>(
+const withPreviewUrlFallback = <TAssetDetail extends StudioMediaPickerAssetDetail>(
   asset: TAssetDetail,
   previewUrlFallback?: string | null
 ): TAssetDetail => {

--- a/packages/studio-ui-react/src/use-studio-media-picker-overlay.state.ts
+++ b/packages/studio-ui-react/src/use-studio-media-picker-overlay.state.ts
@@ -9,7 +9,7 @@ import {
   type StudioMediaPickerUploadPhase,
 } from './studio-media-picker-overlay.shared.js';
 
-export const emptyMetadataDraft: StudioMediaPickerMetadataDraft = {
+const emptyMetadataDraft: StudioMediaPickerMetadataDraft = {
   title: '',
   altText: '',
   description: '',

--- a/scripts/ci/affected-coverage-gate.ts
+++ b/scripts/ci/affected-coverage-gate.ts
@@ -4,15 +4,11 @@ import { createRequire } from 'node:module';
 import { performance } from 'node:perf_hooks';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { parseBaseHeadCliOptions, type BaseHeadCliOptions } from './base-head-cli-options.ts';
 
 export interface DurationEntry {
   label: string;
   durationMs: number;
-}
-
-interface AffectedCoverageGateOptions {
-  base: string;
-  head: string;
 }
 
 const APP_PROJECT = 'sva-studio-react';
@@ -20,36 +16,6 @@ const APP_VITEST_CONFIG = 'apps/sva-studio-react/vitest.config.ts';
 const COVERAGE_WORKSPACE_ROOTS = ['apps', 'packages'] as const;
 const IGNORED_DIRECTORY_NAMES = new Set(['node_modules', '.git', '.nx', '.output', 'dist', 'build', '.generated']);
 const require = createRequire(import.meta.url);
-
-const parseCliOptions = (args: readonly string[]): AffectedCoverageGateOptions => {
-  let base = 'origin/main';
-  let head = 'HEAD';
-
-  for (let index = 0; index < args.length; index += 1) {
-    const argument = args[index];
-
-    if (argument === '--base') {
-      const value = args[index + 1];
-      if (!value) {
-        throw new Error('Fehlender Wert für --base');
-      }
-      base = value;
-      index += 1;
-      continue;
-    }
-
-    if (argument === '--head') {
-      const value = args[index + 1];
-      if (!value) {
-        throw new Error('Fehlender Wert für --head');
-      }
-      head = value;
-      index += 1;
-    }
-  }
-
-  return { base, head };
-};
 
 const runCommand = (command: string): number => {
   console.log(`\n$ ${command}`);
@@ -107,7 +73,7 @@ export const clearWorkspaceCoverageOutputs = (rootDir = process.cwd()): void => 
 };
 
 export const runAffectedCoverageGate = (
-  options: AffectedCoverageGateOptions,
+  options: BaseHeadCliOptions,
   reportDuration?: (entry: DurationEntry) => void
 ): DurationEntry[] => {
   clearWorkspaceCoverageOutputs();
@@ -159,7 +125,7 @@ export const runAffectedCoverageGate = (
 const formatDuration = (durationMs: number): string => `${(durationMs / 1000).toFixed(2)}s`;
 
 export const runAffectedCoverageGateCli = (args: readonly string[]): number => {
-  const options = parseCliOptions(args);
+  const options = parseBaseHeadCliOptions(args);
   const durationEntries = runAffectedCoverageGate(options);
 
   if (durationEntries.length > 0) {

--- a/scripts/ci/affected-unit-gate.ts
+++ b/scripts/ci/affected-unit-gate.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import { performance } from 'node:perf_hooks';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { parseBaseHeadCliOptions, type BaseHeadCliOptions } from './base-head-cli-options.ts';
 import { buildAppUnitCommand, planAppUnitExecution } from './affected-unit-plan.ts';
 import { resolveChangedFiles } from './pr-scope.ts';
 
@@ -11,43 +12,8 @@ export interface DurationEntry {
   durationMs: number;
 }
 
-interface AffectedUnitGateOptions {
-  base: string;
-  head: string;
-}
-
 const APP_PROJECT = 'sva-studio-react';
 const require = createRequire(import.meta.url);
-const parseCliOptions = (args: readonly string[]): AffectedUnitGateOptions => {
-  let base = 'origin/main';
-  let head = 'HEAD';
-
-  for (let index = 0; index < args.length; index += 1) {
-    const argument = args[index];
-
-    if (argument === '--base') {
-      const value = args[index + 1];
-      if (!value) {
-        throw new Error('Fehlender Wert für --base');
-      }
-      base = value;
-      index += 1;
-      continue;
-    }
-
-    if (argument === '--head') {
-      const value = args[index + 1];
-      if (!value) {
-        throw new Error('Fehlender Wert für --head');
-      }
-      head = value;
-      index += 1;
-    }
-  }
-
-  return { base, head };
-};
-
 const runCommand = (
   command: string,
   options?: Readonly<{
@@ -126,7 +92,7 @@ const getAffectedUnitProjects = (base: string, head: string): string[] => {
 };
 
 export const runAffectedUnitGate = (
-  options: AffectedUnitGateOptions,
+  options: BaseHeadCliOptions,
   reportDuration?: (entry: DurationEntry) => void
 ): DurationEntry[] => {
   const changedFiles = resolveChangedFiles(options.base, options.head);
@@ -189,7 +155,7 @@ export const runAffectedUnitGate = (
 const formatDuration = (durationMs: number): string => `${(durationMs / 1000).toFixed(2)}s`;
 
 export const runAffectedUnitGateCli = (args: readonly string[]): number => {
-  const options = parseCliOptions(args);
+  const options = parseBaseHeadCliOptions(args);
   const durationEntries = runAffectedUnitGate(options);
 
   if (durationEntries.length > 0) {

--- a/scripts/ci/base-head-cli-options.test.ts
+++ b/scripts/ci/base-head-cli-options.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parseBaseHeadCliOptions } from './base-head-cli-options.ts';
+
+describe('parseBaseHeadCliOptions', () => {
+  it('uses the PR gate defaults', () => {
+    expect(parseBaseHeadCliOptions([])).toEqual({ base: 'origin/main', head: 'HEAD' });
+  });
+
+  it('reads base and head regardless of their order', () => {
+    expect(parseBaseHeadCliOptions(['--head', 'feature', '--base', 'main'])).toEqual({
+      base: 'main',
+      head: 'feature',
+    });
+  });
+
+  it.each(['--base', '--head'])('rejects a missing value for %s', (option) => {
+    expect(() => parseBaseHeadCliOptions([option])).toThrow(`Fehlender Wert für ${option}`);
+  });
+});

--- a/scripts/ci/base-head-cli-options.ts
+++ b/scripts/ci/base-head-cli-options.ts
@@ -1,0 +1,30 @@
+export interface BaseHeadCliOptions {
+  base: string;
+  head: string;
+}
+
+export const parseBaseHeadCliOptions = (args: readonly string[]): BaseHeadCliOptions => {
+  let base = 'origin/main';
+  let head = 'HEAD';
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument !== '--base' && argument !== '--head') {
+      continue;
+    }
+
+    const value = args[index + 1];
+    if (!value) {
+      throw new Error(`Fehlender Wert für ${argument}`);
+    }
+
+    if (argument === '--base') {
+      base = value;
+    } else {
+      head = value;
+    }
+    index += 1;
+  }
+
+  return { base, head };
+};

--- a/scripts/ci/run-pr-gate.ts
+++ b/scripts/ci/run-pr-gate.ts
@@ -1,44 +1,11 @@
 import { execSync } from 'node:child_process';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
+import { parseBaseHeadCliOptions } from './base-head-cli-options.ts';
 
 import { classifyPrScope, resolveChangedFiles, type GateMode } from './pr-scope.ts';
 import { runAffectedUnitGate, type DurationEntry } from './affected-unit-gate.ts';
 import { runIntegrationGate as runSelectedIntegrationGate } from './run-integration-gate.ts';
-
-interface RunPrGateOptions {
-  base: string;
-  head: string;
-}
-
-const parseCliOptions = (args: readonly string[]): RunPrGateOptions => {
-  let base = 'origin/main';
-  let head = 'HEAD';
-
-  for (let index = 0; index < args.length; index += 1) {
-    const argument = args[index];
-    if (argument === '--base') {
-      const value = args[index + 1];
-      if (!value) {
-        throw new Error('Fehlender Wert für --base');
-      }
-      base = value;
-      index += 1;
-      continue;
-    }
-
-    if (argument === '--head') {
-      const value = args[index + 1];
-      if (!value) {
-        throw new Error('Fehlender Wert für --head');
-      }
-      head = value;
-      index += 1;
-    }
-  }
-
-  return { base, head };
-};
 
 const runCommand = (command: string): number => {
   console.log(`\n$ ${command}`);
@@ -151,7 +118,7 @@ export const formatDurationSummary = (durations: readonly DurationEntry[]): stri
   durations.map((entry) => `- ${entry.label}: ${(entry.durationMs / 1000).toFixed(2)}s`).join('\n');
 
 export const runPrGate = (args: readonly string[]): number => {
-  const options = parseCliOptions(args);
+  const options = parseBaseHeadCliOptions(args);
   const changedFiles = resolveChangedFiles(options.base, options.head);
   const decision = classifyPrScope(changedFiles);
   const durations: DurationEntry[] = [];


### PR DESCRIPTION
## Zusammenfassung

- entfernt nachweislich ungenutzte interne Exporte in Auth-Runtime, Studio, Routing und Studio-UI
- entfernt eine unerreichbare Typdatei und eine veraltete Fallow-Suppression
- zentralisiert das identische `--base`/`--head`-Parsing dreier CI-Gates inklusive Charakterisierungstests

## Motivation und Wirkung

Der PR reduziert verifizierten Technical Debt, ohne öffentliche APIs oder Laufzeitverhalten zu verändern. Öffentliche, dynamische, generierte und mit aktiven OpenSpec-Changes überlappende Kandidaten wurden bewusst nicht angefasst.

Fallow vorher → nachher:

- Gesamtbefunde: 396 → 373
- ungenutzte Exporte: 211 → 190
- ungenutzte Dateien: 8 → 7
- veraltete Suppressionen: 1 → 0
- Klon-Gruppen: 601 → 598
- duplizierte Zeilen: 24.641 → 24.540
- Duplikationsrate: 8,8069 % → 8,7735 %
- Komplexitätsbefunde: 768 → 767
- kritische/hohe Komplexität unverändert: 137 / 228

## Validierung

- `pnpm test:pr`
  - Coverage-, Patch-Coverage- und Sonar-New-Code-Gates
  - Complexity-Gate
  - affected Lint, Unit und Types
  - Integration und kritische Ops-Tests
  - App-Build
  - E2E: 44 bestanden, 2 manuelle Tests erwartungsgemäß übersprungen
- `pnpm check:file-placement`
- Fallow Boundary-Check
- vollständiger Fallow-Vorher-/Nachher-Vergleich

## Bewusst außerhalb des Scopes

- dynamische OTEL-Build-Artefakt-Imports
- nicht eindeutig zuordenbare OTel-/`h3`-Debug-Dependencies
- öffentliche Package-Exports und OpenSpec-nahe Strukturrefactorings
- DB-, Auth-, Routing- oder Plugin-Verhaltensänderungen
