### PR TITLE
fix: execute backup job shell command

### DIFF
--- a/docs/changelog/entries/pr-757.json
+++ b/docs/changelog/entries/pr-757.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 757,
+  "body": "Der temporäre Datenbank-Backup-Job übergibt sein Shell-Skript nun als ein Compose-Argument, sodass Dump, MinIO-Upload und Integritätsprüfung tatsächlich ausgeführt werden."
+}

--- a/scripts/ci/promote-backup-job.test.ts
+++ b/scripts/ci/promote-backup-job.test.ts
@@ -39,6 +39,8 @@ describe('promote backup job', () => {
     expect(document.networks.internal).toEqual({ external: true, name: 'studio-staging_default' });
     expect(document.services.backup.networks).toEqual(['internal']);
     expect(document.services.backup.environment).toMatchObject({ POSTGRES_HOST: 'studio-staging_postgres', S3_BUCKET: 'studio-db-backup-staging' });
+    expect(document.services.backup.command).toEqual([backupCommand]);
+    expect(document.services.backup.entrypoint).toEqual(['sh', '-ec']);
     expect(backupCommand).toContain('aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump"');
     expect(backupCommand).toContain('export PGPASSWORD="$POSTGRES_PASSWORD"');
     expect(backupCommand.indexOf('export PGPASSWORD="$POSTGRES_PASSWORD"')).toBeLessThan(backupCommand.indexOf('pg_dump'));

--- a/scripts/ci/promote-backup-job.ts
+++ b/scripts/ci/promote-backup-job.ts
@@ -86,7 +86,7 @@ export const buildBackupComposeDocument = (
   services: {
     backup: {
       ...migrate,
-      command: backupCommand,
+      command: [backupCommand],
       entrypoint: ['sh', '-ec'],
       environment: { ...(migrate.environment as Record<string, unknown>), AWS_ACCESS_KEY_ID: input.accessKey, AWS_SECRET_ACCESS_KEY: input.secretKey, AWS_EC2_METADATA_DISABLED: 'true', S3_BUCKET: input.bucket, S3_ENDPOINT: input.endpoint, S3_OBJECT_KEY: input.objectKey, POSTGRES_HOST: `${input.sourceStack}_postgres` },
       networks: ['internal'],


### PR DESCRIPTION
## Ursache

Der Backup-Shellcode wurde als Compose-String serialisiert. In Verbindung mit `sh -ec` wurde dadurch nur das erste Token ausgeführt; der Task endete erfolgreich, ohne Dump oder MinIO-Upload.

## Änderung

- übergibt das Shell-Skript als einzelnes Compose-Command-Argument
- sichert die Serialisierung im Unit-Test ab

## Validierung

- `pnpm exec vitest run scripts/ci/promote-backup-job.test.ts scripts/ci/verify-promote-backup.test.ts scripts/ci/promote-workflow-contract.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`

Refs #752