### PR TITLE
fix: configure remote runtime smoke context

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -356,6 +356,8 @@ jobs:
         if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_STACK_NAME: studio-${{ inputs.environment }}
         run: |
           set -euo pipefail
           umask 077

--- a/docs/changelog/entries/pr-762.json
+++ b/docs/changelog/entries/pr-762.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 762,
+  "body": "Allgemeine Verbesserungen der Zuverlässigkeit bei der Bereitstellung von Studio-Updates."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -27,6 +27,8 @@ describe('Promote workflow contract', () => {
     expect(workflow.indexOf('Login to GHCR')).toBeLessThan(workflow.indexOf('validate image contract'));
     expect(workflow).toContain("trap 'rm -f .env config/runtime/base.vars config/runtime/studio.vars' EXIT");
     expect(workflow.match(/printf '%s\\n' "\$\{APP_CONFIG\}" > config\/runtime\/base\.vars/gu)).toHaveLength(2);
+    expect(workflow).toContain('SVA_STACK_NAME: studio-${{ inputs.environment }}');
+    expect(workflow).toContain('QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}');
   });
 
   it('requires a maintenance reference and guards production mutations with staging parity', () => {


### PR DESCRIPTION
## Zusammenfassung

- Übergibt dem Remote-Smoketest den Quantum-Endpunkt und den zielgerichteten Stacknamen.
- Sichert den Workflow-Vertrag per Test ab.

## Ursache

Der Staging-Deploy war erfolgreich, aber der nachgelagerte Runtime-Smoketest konnte ohne `SVA_STACK_NAME` und `QUANTUM_ENDPOINT` keinen Remote-Stack adressieren.

## Validierung

- `pnpm exec vitest run scripts/ci/promote-workflow-contract.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`