### PR TITLE
fix(deploy): Dev-Router mit aktivem ACME-Resolver

### DIFF
--- a/deploy/compose.dev.yaml
+++ b/deploy/compose.dev.yaml
@@ -28,7 +28,7 @@ services:
         - 'traefik.http.routers.studio-dev-app.rule=Host(`studio-dev.smart-village.app`)'
         - 'traefik.http.routers.studio-dev-app.entrypoints=web,websecure'
         - 'traefik.http.routers.studio-dev-app.tls=true'
-        - 'traefik.http.routers.studio-dev-app.tls.certresolver=letsencrypt'
+        - 'traefik.http.routers.studio-dev-app.tls.certresolver=default'
         - 'traefik.http.services.studio-dev-app.loadbalancer.server.port=3000'
 
   provisioner:

--- a/docs/changelog/entries/pr-715.json
+++ b/docs/changelog/entries/pr-715.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 715,
+  "body": "Der Dev-Router verwendet jetzt den auf dem Swarm konfigurierten Traefik-Resolver, damit ein gültiges Let's-Encrypt-Zertifikat bereitgestellt wird."
+}

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -66,7 +66,7 @@ describe('deployment contracts', () => {
     const compose = load('deploy/compose.dev.yaml');
 
     expect(compose).toContain('traefik.http.routers.studio-dev-app.entrypoints=web,websecure');
-    expect(compose).toContain('traefik.http.routers.studio-dev-app.tls.certresolver=letsencrypt');
+    expect(compose).toContain('traefik.http.routers.studio-dev-app.tls.certresolver=default');
   });
 
   it('documents the active Traefik v3 ingress contract', () => {


### PR DESCRIPTION
## Zusammenfassung

Der auf `sva` laufende Traefik v3.6 nennt seinen ACME-Resolver `default`, nicht `letsencrypt`. Der Dev-Router referenziert jetzt den tatsächlich konfigurierten Resolver.

Die Live-Korrektur wurde verifiziert: `studio-dev.smart-village.app` liefert ein gültiges Let’s-Encrypt-Zertifikat.

## Verifikation

- Traefik-Service-Args auf Endpoint `sva` geprüft.
- TLS-Handshake: Zertifikat für `studio-dev.smart-village.app`, Aussteller Let’s Encrypt.
- `pnpm nx run tooling-testing:test:unit`