### PR TITLE
fix(deploy): Dev-Router über Let's Encrypt absichern

### DIFF
--- a/.github/agents/rollout-operator.agent.md
+++ b/.github/agents/rollout-operator.agent.md
@@ -46,7 +46,7 @@ Lies diese Dateien zu Beginn jedes Rollouts:
 - **Kein `--force`**: Docker Swarm Rollbacks nur über die dokumentierten Wege
 - **Strikte Stack-Grenze**: Niemals Ressourcen außerhalb des explizit zugewiesenen Stacks ändern; betroffen sind insbesondere andere Stacks, globale Swarm-Ressourcen, gemeinsame Netzwerke und Ingress-Komponenten
 - **Traefik bleibt unberührt**: Den Traefik-Stack, Traefik-Services, deren Labels, Routing-Regeln, Zertifikatsresolver, Netzwerke oder statische/dynamische Konfiguration niemals ändern, neu deployen, skalieren, restarten oder löschen
-- **Traefik-Version fest annehmen**: Auf dem Swarm-Server läuft Traefik `v1.7.34`; alle Ingress-Annahmen und Labels müssen dazu kompatibel sein
+- **Traefik-Version fest annehmen**: Auf dem Swarm-Server läuft Traefik `v3.6`; Ingress-Router verwenden die `traefik.http.*`-Labels und den konfigurierten TLS-Resolver
 - **Monitoring-Gates beachten**: Deploy erst als erfolgreich melden, wenn Health + Smoke grün sind
 - **Learnings pflegen**: Bei unerwarteten Fehlern oder Workarounds sofort `/memories/repo/rollout-learnings.md` aktualisieren
 
@@ -110,9 +110,9 @@ Kurz notiert:
 - Bei `401 Invalid JWT token` nicht nur den Server verdächtigen: ein lokales, veraltetes `QUANTUM_API_KEY` kann einen ansonsten funktionierenden Quantum-Kontext überschreiben. Einmal mit `env -u QUANTUM_API_KEY quantum-cli ...` gegenprüfen
 - Fuer `studio` koennen Shell-Overrides und einzelne Runtime-Variablen beim direkten `quantum-cli stacks update` verloren gehen; wenn Env-Propagation zweifelhaft ist, ein temporaeres Quantum-Projekt mit vorgerenderter Compose verwenden
 - `docker compose config` ist nicht 1:1 Portainer-kompatibel; beim Vorab-Rendering muessen mindestens das Top-Level-Feld `name:` entfernt und numerische `deploy.resources.limits.cpus` wieder als Strings serialisiert werden
-- Auf dem Endpoint `sva` läuft Traefik `v1.7.34`; daher nur Traefik-v1-Labels verwenden. `traefik.http.routers.*` wird ignoriert
+- Auf dem Endpoint `sva` läuft Traefik `v3.6`; für Ingress-Router sind `traefik.http.*`-Labels mit explizitem TLS-Resolver maßgeblich
 - Traefik ist als externe, nicht diesem Agenten zugeordnete Ingress-Komponente zu behandeln; Diagnosen sind erlaubt, Änderungen daran nicht
-- Für Let's Encrypt bei Instanz-Subdomains konkrete `Host:`-Einträge ergänzen; `HostRegexp` allein reicht auf Traefik v1 nicht für ACME
+- Für Let's Encrypt muss jeder Router einen konkreten Host-Regel-Ausdruck sowie den konfigurierten TLS-Resolver setzen
 - Fuer `studio` ist der kanonische Betriebsweg `Studio Image Build` -> `Studio Artifact Verify` -> `pnpm env:release:studio:local`
 - `studio` mutiert ausschliesslich den Stack `studio` auf Endpoint `sva`; direkte Service-Updates oder Portainer-Handedits sind nur dokumentierter Notfallpfad
 

--- a/deploy/compose.dev.yaml
+++ b/deploy/compose.dev.yaml
@@ -26,7 +26,9 @@ services:
         - 'traefik.frontend.rule=Host:studio-dev.smart-village.app'
         - 'traefik.port=3000'
         - 'traefik.http.routers.studio-dev-app.rule=Host(`studio-dev.smart-village.app`)'
+        - 'traefik.http.routers.studio-dev-app.entrypoints=web,websecure'
         - 'traefik.http.routers.studio-dev-app.tls=true'
+        - 'traefik.http.routers.studio-dev-app.tls.certresolver=letsencrypt'
         - 'traefik.http.services.studio-dev-app.loadbalancer.server.port=3000'
 
   provisioner:

--- a/docs/changelog/entries/pr-713.json
+++ b/docs/changelog/entries/pr-713.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 713,
+  "body": "Der Dev-Router fordert für studio-dev.smart-village.app jetzt ein gültiges Let's-Encrypt-Zertifikat an."
+}

--- a/docs/guides/deployment-overview.md
+++ b/docs/guides/deployment-overview.md
@@ -47,7 +47,7 @@ Das Studio-Profil bildet einen separaten produktionsnahen Rollout-Pfad:
 - Runtime-Profil: `studio`
 - Stack typischerweise: `studio`
 - Quantum-Environment: `studio`
-- Traefik auf `sva` läuft derzeit v1.7.34; daher sind nur v1-kompatible Labels wirksam
+- Traefik auf `sva` läuft derzeit v3.6; Ingress-Router verwenden `traefik.http.*`-Labels und den konfigurierten TLS-Resolver
 
 Wichtig:
 

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -61,4 +61,11 @@ describe('deployment contracts', () => {
 
     expect(workflow).toContain('image_ref: ${{ github.sha }}');
   });
+
+  it('configures the Dev router for the Traefik ACME resolver', () => {
+    const compose = load('deploy/compose.dev.yaml');
+
+    expect(compose).toContain('traefik.http.routers.studio-dev-app.entrypoints=web,websecure');
+    expect(compose).toContain('traefik.http.routers.studio-dev-app.tls.certresolver=letsencrypt');
+  });
 });

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -68,4 +68,13 @@ describe('deployment contracts', () => {
     expect(compose).toContain('traefik.http.routers.studio-dev-app.entrypoints=web,websecure');
     expect(compose).toContain('traefik.http.routers.studio-dev-app.tls.certresolver=letsencrypt');
   });
+
+  it('documents the active Traefik v3 ingress contract', () => {
+    const overview = load('docs/guides/deployment-overview.md');
+    const rolloutAgent = load('.github/agents/rollout-operator.agent.md');
+
+    expect(overview).toContain('Traefik auf `sva` läuft derzeit v3.6');
+    expect(rolloutAgent).toContain('Auf dem Swarm-Server läuft Traefik `v3.6`');
+    expect(rolloutAgent).not.toContain('v1.7.34');
+  });
 });


### PR DESCRIPTION
## Zusammenfassung

Der Dev-Router hat nach dem Traefik-Upgrade zwar die HTTP-Routen gelesen, aber ohne Zertifikatsresolver nur das selbstsignierte Traefik-Standardzertifikat ausgeliefert.

Der Router erhält jetzt die Entry Points `web,websecure` und den vorhandenen ACME-Resolver `letsencrypt`.

## Verifikation

- Live-Labels des laufenden `studio-dev_app` geprüft: Resolver fehlte.
- `pnpm nx run tooling-testing:test:unit`

----
## Summary by Gitar

- **Documentation updates:**
  - Aligned Traefik version guidance with `v3.6` in `.github/agents/rollout-operator.agent.md` and `docs/guides/deployment-overview.md`.
  - Added a new changelog entry in `docs/changelog/entries/pr-713.json` reflecting the TLS certificate configuration.
- **Test coverage:**
  - Added unit tests in `tooling/testing/tests/deployment-contract.test.ts` to verify the Traefik ACME resolver configuration and documentation consistency.

<sub>This will update automatically on new commits.</sub>