### PR TITLE
fix: add staging backup drill diagnostics

### DIFF
--- a/.github/workflows/staging-backup-drill.yml
+++ b/.github/workflows/staging-backup-drill.yml
@@ -1,0 +1,103 @@
+name: Staging Backup Drill
+run-name: Staging backup drill ${{ inputs.image_ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: 'Immutable Studio image reference to run for the backup job'
+        required: true
+        type: string
+      change_head:
+        description: 'Commit revision represented by the immutable image'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  backup:
+    name: backup staging database
+    environment: staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: bind executor source to image revision
+        env:
+          CHANGE_HEAD: ${{ inputs.change_head }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
+          head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
+          git merge-base --is-ancestor "${head}" origin/main
+          git checkout --detach "${head}"
+
+      - name: setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm-workspace
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: validate image contract
+        id: image_contract
+        env:
+          IMAGE_INPUT: ${{ inputs.image_ref }}
+          CHANGE_HEAD: ${{ inputs.change_head }}
+        run: |
+          set -euo pipefail
+          pnpm exec tsx scripts/ci/promote-image-contract.ts \
+            --environment staging \
+            --image "${IMAGE_INPUT}" \
+            --expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
+
+      - name: setup quantum-cli
+        uses: hostwithquantum/setup-quantum-cli@v2.0.0
+        with:
+          api-key: ${{ secrets.QUANTUM_API_KEY }}
+          version: 3.2.1
+
+      - name: create and verify database backup
+        id: backup_job
+        env:
+          APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_ENDPOINT: https://fileserver.smart-village.app
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          umask 077
+          trap 'rm -f .env' EXIT
+          pnpm exec tsx scripts/ci/render-compose-env.ts --output .env
+          printf '\nIMAGE_REF=%s\n' "${{ steps.image_contract.outputs.deploy_image_ref }}" >> .env
+          pnpm exec tsx scripts/ci/promote-backup-job.ts staging
+
+      - name: verify database backup object
+        if: success()
+        env:
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket }}
+          S3_ENDPOINT: https://fileserver.smart-village.app
+          S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object }}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: pnpm exec tsx scripts/ci/verify-promote-backup.ts
+
+      - name: upload backup drill evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-backup-drill-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/promote-backup-*.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/changelog/entries/pr-763.json
+++ b/docs/changelog/entries/pr-763.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 763,
+  "body": "Staging-Datenbank-Backups liefern nun redigierte Diagnosen in MinIO; ein separater Drill prüft sie ohne die Staging-Anwendung zu verändern."
+}

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -278,6 +278,18 @@ Operator-Regel:
 - Vor einem Merge muss das GitHub-Environment `staging` mit Required Reviewers geschützt sein; `QUANTUM_API_KEY` und weitere mutierende Credentials dürfen ausschließlich als Environment-Secrets vorliegen.
 - Lokale Befehle bleiben für `status`, `doctor`, `precheck`, Diagnose und Recovery zulässig, aber nicht der konkurrierende Standardweg für Staging-Rollouts.
 
+### Staging-Backup-Drill
+
+Der manuelle GitHub-Workflow **Staging Backup Drill** prüft den Backup-Pfad ohne Migration, Bootstrap oder App-Deployment. Er akzeptiert ausschließlich eine unveränderliche Image-Referenz und die dazugehörige Commit-Revision. Der Workflow startet einen kurzlebigen Backup-Stack im Staging-Overlay, validiert Dump, Download, Prüfsumme und Archiv und entfernt den Stack anschließend wieder.
+
+Ein erfolgreicher Drill hinterlässt im Bucket `studio-db-backup-staging`:
+
+- `<objektpfad>.dump` und `<objektpfad>.dump.sha256`
+- `<objektpfad>.dump.diagnostic.ndjson` mit redigierten Schritt-Ereignissen
+- ein GitHub-Artifact mit der redigierten Runner-Evidenz
+
+Bei einem Fehler ist zuerst die Diagnosedatei in MinIO auszuwerten. Fehlt sie wegen eines Storage-Fehlers, ist das GitHub-Artifact die maßgebliche Fallback-Evidenz. Ohne erfolgreiche Dump-, Prüfsummen- und Archivprüfung darf kein mutierender Staging-Promote gestartet werden.
+
 Prod-Hinweis:
 
 - Für Produktion verlangt `Promote` bei beiden `run`-Modi ein revisionsfähiges Wartungsfenster sowie ein erfolgreiches Artifact eines abgeschlossenen mutierenden Staging-Pfads für exakt dasselbe Image-Digest. Ein App-only-Staging-Deploy genügt nicht. Fehlt einer dieser Nachweise, blockiert der Lauf vor Backup und Mutation.

--- a/scripts/ci/promote-backup-job.test.ts
+++ b/scripts/ci/promote-backup-job.test.ts
@@ -4,6 +4,7 @@ import {
   backupBucketFor,
   backupCommand,
   buildBackupComposeDocument,
+  buildBackupDiagnosticObjectKey,
   buildBackupEvidence,
   buildBackupObjectKey,
   redactBackupError,
@@ -25,6 +26,10 @@ describe('promote backup job', () => {
     })).toBe('staging/2026-07-23T08-45-12-345Z/abc123/456-2.dump');
   });
 
+  it('stores redacted step diagnostics next to the backup object', () => {
+    expect(buildBackupDiagnosticObjectKey('staging/example.dump')).toBe('staging/example.dump.diagnostic.ndjson');
+  });
+
   it('redacts backup credentials from propagated errors', () => {
     expect(redactBackupError(
       'Upload to https://fileserver.smart-village.app failed for access-key/secret-key',
@@ -39,6 +44,7 @@ describe('promote backup job', () => {
   it('writes safe failure evidence with the terminal task and log tail', () => {
     expect(buildBackupEvidence({
       bucket: 'studio-db-backup-staging',
+      diagnosticObjectKey: 'staging/example.dump.diagnostic.ndjson',
       environment: 'staging',
       error: 'Backup failed',
       logTail: 'backup.step=minio_upload_dump state=failed exit_code=1',
@@ -47,6 +53,7 @@ describe('promote backup job', () => {
       task: { exitCode: 1, state: 'complete', taskId: 'task-1' },
     })).toEqual({
       bucket: 'studio-db-backup-staging',
+      diagnosticObjectKey: 'staging/example.dump.diagnostic.ndjson',
       environment: 'staging',
       error: 'Backup failed',
       logTail: 'backup.step=minio_upload_dump state=failed exit_code=1',
@@ -69,6 +76,10 @@ describe('promote backup job', () => {
     expect(backupCommand).toContain('aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump"');
     expect(backupCommand).toContain('backup.step=%s state=started');
     expect(backupCommand).toContain('backup.step=%s state=failed exit_code=%s');
+    expect(backupCommand).toContain('backup-diagnostic.ndjson');
+    expect(backupCommand).toContain('backup_event "$step" failed "$status"');
+    expect(backupCommand).toContain('upload_diagnostic || printf "backup.diagnostic_upload state=failed');
+    expect(backupCommand).toContain('backup_event dump_bytes succeeded 0');
     expect(backupCommand).toContain('backup_step minio_upload_dump');
     expect(backupCommand).toContain('export PGPASSWORD="$POSTGRES_PASSWORD"');
     expect(backupCommand.indexOf('export PGPASSWORD="$POSTGRES_PASSWORD"')).toBeLessThan(backupCommand.indexOf('pg_dump'));

--- a/scripts/ci/promote-backup-job.ts
+++ b/scripts/ci/promote-backup-job.ts
@@ -46,6 +46,8 @@ export const buildBackupObjectKey = ({
   timestamp: Date;
 }) => `${environment}/${timestamp.toISOString().replace(/[:.]/gu, '-')}/${deployImageDigest.replace(/^sha256:/u, '')}/${runId}-${attempt}.dump`;
 
+export const buildBackupDiagnosticObjectKey = (objectKey: string) => `${objectKey}.diagnostic.ndjson`;
+
 export const redactBackupError = (value: string, sensitiveValues: readonly string[]) =>
   sensitiveValues
     .filter((sensitiveValue) => sensitiveValue.trim().length > 0)
@@ -66,26 +68,34 @@ export const buildQuantumBackupDeployArgs = (endpoint: string, stackName: string
 
 export const backupCommand = [
   'set -eu',
+  'workdir="$(mktemp -d)"',
+  'diagnostic="$workdir/backup-diagnostic.ndjson"',
+  'diagnostic_object="$S3_OBJECT_KEY.diagnostic.ndjson"',
+  'backup_event() { printf "{\\"step\\":\\"%s\\",\\"state\\":\\"%s\\",\\"exitCode\\":%s,\\"bytes\\":%s}\\n" "$1" "$2" "$3" "${4:-null}" >> "$diagnostic"; }',
+  'upload_diagnostic() { aws --endpoint-url "$S3_ENDPOINT" s3 cp "$diagnostic" "s3://$S3_BUCKET/$diagnostic_object" --only-show-errors; }',
+  'on_exit() { status="$?"; if [ "$status" -eq 0 ]; then backup_event job succeeded 0; else backup_event job failed "$status"; fi; upload_diagnostic || printf "backup.diagnostic_upload state=failed\\n" >&2; rm -rf "$workdir"; exit "$status"; }',
+  'trap on_exit EXIT',
   'backup_step() {',
   '  step="$1"',
   '  shift',
   '  printf "backup.step=%s state=started\\n" "$step"',
   '  if "$@"; then',
   '    printf "backup.step=%s state=succeeded\\n" "$step"',
+  '    backup_event "$step" succeeded 0',
   '  else',
   '    status="$?"',
   '    printf "backup.step=%s state=failed exit_code=%s\\n" "$step" "$status" >&2',
+  '    backup_event "$step" failed "$status"',
   '    return "$status"',
   '  fi',
   '}',
-  'workdir="$(mktemp -d)"',
-  'trap "rm -rf \"$workdir\"" EXIT',
   'dump="$workdir/backup.dump"',
   'download="$workdir/backup.download"',
   'checksum="$workdir/backup.sha256"',
   'export PGPASSWORD="$POSTGRES_PASSWORD"',
   'backup_step pg_dump pg_dump --format=custom --no-owner --no-privileges --host "$POSTGRES_HOST" --port "$POSTGRES_PORT" --username "$POSTGRES_USER" --file "$dump" "$POSTGRES_DB"',
   'backup_step dump_nonempty test -s "$dump"',
+  'backup_event dump_bytes succeeded 0 "$(wc -c < "$dump")"',
   "backup_step checksum_create sh -c 'sha256sum \"$1\" > \"$2\"' -- \"$dump\" \"$checksum\"",
   'backup_step minio_upload_dump aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump" "s3://$S3_BUCKET/$S3_OBJECT_KEY" --only-show-errors',
   'backup_step minio_upload_checksum aws --endpoint-url "$S3_ENDPOINT" s3 cp "$checksum" "s3://$S3_BUCKET/$S3_OBJECT_KEY.sha256" --only-show-errors',
@@ -95,6 +105,7 @@ export const backupCommand = [
   "backup_step checksum_verify sh -c 'printf \"%s  %s\\n\" \"$(cut -d \" \" -f1 \"$1\")\" \"$2\" | sha256sum -c -' -- \"$checksum\" \"$download\"",
   "backup_step archive_validate sh -c 'pg_restore --list \"$1\" >/dev/null' -- \"$download\"",
   'printf "backup_object=%s\\n" "$S3_OBJECT_KEY"',
+  'printf "backup_diagnostic_object=%s\\n" "$diagnostic_object"',
   'printf "backup_sha256=%s\\n" "$(cut -d " " -f1 "$checksum")"',
 ].join('\n');
 
@@ -118,6 +129,7 @@ export const buildBackupComposeDocument = (
 
 export const buildBackupEvidence = ({
   bucket,
+  diagnosticObjectKey,
   environment,
   error,
   logTail,
@@ -126,6 +138,7 @@ export const buildBackupEvidence = ({
   task,
 }: {
   bucket: string;
+  diagnosticObjectKey: string;
   environment: PromoteEnvironment;
   error?: string;
   logTail?: string;
@@ -134,6 +147,7 @@ export const buildBackupEvidence = ({
   task?: MigrationJobTaskSnapshot | null;
 }) => ({
   bucket,
+  diagnosticObjectKey,
   environment,
   error,
   logTail,
@@ -204,6 +218,7 @@ const main = async () => {
     runId,
     timestamp: new Date(),
   });
+  const diagnosticObjectKey = buildBackupDiagnosticObjectKey(objectKey);
   const resultPath = resolve(process.env.RUNNER_TEMP ?? rootDir, `promote-backup-${runId}-${attempt}.json`);
   const projectDir = resolve(process.env.RUNNER_TEMP ?? rootDir, `promote-backup-${runId}-${attempt}`);
   const composePath = resolve(projectDir, 'docker-compose.json');
@@ -238,8 +253,8 @@ const main = async () => {
       jobStack,
       quantumEndpoint,
     });
-    writeFileSync(resultPath, `${JSON.stringify(buildBackupEvidence({ bucket, environment, objectKey, status: 'ok', task }), null, 2)}\n`);
-    if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `backup_bucket=${bucket}\nbackup_object=${objectKey}\nbackup_evidence_path=${resultPath}\n`);
+    writeFileSync(resultPath, `${JSON.stringify(buildBackupEvidence({ bucket, diagnosticObjectKey, environment, objectKey, status: 'ok', task }), null, 2)}\n`);
+    if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `backup_bucket=${bucket}\nbackup_object=${objectKey}\nbackup_diagnostic_object=${diagnosticObjectKey}\nbackup_evidence_path=${resultPath}\n`);
   } catch (error) {
     const failedJob = error instanceof BackupJobFailure ? error : undefined;
     const remoteLogTail = await readRemoteJobLogTail(
@@ -254,6 +269,7 @@ const main = async () => {
     const errorText = redactBackupError(error instanceof Error ? error.message : String(error), sensitiveValues);
     writeFileSync(resultPath, `${JSON.stringify(buildBackupEvidence({
       bucket,
+      diagnosticObjectKey,
       environment,
       error: errorText,
       logTail: redactBackupError(remoteLogTail, sensitiveValues),

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/promote.yml'), 'utf8');
+const backupDrillWorkflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/staging-backup-drill.yml'), 'utf8');
 
 describe('Promote workflow contract', () => {
   it('runs staging phases in the required fail-closed order', () => {
@@ -67,5 +68,15 @@ describe('Promote workflow contract', () => {
     expect(buildWorkflow).toContain('SVA_IMAGE_REVISION=${{ github.sha }}');
     expect(workflow).toContain('migration_should_run');
     expect(workflow).toContain('bootstrap_should_run');
+  });
+
+  it('offers a staging-only backup drill without application mutation', () => {
+    expect(backupDrillWorkflow).toContain('name: Staging Backup Drill');
+    expect(backupDrillWorkflow).toContain('environment: staging');
+    expect(backupDrillWorkflow).toContain('promote-backup-job.ts staging');
+    expect(backupDrillWorkflow).toContain('verify-promote-backup.ts');
+    expect(backupDrillWorkflow).toContain('staging-backup-drill-${{ github.run_id }}-${{ github.run_attempt }}');
+    expect(backupDrillWorkflow).not.toContain('promote-one-shot-job.ts');
+    expect(backupDrillWorkflow).not.toContain('quantum-cli stacks deploy');
   });
 });


### PR DESCRIPTION
## Ziel
Dauerhafte, redigierte Backup-Evidenz in MinIO und ein rein manueller Staging-Backup-Drill ohne Migration, Bootstrap oder App-Deployment.

## Enthalten
- NDJSON-Schrittprotokoll als `<dump>.diagnostic.ndjson` mit fail-safe Upload
- Runner-Evidenz als GitHub-Artifact-Fallback
- Staging-only Workflow mit Image-/Revision-Vertrag und Backup-Verifikation
- Runbook und Workflow-/Unit-Tests

## Validierung
- `pnpm test:pr`
- lokaler PostgreSQL-zu-MinIO-End-to-End-Test einschließlich Diagnoseobjekt und Redaktionsprüfung

Production bleibt bis zum vollständigen erfolgreichen Staging-Nachweis gesperrt.