### PR TITLE
fix(ci): Dev-Promote über Commit-Tag ausrollen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,5 +57,5 @@ jobs:
       change_base: ${{ github.event.before }}
       change_head: ${{ github.sha }}
       environment: dev
-      image_ref: ${{ needs.build.outputs.image_digest }}
+      image_ref: ${{ github.sha }}
       migration_mode: assert-none

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -212,8 +212,7 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
-          quantum_project_dir="$(mktemp -d)"
-          trap 'rm -rf "${quantum_project_dir}"; rm -f .env stack.json stack.yaml' EXIT
+          trap 'rm -f .env stack.json stack.yaml' EXIT
 
           if [ -z "${QUANTUM_ENDPOINT}" ]; then
             echo "'QUANTUM_ENDPOINT' must not be empty." >&2
@@ -233,13 +232,7 @@ jobs:
           docker compose -f compose.yaml -f ./deploy/compose.${ENVIRONMENT}.yaml config --no-normalize --format json > stack.json
           pnpm exec tsx scripts/ci/render-quantum-stack.ts --input stack.json --output stack.yaml
 
-          pre_pull_args=()
-          if [ "${ENVIRONMENT}" = "dev" ]; then
-            pre_pull_args=(--no-pre-pull)
-          fi
-          printf '%s\n' 'version: "1.0"' 'compose: stack.yaml' > "${quantum_project_dir}/.quantum"
-          cp stack.yaml "${quantum_project_dir}/stack.yaml"
-          quantum-cli stacks update --create --wait --project "${quantum_project_dir}" --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}" "${pre_pull_args[@]}"
+          quantum-cli stacks deploy -f stack.yaml --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}"
 
       - name: write deploy summary
         if: always()

--- a/docs/changelog/entries/pr-712.json
+++ b/docs/changelog/entries/pr-712.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 712,
+  "body": "Der Dev-Promote verwendet jetzt den beim Build veröffentlichten Commit-Tag, damit der Swarm das neue Container-Image zuverlässig auflösen kann."
+}

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -39,24 +39,26 @@ describe('deployment contracts', () => {
     expect(workflow).toContain('actions/checkout@v7');
   });
 
-  it('skips Quantum pre-pull only for the diagnostic dev deployment path', () => {
+  it('uses the Quantum CLI v3 stack deploy contract', () => {
     const workflow = load('.github/workflows/promote.yml');
 
-    expect(workflow).toContain('if [ "${ENVIRONMENT}" = "dev" ]; then');
-    expect(workflow).toContain('pre_pull_args=(--no-pre-pull)');
-    expect(workflow).toContain('"${pre_pull_args[@]}"');
-    expect(workflow).toContain('quantum-cli stacks update --create --wait');
-    expect(workflow).toContain('--project "${quantum_project_dir}"');
-    expect(workflow).toContain("'compose: stack.yaml'");
+    expect(workflow).toContain(
+      'quantum-cli stacks deploy -f stack.yaml --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}"'
+    );
+    expect(workflow).not.toContain('--no-pre-pull');
+    expect(workflow).not.toContain('quantum_project_dir');
   });
 
   it('protects and removes rendered deployment secret files', () => {
     const workflow = load('.github/workflows/promote.yml');
 
     expect(workflow).toContain('umask 077');
-    expect(workflow).toContain('quantum_project_dir="$(mktemp -d)"');
-    expect(workflow).toContain(
-      "trap 'rm -rf \"${quantum_project_dir}\"; rm -f .env stack.json stack.yaml' EXIT"
-    );
+    expect(workflow).toContain("trap 'rm -f .env stack.json stack.yaml' EXIT");
+  });
+
+  it('promotes Dev with the immutable build commit tag', () => {
+    const workflow = load('.github/workflows/build.yml');
+
+    expect(workflow).toContain('image_ref: ${{ github.sha }}');
   });
 });


### PR DESCRIPTION
## Zusammenfassung

Der Dev-Promote verwendet den beim Build veröffentlichten, unveränderlichen Commit-Tag statt der Digest-Referenz. Dadurch verwendet Portainer einen von GHCR korrekt auflösbaren Image-Vertrag.

Der Deploy-Aufruf wird zugleich auf die tatsächlich in CI installierte Quantum CLI 3.2.1 zurückgeführt: `quantum-cli stacks deploy -f stack.yaml`.

Staging und Produktion bleiben unverändert.

## Verifikation

- Der Commit-Tag des fehlgeschlagenen Laufs wurde gegen GHCR aufgelöst.
- `pnpm nx run tooling-testing:test:unit`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`