### PR TITLE
fix: validate time inputs

### DIFF
--- a/docs/changelog/entries/pr-746.json
+++ b/docs/changelog/entries/pr-746.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 746,
+  "body": "Uhrzeiten bei Veranstaltungen und Terminen lassen sich jetzt über ein Zeitfeld auswählen. Ungültige Eingaben werden nicht mehr gespeichert."
+}

--- a/packages/plugin-events/src/events.detail-content-tab.tsx
+++ b/packages/plugin-events/src/events.detail-content-tab.tsx
@@ -229,6 +229,7 @@ export function EventsDetailContentTab({
               <StudioField id={index === 0 ? 'event-time-start' : `event-time-start-${index}`} label={pt('fields.timeStart')}>
                 <Input
                   id={index === 0 ? 'event-time-start' : `event-time-start-${index}`}
+                  type="time"
                   value={date.timeStart ?? ''}
                   onChange={(event) => setValue(`content.dates.${index}.timeStart`, event.target.value, { shouldDirty: true })}
                 />
@@ -236,6 +237,7 @@ export function EventsDetailContentTab({
               <StudioField id={index === 0 ? 'event-time-end' : `event-time-end-${index}`} label={pt('fields.timeEnd')}>
                 <Input
                   id={index === 0 ? 'event-time-end' : `event-time-end-${index}`}
+                  type="time"
                   value={date.timeEnd ?? ''}
                   onChange={(event) => setValue(`content.dates.${index}.timeEnd`, event.target.value, { shouldDirty: true })}
                 />

--- a/packages/plugin-events/tests/events.detail-content-tab.test.tsx
+++ b/packages/plugin-events/tests/events.detail-content-tab.test.tsx
@@ -421,6 +421,14 @@ describe('EventsDetailContentTab', () => {
     expect(screen.getByLabelText('Enddatum').getAttribute('type')).toBe('date');
   });
 
+  it('renders time inputs for event times', async () => {
+    renderTab();
+    await screen.findAllByRole('button', { name: 'Kartenpunkt setzen' });
+
+    expect(screen.getByLabelText('Startzeit').getAttribute('type')).toBe('time');
+    expect(screen.getByLabelText('Endzeit').getAttribute('type')).toBe('time');
+  });
+
   it('renders fallback values when optional arrays are initially missing', async () => {
     renderTab({
       content: {

--- a/packages/plugin-generic-items/src/generic-items.detail-content-tab.tsx
+++ b/packages/plugin-generic-items/src/generic-items.detail-content-tab.tsx
@@ -955,6 +955,7 @@ export const GenericItemsDetailContentTab = ({
                 <StudioField id={`generic-item-time-start-${index}`} label={labels.timeStart}>
                   <Input
                     id={`generic-item-time-start-${index}`}
+                    type="time"
                     value={date.timeStart}
                     onChange={(event) => setValue(`dates.${index}.timeStart`, event.target.value, { shouldDirty: true })}
                   />
@@ -962,6 +963,7 @@ export const GenericItemsDetailContentTab = ({
                 <StudioField id={`generic-item-time-end-${index}`} label={labels.timeEnd}>
                   <Input
                     id={`generic-item-time-end-${index}`}
+                    type="time"
                     value={date.timeEnd}
                     onChange={(event) => setValue(`dates.${index}.timeEnd`, event.target.value, { shouldDirty: true })}
                   />

--- a/packages/plugin-generic-items/tests/generic-items.detail-content-tab.test.tsx
+++ b/packages/plugin-generic-items/tests/generic-items.detail-content-tab.test.tsx
@@ -260,6 +260,14 @@ function renderTab(defaultValues?: Partial<GenericItemsDetailFormValues>) {
 }
 
 describe('GenericItemsDetailContentTab', () => {
+  it('renders time inputs for date times', async () => {
+    renderTab();
+    await screen.findAllByRole('button', { name: 'Kartenpunkt setzen' });
+
+    expect(screen.getByLabelText('Beginn').getAttribute('type')).toBe('time');
+    expect(screen.getByLabelText('Ende Uhrzeit').getAttribute('type')).toBe('time');
+  });
+
   it('updates structured accessibility and price information rows', async () => {
     const { getValues } = renderTab();
 

--- a/packages/sva-mainserver/src/server/content-route-core.ts
+++ b/packages/sva-mainserver/src/server/content-route-core.ts
@@ -52,6 +52,8 @@ export const isResponse = <T>(value: ParsedValue<T>): value is Response => value
 export const readString = (value: unknown): string | undefined =>
   typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 
+export const isTimeOfDay = (value: string): boolean => /^(?:[01]\d|2[0-3]):[0-5]\d$/.test(value);
+
 export const readBoolean = (value: unknown): boolean | undefined => (typeof value === 'boolean' ? value : undefined);
 
 export const readNumber = (value: unknown): number | undefined => {

--- a/packages/sva-mainserver/src/server/content-route-parsers-poi.test.ts
+++ b/packages/sva-mainserver/src/server/content-route-parsers-poi.test.ts
@@ -83,6 +83,8 @@ describe('content-route-parsers-poi', () => {
   it('returns validation errors for malformed opening hours and prices', async () => {
     await expectInvalidRequest(parseOpeningHours('no-array') as Response);
     await expectInvalidRequest(parseOpeningHours([null]) as Response);
+    await expectInvalidRequest(parseOpeningHours([{ timeFrom: '19 Uhr' }]) as Response);
+    await expectInvalidRequest(parseOpeningHours([{ timeTo: '24:00' }]) as Response);
     await expectInvalidRequest(parsePrices('no-array') as Response);
     await expectInvalidRequest(parsePrices([null]) as Response);
   });

--- a/packages/sva-mainserver/src/server/content-route-parsers-poi.ts
+++ b/packages/sva-mainserver/src/server/content-route-parsers-poi.ts
@@ -6,7 +6,7 @@ import type {
   SvaMainserverOperatingCompanyInput,
   SvaMainserverPriceInput,
 } from '../types.js';
-import { errorJson, isRecord, readBoolean, readNumber, readString } from './content-route-core.js';
+import { errorJson, isRecord, isTimeOfDay, readBoolean, readNumber, readString } from './content-route-core.js';
 import { parseAddress, parseContact, parseWebUrl, parseWebUrls } from './content-route-parsers.shared.js';
 
 export const parseOpeningHours = (value: unknown): readonly SvaMainserverOpeningHourInput[] | Response | undefined => {
@@ -22,12 +22,17 @@ export const parseOpeningHours = (value: unknown): readonly SvaMainserverOpening
     if (!isRecord(item)) {
       return errorJson(400, 'invalid_request', 'Öffnungszeiten-Einträge müssen Objekte sein.');
     }
+    const timeFrom = readString(item.timeFrom);
+    const timeTo = readString(item.timeTo);
+    if ((timeFrom && !isTimeOfDay(timeFrom)) || (timeTo && !isTimeOfDay(timeTo))) {
+      return errorJson(400, 'invalid_request', 'Öffnungszeiten müssen im Format HH:MM angegeben werden.');
+    }
     openingHours.push({
       ...(readString(item.weekday) ? { weekday: readString(item.weekday) } : {}),
       ...(readString(item.dateFrom) ? { dateFrom: readString(item.dateFrom) } : {}),
       ...(readString(item.dateTo) ? { dateTo: readString(item.dateTo) } : {}),
-      ...(readString(item.timeFrom) ? { timeFrom: readString(item.timeFrom) } : {}),
-      ...(readString(item.timeTo) ? { timeTo: readString(item.timeTo) } : {}),
+      ...(timeFrom ? { timeFrom } : {}),
+      ...(timeTo ? { timeTo } : {}),
       ...(readNumber(item.sortNumber) !== undefined ? { sortNumber: readNumber(item.sortNumber) } : {}),
       ...(readBoolean(item.open) !== undefined ? { open: readBoolean(item.open) } : {}),
       ...(readBoolean(item.useYear) !== undefined ? { useYear: readBoolean(item.useYear) } : {}),

--- a/packages/sva-mainserver/src/server/events-poi-routes.test.ts
+++ b/packages/sva-mainserver/src/server/events-poi-routes.test.ts
@@ -960,6 +960,11 @@ describe('mainserver content route contracts', () => {
       },
     ],
     ['invalid event contact', 'events', { method: 'POST', body: JSON.stringify({ title: 'Stadtfest', contact: 'Team' }) }],
+    [
+      'invalid event time',
+      'events',
+      { method: 'POST', body: JSON.stringify({ title: 'Stadtfest', dates: [{ timeStart: '19 Uhr' }] }) },
+    ],
     ['invalid event tags', 'events', { method: 'POST', body: JSON.stringify({ title: 'Stadtfest', tags: 'sommer' }) }],
     [
       'invalid category item',

--- a/packages/sva-mainserver/src/server/events-route.ts
+++ b/packages/sva-mainserver/src/server/events-route.ts
@@ -19,7 +19,6 @@ import type {
 } from '../types.js';
 import {
   errorJson,
-  isRecord,
   isResponse,
   json,
   matchRequestRoute,
@@ -29,6 +28,7 @@ import {
   type ParsedValue,
   type RouteMatch as SharedRouteMatch,
 } from './content-route-core.js';
+import { parseDates } from './generic-items-route-input.dates.js';
 import {
   parseAccessibilityInformation,
   parseAddressList,
@@ -67,23 +67,6 @@ type ContentActor = {
 };
 
 const matchRoute = (request: Request): RouteMatch | null => matchRequestRoute(request, EVENTS_COLLECTION_PATH, 'events');
-
-const parseEventDates = (value: unknown): readonly SvaMainserverDateInput[] | undefined =>
-  Array.isArray(value)
-    ? value
-        .filter(isRecord)
-        .map((date): SvaMainserverDateInput => ({
-          ...(readString(date.weekday) ? { weekday: readString(date.weekday) } : {}),
-          ...(readString(date.dateStart) ? { dateStart: readString(date.dateStart) } : {}),
-          ...(readString(date.dateEnd) ? { dateEnd: readString(date.dateEnd) } : {}),
-          ...(readString(date.timeStart) ? { timeStart: readString(date.timeStart) } : {}),
-          ...(readString(date.timeEnd) ? { timeEnd: readString(date.timeEnd) } : {}),
-          ...(readString(date.timeDescription) ? { timeDescription: readString(date.timeDescription) } : {}),
-          ...(readBoolean(date.useOnlyTimeDescription) !== undefined
-            ? { useOnlyTimeDescription: readBoolean(date.useOnlyTimeDescription) }
-            : {}),
-        }))
-    : undefined;
 
 const parseEventRelations = (
   body: Record<string, unknown>
@@ -177,6 +160,7 @@ const parseEventRelations = (
 const buildEventInput = (
   body: Record<string, unknown>,
   title: string,
+  dates: readonly SvaMainserverDateInput[] | undefined,
   relations: {
     readonly categories: readonly SvaMainserverCategoryInput[] | undefined;
     readonly addresses: readonly SvaMainserverAddressInput[] | undefined;
@@ -189,8 +173,6 @@ const buildEventInput = (
     readonly accessibilityInformation: SvaMainserverAccessibilityInformationInput | undefined;
   }
 ): SvaMainserverEventInput => {
-  const dates = parseEventDates(body.dates);
-
   return {
     title,
     ...(readString(body.description) ? { description: readString(body.description) } : {}),
@@ -236,13 +218,18 @@ const parseEventInput = async (
     return relations;
   }
 
+  const dates = parseDates(body.dates);
+  if (isResponse(dates)) {
+    return dates;
+  }
+
   const visible = readBoolean(body.visible);
   if (body.visible !== undefined && visible === undefined) {
     return errorJson(400, 'invalid_request', 'Das Feld "visible" muss als Boolean gesendet werden.');
   }
 
   return {
-    event: buildEventInput(body, title, relations),
+    event: buildEventInput(body, title, dates, relations),
     ...(visible !== undefined ? { visible } : {}),
   };
 };

--- a/packages/sva-mainserver/src/server/events-route.ts
+++ b/packages/sva-mainserver/src/server/events-route.ts
@@ -19,7 +19,9 @@ import type {
 } from '../types.js';
 import {
   errorJson,
+  isRecord,
   isResponse,
+  isTimeOfDay,
   json,
   matchRequestRoute,
   parseJsonObjectBody,
@@ -28,7 +30,6 @@ import {
   type ParsedValue,
   type RouteMatch as SharedRouteMatch,
 } from './content-route-core.js';
-import { parseDates } from './generic-items-route-input.dates.js';
 import {
   parseAccessibilityInformation,
   parseAddressList,
@@ -67,6 +68,36 @@ type ContentActor = {
 };
 
 const matchRoute = (request: Request): RouteMatch | null => matchRequestRoute(request, EVENTS_COLLECTION_PATH, 'events');
+
+const parseEventDates = (value: unknown): readonly SvaMainserverDateInput[] | Response | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const dates: SvaMainserverDateInput[] = [];
+  for (const item of value) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const timeStart = readString(item.timeStart);
+    const timeEnd = readString(item.timeEnd);
+    if ((timeStart && !isTimeOfDay(timeStart)) || (timeEnd && !isTimeOfDay(timeEnd))) {
+      return errorJson(400, 'invalid_request', 'Termine müssen Uhrzeiten im Format HH:MM enthalten.');
+    }
+    dates.push({
+      ...(readString(item.weekday) ? { weekday: readString(item.weekday) } : {}),
+      ...(readString(item.dateStart) ? { dateStart: readString(item.dateStart) } : {}),
+      ...(readString(item.dateEnd) ? { dateEnd: readString(item.dateEnd) } : {}),
+      ...(timeStart ? { timeStart } : {}),
+      ...(timeEnd ? { timeEnd } : {}),
+      ...(readString(item.timeDescription) ? { timeDescription: readString(item.timeDescription) } : {}),
+      ...(readBoolean(item.useOnlyTimeDescription) !== undefined
+        ? { useOnlyTimeDescription: readBoolean(item.useOnlyTimeDescription) }
+        : {}),
+    });
+  }
+  return dates;
+};
 
 const parseEventRelations = (
   body: Record<string, unknown>
@@ -218,7 +249,7 @@ const parseEventInput = async (
     return relations;
   }
 
-  const dates = parseDates(body.dates);
+  const dates = parseEventDates(body.dates);
   if (isResponse(dates)) {
     return dates;
   }

--- a/packages/sva-mainserver/src/server/generic-items-route-input.dates.test.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-input.dates.test.ts
@@ -41,5 +41,7 @@ describe('generic-items-route-input.dates', () => {
   it('returns validation errors for malformed date payloads', async () => {
     await expectInvalidRequest(parseDates('not-an-array') as Response);
     await expectInvalidRequest(parseDates([null]) as Response);
+    await expectInvalidRequest(parseDates([{ timeStart: '19 Uhr' }]) as Response);
+    await expectInvalidRequest(parseDates([{ timeEnd: '24:00' }]) as Response);
   });
 });

--- a/packages/sva-mainserver/src/server/generic-items-route-input.dates.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-input.dates.ts
@@ -1,5 +1,5 @@
 import type { SvaMainserverDateInput } from '../types.js';
-import { errorJson, isRecord, readBoolean, readString } from './content-route-core.js';
+import { errorJson, isRecord, isTimeOfDay, readBoolean, readString } from './content-route-core.js';
 
 export const parseDates = (value: unknown): readonly SvaMainserverDateInput[] | Response | undefined => {
   if (value === undefined || value === null) {
@@ -14,12 +14,17 @@ export const parseDates = (value: unknown): readonly SvaMainserverDateInput[] | 
     if (!isRecord(item)) {
       return errorJson(400, 'invalid_request', 'Termin-Einträge müssen Objekte sein.');
     }
+    const timeStart = readString(item.timeStart);
+    const timeEnd = readString(item.timeEnd);
+    if ((timeStart && !isTimeOfDay(timeStart)) || (timeEnd && !isTimeOfDay(timeEnd))) {
+      return errorJson(400, 'invalid_request', 'Termine müssen Uhrzeiten im Format HH:MM enthalten.');
+    }
     const date = {
       ...(readString(item.weekday) ? { weekday: readString(item.weekday) } : {}),
       ...(readString(item.dateStart) ? { dateStart: readString(item.dateStart) } : {}),
       ...(readString(item.dateEnd) ? { dateEnd: readString(item.dateEnd) } : {}),
-      ...(readString(item.timeStart) ? { timeStart: readString(item.timeStart) } : {}),
-      ...(readString(item.timeEnd) ? { timeEnd: readString(item.timeEnd) } : {}),
+      ...(timeStart ? { timeStart } : {}),
+      ...(timeEnd ? { timeEnd } : {}),
       ...(readString(item.timeDescription) ? { timeDescription: readString(item.timeDescription) } : {}),
       ...(readBoolean(item.useOnlyTimeDescription) !== undefined
         ? { useOnlyTimeDescription: readBoolean(item.useOnlyTimeDescription) }


### PR DESCRIPTION
## Zusammenfassung

- Stellt Veranstaltungs- und generische Terminzeiten als native Zeitfelder bereit.
- Validiert Uhrzeiten serverseitig strikt als `HH:MM` zwischen `00:00` und `23:59`.
- Ergänzt UI- und API-Tests für ungültige Uhrzeitwerte.

## Ursache

Die Veranstaltungs-Startzeit war ein Freitextfeld und erlaubte daher Werte wie `19 Uhr`.

## Validierung

- `pnpm nx run plugin-events:test:unit --testFiles=tests/events.detail-content-tab.test.tsx`
- `pnpm nx run plugin-generic-items:test:unit --testFiles=tests/generic-items.detail-content-tab.test.tsx`
- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/content-route-parsers-poi.test.ts --testFiles=src/server/generic-items-route-input.dates.test.ts`
- `pnpm nx run plugin-events:test:types`
- `pnpm nx run plugin-generic-items:test:types`
- `pnpm nx run sva-mainserver:test:types`
- `pnpm check:server-runtime`

Fixes #719