### PR TITLE
Fix Instance-Create feature flag cast

### DIFF
--- a/docs/changelog/entries/pr-723.json
+++ b/docs/changelog/entries/pr-723.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 723,
+  "body": "Neue Studio-Instanzen mit hinterlegter Mainserver-Referenz können wieder zuverlässig angelegt werden; die Feature-Flags werden beim Speichern korrekt verarbeitet."
+}

--- a/packages/data-repositories/src/instance-registry/repository-mutations.ts
+++ b/packages/data-repositories/src/instance-registry/repository-mutations.ts
@@ -99,7 +99,7 @@ INSERT INTO iam.instances (
   tenant_admin_username, tenant_admin_email, tenant_admin_first_name, tenant_admin_last_name, theme_key,
   feature_flags, mainserver_config_ref, created_by, updated_by
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19::jsonb, $20, $20)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18::jsonb, $19, $20, $20)
 ON CONFLICT (id) DO NOTHING
 RETURNING
 ${buildInstanceSelectColumns()};

--- a/packages/data-repositories/src/instance-registry/repository-provisioning.test.ts
+++ b/packages/data-repositories/src/instance-registry/repository-provisioning.test.ts
@@ -235,6 +235,8 @@ describe('instance registry repository provisioning', () => {
         realmMode: 'shared',
         authRealm: 'sva',
         authClientId: 'studio',
+        featureFlags: { preview: true },
+        mainserverConfigRef: 'mainserver-ref',
         actorId: 'actor-1',
       })
     ).resolves.toMatchObject({ instanceId: 'tenant-a' });
@@ -253,7 +255,9 @@ describe('instance registry repository provisioning', () => {
     ).resolves.toMatchObject({ instanceId: 'tenant-a' });
 
     expect(statements.filter((statement) => statement.text.includes('iam.instance_hostnames'))).toHaveLength(2);
-    expect(statements[0]?.values.at(17)).toBe('{}');
+    expect(statements[0]?.text).toContain('$18::jsonb, $19, $20, $20');
+    expect(statements[0]?.values.at(17)).toBe('{"preview":true}');
+    expect(statements[0]?.values.at(18)).toBe('mainserver-ref');
     expect(statements[2]?.values.at(8)).toBe(true);
     expect(statements[0]?.text).toContain('ON CONFLICT (id) DO NOTHING');
   });


### PR DESCRIPTION
## Änderung

- korrigiert beim Registry-Insert den JSONB-Cast von der Mainserver-Referenz auf den Feature-Flags-Parameter
- ergänzt einen Regressionstest für die SQL-/Parameterzuordnung

## Ursache und Auswirkung

Der Create-Pfad castete `$19` statt `$18` als JSONB. Bei gesetzter Mainserver-Referenz führte das zu PostgreSQL SQLSTATE `22P02` im Schritt `registry_insert`. Der Fix benötigt keine Migration und verändert keinen öffentlichen Vertrag.

## Validierung

- `pnpm nx run data-repositories:test:unit --testFiles=src/instance-registry/repository-provisioning.test.ts`
- `pnpm nx run data-repositories:test:types`
- `pnpm check:server-runtime`