### PR TITLE
fix(ci): deploy gerenderte Quantum-Stacks

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -212,7 +212,8 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
-          trap 'rm -f .env stack.json stack.yaml' EXIT
+          quantum_project_dir="$(mktemp -d)"
+          trap 'rm -rf "${quantum_project_dir}"; rm -f .env stack.json stack.yaml' EXIT
 
           if [ -z "${QUANTUM_ENDPOINT}" ]; then
             echo "'QUANTUM_ENDPOINT' must not be empty." >&2
@@ -236,7 +237,9 @@ jobs:
           if [ "${ENVIRONMENT}" = "dev" ]; then
             pre_pull_args=(--no-pre-pull)
           fi
-          quantum-cli stack deploy -f stack.yaml --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}" "${pre_pull_args[@]}"
+          printf '%s\n' 'version: "1.0"' 'compose: stack.yaml' > "${quantum_project_dir}/.quantum"
+          cp stack.yaml "${quantum_project_dir}/stack.yaml"
+          quantum-cli stacks update --create --wait --project "${quantum_project_dir}" --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}" "${pre_pull_args[@]}"
 
       - name: write deploy summary
         if: always()

--- a/docs/changelog/entries/pr-711.json
+++ b/docs/changelog/entries/pr-711.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 711,
+  "body": "Der Dev-Releasepfad verwendet für gerenderte Stacks nun den kompatiblen Quantum-CLI-Aufruf und kann die vorgeschaltete Image-Bereitstellung gezielt überspringen."
+}

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -45,12 +45,18 @@ describe('deployment contracts', () => {
     expect(workflow).toContain('if [ "${ENVIRONMENT}" = "dev" ]; then');
     expect(workflow).toContain('pre_pull_args=(--no-pre-pull)');
     expect(workflow).toContain('"${pre_pull_args[@]}"');
+    expect(workflow).toContain('quantum-cli stacks update --create --wait');
+    expect(workflow).toContain('--project "${quantum_project_dir}"');
+    expect(workflow).toContain("'compose: stack.yaml'");
   });
 
   it('protects and removes rendered deployment secret files', () => {
     const workflow = load('.github/workflows/promote.yml');
 
     expect(workflow).toContain('umask 077');
-    expect(workflow).toContain("trap 'rm -f .env stack.json stack.yaml' EXIT");
+    expect(workflow).toContain('quantum_project_dir="$(mktemp -d)"');
+    expect(workflow).toContain(
+      "trap 'rm -rf \"${quantum_project_dir}\"; rm -f .env stack.json stack.yaml' EXIT"
+    );
   });
 });


### PR DESCRIPTION
## Zusammenfassung

Der Dev-Promote-Workflow kann den gerenderten Swarm-Stack wieder ausrollen.

Der bisherige Aufruf verwendete einen Quantum-CLI-Unterbefehl, der `--no-pre-pull` nicht unterstützt. Der Workflow erzeugt deshalb jetzt ein temporäres Quantum-Projekt aus der bereits gerenderten `stack.yaml` und führt den unterstützten Rollout mit `quantum-cli stacks update --create --wait` aus.

`--no-pre-pull` bleibt auf die Dev-Umgebung begrenzt; Staging und Produktion verwenden weiterhin den normalen Pre-Pull.

## Verifikation

- `pnpm nx run tooling-testing:test:unit`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- Lokaler Quantum-CLI-Test: Projektvalidierung erfolgreich; der Aufruf akzeptiert `--no-pre-pull` und endet mit ungültigem Test-Token vor jeder Mutation.