### PR TITLE
fix(iam): allow missing tenant secret rotation

### DIFF
--- a/docs/changelog/entries/pr-730.json
+++ b/docs/changelog/entries/pr-730.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 730,
+  "body": "Die gezielte Tenant-Client-Secret-Rotation kann nun einen fehlenden Registry-Eintrag wiederherstellen, sofern keine weiteren Keycloak- oder Tenant-Blocker vorliegen."
+}

--- a/packages/instance-registry/src/service-keycloak-execution.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.ts
@@ -128,10 +128,14 @@ const executeClaimedRun = async (deps: InstanceRegistryServiceDeps, run: Instanc
     appendPlanSnapshot(deps, run, provisioningInput)
   );
 
-  if (run.mode === 'existing' && run.intent !== 'provision_admin_client' && !loaded.authClientSecret) {
+  const rotatingMissingTenantSecret = run.intent === 'rotate_client_secret' && !loaded.authClientSecret;
+  if (run.mode === 'existing' && run.intent !== 'provision_admin_client' && !rotatingMissingTenantSecret && !loaded.authClientSecret) {
     throw new Error('tenant_auth_client_secret_missing');
   }
-  if (preflight.overallStatus === 'blocked' || plan.overallStatus === 'blocked') {
+  const secretRotationRecovery = rotatingMissingTenantSecret &&
+    preflight.checks.every((check) => check.checkKey === 'tenant_secret' || check.status !== 'blocked') &&
+    plan.steps.every((step) => step.stepKey === 'secret' || step.stepKey === 'tenant_admin_client_secret' || step.status !== 'blocked');
+  if (!secretRotationRecovery && (preflight.overallStatus === 'blocked' || plan.overallStatus === 'blocked')) {
     await deps.repository.updateKeycloakProvisioningRun({
       runId: run.id,
       overallStatus: 'failed',


### PR DESCRIPTION
## Ziel\nErmöglicht die gezielte Wiederherstellung eines fehlenden Tenant-Auth-Client-Secrets über den vorhandenen Rotationspfad.\n\n## Validierung\n- 
> nx run instance-registry:"test:unit" --testFiles=src/service-keycloak-execution.test.ts  [existing outputs match the cache, left as is]

> pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests --testFiles=src/service-keycloak-execution.test.ts


 RUN  v4.1.9 /Users/wilimzig/Documents/Projects/SVA/sva-studio/packages/instance-registry

 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > returns null when no claimed run is available 31ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > fails claimed runs when worker dependencies are missing 2ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > returns the persisted run when the claimed instance no longer exists 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > marks runs as failed when preflight or plan reports blockers 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > processes rotate_client_secret runs with the rotated secret sync path 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > limits reset_tenant_admin runs to tenant-admin user reconciliation 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > passes the configured tenant admin bootstrap to the local sync hook after provisioning 0ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > fails the run when execution throws and reloads the persisted run state 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > enqueues provisioning runs only for existing instances 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > surfaces blocked preflight summaries before enqueuing reconcile runs 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > claims the next queued run via the repository helper 0ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > passes claim filters through to the repository helper 0ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  21:45:39
   Duration  614ms (transform 88ms, setup 0ms, import 95ms, tests 40ms, environment 0ms)




 NX   Successfully ran target test:unit for project instance-registry

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.

View logs and run details at https://nx.app/runs/uJxf9OWTJS

Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.