### PR TITLE
fix: escape backup command for Compose

### DIFF
--- a/docs/changelog/entries/pr-764.json
+++ b/docs/changelog/entries/pr-764.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 764,
+  "body": "Der Staging-Backup-Drill schützt Shell-Variablen nun korrekt vor der Compose-Interpolation."
+}

--- a/scripts/ci/promote-backup-job.test.ts
+++ b/scripts/ci/promote-backup-job.test.ts
@@ -71,8 +71,11 @@ describe('promote backup job', () => {
     expect(document.networks.internal).toEqual({ external: true, name: 'studio-staging_default' });
     expect(document.services.backup.networks).toEqual(['internal']);
     expect(document.services.backup.environment).toMatchObject({ AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required', POSTGRES_HOST: 'studio-staging_postgres', S3_BUCKET: 'studio-db-backup-staging' });
-    expect(document.services.backup.command).toEqual([backupCommand]);
     expect(document.services.backup.entrypoint).toEqual(['sh', '-ec']);
+    expect(document.services.backup.command).toEqual([backupCommand.replaceAll('$', () => '$$')]);
+    expect(document.services.backup.command[0]).toContain('$$(mktemp -d)');
+    expect(document.services.backup.command[0]).toContain('$${4:-null}');
+    expect(document.services.backup.command[0]).not.toMatch(/(?<!\$)\$(?!\$)/u);
     expect(backupCommand).toContain('aws --endpoint-url "$S3_ENDPOINT" s3 cp "$dump"');
     expect(backupCommand).toContain('backup.step=%s state=started');
     expect(backupCommand).toContain('backup.step=%s state=failed exit_code=%s');

--- a/scripts/ci/promote-backup-job.ts
+++ b/scripts/ci/promote-backup-job.ts
@@ -117,7 +117,9 @@ export const buildBackupComposeDocument = (
   services: {
     backup: {
       ...migrate,
-      command: [backupCommand],
+      // Compose interprets `$` before the container starts. Preserve the shell
+      // command by escaping every dollar sign in the Compose representation.
+      command: [backupCommand.replaceAll('$', () => '$$')],
       entrypoint: ['sh', '-ec'],
       environment: { ...(migrate.environment as Record<string, unknown>), AWS_ACCESS_KEY_ID: input.accessKey, AWS_EC2_METADATA_DISABLED: 'true', AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required', AWS_SECRET_ACCESS_KEY: input.secretKey, S3_BUCKET: input.bucket, S3_ENDPOINT: input.endpoint, S3_OBJECT_KEY: input.objectKey, POSTGRES_HOST: `${input.sourceStack}_postgres` },
       networks: ['internal'],


### PR DESCRIPTION
## Ursache
Der Backup-Command enthielt Shell-Dollarzeichen, die Quantum/Compose vor dem Containerstart interpolierte.

## Änderung
Die Compose-Repräsentation escaped jedes `$` als `$$`; der lokale Shell-Command bleibt unverändert. Ein Test prüft insbesondere Command-Substitution, Parametererweiterung und das Fehlen einzelner, unescapeter Dollarzeichen.

## Validierung
- `pnpm exec vitest run scripts/ci/promote-backup-job.test.ts scripts/ci/promote-workflow-contract.test.ts --reporter=verbose`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- Shell-Syntaxcheck des Rohcommands