### PR TITLE
fix(ci): run promote gates without top-level await

### DIFF
--- a/docs/changelog/entries/pr-709.json
+++ b/docs/changelog/entries/pr-709.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 709,
+  "body": "Der automatische Promote-Pfad kann seine Migrations- und Bootstrap-Gates wieder zuverlässig ausführen. Der CI-Skripteinstieg ist nun auch mit der CommonJS-Transformation des GitHub-Runners kompatibel."
+}

--- a/docs/changelog/entries/pr-709.json
+++ b/docs/changelog/entries/pr-709.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 709,
-  "body": "Der automatische Promote-Pfad kann seine Migrations- und Bootstrap-Gates wieder zuverlässig ausführen. Der CI-Skripteinstieg ist nun auch mit der CommonJS-Transformation des GitHub-Runners kompatibel."
+  "body": "Der automatische Promote-Pfad prüft Migrations- und Bootstrap-Gates wieder zuverlässig, bevor ein Release ausgerollt wird."
 }

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -314,13 +314,5 @@ export const runPromoteDeployGates = async (args: readonly string[]): Promise<nu
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  void runPromoteDeployGates(process.argv.slice(2)).then(
-    (exitCode) => {
-      process.exitCode = exitCode;
-    },
-    (error: unknown) => {
-      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-      process.exitCode = 2;
-    }
-  );
+  void runPromoteDeployGates(process.argv.slice(2)).then(process.exit);
 }

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -314,6 +314,13 @@ export const runPromoteDeployGates = async (args: readonly string[]): Promise<nu
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const exitCode = await runPromoteDeployGates(process.argv.slice(2));
-  process.exit(exitCode);
+  void runPromoteDeployGates(process.argv.slice(2)).then(
+    (exitCode) => {
+      process.exitCode = exitCode;
+    },
+    (error: unknown) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 2;
+    }
+  );
 }

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -277,11 +277,10 @@ export const executePromoteDeployGates = async (
 ): Promise<{ exitCode: number; stderr: string; stdout: string }> => {
   try {
     const options = parseCliOptions(args);
-    const changedFiles = resolveCliChangedFiles(options);
     const evaluation = evaluatePromoteDeployGates({
       bootstrapExecutorConfigured: options.bootstrapExecutorConfigured,
       bootstrapMode: options.bootstrapMode,
-      changedFiles,
+      changedFiles: resolveCliChangedFiles(options),
       migrationExecutorConfigured: options.migrationExecutorConfigured,
       migrationMode: options.migrationMode,
     });
@@ -303,16 +302,18 @@ export const executePromoteDeployGates = async (
 
 export const runPromoteDeployGates = async (args: readonly string[]): Promise<number> => {
   const result = await executePromoteDeployGates(args);
-
-  if (result.stdout) {
-    process.stdout.write(`${result.stdout}\n`);
-  }
-  if (result.stderr) {
-    process.stderr.write(`${result.stderr}\n`);
-  }
+  if (result.stdout) process.stdout.write(`${result.stdout}\n`);
+  if (result.stderr) process.stderr.write(`${result.stderr}\n`);
   return result.exitCode;
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  void runPromoteDeployGates(process.argv.slice(2)).then(process.exit);
+  void runPromoteDeployGates(process.argv.slice(2))
+    .then((exitCode) => (process.exitCode = exitCode))
+    .catch((error: unknown) => {
+      process.stderr.write(
+        `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
+      );
+      process.exitCode = 2;
+    });
 }


### PR DESCRIPTION
## Änderung

Führt den CLI-Einstieg der Promote-Gates ohne Top-Level-`await` aus.

## Ursache

Der GitHub-Runner transformierte das Script als CommonJS und brach deshalb vor jeder Deploy-Gate-Prüfung ab.

## Validierung

- Tooling-Unit-Tests
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- direkter `tsx`-Lauf von `scripts/ci/promote-deploy-gates.ts`