### PR TITLE
fix: correlate instance provisioning failures

### DIFF
--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -579,3 +579,6 @@ Referenzen:
 - Der versionierte Fehlervertrag trennt stabilen Code, Kategorie, Wiederholbarkeit, Folgeaktion und Korrelation. `internal_unclassified` bleibt eine eigene Klasse und wird nicht als Abhängigkeitsfehler geraten.
 - OTEL-Metriken verwenden nur Action, Risikostufe, Ergebnis und stabilen Fehlercode. Instanz-ID, Token-Subject, Idempotency-Key und freie Fehlertexte sind keine Labels.
 - Kritische Aktionen benötigen eine serverseitige, kurzlebige, einmalige und zustandsgebundene Challenge. Clientseitige Bestätigungsmarker allein sind wertlos.
+- Die MCP-Create-Prozesskette korreliert HTTP-Eingang, Registry-Schritte, Queue und Keycloak-Worker über Request-, Instanz- und Run-ID im Log-Body. Stabile `step_key`-Werte benennen die technische Fehlerstufe; pro Fehler entsteht genau ein kanonisches Error-Event.
+- PostgreSQL-Logs erlauben nur SQLSTATE, Tabelle, Spalte und Constraint. Rohe Meldungen, Details, Hints, Queries, Parameter, Stacktraces und Providerantworten bleiben ebenso ausgeschlossen wie E-Mail, Passwort, Token und Connection-String.
+- Audit-Ereignisse bleiben fachlich und append-only; technische Diagnosedetails werden nicht in den Audit-Pfad verschoben. Der lokale stdio-MCP hält `stdout` für das MCP-Protokoll frei.

--- a/docs/architecture/logging-architecture.md
+++ b/docs/architecture/logging-architecture.md
@@ -142,6 +142,14 @@ Pseudonyme technische IDs bleiben dennoch personenbeziehbar und duerfen nur bei 
 - `debug` -> 5
 - `verbose` -> 1
 
+## MCP-Instanz-Prozesskettenvertrag
+
+Die Instanzanlage ist anhand der Request-ID vom Studio-HTTP-Eingang über Registry-Persistenz und Provisioning-Queue bis zum Keycloak-Worker korrelierbar. Kanonische Fehlerereignisse enthalten `operation`, `result`, `request_id`, `error_type`, `error_code` und `classification`; verfügbare Felder sind `instance_id`, `run_id`, `intent`, `step_key`, `dependency` und `http_status`.
+
+Für den Create-Pfad sind `registry_lookup`, `registry_insert`, `primary_hostname_upsert`, `provisioning_run_insert`, `audit_event_insert` und `host_cache_invalidate` stabile Stufen. Der Worker verwendet `queue_enqueue`, `worker_claim`, `worker_preflight`, `worker_plan`, `keycloak_execution`, `secret_sync`, `admin_bootstrap` und `worker_complete`. Interne Schichten annotieren Fehler nur; das kanonische Error-Event entsteht einmalig an der zuständigen Fehlergrenze.
+
+PostgreSQL-Diagnostik ist auf SQLSTATE, Tabelle, Spalte und Constraint begrenzt. Meldung, Detail, Hint, Query, Parameter, Stacktrace, Providerantworten, E-Mail-Adressen, Passwörter, Tokens und Connection-Strings sind ausgeschlossen. Request-, Instanz- und Run-IDs werden ausschließlich im Log-Body geführt. Der stdio-MCP verwendet kein Console-Logging, weil `stdout` dem Protokoll vorbehalten ist.
+
 ## Routing-Observability-Vertrag
 
 `@sva/routing` nutzt fuer routing-relevante Entscheidungen einen kleinen Diagnostics-Vertrag statt verteilter Logger-Zugriffe.

--- a/docs/changelog/entries/pr-722.json
+++ b/docs/changelog/entries/pr-722.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 722,
+  "body": "Fehler bei der MCP-gestützten Instanzanlage und anschließenden Keycloak-Provisionierung sind jetzt über stabile Prozessstufen und Request-Korrelation nachvollziehbar, ohne sensible Provider-, Datenbank- oder Nutzerdaten zu protokollieren."
+}

--- a/openspec/changes/add-studio-instance-create-mcp/design.md
+++ b/openspec/changes/add-studio-instance-create-mcp/design.md
@@ -113,6 +113,14 @@ Alternativen:
 6. Bei einem Fehler liefert Studio dessen stabilen Fehlervertrag; der MCP-Server liest abhängig von der Klasse begrenzte Diagnose-Evidenz.
 7. Studio speichert Audit-Ereignis und fachliche Artefakte; das Tool liefert ausschließlich die sichere Ergebnis- oder Diagnosezusammenfassung zurück.
 
+### Decision: Ein kanonisches Fehlerereignis mit stufengenauer Korrelation
+
+Die Instance Registry erzeugt pro fehlgeschlagener Mutation genau ein kanonisches Error-Event an der HTTP-Grenze. Interne Schritte annotieren den Fehler lediglich mit einem stabilen `step_key`; sie schreiben kein zweites Fehlerlog. Der typisierte Kontext enthält `operation`, `result`, `request_id` und, soweit vorhanden, `instance_id`, `run_id`, `intent`, `dependency`, `error_type`, `error_code`, `classification` und `http_status`.
+
+Für PostgreSQL werden ausschließlich SQLSTATE, Tabelle, Spalte und Constraint übernommen. Meldung, Detail, Hint, Query, Parameter und Stacktrace bleiben ausgeschlossen. Worker-Fehler verwenden denselben sicheren Kontext; `provisioning_run_failed` ist dort das kanonische Ereignis. Request-, Instanz- und Run-IDs bleiben Log-Felder und werden weder Loki-Labels noch Metrikdimensionen. Append-only Audit und technische Logs bleiben getrennt.
+
+Der lokale stdio-MCP schreibt keine Diagnose auf `stdout`, weil dieser Kanal dem MCP-Protokoll gehört. Seine strukturierte Tool-Antwort bleibt die lokale Diagnoseoberfläche; Tokens, Payloads und Secrets werden nicht geloggt.
+
 ## Risks / Trade-offs
 
 - Token-Diebstahl ermöglicht Instanzanlage innerhalb des Token-Scopes. → Kurze Laufzeit, enger Audience-/Scope-Bindung, sichere lokale Ablage, Rotation und vollständiges Audit.

--- a/openspec/changes/add-studio-instance-create-mcp/proposal.md
+++ b/openspec/changes/add-studio-instance-create-mcp/proposal.md
@@ -14,6 +14,7 @@ Operatoren sollen neue Studio-Instanzen aus Codex oder einer CLI heraus kontroll
 - Nach einem fehlgeschlagenen Create-Aufruf ergänzt das MCP-Tool eine begrenzte, Read-only-Diagnose; deren Evidenz bleibt geheimnisfrei und verändert keinen Instanzzustand.
 - Der lokale MCP-Server stellt die vorhandene Instanz-Control-Plane als dreistufige Tool-Fläche für Lesen/Diagnose, kontrollierte Mutationen und kritische Mutationen bereit.
 - Kritische Mutationen wie Aktivierung, Suspendierung, Archivierung, Modulentzug und Secret-Rotation verlangen serverseitig gebundene, kurzlebige Bestätigungs-Challenges, einen engsten Action-Scope sowie einen aktuellen Vorab-Read oder Plan.
+- Die Create- und Provisioning-Prozesskette erhält einen einheitlichen, strukturierten und geheimnisfreien Fehlerkontext vom HTTP-Eingang bis zum Keycloak-Worker.
 
 ## Impact
 

--- a/openspec/changes/add-studio-instance-create-mcp/specs/instance-provisioning/spec.md
+++ b/openspec/changes/add-studio-instance-create-mcp/specs/instance-provisioning/spec.md
@@ -69,3 +69,27 @@ Das System SHALL die vorhandenen Instanzverwaltungs- und Provisioning-Fähigkeit
 - **THEN** verlangt Studio einen action-spezifischen Scope, eine gültige aktuelle Bestätigungs-Challenge, einen Idempotenz-Key und eine explizite Bestätigungsphrase
 - **AND** lehnt Studio eine abgelaufene, wiederverwendete oder durch Zustandsänderung ungültig gewordene Challenge fail-closed ab
 - **AND** wird die Mutation einschließlich Bestätigung und Ergebnis append-only auditiert
+
+### Requirement: Durchgängig korrelierbares Prozessketten-Logging
+
+Das System SHALL die MCP-Create- und nachgelagerte Provisioning-/Keycloak-Kette mit stabilen Operationen, Ergebnissen und Prozessstufen strukturiert protokollieren. Pro Fehler SHALL genau ein kanonisches Error-Event entstehen. Freie Provider-, Datenbank- und Nutzereingaben dürfen nicht Bestandteil des Log-Ereignisses sein.
+
+#### Scenario: Create-Fehler benennt die konkrete Prozessstufe
+
+- **WHEN** Bestandsprüfung, Registry-Insert, Primary-Hostname-Upsert, Provisioning-Run, Audit-Ereignis oder Cache-Invalidierung fehlschlägt
+- **THEN** enthält das kanonische Error-Event `operation`, `result`, `request_id`, die verfügbare Instanzkorrelation sowie einen stabilen `step_key`
+- **AND** werden von PostgreSQL ausschließlich SQLSTATE, Tabelle, Spalte und Constraint übernommen
+- **AND** entstehen an Service- und HTTP-Grenze keine doppelten Error-Events
+
+#### Scenario: Worker-Fehler bleibt sicher und korrelierbar
+
+- **WHEN** Queue, Claim, Preflight, Plan, Keycloak-Ausführung, Secret-Synchronisierung, Admin-Bootstrap oder Abschluss fehlschlägt
+- **THEN** enthält `provisioning_run_failed` Request-, Instanz-, Run-, Intent-, Stufen- und Fehlerklassen-Kontext, soweit verfügbar
+- **AND** enthalten Log und persistierte Zusammenfassung keine Providerdetails, E-Mail-Adressen, Passwörter, Tokens, Connection-Strings, SQL-Werte oder Stacktraces
+- **AND** bleiben Request-, Instanz- und Run-IDs Log-Felder statt Loki-Labels oder Metrikdimensionen
+
+#### Scenario: Lokaler stdio-MCP schützt den Protokollkanal
+
+- **WHEN** das lokale MCP-Tool einen Erfolg oder Fehler verarbeitet
+- **THEN** bleibt `stdout` ausschließlich dem MCP-Protokoll vorbehalten
+- **AND** erfolgt die lokale Diagnose über die strukturierte Tool-Antwort ohne Token-, Payload- oder Secret-Logging

--- a/openspec/changes/add-studio-instance-create-mcp/tasks.md
+++ b/openspec/changes/add-studio-instance-create-mcp/tasks.md
@@ -37,3 +37,11 @@
 - [x] 4.7 Relevante Nx-Unit-, Type-, Runtime- und Sicherheits-Gates ausführen.
 - [x] 4.8 Rolloutreihenfolge `studio-dev` → `studio-staging` → `sva-studio`, Secret-Rotation, OTEL-Abnahmekriterien und Kill-Switch-Rollback dokumentieren.
 - [ ] 4.9 Pro Zielrealm einen Read-only-Smoke, eine kontrollierte Testmutation und eine Challenge-geschützte Testmutation mit Audit- und Telemetrie-Evidenz abnehmen.
+
+## 5. Prozessketten-Logging
+
+- [x] 5.1 Typisierten, PII-/secret-sicheren Fehlerkontext und PostgreSQL-Allowlist implementieren.
+- [x] 5.2 Create-Schritte vom Lookup bis zur Cache-Invalidierung stufengenau und ohne doppelte Error-Events korrelieren.
+- [x] 5.3 Queue und Worker mit stabilen Stufen für Claim, Preflight, Plan, Keycloak, Secret-Sync, Admin-Bootstrap und Abschluss vereinheitlichen.
+- [x] 5.4 Rohe Provider- und Fehlermeldungen aus Provisioning-, Audit- und Worker-Logs entfernen und Redaction-Verträge testen.
+- [ ] 5.5 Relevante Unit-, Type-, Runtime- und OpenSpec-Gates ausführen sowie den Dev-Smoke in Loki anhand der Request-ID abnehmen.

--- a/packages/data-repositories/src/instance-registry/repository-mutations.ts
+++ b/packages/data-repositories/src/instance-registry/repository-mutations.ts
@@ -10,6 +10,25 @@ type MutationRepository = Pick<InstanceRegistryRepository, 'createInstance' | 'u
 
 const defaultActorId = (actorId: string | undefined): string => actorId ?? 'system';
 
+const runMutationStep = async <T>(stepKey: string, work: () => Promise<T>): Promise<T> => {
+  try {
+    return await work();
+  } catch (error) {
+    if (error !== null && typeof error === 'object') {
+      try {
+        Object.defineProperty(error, 'instanceRegistryStep', {
+          configurable: true,
+          enumerable: false,
+          value: stepKey,
+        });
+      } catch {
+        // Preserve non-extensible database errors without replacing their original identity.
+      }
+    }
+    throw error;
+  }
+};
+
 const upsertPrimaryHostname = async (
   executor: SqlExecutor,
   hostname: string,
@@ -70,7 +89,7 @@ const updateInstanceValues = (input: Parameters<MutationRepository['updateInstan
 ];
 
 const createInstance = async (executor: SqlExecutor, input: Parameters<MutationRepository['createInstance']>[0]) => {
-  const rows = await queryRows<InstanceListRow>(
+  const rows = await runMutationStep('registry_insert', () => queryRows<InstanceListRow>(
     executor,
     {
       text: `
@@ -87,11 +106,13 @@ ${buildInstanceSelectColumns()};
 `,
       values: createInstanceValues(input),
     }
-  );
+  ));
   if (!rows[0]) {
     return null;
   }
-  await upsertPrimaryHostname(executor, input.primaryHostname, input.instanceId, input.actorId);
+  await runMutationStep('primary_hostname_upsert', () =>
+    upsertPrimaryHostname(executor, input.primaryHostname, input.instanceId, input.actorId)
+  );
   return mapInstance(rows[0]);
 };
 

--- a/packages/data-repositories/src/instance-registry/repository-provisioning.test.ts
+++ b/packages/data-repositories/src/instance-registry/repository-provisioning.test.ts
@@ -279,6 +279,33 @@ describe('instance registry repository provisioning', () => {
     expect(statements[0]?.text).toContain('ON CONFLICT (id) DO NOTHING');
   });
 
+  it('annotates create and primary-hostname failures with their precise process step', async () => {
+    const insertError = new Error('sensitive insert diagnostics');
+    const insertRepository = createInstanceRegistryRepository({
+      execute: async () => { throw insertError; },
+    });
+    const input = {
+      instanceId: 'tenant-a', displayName: 'Tenant A', status: 'active' as const,
+      parentDomain: 'example.test', primaryHostname: 'tenant-a.example.test',
+      realmMode: 'shared' as const, authRealm: 'sva', authClientId: 'studio', actorId: 'actor-1',
+    };
+
+    await expect(insertRepository.createInstance(input)).rejects.toBe(insertError);
+    expect((insertError as Error & { instanceRegistryStep?: string }).instanceRegistryStep).toBe('registry_insert');
+
+    const hostnameError = new Error('sensitive hostname diagnostics');
+    let invocation = 0;
+    const hostnameRepository = createInstanceRegistryRepository({
+      execute: async <TRow>() => {
+        invocation += 1;
+        if (invocation === 1) return { rowCount: 1, rows: [instanceRow] as TRow[] };
+        throw hostnameError;
+      },
+    });
+    await expect(hostnameRepository.createInstance(input)).rejects.toBe(hostnameError);
+    expect((hostnameError as Error & { instanceRegistryStep?: string }).instanceRegistryStep).toBe('primary_hostname_upsert');
+  });
+
   it('returns null for empty mutations and maps created runs and steps', async () => {
     const { executor } = createQueuedExecutor([[], [], [provisioningRow], [keycloakRunRow], [], [keycloakRunRow], [stepRow], [stepRow]]);
     const repository = createInstanceRegistryRepository(executor);

--- a/packages/instance-registry/src/http-instance-handlers.test.ts
+++ b/packages/instance-registry/src/http-instance-handlers.test.ts
@@ -158,7 +158,9 @@ describe('http-instance-handlers', () => {
     );
 
     expect(response.status).toBe(502);
-    expect(deps.mapMutationError).toHaveBeenCalledWith(thrown);
+    expect(deps.mapMutationError).toHaveBeenCalledWith(thrown, {
+      operation: 'create_instance', requestId: 'req-1', instanceId: 'demo',
+    });
     expect(deps.onInstanceProvisioningRequested).not.toHaveBeenCalled();
   });
 
@@ -183,7 +185,9 @@ describe('http-instance-handlers', () => {
     );
 
     expect(response.status).toBe(502);
-    expect(deps.mapMutationError).toHaveBeenCalledWith(thrown);
+    expect(deps.mapMutationError).toHaveBeenCalledWith(thrown, {
+      operation: 'update_instance', requestId: 'req-1', instanceId: 'demo',
+    });
   });
 
   it('updates instances without requiring fresh reauthentication', async () => {

--- a/packages/instance-registry/src/http-instance-shared.ts
+++ b/packages/instance-registry/src/http-instance-shared.ts
@@ -3,6 +3,7 @@ import type { z } from 'zod';
 
 import { readDetailInstanceId } from './http-contracts.js';
 import type { InstanceRegistryService } from './service-types.js';
+import type { InstanceRegistryMutationErrorMapper } from './observability.js';
 
 export type CreateApiError = (
   status: number,
@@ -41,7 +42,7 @@ export type InstanceRegistryHttpDeps<TContext> = {
   readonly asApiList: AsApiList;
   readonly parseRequestBody: ParseRequestBody;
   readonly requireIdempotencyKey: RequireIdempotencyKey;
-  readonly mapMutationError: (error: unknown) => Response;
+  readonly mapMutationError: InstanceRegistryMutationErrorMapper;
   readonly ensurePlatformAccess: (request: Request, ctx: TContext) => Response | null;
   readonly validateCsrf: (request: Request, requestId?: string) => Response | null;
   readonly requireFreshReauth: (request: Request, ctx: TContext) => Response | null;

--- a/packages/instance-registry/src/http-instance-write-handlers.ts
+++ b/packages/instance-registry/src/http-instance-write-handlers.ts
@@ -34,7 +34,11 @@ export const createCreateInstanceHandler =
         }))
       );
     } catch (error) {
-      return deps.mapMutationError(error);
+      return deps.mapMutationError(error, {
+        operation: 'create_instance',
+        requestId: deps.getRequestId(),
+        instanceId: payloadResult.data.instanceId,
+      });
     }
 
     if (!result.ok) {
@@ -82,6 +86,10 @@ export const createUpdateInstanceHandler =
 
       return deps.jsonResponse(200, deps.asApiItem(updated, deps.getRequestId()));
     } catch (error) {
-      return deps.mapMutationError(error);
+      return deps.mapMutationError(error, {
+        operation: 'update_instance',
+        requestId: deps.getRequestId(),
+        instanceId,
+      });
     }
   };

--- a/packages/instance-registry/src/http-keycloak-handlers.test.ts
+++ b/packages/instance-registry/src/http-keycloak-handlers.test.ts
@@ -113,6 +113,11 @@ describe('http-keycloak-handlers', () => {
     );
 
     expect(response.status).toBe(502);
-    expect(deps.mapMutationError).toHaveBeenCalledWith(thrown);
+    expect(deps.mapMutationError).toHaveBeenCalledWith(thrown, {
+      operation: 'get_instance_keycloak_provisioning_run',
+      requestId: 'req-1',
+      instanceId: 'demo',
+      runId: 'run-1',
+    });
   });
 });

--- a/packages/instance-registry/src/http-keycloak-handlers.ts
+++ b/packages/instance-registry/src/http-keycloak-handlers.ts
@@ -1,5 +1,6 @@
 import type { InstanceRegistryService } from './service-types.js';
 import { readDetailInstanceId, readKeycloakRunId } from './http-contracts.js';
+import type { InstanceRegistryMutationErrorMapper } from './observability.js';
 
 type CreateApiError = (
   status: number,
@@ -18,7 +19,7 @@ export type InstanceRegistryKeycloakHttpDeps<TContext> = {
   readonly createApiError: CreateApiError;
   readonly jsonResponse: JsonResponse;
   readonly asApiItem: AsApiItem;
-  readonly mapMutationError: (error: unknown) => Response;
+  readonly mapMutationError: InstanceRegistryMutationErrorMapper;
   readonly ensurePlatformAccess: (request: Request, ctx: TContext) => Response | null;
   readonly validateCsrf: (request: Request, requestId?: string) => Response | null;
   readonly requireFreshReauth: (request: Request, ctx: TContext) => Response | null;
@@ -58,6 +59,7 @@ const respondWithInstanceLookup = async <TContext, TValue>(
   ctx: TContext,
   work: (instanceId: string) => Promise<TValue | null>,
   notFoundMessage: string,
+  operation: string,
   requireMutationGuards = false
 ): Promise<Response> => {
   const guarded = guardKeycloakReadRequest(deps, request, ctx, requireMutationGuards);
@@ -72,7 +74,11 @@ const respondWithInstanceLookup = async <TContext, TValue>(
     }
     return deps.jsonResponse(200, deps.asApiItem(value, deps.getRequestId()));
   } catch (error) {
-    return deps.mapMutationError(error);
+    return deps.mapMutationError(error, {
+      operation,
+      requestId: deps.getRequestId(),
+      instanceId: guarded,
+    });
   }
 };
 
@@ -85,7 +91,8 @@ export const createInstanceRegistryKeycloakHttpHandlers = <TContext>(
       request,
       ctx,
       async (instanceId) => deps.withRegistryService((service) => service.getKeycloakStatus(instanceId)),
-      'Instanz wurde nicht gefunden.'
+      'Instanz wurde nicht gefunden.',
+      'get_instance_keycloak_status'
     ),
 
   getInstanceKeycloakPreflight: (request: Request, ctx: TContext): Promise<Response> =>
@@ -94,7 +101,8 @@ export const createInstanceRegistryKeycloakHttpHandlers = <TContext>(
       request,
       ctx,
       async (instanceId) => deps.withRegistryService((service) => service.getKeycloakPreflight(instanceId)),
-      'Instanz wurde nicht gefunden.'
+      'Instanz wurde nicht gefunden.',
+      'get_instance_keycloak_preflight'
     ),
 
   planInstanceKeycloakProvisioning: (request: Request, ctx: TContext): Promise<Response> =>
@@ -104,6 +112,7 @@ export const createInstanceRegistryKeycloakHttpHandlers = <TContext>(
       ctx,
       async (instanceId) => deps.withRegistryService((service) => service.planKeycloakProvisioning(instanceId)),
       'Instanz wurde nicht gefunden.',
+      'plan_instance_keycloak_provisioning',
       true
     ),
 
@@ -125,7 +134,12 @@ export const createInstanceRegistryKeycloakHttpHandlers = <TContext>(
       }
       return deps.jsonResponse(200, deps.asApiItem(run, deps.getRequestId()));
     } catch (error) {
-      return deps.mapMutationError(error);
+      return deps.mapMutationError(error, {
+        operation: 'get_instance_keycloak_provisioning_run',
+        requestId: deps.getRequestId(),
+        instanceId: guarded,
+        runId,
+      });
     }
   },
 });

--- a/packages/instance-registry/src/http-mutation-actions.ts
+++ b/packages/instance-registry/src/http-mutation-actions.ts
@@ -5,6 +5,7 @@ import {
 } from './http-contracts.js';
 import type { InstanceRegistryMutationHttpDeps } from './http-mutation-shared.js';
 import { createScopedRegistryMutationHandler } from './http-mutation-shared.js';
+import type { InstanceRegistryMutationErrorMapper } from './observability.js';
 import {
   buildExecuteInstanceKeycloakProvisioningInput,
   buildProbeTenantIamAccessInput,
@@ -15,8 +16,9 @@ import {
 } from './mutation-input-builders.js';
 
 export const createReconcileInstanceKeycloakHandler =
-  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>, mapMutationError: (error: unknown) => Response) =>
+  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>, mapMutationError: InstanceRegistryMutationErrorMapper) =>
   createScopedRegistryMutationHandler(deps, {
+    operation: 'reconcile_instance_keycloak',
     parse: (request) => deps.parseRequestBody<ReconcileKeycloakPayload>(request, reconcileKeycloakSchema),
     execute: (service, input) =>
       service.reconcileKeycloak(
@@ -36,10 +38,13 @@ export const createReconcileInstanceKeycloakHandler =
 export const createExecuteInstanceKeycloakProvisioningHandler =
   <TContext>(
     deps: InstanceRegistryMutationHttpDeps<TContext>,
-    mapMutationError: (error: unknown) => Response,
+    mapMutationError: InstanceRegistryMutationErrorMapper,
     options?: { readonly secretRotationOnly?: boolean }
   ) =>
   createScopedRegistryMutationHandler(deps, {
+    operation: options?.secretRotationOnly
+      ? 'rotate_instance_keycloak_secret'
+      : 'execute_instance_keycloak_provisioning',
     ...(options?.secretRotationOnly ? { criticalActionId: 'instance.secret.rotate' } : {}),
     parse: async (request) => {
       const parsed = await deps.parseRequestBody<ExecuteKeycloakProvisioningPayload>(request, executeKeycloakProvisioningSchema);
@@ -65,8 +70,9 @@ export const createExecuteInstanceKeycloakProvisioningHandler =
   });
 
 export const createProbeTenantIamAccessHandler =
-  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>, mapMutationError: (error: unknown) => Response) =>
+  <TContext>(deps: InstanceRegistryMutationHttpDeps<TContext>, mapMutationError: InstanceRegistryMutationErrorMapper) =>
   createScopedRegistryMutationHandler(deps, {
+    operation: 'probe_tenant_iam_access',
     parse: (request) => deps.parseRequestBody<ProbeTenantIamAccessPayload>(request, probeTenantIamAccessSchema),
     execute: (service, input) =>
       service.probeTenantIamAccess(

--- a/packages/instance-registry/src/http-mutation-handlers.test.ts
+++ b/packages/instance-registry/src/http-mutation-handlers.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const logger = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock('@sva/server-runtime', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@sva/server-runtime')>()),
+  createSdkLogger: () => logger,
+}));
+
 import {
   createInstanceMutationErrorMapper,
   createInstanceRegistryMutationHttpHandlers,
@@ -91,6 +98,29 @@ describe('http mutation handlers', () => {
     expect(body).toMatchObject({
       code: 'tenant_auth_client_secret_missing',
       requestId: 'req-test',
+    });
+  });
+
+  it('logs safe mutation error diagnostics with the request correlation', async () => {
+    const mapError = createInstanceMutationErrorMapper(deps);
+
+    mapError(Object.assign(new Error('duplicate value violates unique constraint'), {
+      code: '23505',
+      table: 'instances',
+      constraint: 'instances_pkey',
+    }));
+
+    expect(logger.error).toHaveBeenCalledWith('Instance registry mutation failed', {
+      operation: 'instance_registry_mutation',
+      result: 'failed',
+      error: 'internal_unclassified',
+      request_id: 'req-test',
+      error_type: 'Error',
+      error_code: '23505',
+      database_table: 'instances',
+      database_constraint: 'instances_pkey',
+      classification: 'internal_unclassified',
+      http_status: 500,
     });
   });
 

--- a/packages/instance-registry/src/http-mutation-module-actions.ts
+++ b/packages/instance-registry/src/http-mutation-module-actions.ts
@@ -9,6 +9,7 @@ import {
 } from './http-contracts.js';
 import type { InstanceRegistryMutationHttpDeps } from './http-mutation-shared.js';
 import { createScopedRegistryMutationHandler } from './http-mutation-shared.js';
+import type { InstanceRegistryMutationErrorMapper } from './observability.js';
 import {
   buildAssignInstanceModuleInput,
   buildBootstrapAdminStructureInput,
@@ -23,9 +24,10 @@ import {
 export const createAssignModuleHandler =
   <TContext>(
     deps: InstanceRegistryMutationHttpDeps<TContext>,
-    mapMutationError: (error: unknown) => Response
+    mapMutationError: InstanceRegistryMutationErrorMapper
   ) =>
   createScopedRegistryMutationHandler(deps, {
+    operation: 'assign_instance_module',
     parse: (request) => deps.parseRequestBody<AssignInstanceModulePayload>(request, assignModuleSchema),
     execute: (service, input) =>
       service.assignModule(
@@ -54,9 +56,10 @@ export const createAssignModuleHandler =
 export const createBootstrapAdminStructureHandler =
   <TContext>(
     deps: InstanceRegistryMutationHttpDeps<TContext>,
-    mapMutationError: (error: unknown) => Response
+    mapMutationError: InstanceRegistryMutationErrorMapper
   ) =>
   createScopedRegistryMutationHandler(deps, {
+    operation: 'bootstrap_instance_admin_structure',
     parse: (request) => deps.parseRequestBody<BootstrapAdminStructurePayload>(request, bootstrapAdminStructureSchema),
     execute: (service, input) =>
       service.bootstrapAdminStructure(
@@ -85,9 +88,10 @@ export const createBootstrapAdminStructureHandler =
 export const createRevokeModuleHandler =
   <TContext>(
     deps: InstanceRegistryMutationHttpDeps<TContext>,
-    mapMutationError: (error: unknown) => Response
+    mapMutationError: InstanceRegistryMutationErrorMapper
   ) =>
   createScopedRegistryMutationHandler(deps, {
+    operation: 'revoke_instance_module',
     criticalActionId: 'instance.module.revoke',
     resolveCriticalModuleId: (payload: RevokeInstanceModulePayload) => payload.moduleId,
     parse: (request) => deps.parseRequestBody<RevokeInstanceModulePayload>(request, revokeModuleSchema),
@@ -118,9 +122,10 @@ export const createRevokeModuleHandler =
 export const createSeedIamBaselineHandler =
   <TContext>(
     deps: InstanceRegistryMutationHttpDeps<TContext>,
-    mapMutationError: (error: unknown) => Response
+    mapMutationError: InstanceRegistryMutationErrorMapper
   ) =>
   createScopedRegistryMutationHandler(deps, {
+    operation: 'seed_instance_iam_baseline',
     parse: (request) => deps.parseRequestBody<Record<string, never>>(request, seedIamBaselineSchema),
     execute: (service, input) =>
       service.seedIamBaseline(
@@ -140,10 +145,11 @@ export const createSeedIamBaselineHandler =
 export const createMutateInstanceStatusHandler =
   <TContext>(
     deps: InstanceRegistryMutationHttpDeps<TContext>,
-    mapMutationError: (error: unknown) => Response
+    mapMutationError: InstanceRegistryMutationErrorMapper
   ) => {
   const createStatusMutationHandler = (nextStatus: Extract<InstanceStatus, 'active' | 'suspended' | 'archived'>) =>
     createScopedRegistryMutationHandler(deps, {
+      operation: `change_instance_status_${nextStatus}`,
       criticalActionId: `instance.status.${nextStatus === 'active' ? 'activate' : nextStatus === 'suspended' ? 'suspend' : 'archive'}`,
       parse: async (inputRequest) => {
         const payloadResult = await deps.parseRequestBody<{ status: Extract<InstanceStatus, 'active' | 'suspended' | 'archived'> }>(

--- a/packages/instance-registry/src/http-mutation-shared.ts
+++ b/packages/instance-registry/src/http-mutation-shared.ts
@@ -1,9 +1,15 @@
-import { createMutationWorkflow } from '@sva/server-runtime';
+import { createMutationWorkflow, createSdkLogger } from '@sva/server-runtime';
 import type { z } from 'zod';
 
 import { readDetailInstanceId } from './http-contracts.js';
 import { classifyInstanceMutationError, type InstanceMutationErrorCode } from './mutation-errors.js';
+import {
+  buildInstanceRegistryFailureLog,
+  type InstanceRegistryMutationErrorMapper,
+} from './observability.js';
 import type { InstanceRegistryService } from './service-types.js';
+
+const logger = createSdkLogger({ component: 'iam-instance-registry-http', level: 'info' });
 
 type CreateApiError = (
   status: number,
@@ -78,6 +84,7 @@ type ScopedRegistryMutationExecuteInput<TData> = {
 };
 
 type ScopedRegistryMutationHandlerOptions<TContext, TData, TResult> = {
+  readonly operation: string;
   readonly criticalActionId?: string;
   readonly resolveCriticalModuleId?: (payload: TData) => string | undefined;
   readonly parse: (request: Request) => Promise<ParsedRequestBody<TData>>;
@@ -86,7 +93,7 @@ type ScopedRegistryMutationHandlerOptions<TContext, TData, TResult> = {
     input: ScopedRegistryMutationExecuteInput<TData>
   ) => Promise<TResult>;
   readonly respond: (result: TResult, state: ScopedRegistryMutationState<TContext>) => Response;
-  readonly mapMutationError: (error: unknown) => Response;
+  readonly mapMutationError: InstanceRegistryMutationErrorMapper;
 };
 
 const mutationErrorMessages: Record<InstanceMutationErrorCode, string> = {
@@ -110,8 +117,17 @@ const mutationErrorMessages: Record<InstanceMutationErrorCode, string> = {
 
 export const createInstanceMutationErrorMapper = (
   deps: Pick<InstanceRegistryMutationHttpDeps<unknown>, 'createApiError' | 'getRequestId'>
-) => (error: unknown): Response => {
+): InstanceRegistryMutationErrorMapper => (error, context) => {
   const classification = classifyInstanceMutationError(error);
+  logger.error('Instance registry mutation failed', buildInstanceRegistryFailureLog(error, {
+    operation: context?.operation ?? 'instance_registry_mutation',
+    requestId: context?.requestId ?? deps.getRequestId(),
+    instanceId: context?.instanceId,
+    runId: context?.runId,
+    intent: context?.intent,
+    stepKey: context?.stepKey,
+    dependency: context?.dependency,
+  }, classification));
   return deps.createApiError(
     classification.status,
     classification.code,
@@ -211,7 +227,11 @@ export const createScopedRegistryMutationHandler = <TContext, TData, TResult>(
       return parsed.ok ? parsed.data : deps.createApiError(400, 'invalid_request', parsed.message, requestId);
     },
     execute: (state: ScopedExecutionState<TContext, TData>) => executeScopedMutation(deps, options, state),
-    mapError: options.mapMutationError,
+    mapError: (error, state) => options.mapMutationError(error, {
+      operation: options.operation,
+      requestId: state.requestId,
+      instanceId: state.instanceId,
+    }),
     respond: (
       result: TResult | Response,
       state: {

--- a/packages/instance-registry/src/observability.test.ts
+++ b/packages/instance-registry/src/observability.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyInstanceMutationError } from './mutation-errors.js';
+import {
+  buildInstanceRegistryFailureLog,
+  readInstanceRegistryStepKey,
+  runInstanceRegistryStep,
+} from './observability.js';
+
+describe('instance registry observability', () => {
+  it('allowlists PostgreSQL diagnostics and correlation fields', () => {
+    const error = Object.assign(new Error('secret@example.test password=hunter2'), {
+      code: '23505',
+      table: 'instances',
+      column: 'id',
+      constraint: 'instances_pkey',
+      detail: 'Key (email)=(secret@example.test) already exists',
+      query: 'INSERT INTO iam.instances ...',
+    });
+
+    const log = buildInstanceRegistryFailureLog(error, {
+      operation: 'create_instance', requestId: 'req-1', instanceId: 'demo', stepKey: 'registry_insert',
+    }, classifyInstanceMutationError(error));
+
+    expect(log).toMatchObject({
+      operation: 'create_instance', result: 'failed', request_id: 'req-1', instance_id: 'demo',
+      step_key: 'registry_insert', error_type: 'Error', error_code: '23505',
+      database_table: 'instances', database_column: 'id', database_constraint: 'instances_pkey',
+    });
+    expect(JSON.stringify(log)).not.toContain('secret@example.test');
+    expect(log).not.toHaveProperty('detail');
+    expect(log).not.toHaveProperty('query');
+  });
+
+  it('never serializes raw provider diagnostics or secrets', () => {
+    const fragments = [
+      'admin@smart-village.app',
+      'password=top-secret',
+      'Bearer token-value',
+      'postgres://user:password@database/internal',
+      "VALUES ('private-value')",
+    ];
+    const error = Object.assign(new Error(fragments.join(' ')), {
+      detail: fragments[0], hint: fragments[1], query: fragments[4], parameters: fragments,
+      stack: fragments.join('\n'), code: '08006',
+    });
+    const serialized = JSON.stringify(buildInstanceRegistryFailureLog(error, {
+      operation: 'create_instance', requestId: 'req-safe',
+    }, classifyInstanceMutationError(error)));
+
+    for (const fragment of fragments) expect(serialized).not.toContain(fragment);
+  });
+
+  it('keeps the concrete failure step without exposing it as an enumerable error field', async () => {
+    const error = new Error('provider secret');
+    await expect(runInstanceRegistryStep('audit_event_insert', async () => {
+      throw error;
+    })).rejects.toBe(error);
+    expect(readInstanceRegistryStepKey(error)).toBe('audit_event_insert');
+    expect(JSON.stringify(error)).not.toContain('audit_event_insert');
+  });
+
+  it('uses the stable classification when no provider code exists', () => {
+    expect(buildInstanceRegistryFailureLog('boom', { operation: 'create_instance' }, {
+      status: 500, code: 'internal_unclassified',
+    })).toMatchObject({
+      operation: 'create_instance', result: 'failed', error: 'internal_unclassified',
+      error_type: 'string', error_code: 'internal_unclassified', classification: 'internal_unclassified', http_status: 500,
+    });
+  });
+});

--- a/packages/instance-registry/src/observability.ts
+++ b/packages/instance-registry/src/observability.ts
@@ -1,0 +1,93 @@
+import type { InstanceMutationErrorClassification } from './mutation-errors.js';
+
+export type InstanceRegistryFailureContext = {
+  readonly operation: string;
+  readonly requestId?: string;
+  readonly instanceId?: string;
+  readonly runId?: string;
+  readonly intent?: string;
+  readonly stepKey?: string;
+  readonly dependency?: string;
+};
+
+export type InstanceRegistryMutationErrorMapper = (
+  error: unknown,
+  context?: InstanceRegistryFailureContext
+) => Response;
+
+const readSafeString = (value: unknown, key: string): string | undefined => {
+  if (value === null || typeof value !== 'object') return undefined;
+  const candidate = (value as Record<string, unknown>)[key];
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : undefined;
+};
+
+const stepKeys = new Set([
+  'registry_lookup',
+  'registry_insert',
+  'primary_hostname_upsert',
+  'provisioning_run_insert',
+  'audit_event_insert',
+  'host_cache_invalidate',
+  'queue_enqueue',
+  'worker_claim',
+  'worker_preflight',
+  'worker_plan',
+  'keycloak_execution',
+  'secret_sync',
+  'admin_bootstrap',
+  'worker_complete',
+]);
+
+export const readInstanceRegistryStepKey = (error: unknown): string | undefined => {
+  const stepKey = readSafeString(error, 'instanceRegistryStep');
+  return stepKey && stepKeys.has(stepKey) ? stepKey : undefined;
+};
+
+export const annotateInstanceRegistryError = (error: unknown, stepKey: string): unknown => {
+  if (error !== null && typeof error === 'object' && stepKeys.has(stepKey)) {
+    try {
+      Object.defineProperty(error, 'instanceRegistryStep', {
+        configurable: true,
+        enumerable: false,
+        value: stepKey,
+      });
+    } catch {
+      // Preserve non-extensible upstream errors without replacing their original identity.
+    }
+  }
+  return error;
+};
+
+export const runInstanceRegistryStep = async <T>(stepKey: string, work: () => Promise<T>): Promise<T> => {
+  try {
+    return await work();
+  } catch (error) {
+    throw annotateInstanceRegistryError(error, stepKey);
+  }
+};
+
+export const buildInstanceRegistryFailureLog = (
+  error: unknown,
+  context: InstanceRegistryFailureContext,
+  classification: InstanceMutationErrorClassification
+): Record<string, unknown> => {
+  const stepKey = context.stepKey ?? readInstanceRegistryStepKey(error);
+  return {
+    operation: context.operation,
+    result: 'failed',
+    error: classification.code,
+    error_type: error instanceof Error ? error.name : typeof error,
+    error_code: readSafeString(error, 'code') ?? classification.code,
+    classification: classification.code,
+    http_status: classification.status,
+    ...(context.requestId ? { request_id: context.requestId } : {}),
+    ...(context.instanceId ? { instance_id: context.instanceId } : {}),
+    ...(context.runId ? { run_id: context.runId } : {}),
+    ...(context.intent ? { intent: context.intent } : {}),
+    ...(stepKey ? { step_key: stepKey } : {}),
+    ...(context.dependency ? { dependency: context.dependency } : {}),
+    ...(readSafeString(error, 'table') ? { database_table: readSafeString(error, 'table') } : {}),
+    ...(readSafeString(error, 'column') ? { database_column: readSafeString(error, 'column') } : {}),
+    ...(readSafeString(error, 'constraint') ? { database_constraint: readSafeString(error, 'constraint') } : {}),
+  };
+};

--- a/packages/instance-registry/src/provisioning-worker.test.ts
+++ b/packages/instance-registry/src/provisioning-worker.test.ts
@@ -73,8 +73,12 @@ describe('provisioning-worker', () => {
       'keycloak_provisioner_worker_iteration_failed',
       expect.objectContaining({
         operation: 'keycloak_provisioner_worker_loop',
-        error: 'boom',
+        result: 'failed',
+        step_key: 'worker_claim',
+        error_type: 'Error',
+        error_code: 'WORKER_ITERATION_FAILED',
       })
     );
+    expect(JSON.stringify(state.logger.error.mock.calls)).not.toContain('boom');
   });
 });

--- a/packages/instance-registry/src/provisioning-worker.ts
+++ b/packages/instance-registry/src/provisioning-worker.ts
@@ -77,7 +77,10 @@ export const runKeycloakProvisioningWorkerLoop = async (
       } catch (error) {
         logger.error('keycloak_provisioner_worker_iteration_failed', {
           operation: 'keycloak_provisioner_worker_loop',
-          error: error instanceof Error ? error.message : String(error),
+          result: 'failed',
+          step_key: 'worker_claim',
+          error_type: error instanceof Error ? error.name : typeof error,
+          error_code: 'WORKER_ITERATION_FAILED',
         });
         await sleep(pollIntervalMs);
       }

--- a/packages/instance-registry/src/service-audit-helpers.test.ts
+++ b/packages/instance-registry/src/service-audit-helpers.test.ts
@@ -132,7 +132,7 @@ describe('service-audit helpers', () => {
     expect(result).toMatchObject({
       status: null,
       evidenceSource: 'keycloak_live',
-      error: 'HTTP 403 Forbidden',
+      error: 'KEYCLOAK_STATUS_UNAVAILABLE',
       fallbackEvidenceSource: 'keycloak_snapshot',
     });
     expect(result.fallbackStatus).toBeTruthy();
@@ -168,9 +168,9 @@ describe('service-audit helpers', () => {
     expect(result).toMatchObject({
       status: null,
       evidenceSource: 'keycloak_live',
-      error: 'HTTP 403 Forbidden',
+      error: 'KEYCLOAK_STATUS_UNAVAILABLE',
       fallbackEvidenceSource: 'keycloak_snapshot',
-      fallbackError: 'snapshot unavailable',
+      fallbackError: 'KEYCLOAK_SNAPSHOT_UNAVAILABLE',
     });
     expect(result.fallbackStatus).toBeUndefined();
   });

--- a/packages/instance-registry/src/service-audit-keycloak.ts
+++ b/packages/instance-registry/src/service-audit-keycloak.ts
@@ -50,32 +50,40 @@ export const resolveKeycloakStatus = async (
       });
       return { status, evidenceSource: 'keycloak_live' };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const reasonCode = 'KEYCLOAK_STATUS_UNAVAILABLE';
       logger.warn('instance_audit_keycloak_status_failed', {
+        operation: 'audit_instance_keycloak',
+        result: 'failed',
         instance_id: instanceId,
-        error: message,
+        dependency: 'keycloak',
+        error_type: error instanceof Error ? error.name : typeof error,
+        error_code: reasonCode,
       });
       try {
         const fallback = await createGetKeycloakStatusHandler(deps)(instanceId);
         return {
           status: null,
           evidenceSource: 'keycloak_live',
-          error: message,
+          error: reasonCode,
           fallbackStatus: fallback,
           fallbackEvidenceSource: 'keycloak_snapshot',
         };
       } catch (fallbackError) {
-        const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+        const fallbackReasonCode = 'KEYCLOAK_SNAPSHOT_UNAVAILABLE';
         logger.warn('instance_audit_keycloak_fallback_failed', {
+          operation: 'audit_instance_keycloak',
+          result: 'failed',
           instance_id: instanceId,
-          error: fallbackMessage,
+          dependency: 'instance_registry',
+          error_type: fallbackError instanceof Error ? fallbackError.name : typeof fallbackError,
+          error_code: fallbackReasonCode,
         });
         return {
           status: null,
           evidenceSource: 'keycloak_live',
-          error: message,
+          error: reasonCode,
           fallbackEvidenceSource: 'keycloak_snapshot',
-          fallbackError: fallbackMessage,
+          fallbackError: fallbackReasonCode,
         };
       }
     }

--- a/packages/instance-registry/src/service-instance-mutations.ts
+++ b/packages/instance-registry/src/service-instance-mutations.ts
@@ -12,6 +12,7 @@ import {
   invalidateHostWithLog,
 } from './service-shared.js';
 import type { InstanceRegistryService, InstanceRegistryServiceDeps } from './service-types.js';
+import { annotateInstanceRegistryError, runInstanceRegistryStep } from './observability.js';
 
 export const createProvisioningRequestHandler =
   (deps: InstanceRegistryServiceDeps): InstanceRegistryService['createProvisioningRequest'] =>
@@ -22,7 +23,9 @@ export const createProvisioningRequestHandler =
       request_id: input.requestId,
       actor_id: input.actorId,
     });
-    const existing = await deps.repository.getInstanceById(input.instanceId);
+    const existing = await runInstanceRegistryStep('registry_lookup', () =>
+      deps.repository.getInstanceById(input.instanceId)
+    );
     if (existing) {
       instanceRegistryServiceLogger.warn('instance_create_rejected_duplicate', {
         operation: 'create_instance',
@@ -35,7 +38,7 @@ export const createProvisioningRequestHandler =
     const normalizedParentDomain = normalizeHost(input.parentDomain);
     const primaryHostname = buildPrimaryHostname(input.instanceId, normalizedParentDomain);
     const tenantAdminClient = input.tenantAdminClient ?? { clientId: DEFAULT_TENANT_ADMIN_CLIENT_ID };
-    const instance = await deps.repository.createInstance({
+    const instance = await runInstanceRegistryStep('registry_insert', () => deps.repository.createInstance({
       instanceId: input.instanceId,
       displayName: input.displayName,
       status: 'requested',
@@ -58,7 +61,7 @@ export const createProvisioningRequestHandler =
       themeKey: input.themeKey,
       featureFlags: input.featureFlags,
       mainserverConfigRef: input.mainserverConfigRef,
-    });
+    }));
     if (!instance) {
       instanceRegistryServiceLogger.warn('instance_create_rejected_duplicate', {
         operation: 'create_instance',
@@ -69,7 +72,11 @@ export const createProvisioningRequestHandler =
     }
 
     await createProvisioningArtifacts(deps.repository, instance, input);
-    invalidateHostWithLog(deps.invalidateHost, instance.primaryHostname, instance.instanceId);
+    try {
+      invalidateHostWithLog(deps.invalidateHost, instance.primaryHostname, instance.instanceId);
+    } catch (error) {
+      throw annotateInstanceRegistryError(error, 'host_cache_invalidate');
+    }
     instanceRegistryServiceLogger.info('instance_create_completed', {
       operation: 'create_instance',
       instance_id: instance.instanceId,

--- a/packages/instance-registry/src/service-keycloak-execution-failures.test.ts
+++ b/packages/instance-registry/src/service-keycloak-execution-failures.test.ts
@@ -16,6 +16,8 @@ describe('service-keycloak-execution-failures', () => {
       {
         runId: 'run-1',
         requestId: 'req-1',
+        instanceId: 'demo',
+        intent: 'reconcile',
         error: new Error('boom'),
       }
     );
@@ -23,7 +25,7 @@ describe('service-keycloak-execution-failures', () => {
     expect(repository.appendKeycloakProvisioningStep).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: 'run-1',
-        stepKey: 'execution',
+        stepKey: 'keycloak_execution',
         status: 'failed',
       })
     );
@@ -48,6 +50,8 @@ describe('service-keycloak-execution-failures', () => {
       {
         runId: 'run-2',
         requestId: 'req-2',
+        instanceId: 'demo',
+        intent: 'reconcile',
         summary: 'dependency missing',
         details: { reason: 'dependency_missing' },
       }

--- a/packages/instance-registry/src/service-keycloak-execution-failures.ts
+++ b/packages/instance-registry/src/service-keycloak-execution-failures.ts
@@ -2,6 +2,7 @@ import { createSdkLogger } from '@sva/server-runtime';
 
 import { appendRunStep } from './service-keycloak-run-steps.js';
 import type { InstanceRegistryServiceDeps } from './service-types.js';
+import { readInstanceRegistryStepKey } from './observability.js';
 
 const logger = createSdkLogger({ component: 'keycloak-provisioning-failures', level: 'error' });
 
@@ -40,22 +41,36 @@ export const failRun = async (
   input: {
     runId: string;
     requestId?: string;
+    instanceId: string;
+    intent: string;
     error: unknown;
   }
 ) => {
   const { reasonCode, safeSummary } = classifyError(input.error);
+  const stepKey = readInstanceRegistryStepKey(input.error) ?? 'keycloak_execution';
+  const dependency = stepKey === 'keycloak_execution'
+    ? 'keycloak'
+    : stepKey === 'secret_sync' || stepKey === 'admin_bootstrap'
+      ? 'instance_registry'
+      : undefined;
 
-  // Log the detailed error for operators with structured context.
-  // rawErrorMessage is deliberately omitted to avoid leaking PII or secrets
-  // from upstream error messages (HTTP responses, Keycloak errors, etc.).
   logger.error('provisioning_run_failed', {
-    runId: input.runId,
-    reasonCode,
+    operation: 'process_keycloak_provisioning_run',
+    result: 'failed',
+    request_id: input.requestId,
+    instance_id: input.instanceId,
+    run_id: input.runId,
+    intent: input.intent,
+    step_key: stepKey,
+    ...(dependency ? { dependency } : {}),
+    error_type: input.error instanceof Error ? input.error.name : typeof input.error,
+    error_code: reasonCode,
+    classification: reasonCode,
   });
 
   await appendRunStep(deps, {
     runId: input.runId,
-    stepKey: 'execution',
+    stepKey,
     title: 'Provisioning ausführen',
     status: 'failed',
     summary: safeSummary,
@@ -74,10 +89,27 @@ export const failClaimedRun = async (
   input: {
     runId: string;
     requestId?: string;
+    instanceId: string;
+    intent: string;
     summary: string;
     details?: Readonly<Record<string, unknown>>;
   }
 ) => {
+  const reasonCode = typeof input.details?.reason === 'string'
+    ? input.details.reason.toUpperCase()
+    : 'WORKER_PRECONDITION_FAILED';
+  logger.error('provisioning_run_failed', {
+    operation: 'process_keycloak_provisioning_run',
+    result: 'failed',
+    request_id: input.requestId,
+    instance_id: input.instanceId,
+    run_id: input.runId,
+    intent: input.intent,
+    step_key: 'worker_preflight',
+    error_type: 'ProvisioningPreconditionError',
+    error_code: reasonCode,
+    classification: reasonCode,
+  });
   await appendRunStep(deps, {
     runId: input.runId,
     stepKey: 'worker',

--- a/packages/instance-registry/src/service-keycloak-execution.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.ts
@@ -8,6 +8,7 @@ import { appendRunStep } from './service-keycloak-run-steps.js';
 import { buildProvisioningInput, completeRun, createQueuedRun, readQueuedTemporaryPassword, syncProvisionedClientSecretToRegistry, syncRotatedClientSecretToRegistry } from './service-keycloak-execution-shared.js';
 import { failClaimedRun, failRun } from './service-keycloak-execution-failures.js';
 import { buildProvisioningExecutionOptions, ensureReconcilePreconditions, resolveReconcileIntent } from './service-keycloak-reconcile-helpers.js';
+import { runInstanceRegistryStep } from './observability.js';
 
 const logger = createSdkLogger({ component: 'iam-instance-registry-keycloak', level: 'info' });
 
@@ -20,6 +21,8 @@ const loadClaimedRunInstance = async (deps: InstanceRegistryServiceDeps, run: In
     await failClaimedRun(deps, {
       runId: run.id,
       requestId: run.requestId,
+      instanceId: run.instanceId,
+      intent: run.intent,
       summary: 'Die Instanz konnte für den Provisioning-Lauf nicht mehr geladen werden.',
       details: { reason: 'instance_not_found' },
     });
@@ -118,8 +121,12 @@ const syncTenantAdminBootstrapAccountAfterProvisioning = async (
 };
 
 const executeClaimedRun = async (deps: InstanceRegistryServiceDeps, run: InstanceKeycloakProvisioningRun, loaded: NonNullable<Awaited<ReturnType<typeof loadInstanceWithSecret>>>, tenantAdminTemporaryPassword: string | undefined, provisioningInput: ReturnType<typeof buildProvisioningInput>) => {
-  const preflight = await appendPreflightSnapshot(deps, run, provisioningInput);
-  const plan = await appendPlanSnapshot(deps, run, provisioningInput);
+  const preflight = await runInstanceRegistryStep('worker_preflight', () =>
+    appendPreflightSnapshot(deps, run, provisioningInput)
+  );
+  const plan = await runInstanceRegistryStep('worker_plan', () =>
+    appendPlanSnapshot(deps, run, provisioningInput)
+  );
 
   if (run.mode === 'existing' && run.intent !== 'provision_admin_client' && !loaded.authClientSecret) {
     throw new Error('tenant_auth_client_secret_missing');
@@ -138,27 +145,31 @@ const executeClaimedRun = async (deps: InstanceRegistryServiceDeps, run: Instanc
     throw new Error('dependency_missing_provisionInstanceAuth');
   }
 
-  await provisionInstanceAuth({
+  await runInstanceRegistryStep('keycloak_execution', () => provisionInstanceAuth({
     ...provisioningInput,
     tenantAdminTemporaryPassword,
     rotateClientSecret: run.intent === 'rotate_client_secret',
     ...buildProvisioningExecutionOptions(run.intent),
-  });
+  }));
 
-  await syncClientSecretAfterProvisioning(deps, run, loaded);
-  await syncTenantAdminBootstrapAccountAfterProvisioning(deps, run, loaded);
+  await runInstanceRegistryStep('secret_sync', () => syncClientSecretAfterProvisioning(deps, run, loaded));
+  await runInstanceRegistryStep('admin_bootstrap', () =>
+    syncTenantAdminBootstrapAccountAfterProvisioning(deps, run, loaded)
+  );
 
-  const finalRunStatus = await completeRun(deps, {
+  const finalRunStatus = await runInstanceRegistryStep('worker_complete', () => completeRun(deps, {
     loaded,
     runId: run.id,
     requestId: run.requestId,
     actorId: run.actorId,
     intent: run.intent,
     tenantAdminTemporaryPassword,
-  });
+  }));
 
   logger.info('keycloak_provisioning_completed', {
     operation: 'process_keycloak_provisioning_run',
+    result: 'completed',
+    step_key: 'worker_complete',
     instance_id: loaded.instance.instanceId,
     request_id: run.requestId,
     run_id: run.id,
@@ -180,6 +191,8 @@ export const processClaimedKeycloakProvisioningRun = async (
     await failClaimedRun(deps, {
       runId: run.id,
       requestId: run.requestId,
+      instanceId: run.instanceId,
+      intent: run.intent,
       summary: 'Provisioning-Worker ist unvollständig konfiguriert.',
       details: { reason: 'dependency_missing' },
     });
@@ -196,17 +209,25 @@ export const processClaimedKeycloakProvisioningRun = async (
   const provisioningInput = buildProvisioningInput(loaded);
 
   await appendWorkerRunningStep(deps, run);
+  logger.info('keycloak_provisioning_claimed', {
+    operation: 'process_keycloak_provisioning_run',
+    result: 'claimed',
+    request_id: run.requestId,
+    instance_id: run.instanceId,
+    run_id: run.id,
+    intent: run.intent,
+    step_key: 'worker_claim',
+  });
 
   try {
     return await executeClaimedRun(deps, run, loaded, tenantAdminTemporaryPassword, provisioningInput);
   } catch (error) {
-    await failRun(deps, { runId: run.id, requestId: run.requestId, error });
-    logger.error('keycloak_provisioning_failed', {
-      operation: 'process_keycloak_provisioning_run',
-      instance_id: run.instanceId,
-      request_id: run.requestId,
-      run_id: run.id,
-      error: error instanceof Error ? error.message : String(error),
+    await failRun(deps, {
+      runId: run.id,
+      requestId: run.requestId,
+      instanceId: run.instanceId,
+      intent: run.intent,
+      error,
     });
     return deps.repository.getKeycloakProvisioningRun(run.instanceId, run.id);
   }
@@ -227,6 +248,8 @@ export const createExecuteKeycloakProvisioningHandler =
   async (input: ExecuteInstanceKeycloakProvisioningInput) => {
     logger.info('keycloak_provisioning_enqueued', {
       operation: 'execute_keycloak_provisioning',
+      result: 'enqueued',
+      step_key: 'queue_enqueue',
       instance_id: input.instanceId,
       request_id: input.requestId,
       actor_id: input.actorId,

--- a/packages/instance-registry/src/service-provisioning.test.ts
+++ b/packages/instance-registry/src/service-provisioning.test.ts
@@ -155,7 +155,7 @@ describe('service-provisioning', () => {
       expect.objectContaining({
         status: 'failed',
         errorCode: 'keycloak_provisioning_failed',
-        errorMessage: 'keycloak down',
+        errorMessage: 'Keycloak-Provisionierung fehlgeschlagen.',
       })
     );
   });

--- a/packages/instance-registry/src/service-provisioning.ts
+++ b/packages/instance-registry/src/service-provisioning.ts
@@ -3,6 +3,7 @@ import type { InstanceRegistryRepository } from '@sva/data-repositories';
 import type { CreateInstanceProvisioningInput } from './mutation-types.js';
 import type { InstanceRegistryServiceDeps } from './service-types.js';
 import { createAuditDetails } from './service-helpers.js';
+import { runInstanceRegistryStep } from './observability.js';
 
 const logger = createSdkLogger({ component: 'iam-instance-registry-provisioning', level: 'info' });
 
@@ -13,15 +14,15 @@ export const createProvisioningArtifacts = async (
   instance: CreatedInstanceRecord,
   input: CreateInstanceProvisioningInput
 ): Promise<void> => {
-  await repository.createProvisioningRun({
+  await runInstanceRegistryStep('provisioning_run_insert', () => repository.createProvisioningRun({
     instanceId: instance.instanceId,
     operation: 'create',
     status: 'requested',
     idempotencyKey: input.idempotencyKey,
     actorId: input.actorId,
     requestId: input.requestId,
-  });
-  await repository.appendAuditEvent({
+  }));
+  await runInstanceRegistryStep('audit_event_insert', () => repository.appendAuditEvent({
     instanceId: instance.instanceId,
     eventType: 'instance_requested',
     actorId: input.actorId,
@@ -30,7 +31,7 @@ export const createProvisioningArtifacts = async (
       parentDomain: instance.parentDomain,
       primaryHostname: instance.primaryHostname,
     }),
-  });
+  }));
 };
 
 export const provisionInstanceAuth = async (
@@ -115,7 +116,7 @@ export const provisionInstanceAuth = async (
       actorId: input.actorId,
       requestId: input.requestId,
       errorCode: 'keycloak_provisioning_failed',
-      errorMessage: error instanceof Error ? error.message : String(error),
+      errorMessage: 'Keycloak-Provisionierung fehlgeschlagen.',
     });
 
     logger.error('provisioning_step_failed', {
@@ -123,7 +124,10 @@ export const provisionInstanceAuth = async (
       step_key: 'keycloak',
       instance_id: failedInstance.instanceId,
       request_id: input.requestId,
-      error: error instanceof Error ? error.message : String(error),
+      result: 'failed',
+      dependency: 'keycloak',
+      error_type: error instanceof Error ? error.name : typeof error,
+      error_code: 'KEYCLOAK_PROVISIONING_FAILED',
     });
     return failedInstance;
   }

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -339,7 +339,7 @@ describe('instance registry service facade', () => {
         expect.objectContaining({
           checkId: 'keycloak.access.read',
           status: 'warn',
-          actual: 'keycloak unavailable',
+          actual: 'KEYCLOAK_STATUS_UNAVAILABLE',
           details: expect.objectContaining({
             primaryEvidenceSource: 'keycloak_live',
             secondaryEvidenceSource: 'keycloak_snapshot',
@@ -496,6 +496,36 @@ describe('instance registry service facade', () => {
       expect.objectContaining({ operation: 'create', status: 'requested' })
     );
     expect(deps.invalidateHost).toHaveBeenCalledWith('demo.studio.example.org');
+  });
+
+  it.each([
+    ['registry_lookup', { getInstanceById: vi.fn(async () => { throw new Error('lookup secret'); }) }, undefined],
+    ['registry_insert', {
+      getInstanceById: vi.fn(async () => null),
+      createInstance: vi.fn(async () => { throw new Error('insert secret'); }),
+    }, undefined],
+    ['provisioning_run_insert', {
+      getInstanceById: vi.fn(async () => null),
+      createProvisioningRun: vi.fn(async () => { throw new Error('run secret'); }),
+    }, undefined],
+    ['audit_event_insert', {
+      getInstanceById: vi.fn(async () => null),
+      appendAuditEvent: vi.fn(async () => { throw new Error('audit secret'); }),
+    }, undefined],
+    ['host_cache_invalidate', { getInstanceById: vi.fn(async () => null) }, vi.fn(() => {
+      throw new Error('cache secret');
+    })],
+  ] as const)('annotates create failures at %s', async (stepKey, overrides, invalidateHost) => {
+    const repository = createRepository(overrides);
+    const deps = createDeps(repository);
+    if (invalidateHost) deps.invalidateHost = invalidateHost;
+    const service = createInstanceRegistryService(deps);
+
+    const result = service.createProvisioningRequest({
+      instanceId: 'demo', displayName: 'Demo', parentDomain: 'studio.example.org',
+      realmMode: 'new', authRealm: 'demo', authClientId: 'studio-client', idempotencyKey: 'idem-errors',
+    });
+    await expect(result).rejects.toMatchObject({ instanceRegistryStep: stepKey });
   });
 
   it('does not persist legacy waste-management settings during create', async () => {

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -81,7 +81,11 @@ describe('Studio MCP tools', () => {
       instanceId: 'demo', displayName: 'Demo', parentDomain: 'example.org', realmMode: 'new', authRealm: 'demo', authClientId: 'studio',
     } });
     expect(response.structuredContent).toMatchObject({ ok: true });
-    expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'POST', idempotencyKey: expect.any(String) }));
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'POST',
+      body: expect.objectContaining({ instanceId: 'demo' }),
+      idempotencyKey: expect.any(String),
+    }));
     await Promise.all([client.close(), server.close()]);
   });
 

--- a/packages/studio-mcp/src/tools.ts
+++ b/packages/studio-mcp/src/tools.ts
@@ -44,12 +44,22 @@ const call = async (
   }
 };
 
-const mutation = (path: string, params: Record<string, unknown>, method: 'POST' | 'PATCH' = 'POST'): StudioApiRequest => {
+const mutation = (
+  path: string,
+  params: Record<string, unknown>,
+  method: 'POST' | 'PATCH' = 'POST',
+  includeInstanceId = false
+): StudioApiRequest => {
   const requestId = randomUUID();
   const idempotency = typeof params.idempotencyKey === 'string' ? params.idempotencyKey : randomUUID();
   return {
     method, path,
-    body: without(params, ['instanceId', 'idempotencyKey', 'challengeId', 'confirmationPhrase']),
+    body: without(params, [
+      ...(includeInstanceId ? [] : ['instanceId']),
+      'idempotencyKey',
+      'challengeId',
+      'confirmationPhrase',
+    ]),
     requestId,
     idempotencyKey: idempotency,
     ...(typeof params.challengeId === 'string' ? { confirmationChallengeId: params.challengeId } : {}),
@@ -94,7 +104,7 @@ export const registerStudioTools = (server: McpServer, client: StudioApiClient, 
     (p) => call(client, { path: `/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/keycloak/runs/${encodeURIComponent(p.runId)}` }));
 
   register('studio_instances_create', 'Studio-Instanz erstellen', 'Erstellt idempotent eine Registry-Instanz; Provisionierung und Aktivierung bleiben getrennt.', schemas.create, writeAnnotations,
-    (p) => call(client, mutation('/api/v1/iam/instances', p), { instanceId: p.instanceId, timeoutMs: config.diagnosisTimeoutMs }));
+    (p) => call(client, mutation('/api/v1/iam/instances', p, 'POST', true), { instanceId: p.instanceId, timeoutMs: config.diagnosisTimeoutMs }));
   register('studio_instance_update', 'Studio-Instanz aktualisieren', 'Aktualisiert die Konfiguration einer vorhandenen Instanz idempotent.', schemas.update, writeAnnotations,
     (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}`, p, 'PATCH'), { instanceId: p.instanceId, timeoutMs: config.diagnosisTimeoutMs }));
   register('studio_instance_provisioning_plan', 'Provisionierung planen', 'Erzeugt den serverseitigen Keycloak-Provisioning-Plan ohne ihn auszuführen.', schemas.plan, writeAnnotations,


### PR DESCRIPTION
## Zusammenfassung
- führt einen sicheren, typisierten Fehlerkontext für die Instance Registry ein
- korreliert Create-, Queue- und Keycloak-Worker-Stufen ohne doppelte Fehlerlogs
- entfernt rohe Provider- und Datenbankfehlermeldungen aus operativen Logs
- ergänzt Redaction-, Übergangs- und MCP-Regressionstests sowie OpenSpec-/Architekturdokumentation

## Verifikation
- pnpm test:pr
- pnpm check:server-runtime
- openspec validate add-studio-instance-create-mcp --strict
- vollständige Unit-/Type-/Lint-Gates für instance-registry, data-repositories und studio-mcp

Keine Datenbankmigration erforderlich.