### PR TITLE
fix(ci): skip Quantum pre-pull for dev

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -232,7 +232,11 @@ jobs:
           docker compose -f compose.yaml -f ./deploy/compose.${ENVIRONMENT}.yaml config --no-normalize --format json > stack.json
           pnpm exec tsx scripts/ci/render-quantum-stack.ts --input stack.json --output stack.yaml
 
-          quantum-cli stack deploy -f stack.yaml --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}"
+          pre_pull_args=()
+          if [ "${ENVIRONMENT}" = "dev" ]; then
+            pre_pull_args=(--no-pre-pull)
+          fi
+          quantum-cli stack deploy -f stack.yaml --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}" "${pre_pull_args[@]}"
 
       - name: write deploy summary
         if: always()

--- a/docs/changelog/entries/pr-710.json
+++ b/docs/changelog/entries/pr-710.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 710,
+  "body": "Der Dev-Releasepfad kann Container-Images jetzt über die bestehende Swarm-Registry-Konfiguration beziehen, wenn die vorgeschaltete Bereitstellungsprüfung nicht verfügbar ist."
+}

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -39,6 +39,14 @@ describe('deployment contracts', () => {
     expect(workflow).toContain('actions/checkout@v7');
   });
 
+  it('skips Quantum pre-pull only for the diagnostic dev deployment path', () => {
+    const workflow = load('.github/workflows/promote.yml');
+
+    expect(workflow).toContain('if [ "${ENVIRONMENT}" = "dev" ]; then');
+    expect(workflow).toContain('pre_pull_args=(--no-pre-pull)');
+    expect(workflow).toContain('"${pre_pull_args[@]}"');
+  });
+
   it('protects and removes rendered deployment secret files', () => {
     const workflow = load('.github/workflows/promote.yml');
 


### PR DESCRIPTION
## Änderung

Der Dev-Promote-Pfad überspringt den Quantum-Pre-Pull und überlässt den Image-Pull dem Swarm. Staging und Produktion bleiben unverändert.

## Ursache

Der Quantum-Pre-Pull konnte den gültigen privaten GHCR-Digest nicht auflösen, bevor der Swarm seine vorhandene Registry-Konfiguration verwenden konnte.

## Validierung

- Tooling-Tests mit Deployment-Vertrag