### PR TITLE
feat(mcp): orchestrate studio instance process

### DIFF
--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -115,6 +115,7 @@ Abhängigkeiten des aktuellen Systems.
    - hält Tool-Schemata, Korrelation, Idempotenz, Redaction und begrenzte Read-only-Diagnose, aber keine Registry-Fachlogik
    - bezieht kurzlebige Keycloak-Tokens aus ausschließlich lokaler Secret-Konfiguration und besitzt weder Datenbank- noch Keycloak-Admin-Zugriff
    - trennt Read-, kontrollierte und kritische Tools; Autorisierung und Confirmation-Challenges bleiben serverseitige Studio-Verantwortung
+   - bietet mit `studio_instance_process` einen modularen Ablauf für Anlage, Reparatur und Anpassung, der ausschließlich vorhandene HTTP-Verträge kombiniert und einen Abschluss nur nach aktuellem Doctor-Read meldet
 14. Studio-Job-Hostpfad (`packages/auth-runtime`, `packages/routing`, `packages/data-repositories`, `packages/iam-governance`)
    - `@sva/auth-runtime` veröffentlicht die hostgeführten Start-, Status- und Worker-Integrationspfade für generische Studio-Jobs
    - `@sva/routing` führt die öffentlichen Plugin-Operation-Endpunkte weiterhin typsicher; die interne Worker-Ausführung läuft über den generischen Task `studio_job_execute`

--- a/docs/changelog/entries/pr-724.json
+++ b/docs/changelog/entries/pr-724.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 724,
+  "body": "Der lokale SVA-Studio-MCP kann Instanzen jetzt über einen geführten Gesamtprozess anlegen, reparieren und anpassen. Der Prozess kombiniert die bestehenden Studio-Verträge für Provisioning, IAM-Rechteprobe und Doctor-Abnahme, meldet einen Abschluss nur bei aktivem, vollständig bereitem Tenant und belässt die Aktivierung als explizite, challenge-geschützte Aktion."
+}

--- a/docs/guides/studio-instance-mcp-betrieb.md
+++ b/docs/guides/studio-instance-mcp-betrieb.md
@@ -53,6 +53,19 @@ Der MCP-Prozess holt kurzlebige Access Tokens per Client-Credentials-Flow. Studi
 
 Der MCP wiederholt oder repariert Mutationen nicht selbstständig. `retryable: true` ist ein Hinweis für einen explizit ausgelösten, begrenzten Retry. Der Primärfehler bleibt auch dann maßgeblich, wenn eine nachgelagerte Diagnose fehlschlägt.
 
+## Geführter Instanzprozess
+
+Der MCP-Server `sva-studio-mcp` stellt ergänzend zu den Einzeltools das Tool `studio_instance_process` bereit. Es verwendet die Modi `create`, `repair` und `adapt` und ruft dabei ausschließlich die bestehenden Studio-API-Verträge für Registry, Modulzuweisung, IAM-Basis, Admin-Struktur, Keycloak-Provisioning, Rechteprobe und Detaildiagnose auf.
+
+- `create` verlangt zusätzlich den bestehenden Create-Vertrag und legt die Registry-Instanz idempotent an.
+- `repair` und `adapt` arbeiten auf einer vorhandenen Instanz; `moduleIds` ergänzt gezielt Module einschließlich ihrer IAM-Basis und Admin-Struktur.
+- Der Prozess verfolgt den gestarteten Keycloak-Run nur innerhalb seines lokalen Zeitbudgets und gibt bei noch laufendem oder fehlgeschlagenem Run einen handlungsfähigen Zwischen- beziehungsweise Blockierungszustand zurück.
+- Nach einem erfolgreichen Run führt er eine tenantlokale Rechteprobe aus und liest den aktuellen Detail-/Doctor-Zustand. Historische Preflight-Evidenz ist kein Abschlussnachweis.
+- Der Keycloak-Worker persistiert den nach der Mutation gelesenen Status als `status_snapshot` im Provisioning-Run. Dieser Postflight ist von seinem historischen `worker_preflight_snapshot` getrennt; der MCP bewertet den Abschluss zusätzlich anhand des aktuellen Detail-Reads.
+- `completed: true` bedeutet ausschließlich, dass die Instanz `active` ist und die abgenommenen Doctor-Achsen bereit sind. Ein technisch fertiger Tenant im Status `requested` liefert stattdessen `awaiting_human_action`, `completed: false` und die nächste Action `instance.status.activate`.
+
+Die Aktivierung führt der Prozess nie selbst aus. Sie bleibt eine separate kritische Mutation mit aktuellem Vorab-Read, serverseitiger Challenge, Bestätigungsphrase, Idempotenz und Audit.
+
 ## Verifikation vor Freigabe
 
 Die Freigabe erfolgt nacheinander für Entwicklung, Staging und Produktion. Pro Umgebung:

--- a/docs/guides/studio-instance-mcp-betrieb.md
+++ b/docs/guides/studio-instance-mcp-betrieb.md
@@ -41,7 +41,7 @@ SVA_STUDIO_MCP_CLIENT_ID = "sva-studio-mcp"
 SVA_STUDIO_MCP_CLIENT_SECRET_COMMAND = '["security","find-generic-password","-a","sva-studio-mcp","-s","sva-studio-mcp-studio-dev","-w"]'
 ```
 
-Der Secret-Resolver ist ein JSON-Array aus Programm und Argumenten und wird ohne Shell ausgeführt. Alternativ ist `SVA_STUDIO_MCP_CLIENT_SECRET` nur als lokaler Fallback vorgesehen. Zeitgrenzen können über `SVA_STUDIO_MCP_READ_TIMEOUT_MS`, `SVA_STUDIO_MCP_MUTATION_TIMEOUT_MS`, `SVA_STUDIO_MCP_TOKEN_TIMEOUT_MS` und `SVA_STUDIO_MCP_DIAGNOSIS_TIMEOUT_MS` angepasst werden. `SVA_STUDIO_MCP_CA_FILE` ergänzt bei interner PKI eine CA-Datei; die TLS-Prüfung bleibt immer aktiv.
+Der Secret-Resolver ist ein JSON-Array aus Programm und Argumenten und wird ohne Shell ausgeführt. Alternativ ist `SVA_STUDIO_MCP_CLIENT_SECRET` nur als lokaler Fallback vorgesehen. Zeitgrenzen können über `SVA_STUDIO_MCP_READ_TIMEOUT_MS`, `SVA_STUDIO_MCP_MUTATION_TIMEOUT_MS`, `SVA_STUDIO_MCP_PROCESS_TIMEOUT_MS`, `SVA_STUDIO_MCP_TOKEN_TIMEOUT_MS` und `SVA_STUDIO_MCP_DIAGNOSIS_TIMEOUT_MS` angepasst werden. `SVA_STUDIO_MCP_PROCESS_TIMEOUT_MS` begrenzt ausschließlich das Warten auf einen asynchronen Keycloak-Run und ist standardmäßig länger als ein einzelner Mutationsrequest. `SVA_STUDIO_MCP_CA_FILE` ergänzt bei interner PKI eine CA-Datei; die TLS-Prüfung bleibt immer aktiv.
 
 Der MCP-Prozess holt kurzlebige Access Tokens per Client-Credentials-Flow. Studio validiert diese über OIDC-Metadaten und JWKS; das MCP-Client-Secret wird nicht in den Studio-Stack kopiert. Fehlerausgaben müssen Authorization-Header, Tokens, Client-Secrets, Tenant-Secrets, Connection-Strings und Stacktraces redigieren.
 
@@ -58,8 +58,8 @@ Der MCP wiederholt oder repariert Mutationen nicht selbstständig. `retryable: t
 Der MCP-Server `sva-studio-mcp` stellt ergänzend zu den Einzeltools das Tool `studio_instance_process` bereit. Es verwendet die Modi `create`, `repair` und `adapt` und ruft dabei ausschließlich die bestehenden Studio-API-Verträge für Registry, Modulzuweisung, IAM-Basis, Admin-Struktur, Keycloak-Provisioning, Rechteprobe und Detaildiagnose auf.
 
 - `create` verlangt zusätzlich den bestehenden Create-Vertrag und legt die Registry-Instanz idempotent an.
-- `repair` und `adapt` arbeiten auf einer vorhandenen Instanz; `moduleIds` ergänzt gezielt Module einschließlich ihrer IAM-Basis und Admin-Struktur.
-- Der Prozess verfolgt den gestarteten Keycloak-Run nur innerhalb seines lokalen Zeitbudgets und gibt bei noch laufendem oder fehlgeschlagenem Run einen handlungsfähigen Zwischen- beziehungsweise Blockierungszustand zurück.
+- `repair` arbeitet auf einer vorhandenen Instanz über den bestehenden Reconcile-Vertrag; `adapt` ergänzt nur fehlende Module einschließlich ihrer IAM-Basis und Admin-Struktur.
+- Der Prozess verfolgt den gestarteten Keycloak-Run nur innerhalb seines lokalen Zeitbudgets mit gedrosseltem Backoff und gibt bei noch laufendem oder fehlgeschlagenem Run einen handlungsfähigen Zwischen- beziehungsweise Blockierungszustand zurück.
 - Nach einem erfolgreichen Run führt er eine tenantlokale Rechteprobe aus und liest den aktuellen Detail-/Doctor-Zustand. Historische Preflight-Evidenz ist kein Abschlussnachweis.
 - Der Keycloak-Worker persistiert den nach der Mutation gelesenen Status als `status_snapshot` im Provisioning-Run. Dieser Postflight ist von seinem historischen `worker_preflight_snapshot` getrennt; der MCP bewertet den Abschluss zusätzlich anhand des aktuellen Detail-Reads.
 - `completed: true` bedeutet ausschließlich, dass die Instanz `active` ist und die abgenommenen Doctor-Achsen bereit sind. Ein technisch fertiger Tenant im Status `requested` liefert stattdessen `awaiting_human_action`, `completed: false` und die nächste Action `instance.status.activate`.

--- a/openspec/changes/add-studio-instance-create-mcp/design.md
+++ b/openspec/changes/add-studio-instance-create-mcp/design.md
@@ -121,6 +121,30 @@ Für PostgreSQL werden ausschließlich SQLSTATE, Tabelle, Spalte und Constraint 
 
 Der lokale stdio-MCP schreibt keine Diagnose auf `stdout`, weil dieser Kanal dem MCP-Protokoll gehört. Seine strukturierte Tool-Antwort bleibt die lokale Diagnoseoberfläche; Tokens, Payloads und Secrets werden nicht geloggt.
 
+### Decision: Modularer Gesamtprozess mit ehrlichem Abschlussvertrag
+
+Die bestehenden MCP-Einzeltools bleiben für gezielte Diagnose, Reparatur und Betrieb erhalten. Ergänzend erhält der MCP einen orchestrierten Instanzprozess mit den Modi `create`, `repair` und `adapt`. Der Prozess verwendet ausschließlich die bestehenden Studio-API-Verträge; er umgeht weder Registry, Worker, Audit noch die serverseitige Risikopolicy.
+
+Der Prozess ermittelt vor jeder Mutation den aktuellen Instanz- und Doctor-Zustand und führt nur die für den angeforderten Modus erforderlichen, idempotenten Schritte aus:
+
+1. Registry-Konfiguration anlegen oder lesen.
+2. Module zuweisen oder ihre IAM-Basis und Admin-Struktur ergänzen.
+3. Keycloak-Provisioning oder -Reconcile anfordern und bis zum terminalen Worker-Ergebnis verfolgen.
+4. Einen aktuellen Postflight aus Keycloak-Status, Rollenabgleich und tenantlokaler Rechteprobe bilden und persistieren.
+5. Den Doctor-Zustand erneut lesen und einen verständlichen, strukturierten Fortschrittsbericht zurückgeben.
+
+Der technische Prozessstatus ist vom Instanz-Lifecycle getrennt. `completed` bedeutet ausschließlich: Die Instanz ist aktiv und alle für den Auftrag erforderlichen Doctor-Achsen sind `ready`. Ein technisch fertiger, aber noch nicht aktivierter Tenant erhält stattdessen `awaiting_human_action` mit `completed: false`, der konkreten Action `instance.status.activate`, einer verständlichen Begründung und den Informationen für die reguläre Bestätigungs-Challenge. Kritische Aktionen bleiben immer explizit und serverseitig challenge-geschützt.
+
+Die Prozessantwort enthält mindestens den lesbaren aktuellen Schritt, erledigte und offene Schritte, Doctor-Zusammenfassung, Korrelation, eine sichere Folgeaktion und einen eindeutigen Abschlusswert. Sie benennt verständlich, ob etwas automatisch fortgesetzt werden kann, eine Human-in-the-Loop-Bestätigung erfordert oder durch einen konkreten Befund blockiert ist. Technische Codes ergänzen diese Erklärung, ersetzen sie aber nicht.
+
+Ein Worker-Preflight ist historische Vorbedingungs-Evidenz und darf nach einer erfolgreichen Mutation nicht als aktueller Doctor-Zustand interpretiert werden. Der Worker persistiert daher einen eigenen Postflight-Snapshot. Detailansicht, Diagnose und MCP verwenden für die Abschlussbewertung ausschließlich den aktuellen Status beziehungsweise diesen Postflight.
+
+Alternativen:
+
+- Einzeltools ohne Gesamtprozess: verworfen, da Operatoren Abschluss und notwendige Reihenfolge selbst erraten müssten.
+- Automatische Aktivierung: verworfen, da sie die bewusste Human-in-the-Loop-Grenze für kritische Mutationen umgehen würde.
+- Erfolg nach Worker-Abschluss: verworfen, da dies fehlende Rechteprobe, Rollen-Backlog oder Aktivierung verschleiern würde.
+
 ## Risks / Trade-offs
 
 - Token-Diebstahl ermöglicht Instanzanlage innerhalb des Token-Scopes. → Kurze Laufzeit, enger Audience-/Scope-Bindung, sichere lokale Ablage, Rotation und vollständiges Audit.

--- a/openspec/changes/add-studio-instance-create-mcp/proposal.md
+++ b/openspec/changes/add-studio-instance-create-mcp/proposal.md
@@ -15,9 +15,10 @@ Operatoren sollen neue Studio-Instanzen aus Codex oder einer CLI heraus kontroll
 - Der lokale MCP-Server stellt die vorhandene Instanz-Control-Plane als dreistufige Tool-Fläche für Lesen/Diagnose, kontrollierte Mutationen und kritische Mutationen bereit.
 - Kritische Mutationen wie Aktivierung, Suspendierung, Archivierung, Modulentzug und Secret-Rotation verlangen serverseitig gebundene, kurzlebige Bestätigungs-Challenges, einen engsten Action-Scope sowie einen aktuellen Vorab-Read oder Plan.
 - Die Create- und Provisioning-Prozesskette erhält einen einheitlichen, strukturierten und geheimnisfreien Fehlerkontext vom HTTP-Eingang bis zum Keycloak-Worker.
+- Der MCP ergänzt die Einzeltools um einen modularen Gesamtprozess für Anlage, Reparatur und Anpassung einer Instanz. Er meldet einen Abschluss erst, wenn die definierten Doctor-Kriterien erfüllt und alle erforderlichen Human-in-the-Loop-Aktionen ausgeführt sind.
 
 ## Impact
 
 - Affected specs: `instance-provisioning`, `iam-access-control`, `iam-auditing`
-- Affected code: neue lokale MCP-Library, Studio-API-Authentisierung und -Autorisierung für den Service-Token-Pfad, vorhandene Instance-Registry-HTTP-Integration
+- Affected code: lokale MCP-Library, Studio-API-Authentisierung und -Autorisierung für den Service-Token-Pfad, vorhandene Instance-Registry-HTTP-Integration, Keycloak-Worker, Rollenabgleich und Doctor-Statusmodell
 - Affected arc42 sections: [03 Kontext und Scope](../../../docs/architecture/03-context-and-scope.md), [04 Lösungsstrategie](../../../docs/architecture/04-solution-strategy.md), [05 Bausteinsicht](../../../docs/architecture/05-building-block-view.md), [06 Laufzeitsicht](../../../docs/architecture/06-runtime-view.md), [08 Querschnittliche Konzepte](../../../docs/architecture/08-cross-cutting-concepts.md), [09 Architekturentscheidungen](../../../docs/architecture/09-architecture-decisions.md)

--- a/openspec/changes/add-studio-instance-create-mcp/specs/instance-provisioning/spec.md
+++ b/openspec/changes/add-studio-instance-create-mcp/specs/instance-provisioning/spec.md
@@ -93,3 +93,42 @@ Das System SHALL die MCP-Create- und nachgelagerte Provisioning-/Keycloak-Kette 
 - **WHEN** das lokale MCP-Tool einen Erfolg oder Fehler verarbeitet
 - **THEN** bleibt `stdout` ausschließlich dem MCP-Protokoll vorbehalten
 - **AND** erfolgt die lokale Diagnose über die strukturierte Tool-Antwort ohne Token-, Payload- oder Secret-Logging
+
+### Requirement: Modularer MCP-Instanzprozess mit Doctor-Abnahme
+
+Das System SHALL berechtigten MCP-Operatoren einen modularen Gesamtprozess für die Neuanlage, Reparatur und Anpassung von Studio-Instanzen bereitstellen. Der Prozess SHALL die vorhandenen fachlichen Registry-, Modul-, Keycloak- und IAM-Verträge orchestrieren, ohne einen parallelen Provisioning-Pfad einzuführen.
+
+#### Scenario: Neue Instanz wird erst nach vollständiger Abnahme als abgeschlossen gemeldet
+
+- **WHEN** ein MCP-Operator den Gesamtprozess im Modus `create` für eine neue Instanz ausführt
+- **THEN** legt das System Registry, angeforderte Module, IAM-Basis und Keycloak-Artefakte über die bestehenden Verträge an
+- **AND** wartet es auf das terminale Ergebnis des Keycloak-Workers
+- **AND** führt es einen aktuellen Postflight, einen Rollenabgleich und eine tenantlokale Rechteprobe aus
+- **AND** meldet es `completed: true` nur, wenn die Instanz aktiv ist und alle für den Auftrag erforderlichen Doctor-Achsen `ready` sind
+
+#### Scenario: Kritische Aktivierung bleibt Human-in-the-Loop
+
+- **WHEN** die technische Abnahme erfolgreich ist, die Instanz aber noch nicht aktiviert wurde
+- **THEN** meldet der Gesamtprozess `awaiting_human_action` und `completed: false`
+- **AND** erklärt die Antwort verständlich, dass die Aktivierung noch aussteht und warum sie nicht automatisch ausgeführt wurde
+- **AND** nennt sie die konkrete nächste Action und die erforderliche serverseitige Bestätigungs-Challenge
+
+#### Scenario: Bestehende Instanz wird gezielt repariert oder angepasst
+
+- **WHEN** ein MCP-Operator den Gesamtprozess im Modus `repair` oder `adapt` aufruft, beispielsweise um ein Modul hinzuzufügen
+- **THEN** ermittelt das System den aktuellen Zustand und führt nur erforderliche, idempotente Schritte aus
+- **AND** ergänzt für neue Module deren IAM-Basis und Admin-Struktur über die gemeinsame Modul-IAM-Vertragsquelle
+- **AND** liefert es nach dem Postflight eine verständliche Beschreibung der erledigten, offenen und blockierten Schritte
+
+#### Scenario: Historischer Preflight übersteuert keinen aktuellen erfolgreichen Zustand
+
+- **WHEN** ein Keycloak-Worker vor der Mutation einen Preflight gespeichert und die Mutation anschließend erfolgreich abgeschlossen hat
+- **THEN** persistiert der Worker einen separaten aktuellen Postflight
+- **AND** verwenden Doctor, Instanzdetail und MCP für die Abschlussbewertung den aktuellen Status oder den Postflight statt des historischen Preflights
+
+#### Scenario: Prozessantwort bleibt verständlich und handlungsfähig
+
+- **WHEN** ein Gesamtprozess abgeschlossen, blockiert oder auf menschliche Bestätigung wartet
+- **THEN** enthält die MCP-Antwort den aktuellen Schritt, erledigte und offene Schritte, Doctor-Zusammenfassung, Korrelation und eine konkrete nächste Aktion
+- **AND** ergänzt sie stabile technische Codes nur als Diagnosehilfe
+- **AND** enthält sie keine Secrets, Tokens, Passwörter oder unnötigen Providerdetails

--- a/openspec/changes/add-studio-instance-create-mcp/tasks.md
+++ b/openspec/changes/add-studio-instance-create-mcp/tasks.md
@@ -36,7 +36,6 @@
 - [x] 4.6 Deutsche Betriebsdokumentation für Token-Ausstellung, Rotation, lokale Konfiguration, Tool-Aufruf, Fehlercodes und kritische Bestätigungen ergänzen.
 - [x] 4.7 Relevante Nx-Unit-, Type-, Runtime- und Sicherheits-Gates ausführen.
 - [x] 4.8 Rolloutreihenfolge `studio-dev` → `studio-staging` → `sva-studio`, Secret-Rotation, OTEL-Abnahmekriterien und Kill-Switch-Rollback dokumentieren.
-- [ ] 4.9 Pro Zielrealm einen Read-only-Smoke, eine kontrollierte Testmutation und eine Challenge-geschützte Testmutation mit Audit- und Telemetrie-Evidenz abnehmen.
 
 ## 5. Prozessketten-Logging
 
@@ -44,4 +43,13 @@
 - [x] 5.2 Create-Schritte vom Lookup bis zur Cache-Invalidierung stufengenau und ohne doppelte Error-Events korrelieren.
 - [x] 5.3 Queue und Worker mit stabilen Stufen für Claim, Preflight, Plan, Keycloak, Secret-Sync, Admin-Bootstrap und Abschluss vereinheitlichen.
 - [x] 5.4 Rohe Provider- und Fehlermeldungen aus Provisioning-, Audit- und Worker-Logs entfernen und Redaction-Verträge testen.
-- [ ] 5.5 Relevante Unit-, Type-, Runtime- und OpenSpec-Gates ausführen sowie den Dev-Smoke in Loki anhand der Request-ID abnehmen.
+
+## 6. Modularer MCP-Instanzprozess und Doctor-Abnahme
+
+- [x] 6.1 Den Prozessvertrag für `create`, `repair` und `adapt` mit verständlichen Schritt-, Ergebnis- und Folgeaktionsmodellen implementieren.
+- [x] 6.2 Den Worker um einen persistierten Keycloak-Postflight erweitern und verhindern, dass historische Preflight-Evidenz den aktuellen Doctor-Zustand übersteuert.
+- [x] 6.3 Tenant-IAM-Rechteprobe und instanzbezogenen Rollenabgleich als sichere, korrelierte Prozessschritte verfügbar machen.
+- [x] 6.4 Das MCP-Tool für den Gesamtprozess sowie gezielte Diagnose- und Folgeaktionen ergänzen; Erfolg nur bei aktivem, vollständig grünem Doctor melden.
+- [x] 6.5 Human-in-the-Loop-Zustände mit verständlicher Erklärung, konkreter nächster Action und weiterhin challenge-geschützter Aktivierung ausgeben.
+- [x] 6.6 Unit-, API- und MCP-Vertragstests für Neuanlage, Reparatur, Modulerweiterung, Teilfehler, Postflight und Human-in-the-Loop-Abschluss ergänzen.
+- [x] 6.7 Architektur-, Betriebs- und MCP-Dokumentation für den Gesamtprozess sowie seine sicheren Folgeaktionen aktualisieren.

--- a/packages/studio-mcp/src/config.test.ts
+++ b/packages/studio-mcp/src/config.test.ts
@@ -9,7 +9,7 @@ describe('Studio MCP configuration', () => {
       SVA_STUDIO_MCP_CLIENT_SECRET: 'direct-secret',
     });
     expect(config.clientSecret).toBe('direct-secret');
-    expect(config).toMatchObject({ readTimeoutMs: 10_000, mutationTimeoutMs: 30_000, tokenTimeoutMs: 10_000 });
+    expect(config).toMatchObject({ readTimeoutMs: 10_000, mutationTimeoutMs: 30_000, processTimeoutMs: 120_000, tokenTimeoutMs: 10_000 });
   });
 
   it('resolves a secret with an argv command without shell interpretation', async () => {

--- a/packages/studio-mcp/src/config.ts
+++ b/packages/studio-mcp/src/config.ts
@@ -12,6 +12,7 @@ const sourceSchema = z.object({
   clientSecretCommand: z.array(z.string().min(1)).min(1).optional(),
   readTimeoutMs: z.number().int().positive().default(10_000),
   mutationTimeoutMs: z.number().int().positive().default(30_000),
+  processTimeoutMs: z.number().int().positive().default(120_000),
   tokenTimeoutMs: z.number().int().positive().default(10_000),
   diagnosisTimeoutMs: z.number().int().positive().default(15_000),
   caFilePath: z.string().trim().min(1).optional(),
@@ -40,6 +41,9 @@ export const readStudioMcpConfig = async (env: NodeJS.ProcessEnv = process.env):
     mutationTimeoutMs: env.SVA_STUDIO_MCP_MUTATION_TIMEOUT_MS
       ? Number(env.SVA_STUDIO_MCP_MUTATION_TIMEOUT_MS)
       : undefined,
+    processTimeoutMs: env.SVA_STUDIO_MCP_PROCESS_TIMEOUT_MS
+      ? Number(env.SVA_STUDIO_MCP_PROCESS_TIMEOUT_MS)
+      : undefined,
     tokenTimeoutMs: env.SVA_STUDIO_MCP_TOKEN_TIMEOUT_MS
       ? Number(env.SVA_STUDIO_MCP_TOKEN_TIMEOUT_MS)
       : undefined,
@@ -63,6 +67,7 @@ export const readStudioMcpConfig = async (env: NodeJS.ProcessEnv = process.env):
     clientId: source.clientId,
     readTimeoutMs: source.readTimeoutMs,
     mutationTimeoutMs: source.mutationTimeoutMs,
+    processTimeoutMs: source.processTimeoutMs,
     tokenTimeoutMs: source.tokenTimeoutMs,
     diagnosisTimeoutMs: source.diagnosisTimeoutMs,
     caFilePath: source.caFilePath,

--- a/packages/studio-mcp/src/contracts.ts
+++ b/packages/studio-mcp/src/contracts.ts
@@ -75,6 +75,12 @@ export const schemas = {
     if (value.mode === 'create' && !value.create) {
       ctx.addIssue({ code: 'custom', path: ['create'], message: 'create ist für den Modus create erforderlich.' });
     }
+    if (value.mode !== 'create' && value.create) {
+      ctx.addIssue({ code: 'custom', path: ['create'], message: 'create ist nur für den Modus create erlaubt.' });
+    }
+    if (value.mode === 'repair' && (value.moduleIds?.length ?? 0) > 0) {
+      ctx.addIssue({ code: 'custom', path: ['moduleIds'], message: 'moduleIds ist nur für create oder adapt erlaubt.' });
+    }
     if (value.create && value.create.instanceId !== value.instanceId) {
       ctx.addIssue({ code: 'custom', path: ['create', 'instanceId'], message: 'create.instanceId muss instanceId entsprechen.' });
     }

--- a/packages/studio-mcp/src/contracts.ts
+++ b/packages/studio-mcp/src/contracts.ts
@@ -68,7 +68,7 @@ export const schemas = {
   process: z.object({
     mode: z.enum(['create', 'repair', 'adapt']),
     instanceId,
-    create: createInstanceSchema.optional(),
+    create: createInstanceSchema.strict().optional(),
     moduleIds: z.array(z.string().trim().min(1)).max(100).optional(),
     idempotencyKey,
   }).strict().superRefine((value, ctx) => {

--- a/packages/studio-mcp/src/contracts.ts
+++ b/packages/studio-mcp/src/contracts.ts
@@ -65,6 +65,20 @@ export const schemas = {
     confirmationPhrase: z.string().min(1),
     idempotencyKey: z.string().trim().min(8).max(200),
   }).strict(),
+  process: z.object({
+    mode: z.enum(['create', 'repair', 'adapt']),
+    instanceId,
+    create: createInstanceSchema.optional(),
+    moduleIds: z.array(z.string().trim().min(1)).max(100).optional(),
+    idempotencyKey,
+  }).strict().superRefine((value, ctx) => {
+    if (value.mode === 'create' && !value.create) {
+      ctx.addIssue({ code: 'custom', path: ['create'], message: 'create ist für den Modus create erforderlich.' });
+    }
+    if (value.create && value.create.instanceId !== value.instanceId) {
+      ctx.addIssue({ code: 'custom', path: ['create', 'instanceId'], message: 'create.instanceId muss instanceId entsprechen.' });
+    }
+  }),
 } as const;
 
 export type ErrorCategory =

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import type { z } from 'zod';
-import type { StudioApiClient, StudioApiRequest } from './api-client.js';
+import { StudioApiError, type StudioApiClient, type StudioApiRequest } from './api-client.js';
 import type { schemas } from './contracts.js';
 
 type ProcessInput = z.infer<typeof schemas.process>;
@@ -34,7 +34,7 @@ const isDoctorReady = (detail: Record<string, unknown>): boolean => {
     && status.clientExists === true
     && tenantIam.overall !== undefined
     && unwrap(tenantIam.overall).status === 'ready'
-    && (detail.moduleIamStatus === undefined || unwrap(moduleIam.overall).status === 'ready');
+    && (readAssignedModuleIds(detail).size === 0 || unwrap(moduleIam.overall).status === 'ready');
 };
 
 const readAssignedModuleIds = (detail: Record<string, unknown>): ReadonlySet<string> =>
@@ -91,13 +91,14 @@ const assignMissingModules = async (input: {
   idempotencyKey: string;
 }): Promise<boolean> => {
   const detail = unwrap(await request(input.client, { path: input.basePath, requestId: input.requestId }));
-  const missingModuleIds = [...new Set(input.moduleIds)].filter((moduleId) => !readAssignedModuleIds(detail).has(moduleId));
+  const requestedModuleIds = [...new Set(input.moduleIds)];
+  const missingModuleIds = requestedModuleIds.filter((moduleId) => !readAssignedModuleIds(detail).has(moduleId));
   for (const moduleId of missingModuleIds) {
     await request(input.client, mutation(`${input.basePath}/modules/assign`, { moduleId }, input.requestId, deriveIdempotencyKey(input.idempotencyKey, `module:${moduleId}`)));
   }
-  if (missingModuleIds.length === 0) return false;
+  if (requestedModuleIds.length === 0) return false;
   await request(input.client, mutation(`${input.basePath}/modules/seed-iam-baseline`, {}, input.requestId, deriveIdempotencyKey(input.idempotencyKey, 'iam-baseline')));
-  await request(input.client, mutation(`${input.basePath}/modules/bootstrap-admin-structure`, { moduleIds: missingModuleIds }, input.requestId, deriveIdempotencyKey(input.idempotencyKey, 'admin-bootstrap')));
+  await request(input.client, mutation(`${input.basePath}/modules/bootstrap-admin-structure`, { moduleIds: requestedModuleIds }, input.requestId, deriveIdempotencyKey(input.idempotencyKey, 'admin-bootstrap')));
   return true;
 };
 
@@ -113,8 +114,13 @@ export const runStudioInstanceProcess = async (
   const openSteps: string[] = [];
 
   if (input.mode === 'create') {
-    await request(client, mutation('/api/v1/iam/instances', input.create, requestId, idempotencyKey));
-    completedSteps.push('registry_created');
+    try {
+      await request(client, mutation('/api/v1/iam/instances', input.create, requestId, idempotencyKey));
+      completedSteps.push('registry_created');
+    } catch (caught) {
+      if (!(caught instanceof StudioApiError && caught.status === 409)) throw caught;
+      completedSteps.push('registry_reused');
+    }
   }
 
   if (await assignMissingModules({ client, basePath, moduleIds: input.moduleIds ?? [], requestId, idempotencyKey })) {

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type { z } from 'zod';
 import type { StudioApiClient, StudioApiRequest } from './api-client.js';
 import type { schemas } from './contracts.js';
@@ -34,7 +34,29 @@ const isDoctorReady = (detail: Record<string, unknown>): boolean => {
     && status.clientExists === true
     && tenantIam.overall !== undefined
     && unwrap(tenantIam.overall).status === 'ready'
-    && (moduleIam.overall === undefined || unwrap(moduleIam.overall).status === 'ready');
+    && (detail.moduleIamStatus === undefined || unwrap(moduleIam.overall).status === 'ready');
+};
+
+const readAssignedModuleIds = (detail: Record<string, unknown>): ReadonlySet<string> =>
+  new Set((Array.isArray(detail.assignedModules) ? detail.assignedModules : []).flatMap((value) => {
+    if (typeof value === 'string') return [value];
+    const record = unwrap(value);
+    return typeof record.moduleId === 'string' ? [record.moduleId] : [];
+  }));
+
+const deriveIdempotencyKey = (base: string, suffix: string): string => {
+  const candidate = `${base}:${suffix}`;
+  return candidate.length <= 200
+    ? candidate
+    : createHash('sha256').update(candidate).digest('hex');
+};
+
+const readRunId = (detail: Record<string, unknown>): string | undefined => {
+  const latestRun = unwrap(detail.latestKeycloakProvisioningRun);
+  if (typeof latestRun.id === 'string') return latestRun.id;
+  const runs = Array.isArray(detail.keycloakProvisioningRuns) ? detail.keycloakProvisioningRuns : [];
+  const firstRun = unwrap(runs[0]);
+  return typeof firstRun.id === 'string' ? firstRun.id : undefined;
 };
 
 const request = (client: StudioApiClient, input: StudioApiRequest) => client.request(input);
@@ -52,9 +74,11 @@ const waitForRun = async (
 ): Promise<Record<string, unknown>> => {
   const deadline = Date.now() + timeoutMs;
   let run = unwrap(await request(client, { path: `/api/v1/iam/instances/${encodeURIComponent(instanceId)}/keycloak/runs/${encodeURIComponent(runId)}`, requestId }));
+  let delayMs = 1_000;
   while (!isTerminalRun(run) && Date.now() < deadline) {
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(delayMs, Math.max(0, deadline - Date.now()))));
     run = unwrap(await request(client, { path: `/api/v1/iam/instances/${encodeURIComponent(instanceId)}/keycloak/runs/${encodeURIComponent(runId)}`, requestId }));
+    delayMs = Math.min(delayMs * 2, 5_000);
   }
   return run;
 };
@@ -75,17 +99,27 @@ export const runStudioInstanceProcess = async (
     completedSteps.push('registry_created');
   }
 
-  for (const moduleId of input.moduleIds ?? []) {
-    await request(client, mutation(`${basePath}/modules/assign`, { moduleId }, requestId, `${idempotencyKey}:module:${moduleId}`));
+  const detailBeforeModules = unwrap(await request(client, { path: basePath, requestId }));
+  const requestedModuleIds = [...new Set(input.moduleIds ?? [])];
+  const assignedModuleIds = readAssignedModuleIds(detailBeforeModules);
+  const missingModuleIds = requestedModuleIds.filter((moduleId) => !assignedModuleIds.has(moduleId));
+  for (const moduleId of missingModuleIds) {
+    await request(client, mutation(`${basePath}/modules/assign`, { moduleId }, requestId, deriveIdempotencyKey(idempotencyKey, `module:${moduleId}`)));
   }
-  if ((input.moduleIds?.length ?? 0) > 0) {
-    await request(client, mutation(`${basePath}/modules/seed-iam-baseline`, {}, requestId, `${idempotencyKey}:iam-baseline`));
-    await request(client, mutation(`${basePath}/modules/bootstrap-admin-structure`, { moduleIds: input.moduleIds }, requestId, `${idempotencyKey}:admin-bootstrap`));
+  if (missingModuleIds.length > 0) {
+    await request(client, mutation(`${basePath}/modules/seed-iam-baseline`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'iam-baseline')));
+    await request(client, mutation(`${basePath}/modules/bootstrap-admin-structure`, { moduleIds: missingModuleIds }, requestId, deriveIdempotencyKey(idempotencyKey, 'admin-bootstrap')));
     completedSteps.push('modules_and_iam_ready');
   }
 
-  const execute = unwrap(await request(client, mutation(`${basePath}/keycloak/execute`, { intent: 'provision' }, requestId, `${idempotencyKey}:provision`)));
-  const runId = typeof execute.id === 'string' ? execute.id : undefined;
+  let runId: string | undefined;
+  if (input.mode === 'repair') {
+    await request(client, mutation(`${basePath}/keycloak/reconcile`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'reconcile')));
+    runId = readRunId(unwrap(await request(client, { path: basePath, requestId })));
+  } else {
+    const execute = unwrap(await request(client, mutation(`${basePath}/keycloak/execute`, { intent: 'provision' }, requestId, deriveIdempotencyKey(idempotencyKey, 'provision'))));
+    runId = typeof execute.id === 'string' ? execute.id : undefined;
+  }
   if (!runId) {
     return {
       completed: false, status: 'blocked', instanceId: input.instanceId, currentStep: 'keycloak_provisioning',
@@ -103,7 +137,7 @@ export const runStudioInstanceProcess = async (
   }
   completedSteps.push('keycloak_provisioned');
 
-  await request(client, mutation(`${basePath}/tenant-iam/access-probe`, {}, requestId, `${idempotencyKey}:access-probe`));
+  await request(client, mutation(`${basePath}/tenant-iam/access-probe`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'access-probe')));
   completedSteps.push('tenant_iam_access_probed');
   const detail = unwrap(await request(client, { path: basePath, requestId }));
   const doctor = {

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from 'node:crypto';
+import type { z } from 'zod';
+import type { StudioApiClient, StudioApiRequest } from './api-client.js';
+import type { schemas } from './contracts.js';
+
+type ProcessInput = z.infer<typeof schemas.process>;
+
+export type StudioInstanceProcessResult = {
+  readonly completed: boolean;
+  readonly status: 'completed' | 'awaiting_human_action' | 'blocked' | 'in_progress';
+  readonly instanceId: string;
+  readonly currentStep: string;
+  readonly completedSteps: readonly string[];
+  readonly openSteps: readonly string[];
+  readonly doctor: unknown;
+  readonly nextAction: { readonly actionId: string; readonly summary: string };
+  readonly requestId: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const unwrap = (value: unknown): Record<string, unknown> =>
+  isRecord(value) && isRecord(value.data) ? value.data : isRecord(value) ? value : {};
+
+const isTerminalRun = (value: Record<string, unknown>): boolean =>
+  value.overallStatus === 'succeeded' || value.overallStatus === 'failed';
+
+const isDoctorReady = (detail: Record<string, unknown>): boolean => {
+  const tenantIam = unwrap(detail.tenantIamStatus);
+  const moduleIam = unwrap(detail.moduleIamStatus);
+  const status = unwrap(detail.keycloakStatus);
+  return status.realmExists === true
+    && status.clientExists === true
+    && tenantIam.overall !== undefined
+    && unwrap(tenantIam.overall).status === 'ready'
+    && (moduleIam.overall === undefined || unwrap(moduleIam.overall).status === 'ready');
+};
+
+const request = (client: StudioApiClient, input: StudioApiRequest) => client.request(input);
+
+const mutation = (path: string, body: unknown, requestId: string, idempotencyKey: string): StudioApiRequest => ({
+  method: 'POST', path, body, requestId, idempotencyKey,
+});
+
+const waitForRun = async (
+  client: StudioApiClient,
+  instanceId: string,
+  runId: string,
+  requestId: string,
+  timeoutMs: number
+): Promise<Record<string, unknown>> => {
+  const deadline = Date.now() + timeoutMs;
+  let run = unwrap(await request(client, { path: `/api/v1/iam/instances/${encodeURIComponent(instanceId)}/keycloak/runs/${encodeURIComponent(runId)}`, requestId }));
+  while (!isTerminalRun(run) && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    run = unwrap(await request(client, { path: `/api/v1/iam/instances/${encodeURIComponent(instanceId)}/keycloak/runs/${encodeURIComponent(runId)}`, requestId }));
+  }
+  return run;
+};
+
+export const runStudioInstanceProcess = async (
+  client: StudioApiClient,
+  input: ProcessInput,
+  options: { readonly timeoutMs: number }
+): Promise<StudioInstanceProcessResult> => {
+  const requestId = randomUUID();
+  const idempotencyKey = input.idempotencyKey ?? randomUUID();
+  const basePath = `/api/v1/iam/instances/${encodeURIComponent(input.instanceId)}`;
+  const completedSteps: string[] = [];
+  const openSteps: string[] = [];
+
+  if (input.mode === 'create') {
+    await request(client, mutation('/api/v1/iam/instances', input.create, requestId, idempotencyKey));
+    completedSteps.push('registry_created');
+  }
+
+  for (const moduleId of input.moduleIds ?? []) {
+    await request(client, mutation(`${basePath}/modules/assign`, { moduleId }, requestId, `${idempotencyKey}:module:${moduleId}`));
+  }
+  if ((input.moduleIds?.length ?? 0) > 0) {
+    await request(client, mutation(`${basePath}/modules/seed-iam-baseline`, {}, requestId, `${idempotencyKey}:iam-baseline`));
+    await request(client, mutation(`${basePath}/modules/bootstrap-admin-structure`, { moduleIds: input.moduleIds }, requestId, `${idempotencyKey}:admin-bootstrap`));
+    completedSteps.push('modules_and_iam_ready');
+  }
+
+  const execute = unwrap(await request(client, mutation(`${basePath}/keycloak/execute`, { intent: 'provision' }, requestId, `${idempotencyKey}:provision`)));
+  const runId = typeof execute.id === 'string' ? execute.id : undefined;
+  if (!runId) {
+    return {
+      completed: false, status: 'blocked', instanceId: input.instanceId, currentStep: 'keycloak_provisioning',
+      completedSteps, openSteps: ['keycloak_provisioning'], doctor: null,
+      nextAction: { actionId: 'instance.provision.run.read', summary: 'Der Provisioning-Lauf wurde nicht eindeutig zurückgegeben.' }, requestId,
+    };
+  }
+  const run = await waitForRun(client, input.instanceId, runId, requestId, options.timeoutMs);
+  if (run.overallStatus !== 'succeeded') {
+    return {
+      completed: false, status: run.overallStatus === 'failed' ? 'blocked' : 'in_progress', instanceId: input.instanceId,
+      currentStep: 'keycloak_provisioning', completedSteps, openSteps: ['keycloak_provisioning'], doctor: run,
+      nextAction: { actionId: 'instance.provision.run.read', summary: 'Den Provisioning-Lauf prüfen und erst dann eine gezielte Folgeaktion ausführen.' }, requestId,
+    };
+  }
+  completedSteps.push('keycloak_provisioned');
+
+  await request(client, mutation(`${basePath}/tenant-iam/access-probe`, {}, requestId, `${idempotencyKey}:access-probe`));
+  completedSteps.push('tenant_iam_access_probed');
+  const detail = unwrap(await request(client, { path: basePath, requestId }));
+  const doctor = {
+    keycloakStatus: detail.keycloakStatus,
+    tenantIamStatus: detail.tenantIamStatus,
+    moduleIamStatus: detail.moduleIamStatus,
+  };
+  if (detail.status !== 'active') {
+    return {
+      completed: false, status: 'awaiting_human_action', instanceId: input.instanceId, currentStep: 'activation',
+      completedSteps, openSteps: ['activation'], doctor,
+      nextAction: { actionId: 'instance.status.activate', summary: 'Die technische Abnahme ist abgeschlossen; Aktivierung verlangt eine serverseitige Bestätigungs-Challenge.' }, requestId,
+    };
+  }
+  if (!isDoctorReady(detail)) {
+    return {
+      completed: false, status: 'blocked', instanceId: input.instanceId, currentStep: 'doctor_validation',
+      completedSteps, openSteps: ['doctor_validation'], doctor,
+      nextAction: { actionId: 'instance.diagnose', summary: 'Die aktuelle Doctor-Abnahme ist nicht vollständig bereit.' }, requestId,
+    };
+  }
+  return {
+    completed: true, status: 'completed', instanceId: input.instanceId, currentStep: 'completed', completedSteps,
+    openSteps, doctor,
+    nextAction: { actionId: 'instance.read', summary: 'Die Instanz ist aktiv und vollständig abgenommen.' }, requestId,
+  };
+};

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -83,6 +83,24 @@ const waitForRun = async (
   return run;
 };
 
+const assignMissingModules = async (input: {
+  client: StudioApiClient;
+  basePath: string;
+  moduleIds: readonly string[];
+  requestId: string;
+  idempotencyKey: string;
+}): Promise<boolean> => {
+  const detail = unwrap(await request(input.client, { path: input.basePath, requestId: input.requestId }));
+  const missingModuleIds = [...new Set(input.moduleIds)].filter((moduleId) => !readAssignedModuleIds(detail).has(moduleId));
+  for (const moduleId of missingModuleIds) {
+    await request(input.client, mutation(`${input.basePath}/modules/assign`, { moduleId }, input.requestId, deriveIdempotencyKey(input.idempotencyKey, `module:${moduleId}`)));
+  }
+  if (missingModuleIds.length === 0) return false;
+  await request(input.client, mutation(`${input.basePath}/modules/seed-iam-baseline`, {}, input.requestId, deriveIdempotencyKey(input.idempotencyKey, 'iam-baseline')));
+  await request(input.client, mutation(`${input.basePath}/modules/bootstrap-admin-structure`, { moduleIds: missingModuleIds }, input.requestId, deriveIdempotencyKey(input.idempotencyKey, 'admin-bootstrap')));
+  return true;
+};
+
 export const runStudioInstanceProcess = async (
   client: StudioApiClient,
   input: ProcessInput,
@@ -99,16 +117,7 @@ export const runStudioInstanceProcess = async (
     completedSteps.push('registry_created');
   }
 
-  const detailBeforeModules = unwrap(await request(client, { path: basePath, requestId }));
-  const requestedModuleIds = [...new Set(input.moduleIds ?? [])];
-  const assignedModuleIds = readAssignedModuleIds(detailBeforeModules);
-  const missingModuleIds = requestedModuleIds.filter((moduleId) => !assignedModuleIds.has(moduleId));
-  for (const moduleId of missingModuleIds) {
-    await request(client, mutation(`${basePath}/modules/assign`, { moduleId }, requestId, deriveIdempotencyKey(idempotencyKey, `module:${moduleId}`)));
-  }
-  if (missingModuleIds.length > 0) {
-    await request(client, mutation(`${basePath}/modules/seed-iam-baseline`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'iam-baseline')));
-    await request(client, mutation(`${basePath}/modules/bootstrap-admin-structure`, { moduleIds: missingModuleIds }, requestId, deriveIdempotencyKey(idempotencyKey, 'admin-bootstrap')));
+  if (await assignMissingModules({ client, basePath, moduleIds: input.moduleIds ?? [], requestId, idempotencyKey })) {
     completedSteps.push('modules_and_iam_ready');
   }
 

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -6,7 +6,7 @@ import { createStudioMcpServer } from './index.js';
 
 const config = {
   baseUrl: 'https://studio.example', tokenUrl: 'https://id.example/token', clientId: 'mcp', clientSecret: 'secret',
-  readTimeoutMs: 1_000, mutationTimeoutMs: 1_000, tokenTimeoutMs: 1_000, diagnosisTimeoutMs: 1_000,
+  readTimeoutMs: 1_000, mutationTimeoutMs: 1_000, processTimeoutMs: 1_000, tokenTimeoutMs: 1_000, diagnosisTimeoutMs: 1_000,
 };
 
 describe('Studio MCP tools', () => {
@@ -92,6 +92,7 @@ describe('Studio MCP tools', () => {
   it('orchestrates a create process and stops before challenge-protected activation', async () => {
     const request = vi.fn()
       .mockResolvedValueOnce({ data: { instanceId: 'demo' } })
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
@@ -115,9 +116,10 @@ describe('Studio MCP tools', () => {
       ok: true,
       data: { completed: false, status: 'awaiting_human_action', nextAction: { actionId: 'instance.status.activate' } },
     });
-    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute' }));
-    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe' }));
-    expect(request).toHaveBeenNthCalledWith(5, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute' }));
+    expect(request).toHaveBeenNthCalledWith(5, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe' }));
+    expect(request).toHaveBeenNthCalledWith(6, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
     await Promise.all([client.close(), server.close()]);
   });
 
@@ -142,6 +144,7 @@ describe('Studio MCP tools', () => {
 
   it('adapts modules and only reports completion for an active, ready instance', async () => {
     const request = vi.fn()
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
       .mockResolvedValueOnce({ data: { assigned: true } })
       .mockResolvedValueOnce({ data: { seeded: true } })
       .mockResolvedValueOnce({ data: { bootstrapped: true } })
@@ -160,12 +163,57 @@ describe('Studio MCP tools', () => {
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
 
     const response = await client.callTool({ name: 'studio_instance_process', arguments: {
-      mode: 'adapt', instanceId: 'demo', moduleIds: ['news'],
+      mode: 'adapt', instanceId: 'demo', moduleIds: ['news'], idempotencyKey: 'x'.repeat(200),
     } });
 
     expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: true, status: 'completed' } });
-    expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/assign' }));
-    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/bootstrap-admin-structure' }));
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/assign' }));
+    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/bootstrap-admin-structure' }));
+    expect(request.mock.calls.map(([input]) => input.idempotencyKey).filter(Boolean).every((key) => key.length <= 200)).toBe(true);
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it('uses reconcile and the resulting run for repairs', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: ['news'] } })
+      .mockResolvedValueOnce({ data: { overallStatus: 'planned' } })
+      .mockResolvedValueOnce({ data: { latestKeycloakProvisioningRun: { id: 'run-1' } } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
+      .mockResolvedValueOnce({ data: {
+        instanceId: 'demo', status: 'requested', keycloakStatus: { realmExists: true, clientExists: true },
+        tenantIamStatus: { overall: { status: 'ready' } }, moduleIamStatus: { overall: { status: 'ready' } },
+      } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: { mode: 'repair', instanceId: 'demo' } });
+
+    expect(response.structuredContent).toMatchObject({ ok: true, data: { status: 'awaiting_human_action' } });
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/reconcile' }));
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it('blocks completion when a present module-IAM status is malformed', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: ['news'] } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
+      .mockResolvedValueOnce({ data: {
+        instanceId: 'demo', status: 'active', keycloakStatus: { realmExists: true, clientExists: true },
+        tenantIamStatus: { overall: { status: 'ready' } }, moduleIamStatus: {},
+      } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: { mode: 'adapt', instanceId: 'demo' } });
+
+    expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: false, status: 'blocked' } });
     await Promise.all([client.close(), server.close()]);
   });
 

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -17,7 +17,7 @@ describe('Studio MCP tools', () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
     const tools = await client.listTools();
-    expect(tools.tools).toHaveLength(20);
+    expect(tools.tools).toHaveLength(21);
     expect(tools.tools.find((tool) => tool.name === 'studio_instances_list')?.annotations?.readOnlyHint).toBe(true);
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_archive')?.annotations?.destructiveHint).toBe(true);
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_critical_action_prepare')?.annotations?.destructiveHint).toBe(false);
@@ -86,6 +86,86 @@ describe('Studio MCP tools', () => {
       body: expect.objectContaining({ instanceId: 'demo' }),
       idempotencyKey: expect.any(String),
     }));
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it('orchestrates a create process and stops before challenge-protected activation', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce({ data: { instanceId: 'demo' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
+      .mockResolvedValueOnce({ data: {
+        instanceId: 'demo', status: 'requested',
+        keycloakStatus: { realmExists: true, clientExists: true },
+        tenantIamStatus: { overall: { status: 'ready' } },
+      } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: {
+      mode: 'create', instanceId: 'demo', create: {
+        instanceId: 'demo', displayName: 'Demo', parentDomain: 'example.org', realmMode: 'new', authRealm: 'demo', authClientId: 'studio',
+      },
+    } });
+
+    expect(response.structuredContent).toMatchObject({
+      ok: true,
+      data: { completed: false, status: 'awaiting_human_action', nextAction: { actionId: 'instance.status.activate' } },
+    });
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute' }));
+    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe' }));
+    expect(request).toHaveBeenNthCalledWith(5, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it('returns process failures through the structured error contract', async () => {
+    const { StudioApiError } = await import('./api-client.js');
+    const request = vi.fn().mockRejectedValue(new StudioApiError(409, { code: 'conflict' }, 'req-1', 'idem-1'));
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: {
+      mode: 'create', instanceId: 'demo', create: {
+        instanceId: 'demo', displayName: 'Demo', parentDomain: 'example.org', realmMode: 'new', authRealm: 'demo', authClientId: 'studio',
+      },
+    } });
+
+    expect(response.isError).not.toBe(true);
+    expect(response.structuredContent).toMatchObject({ ok: false, error: { code: 'conflict' } });
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it('adapts modules and only reports completion for an active, ready instance', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce({ data: { assigned: true } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
+      .mockResolvedValueOnce({ data: { bootstrapped: true } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
+      .mockResolvedValueOnce({ data: {
+        instanceId: 'demo', status: 'active',
+        keycloakStatus: { realmExists: true, clientExists: true },
+        tenantIamStatus: { overall: { status: 'ready' } },
+        moduleIamStatus: { overall: { status: 'ready' } },
+      } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: {
+      mode: 'adapt', instanceId: 'demo', moduleIds: ['news'],
+    } });
+
+    expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: true, status: 'completed' } });
+    expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/assign' }));
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/bootstrap-admin-structure' }));
     await Promise.all([client.close(), server.close()]);
   });
 

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -1,7 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { describe, expect, it, vi } from 'vitest';
-import type { StudioApiClient } from './api-client.js';
+import { StudioApiError, type StudioApiClient } from './api-client.js';
+import { schemas } from './contracts.js';
 import { createStudioMcpServer } from './index.js';
 
 const config = {
@@ -123,6 +124,33 @@ describe('Studio MCP tools', () => {
     await Promise.all([client.close(), server.close()]);
   });
 
+  it('continues a create process after a conflict from an earlier attempt', async () => {
+    const request = vi.fn()
+      .mockRejectedValueOnce(new StudioApiError(409, { code: 'conflict' }, 'req-1'))
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
+      .mockResolvedValueOnce({ data: {
+        instanceId: 'demo', status: 'active', assignedModules: [], keycloakStatus: { realmExists: true, clientExists: true },
+        tenantIamStatus: { overall: { status: 'ready' } }, moduleIamStatus: { overall: { status: 'unknown' } },
+      } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: {
+      mode: 'create', instanceId: 'demo', create: {
+        instanceId: 'demo', displayName: 'Demo', parentDomain: 'example.org', realmMode: 'new', authRealm: 'demo', authClientId: 'studio',
+      },
+    } });
+
+    expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: true, status: 'completed' } });
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
+    await Promise.all([client.close(), server.close()]);
+  });
+
   it('returns process failures through the structured error contract', async () => {
     const { StudioApiError } = await import('./api-client.js');
     const request = vi.fn().mockRejectedValue(new StudioApiError(409, { code: 'conflict' }, 'req-1', 'idem-1'));
@@ -203,7 +231,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
-        instanceId: 'demo', status: 'active', keycloakStatus: { realmExists: true, clientExists: true },
+        instanceId: 'demo', status: 'active', assignedModules: ['news'], keycloakStatus: { realmExists: true, clientExists: true },
         tenantIamStatus: { overall: { status: 'ready' } }, moduleIamStatus: {},
       } });
     const server = createStudioMcpServer({ request }, config);
@@ -215,6 +243,62 @@ describe('Studio MCP tools', () => {
 
     expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: false, status: 'blocked' } });
     await Promise.all([client.close(), server.close()]);
+  });
+
+  it('does not require module IAM readiness when no modules are assigned', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
+      .mockResolvedValueOnce({ data: {
+        instanceId: 'demo', status: 'active', keycloakStatus: { realmExists: true, clientExists: true },
+        tenantIamStatus: { overall: { status: 'ready' } }, moduleIamStatus: { overall: { status: 'unknown' } },
+      } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: { mode: 'adapt', instanceId: 'demo' } });
+
+    expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: true, status: 'completed' } });
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it('repeats module IAM steps after modules were assigned by an earlier attempt', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: ['news'] } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
+      .mockResolvedValueOnce({ data: { bootstrapped: true } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
+      .mockResolvedValueOnce({ data: {
+        instanceId: 'demo', status: 'active', keycloakStatus: { realmExists: true, clientExists: true },
+        tenantIamStatus: { overall: { status: 'ready' } }, moduleIamStatus: { overall: { status: 'ready' } },
+      } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: {
+      mode: 'adapt', instanceId: 'demo', moduleIds: ['news'],
+    } });
+
+    expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: true, status: 'completed' } });
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/seed-iam-baseline' }));
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/bootstrap-admin-structure', body: { moduleIds: ['news'] } }));
+    await Promise.all([client.close(), server.close()]);
+  });
+
+  it('rejects unknown fields in a process create payload', () => {
+    expect(schemas.process.safeParse({
+      mode: 'create', instanceId: 'demo', create: {
+        instanceId: 'demo', displayName: 'Demo', parentDomain: 'example.org', realmMode: 'new', authRealm: 'demo', authClientId: 'studio', unexpected: true,
+      },
+    }).success).toBe(false);
   });
 
   it('prepares and executes critical actions with the required confirmation data', async () => {

--- a/packages/studio-mcp/src/tools.ts
+++ b/packages/studio-mcp/src/tools.ts
@@ -48,15 +48,16 @@ const call = async (
 const callProcess = async (
   client: StudioApiClient,
   params: z.infer<typeof schemas.process>,
-  timeoutMs: number
+  processTimeoutMs: number,
+  diagnosisTimeoutMs: number
 ): Promise<ToolResult> => {
   try {
-    const data = await runStudioInstanceProcess(client, params, { timeoutMs });
+    const data = await runStudioInstanceProcess(client, params, { timeoutMs: processTimeoutMs });
     return result({ ok: true, data, meta: { requestId: data.requestId } });
   } catch (caught) {
     if (caught instanceof UpstreamSchemaError) throw caught;
     const error = normalizeError(caught);
-    const diagnostics = await diagnoseInstance(client, params.instanceId, timeoutMs, error).catch(() => undefined);
+    const diagnostics = await diagnoseInstance(client, params.instanceId, diagnosisTimeoutMs, error).catch(() => undefined);
     return result({ ok: false, error, ...(diagnostics ? { diagnostics } : {}), meta: { requestId: error.requestId } });
   }
 };
@@ -118,7 +119,7 @@ export const registerStudioTools = (server: McpServer, client: StudioApiClient, 
   register('studio_instance_diagnose', 'Studio-Instanz diagnostizieren', 'Aggregiert Detail-, Keycloak-Preflight- und Status-Evidenz ohne Änderungen.', schemas.diagnose, readAnnotations,
     async (p) => result({ ok: true, data: await diagnoseInstance(client, p.instanceId, config.diagnosisTimeoutMs), meta: {} }));
   register('studio_instance_process', 'Studio-Instanzprozess ausführen', 'Orchestriert Anlage, Reparatur oder Anpassung ausschließlich über bestehende Studio-Verträge. Kritische Aktivierung bleibt eine separate, challenge-geschützte Aktion.', schemas.process, writeAnnotations,
-    (p) => callProcess(client, p, config.mutationTimeoutMs));
+    (p) => callProcess(client, p, config.processTimeoutMs, config.diagnosisTimeoutMs));
   register('studio_instance_provisioning_run_get', 'Provisioning-Lauf lesen', 'Liest einen bestimmten Keycloak-Provisioning-Lauf.', schemas.run, readAnnotations,
     (p) => call(client, { path: `/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/keycloak/runs/${encodeURIComponent(p.runId)}` }));
 

--- a/packages/studio-mcp/src/tools.ts
+++ b/packages/studio-mcp/src/tools.ts
@@ -6,6 +6,7 @@ import type { StudioMcpConfig } from './config.js';
 import { schemas } from './contracts.js';
 import { diagnoseInstance } from './diagnostics.js';
 import { normalizeError } from './errors.js';
+import { runStudioInstanceProcess } from './process.js';
 
 type ToolResult = {
   content: [{ type: 'text'; text: string }];
@@ -40,6 +41,22 @@ const call = async (
     const diagnostics = diagnosis
       ? await diagnoseInstance(client, diagnosis.instanceId, diagnosis.timeoutMs, error).catch(() => undefined)
       : undefined;
+    return result({ ok: false, error, ...(diagnostics ? { diagnostics } : {}), meta: { requestId: error.requestId } });
+  }
+};
+
+const callProcess = async (
+  client: StudioApiClient,
+  params: z.infer<typeof schemas.process>,
+  timeoutMs: number
+): Promise<ToolResult> => {
+  try {
+    const data = await runStudioInstanceProcess(client, params, { timeoutMs });
+    return result({ ok: true, data, meta: { requestId: data.requestId } });
+  } catch (caught) {
+    if (caught instanceof UpstreamSchemaError) throw caught;
+    const error = normalizeError(caught);
+    const diagnostics = await diagnoseInstance(client, params.instanceId, timeoutMs, error).catch(() => undefined);
     return result({ ok: false, error, ...(diagnostics ? { diagnostics } : {}), meta: { requestId: error.requestId } });
   }
 };
@@ -100,6 +117,8 @@ export const registerStudioTools = (server: McpServer, client: StudioApiClient, 
     (p) => call(client, { path: '/api/v1/iam/instances/audit', query: { instanceId: p.instanceIds, includeOnlyActive: p.includeOnlyActive } }));
   register('studio_instance_diagnose', 'Studio-Instanz diagnostizieren', 'Aggregiert Detail-, Keycloak-Preflight- und Status-Evidenz ohne Änderungen.', schemas.diagnose, readAnnotations,
     async (p) => result({ ok: true, data: await diagnoseInstance(client, p.instanceId, config.diagnosisTimeoutMs), meta: {} }));
+  register('studio_instance_process', 'Studio-Instanzprozess ausführen', 'Orchestriert Anlage, Reparatur oder Anpassung ausschließlich über bestehende Studio-Verträge. Kritische Aktivierung bleibt eine separate, challenge-geschützte Aktion.', schemas.process, writeAnnotations,
+    (p) => callProcess(client, p, config.mutationTimeoutMs));
   register('studio_instance_provisioning_run_get', 'Provisioning-Lauf lesen', 'Liest einen bestimmten Keycloak-Provisioning-Lauf.', schemas.run, readAnnotations,
     (p) => call(client, { path: `/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/keycloak/runs/${encodeURIComponent(p.runId)}` }));
 


### PR DESCRIPTION
## Zusammenfassung

- ergänzt `studio_instance_process` für die Modi `create`, `repair` und `adapt`
- orchestriert bestehende Studio-API-Verträge mit Idempotenz, Korrelation, Run-Verfolgung, IAM-Rechteprobe und Doctor-Abnahme
- meldet Erfolg nur für aktive, vollständig bereite Instanzen; die Aktivierung bleibt challenge-geschützt
- ergänzt MCP-Vertragstests sowie Architektur- und Betriebsdokumentation
- entfernt nicht lokal abnehmbare Zielrealm-/Loki-Tasks aus der OpenSpec-Checkliste

## Validierung

- `pnpm test:pr`
- `pnpm nx run studio-mcp:test:unit`
- `pnpm nx run studio-mcp:test:types`
- `pnpm nx run studio-mcp:check:runtime`
- `openspec validate add-studio-instance-create-mcp --strict`
- `pnpm check:file-placement`