### PR TITLE
fix(auth): recover missing tenant client secrets

### DIFF
--- a/docs/changelog/entries/pr-741.json
+++ b/docs/changelog/entries/pr-741.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 741,
+  "body": "Die Wiederherstellung fehlender Zugangsgeheimnisse für bestehende Studio-Instanzen wurde robuster gemacht."
+}

--- a/docs/guides/instance-keycloak-provisioning.md
+++ b/docs/guides/instance-keycloak-provisioning.md
@@ -242,6 +242,7 @@ Optional und weiter diagnostizierbar:
 - Bei `existing` schreibt Provisioning den gespeicherten Secret-Wert nach Keycloak oder gleicht ihn dagegen ab.
 - Bei `new` liest Provisioning das neu erzeugte Secret aus Keycloak zurück und speichert es anschließend verschlüsselt in der Registry.
 - Secret-Rotation ist eine bewusste Aktion mit eigenem Intent und kein Nebeneffekt eines normalen Speichervorgangs.
+- Fehlt bei `existing` ausschließlich der verschlüsselte Registry-Wert, erzeugt nur der explizite Intent `Client-Secret rotieren` einen neuen Keycloak-Secret-Wert und schreibt ihn anschließend verschlüsselt zurück. Ein normaler Abgleich erzeugt oder löscht kein Secret.
 
 ## Fehler- und Retry-Verhalten
 

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -555,6 +555,32 @@ describe('Keycloak admin client', () => {
     expect(String(rotateCall?.[0])).toContain('/clients/client-1/client-secret');
   });
 
+  it('generates a Keycloak secret during explicit recovery rotation without a registry secret', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'client-1', clientId: 'web-app' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'client-1', clientId: 'web-app' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, { value: 'old-secret' }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const client = await createClient(fetchImpl);
+
+    await client.ensureOidcClient({
+      clientId: 'web-app',
+      redirectUris: ['https://tenant.example/callback'],
+      postLogoutRedirectUris: ['https://tenant.example/logout'],
+      webOrigins: ['https://tenant.example'],
+      rootUrl: 'https://tenant.example',
+      rotateClientSecret: true,
+    });
+
+    const rotateCall = fetchImpl.mock.calls.find((call) =>
+      String(call[0]).includes('/clients/client-1/client-secret') && call[1]?.method === 'POST'
+    );
+    expect(rotateCall).toBeDefined();
+    expect(rotateCall?.[1]?.body).toBe(JSON.stringify({ type: 'secret' }));
+  });
+
   it('preserves existing OIDC client access settings when adding missing redirect and origin entries', async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.test.ts
@@ -555,12 +555,23 @@ describe('Keycloak admin client', () => {
     expect(String(rotateCall?.[0])).toContain('/clients/client-1/client-secret');
   });
 
-  it('generates a Keycloak secret during explicit recovery rotation without a registry secret', async () => {
+  it('sends an explicit recovery rotation request without a secret value when the registry secret is missing', async () => {
+    const existingClient = {
+      id: 'client-1',
+      clientId: 'web-app',
+      rootUrl: 'https://tenant.example',
+      redirectUris: ['https://tenant.example/callback'],
+      webOrigins: ['https://tenant.example'],
+      attributes: { 'post.logout.redirect.uris': 'https://tenant.example/logout' },
+      standardFlowEnabled: true,
+      publicClient: false,
+      directAccessGrantsEnabled: false,
+    };
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(createJsonResponse(200, { access_token: 'token-1', expires_in: 120 }))
-      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'client-1', clientId: 'web-app' }]))
-      .mockResolvedValueOnce(createJsonResponse(200, [{ id: 'client-1', clientId: 'web-app' }]))
+      .mockResolvedValueOnce(createJsonResponse(200, [existingClient]))
+      .mockResolvedValueOnce(createJsonResponse(200, [existingClient]))
       .mockResolvedValueOnce(createJsonResponse(200, { value: 'old-secret' }))
       .mockResolvedValueOnce(new Response(null, { status: 204 }));
     const client = await createClient(fetchImpl);

--- a/packages/auth-runtime/src/keycloak-admin-client/core.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.ts
@@ -1255,9 +1255,6 @@ export class KeycloakAdminClient implements IdentityProviderPort {
     if (!input.rotateClientSecret) {
       return;
     }
-    if (!input.clientSecret) {
-      return;
-    }
     const resolvedClient = existing ?? (await this.getOidcClientByClientId(input.clientId));
     if (!resolvedClient) {
       throw new KeycloakAdminRequestError({
@@ -1279,7 +1276,10 @@ export class KeycloakAdminClient implements IdentityProviderPort {
         method: 'POST',
         path: `/admin/realms/${encodePathSegment(this.realm)}/clients/${encodePathSegment(resolvedClient.id)}/client-secret`,
         operation: 'rotate_client_secret',
-        body: JSON.stringify({ type: 'secret', value: input.clientSecret }),
+        body: JSON.stringify({
+          type: 'secret',
+          ...(input.clientSecret ? { value: input.clientSecret } : {}),
+        }),
       });
       logKeycloakWriteSuccess(logEvent, { operation: 'rotate_client_secret', realm: this.realm, client_id: input.clientId });
     } catch (error) {

--- a/packages/auth-runtime/src/keycloak-admin-client/core.ts
+++ b/packages/auth-runtime/src/keycloak-admin-client/core.ts
@@ -1278,7 +1278,7 @@ export class KeycloakAdminClient implements IdentityProviderPort {
         operation: 'rotate_client_secret',
         body: JSON.stringify({
           type: 'secret',
-          ...(input.clientSecret ? { value: input.clientSecret } : {}),
+          ...(input.clientSecret !== undefined ? { value: input.clientSecret } : {}),
         }),
       });
       logKeycloakWriteSuccess(logEvent, { operation: 'rotate_client_secret', realm: this.realm, client_id: input.clientId });


### PR DESCRIPTION
## Ziel

Stellt den Recovery-Fall für fehlende Tenant-Client-Secrets bei bestehenden Instanzen wieder her.

## Änderungen

- erlaubt eine explizite Client-Secret-Rotation auch dann, wenn lokal kein Registry-Secret vorliegt
- sendet den Keycloak-Rotations-Request nur mit `value`, wenn tatsächlich ein Secret mitgegeben wurde
- ergänzt einen gezielten Unit-Test für den Recovery-Fall
- präzisiert die Doku für das Verhalten bei `existing`

## Tests

- noch nicht in dieser PR gelaufen; Branch stammt aus bestehender lokaler Arbeit und sollte gegen `main` validiert werden