### PR TITLE
fix: provide runtime config to promote smoke checks

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -302,8 +302,11 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
-          trap 'rm -f .env' EXIT
+          trap 'rm -f .env config/runtime/base.vars config/runtime/studio.vars' EXIT
           pnpm exec tsx scripts/ci/render-compose-env.ts --output .env
+          mkdir -p config/runtime
+          printf '%s\n' "${APP_CONFIG}" > config/runtime/base.vars
+          : > config/runtime/studio.vars
           pnpm exec tsx scripts/ops/runtime-env.ts doctor studio
 
       - name: deploy
@@ -346,8 +349,11 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
-          trap 'rm -f .env' EXIT
+          trap 'rm -f .env config/runtime/base.vars config/runtime/studio.vars' EXIT
           pnpm exec tsx scripts/ci/render-compose-env.ts --output .env
+          mkdir -p config/runtime
+          printf '%s\n' "${APP_CONFIG}" > config/runtime/base.vars
+          : > config/runtime/studio.vars
           pnpm exec tsx scripts/ops/runtime-env.ts smoke studio
 
       - name: verify deployed runtime image digest

--- a/docs/changelog/entries/pr-751.json
+++ b/docs/changelog/entries/pr-751.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 751,
+  "body": "Staging- und Production-Promotes stellen APP_CONFIG für Runtime-Smoke- und Doctor-Checks nun geschützt im GitHub-Runner bereit."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -24,6 +24,8 @@ describe('Promote workflow contract', () => {
     expect(offsets).toEqual([...offsets].sort((left, right) => left - right));
     expect(workflow).toMatch(/- name: deploy\s+id: deploy/u);
     expect(workflow.indexOf('Login to GHCR')).toBeLessThan(workflow.indexOf('validate image contract'));
+    expect(workflow).toContain("trap 'rm -f .env config/runtime/base.vars config/runtime/studio.vars' EXIT");
+    expect(workflow.match(/printf '%s\\n' "\$\{APP_CONFIG\}" > config\/runtime\/base\.vars/gu)).toHaveLength(2);
   });
 
   it('requires a maintenance reference and guards production mutations with staging parity', () => {


### PR DESCRIPTION
## Zusammenfassung

Stellt `APP_CONFIG` für die Runtime-Doctor- und Smoke-Checks temporär als geschützte Runtime-Dateien bereit.

## Validierung

- `pnpm exec vitest run scripts/ci/promote-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm test:pr`