### PR TITLE
fix: retain backup job diagnostics

### DIFF
--- a/docs/changelog/entries/pr-759.json
+++ b/docs/changelog/entries/pr-759.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 759,
+  "body": "Datenbank-Backup-Jobs protokollieren ihre einzelnen Schritte nun nachvollziehbar und sichern bei Fehlern redigierte Task-Logs vor dem Cleanup."
+}

--- a/scripts/ci/promote-backup-job.test.ts
+++ b/scripts/ci/promote-backup-job.test.ts
@@ -32,6 +32,10 @@ describe('promote backup job', () => {
     )).toBe('Upload to https://fileserver.smart-village.app failed for [REDACTED]/[REDACTED]');
   });
 
+  it('redacts bearer tokens in propagated authorization headers', () => {
+    expect(redactBackupError('Authorization: Bearer sensitive-token', [])).toBe('Authorization: Bearer [REDACTED]');
+  });
+
   it('writes safe failure evidence with the terminal task and log tail', () => {
     expect(buildBackupEvidence({
       bucket: 'studio-db-backup-staging',

--- a/scripts/ci/promote-backup-job.test.ts
+++ b/scripts/ci/promote-backup-job.test.ts
@@ -4,6 +4,7 @@ import {
   backupBucketFor,
   backupCommand,
   buildBackupComposeDocument,
+  buildBackupEvidence,
   buildBackupObjectKey,
   redactBackupError,
 } from './promote-backup-job.ts';
@@ -31,6 +32,26 @@ describe('promote backup job', () => {
     )).toBe('Upload to https://fileserver.smart-village.app failed for [REDACTED]/[REDACTED]');
   });
 
+  it('writes safe failure evidence with the terminal task and log tail', () => {
+    expect(buildBackupEvidence({
+      bucket: 'studio-db-backup-staging',
+      environment: 'staging',
+      error: 'Backup failed',
+      logTail: 'backup.step=minio_upload_dump state=failed exit_code=1',
+      objectKey: 'staging/example.dump',
+      status: 'failed',
+      task: { exitCode: 1, state: 'complete', taskId: 'task-1' },
+    })).toEqual({
+      bucket: 'studio-db-backup-staging',
+      environment: 'staging',
+      error: 'Backup failed',
+      logTail: 'backup.step=minio_upload_dump state=failed exit_code=1',
+      objectKey: 'staging/example.dump',
+      status: 'failed',
+      task: { exitCode: 1, state: 'complete', taskId: 'task-1' },
+    });
+  });
+
   it('renders an isolated job with upload, download and archive validation', () => {
     const document = buildBackupComposeDocument({ environment: { POSTGRES_PORT: '5432' }, image: 'example@sha256:test' }, {
       accessKey: 'access', bucket: 'studio-db-backup-staging', endpoint: 'https://fileserver.smart-village.app', internalNetwork: 'studio-staging_default', objectKey: 'staging/example.dump', secretKey: 'secret', sourceStack: 'studio-staging',
@@ -42,11 +63,14 @@ describe('promote backup job', () => {
     expect(document.services.backup.command).toEqual([backupCommand]);
     expect(document.services.backup.entrypoint).toEqual(['sh', '-ec']);
     expect(backupCommand).toContain('aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump"');
+    expect(backupCommand).toContain('backup.step=%s state=started');
+    expect(backupCommand).toContain('backup.step=%s state=failed exit_code=%s');
+    expect(backupCommand).toContain('backup_step minio_upload_dump');
     expect(backupCommand).toContain('export PGPASSWORD="$POSTGRES_PASSWORD"');
     expect(backupCommand.indexOf('export PGPASSWORD="$POSTGRES_PASSWORD"')).toBeLessThan(backupCommand.indexOf('pg_dump'));
     expect(backupCommand).toContain('sha256sum -c -');
-    expect(backupCommand).toContain('test "$(wc -c < "$dump")" -eq "$(wc -c < "$download")"');
-    expect(backupCommand.indexOf('test "$(wc -c < "$dump")" -eq "$(wc -c < "$download")"')).toBeLessThan(backupCommand.indexOf('sha256sum -c -'));
+    expect(backupCommand).toContain('backup_step size_verify');
+    expect(backupCommand.indexOf('backup_step size_verify')).toBeLessThan(backupCommand.indexOf('backup_step checksum_verify'));
     expect(backupCommand).toContain('pg_restore --list');
     expect(backupCommand).not.toContain('S3_SECRET_ACCESS_KEY=');
   });

--- a/scripts/ci/promote-backup-job.ts
+++ b/scripts/ci/promote-backup-job.ts
@@ -148,6 +148,47 @@ export const buildBackupEvidence = ({
     : undefined,
 });
 
+class BackupJobFailure extends Error {
+  constructor(
+    message: string,
+    readonly task: MigrationJobTaskSnapshot | null,
+    readonly timedOut: boolean,
+  ) {
+    super(message);
+  }
+}
+
+const readLatestBackupTask = (
+  env: NodeJS.ProcessEnv,
+  jobStack: string,
+  quantumEndpoint: string,
+) => {
+  const snapshot = runCaptureDetailed(rootDir, 'quantum-cli', ['ps', '--endpoint', quantumEndpoint, '--stack', jobStack, '--service', 'backup', '--all', '-o', 'json'], withoutDebugEnv(env));
+  const payload = extractQuantumJsonPayload(`${snapshot.stdout}\n${snapshot.stderr}`.split('\n'));
+  return payload ? selectLatestMigrationTask(collectQuantumTaskSnapshots(JSON.parse(payload) as unknown)) : null;
+};
+
+const waitForBackupTask = async ({
+  deadline,
+  env,
+  jobStack,
+  quantumEndpoint,
+}: {
+  deadline: number;
+  env: NodeJS.ProcessEnv;
+  jobStack: string;
+  quantumEndpoint: string;
+}) => {
+  for (;;) {
+    const task = readLatestBackupTask(env, jobStack, quantumEndpoint);
+    const state = getMigrationJobTerminalState(task);
+    if (state === 'succeeded') return task;
+    if (state === 'failed') throw new BackupJobFailure(`Backup-Job ${jobStack} ist fehlgeschlagen (exitCode=${String(task?.exitCode)}).`, task, false);
+    if (Date.now() >= deadline) throw new BackupJobFailure(`Backup-Job ${jobStack} hat das Timeout erreicht.`, task, true);
+    await wait(2_000);
+  }
+};
+
 const main = async () => {
   process.umask(0o077);
   const environment = parseEnvironment(process.argv[2]);
@@ -173,7 +214,6 @@ const main = async () => {
     process.env.S3_ACCESS_KEY_ID ?? '',
     process.env.S3_SECRET_ACCESS_KEY ?? '',
   ];
-  let latestTask: MigrationJobTaskSnapshot | null = null;
 
   required(process.env.S3_ACCESS_KEY_ID, 'S3_ACCESS_KEY_ID');
   required(process.env.S3_SECRET_ACCESS_KEY, 'S3_SECRET_ACCESS_KEY');
@@ -192,29 +232,23 @@ const main = async () => {
     const backupCompose = buildBackupComposeDocument(migrate, { accessKey: required(process.env.S3_ACCESS_KEY_ID, 'S3_ACCESS_KEY_ID'), bucket, endpoint: required(process.env.S3_ENDPOINT, 'S3_ENDPOINT'), internalNetwork, objectKey, secretKey: required(process.env.S3_SECRET_ACCESS_KEY, 'S3_SECRET_ACCESS_KEY'), sourceStack });
     writeFileSync(composePath, `${JSON.stringify({ ...backupCompose, version: compose.version ?? backupCompose.version }, null, 2)}\n`);
     run(rootDir, 'quantum-cli', buildQuantumBackupDeployArgs(quantumEndpoint, jobStack, composePath), withoutDebugEnv(env));
-    const deadline = Date.now() + Number(process.env.SVA_BACKUP_JOB_TIMEOUT_MS ?? '900000');
-    for (;;) {
-      const snapshot = runCaptureDetailed(rootDir, 'quantum-cli', ['ps', '--endpoint', quantumEndpoint, '--stack', jobStack, '--service', 'backup', '--all', '-o', 'json'], withoutDebugEnv(env));
-      const payload = extractQuantumJsonPayload(`${snapshot.stdout}\n${snapshot.stderr}`.split('\n'));
-      latestTask = payload ? selectLatestMigrationTask(collectQuantumTaskSnapshots(JSON.parse(payload) as unknown)) : null;
-      const state = getMigrationJobTerminalState(latestTask);
-      if (state === 'succeeded') {
-        writeFileSync(resultPath, `${JSON.stringify(buildBackupEvidence({ bucket, environment, objectKey, status: 'ok', task: latestTask }), null, 2)}\n`);
-        if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `backup_bucket=${bucket}\nbackup_object=${objectKey}\nbackup_evidence_path=${resultPath}\n`);
-        return;
-      }
-      if (state === 'failed') throw new Error(`Backup-Job ${jobStack} ist fehlgeschlagen (exitCode=${String(latestTask?.exitCode)}).`);
-      if (Date.now() >= deadline) throw new Error(`Backup-Job ${jobStack} hat das Timeout erreicht.`);
-      await wait(2_000);
-    }
+    const task = await waitForBackupTask({
+      deadline: Date.now() + Number(process.env.SVA_BACKUP_JOB_TIMEOUT_MS ?? '900000'),
+      env,
+      jobStack,
+      quantumEndpoint,
+    });
+    writeFileSync(resultPath, `${JSON.stringify(buildBackupEvidence({ bucket, environment, objectKey, status: 'ok', task }), null, 2)}\n`);
+    if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `backup_bucket=${bucket}\nbackup_object=${objectKey}\nbackup_evidence_path=${resultPath}\n`);
   } catch (error) {
+    const failedJob = error instanceof BackupJobFailure ? error : undefined;
     const remoteLogTail = await readRemoteJobLogTail(
       { commandExists, rootDir, runCapture },
       env,
       {
-        containerId: latestTask?.containerId,
+        containerId: failedJob?.task?.containerId,
         quantumEndpoint,
-        serviceId: latestTask?.serviceId,
+        serviceId: failedJob?.task?.serviceId,
       },
     );
     const errorText = redactBackupError(error instanceof Error ? error.message : String(error), sensitiveValues);
@@ -224,8 +258,8 @@ const main = async () => {
       error: errorText,
       logTail: redactBackupError(remoteLogTail, sensitiveValues),
       objectKey,
-      status: errorText.includes('Timeout') ? 'timed_out' : 'failed',
-      task: latestTask,
+      status: failedJob?.timedOut ? 'timed_out' : 'failed',
+      task: failedJob?.task,
     }), null, 2)}\n`);
     throw error;
   } finally {

--- a/scripts/ci/promote-backup-job.ts
+++ b/scripts/ci/promote-backup-job.ts
@@ -4,7 +4,13 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { commandExists, run, runCapture, runCaptureDetailed, wait, withoutDebugEnv } from '../ops/runtime/process.ts';
-import { collectQuantumTaskSnapshots, getMigrationJobTerminalState, selectLatestMigrationTask } from '../ops/runtime/migration-job.ts';
+import {
+  collectQuantumTaskSnapshots,
+  getMigrationJobTerminalState,
+  readRemoteJobLogTail,
+  selectLatestMigrationTask,
+  type MigrationJobTaskSnapshot,
+} from '../ops/runtime/migration-job.ts';
 import { extractQuantumJsonPayload } from '../ops/runtime/migration-job.ts';
 import { inspectRemoteServiceContract } from '../ops/runtime/remote-service-spec.ts';
 import { pickInternalNetworkName } from '../ops/runtime/internal-network.ts';
@@ -43,7 +49,9 @@ export const buildBackupObjectKey = ({
 export const redactBackupError = (value: string, sensitiveValues: readonly string[]) =>
   sensitiveValues
     .filter((sensitiveValue) => sensitiveValue.trim().length > 0)
-    .reduce((redacted, sensitiveValue) => redacted.replaceAll(sensitiveValue, '[REDACTED]'), value);
+    .reduce((redacted, sensitiveValue) => redacted.replaceAll(sensitiveValue, '[REDACTED]'), value)
+    .replace(/((?:password|token|secret|authorization)\s*[=:]\s*)[^\s]+/giu, '$1[REDACTED]')
+    .slice(-8_000);
 
 export const buildQuantumBackupDeployArgs = (endpoint: string, stackName: string, composePath: string) => [
   'stacks',
@@ -58,22 +66,34 @@ export const buildQuantumBackupDeployArgs = (endpoint: string, stackName: string
 
 export const backupCommand = [
   'set -eu',
+  'backup_step() {',
+  '  step="$1"',
+  '  shift',
+  '  printf "backup.step=%s state=started\\n" "$step"',
+  '  if "$@"; then',
+  '    printf "backup.step=%s state=succeeded\\n" "$step"',
+  '  else',
+  '    status="$?"',
+  '    printf "backup.step=%s state=failed exit_code=%s\\n" "$step" "$status" >&2',
+  '    return "$status"',
+  '  fi',
+  '}',
   'workdir="$(mktemp -d)"',
   'trap "rm -rf \"$workdir\"" EXIT',
   'dump="$workdir/backup.dump"',
   'download="$workdir/backup.download"',
   'checksum="$workdir/backup.sha256"',
   'export PGPASSWORD="$POSTGRES_PASSWORD"',
-  'pg_dump --format=custom --no-owner --no-privileges --host "$POSTGRES_HOST" --port "$POSTGRES_PORT" --username "$POSTGRES_USER" --file "$dump" "$POSTGRES_DB"',
-  'test -s "$dump"',
-  'sha256sum "$dump" > "$checksum"',
-  'aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump" "s3://$S3_BUCKET/$S3_OBJECT_KEY" --only-show-errors',
-  'aws --endpoint-url "$S3_ENDPOINT" s3 cp "$checksum" "s3://$S3_BUCKET/$S3_OBJECT_KEY.sha256" --only-show-errors',
-  'aws --endpoint-url "$S3_ENDPOINT" s3 cp "s3://$S3_BUCKET/$S3_OBJECT_KEY" "$download" --only-show-errors',
-  'test -s "$download"',
-  'test "$(wc -c < "$dump")" -eq "$(wc -c < "$download")"',
-  'printf "%s  %s\\n" "$(cut -d " " -f1 "$checksum")" "$download" | sha256sum -c -',
-  'pg_restore --list "$download" >/dev/null',
+  'backup_step pg_dump pg_dump --format=custom --no-owner --no-privileges --host "$POSTGRES_HOST" --port "$POSTGRES_PORT" --username "$POSTGRES_USER" --file "$dump" "$POSTGRES_DB"',
+  'backup_step dump_nonempty test -s "$dump"',
+  "backup_step checksum_create sh -c 'sha256sum \"$1\" > \"$2\"' -- \"$dump\" \"$checksum\"",
+  'backup_step minio_upload_dump aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump" "s3://$S3_BUCKET/$S3_OBJECT_KEY" --only-show-errors',
+  'backup_step minio_upload_checksum aws --endpoint-url "$S3_ENDPOINT" s3 cp "$checksum" "s3://$S3_BUCKET/$S3_OBJECT_KEY.sha256" --only-show-errors',
+  'backup_step minio_download_dump aws --endpoint-url "$S3_ENDPOINT" s3 cp "s3://$S3_BUCKET/$S3_OBJECT_KEY" "$download" --only-show-errors',
+  'backup_step download_nonempty test -s "$download"',
+  "backup_step size_verify sh -c 'test \"$(wc -c < \"$1\")\" -eq \"$(wc -c < \"$2\")\"' -- \"$dump\" \"$download\"",
+  "backup_step checksum_verify sh -c 'printf \"%s  %s\\n\" \"$(cut -d \" \" -f1 \"$1\")\" \"$2\" | sha256sum -c -' -- \"$checksum\" \"$download\"",
+  "backup_step archive_validate sh -c 'pg_restore --list \"$1\" >/dev/null' -- \"$download\"",
   'printf "backup_object=%s\\n" "$S3_OBJECT_KEY"',
   'printf "backup_sha256=%s\\n" "$(cut -d " " -f1 "$checksum")"',
 ].join('\n');
@@ -96,6 +116,38 @@ export const buildBackupComposeDocument = (
   networks: { internal: { external: true, name: input.internalNetwork } },
 });
 
+export const buildBackupEvidence = ({
+  bucket,
+  environment,
+  error,
+  logTail,
+  objectKey,
+  status,
+  task,
+}: {
+  bucket: string;
+  environment: PromoteEnvironment;
+  error?: string;
+  logTail?: string;
+  objectKey: string;
+  status: 'failed' | 'ok' | 'timed_out';
+  task?: MigrationJobTaskSnapshot | null;
+}) => ({
+  bucket,
+  environment,
+  error,
+  logTail,
+  objectKey,
+  status,
+  task: task
+    ? {
+      exitCode: task.exitCode,
+      state: task.state,
+      taskId: task.taskId,
+    }
+    : undefined,
+});
+
 const main = async () => {
   process.umask(0o077);
   const environment = parseEnvironment(process.argv[2]);
@@ -116,6 +168,12 @@ const main = async () => {
   const composePath = resolve(projectDir, 'docker-compose.json');
   const jobStack = `${sourceStack}-backup-gha-${runId}-${attempt}`.replace(/[^a-zA-Z0-9_.-]/gu, '-');
   const env = { ...process.env };
+  const sensitiveValues = [
+    process.env.APP_CONFIG ?? '',
+    process.env.S3_ACCESS_KEY_ID ?? '',
+    process.env.S3_SECRET_ACCESS_KEY ?? '',
+  ];
+  let latestTask: MigrationJobTaskSnapshot | null = null;
 
   required(process.env.S3_ACCESS_KEY_ID, 'S3_ACCESS_KEY_ID');
   required(process.env.S3_SECRET_ACCESS_KEY, 'S3_SECRET_ACCESS_KEY');
@@ -138,17 +196,38 @@ const main = async () => {
     for (;;) {
       const snapshot = runCaptureDetailed(rootDir, 'quantum-cli', ['ps', '--endpoint', quantumEndpoint, '--stack', jobStack, '--service', 'backup', '--all', '-o', 'json'], withoutDebugEnv(env));
       const payload = extractQuantumJsonPayload(`${snapshot.stdout}\n${snapshot.stderr}`.split('\n'));
-      const task = payload ? selectLatestMigrationTask(collectQuantumTaskSnapshots(JSON.parse(payload) as unknown)) : null;
-      const state = getMigrationJobTerminalState(task);
+      latestTask = payload ? selectLatestMigrationTask(collectQuantumTaskSnapshots(JSON.parse(payload) as unknown)) : null;
+      const state = getMigrationJobTerminalState(latestTask);
       if (state === 'succeeded') {
-        writeFileSync(resultPath, `${JSON.stringify({ bucket, environment, objectKey, status: 'ok', taskId: task?.taskId }, null, 2)}\n`);
+        writeFileSync(resultPath, `${JSON.stringify(buildBackupEvidence({ bucket, environment, objectKey, status: 'ok', task: latestTask }), null, 2)}\n`);
         if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `backup_bucket=${bucket}\nbackup_object=${objectKey}\nbackup_evidence_path=${resultPath}\n`);
         return;
       }
-      if (state === 'failed') throw new Error(`Backup-Job ${jobStack} ist fehlgeschlagen (exitCode=${String(task?.exitCode)}).`);
+      if (state === 'failed') throw new Error(`Backup-Job ${jobStack} ist fehlgeschlagen (exitCode=${String(latestTask?.exitCode)}).`);
       if (Date.now() >= deadline) throw new Error(`Backup-Job ${jobStack} hat das Timeout erreicht.`);
       await wait(2_000);
     }
+  } catch (error) {
+    const remoteLogTail = await readRemoteJobLogTail(
+      { commandExists, rootDir, runCapture },
+      env,
+      {
+        containerId: latestTask?.containerId,
+        quantumEndpoint,
+        serviceId: latestTask?.serviceId,
+      },
+    );
+    const errorText = redactBackupError(error instanceof Error ? error.message : String(error), sensitiveValues);
+    writeFileSync(resultPath, `${JSON.stringify(buildBackupEvidence({
+      bucket,
+      environment,
+      error: errorText,
+      logTail: redactBackupError(remoteLogTail, sensitiveValues),
+      objectKey,
+      status: errorText.includes('Timeout') ? 'timed_out' : 'failed',
+      task: latestTask,
+    }), null, 2)}\n`);
+    throw error;
   } finally {
     try { run(rootDir, 'quantum-cli', ['stacks', 'remove', '--force', '--endpoint', quantumEndpoint, '--stack', jobStack], withoutDebugEnv(env)); } catch { /* Cleanup darf den Primärfehler nicht überschreiben. */ }
     try { run(rootDir, 'rm', ['-rf', projectDir]); } catch { /* Cleanup darf den Primärfehler nicht überschreiben. */ }

--- a/scripts/ci/promote-backup-job.ts
+++ b/scripts/ci/promote-backup-job.ts
@@ -50,7 +50,7 @@ export const redactBackupError = (value: string, sensitiveValues: readonly strin
   sensitiveValues
     .filter((sensitiveValue) => sensitiveValue.trim().length > 0)
     .reduce((redacted, sensitiveValue) => redacted.replaceAll(sensitiveValue, '[REDACTED]'), value)
-    .replace(/((?:password|token|secret|authorization)\s*[=:]\s*)[^\s]+/giu, '$1[REDACTED]')
+    .replace(/((?:password|token|secret)\s*[=:]\s*|authorization\s*[=:]\s*(?:bearer\s+)?)[^\s]+/giu, '$1[REDACTED]')
     .slice(-8_000);
 
 export const buildQuantumBackupDeployArgs = (endpoint: string, stackName: string, composePath: string) => [


### PR DESCRIPTION
## Änderung
- protokolliert jeden Backup-Schritt mit Start, Erfolg oder Fehler samt Exit-Code
- ruft redigierte Container-/Service-Logs vor dem Stack-Cleanup ab
- sichert Fehler- und Timeout-Evidence mit Task-ID, Zustand und Log-Ausschnitt

## Validierung
- pnpm exec vitest run scripts/ci/promote-backup-job.test.ts scripts/ci/promote-workflow-contract.test.ts --reporter=verbose
- Shell-Syntax des gerenderten Backup-Skripts via sh -n
- pnpm exec tsc -p tsconfig.scripts.json --noEmit
- pnpm check:file-placement