### PR TITLE
fix: configure runtime smoke stack target

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -299,6 +299,8 @@ jobs:
         if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_STACK_NAME: studio-${{ inputs.environment }}
         run: |
           set -euo pipefail
           umask 077
@@ -346,6 +348,8 @@ jobs:
         if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_STACK_NAME: studio-${{ inputs.environment }}
         run: |
           set -euo pipefail
           umask 077

--- a/docs/changelog/entries/pr-753.json
+++ b/docs/changelog/entries/pr-753.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 753,
+  "body": "Staging- und Production-Promotes übergeben den Ziel-Stack und Quantum-Endpunkt nun auch an die Runtime-Postcondition-Checks."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -26,6 +26,8 @@ describe('Promote workflow contract', () => {
     expect(workflow.indexOf('Login to GHCR')).toBeLessThan(workflow.indexOf('validate image contract'));
     expect(workflow).toContain("trap 'rm -f .env config/runtime/base.vars config/runtime/studio.vars' EXIT");
     expect(workflow.match(/printf '%s\\n' "\$\{APP_CONFIG\}" > config\/runtime\/base\.vars/gu)).toHaveLength(2);
+    expect(workflow.match(/QUANTUM_ENDPOINT: \$\{\{ vars\.QUANTUM_ENDPOINT \}\}/gu)).toHaveLength(8);
+    expect(workflow.match(/SVA_STACK_NAME: studio-\$\{\{ inputs\.environment \}\}/gu)).toHaveLength(2);
   });
 
   it('requires a maintenance reference and guards production mutations with staging parity', () => {


### PR DESCRIPTION
## Zusammenfassung

- übergibt Stack-Name und Quantum-Endpunkt an die Runtime-Postconditions
- behebt den abgebrochenen Staging-Backup-Drill vor dem eigentlichen Deploy
- sichert die Workflow-Konfiguration per Vertragstest ab

## Validierung

- `pnpm exec vitest run scripts/ci/promote-workflow-contract.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`

Closes #752