### PR TITLE
fix(provisioning): enrich failure diagnostics

### DIFF
--- a/docs/changelog/entries/pr-729.json
+++ b/docs/changelog/entries/pr-729.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 729,
+  "body": "Fehlgeschlagene Keycloak-Provisioning-Läufe protokollieren zusätzlich sichere strukturierte Fehler-Metadaten wie Datenbank-Code, Tabelle, Spalte und Constraint. So lassen sich Betriebsfehler gezielt diagnostizieren, ohne Secrets oder Fehlermeldungstexte in Logs abzulegen."
+}

--- a/packages/instance-registry/src/service-keycloak-execution-failures.ts
+++ b/packages/instance-registry/src/service-keycloak-execution-failures.ts
@@ -63,7 +63,7 @@ export const failRun = async (
     stepKey,
     dependency,
   }, {
-    code: reasonCode,
+    code: 'internal_unclassified',
     status: 500,
   }));
 

--- a/packages/instance-registry/src/service-keycloak-execution-failures.ts
+++ b/packages/instance-registry/src/service-keycloak-execution-failures.ts
@@ -1,8 +1,8 @@
 import { createSdkLogger } from '@sva/server-runtime';
 
 import { appendRunStep } from './service-keycloak-run-steps.js';
+import { buildInstanceRegistryFailureLog, readInstanceRegistryStepKey } from './observability.js';
 import type { InstanceRegistryServiceDeps } from './service-types.js';
-import { readInstanceRegistryStepKey } from './observability.js';
 
 const logger = createSdkLogger({ component: 'keycloak-provisioning-failures', level: 'error' });
 
@@ -54,19 +54,18 @@ export const failRun = async (
       ? 'instance_registry'
       : undefined;
 
-  logger.error('provisioning_run_failed', {
+  logger.error('provisioning_run_failed', buildInstanceRegistryFailureLog(input.error, {
     operation: 'process_keycloak_provisioning_run',
-    result: 'failed',
-    request_id: input.requestId,
-    instance_id: input.instanceId,
-    run_id: input.runId,
+    requestId: input.requestId,
+    instanceId: input.instanceId,
+    runId: input.runId,
     intent: input.intent,
-    step_key: stepKey,
-    ...(dependency ? { dependency } : {}),
-    error_type: input.error instanceof Error ? input.error.name : typeof input.error,
-    error_code: reasonCode,
-    classification: reasonCode,
-  });
+    stepKey,
+    dependency,
+  }, {
+    code: reasonCode,
+    status: 500,
+  }));
 
   await appendRunStep(deps, {
     runId: input.runId,


### PR DESCRIPTION
## Kontext

Ein reproduzierbarer MCP-Neuanlage-Lauf auf Dev scheitert im Provisioning-Schritt secret_sync bislang nur mit der Klassifikation UNKNOWN_EXECUTION_FAILED.

## Änderung

Protokolliert für fehlgeschlagene Provisioning-Läufe zusätzlich sichere strukturierte Fehler-Metadaten (Datenbank-Code, Tabelle, Spalte, Constraint), ohne Secrets oder Fehlermeldungstexte zu loggen.

## Prüfung

- pnpm nx run instance-registry:test:unit --testFiles=src/service-keycloak-execution-failures.test.ts