### PR TITLE
fix: verify promoted database backups externally

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -265,6 +265,16 @@ jobs:
           printf '\nIMAGE_REF=%s\n' "${{ steps.image_contract.outputs.deploy_image_ref }}" >> .env
           pnpm exec tsx scripts/ci/promote-backup-job.ts "${{ inputs.environment }}"
 
+      - name: verify database backup object
+        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') }}
+        env:
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket }}
+          S3_ENDPOINT: https://fileserver.smart-village.app
+          S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object }}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: pnpm exec tsx scripts/ci/verify-promote-backup.ts
+
       - name: run migration one-shot job
         id: migration_job
         if: ${{ steps.gate_eval.outputs.migration_should_run == 'true' }}

--- a/docs/changelog/entries/pr-754.json
+++ b/docs/changelog/entries/pr-754.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 754,
+  "body": "Promotes prüfen das erzeugte Datenbank-Backup nun nach dem Quantum-Job unabhängig per S3-Head-Object und brechen bei fehlendem Objekt ab."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -11,6 +11,7 @@ describe('Promote workflow contract', () => {
       'bind executor source to promoted change head',
       'capture previous live app digest',
       'create database backup before one-shot jobs',
+      'verify database backup object',
       'run migration one-shot job',
       'run bootstrap one-shot job',
       'run one-shot postconditions',
@@ -39,6 +40,8 @@ describe('Promote workflow contract', () => {
     expect(workflow).toContain('actions: read');
     expect(workflow).toContain('require successful staging parity for production mutation');
     expect(workflow).toContain('create database backup before one-shot jobs');
+    expect(workflow).toContain('verify database backup object');
+    expect(workflow).toContain('S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object }}');
     expect(workflow).toContain('STAGING_MUTATION: ${{ steps.gate_eval.outputs.migration_should_run == \'true\' || steps.gate_eval.outputs.bootstrap_should_run == \'true\' }}');
     expect(workflow).toContain('name: promote-staging-parity-${{ github.run_id }}-${{ github.run_attempt }}');
     expect(workflow).toContain('--expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"');

--- a/scripts/ci/verify-promote-backup.test.ts
+++ b/scripts/ci/verify-promote-backup.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildBackupVerificationEnv, buildS3HeadObjectArgs } from './verify-promote-backup.ts';
+
+describe('verify promote backup', () => {
+  it('uses an explicit S3 head-object request for the exact backup object', () => {
+    expect(buildS3HeadObjectArgs('https://fileserver.smart-village.app', 'studio-db-backup-staging', 'staging/example.dump')).toEqual([
+      '--endpoint-url',
+      'https://fileserver.smart-village.app',
+      's3api',
+      'head-object',
+      '--bucket',
+      'studio-db-backup-staging',
+      '--key',
+      'staging/example.dump',
+      '--no-cli-pager',
+      '--output',
+      'json',
+    ]);
+  });
+
+  it('maps the S3 secrets to the AWS CLI variables without ambient credential fallback', () => {
+    const env = buildBackupVerificationEnv({ S3_ACCESS_KEY_ID: 'access', S3_SECRET_ACCESS_KEY: 'secret' });
+
+    expect(env).toMatchObject({
+      AWS_ACCESS_KEY_ID: 'access',
+      AWS_DEFAULT_REGION: 'us-east-1',
+      AWS_EC2_METADATA_DISABLED: 'true',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+    });
+  });
+});

--- a/scripts/ci/verify-promote-backup.ts
+++ b/scripts/ci/verify-promote-backup.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { commandExists, runCapture } from '../ops/runtime/process.ts';
+
+const rootDir = resolve(import.meta.dirname, '../..');
+
+const required = (value: string | undefined, name: string) => {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`${name} darf nicht leer sein.`);
+  return trimmed;
+};
+
+export const buildS3HeadObjectArgs = (endpoint: string, bucket: string, objectKey: string) => [
+  '--endpoint-url',
+  endpoint,
+  's3api',
+  'head-object',
+  '--bucket',
+  bucket,
+  '--key',
+  objectKey,
+  '--no-cli-pager',
+  '--output',
+  'json',
+] as const;
+
+export const buildBackupVerificationEnv = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv => ({
+  ...env,
+  AWS_ACCESS_KEY_ID: required(env.S3_ACCESS_KEY_ID, 'S3_ACCESS_KEY_ID'),
+  AWS_DEFAULT_REGION: env.AWS_DEFAULT_REGION?.trim() || 'us-east-1',
+  AWS_EC2_METADATA_DISABLED: 'true',
+  AWS_SECRET_ACCESS_KEY: required(env.S3_SECRET_ACCESS_KEY, 'S3_SECRET_ACCESS_KEY'),
+});
+
+const main = () => {
+  const bucket = required(process.env.S3_BUCKET, 'S3_BUCKET');
+  const endpoint = required(process.env.S3_ENDPOINT, 'S3_ENDPOINT');
+  const objectKey = required(process.env.S3_OBJECT_KEY, 'S3_OBJECT_KEY');
+  const runId = required(process.env.GITHUB_RUN_ID, 'GITHUB_RUN_ID');
+  const attempt = required(process.env.GITHUB_RUN_ATTEMPT, 'GITHUB_RUN_ATTEMPT');
+  if (!commandExists(rootDir, 'aws')) throw new Error('AWS CLI ist für die externe Backup-Verifikation nicht verfügbar.');
+
+  runCapture(rootDir, 'aws', buildS3HeadObjectArgs(endpoint, bucket, objectKey), buildBackupVerificationEnv(process.env));
+
+  const evidencePath = resolve(process.env.RUNNER_TEMP ?? rootDir, `promote-backup-verification-${runId}-${attempt}.json`);
+  writeFileSync(evidencePath, `${JSON.stringify({ bucket, objectKey, status: 'verified' }, null, 2)}\n`);
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## Zusammenfassung

- prüft das Backup-Objekt nach dem Quantum-Job unabhängig vom GitHub-Runner aus
- setzt S3-Secrets explizit als AWS-CLI-Credentials, ohne Fallback auf Runner-Profile
- stoppt den Promote, wenn das Objekt im Ziel-Bucket fehlt

## Validierung

- `pnpm exec vitest run scripts/ci/verify-promote-backup.test.ts scripts/ci/promote-workflow-contract.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`
- realer Negativtest gegen den Staging-Bucket: fehlendes Objekt wird blockiert

Refs #752