### PR TITLE
fix: grant promote workflow action read access

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
   packages: write
 

--- a/docs/changelog/entries/pr-748.json
+++ b/docs/changelog/entries/pr-748.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 748,
+  "body": "Der automatische Dev-Promote erhält die erforderliche Actions-Leseberechtigung und kann nach dem Image-Build wieder starten."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -55,6 +55,7 @@ describe('Promote workflow contract', () => {
 
     expect(buildWorkflow).toContain('bootstrap_mode: auto');
     expect(buildWorkflow).toContain('migration_mode: auto');
+    expect(buildWorkflow).toContain('actions: read');
     expect(workflow).toContain('migration_should_run');
     expect(workflow).toContain('bootstrap_should_run');
   });


### PR DESCRIPTION
## Zusammenfassung

Ergänzt `actions: read` im aufrufenden Build-Workflow, damit der wiederverwendete Promote-Workflow starten kann.

## Validierung

- `pnpm exec vitest run scripts/ci/promote-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm test:pr` (kein committed Diff vor dem Commit, daher No-op außer File-Placement)