### PR TITLE
fix: attest main build image revision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
         id: build_image
         uses: docker/build-push-action@v5
         with:
+          build-args: |
+            SVA_IMAGE_REVISION=${{ github.sha }}
           context: .
           file: ./Dockerfile
           push: true

--- a/docs/changelog/entries/pr-758.json
+++ b/docs/changelog/entries/pr-758.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 758,
+  "body": "Der Main-Image-Build übergibt die Commit-Revision nun an das OCI-Image, sodass Staging die Bildherkunft zuverlässig prüfen kann."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -62,6 +62,7 @@ describe('Promote workflow contract', () => {
     expect(buildWorkflow).toContain('bootstrap_mode: auto');
     expect(buildWorkflow).toContain('migration_mode: auto');
     expect(buildWorkflow).toContain('actions: read');
+    expect(buildWorkflow).toContain('SVA_IMAGE_REVISION=${{ github.sha }}');
     expect(workflow).toContain('migration_should_run');
     expect(workflow).toContain('bootstrap_should_run');
   });


### PR DESCRIPTION
## Ursache
Der aktive Main-Build übergab die Commit-Revision nicht als SVA_IMAGE_REVISION an Docker. Das OCI-Label blieb dadurch leer, weshalb der Staging-Promote korrekt vor jeder Mutation abbrach.

## Änderung
- Commit-SHA als Docker-Build-Argument im Main-Build übergeben
- Workflow-Vertrag darauf prüfen
- Changelog ergänzt

## Validierung
- pnpm exec vitest run scripts/ci/promote-workflow-contract.test.ts --reporter=verbose
- pnpm exec tsc -p tsconfig.scripts.json --noEmit
- pnpm check:file-placement