### PR TITLE
docs(ops): deprecate legacy Quantum scripts

### DIFF
--- a/docs/changelog/entries/pr-737.json
+++ b/docs/changelog/entries/pr-737.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 737,
+  "body": "Historische Quantum- und Swarm-Ops-Skripte sind nun deutlich als deprecated markiert und verweisen auf den kanonischen lokalen Studio-Release-Pfad."
+}

--- a/docs/guides/swarm-deployment-guide.md
+++ b/docs/guides/swarm-deployment-guide.md
@@ -86,7 +86,10 @@ Alle Secrets sind in `~/sva-secrets/` vorhanden:
 
 ### Secrets hochladen & registrieren
 
-#### **Option 1: Portainer REST API (empfohlen – kein SSH erforderlich)** ⭐
+#### **Option 1: Portainer REST API (Legacy, deprecated)**
+
+> [!WARNING]
+> Das Skript `scripts/ops/create-secrets-portainer-api.sh` ist deprecated und darf nicht für reguläre Studio-Rollouts verwendet werden. Der kanonische Rollout läuft über `pnpm env:release:studio:local`.
 
 Scenario: Kein SSH-Zugang zu node-005.sva, aber Zugang zur Portainer Web-UI unter https://console.planetary-quantum.com/#!/64/docker/swarm
 
@@ -188,7 +191,7 @@ EOF
 Für das aktuelle Demo-Profil sind Docker-Secrets nicht erforderlich.
 
 Das alternative Referenzprofil `swarm-secrets` benötigt Secrets über eines der folgenden Verfahren:
-- **Portainer REST API** (empfohlen – `scripts/ops/create-secrets-portainer-api.sh`)
+- **Portainer REST API** (Legacy, deprecated – `scripts/ops/create-secrets-portainer-api.sh`)
 - **Docker CLI** (SSH zu node-005.sva erforderlich)
 - **Portainer Web-UI** (manuell, unter https://console.planetary-quantum.com/#!/64/docker/swarm)
 

--- a/scripts/ops/create-secrets-portainer-api.sh
+++ b/scripts/ops/create-secrets-portainer-api.sh
@@ -2,6 +2,8 @@
 # SVA Studio – Docker Secrets via Portainer API
 # Erstellt alle erforderlichen Secrets auf dem sva-Endpoint (ID 64) über die Portainer REST API
 # Keine SSH erforderlich!
+# DEPRECATED: Dieser Legacy-Pfad wird nicht weiterentwickelt. Für reguläre
+# Studio-Rollouts den kanonischen lokalen Operator-Pfad aus der Deployment-Doku nutzen.
 
 set -euo pipefail
 
@@ -19,6 +21,8 @@ NC='\033[0m'
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║  SVA Studio – Create Secrets via Portainer API             ║${NC}"
 echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+echo -e "${YELLOW}⚠ DEPRECATED: Legacy-Skript. Nicht für reguläre Studio-Rollouts verwenden.${NC}"
+echo -e "${YELLOW}  Kanonischer Pfad: pnpm env:release:studio:local${NC}"
 
 # Step 1: Portainer Token prüfen/erzeugen
 echo -e "\n${YELLOW}Step 1: Portainer Authentication${NC}"
@@ -129,5 +133,4 @@ echo -e "${GREEN}✓ Found $secrets_list sva_studio secrets in Portainer${NC}"
 echo -e "\n${GREEN}=== SUCCESS ===${NC}"
 echo -e "All secrets created! You can now deploy the stack:\n"
 echo -e "  cd $(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-echo -e "  export QUANTUM_API_KEY=ptr_..."
-echo -e "  quantum-cli stacks update --endpoint sva --stack sva-studio --wait --project .\n"
+echo -e "  pnpm env:release:studio:local -- --image-digest=<sha256:...> --release-mode=app-only --rollback-hint=\"Initialer Rollout\"\n"

--- a/scripts/ops/swarm-deployment-runbook.sh
+++ b/scripts/ops/swarm-deployment-runbook.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # SVA Studio – Docker Swarm Deployment Runbook
 # Dieses Skript registriert Secrets und deployed den sva-studio Stack auf Planetary Quantum
+# DEPRECATED: Dieser Legacy-Pfad wird nicht weiterentwickelt. Für reguläre
+# Studio-Rollouts den kanonischen lokalen Operator-Pfad aus der Deployment-Doku nutzen.
 
 set -euo pipefail
 
@@ -16,6 +18,8 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 echo -e "${YELLOW}=== SVA Studio Docker Swarm Setup ===${NC}"
+echo -e "${YELLOW}⚠ DEPRECATED: Legacy-Skript. Nicht für reguläre Studio-Rollouts verwenden.${NC}"
+echo -e "${YELLOW}  Kanonischer Pfad: pnpm env:release:studio:local${NC}"
 
 # Step 1: Secrets validieren
 echo -e "\n${YELLOW}Step 1: Validating secrets...${NC}"
@@ -77,8 +81,4 @@ echo "ssh node-005.sva 'rm -rf \"\$REMOTE_TMP\"'  # Clean up after secret regist
 echo ""
 echo -e "${YELLOW}Step 4: After secrets are registered, deploy stack:${NC}"
 echo "cd $REPO_ROOT"
-echo "quantum-cli stacks update --endpoint $ENDPOINT --stack $STACK_NAME --wait --project ."
-
-echo ""
-echo -e "${YELLOW}Or run this entire setup automatically (if you have SSH/SCP configured):${NC}"
-echo "bash $REPO_ROOT/scripts/ops/deploy-sva-studio.sh"
+echo "pnpm env:release:studio:local -- --image-digest=<sha256:...> --release-mode=app-only --rollback-hint=\"Initialer Rollout\""


### PR DESCRIPTION
## Zusammenfassung

Markiert die beiden historischen Quantum-/Swarm-Ops-Skripte deutlich als deprecated, ersetzt ihre veralteten Deploy-Hinweise durch den kanonischen lokalen Release-Pfad und kennzeichnet den Verweis im Deployment-Guide.

## Validierung

- `bash -n scripts/ops/create-secrets-portainer-api.sh scripts/ops/swarm-deployment-runbook.sh`
- `git diff --check`