### PR TITLE
fix(ci): Ingress-Only-Compose-Änderungen gezielt freigeben

### DIFF
--- a/docs/changelog/entries/pr-716.json
+++ b/docs/changelog/entries/pr-716.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 716,
+  "body": "Reine Traefik-Konfigurationsänderungen können den Dev-Release jetzt ausrollen, ohne fälschlich Migration und Bootstrap zu blockieren."
+}

--- a/scripts/ci/promote-deploy-gates.test.ts
+++ b/scripts/ci/promote-deploy-gates.test.ts
@@ -9,6 +9,7 @@ import {
   evaluatePromoteDeployGates,
   executePromoteDeployGates,
   formatRiskSummary,
+  isTraefikOnlyComposeDiff,
   type DeployGateMode,
 } from './promote-deploy-gates.ts';
 
@@ -91,6 +92,23 @@ describe('promote-deploy-gates', () => {
     expect(result.bootstrap.riskFiles).toEqual(['compose.yaml', 'deploy/compose.prod.yaml']);
     expect(result.migration.ok).toBe(false);
     expect(result.bootstrap.ok).toBe(false);
+  });
+
+  it('allows Traefik-only compose label changes without suppressing other compose risks', () => {
+    const result = evaluatePromoteDeployGates({
+      bootstrapMode: 'assert-none',
+      changedFiles: ['deploy/compose.dev.yaml'],
+      migrationMode: 'assert-none',
+      safeComposeFiles: ['deploy/compose.dev.yaml'],
+    });
+
+    expect(result.migration.ok).toBe(true);
+    expect(result.bootstrap.ok).toBe(true);
+  });
+
+  it('recognizes only label-list changes as Traefik-only compose diffs', () => {
+    expect(isTraefikOnlyComposeDiff("-        - 'traefik.http.routers.app.tls=true'\n+        - 'traefik.http.routers.app.tls.certresolver=default'\n")).toBe(true);
+    expect(isTraefikOnlyComposeDiff('+  postgres:\n+    image: postgres:16-alpine\n')).toBe(false);
   });
 
   it('refuses run mode when no safe executor is configured', () => {

--- a/scripts/ci/promote-deploy-gates.test.ts
+++ b/scripts/ci/promote-deploy-gates.test.ts
@@ -9,9 +9,9 @@ import {
   evaluatePromoteDeployGates,
   executePromoteDeployGates,
   formatRiskSummary,
-  isTraefikOnlyComposeDiff,
   type DeployGateMode,
 } from './promote-deploy-gates.ts';
+import { isTraefikOnlyComposeDiff } from './traefik-compose-diff.ts';
 
 const temporaryDirectories: string[] = [];
 

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { appendFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { resolveChangedFiles } from './pr-scope.ts';
 export type DeployGateMode = 'assert-none' | 'run';
@@ -28,6 +29,7 @@ interface EvaluateDeployGateOptions {
   executorConfigured: boolean;
   kind: DeployGateKind;
   mode: DeployGateMode;
+  safeComposeFiles?: readonly string[];
 }
 
 interface CliOptions {
@@ -68,15 +70,36 @@ const bootstrapRiskPatterns = [
 
 const matchesAnyPattern = (filePath: string, patterns: readonly RegExp[]): boolean =>
   patterns.some((pattern) => pattern.test(filePath));
+
+export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
+  const changedLines = diff
+    .split('\n')
+    .filter((line) => (line.startsWith('+') || line.startsWith('-')) && !line.startsWith('+++') && !line.startsWith('---'));
+
+  return changedLines.length > 0 && changedLines.every((line) => /^[-+]\s*-\s*['"]?traefik\./u.test(line));
+};
+
+const resolveTraefikOnlyComposeFiles = (
+  base: string,
+  head: string,
+  changedFiles: readonly string[],
+): string[] =>
+  changedFiles.filter((filePath) => /^deploy\/compose\.(?:dev|staging|prod)\.yaml$/u.test(filePath) && isTraefikOnlyComposeDiff(
+    execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', filePath], { encoding: 'utf8' })
+  ));
 const uniqueSorted = (values: readonly string[]): string[] =>
   [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort();
 
 export const formatRiskSummary = (riskFiles: readonly string[]): string =>
   riskFiles.length === 0 ? 'none' : uniqueSorted(riskFiles).join(', ');
 
-export const findRiskFiles = (kind: DeployGateKind, changedFiles: readonly string[]): string[] => {
+export const findRiskFiles = (
+  kind: DeployGateKind,
+  changedFiles: readonly string[],
+  safeComposeFiles: readonly string[] = [],
+): string[] => {
   const patterns = kind === 'migration' ? migrationRiskPatterns : bootstrapRiskPatterns;
-  return uniqueSorted(changedFiles.filter((filePath) => matchesAnyPattern(filePath, patterns)));
+  return uniqueSorted(changedFiles.filter((filePath) => !safeComposeFiles.includes(filePath) && matchesAnyPattern(filePath, patterns)));
 };
 
 export const evaluateDeployGate = ({
@@ -85,7 +108,7 @@ export const evaluateDeployGate = ({
   kind,
   mode,
 }: EvaluateDeployGateOptions): DeployGateResult => {
-  const riskFiles = findRiskFiles(kind, changedFiles);
+  const riskFiles = findRiskFiles(kind, changedFiles, safeComposeFiles);
   const label = kind === 'migration' ? 'Migration' : 'Bootstrap';
 
   if (mode === 'assert-none') {
@@ -138,18 +161,21 @@ export const evaluatePromoteDeployGates = ({
   changedFiles,
   migrationExecutorConfigured = false,
   migrationMode,
+  safeComposeFiles = [],
 }: {
   bootstrapExecutorConfigured?: boolean;
   bootstrapMode: DeployGateMode;
   changedFiles: readonly string[];
   migrationExecutorConfigured?: boolean;
   migrationMode: DeployGateMode;
+  safeComposeFiles?: readonly string[];
 }): PromoteDeployGateEvaluation => ({
   bootstrap: evaluateDeployGate({
     changedFiles,
     executorConfigured: bootstrapExecutorConfigured,
     kind: 'bootstrap',
     mode: bootstrapMode,
+    safeComposeFiles,
   }),
   changedFiles: uniqueSorted(changedFiles),
   migration: evaluateDeployGate({
@@ -157,6 +183,7 @@ export const evaluatePromoteDeployGates = ({
     executorConfigured: migrationExecutorConfigured,
     kind: 'migration',
     mode: migrationMode,
+    safeComposeFiles,
   }),
 });
 
@@ -277,12 +304,14 @@ export const executePromoteDeployGates = async (
 ): Promise<{ exitCode: number; stderr: string; stdout: string }> => {
   try {
     const options = parseCliOptions(args);
+    const changedFiles = resolveCliChangedFiles(options);
     const evaluation = evaluatePromoteDeployGates({
       bootstrapExecutorConfigured: options.bootstrapExecutorConfigured,
       bootstrapMode: options.bootstrapMode,
-      changedFiles: resolveCliChangedFiles(options),
+      changedFiles,
       migrationExecutorConfigured: options.migrationExecutorConfigured,
       migrationMode: options.migrationMode,
+      safeComposeFiles: options.changedFiles ? [] : resolveTraefikOnlyComposeFiles(options.base, options.head, changedFiles),
     });
 
     emitEvaluationOutputs(evaluation);

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 import { appendFileSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { resolveChangedFiles } from './pr-scope.ts';
+import { resolveTraefikOnlyComposeFiles } from './traefik-compose-diff.ts';
 export type DeployGateMode = 'assert-none' | 'run';
 export type DeployGateKind = 'bootstrap' | 'migration';
 export type DeployGateResultType =
   'asserted-clean' | 'blocked-missing-executor' | 'blocked-risk' | 'blocked-safe-run-required';
-
 export interface DeployGateResult {
   kind: DeployGateKind;
   message: string;
@@ -17,13 +16,11 @@ export interface DeployGateResult {
   riskDetected: boolean;
   riskFiles: string[];
 }
-
 export interface PromoteDeployGateEvaluation {
   bootstrap: DeployGateResult;
   changedFiles: string[];
   migration: DeployGateResult;
 }
-
 interface EvaluateDeployGateOptions {
   changedFiles: readonly string[];
   executorConfigured: boolean;
@@ -31,7 +28,6 @@ interface EvaluateDeployGateOptions {
   mode: DeployGateMode;
   safeComposeFiles?: readonly string[];
 }
-
 interface CliOptions {
   base: string;
   bootstrapExecutorConfigured: boolean;
@@ -41,7 +37,6 @@ interface CliOptions {
   migrationExecutorConfigured: boolean;
   migrationMode: DeployGateMode;
 }
-
 const DEFAULT_BASE = 'origin/main';
 const DEFAULT_HEAD = 'HEAD';
 const migrationRiskPatterns = [
@@ -67,32 +62,12 @@ const bootstrapRiskPatterns = [
   /^config\/runtime\//u,
   /^scripts\/ops\/runtime\/bootstrap-job\.ts$/u,
 ];
-
 const matchesAnyPattern = (filePath: string, patterns: readonly RegExp[]): boolean =>
   patterns.some((pattern) => pattern.test(filePath));
-
-export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
-  const changedLines = diff
-    .split('\n')
-    .filter((line) => (line.startsWith('+') || line.startsWith('-')) && !line.startsWith('+++') && !line.startsWith('---'));
-
-  return changedLines.length > 0 && changedLines.every((line) => /^[-+]\s*-\s*['"]?traefik\./u.test(line));
-};
-
-const resolveTraefikOnlyComposeFiles = (
-  base: string,
-  head: string,
-  changedFiles: readonly string[],
-): string[] =>
-  changedFiles.filter((filePath) => /^deploy\/compose\.(?:dev|staging|prod)\.yaml$/u.test(filePath) && isTraefikOnlyComposeDiff(
-    execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', filePath], { encoding: 'utf8' })
-  ));
 const uniqueSorted = (values: readonly string[]): string[] =>
   [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort();
-
 export const formatRiskSummary = (riskFiles: readonly string[]): string =>
   riskFiles.length === 0 ? 'none' : uniqueSorted(riskFiles).join(', ');
-
 export const findRiskFiles = (
   kind: DeployGateKind,
   changedFiles: readonly string[],
@@ -101,16 +76,15 @@ export const findRiskFiles = (
   const patterns = kind === 'migration' ? migrationRiskPatterns : bootstrapRiskPatterns;
   return uniqueSorted(changedFiles.filter((filePath) => !safeComposeFiles.includes(filePath) && matchesAnyPattern(filePath, patterns)));
 };
-
 export const evaluateDeployGate = ({
   changedFiles,
   executorConfigured,
   kind,
   mode,
+  safeComposeFiles,
 }: EvaluateDeployGateOptions): DeployGateResult => {
   const riskFiles = findRiskFiles(kind, changedFiles, safeComposeFiles);
   const label = kind === 'migration' ? 'Migration' : 'Bootstrap';
-
   if (mode === 'assert-none') {
     if (riskFiles.length > 0) {
       return {
@@ -154,7 +128,6 @@ export const evaluateDeployGate = ({
     riskFiles,
   };
 };
-
 export const evaluatePromoteDeployGates = ({
   bootstrapExecutorConfigured = false,
   bootstrapMode,
@@ -186,7 +159,6 @@ export const evaluatePromoteDeployGates = ({
     safeComposeFiles,
   }),
 });
-
 const parseBoolean = (value: string): boolean => {
   if (value === 'true') {
     return true;
@@ -196,7 +168,6 @@ const parseBoolean = (value: string): boolean => {
   }
   throw new Error(`Ungültiger Boolean-Wert: ${value}`);
 };
-
 const parseMode = (value: string, flag: string): DeployGateMode => {
   if (value === 'assert-none' || value === 'run') {
     return value;
@@ -212,7 +183,6 @@ const parseCliOptions = (args: readonly string[]): CliOptions => {
   let migrationExecutorConfigured = false;
   let bootstrapExecutorConfigured = false;
   let changedFiles: string[] | null = null;
-
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     const nextValue = (): string => {
@@ -223,7 +193,6 @@ const parseCliOptions = (args: readonly string[]): CliOptions => {
       index += 1;
       return value;
     };
-
     if (argument === '--base') {
       base = nextValue();
       continue;
@@ -311,7 +280,9 @@ export const executePromoteDeployGates = async (
       changedFiles,
       migrationExecutorConfigured: options.migrationExecutorConfigured,
       migrationMode: options.migrationMode,
-      safeComposeFiles: options.changedFiles ? [] : resolveTraefikOnlyComposeFiles(options.base, options.head, changedFiles),
+      safeComposeFiles: options.changedFiles
+        ? []
+        : resolveTraefikOnlyComposeFiles(options.base, options.head, changedFiles),
     });
 
     emitEvaluationOutputs(evaluation);

--- a/scripts/ci/traefik-compose-diff.ts
+++ b/scripts/ci/traefik-compose-diff.ts
@@ -1,0 +1,29 @@
+import { execFileSync } from 'node:child_process';
+
+export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
+  const changedLines = diff
+    .split('\n')
+    .filter(
+      (line) =>
+        (line.startsWith('+') || line.startsWith('-')) &&
+        !line.startsWith('+++') &&
+        !line.startsWith('---')
+    );
+
+  return changedLines.length > 0 && changedLines.every((line) => /^[-+]\s*-\s*['"]?traefik\./u.test(line));
+};
+
+export const resolveTraefikOnlyComposeFiles = (
+  base: string,
+  head: string,
+  changedFiles: readonly string[],
+): string[] =>
+  changedFiles.filter(
+    (filePath) =>
+      /^deploy\/compose\.(?:dev|staging|prod)\.yaml$/u.test(filePath) &&
+      isTraefikOnlyComposeDiff(
+        execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', filePath], {
+          encoding: 'utf8',
+        })
+      )
+  );


### PR DESCRIPTION
## Zusammenfassung

Das Promote-Gate behandelt bisher jede Änderung an `deploy/compose.*.yaml` als migrations- und bootstraprelevant. Dadurch werden reine Traefik-Label-Änderungen blockiert.

Der Gate-Pfad prüft nun den tatsächlichen Diff: Nur wenn alle geänderten Compose-Zeilen Traefik-Label-Einträge sind, wird die Datei für Migration und Bootstrap als sicher eingestuft. Alle anderen Compose-Änderungen bleiben blockierend.

## Verifikation

- Traefik-only-Diff wird freigegeben.
- Postgres-/Service-Änderung bleibt blockierend.
- `pnpm nx run tooling-testing:test:unit`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`