### PR TITLE
fix(iam): reconcile tenant roles through MCP

### DIFF
--- a/docs/changelog/entries/pr-726.json
+++ b/docs/changelog/entries/pr-726.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 726,
+  "body": "Der automatische Dev-Promote erkennt die fest definierte MCP-Service-Token-Konfiguration jetzt als sicheren reinen App-Konfigurationswechsel. Andere Compose-, Migrations- oder Bootstrap-Änderungen bleiben weiterhin durch die bestehenden Gates geschützt."
+}

--- a/docs/changelog/entries/pr-728.json
+++ b/docs/changelog/entries/pr-728.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 728,
-  "body": "Der MCP-Instanzprozess gleicht den Rollen-Katalog eines Tenants nun über die dedizierte, instanzgebundene Action instance.iam.roles.reconcile ab. Damit können aktive Tenants nach erfolgreichem Keycloak-Abgleich, Rollenabgleich und Rechteprobe vollständig grün abgenommen werden."
+  "body": "Der MCP-Instanzprozess gleicht den Rollen-Katalog eines Tenants nun über die dedizierte, instanzgebundene Action instance.iam.roles.reconcile ab. Damit können aktive Tenants nach erfolgreichem Keycloak-Abgleich, Rollenabgleich und Rechteprobe vollständig grün abgenommen werden. Zusätzlich stellt der MCP Keycloak-Status, Keycloak-Preflight und die tenantlokale IAM-Rechteprobe als gezielte Betriebsaktionen bereit."
 }

--- a/docs/changelog/entries/pr-728.json
+++ b/docs/changelog/entries/pr-728.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 728,
+  "body": "Der MCP-Instanzprozess gleicht den Rollen-Katalog eines Tenants nun über die dedizierte, instanzgebundene Action instance.iam.roles.reconcile ab. Damit können aktive Tenants nach erfolgreichem Keycloak-Abgleich, Rollenabgleich und Rechteprobe vollständig grün abgenommen werden."
+}

--- a/docs/guides/studio-instance-mcp-betrieb.md
+++ b/docs/guides/studio-instance-mcp-betrieb.md
@@ -55,12 +55,12 @@ Der MCP wiederholt oder repariert Mutationen nicht selbstständig. `retryable: t
 
 ## Geführter Instanzprozess
 
-Der MCP-Server `sva-studio-mcp` stellt ergänzend zu den Einzeltools das Tool `studio_instance_process` bereit. Es verwendet die Modi `create`, `repair` und `adapt` und ruft dabei ausschließlich die bestehenden Studio-API-Verträge für Registry, Modulzuweisung, IAM-Basis, Admin-Struktur, Keycloak-Provisioning, Rechteprobe und Detaildiagnose auf.
+Der MCP-Server `sva-studio-mcp` stellt ergänzend zu den Einzeltools das Tool `studio_instance_process` bereit. Es verwendet die Modi `create`, `repair` und `adapt` und ruft dabei ausschließlich die bestehenden Studio-API-Verträge für Registry, Modulzuweisung, IAM-Basis, Admin-Struktur, Keycloak-Provisioning, instanzgebundenen Rollenabgleich, Rechteprobe und Detaildiagnose auf. Der Rollenabgleich verwendet die dedizierte Action `instance.iam.roles.reconcile`; eine Browser-Session oder eine pauschale IAM-Admin-Berechtigung ist dafür nicht erforderlich.
 
 - `create` verlangt zusätzlich den bestehenden Create-Vertrag und legt die Registry-Instanz idempotent an.
 - `repair` arbeitet auf einer vorhandenen Instanz über den bestehenden Reconcile-Vertrag; `adapt` ergänzt nur fehlende Module einschließlich ihrer IAM-Basis und Admin-Struktur.
 - Der Prozess verfolgt den gestarteten Keycloak-Run nur innerhalb seines lokalen Zeitbudgets mit gedrosseltem Backoff und gibt bei noch laufendem oder fehlgeschlagenem Run einen handlungsfähigen Zwischen- beziehungsweise Blockierungszustand zurück.
-- Nach einem erfolgreichen Run führt er eine tenantlokale Rechteprobe aus und liest den aktuellen Detail-/Doctor-Zustand. Historische Preflight-Evidenz ist kein Abschlussnachweis.
+- Nach einem erfolgreichen Run gleicht er zuerst den instanzgebundenen Rollen-Katalog ab, führt dann eine tenantlokale Rechteprobe aus und liest den aktuellen Detail-/Doctor-Zustand. Historische Preflight-Evidenz ist kein Abschlussnachweis.
 - Der Keycloak-Worker persistiert den nach der Mutation gelesenen Status als `status_snapshot` im Provisioning-Run. Dieser Postflight ist von seinem historischen `worker_preflight_snapshot` getrennt; der MCP bewertet den Abschluss zusätzlich anhand des aktuellen Detail-Reads.
 - `completed: true` bedeutet ausschließlich, dass die Instanz `active` ist und die abgenommenen Doctor-Achsen bereit sind. Ein technisch fertiger Tenant im Status `requested` liefert stattdessen `awaiting_human_action`, `completed: false` und die nächste Action `instance.status.activate`.
 

--- a/docs/guides/studio-instance-mcp-betrieb.md
+++ b/docs/guides/studio-instance-mcp-betrieb.md
@@ -53,6 +53,8 @@ Der MCP-Prozess holt kurzlebige Access Tokens per Client-Credentials-Flow. Studi
 
 Der MCP wiederholt oder repariert Mutationen nicht selbstständig. `retryable: true` ist ein Hinweis für einen explizit ausgelösten, begrenzten Retry. Der Primärfehler bleibt auch dann maßgeblich, wenn eine nachgelagerte Diagnose fehlschlägt.
 
+Für gezielte Betriebsprüfungen stehen neben der aggregierten Diagnose eigenständige Tools für den aktuellen Keycloak-Status (`studio_instance_keycloak_status`), den Keycloak-Preflight (`studio_instance_keycloak_preflight`) und die tenantlokale IAM-Zugriffsprobe (`studio_instance_tenant_iam_access_probe`) bereit. Die ersten beiden sind Read-only; die Rechteprobe ist eine kontrollierte, auditierte Mutation mit der bestehenden Action `instance.diagnose`.
+
 ## Geführter Instanzprozess
 
 Der MCP-Server `sva-studio-mcp` stellt ergänzend zu den Einzeltools das Tool `studio_instance_process` bereit. Es verwendet die Modi `create`, `repair` und `adapt` und ruft dabei ausschließlich die bestehenden Studio-API-Verträge für Registry, Modulzuweisung, IAM-Basis, Admin-Struktur, Keycloak-Provisioning, instanzgebundenen Rollenabgleich, Rechteprobe und Detaildiagnose auf. Der Rollenabgleich verwendet die dedizierte Action `instance.iam.roles.reconcile`; eine Browser-Session oder eine pauschale IAM-Admin-Berechtigung ist dafür nicht erforderlich.

--- a/docs/guides/studio-instance-mcp-betrieb.md
+++ b/docs/guides/studio-instance-mcp-betrieb.md
@@ -1,8 +1,54 @@
-# Lokalen Instanz-MCP sicher betreiben
+# SVA Studio MCP einrichten und nutzen
 
 ## Zweck
 
 Der lokale stdio-MCP-Server stellt Codex und CLI-Clients die Studio-Instanz-Control-Plane bereit. Er spricht ausschließlich die konfigurierte Studio-API. Direkte Zugriffe auf Studio-Datenbank oder Keycloak-Admin-API gehören nicht zum Betriebsvertrag.
+
+## Schnellstart
+
+### Voraussetzungen
+
+- Node.js und pnpm entsprechend der Workspace-Vorgaben,
+- Zugriff auf die Zielumgebung und einen dafür ausgestellten Keycloak-Service-Account,
+- eine lokale, nicht versionierte Ablage für das Client-Secret, vorzugsweise die OS-Keychain,
+- ein gebautes MCP-Package:
+
+```bash
+pnpm install
+pnpm nx run studio-mcp:build
+```
+
+### Secret lokal ablegen
+
+Das Secret wird nur lokal unter einem eindeutigen Account- und Service-Namen abgelegt. Die verdeckte Eingabe verhindert, dass der Geheimwert als Shell-Argument oder in der History landet.
+
+```bash
+read -rs "sva_mcp_secret?Client-Secret: "
+printf '\n'
+security add-generic-password -U \
+  -a "sva-studio-mcp" \
+  -s "sva-studio-mcp-studio-dev" \
+  -w "$sva_mcp_secret"
+unset sva_mcp_secret
+```
+
+### Codex konfigurieren
+
+Die folgende Konfiguration gehört in die lokale Codex-Konfiguration. Sie startet den gebauten Workspace-Binary über pnpm; ein global installiertes Binary ist nicht erforderlich.
+
+```toml
+[mcp_servers.sva-studio-dev]
+command = "pnpm"
+args = ["exec", "sva-studio-mcp"]
+
+[mcp_servers.sva-studio-dev.env]
+SVA_STUDIO_MCP_BASE_URL = "https://studio-dev.smart-village.app"
+SVA_STUDIO_MCP_TOKEN_URL = "https://keycloak.smart-village.app/realms/studio-dev/protocol/openid-connect/token"
+SVA_STUDIO_MCP_CLIENT_ID = "sva-studio-mcp"
+SVA_STUDIO_MCP_CLIENT_SECRET_COMMAND = '["security","find-generic-password","-a","sva-studio-mcp","-s","sva-studio-mcp-studio-dev","-w"]'
+```
+
+Codex nach der Änderung neu starten oder die MCP-Serverkonfiguration neu laden. Der erste sichere Smoke-Test ist ein read-only Aufruf von `studio_instances_list` oder `studio_instance_diagnose` gegen eine bekannte Testinstanz. Bei einem Startfehler gibt der Prozess absichtlich keine Konfigurations- oder Secret-Details aus.
 
 ## Umgebungen und Keycloak
 
@@ -28,18 +74,7 @@ Die drei Clients verwenden unterschiedliche Secrets. Ein Credential darf nie zwi
 
 Studio-Basis-URL, Realm, Client-ID und Client-Secret werden über OS-Keychain oder eine nicht versionierte lokale Umgebungskonfiguration an den MCP-Prozess gegeben. Secrets gehören nicht in `.codex/config.toml`, Shell-History, Repository-Dateien, Screenshots oder Betriebsberichte.
 
-Beispiel für einen lokal verfügbaren `sva-studio-mcp`-Binary in der Codex-Konfiguration:
-
-```toml
-[mcp_servers.sva-studio-dev]
-command = "sva-studio-mcp"
-
-[mcp_servers.sva-studio-dev.env]
-SVA_STUDIO_MCP_BASE_URL = "https://studio-dev.smart-village.app"
-SVA_STUDIO_MCP_TOKEN_URL = "https://keycloak.smart-village.app/realms/studio-dev/protocol/openid-connect/token"
-SVA_STUDIO_MCP_CLIENT_ID = "sva-studio-mcp"
-SVA_STUDIO_MCP_CLIENT_SECRET_COMMAND = '["security","find-generic-password","-a","sva-studio-mcp","-s","sva-studio-mcp-studio-dev","-w"]'
-```
+Falls ein `sva-studio-mcp`-Binary außerhalb des Workspace installiert ist, kann die oben gezeigte `command`-/`args`-Kombination durch `command = "sva-studio-mcp"` ersetzt werden. Die Umgebungsvariablen bleiben unverändert:
 
 Der Secret-Resolver ist ein JSON-Array aus Programm und Argumenten und wird ohne Shell ausgeführt. Alternativ ist `SVA_STUDIO_MCP_CLIENT_SECRET` nur als lokaler Fallback vorgesehen. Zeitgrenzen können über `SVA_STUDIO_MCP_READ_TIMEOUT_MS`, `SVA_STUDIO_MCP_MUTATION_TIMEOUT_MS`, `SVA_STUDIO_MCP_PROCESS_TIMEOUT_MS`, `SVA_STUDIO_MCP_TOKEN_TIMEOUT_MS` und `SVA_STUDIO_MCP_DIAGNOSIS_TIMEOUT_MS` angepasst werden. `SVA_STUDIO_MCP_PROCESS_TIMEOUT_MS` begrenzt ausschließlich das Warten auf einen asynchronen Keycloak-Run und ist standardmäßig länger als ein einzelner Mutationsrequest. `SVA_STUDIO_MCP_CA_FILE` ergänzt bei interner PKI eine CA-Datei; die TLS-Prüfung bleibt immer aktiv.
 
@@ -54,6 +89,42 @@ Der MCP-Prozess holt kurzlebige Access Tokens per Client-Credentials-Flow. Studi
 Der MCP wiederholt oder repariert Mutationen nicht selbstständig. `retryable: true` ist ein Hinweis für einen explizit ausgelösten, begrenzten Retry. Der Primärfehler bleibt auch dann maßgeblich, wenn eine nachgelagerte Diagnose fehlschlägt.
 
 Für gezielte Betriebsprüfungen stehen neben der aggregierten Diagnose eigenständige Tools für den aktuellen Keycloak-Status (`studio_instance_keycloak_status`), den Keycloak-Preflight (`studio_instance_keycloak_preflight`) und die tenantlokale IAM-Zugriffsprobe (`studio_instance_tenant_iam_access_probe`) bereit. Die ersten beiden sind Read-only; die Rechteprobe ist eine kontrollierte, auditierte Mutation mit der bestehenden Action `instance.diagnose`.
+
+## Tool-Übersicht und benötigte Actions
+
+| Bereich | MCP-Tools | Erforderliche Studio-Action |
+| --- | --- | --- |
+| Bestand und Evidenz | `studio_instances_list`, `studio_instance_get`, `studio_instance_audit`, `studio_instances_audit` | `instance.list`, `instance.read`, `instance.audit.read` |
+| Diagnose | `studio_instance_diagnose`, `studio_instance_keycloak_status`, `studio_instance_keycloak_preflight` | `instance.diagnose` |
+| Provisioning | `studio_instance_provisioning_plan`, `studio_instance_provisioning_execute`, `studio_instance_provisioning_run_get`, `studio_instance_reconcile` | `instance.provision.plan`, `instance.provision.execute`, `instance.provision.run.read`, `instance.reconcile` |
+| Konfiguration und Module | `studio_instances_create`, `studio_instance_update`, `studio_instance_module_assign`, `studio_instance_iam_baseline_seed`, `studio_instance_admin_bootstrap` | `instance.create`, `instance.update`, `instance.module.assign`, `instance.iam.baseline.seed`, `instance.admin.bootstrap` |
+| Tenant-IAM | `studio_instance_tenant_iam_access_probe`, `studio_instance_iam_roles_reconcile` | `instance.diagnose`, `instance.iam.roles.reconcile` |
+| Kritische Aktionen | `studio_instance_activate`, `studio_instance_suspend`, `studio_instance_archive`, `studio_instance_module_revoke`, `studio_instance_secret_rotate` | jeweilige Action plus `instance.confirmation.prepare` |
+| Geführter Ablauf | `studio_instance_process` | Kombination der für die gewählte Aktion benötigten Actions |
+
+Die Tools mit kritischer Aktion verlangen immer zuerst `studio_instance_critical_action_prepare`. Dessen `challengeId` und die zurückgegebene Bestätigungsphrase werden unverändert an das eigentliche Tool übergeben. Challenges sind kurzlebig, zustandsgebunden und nur einmal verwendbar.
+
+## Häufige Abläufe
+
+### Tenant sicher anlegen
+
+1. Mit `studio_instance_process` im Modus `create` den vollständigen Registry-Vertrag einschließlich Tenant-Admin-Profil und der gewünschten `moduleIds` übergeben.
+2. Bei `status: awaiting_human_action` zuerst den aktuellen Zustand mit `studio_instance_get` prüfen.
+3. `instance.status.activate` über `studio_instance_critical_action_prepare` vorbereiten und anschließend mit `studio_instance_activate` bestätigen.
+4. Mit `studio_instance_diagnose` oder den gezielten Status- und Preflight-Tools die Abnahme dokumentieren.
+
+### Fehlerhaften Tenant reparieren
+
+1. Mit `studio_instance_diagnose`, `studio_instance_keycloak_status` und `studio_instance_keycloak_preflight die aktuelle Evidenz lesen.
+2. Bei Rollen- oder Zugriffsproblemen `studio_instance_iam_roles_reconcile` und anschließend `studio_instance_tenant_iam_access_probe` ausführen.
+3. Bei Keycloak-Drift `studio_instance_process` im Modus `repair` verwenden; laufende oder fehlgeschlagene Runs mit `studio_instance_provisioning_run_get` verfolgen.
+4. Erst bei grünem Doctor und notwendiger menschlicher Freigabe aktivieren.
+
+### Modul ergänzen oder entziehen
+
+1. Neue Module über `studio_instance_process` im Modus `adapt` oder gezielt über Zuweisung, IAM-Basis und Admin-Bootstrap ergänzen.
+2. Für einen Modulentzug immer zuerst eine Challenge vorbereiten und dann `studio_instance_module_revoke` mit der exakten Phrase ausführen.
+3. Anschließend Detail, Audit und Tenant-IAM-Zugriffsprobe kontrollieren.
 
 ## Geführter Instanzprozess
 

--- a/docs/guides/studio-instance-mcp-betrieb.md
+++ b/docs/guides/studio-instance-mcp-betrieb.md
@@ -23,7 +23,7 @@ pnpm nx run studio-mcp:build
 Das Secret wird nur lokal unter einem eindeutigen Account- und Service-Namen abgelegt. Die verdeckte Eingabe verhindert, dass der Geheimwert als Shell-Argument oder in der History landet.
 
 ```bash
-read -rs "sva_mcp_secret?Client-Secret: "
+read -r -s -p "Client-Secret: " sva_mcp_secret
 printf '\n'
 security add-generic-password -U \
   -a "sva-studio-mcp" \
@@ -115,7 +115,7 @@ Die Tools mit kritischer Aktion verlangen immer zuerst `studio_instance_critical
 
 ### Fehlerhaften Tenant reparieren
 
-1. Mit `studio_instance_diagnose`, `studio_instance_keycloak_status` und `studio_instance_keycloak_preflight die aktuelle Evidenz lesen.
+1. Mit `studio_instance_diagnose`, `studio_instance_keycloak_status` und `studio_instance_keycloak_preflight` die aktuelle Evidenz lesen.
 2. Bei Rollen- oder Zugriffsproblemen `studio_instance_iam_roles_reconcile` und anschließend `studio_instance_tenant_iam_access_probe` ausführen.
 3. Bei Keycloak-Drift `studio_instance_process` im Modus `repair` verwenden; laufende oder fehlgeschlagene Runs mit `studio_instance_provisioning_run_get` verfolgen.
 4. Erst bei grünem Doctor und notwendiger menschlicher Freigabe aktivieren.

--- a/packages/auth-runtime/src/iam-instance-registry/auth-context.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/auth-context.ts
@@ -5,6 +5,7 @@ export const REGISTRY_ACTIONS = {
   provisionRunRead: 'instance.provision.run.read', create: 'instance.create', update: 'instance.update',
   provisionPlan: 'instance.provision.plan', provisionExecute: 'instance.provision.execute', reconcile: 'instance.reconcile',
   moduleAssign: 'instance.module.assign', moduleRevoke: 'instance.module.revoke', iamBaselineSeed: 'instance.iam.baseline.seed',
+  iamRolesReconcile: 'instance.iam.roles.reconcile',
   adminBootstrap: 'instance.admin.bootstrap', statusActivate: 'instance.status.activate', statusSuspend: 'instance.status.suspend',
   statusArchive: 'instance.status.archive', secretRotate: 'instance.secret.rotate', confirmationPrepare: 'instance.confirmation.prepare',
 } as const;

--- a/packages/auth-runtime/src/iam-instance-registry/core-keycloak.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/core-keycloak.test.ts
@@ -16,6 +16,7 @@ const state = vi.hoisted(() => ({
 }));
 
 vi.mock('@sva/server-runtime', () => ({
+  createSdkLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   getWorkspaceContext: () => ({ requestId: 'req-1' }),
 }));
 
@@ -53,6 +54,10 @@ vi.mock('./core-mutations.js', () => ({
   mapInstanceMutationError: vi.fn((error: unknown) => new Response(String(error), { status: 500 })),
   probeTenantIamAccessMutation: vi.fn(async () => new Response('probe', { status: 200 })),
   reconcileInstanceKeycloakMutation: vi.fn(async () => new Response('reconcile', { status: 200 })),
+}));
+
+vi.mock('./role-reconcile.js', () => ({
+  reconcileInstanceIamRolesInternal: vi.fn(async () => new Response('roles-reconcile', { status: 200 })),
 }));
 
 describe('iam-instance-registry/core-keycloak', () => {

--- a/packages/auth-runtime/src/iam-instance-registry/core-keycloak.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/core-keycloak.ts
@@ -18,6 +18,7 @@ import {
   rotateInstanceSecretMutation,
 } from './core-mutations.js';
 import { withRegistryService } from './repository.js';
+import { reconcileInstanceIamRolesInternal as reconcileRoles } from './role-reconcile.js';
 
 const keycloakHttpHandlers = createInstanceRegistryKeycloakHttpHandlers<RegistryRequestContext>({
   getRequestId: () => getWorkspaceContext().requestId,
@@ -94,3 +95,8 @@ export const probeTenantIamAccessInternal = async (
   request: Request,
   ctx: RegistryRequestContext
 ): Promise<Response> => probeTenantIamAccessMutation(request, ctx);
+
+export const reconcileInstanceIamRolesInternal = async (
+  request: Request,
+  ctx: RegistryRequestContext
+): Promise<Response> => reconcileRoles(request, ctx);

--- a/packages/auth-runtime/src/iam-instance-registry/role-reconcile.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/role-reconcile.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  reconcile: vi.fn(),
+  mapRoleSyncErrorCode: vi.fn(() => 'IDP_TIMEOUT'),
+}));
+
+vi.mock('@sva/instance-registry/http-contracts', () => ({
+  readDetailInstanceId: () => 'demo',
+}));
+
+vi.mock('@sva/server-runtime', () => ({
+  getWorkspaceContext: () => ({ requestId: 'req-1' }),
+}));
+
+vi.mock('../iam-account-management/api-helpers.js', () => ({
+  asApiItem: (value: unknown) => value,
+  createApiError: (status: number, code: string, message: string, requestId?: string, details?: unknown) =>
+    new Response(JSON.stringify({ error: { code, message, details }, requestId }), { status }),
+  requireIdempotencyKey: () => ({ key: 'idempotency-key' }),
+}));
+
+vi.mock('../iam-account-management/csrf.js', () => ({ validateCsrf: () => null }));
+vi.mock('../iam-account-management/reconcile-core.js', () => ({ runRoleCatalogReconciliation: state.reconcile }));
+vi.mock('../iam-account-management/role-audit.js', () => ({ mapRoleSyncErrorCode: state.mapRoleSyncErrorCode }));
+vi.mock('../db.js', () => ({ jsonResponse: (status: number, payload: unknown) => new Response(JSON.stringify(payload), { status }) }));
+vi.mock('./service-token.js', () => ({ isAuthenticatedRegistryServiceRequest: () => true }));
+vi.mock('./http.js', () => ({ ensurePlatformAccess: () => null }));
+
+describe('reconcileInstanceIamRolesInternal', () => {
+  it('returns a structured, redacted synchronization error when reconciliation fails', async () => {
+    state.reconcile.mockRejectedValueOnce(new Error('upstream timeout'));
+    const { reconcileInstanceIamRolesInternal } = await import('./role-reconcile.js');
+
+    const response = await reconcileInstanceIamRolesInternal(
+      new Request('https://studio.example/api/v1/iam/instances/demo/tenant-iam/roles/reconcile', { method: 'POST' }),
+      { user: { id: 'service-account' } } as never
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'keycloak_unavailable',
+        details: {
+          syncState: 'failed',
+          syncError: { code: 'IDP_TIMEOUT' },
+          scope_kind: 'instance',
+          instanceId: 'demo',
+        },
+      },
+      requestId: 'req-1',
+    });
+  });
+});

--- a/packages/auth-runtime/src/iam-instance-registry/role-reconcile.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/role-reconcile.ts
@@ -1,0 +1,41 @@
+import { readDetailInstanceId } from '@sva/instance-registry/http-contracts';
+import { getWorkspaceContext } from '@sva/server-runtime';
+
+import { asApiItem, createApiError, requireIdempotencyKey } from '../iam-account-management/api-helpers.js';
+import { validateCsrf as validateSessionCsrf } from '../iam-account-management/csrf.js';
+import { runRoleCatalogReconciliation } from '../iam-account-management/reconcile-core.js';
+import { jsonResponse } from '../db.js';
+import type { RegistryRequestContext } from './auth-context.js';
+import { isAuthenticatedRegistryServiceRequest } from './service-token.js';
+import { ensurePlatformAccess } from './http.js';
+
+export const reconcileInstanceIamRolesInternal = async (
+  request: Request,
+  ctx: RegistryRequestContext
+): Promise<Response> => {
+  const requestId = getWorkspaceContext().requestId;
+  const instanceId = readDetailInstanceId(request);
+  if (!instanceId) {
+    return createApiError(400, 'invalid_instance_id', 'Instanz-ID fehlt.', requestId);
+  }
+  const platformAccess = ensurePlatformAccess(request, ctx);
+  if (platformAccess) return platformAccess;
+  if (!isAuthenticatedRegistryServiceRequest(request)) {
+    const csrfError = validateSessionCsrf(request, requestId);
+    if (csrfError) return csrfError;
+  }
+  const idempotency = requireIdempotencyKey(request, requestId);
+  if ('error' in idempotency) return idempotency.error;
+
+  try {
+    const report = await runRoleCatalogReconciliation({ instanceId, requestId });
+    return jsonResponse(200, asApiItem(report, requestId));
+  } catch {
+    return createApiError(
+      503,
+      'keycloak_unavailable',
+      'Rollen-Reconciliation konnte nicht ausgeführt werden.',
+      requestId
+    );
+  }
+};

--- a/packages/auth-runtime/src/iam-instance-registry/role-reconcile.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/role-reconcile.ts
@@ -4,6 +4,7 @@ import { getWorkspaceContext } from '@sva/server-runtime';
 import { asApiItem, createApiError, requireIdempotencyKey } from '../iam-account-management/api-helpers.js';
 import { validateCsrf as validateSessionCsrf } from '../iam-account-management/csrf.js';
 import { runRoleCatalogReconciliation } from '../iam-account-management/reconcile-core.js';
+import { mapRoleSyncErrorCode } from '../iam-account-management/role-audit.js';
 import { jsonResponse } from '../db.js';
 import type { RegistryRequestContext } from './auth-context.js';
 import { isAuthenticatedRegistryServiceRequest } from './service-token.js';
@@ -30,12 +31,18 @@ export const reconcileInstanceIamRolesInternal = async (
   try {
     const report = await runRoleCatalogReconciliation({ instanceId, requestId });
     return jsonResponse(200, asApiItem(report, requestId));
-  } catch {
+  } catch (error) {
     return createApiError(
       503,
       'keycloak_unavailable',
       'Rollen-Reconciliation konnte nicht ausgeführt werden.',
-      requestId
+      requestId,
+      {
+        syncState: 'failed',
+        syncError: { code: mapRoleSyncErrorCode(error) },
+        scope_kind: 'instance',
+        instanceId,
+      }
     );
   }
 };

--- a/packages/auth-runtime/src/iam-instance-registry/server.test.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/server.test.ts
@@ -68,6 +68,7 @@ vi.mock('./core-keycloak.js', () => ({
   planInstanceKeycloakProvisioningInternal: vi.fn(async () => new Response('plan', { status: 200 })),
   probeTenantIamAccessInternal: vi.fn(async () => new Response('probe', { status: 200 })),
   reconcileInstanceKeycloakInternal: vi.fn(async () => new Response('reconcile', { status: 200 })),
+  reconcileInstanceIamRolesInternal: vi.fn(async () => new Response('roles-reconcile', { status: 200 })),
   rotateInstanceSecretInternal: vi.fn(async () => new Response('rotate', { status: 200 })),
 }));
 
@@ -143,9 +144,9 @@ describe('iam-instance-registry/server', () => {
       handler(new Request('https://studio.example.org/api/v1/iam/instances/demo'))
     ));
 
-    expect(responses).toHaveLength(22);
+    expect(responses).toHaveLength(23);
     expect(responses.every((response) => response.status === 200)).toBe(true);
-    expect(state.withAuthenticatedUser).toHaveBeenCalledTimes(22);
+    expect(state.withAuthenticatedUser).toHaveBeenCalledTimes(23);
     expect(state.prepareInstanceConfirmationInternal).toHaveBeenCalledOnce();
   });
 });

--- a/packages/auth-runtime/src/iam-instance-registry/server.ts
+++ b/packages/auth-runtime/src/iam-instance-registry/server.ts
@@ -33,6 +33,7 @@ import {
   getSingleInstanceAuditRunInternal,
   planInstanceKeycloakProvisioningInternal,
   probeTenantIamAccessInternal,
+  reconcileInstanceIamRolesInternal,
   reconcileInstanceKeycloakInternal,
   rotateInstanceSecretInternal,
 } from './core-keycloak.js';
@@ -117,6 +118,8 @@ export const instanceRegistryHandlers = {
     withAuthenticatedRegistryHandler(request, 'instance.provision.run.read', getInstanceKeycloakProvisioningRunInternal),
   probeTenantIamAccess: async (request: Request): Promise<Response> =>
     withAuthenticatedRegistryHandler(request, 'instance.diagnose', probeTenantIamAccessInternal),
+  reconcileInstanceIamRoles: async (request: Request): Promise<Response> =>
+    withAuthenticatedRegistryHandler(request, REGISTRY_ACTIONS.iamRolesReconcile, reconcileInstanceIamRolesInternal),
   reconcileInstanceKeycloak: async (request: Request): Promise<Response> =>
     withAuthenticatedRegistryHandler(request, 'instance.reconcile', reconcileInstanceKeycloakInternal),
   activateInstance: async (request: Request): Promise<Response> =>

--- a/packages/auth-runtime/src/routes.ts
+++ b/packages/auth-runtime/src/routes.ts
@@ -185,6 +185,7 @@ export const authRoutePaths = [
   '/api/v1/iam/instances/$instanceId/keycloak/runs/$runId',
   '/api/v1/iam/instances/$instanceId/keycloak/reconcile',
   '/api/v1/iam/instances/$instanceId/tenant-iam/access-probe',
+  '/api/v1/iam/instances/$instanceId/tenant-iam/roles/reconcile',
   '/api/v1/iam/instances/$instanceId/modules/assign',
   '/api/v1/iam/instances/$instanceId/modules/bootstrap-admin-structure',
   '/api/v1/iam/instances/$instanceId/modules/revoke',

--- a/packages/auth-runtime/src/routes.ts
+++ b/packages/auth-runtime/src/routes.ts
@@ -49,6 +49,7 @@ export type AuthRoutePath =
   | '/api/v1/iam/instances/$instanceId/keycloak/runs/$runId'
   | '/api/v1/iam/instances/$instanceId/keycloak/reconcile'
   | '/api/v1/iam/instances/$instanceId/tenant-iam/access-probe'
+  | '/api/v1/iam/instances/$instanceId/tenant-iam/roles/reconcile'
   | '/api/v1/iam/instances/$instanceId/modules/assign'
   | '/api/v1/iam/instances/$instanceId/modules/bootstrap-admin-structure'
   | '/api/v1/iam/instances/$instanceId/modules/revoke'

--- a/packages/routing/src/auth.route-handlers.instances.server.ts
+++ b/packages/routing/src/auth.route-handlers.instances.server.ts
@@ -46,6 +46,9 @@ export const instanceAuthHandlerMap = {
   '/api/v1/iam/instances/$instanceId/tenant-iam/access-probe': {
     POST: routeHandler(authRuntimeRoutes.instanceRegistryHandlers.probeTenantIamAccess),
   },
+  '/api/v1/iam/instances/$instanceId/tenant-iam/roles/reconcile': {
+    POST: routeHandler(authRuntimeRoutes.instanceRegistryHandlers.reconcileInstanceIamRoles),
+  },
   '/api/v1/iam/instances/$instanceId/modules/assign': {
     POST: routeHandler(authRuntimeRoutes.instanceRegistryHandlers.assignInstanceModule),
   },

--- a/packages/routing/src/auth.routes.server.test.ts
+++ b/packages/routing/src/auth.routes.server.test.ts
@@ -136,6 +136,7 @@ const authServerMocks = vi.hoisted(() => {
       prepareInstanceConfirmation: vi.fn(async () => response('prepareInstanceConfirmationHandler')),
       getInstanceKeycloakProvisioningRun: vi.fn(async () => response('getInstanceKeycloakProvisioningRunHandler')),
       reconcileInstanceKeycloak: vi.fn(async () => response('reconcileInstanceKeycloakHandler')),
+      reconcileInstanceIamRoles: vi.fn(async () => response('reconcileInstanceIamRolesHandler')),
       probeTenantIamAccess: vi.fn(async () => response('probeTenantIamAccessHandler')),
       assignInstanceModule: vi.fn(async () => response('assignInstanceModuleHandler')),
       bootstrapInstanceAdminStructure: vi.fn(async () => response('bootstrapInstanceAdminStructureHandler')),
@@ -807,6 +808,7 @@ describe('auth.routes.server', () => {
     expect(authServerMocks.instanceRegistryHandlers.prepareInstanceConfirmation).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.getInstanceKeycloakProvisioningRun).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.reconcileInstanceKeycloak).toHaveBeenCalled();
+    expect(authServerMocks.instanceRegistryHandlers.reconcileInstanceIamRoles).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.probeTenantIamAccess).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.assignInstanceModule).toHaveBeenCalled();
     expect(authServerMocks.instanceRegistryHandlers.bootstrapInstanceAdminStructure).toHaveBeenCalled();

--- a/packages/studio-mcp/src/contracts.ts
+++ b/packages/studio-mcp/src/contracts.ts
@@ -40,6 +40,7 @@ export const schemas = {
   assignModule: assignModuleSchema.extend({ instanceId, ...mutationMeta }).strict(),
   bootstrap: bootstrapAdminStructureSchema.extend({ instanceId, ...mutationMeta }).strict(),
   seed: instanceMutationInput,
+  roleReconcile: instanceMutationInput,
   prepareCritical: z.object({
     instanceId,
     actionId: z.enum([

--- a/packages/studio-mcp/src/contracts.ts
+++ b/packages/studio-mcp/src/contracts.ts
@@ -40,6 +40,7 @@ export const schemas = {
   assignModule: assignModuleSchema.extend({ instanceId, ...mutationMeta }).strict(),
   bootstrap: bootstrapAdminStructureSchema.extend({ instanceId, ...mutationMeta }).strict(),
   seed: instanceMutationInput,
+  accessProbe: instanceMutationInput,
   roleReconcile: instanceMutationInput,
   prepareCritical: z.object({
     instanceId,

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -102,6 +102,38 @@ const assignMissingModules = async (input: {
   return true;
 };
 
+const evaluateDoctor = (input: {
+  detail: Record<string, unknown>;
+  instanceId: string;
+  completedSteps: readonly string[];
+  requestId: string;
+}): StudioInstanceProcessResult => {
+  const doctor = {
+    keycloakStatus: input.detail.keycloakStatus,
+    tenantIamStatus: input.detail.tenantIamStatus,
+    moduleIamStatus: input.detail.moduleIamStatus,
+  };
+  if (input.detail.status !== 'active') {
+    return {
+      completed: false, status: 'awaiting_human_action', instanceId: input.instanceId, currentStep: 'activation',
+      completedSteps: input.completedSteps, openSteps: ['activation'], doctor,
+      nextAction: { actionId: 'instance.status.activate', summary: 'Die technische Abnahme ist abgeschlossen; Aktivierung verlangt eine serverseitige Bestätigungs-Challenge.' }, requestId: input.requestId,
+    };
+  }
+  if (!isDoctorReady(input.detail)) {
+    return {
+      completed: false, status: 'blocked', instanceId: input.instanceId, currentStep: 'doctor_validation',
+      completedSteps: input.completedSteps, openSteps: ['doctor_validation'], doctor,
+      nextAction: { actionId: 'instance.diagnose', summary: 'Die aktuelle Doctor-Abnahme ist nicht vollständig bereit.' }, requestId: input.requestId,
+    };
+  }
+  return {
+    completed: true, status: 'completed', instanceId: input.instanceId, currentStep: 'completed', completedSteps: input.completedSteps,
+    openSteps: [], doctor,
+    nextAction: { actionId: 'instance.read', summary: 'Die Instanz ist aktiv und vollständig abgenommen.' }, requestId: input.requestId,
+  };
+};
+
 export const runStudioInstanceProcess = async (
   client: StudioApiClient,
   input: ProcessInput,
@@ -164,28 +196,5 @@ export const runStudioInstanceProcess = async (
   await request(client, mutation(`${basePath}/tenant-iam/access-probe`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'access-probe')));
   completedSteps.push('tenant_iam_access_probed');
   const detail = unwrap(await request(client, { path: basePath, requestId }));
-  const doctor = {
-    keycloakStatus: detail.keycloakStatus,
-    tenantIamStatus: detail.tenantIamStatus,
-    moduleIamStatus: detail.moduleIamStatus,
-  };
-  if (detail.status !== 'active') {
-    return {
-      completed: false, status: 'awaiting_human_action', instanceId: input.instanceId, currentStep: 'activation',
-      completedSteps, openSteps: ['activation'], doctor,
-      nextAction: { actionId: 'instance.status.activate', summary: 'Die technische Abnahme ist abgeschlossen; Aktivierung verlangt eine serverseitige Bestätigungs-Challenge.' }, requestId,
-    };
-  }
-  if (!isDoctorReady(detail)) {
-    return {
-      completed: false, status: 'blocked', instanceId: input.instanceId, currentStep: 'doctor_validation',
-      completedSteps, openSteps: ['doctor_validation'], doctor,
-      nextAction: { actionId: 'instance.diagnose', summary: 'Die aktuelle Doctor-Abnahme ist nicht vollständig bereit.' }, requestId,
-    };
-  }
-  return {
-    completed: true, status: 'completed', instanceId: input.instanceId, currentStep: 'completed', completedSteps,
-    openSteps, doctor,
-    nextAction: { actionId: 'instance.read', summary: 'Die Instanz ist aktiv und vollständig abgenommen.' }, requestId,
-  };
+  return evaluateDoctor({ detail, instanceId: input.instanceId, completedSteps, requestId });
 };

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -152,7 +152,14 @@ export const runStudioInstanceProcess = async (
   }
   completedSteps.push('keycloak_provisioned');
 
-  await request(client, mutation(`${basePath}/tenant-iam/roles/reconcile`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'roles-reconcile')));
+  const roleReconcile = unwrap(await request(client, mutation(`${basePath}/tenant-iam/roles/reconcile`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'roles-reconcile'))));
+  if (roleReconcile.outcome !== 'success') {
+    return {
+      completed: false, status: 'blocked', instanceId: input.instanceId, currentStep: 'tenant_iam_roles_reconcile',
+      completedSteps, openSteps: ['tenant_iam_roles_reconcile'], doctor: roleReconcile,
+      nextAction: { actionId: 'instance.iam.roles.reconcile', summary: 'Der Rollenabgleich ist nicht vollständig erfolgreich; Ergebnis prüfen.' }, requestId,
+    };
+  }
   completedSteps.push('tenant_iam_roles_reconciled');
   await request(client, mutation(`${basePath}/tenant-iam/access-probe`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'access-probe')));
   completedSteps.push('tenant_iam_access_probed');

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -152,6 +152,8 @@ export const runStudioInstanceProcess = async (
   }
   completedSteps.push('keycloak_provisioned');
 
+  await request(client, mutation(`${basePath}/tenant-iam/roles/reconcile`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'roles-reconcile')));
+  completedSteps.push('tenant_iam_roles_reconciled');
   await request(client, mutation(`${basePath}/tenant-iam/access-probe`, {}, requestId, deriveIdempotencyKey(idempotencyKey, 'access-probe')));
   completedSteps.push('tenant_iam_access_probed');
   const detail = unwrap(await request(client, { path: basePath, requestId }));

--- a/packages/studio-mcp/src/process.ts
+++ b/packages/studio-mcp/src/process.ts
@@ -96,8 +96,8 @@ const assignMissingModules = async (input: {
   for (const moduleId of missingModuleIds) {
     await request(input.client, mutation(`${input.basePath}/modules/assign`, { moduleId }, input.requestId, deriveIdempotencyKey(input.idempotencyKey, `module:${moduleId}`)));
   }
-  if (requestedModuleIds.length === 0) return false;
   await request(input.client, mutation(`${input.basePath}/modules/seed-iam-baseline`, {}, input.requestId, deriveIdempotencyKey(input.idempotencyKey, 'iam-baseline')));
+  if (requestedModuleIds.length === 0) return false;
   await request(input.client, mutation(`${input.basePath}/modules/bootstrap-admin-structure`, { moduleIds: requestedModuleIds }, input.requestId, deriveIdempotencyKey(input.idempotencyKey, 'admin-bootstrap')));
   return true;
 };

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -20,6 +20,7 @@ describe('Studio MCP tools', () => {
     const tools = await client.listTools();
     expect(tools.tools).toHaveLength(25);
     expect(tools.tools.find((tool) => tool.name === 'studio_instances_list')?.annotations?.readOnlyHint).toBe(true);
+    expect(tools.tools.find((tool) => tool.name === 'studio_instance_iam_roles_reconcile')).toBeDefined();
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_archive')?.annotations?.destructiveHint).toBe(true);
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_critical_action_prepare')?.annotations?.destructiveHint).toBe(false);
     expect(tools.tools.every((tool) => tool.inputSchema.type === 'object')).toBe(true);
@@ -257,6 +258,32 @@ describe('Studio MCP tools', () => {
     await Promise.all([client.close(), server.close()]);
   });
 
+  it('blocks the process when tenant role reconciliation is not fully successful', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'partial_failure', requiresManualActionCount: 1 } });
+    const server = createStudioMcpServer({ request }, config);
+    const client = new Client({ name: 'test-client', version: '1' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.callTool({ name: 'studio_instance_process', arguments: { mode: 'adapt', instanceId: 'demo' } });
+
+    expect(response.structuredContent).toMatchObject({
+      ok: true,
+      data: {
+        completed: false, status: 'blocked', currentStep: 'tenant_iam_roles_reconcile',
+        nextAction: { actionId: 'instance.iam.roles.reconcile' },
+      },
+    });
+    expect(request).toHaveBeenCalledTimes(5);
+    expect(request.mock.calls.map(([input]) => input.path)).not.toContain('/api/v1/iam/instances/demo/tenant-iam/access-probe');
+    await Promise.all([client.close(), server.close()]);
+  });
+
   it('does not require module IAM readiness when no modules are assigned', async () => {
     const request = vi.fn()
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
@@ -382,12 +409,13 @@ describe('Studio MCP tools', () => {
     await client.callTool({ name: 'studio_instance_module_assign', arguments: { instanceId: 'demo', moduleId: 'news' } });
     await client.callTool({ name: 'studio_instance_iam_baseline_seed', arguments: { instanceId: 'demo' } });
     await client.callTool({ name: 'studio_instance_tenant_iam_access_probe', arguments: { instanceId: 'demo' } });
+    await client.callTool({ name: 'studio_instance_iam_roles_reconcile', arguments: { instanceId: 'demo' } });
     await client.callTool({ name: 'studio_instance_admin_bootstrap', arguments: { instanceId: 'demo', moduleIds: ['news'] } });
     await client.callTool({ name: 'studio_instance_module_revoke', arguments: {
       instanceId: 'demo', moduleId: 'news', challengeId: 'challenge-1', confirmationPhrase: 'REVOKE news FROM demo', idempotencyKey: 'request-1',
     } });
 
-    expect(request).toHaveBeenCalledTimes(13);
+    expect(request).toHaveBeenCalledTimes(14);
     expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({ path: '/api/v1/iam/instances', query: { status: 'active' } }));
     expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/status' }));
     expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/preflight' }));
@@ -396,7 +424,8 @@ describe('Studio MCP tools', () => {
     expect(request).toHaveBeenNthCalledWith(8, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute', body: { intent: 'provision' } }));
     expect(request).toHaveBeenNthCalledWith(9, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/assign', body: { moduleId: 'news' } }));
     expect(request).toHaveBeenNthCalledWith(11, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe', body: {} }));
-    expect(request).toHaveBeenNthCalledWith(13, expect.objectContaining({
+    expect(request).toHaveBeenNthCalledWith(12, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/roles/reconcile', body: {} }));
+    expect(request).toHaveBeenNthCalledWith(14, expect.objectContaining({
       path: '/api/v1/iam/instances/demo/modules/revoke', body: { moduleId: 'news', confirmation: 'REVOKE' },
       confirmationChallengeId: 'challenge-1', confirmationPhrase: 'REVOKE news FROM demo',
     }));

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -94,6 +94,7 @@ describe('Studio MCP tools', () => {
     const request = vi.fn()
       .mockResolvedValueOnce({ data: { instanceId: 'demo' } })
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { outcome: 'success' } })
@@ -119,10 +120,11 @@ describe('Studio MCP tools', () => {
       data: { completed: false, status: 'awaiting_human_action', nextAction: { actionId: 'instance.status.activate' } },
     });
     expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
-    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute' }));
-    expect(request).toHaveBeenNthCalledWith(5, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/roles/reconcile' }));
-    expect(request).toHaveBeenNthCalledWith(6, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe' }));
-    expect(request).toHaveBeenNthCalledWith(7, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/seed-iam-baseline' }));
+    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute' }));
+    expect(request).toHaveBeenNthCalledWith(6, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/roles/reconcile' }));
+    expect(request).toHaveBeenNthCalledWith(7, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe' }));
+    expect(request).toHaveBeenNthCalledWith(8, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
     await Promise.all([client.close(), server.close()]);
   });
 
@@ -130,6 +132,7 @@ describe('Studio MCP tools', () => {
     const request = vi.fn()
       .mockRejectedValueOnce(new StudioApiError(409, { code: 'conflict' }, 'req-1'))
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { outcome: 'success' } })
@@ -208,6 +211,7 @@ describe('Studio MCP tools', () => {
   it('uses reconcile and the resulting run for repairs', async () => {
     const request = vi.fn()
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: ['news'] } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
       .mockResolvedValueOnce({ data: { overallStatus: 'planned' } })
       .mockResolvedValueOnce({ data: { latestKeycloakProvisioningRun: { id: 'run-1' } } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
@@ -225,13 +229,15 @@ describe('Studio MCP tools', () => {
     const response = await client.callTool({ name: 'studio_instance_process', arguments: { mode: 'repair', instanceId: 'demo' } });
 
     expect(response.structuredContent).toMatchObject({ ok: true, data: { status: 'awaiting_human_action' } });
-    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/reconcile' }));
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/seed-iam-baseline' }));
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/reconcile' }));
     await Promise.all([client.close(), server.close()]);
   });
 
   it('blocks completion when a present module-IAM status is malformed', async () => {
     const request = vi.fn()
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: ['news'] } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { outcome: 'success' } })
@@ -254,6 +260,7 @@ describe('Studio MCP tools', () => {
   it('does not require module IAM readiness when no modules are assigned', async () => {
     const request = vi.fn()
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
+      .mockResolvedValueOnce({ data: { seeded: true } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { outcome: 'success' } })
@@ -270,6 +277,7 @@ describe('Studio MCP tools', () => {
     const response = await client.callTool({ name: 'studio_instance_process', arguments: { mode: 'adapt', instanceId: 'demo' } });
 
     expect(response.structuredContent).toMatchObject({ ok: true, data: { completed: true, status: 'completed' } });
+    expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/seed-iam-baseline' }));
     await Promise.all([client.close(), server.close()]);
   });
 

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -18,7 +18,7 @@ describe('Studio MCP tools', () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
     const tools = await client.listTools();
-    expect(tools.tools).toHaveLength(22);
+    expect(tools.tools).toHaveLength(25);
     expect(tools.tools.find((tool) => tool.name === 'studio_instances_list')?.annotations?.readOnlyHint).toBe(true);
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_archive')?.annotations?.destructiveHint).toBe(true);
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_critical_action_prepare')?.annotations?.destructiveHint).toBe(false);
@@ -362,7 +362,7 @@ describe('Studio MCP tools', () => {
     await Promise.all([client.close(), server.close()]);
   });
 
-  it('maps the remaining audit, provisioning, module, and update tools to their API contracts', async () => {
+  it('maps the remaining audit, provisioning, diagnostic, module, and update tools to their API contracts', async () => {
     const request = vi.fn().mockResolvedValue({ data: { accepted: true } });
     const server = createStudioMcpServer({ request }, config);
     const client = new Client({ name: 'test-client', version: '1' });
@@ -371,6 +371,8 @@ describe('Studio MCP tools', () => {
 
     await client.callTool({ name: 'studio_instances_list', arguments: { status: 'active' } });
     await client.callTool({ name: 'studio_instance_audit', arguments: { instanceId: 'demo' } });
+    await client.callTool({ name: 'studio_instance_keycloak_status', arguments: { instanceId: 'demo' } });
+    await client.callTool({ name: 'studio_instance_keycloak_preflight', arguments: { instanceId: 'demo' } });
     await client.callTool({ name: 'studio_instance_provisioning_run_get', arguments: { instanceId: 'demo', runId: 'run-1' } });
     await client.callTool({ name: 'studio_instance_update', arguments: {
       instanceId: 'demo', displayName: 'Demo', parentDomain: 'example.org', realmMode: 'new', authRealm: 'demo', authClientId: 'studio',
@@ -379,18 +381,22 @@ describe('Studio MCP tools', () => {
     await client.callTool({ name: 'studio_instance_provisioning_execute', arguments: { instanceId: 'demo', intent: 'provision' } });
     await client.callTool({ name: 'studio_instance_module_assign', arguments: { instanceId: 'demo', moduleId: 'news' } });
     await client.callTool({ name: 'studio_instance_iam_baseline_seed', arguments: { instanceId: 'demo' } });
+    await client.callTool({ name: 'studio_instance_tenant_iam_access_probe', arguments: { instanceId: 'demo' } });
     await client.callTool({ name: 'studio_instance_admin_bootstrap', arguments: { instanceId: 'demo', moduleIds: ['news'] } });
     await client.callTool({ name: 'studio_instance_module_revoke', arguments: {
       instanceId: 'demo', moduleId: 'news', challengeId: 'challenge-1', confirmationPhrase: 'REVOKE news FROM demo', idempotencyKey: 'request-1',
     } });
 
-    expect(request).toHaveBeenCalledTimes(10);
+    expect(request).toHaveBeenCalledTimes(13);
     expect(request).toHaveBeenNthCalledWith(1, expect.objectContaining({ path: '/api/v1/iam/instances', query: { status: 'active' } }));
-    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/runs/run-1' }));
-    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({ method: 'PATCH', path: '/api/v1/iam/instances/demo', body: expect.not.objectContaining({ instanceId: 'demo' }) }));
-    expect(request).toHaveBeenNthCalledWith(6, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute', body: { intent: 'provision' } }));
-    expect(request).toHaveBeenNthCalledWith(7, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/assign', body: { moduleId: 'news' } }));
-    expect(request).toHaveBeenNthCalledWith(10, expect.objectContaining({
+    expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/status' }));
+    expect(request).toHaveBeenNthCalledWith(4, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/preflight' }));
+    expect(request).toHaveBeenNthCalledWith(5, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/runs/run-1' }));
+    expect(request).toHaveBeenNthCalledWith(6, expect.objectContaining({ method: 'PATCH', path: '/api/v1/iam/instances/demo', body: expect.not.objectContaining({ instanceId: 'demo' }) }));
+    expect(request).toHaveBeenNthCalledWith(8, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute', body: { intent: 'provision' } }));
+    expect(request).toHaveBeenNthCalledWith(9, expect.objectContaining({ path: '/api/v1/iam/instances/demo/modules/assign', body: { moduleId: 'news' } }));
+    expect(request).toHaveBeenNthCalledWith(11, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe', body: {} }));
+    expect(request).toHaveBeenNthCalledWith(13, expect.objectContaining({
       path: '/api/v1/iam/instances/demo/modules/revoke', body: { moduleId: 'news', confirmation: 'REVOKE' },
       confirmationChallengeId: 'challenge-1', confirmationPhrase: 'REVOKE news FROM demo',
     }));

--- a/packages/studio-mcp/src/tools.integration.test.ts
+++ b/packages/studio-mcp/src/tools.integration.test.ts
@@ -18,7 +18,7 @@ describe('Studio MCP tools', () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
     const tools = await client.listTools();
-    expect(tools.tools).toHaveLength(21);
+    expect(tools.tools).toHaveLength(22);
     expect(tools.tools.find((tool) => tool.name === 'studio_instances_list')?.annotations?.readOnlyHint).toBe(true);
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_archive')?.annotations?.destructiveHint).toBe(true);
     expect(tools.tools.find((tool) => tool.name === 'studio_instance_critical_action_prepare')?.annotations?.destructiveHint).toBe(false);
@@ -96,6 +96,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'success' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
         instanceId: 'demo', status: 'requested',
@@ -119,8 +120,9 @@ describe('Studio MCP tools', () => {
     });
     expect(request).toHaveBeenNthCalledWith(2, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
     expect(request).toHaveBeenNthCalledWith(3, expect.objectContaining({ path: '/api/v1/iam/instances/demo/keycloak/execute' }));
-    expect(request).toHaveBeenNthCalledWith(5, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe' }));
-    expect(request).toHaveBeenNthCalledWith(6, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
+    expect(request).toHaveBeenNthCalledWith(5, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/roles/reconcile' }));
+    expect(request).toHaveBeenNthCalledWith(6, expect.objectContaining({ path: '/api/v1/iam/instances/demo/tenant-iam/access-probe' }));
+    expect(request).toHaveBeenNthCalledWith(7, expect.objectContaining({ path: '/api/v1/iam/instances/demo' }));
     await Promise.all([client.close(), server.close()]);
   });
 
@@ -130,6 +132,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'success' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
         instanceId: 'demo', status: 'active', assignedModules: [], keycloakStatus: { realmExists: true, clientExists: true },
@@ -178,6 +181,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { bootstrapped: true } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'success' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
         instanceId: 'demo', status: 'active',
@@ -207,6 +211,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { overallStatus: 'planned' } })
       .mockResolvedValueOnce({ data: { latestKeycloakProvisioningRun: { id: 'run-1' } } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'success' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
         instanceId: 'demo', status: 'requested', keycloakStatus: { realmExists: true, clientExists: true },
@@ -229,6 +234,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: ['news'] } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'success' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
         instanceId: 'demo', status: 'active', assignedModules: ['news'], keycloakStatus: { realmExists: true, clientExists: true },
@@ -250,6 +256,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { instanceId: 'demo', assignedModules: [] } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'success' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
         instanceId: 'demo', status: 'active', keycloakStatus: { realmExists: true, clientExists: true },
@@ -273,6 +280,7 @@ describe('Studio MCP tools', () => {
       .mockResolvedValueOnce({ data: { bootstrapped: true } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
       .mockResolvedValueOnce({ data: { id: 'run-1', overallStatus: 'succeeded' } })
+      .mockResolvedValueOnce({ data: { outcome: 'success' } })
       .mockResolvedValueOnce({ data: { overall: { status: 'ready' } } })
       .mockResolvedValueOnce({ data: {
         instanceId: 'demo', status: 'active', keycloakStatus: { realmExists: true, clientExists: true },

--- a/packages/studio-mcp/src/tools.ts
+++ b/packages/studio-mcp/src/tools.ts
@@ -137,6 +137,8 @@ export const registerStudioTools = (server: McpServer, client: StudioApiClient, 
     (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/modules/assign`, p)));
   register('studio_instance_iam_baseline_seed', 'IAM-Baseline seeden', 'Seedet die IAM-Baseline der zugewiesenen Module.', schemas.seed, writeAnnotations,
     (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/modules/seed-iam-baseline`, p)));
+  register('studio_instance_iam_roles_reconcile', 'Tenant-Rollen abgleichen', 'Gleicht den Rollen-Katalog einer Instanz kontrolliert ab.', schemas.roleReconcile, writeAnnotations,
+    (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/tenant-iam/roles/reconcile`, p)));
   register('studio_instance_admin_bootstrap', 'Admin-Struktur bootstrappen', 'Erzeugt die Admin-Struktur für ausgewählte Module.', schemas.bootstrap, writeAnnotations,
     (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/modules/bootstrap-admin-structure`, p)));
   register('studio_instance_critical_action_prepare', 'Kritische Aktion vorbereiten', 'Erzeugt eine kurzlebige, zustandsgebundene Bestätigungs-Challenge; führt die Aktion nicht aus.', schemas.prepareCritical, nonIdempotentWriteAnnotations,

--- a/packages/studio-mcp/src/tools.ts
+++ b/packages/studio-mcp/src/tools.ts
@@ -118,6 +118,10 @@ export const registerStudioTools = (server: McpServer, client: StudioApiClient, 
     (p) => call(client, { path: '/api/v1/iam/instances/audit', query: { instanceId: p.instanceIds, includeOnlyActive: p.includeOnlyActive } }));
   register('studio_instance_diagnose', 'Studio-Instanz diagnostizieren', 'Aggregiert Detail-, Keycloak-Preflight- und Status-Evidenz ohne Änderungen.', schemas.diagnose, readAnnotations,
     async (p) => result({ ok: true, data: await diagnoseInstance(client, p.instanceId, config.diagnosisTimeoutMs), meta: {} }));
+  register('studio_instance_keycloak_status', 'Keycloak-Status lesen', 'Liest den aktuellen Keycloak-Status einer Studio-Instanz.', schemas.instance, readAnnotations,
+    (p) => call(client, { path: `/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/keycloak/status` }));
+  register('studio_instance_keycloak_preflight', 'Keycloak-Preflight lesen', 'Liest die aktuelle Provisioning-Vorabprüfung einer Studio-Instanz.', schemas.instance, readAnnotations,
+    (p) => call(client, { path: `/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/keycloak/preflight` }));
   register('studio_instance_process', 'Studio-Instanzprozess ausführen', 'Orchestriert Anlage, Reparatur oder Anpassung ausschließlich über bestehende Studio-Verträge. Kritische Aktivierung bleibt eine separate, challenge-geschützte Aktion.', schemas.process, writeAnnotations,
     (p) => callProcess(client, p, config.processTimeoutMs, config.diagnosisTimeoutMs));
   register('studio_instance_provisioning_run_get', 'Provisioning-Lauf lesen', 'Liest einen bestimmten Keycloak-Provisioning-Lauf.', schemas.run, readAnnotations,
@@ -137,6 +141,8 @@ export const registerStudioTools = (server: McpServer, client: StudioApiClient, 
     (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/modules/assign`, p)));
   register('studio_instance_iam_baseline_seed', 'IAM-Baseline seeden', 'Seedet die IAM-Baseline der zugewiesenen Module.', schemas.seed, writeAnnotations,
     (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/modules/seed-iam-baseline`, p)));
+  register('studio_instance_tenant_iam_access_probe', 'Tenant-IAM-Zugriff prüfen', 'Prüft die tenantlokale IAM-Zugriffsverbindung einer Instanz.', schemas.accessProbe, writeAnnotations,
+    (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/tenant-iam/access-probe`, p)));
   register('studio_instance_iam_roles_reconcile', 'Tenant-Rollen abgleichen', 'Gleicht den Rollen-Katalog einer Instanz kontrolliert ab.', schemas.roleReconcile, writeAnnotations,
     (p) => call(client, mutation(`/api/v1/iam/instances/${encodeURIComponent(p.instanceId)}/tenant-iam/roles/reconcile`, p)));
   register('studio_instance_admin_bootstrap', 'Admin-Struktur bootstrappen', 'Erzeugt die Admin-Struktur für ausgewählte Module.', schemas.bootstrap, writeAnnotations,

--- a/scripts/ci/promote-deploy-gates.test.ts
+++ b/scripts/ci/promote-deploy-gates.test.ts
@@ -11,7 +11,7 @@ import {
   formatRiskSummary,
   type DeployGateMode,
 } from './promote-deploy-gates.ts';
-import { isTraefikOnlyComposeDiff } from './traefik-compose-diff.ts';
+import { isDevMcpOnlyComposeDiff, isTraefikOnlyComposeDiff } from './traefik-compose-diff.ts';
 
 const temporaryDirectories: string[] = [];
 
@@ -109,6 +109,17 @@ describe('promote-deploy-gates', () => {
   it('recognizes only label-list changes as Traefik-only compose diffs', () => {
     expect(isTraefikOnlyComposeDiff("-        - 'traefik.http.routers.app.tls=true'\n+        - 'traefik.http.routers.app.tls.certresolver=default'\n")).toBe(true);
     expect(isTraefikOnlyComposeDiff('+  postgres:\n+    image: postgres:16-alpine\n')).toBe(false);
+  });
+
+  it('recognizes only the fixed Dev MCP service-token configuration as safe', () => {
+    expect(isDevMcpOnlyComposeDiff([
+      '+    environment:',
+      '+      SVA_STUDIO_MCP_ENABLED: "true"',
+      '+      SVA_STUDIO_MCP_ISSUER: "https://keycloak.smart-village.app/realms/studio-dev"',
+      '+      SVA_STUDIO_MCP_AUDIENCE: "sva-studio-mcp"',
+      '+      SVA_STUDIO_MCP_CLIENT_ID: "sva-studio-mcp"',
+    ].join('\n'))).toBe(true);
+    expect(isDevMcpOnlyComposeDiff('+      SVA_STUDIO_MCP_ENABLED: "false"')).toBe(false);
   });
 
   it('refuses run mode when no safe executor is configured', () => {

--- a/scripts/ci/traefik-compose-diff.ts
+++ b/scripts/ci/traefik-compose-diff.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
-export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
-  const changedLines = diff
+const changedComposeLines = (diff: string): string[] =>
+  diff
     .split('\n')
     .filter(
       (line) =>
@@ -10,7 +10,24 @@ export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
         !line.startsWith('---')
     );
 
+export const isTraefikOnlyComposeDiff = (diff: string): boolean => {
+  const changedLines = changedComposeLines(diff);
+
   return changedLines.length > 0 && changedLines.every((line) => /^[-+]\s*-\s*['"]?traefik\./u.test(line));
+};
+
+const devMcpConfigurationLines = new Set([
+  '+    environment:',
+  '+      SVA_STUDIO_MCP_ENABLED: "true"',
+  '+      SVA_STUDIO_MCP_ISSUER: "https://keycloak.smart-village.app/realms/studio-dev"',
+  '+      SVA_STUDIO_MCP_AUDIENCE: "sva-studio-mcp"',
+  '+      SVA_STUDIO_MCP_CLIENT_ID: "sva-studio-mcp"',
+]);
+
+export const isDevMcpOnlyComposeDiff = (diff: string): boolean => {
+  const changedLines = changedComposeLines(diff);
+  return changedLines.length === devMcpConfigurationLines.size
+    && changedLines.every((line) => devMcpConfigurationLines.has(line));
 };
 
 export const resolveTraefikOnlyComposeFiles = (
@@ -21,9 +38,11 @@ export const resolveTraefikOnlyComposeFiles = (
   changedFiles.filter(
     (filePath) =>
       /^deploy\/compose\.(?:dev|staging|prod)\.yaml$/u.test(filePath) &&
-      isTraefikOnlyComposeDiff(
-        execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', filePath], {
+      (() => {
+        const diff = execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', filePath], {
           encoding: 'utf8',
-        })
-      )
+        });
+        return isTraefikOnlyComposeDiff(diff)
+          || (filePath === 'deploy/compose.dev.yaml' && isDevMcpOnlyComposeDiff(diff));
+      })()
   );


### PR DESCRIPTION
## Zusammenfassung
- ergänzt den instanzgebundenen MCP-Action-Scope instance.iam.roles.reconcile
- führt den Rollenabgleich vor Rechteprobe und Doctor-Abnahme aus
- dokumentiert den sicheren Betriebsweg

## Validierung
- auth-runtime Unit-Test für den Registry-Server
- studio-mcp Integrations-Test für die Tool-Fläche
- Type-Tests für auth-runtime und studio-mcp