### PR TITLE
fix(ci): run dev bootstrap gate

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -138,6 +138,7 @@ jobs:
       - name: evaluate migration and bootstrap gates
         id: gate_eval
         env:
+          ENVIRONMENT: ${{ inputs.environment }}
           CHANGE_BASE: ${{ inputs.change_base }}
           CHANGE_HEAD: ${{ inputs.change_head }}
           MIGRATION_MODE: ${{ inputs.migration_mode }}
@@ -156,7 +157,7 @@ jobs:
           fi
 
           bootstrap_executor_configured=false
-          if [ -n "${PROMOTE_BOOTSTRAP_EXECUTOR}" ]; then
+          if [ "${ENVIRONMENT}" = "dev" ] && [ "${BOOTSTRAP_MODE}" = "run" ]; then
             bootstrap_executor_configured=true
           fi
 
@@ -200,6 +201,28 @@ jobs:
         uses: hostwithquantum/setup-quantum-cli@v2.0.0
         with:
           api-key: ${{ secrets.QUANTUM_API_KEY }}
+
+      - name: run dev bootstrap job
+        if: ${{ inputs.environment == 'dev' && inputs.bootstrap_mode == 'run' }}
+        env:
+          APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          DEPLOY_IMAGE_REF: ${{ steps.image_contract.outputs.deploy_image_ref }}
+          DEPLOY_REVISION: ${{ steps.image_contract.outputs.deploy_revision }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          umask 077
+          job_stack="studio-dev-bootstrap-${GITHUB_RUN_ID}"
+          trap 'quantum-cli stacks remove --force --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" || true; rm -f .env stack.json bootstrap-stack.json .quantum' EXIT
+          pnpm exec tsx scripts/ci/render-compose-env.ts --output .env
+          printf '\nIMAGE_REF=%s\nSVA_DEPLOY_REVISION=%s\n' "${DEPLOY_IMAGE_REF}" "${DEPLOY_REVISION}" >> .env
+          docker compose -f compose.yaml -f ./deploy/compose.dev.yaml config --format json > stack.json
+          jq --arg host 'studio-dev_postgres' --arg job "${job_stack}" '{version:"3.8",services:{bootstrap:(.services.bootstrap | .networks=["internal"] | .environment.POSTGRES_HOST=$host | .environment.SVA_BOOTSTRAP_JOB_STACK=$job | .environment.SVA_BOOTSTRAP_TARGET_STACK="studio-dev" | .deploy.replicas=1 | .deploy.restart_policy.condition="none")},networks:{internal:{external:true,name:"studio-dev_default"}}}' stack.json > bootstrap-stack.json
+          printf '%s\n' '---' 'version: "1.0"' 'compose: bootstrap-stack.json' > .quantum
+          quantum-cli stacks deploy --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --project . --wait
+          task_json="$(quantum-cli ps --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --all -o json)"
+          exit_code="$(printf '%s' "${task_json}" | jq -r '.. | objects | select(.Status?.ContainerStatus?.ExitCode? != null) | .Status.ContainerStatus.ExitCode' | tail -n1)"
+          test "${exit_code}" = "0"
 
       - name: deploy
         id: deploy

--- a/docs/changelog/entries/pr-733.json
+++ b/docs/changelog/entries/pr-733.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 733,
+  "body": "Der Dev-Promote-Workflow führt Bootstrap-Runs nun über einen gehärteten One-shot-Executor mit Exit-Code-Evidenz aus. Dadurch kann das Bootstrap-Gate bei passenden Änderungen sicher abgeschlossen werden."
+}

--- a/scripts/ci/promote-deploy-gates-cli.ts
+++ b/scripts/ci/promote-deploy-gates-cli.ts
@@ -1,0 +1,12 @@
+import type { DeployGateMode } from './promote-deploy-gates.ts';
+
+export const parseBoolean = (value: string): boolean => {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new Error(`Ungültiger Boolean-Wert: ${value}`);
+};
+
+export const parseMode = (value: string, flag: string): DeployGateMode => {
+  if (value === 'assert-none' || value === 'run') return value;
+  throw new Error(`Ungültiger Wert für ${flag}: ${value}`);
+};

--- a/scripts/ci/promote-deploy-gates.test.ts
+++ b/scripts/ci/promote-deploy-gates.test.ts
@@ -139,21 +139,21 @@ describe('promote-deploy-gates', () => {
     expect(result.message).toContain('Kein sicherer One-shot-Executor');
   });
 
-  it('still blocks run mode when a configured executor is not wired as a hardened promote step', () => {
+  it('authorizes bootstrap run mode when a hardened executor is wired by the workflow', () => {
     const result = evaluateDeployGate({
-      changedFiles: ['migrate-entrypoint.sh'],
+      changedFiles: ['bootstrap-entrypoint.sh'],
       executorConfigured: true,
-      kind: 'migration',
+      kind: 'bootstrap',
       mode: 'run',
     });
 
     expect(result).toMatchObject({
       mode: 'run',
-      ok: false,
-      result: 'blocked-safe-run-required',
+      ok: true,
+      result: 'asserted-clean',
       riskDetected: true,
     });
-    expect(result.message).toContain('gehärteter Exit-Code-/Log-Evidenz');
+    expect(result.message).toContain('Exit-Code-Evidenz');
   });
 
   it('formats risk summaries deterministically', () => {

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -118,6 +118,17 @@ export const evaluateDeployGate = ({
       riskFiles,
     };
   }
+  if (kind === 'bootstrap') {
+    return {
+      kind,
+      message: 'Bootstrap-Gate freigegeben: Der gehärtete One-shot-Executor wird im Promote-Workflow mit Exit-Code-Evidenz ausgeführt.',
+      mode,
+      ok: true,
+      result: 'asserted-clean',
+      riskDetected: riskFiles.length > 0,
+      riskFiles,
+    };
+  }
   return {
     kind,
     message: `${label}-Gate blockiert: Ein Executor ist konfiguriert, aber im Promote-Workflow nicht mit gehärteter Exit-Code-/Log-Evidenz verdrahtet. Nutze den kanonischen Operator-Pfad statt Blindautomatisierung.`,

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { appendFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
+import { parseBoolean, parseMode } from './promote-deploy-gates-cli.ts';
 import { resolveChangedFiles } from './pr-scope.ts';
 import { resolveTraefikOnlyComposeFiles } from './traefik-compose-diff.ts';
 export type DeployGateMode = 'assert-none' | 'run';
@@ -170,22 +171,6 @@ export const evaluatePromoteDeployGates = ({
     safeComposeFiles,
   }),
 });
-const parseBoolean = (value: string): boolean => {
-  if (value === 'true') {
-    return true;
-  }
-  if (value === 'false') {
-    return false;
-  }
-  throw new Error(`Ungültiger Boolean-Wert: ${value}`);
-};
-const parseMode = (value: string, flag: string): DeployGateMode => {
-  if (value === 'assert-none' || value === 'run') {
-    return value;
-  }
-  throw new Error(`Ungültiger Wert für ${flag}: ${value}`);
-};
-
 const parseCliOptions = (args: readonly string[]): CliOptions => {
   let base = DEFAULT_BASE;
   let head = DEFAULT_HEAD;


### PR DESCRIPTION
## Änderung

Der Promote-Workflow führt bei einem Dev-Promote im Bootstrap-Modus den gehärteten One-shot-Bootstrap-Job aus und wertet dessen Exit-Code aus. Das Gate erkennt diese Verdrahtung als zulässigen Executor.

## Ursache

Bisher konnte das Bootstrap-Gate trotz gewünschtem Run-Modus nicht erfolgreich durchlaufen, weil kein gehärteter Executor im Workflow hinterlegt war.

## Validierung

- `pnpm exec vitest run scripts/ci/promote-deploy-gates.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`