### PR TITLE
fix(ci): link GHCR image to repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,8 @@ RUN find /workspace/.deploy/sva-studio-react/node_modules/.pnpm \
 
 FROM node:24.15.0-alpine AS runtime
 
+LABEL org.opencontainers.image.source="https://github.com/smart-village-solutions/sva-studio"
+
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/docs/changelog/entries/pr-708.json
+++ b/docs/changelog/entries/pr-708.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 708,
+  "body": "Der Container-Build verknüpft das SVA-Studio-Image künftig eindeutig mit seinem GitHub-Repository. Dadurch kann GitHub Actions die erforderlichen GHCR-Schreibrechte für veröffentlichte Images korrekt übernehmen."
+}


### PR DESCRIPTION
## Änderung

Fügt dem Runtime-Image das OCI-Quelllabel hinzu, damit GHCR das Container-Paket dem Repository zuordnen und GitHub Actions Schreibzugriff erben kann.

## Ursache

Das private Container-Paket `sva-studio` war keinem Repository zugeordnet; Builds scheiterten beim Push nach GHCR mit `403 Forbidden`.

## Validierung

- `docker buildx build --check -f Dockerfile .`