### PR TITLE
fix(ci): support Quantum bootstrap CLI

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -219,7 +219,7 @@ jobs:
           docker compose -f compose.yaml -f ./deploy/compose.dev.yaml config --format json > stack.json
           jq --arg host 'studio-dev_postgres' --arg job "${job_stack}" '{version:"3.8",services:{bootstrap:(.services.bootstrap | .networks=["internal"] | .environment.POSTGRES_HOST=$host | .environment.SVA_BOOTSTRAP_JOB_STACK=$job | .environment.SVA_BOOTSTRAP_TARGET_STACK="studio-dev" | .deploy.replicas=1 | .deploy.restart_policy.condition="none")},networks:{internal:{external:true,name:"studio-dev_default"}}}' stack.json > bootstrap-stack.json
           printf '%s\n' '---' 'version: "1.0"' 'compose: bootstrap-stack.json' > .quantum
-          quantum-cli stacks create --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --project . --wait
+          quantum-cli stacks create --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --wait
           task_json="$(quantum-cli ps --endpoint "${QUANTUM_ENDPOINT}" --stack "${job_stack}" --all -o json)"
           exit_code="$(printf '%s' "${task_json}" | jq -r '.. | objects | select(.Status?.ContainerStatus?.ExitCode? != null) | .Status.ContainerStatus.ExitCode' | tail -n1)"
           test "${exit_code}" = "0"

--- a/docs/changelog/entries/pr-735.json
+++ b/docs/changelog/entries/pr-735.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 735,
+  "body": "Der Dev-Bootstrap-Executor ist mit der in CI verwendeten Quantum-CLI 3.2.1 kompatibel und kann den temporären One-shot-Stack wieder starten."
+}


### PR DESCRIPTION
## Zusammenfassung

Entfernt das in Quantum-CLI 3.2.1 nicht unterstützte, redundante Flag `--project .` aus dem One-shot-Bootstrap. Der Projektpfad ist ohnehin das Checkout-Arbeitsverzeichnis.

## Validierung

- `pnpm exec prettier --check .github/workflows/promote.yml`
- `git diff --check -- .github/workflows/promote.yml`

## Betrieb

Nach dem Merge wird der explizite Dev-Promote-Lauf mit `bootstrap_mode=run` erneut gestartet.