### PR TITLE
fix(ci): allow safe Dev MCP promote

### DIFF
--- a/docs/changelog/entries/pr-726.json
+++ b/docs/changelog/entries/pr-726.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 726,
+  "body": "Der automatische Dev-Promote erkennt die fest definierte MCP-Service-Token-Konfiguration jetzt als sicheren reinen App-Konfigurationswechsel. Andere Compose-, Migrations- oder Bootstrap-Änderungen bleiben weiterhin durch die bestehenden Gates geschützt."
+}

--- a/scripts/ci/promote-deploy-gates.test.ts
+++ b/scripts/ci/promote-deploy-gates.test.ts
@@ -11,7 +11,7 @@ import {
   formatRiskSummary,
   type DeployGateMode,
 } from './promote-deploy-gates.ts';
-import { isTraefikOnlyComposeDiff } from './traefik-compose-diff.ts';
+import { isDevMcpOnlyComposeDiff, isTraefikOnlyComposeDiff } from './traefik-compose-diff.ts';
 
 const temporaryDirectories: string[] = [];
 
@@ -109,6 +109,17 @@ describe('promote-deploy-gates', () => {
   it('recognizes only label-list changes as Traefik-only compose diffs', () => {
     expect(isTraefikOnlyComposeDiff("-        - 'traefik.http.routers.app.tls=true'\n+        - 'traefik.http.routers.app.tls.certresolver=default'\n")).toBe(true);
     expect(isTraefikOnlyComposeDiff('+  postgres:\n+    image: postgres:16-alpine\n')).toBe(false);
+  });
+
+  it('recognizes only the fixed Dev MCP service-token configuration as safe', () => {
+    expect(isDevMcpOnlyComposeDiff([
+      '+    environment:',
+      '+      SVA_STUDIO_MCP_ENABLED: "true"',
+      '+      SVA_STUDIO_MCP_ISSUER: "https://keycloak.smart-village.app/realms/studio-dev"',
+      '+      SVA_STUDIO_MCP_AUDIENCE: "sva-studio-mcp"',
+      '+      SVA_STUDIO_MCP_CLIENT_ID: "sva-studio-mcp"',
+    ].join('\n'))).toBe(true);
+    expect(isDevMcpOnlyComposeDiff('+      SVA_STUDIO_MCP_ENABLED: "false"')).toBe(false);
   });
 
   it('refuses run mode when no safe executor is configured', () => {

--- a/scripts/ci/traefik-compose-diff.ts
+++ b/scripts/ci/traefik-compose-diff.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
-export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
-  const changedLines = diff
+const changedComposeLines = (diff: string): string[] =>
+  diff
     .split('\n')
     .filter(
       (line) =>
@@ -10,7 +10,24 @@ export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
         !line.startsWith('---')
     );
 
+export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
+  const changedLines = changedComposeLines(diff);
+
   return changedLines.length > 0 && changedLines.every((line) => /^[-+]\s*-\s*['"]?traefik\./u.test(line));
+};
+
+const devMcpConfigurationLines = new Set([
+  '+    environment:',
+  '+      SVA_STUDIO_MCP_ENABLED: "true"',
+  '+      SVA_STUDIO_MCP_ISSUER: "https://keycloak.smart-village.app/realms/studio-dev"',
+  '+      SVA_STUDIO_MCP_AUDIENCE: "sva-studio-mcp"',
+  '+      SVA_STUDIO_MCP_CLIENT_ID: "sva-studio-mcp"',
+]);
+
+export const isDevMcpOnlyComposeDiff = (diff: string): boolean => {
+  const changedLines = changedComposeLines(diff);
+  return changedLines.length === devMcpConfigurationLines.size
+    && changedLines.every((line) => devMcpConfigurationLines.has(line));
 };
 
 export const resolveTraefikOnlyComposeFiles = (
@@ -21,9 +38,11 @@ export const resolveTraefikOnlyComposeFiles = (
   changedFiles.filter(
     (filePath) =>
       /^deploy\/compose\.(?:dev|staging|prod)\.yaml$/u.test(filePath) &&
-      isTraefikOnlyComposeDiff(
-        execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', filePath], {
+      (() => {
+        const diff = execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', filePath], {
           encoding: 'utf8',
-        })
-      )
+        });
+        return isTraefikOnlyComposeDiff(diff)
+          || (filePath === 'deploy/compose.dev.yaml' && isDevMcpOnlyComposeDiff(diff));
+      })()
   );


### PR DESCRIPTION
## Änderung

Der Promote-Gate erkennt ausschließlich die fest definierte Dev-MCP-Konfiguration als migrations- und bootstrapneutral.

## Warum

Der Dev-Compose-Overlay aktiviert den MCP-Service-Token-Pfad dauerhaft. Ohne diese eng begrenzte Ausnahme blockierte der automatische Dev-Promote den reinen Konfigurationsrollout.

## Validierung

- `scripts/ci/promote-deploy-gates.test.ts`
- `tsc -p tsconfig.scripts.json --noEmit`
- ESLint für die geänderten CI-Skripte