### PR TITLE
fix(deploy): enable MCP in dev

### DIFF
--- a/deploy/compose.dev.yaml
+++ b/deploy/compose.dev.yaml
@@ -1,5 +1,10 @@
 services:
   app:
+    environment:
+      SVA_STUDIO_MCP_ENABLED: "true"
+      SVA_STUDIO_MCP_ISSUER: "https://keycloak.smart-village.app/realms/studio-dev"
+      SVA_STUDIO_MCP_AUDIENCE: "sva-studio-mcp"
+      SVA_STUDIO_MCP_CLIENT_ID: "sva-studio-mcp"
     image: ${IMAGE_REF:-ghcr.io/smart-village-solutions/sva-studio:${TAG:-latest}}
     networks:
       - network-node-005

--- a/docs/changelog/entries/pr-725.json
+++ b/docs/changelog/entries/pr-725.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 725,
+  "body": "Die Dev-Umgebung aktiviert den SVA-Studio-MCP jetzt verbindlich im versionierten Compose-Overlay. Der Service-Token-Pfad bleibt damit auch dann verfügbar, wenn die extern hinterlegte Laufzeitkonfiguration diese nicht geheimen MCP-Werte nicht enthält."
+}


### PR DESCRIPTION
## Änderung

Der versionierte Dev-Compose-Overlay setzt die MCP-Service-Token-Konfiguration für den App-Service verbindlich.

## Ursache

Der vorherige Dev-Rollout bezog diese Werte ausschließlich aus dem Environment-Secret `APP_CONFIG`; fehlende Werte führten zu `service_token_not_configured`.

## Validierung

- Compose-Renderprüfung mit dem Dev-Profil
- `scripts/ci/promote-deploy-gates.test.ts`
- `pnpm check:file-placement`