### PR TITLE
fix: stabilize confirmation module sorting

### DIFF
--- a/docs/changelog/entries/pr-721.json
+++ b/docs/changelog/entries/pr-721.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 721,
+  "body": "Kritische Instanzbestätigungen bleiben bei unterschiedlicher Reihenfolge zugewiesener Module stabil und lösen keine unnötigen Bestätigungswechsel mehr aus."
+}

--- a/packages/auth-runtime/src/iam-instance-registry/confirmation.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/confirmation.test.ts
@@ -40,6 +40,14 @@ describe('critical registry confirmation', () => {
     expect(changed).not.toBe(first);
   });
 
+  it('fingerprints assigned modules independently of their input order', async () => {
+    const { fingerprintInstanceConfirmationState } = await import('./confirmation.js');
+    const first = fingerprintInstanceConfirmationState({ ...detail, assignedModules: ['news', 'events'] });
+    const second = fingerprintInstanceConfirmationState({ ...detail, assignedModules: ['events', 'news'] });
+
+    expect(first).toBe(second);
+  });
+
   it('keeps all five critical actions static and requires a module for revoke prepare', async () => {
     const { CRITICAL_REGISTRY_ACTIONS, validateConfirmationModuleId } = await import('./confirmation.js');
     expect(CRITICAL_REGISTRY_ACTIONS).toEqual([

--- a/packages/auth-runtime/src/iam-instance-registry/confirmation.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/confirmation.ts
@@ -42,7 +42,7 @@ export const fingerprintInstanceConfirmationState = (instance: {
     instanceId: instance.instanceId,
     updatedAt: instance.updatedAt,
     status: instance.status,
-    assignedModules: [...instance.assignedModules].sort(),
+    assignedModules: [...instance.assignedModules].sort((left, right) => left.localeCompare(right)),
     featureFlags,
     realmMode: instance.realmMode,
     authRealm: instance.authRealm,


### PR DESCRIPTION
## Änderung
Stabilisiert die Sortierung von Instanzmodulen im Bestätigungs-Fingerprint mit `localeCompare`.

## Ursache
SonarCloud meldete `typescript:S2871`: eine alphabetische Sortierung ohne explizite Vergleichsfunktion. Dadurch fiel die Reliability-Bewertung für neuen Code auf D.

## Validierung
- `pnpm nx run auth-runtime:test:unit --skip-nx-cache --testFiles=src/iam-instance-registry/confirmation.test.ts`
- `pnpm nx run auth-runtime:test:types --skip-nx-cache`
- `pnpm check:server-runtime`