### PR TITLE
fix: verify backups with MinIO-compatible client

### DIFF
--- a/docs/changelog/entries/pr-755.json
+++ b/docs/changelog/entries/pr-755.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 755,
+  "body": "Die externe Datenbank-Backup-Prüfung verwendet nun den im Workspace etablierten MinIO-kompatiblen S3-Client statt einer nicht garantierten Runner-AWS-CLI."
+}

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "homepage": "https://github.com/smart-village-solutions/sva-studio#readme",
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.1073.0",
     "@eslint/js": "^10.0.1",
     "@nx/eslint": "^23.0.1",
     "@nx/eslint-plugin": "^23.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
 
   .:
     devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
@@ -156,7 +159,7 @@ importers:
         version: link:../../packages/core
       '@sva/data-repositories':
         specifier: workspace:*
-        version: file:packages/data-repositories(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
+        version: link:../../packages/data-repositories
       '@tabler/icons-react':
         specifier: ^3.41.1
         version: 3.44.0(react@19.2.6)
@@ -9190,20 +9193,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -9213,7 +9216,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -9221,7 +9224,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -9230,7 +9233,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.13
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -9285,12 +9288,12 @@ snapshots:
 
   '@aws-sdk/core@3.974.13':
     dependencies:
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/xml-builder': 3.972.25
       '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.4
+      '@smithy/core': 3.25.1
       '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       bowser: 2.14.1
       tslib: 2.8.1
 
@@ -9307,15 +9310,15 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.9':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.39':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.48':
@@ -9328,12 +9331,12 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.41':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.50':
@@ -9348,7 +9351,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/credential-provider-env': 3.972.39
       '@aws-sdk/credential-provider-http': 3.972.41
       '@aws-sdk/credential-provider-login': 3.972.43
@@ -9356,10 +9359,10 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.43
       '@aws-sdk/credential-provider-web-identity': 3.972.43
       '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
       '@smithy/credential-provider-imds': 4.3.4
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.55':
@@ -9380,11 +9383,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.54':
@@ -9404,10 +9407,10 @@ snapshots:
       '@aws-sdk/credential-provider-process': 3.972.39
       '@aws-sdk/credential-provider-sso': 3.972.43
       '@aws-sdk/credential-provider-web-identity': 3.972.43
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
       '@smithy/credential-provider-imds': 4.3.4
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.57':
@@ -9426,10 +9429,10 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.39':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.48':
@@ -9442,12 +9445,12 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/token-providers': 3.1052.0
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.54':
@@ -9462,11 +9465,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.54':
@@ -9480,17 +9483,17 @@ snapshots:
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.15':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-expect-continue@3.972.13':
     dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.21':
@@ -9498,11 +9501,11 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/crc64-nvme': 3.972.9
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.32':
@@ -9512,18 +9515,18 @@ snapshots:
 
   '@aws-sdk/middleware-location-constraint@3.972.11':
     dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.42':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.28
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
       '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.53':
@@ -9537,21 +9540,21 @@ snapshots:
 
   '@aws-sdk/middleware-ssec@3.972.11':
     dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.11':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.28
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.1
+      '@smithy/node-http-handler': 4.8.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.22':
@@ -9587,10 +9590,10 @@ snapshots:
 
   '@aws-sdk/signature-v4-multi-region@3.996.28':
     dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
       '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.35':
@@ -9602,11 +9605,11 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1052.0':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1071.0':
@@ -9625,7 +9628,7 @@ snapshots:
 
   '@aws-sdk/types@3.973.9':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -9635,7 +9638,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.25':
     dependencies:
       '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
@@ -12932,7 +12935,7 @@ snapshots:
   '@smithy/core@3.24.4':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/core@3.25.1':
@@ -12943,8 +12946,8 @@ snapshots:
 
   '@smithy/credential-provider-imds@4.3.4':
     dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.4.1':
@@ -12961,8 +12964,8 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.4.4':
     dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.5.1':
@@ -12977,8 +12980,8 @@ snapshots:
 
   '@smithy/node-http-handler@4.7.4':
     dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.8.1':
@@ -12989,8 +12992,8 @@ snapshots:
 
   '@smithy/signature-v4@5.4.4':
     dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.5.1':

--- a/scripts/ci/verify-promote-backup.test.ts
+++ b/scripts/ci/verify-promote-backup.test.ts
@@ -1,32 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildBackupVerificationEnv, buildS3HeadObjectArgs } from './verify-promote-backup.ts';
+import { buildMinioS3ClientConfig } from './verify-promote-backup.ts';
 
 describe('verify promote backup', () => {
-  it('uses an explicit S3 head-object request for the exact backup object', () => {
-    expect(buildS3HeadObjectArgs('https://fileserver.smart-village.app', 'studio-db-backup-staging', 'staging/example.dump')).toEqual([
-      '--endpoint-url',
-      'https://fileserver.smart-village.app',
-      's3api',
-      'head-object',
-      '--bucket',
-      'studio-db-backup-staging',
-      '--key',
-      'staging/example.dump',
-      '--no-cli-pager',
-      '--output',
-      'json',
-    ]);
-  });
-
-  it('maps the S3 secrets to the AWS CLI variables without ambient credential fallback', () => {
-    const env = buildBackupVerificationEnv({ S3_ACCESS_KEY_ID: 'access', S3_SECRET_ACCESS_KEY: 'secret' });
-
-    expect(env).toMatchObject({
-      AWS_ACCESS_KEY_ID: 'access',
-      AWS_DEFAULT_REGION: 'us-east-1',
-      AWS_EC2_METADATA_DISABLED: 'true',
-      AWS_SECRET_ACCESS_KEY: 'secret',
+  it('configures the established MinIO endpoint with path-style addressing', () => {
+    expect(buildMinioS3ClientConfig({
+      S3_ACCESS_KEY_ID: 'access',
+      S3_ENDPOINT: 'https://fileserver.smart-village.app',
+      S3_SECRET_ACCESS_KEY: 'secret',
+    })).toEqual({
+      credentials: {
+        accessKeyId: 'access',
+        secretAccessKey: 'secret',
+      },
+      endpoint: 'https://fileserver.smart-village.app',
+      forcePathStyle: true,
+      region: 'us-east-1',
     });
   });
 });

--- a/scripts/ci/verify-promote-backup.ts
+++ b/scripts/ci/verify-promote-backup.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { commandExists, runCapture } from '../ops/runtime/process.ts';
+import { HeadObjectCommand, S3Client, type S3ClientConfig } from '@aws-sdk/client-s3';
 
 const rootDir = resolve(import.meta.dirname, '../..');
 
@@ -13,42 +13,31 @@ const required = (value: string | undefined, name: string) => {
   return trimmed;
 };
 
-export const buildS3HeadObjectArgs = (endpoint: string, bucket: string, objectKey: string) => [
-  '--endpoint-url',
-  endpoint,
-  's3api',
-  'head-object',
-  '--bucket',
-  bucket,
-  '--key',
-  objectKey,
-  '--no-cli-pager',
-  '--output',
-  'json',
-] as const;
-
-export const buildBackupVerificationEnv = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv => ({
-  ...env,
-  AWS_ACCESS_KEY_ID: required(env.S3_ACCESS_KEY_ID, 'S3_ACCESS_KEY_ID'),
-  AWS_DEFAULT_REGION: env.AWS_DEFAULT_REGION?.trim() || 'us-east-1',
-  AWS_EC2_METADATA_DISABLED: 'true',
-  AWS_SECRET_ACCESS_KEY: required(env.S3_SECRET_ACCESS_KEY, 'S3_SECRET_ACCESS_KEY'),
+export const buildMinioS3ClientConfig = (env: NodeJS.ProcessEnv): S3ClientConfig => ({
+  endpoint: required(env.S3_ENDPOINT, 'S3_ENDPOINT'),
+  region: env.AWS_DEFAULT_REGION?.trim() || 'us-east-1',
+  forcePathStyle: true,
+  credentials: {
+    accessKeyId: required(env.S3_ACCESS_KEY_ID, 'S3_ACCESS_KEY_ID'),
+    secretAccessKey: required(env.S3_SECRET_ACCESS_KEY, 'S3_SECRET_ACCESS_KEY'),
+  },
 });
 
-const main = () => {
+const main = async () => {
   const bucket = required(process.env.S3_BUCKET, 'S3_BUCKET');
-  const endpoint = required(process.env.S3_ENDPOINT, 'S3_ENDPOINT');
   const objectKey = required(process.env.S3_OBJECT_KEY, 'S3_OBJECT_KEY');
   const runId = required(process.env.GITHUB_RUN_ID, 'GITHUB_RUN_ID');
   const attempt = required(process.env.GITHUB_RUN_ATTEMPT, 'GITHUB_RUN_ATTEMPT');
-  if (!commandExists(rootDir, 'aws')) throw new Error('AWS CLI ist für die externe Backup-Verifikation nicht verfügbar.');
-
-  runCapture(rootDir, 'aws', buildS3HeadObjectArgs(endpoint, bucket, objectKey), buildBackupVerificationEnv(process.env));
+  const client = new S3Client(buildMinioS3ClientConfig(process.env));
+  await client.send(new HeadObjectCommand({ Bucket: bucket, Key: objectKey }));
 
   const evidencePath = resolve(process.env.RUNNER_TEMP ?? rootDir, `promote-backup-verification-${runId}-${attempt}.json`);
   writeFileSync(evidencePath, `${JSON.stringify({ bucket, objectKey, status: 'verified' }, null, 2)}\n`);
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main();
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
 }


### PR DESCRIPTION
## Zusammenfassung

- ersetzt die nicht garantierte AWS-CLI im GitHub-Runner durch den bereits verwendeten S3-SDK-Client
- nutzt für MinIO explizit Path-Style-Adressierung und die Environment-Secrets
- erhält den externen, fail-closed S3-Objektnachweis

## Validierung

- `pnpm exec vitest run scripts/ci/verify-promote-backup.test.ts scripts/ci/promote-workflow-contract.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- realer MinIO-Negativtest: fehlendes Objekt wird blockiert
- `pnpm check:file-placement`

Refs #752