### PR TITLE
fix: authenticate promote image inspection

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -152,6 +152,13 @@ jobs:
       - name: setup pnpm workspace
         uses: ./.github/actions/setup-pnpm-workspace
 
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: validate image contract
         id: image_contract
         env:

--- a/docs/changelog/entries/pr-750.json
+++ b/docs/changelog/entries/pr-750.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 750,
+  "body": "Staging- und Production-Promotes authentifizieren die Bildvertragsprüfung jetzt bei GHCR, sodass private Images vor dem Deployment zuverlässig verifiziert werden."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -23,6 +23,7 @@ describe('Promote workflow contract', () => {
     expect(offsets.every((offset) => offset >= 0)).toBe(true);
     expect(offsets).toEqual([...offsets].sort((left, right) => left - right));
     expect(workflow).toMatch(/- name: deploy\s+id: deploy/u);
+    expect(workflow.indexOf('Login to GHCR')).toBeLessThan(workflow.indexOf('validate image contract'));
   });
 
   it('requires a maintenance reference and guards production mutations with staging parity', () => {


### PR DESCRIPTION
## Zusammenfassung

Der Promote-Workflow authentifiziert sich vor der Bildvertragsprüfung bei GHCR. Dadurch kann Staging private Images fail-closed verifizieren.

## Validierung

- `pnpm exec vitest run scripts/ci/promote-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm test:pr`