### PR TITLE
fix(deploy): Staging-Umgebung vorbereiten

### DIFF
--- a/deploy/compose.staging.yaml
+++ b/deploy/compose.staging.yaml
@@ -26,7 +26,9 @@ services:
         - 'traefik.frontend.rule=Host:studio-staging.smart-village.app'
         - 'traefik.port=3000'
         - 'traefik.http.routers.studio-staging-app.rule=Host(`studio-staging.smart-village.app`)'
+        - 'traefik.http.routers.studio-staging-app.entrypoints=web,websecure'
         - 'traefik.http.routers.studio-staging-app.tls=true'
+        - 'traefik.http.routers.studio-staging-app.tls.certresolver=default'
         - 'traefik.http.services.studio-staging-app.loadbalancer.server.port=3000'
 
   provisioner:

--- a/docs/changelog/entries/pr-717.json
+++ b/docs/changelog/entries/pr-717.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 717,
+  "body": "Die Staging-Umgebung verwendet für ihren Studio-Ingress jetzt den Traefik-v3-TLS-Vertrag mit dem aktiven ACME-Resolver."
+}

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -69,6 +69,13 @@ describe('deployment contracts', () => {
     expect(compose).toContain('traefik.http.routers.studio-dev-app.tls.certresolver=default');
   });
 
+  it('configures the Staging router for the Traefik ACME resolver', () => {
+    const compose = load('deploy/compose.staging.yaml');
+
+    expect(compose).toContain('traefik.http.routers.studio-staging-app.entrypoints=web,websecure');
+    expect(compose).toContain('traefik.http.routers.studio-staging-app.tls.certresolver=default');
+  });
+
   it('documents the active Traefik v3 ingress contract', () => {
     const overview = load('docs/guides/deployment-overview.md');
     const rolloutAgent = load('.github/agents/rollout-operator.agent.md');


### PR DESCRIPTION
## Zusammenfassung
- richtet den Staging-Ingress auf Traefik v3 mit dem aktiven ACME-Resolver aus
- sichert den Vertrag per Deployment-Test ab

## Validierung
- gezielter Deployment-Vertragstest
- Script-Typecheck

Der Stack wird erst nach Hinterlegung des separaten APP_CONFIG im GitHub-Environment staging ausgerollt.