### PR TITLE
fix(ci): create dev bootstrap stack

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -219,7 +219,7 @@ jobs:
           docker compose -f compose.yaml -f ./deploy/compose.dev.yaml config --format json > stack.json
           jq --arg host 'studio-dev_postgres' --arg job "${job_stack}" '{version:"3.8",services:{bootstrap:(.services.bootstrap | .networks=["internal"] | .environment.POSTGRES_HOST=$host | .environment.SVA_BOOTSTRAP_JOB_STACK=$job | .environment.SVA_BOOTSTRAP_TARGET_STACK="studio-dev" | .deploy.replicas=1 | .deploy.restart_policy.condition="none")},networks:{internal:{external:true,name:"studio-dev_default"}}}' stack.json > bootstrap-stack.json
           printf '%s\n' '---' 'version: "1.0"' 'compose: bootstrap-stack.json' > .quantum
-          quantum-cli stacks deploy --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --project . --wait
+          quantum-cli stacks create --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --project . --wait
           task_json="$(quantum-cli ps --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --all -o json)"
           exit_code="$(printf '%s' "${task_json}" | jq -r '.. | objects | select(.Status?.ContainerStatus?.ExitCode? != null) | .Status.ContainerStatus.ExitCode' | tail -n1)"
           test "${exit_code}" = "0"

--- a/docs/changelog/entries/pr-734.json
+++ b/docs/changelog/entries/pr-734.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 734,
+  "body": "Der Dev-Bootstrap-Executor verwendet für seinen temporären Quantum-Stack nun den unterstützten Create-Befehl. Damit kann der One-shot-Bootstrap vor dem Dev-Deploy tatsächlich ausgeführt werden."
+}


### PR DESCRIPTION
## Änderung

Der Dev-Bootstrap-Executor verwendet den von der installierten Quantum-CLI unterstützten Create-Befehl für seinen temporären One-shot-Stack.

## Ursache

Der bisherige Aufruf `quantum-cli stacks deploy --project` ist in der verwendeten CLI nicht vorhanden und brach vor der Stack-Erstellung ab.

## Validierung

- `quantum-cli stacks create --help`
- `pnpm exec prettier --check .github/workflows/promote.yml`