### PR TITLE
fix: support MinIO backups with current AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,9 @@ ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
 
-RUN apk add --no-cache aws-cli bash curl ca-certificates postgresql-client
+RUN apk add --no-cache aws-cli bash curl ca-certificates postgresql-client \
+  && aws --version \
+  && pg_dump --version
 RUN mkdir -p artifacts/tools/goose packages/data/scripts packages/data/migrations
 
 COPY --from=build --chown=node:node /workspace/.deploy/sva-studio-react/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,8 @@ ENV PORT=3000
 
 RUN apk add --no-cache aws-cli bash curl ca-certificates postgresql-client \
   && aws --version \
-  && pg_dump --version
+  && pg_dump --version \
+  && pg_restore --version
 RUN mkdir -p artifacts/tools/goose packages/data/scripts packages/data/migrations
 
 COPY --from=build --chown=node:node /workspace/.deploy/sva-studio-react/node_modules ./node_modules

--- a/docs/changelog/entries/pr-761.json
+++ b/docs/changelog/entries/pr-761.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 761,
+  "body": "Datenbank-Backups werden mit dem eingesetzten MinIO-Dateispeicher wieder zuverlässig hochgeladen und geprüft."
+}

--- a/scripts/ci/promote-backup-job.test.ts
+++ b/scripts/ci/promote-backup-job.test.ts
@@ -63,7 +63,7 @@ describe('promote backup job', () => {
     expect(Object.keys(document.services)).toEqual(['backup']);
     expect(document.networks.internal).toEqual({ external: true, name: 'studio-staging_default' });
     expect(document.services.backup.networks).toEqual(['internal']);
-    expect(document.services.backup.environment).toMatchObject({ POSTGRES_HOST: 'studio-staging_postgres', S3_BUCKET: 'studio-db-backup-staging' });
+    expect(document.services.backup.environment).toMatchObject({ AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required', POSTGRES_HOST: 'studio-staging_postgres', S3_BUCKET: 'studio-db-backup-staging' });
     expect(document.services.backup.command).toEqual([backupCommand]);
     expect(document.services.backup.entrypoint).toEqual(['sh', '-ec']);
     expect(backupCommand).toContain('aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump"');

--- a/scripts/ci/promote-backup-job.ts
+++ b/scripts/ci/promote-backup-job.ts
@@ -108,7 +108,7 @@ export const buildBackupComposeDocument = (
       ...migrate,
       command: [backupCommand],
       entrypoint: ['sh', '-ec'],
-      environment: { ...(migrate.environment as Record<string, unknown>), AWS_ACCESS_KEY_ID: input.accessKey, AWS_SECRET_ACCESS_KEY: input.secretKey, AWS_EC2_METADATA_DISABLED: 'true', S3_BUCKET: input.bucket, S3_ENDPOINT: input.endpoint, S3_OBJECT_KEY: input.objectKey, POSTGRES_HOST: `${input.sourceStack}_postgres` },
+      environment: { ...(migrate.environment as Record<string, unknown>), AWS_ACCESS_KEY_ID: input.accessKey, AWS_EC2_METADATA_DISABLED: 'true', AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required', AWS_SECRET_ACCESS_KEY: input.secretKey, S3_BUCKET: input.bucket, S3_ENDPOINT: input.endpoint, S3_OBJECT_KEY: input.objectKey, POSTGRES_HOST: `${input.sourceStack}_postgres` },
       networks: ['internal'],
       deploy: { ...((migrate.deploy as Record<string, unknown> | undefined) ?? {}), replicas: 1, restart_policy: { condition: 'none' } },
     },


### PR DESCRIPTION
## Zusammenfassung

- Prüft `aws` und `pg_dump` beim Build des Runtime-Images.
- Setzt für den temporären Backup-Service `AWS_REQUEST_CHECKSUM_CALCULATION=when_required`.

## Ursache

AWS CLI 2.32 verwendet beim Upload eine optionale S3-Prüfsummen-/Streaming-Übertragung, die der vorhandene MinIO-Endpoint schließt. Mit `when_required` bleiben die explizite SHA-256-Prüfung sowie Upload und Rückdownload erhalten, während die inkompatible optionale Übertragung deaktiviert wird.

## Validierung

- `pnpm exec vitest run scripts/ci/promote-backup-job.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `docker buildx build --check .`
- Vollständiger lokaler End-to-End-Backup-Test: PostgreSQL-Dump, MinIO-Upload/-Download, Größen- und SHA-256-Prüfung sowie `pg_restore --list`.
- `pnpm test:pr` gestartet: Dateiablage- und Toolchain-Checks sowie der breite Coverage-Teil liefen grün an; der lokale breite Nx-Coverage-Aggregator hing anschließend ohne laufenden Teilprozess und wurde gemäß Repository-Regel beendet. Die PR-CI prüft den Commit erneut.