### PR TITLE
fix(iam): recover missing tenant secret rotation

### DIFF
--- a/docs/changelog/entries/pr-731.json
+++ b/docs/changelog/entries/pr-731.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 731,
+  "body": "Die Rotation eines fehlenden Tenant-Client-Secrets führt den gezielten Recovery-Lauf nun auch aus, wenn der abgeleitete Provisioning-Plan den ursprünglichen Preflight-Blocker weiterführt."
+}

--- a/packages/instance-registry/src/service-keycloak-execution.test.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.test.ts
@@ -235,6 +235,41 @@ describe('service-keycloak-execution', () => {
     expect(state.completeRun).toHaveBeenCalled();
   });
 
+  it('recovers a missing tenant secret even when the derived plan remains blocked', async () => {
+    const { processClaimedKeycloakProvisioningRun } = await import('./service-keycloak-execution.js');
+    const provisionInstanceAuth = vi.fn().mockResolvedValue(undefined);
+    const repository = {
+      getKeycloakProvisioningRun: vi.fn().mockResolvedValue({ id: 'run-1', overallStatus: 'succeeded' }),
+    };
+    state.loadInstanceWithSecret.mockResolvedValue({ ...createLoaded(), authClientSecret: undefined });
+
+    await expect(
+      processClaimedKeycloakProvisioningRun(
+        {
+          repository: repository as never,
+          provisionInstanceAuth,
+          getKeycloakStatus: vi.fn(),
+          getKeycloakPreflight: vi.fn().mockResolvedValue({
+            overallStatus: 'blocked',
+            checks: [{ checkKey: 'tenant_secret', status: 'blocked' }],
+          }),
+          planKeycloakProvisioning: vi.fn().mockResolvedValue({
+            overallStatus: 'blocked',
+            driftSummary: 'blocked',
+            steps: [
+              { stepKey: 'realm', status: 'blocked' },
+              { stepKey: 'secret', status: 'blocked' },
+            ],
+          }),
+        } as never,
+        createRun({ intent: 'rotate_client_secret', mode: 'existing' })
+      )
+    ).resolves.toEqual({ id: 'run-1', overallStatus: 'succeeded' });
+
+    expect(provisionInstanceAuth).toHaveBeenCalledWith(expect.objectContaining({ rotateClientSecret: true }));
+    expect(state.syncRotatedClientSecretToRegistry).toHaveBeenCalled();
+  });
+
   it('limits reset_tenant_admin runs to tenant-admin user reconciliation', async () => {
     const { processClaimedKeycloakProvisioningRun } = await import('./service-keycloak-execution.js');
     const repository = {

--- a/packages/instance-registry/src/service-keycloak-execution.ts
+++ b/packages/instance-registry/src/service-keycloak-execution.ts
@@ -133,8 +133,7 @@ const executeClaimedRun = async (deps: InstanceRegistryServiceDeps, run: Instanc
     throw new Error('tenant_auth_client_secret_missing');
   }
   const secretRotationRecovery = rotatingMissingTenantSecret &&
-    preflight.checks.every((check) => check.checkKey === 'tenant_secret' || check.status !== 'blocked') &&
-    plan.steps.every((step) => step.stepKey === 'secret' || step.stepKey === 'tenant_admin_client_secret' || step.status !== 'blocked');
+    preflight.checks.every((check) => check.checkKey === 'tenant_secret' || check.status !== 'blocked');
   if (!secretRotationRecovery && (preflight.overallStatus === 'blocked' || plan.overallStatus === 'blocked')) {
     await deps.repository.updateKeycloakProvisioningRun({
       runId: run.id,


### PR DESCRIPTION
## Ziel\nErmöglicht die Wiederherstellung eines fehlenden Tenant-Client-Secrets, auch wenn der abgeleitete Plan den ursprünglichen Preflight-Blocker fortschreibt.\n\n## Validierung\n- 
> nx run instance-registry:"test:unit" --testFiles=src/service-keycloak-execution.test.ts  [existing outputs match the cache, left as is]

> pnpm exec tsx ../../scripts/ci/run-vitest-target.ts --reporter=verbose --config vitest.config.ts --passWithNoTests --testFiles=src/service-keycloak-execution.test.ts


 RUN  v4.1.9 /Users/wilimzig/Documents/Projects/SVA/sva-studio/packages/instance-registry

 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > returns null when no claimed run is available 43ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > fails claimed runs when worker dependencies are missing 2ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > returns the persisted run when the claimed instance no longer exists 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > marks runs as failed when preflight or plan reports blockers 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > processes rotate_client_secret runs with the rotated secret sync path 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > recovers a missing tenant secret even when the derived plan remains blocked 2ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > limits reset_tenant_admin runs to tenant-admin user reconciliation 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > passes the configured tenant admin bootstrap to the local sync hook after provisioning 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > fails the run when execution throws and reloads the persisted run state 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > enqueues provisioning runs only for existing instances 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > surfaces blocked preflight summaries before enqueuing reconcile runs 1ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > claims the next queued run via the repository helper 0ms
 ✓ src/service-keycloak-execution.test.ts > service-keycloak-execution > passes claim filters through to the repository helper 0ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  07:51:55
   Duration  358ms (transform 73ms, setup 0ms, import 53ms, tests 54ms, environment 0ms)




 NX   Successfully ran target test:unit for project instance-registry

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.

View logs and run details at https://nx.app/runs/rejxdl9tYY

Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.