### PR TITLE
feat: add central backup agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     if: github.event_name == 'push' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
+      backup_agent_image_digest: ${{ steps.build_backup_agent_image.outputs.digest }}
       image_digest: ${{ steps.build_image.outputs.digest }}
     steps:
       - name: Checkout
@@ -48,6 +49,19 @@ jobs:
           tags: |
             ghcr.io/smart-village-solutions/sva-studio:${{ github.sha }}
             ghcr.io/smart-village-solutions/sva-studio:latest
+
+      - name: Build and push backup agent image
+        id: build_backup_agent_image
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            SVA_IMAGE_REVISION=${{ github.sha }}
+          context: .
+          file: ./deploy/backup-agent/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/smart-village-solutions/sva-studio-backup-agent:${{ github.sha }}
+            ghcr.io/smart-village-solutions/sva-studio-backup-agent:latest
 
   promote-dev:
     name: Promote dev

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -64,6 +64,7 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
   packages: read
 
 concurrency:
@@ -249,7 +250,19 @@ jobs:
 
       - name: create database backup before one-shot jobs
         id: backup_job
-        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') }}
+        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') && vars.BACKUP_EXECUTOR != 'temporary' }}
+        env:
+          BACKUP_AGENT_SIGNING_KEY: ${{ secrets.BACKUP_AGENT_SIGNING_KEY }}
+          DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
+          MAINTENANCE_WINDOW_REFERENCE: ${{ inputs.maintenance_window }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_ENDPOINT: https://fileserver.smart-village.app
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: pnpm exec tsx scripts/ci/submit-backup-agent-request.ts "${{ inputs.environment }}"
+
+      - name: create temporary database backup fallback
+        id: backup_fallback_job
+        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') && vars.BACKUP_EXECUTOR == 'temporary' }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
           DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
@@ -269,9 +282,9 @@ jobs:
         if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') }}
         env:
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-          S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket }}
+          S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket || steps.backup_fallback_job.outputs.backup_bucket }}
           S3_ENDPOINT: https://fileserver.smart-village.app
-          S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object }}
+          S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object || steps.backup_fallback_job.outputs.backup_object }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
         run: pnpm exec tsx scripts/ci/verify-promote-backup.ts
 

--- a/.github/workflows/staging-backup-drill.yml
+++ b/.github/workflows/staging-backup-drill.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   packages: read
 
 jobs:
@@ -61,6 +62,7 @@ jobs:
             --expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
 
       - name: setup quantum-cli
+        if: ${{ vars.BACKUP_EXECUTOR == 'temporary' }}
         uses: hostwithquantum/setup-quantum-cli@v2.0.0
         with:
           api-key: ${{ secrets.QUANTUM_API_KEY }}
@@ -68,6 +70,18 @@ jobs:
 
       - name: create and verify database backup
         id: backup_job
+        if: ${{ vars.BACKUP_EXECUTOR != 'temporary' }}
+        env:
+          BACKUP_AGENT_SIGNING_KEY: ${{ secrets.BACKUP_AGENT_SIGNING_KEY }}
+          DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_ENDPOINT: https://fileserver.smart-village.app
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: pnpm exec tsx scripts/ci/submit-backup-agent-request.ts staging
+
+      - name: create temporary database backup fallback
+        id: backup_fallback_job
+        if: ${{ vars.BACKUP_EXECUTOR == 'temporary' }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
           DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
@@ -87,9 +101,9 @@ jobs:
         if: success()
         env:
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-          S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket }}
+          S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket || steps.backup_fallback_job.outputs.backup_bucket }}
           S3_ENDPOINT: https://fileserver.smart-village.app
-          S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object }}
+          S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object || steps.backup_fallback_job.outputs.backup_object }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
         run: pnpm exec tsx scripts/ci/verify-promote-backup.ts
 

--- a/deploy/backup-agent-stack.test.ts
+++ b/deploy/backup-agent-stack.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'backup-agent-stack.yaml'), 'utf8');
+const dockerfile = readFileSync(resolve(import.meta.dirname, 'backup-agent/Dockerfile'), 'utf8');
+
+describe('backup agent stack', () => {
+  it('has one replica, no published ports and all required networks', () => {
+    expect(source).not.toMatch(/^\s+ports:/mu);
+    expect(source).toContain("replicas: 1");
+    expect(source).toContain("      - ingress\n      - staging\n      - production");
+  });
+
+  it('routes only the exact POST endpoint on the existing hosts', () => {
+    expect(source).toContain('Host(`studio-staging.smart-village.app`) && Path(`/_ops/backup/v1/requests`) && Method(`POST`)');
+    expect(source).toContain('Host(`studio.smart-village.app`) && Path(`/_ops/backup/v1/requests`) && Method(`POST`)');
+    expect(source).toContain('backup-agent-rate-limit.ratelimit.average=2');
+    expect(source).not.toContain('traefik.http.routers.backup-agent-prod.entrypoints=web,');
+  });
+
+  it('uses a minimal dedicated image with required backup tools', () => {
+    expect(dockerfile).toContain('aws-cli');
+    expect(dockerfile).toContain('postgresql-client');
+    expect(dockerfile).not.toContain('sva-studio-react');
+    expect(dockerfile).not.toContain('pnpm install');
+  });
+});

--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -1,0 +1,91 @@
+services:
+  backup-agent:
+    image: ${IMAGE_REF}
+    environment:
+      BACKUP_AGENT_ALLOWED_WORKFLOWS: promote.yml,staging-backup-drill.yml
+      BACKUP_AGENT_GITHUB_REPOSITORY: smart-village-solutions/sva-studio
+      BACKUP_AGENT_IMAGE_REF: ${IMAGE_REF}
+      BACKUP_AGENT_OIDC_AUDIENCE: studio-backup-agent
+      BACKUP_AGENT_PORT: '3080'
+      BACKUP_S3_ENDPOINT: https://fileserver.smart-village.app
+      BACKUP_STAGING_POSTGRES_PASSWORD_FILE: /run/secrets/backup_staging_postgres_password
+      BACKUP_STAGING_S3_ACCESS_KEY_FILE: /run/secrets/backup_staging_s3_access_key
+      BACKUP_STAGING_S3_SECRET_KEY_FILE: /run/secrets/backup_staging_s3_secret_key
+      BACKUP_STAGING_SIGNING_KEY_FILE: /run/secrets/backup_staging_signing_key
+      BACKUP_PROD_POSTGRES_PASSWORD_FILE: /run/secrets/backup_prod_postgres_password
+      BACKUP_PROD_S3_ACCESS_KEY_FILE: /run/secrets/backup_prod_s3_access_key
+      BACKUP_PROD_S3_SECRET_KEY_FILE: /run/secrets/backup_prod_s3_secret_key
+      BACKUP_PROD_SIGNING_KEY_FILE: /run/secrets/backup_prod_signing_key
+    networks:
+      - ingress
+      - staging
+      - production
+    secrets:
+      - backup_staging_postgres_password
+      - backup_staging_s3_access_key
+      - backup_staging_s3_secret_key
+      - backup_staging_signing_key
+      - backup_prod_postgres_password
+      - backup_prod_s3_access_key
+      - backup_prod_s3_secret_key
+      - backup_prod_signing_key
+    healthcheck:
+      test: ['CMD', 'curl', '--fail', '--silent', 'http://127.0.0.1:3080/health/live']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == node-005.sva
+      restart_policy:
+        condition: on-failure
+      labels:
+        - 'traefik.enable=true'
+        - 'traefik.docker.network=network-node-005'
+        - 'traefik.http.routers.backup-agent-staging.rule=Host(`studio-staging.smart-village.app`) && Path(`/_ops/backup/v1/requests`) && Method(`POST`)'
+        - 'traefik.http.routers.backup-agent-staging.entrypoints=websecure'
+        - 'traefik.http.routers.backup-agent-staging.priority=200'
+        - 'traefik.http.routers.backup-agent-staging.middlewares=backup-agent-rate-limit'
+        - 'traefik.http.routers.backup-agent-staging.tls=true'
+        - 'traefik.http.routers.backup-agent-staging.tls.certresolver=default'
+        - 'traefik.http.routers.backup-agent-staging.service=backup-agent'
+        - 'traefik.http.routers.backup-agent-prod.rule=Host(`studio.smart-village.app`) && Path(`/_ops/backup/v1/requests`) && Method(`POST`)'
+        - 'traefik.http.routers.backup-agent-prod.entrypoints=websecure'
+        - 'traefik.http.routers.backup-agent-prod.priority=200'
+        - 'traefik.http.routers.backup-agent-prod.middlewares=backup-agent-rate-limit'
+        - 'traefik.http.routers.backup-agent-prod.tls=true'
+        - 'traefik.http.routers.backup-agent-prod.service=backup-agent'
+        - 'traefik.http.services.backup-agent.loadbalancer.server.port=3080'
+        - 'traefik.http.middlewares.backup-agent-rate-limit.ratelimit.average=2'
+        - 'traefik.http.middlewares.backup-agent-rate-limit.ratelimit.burst=4'
+
+networks:
+  ingress:
+    external: true
+    name: network-node-005
+  staging:
+    external: true
+    name: studio-staging_default
+  production:
+    external: true
+    name: studio-prod_default
+
+secrets:
+  backup_staging_postgres_password:
+    external: true
+  backup_staging_s3_access_key:
+    external: true
+  backup_staging_s3_secret_key:
+    external: true
+  backup_staging_signing_key:
+    external: true
+  backup_prod_postgres_password:
+    external: true
+  backup_prod_s3_access_key:
+    external: true
+  backup_prod_s3_secret_key:
+    external: true
+  backup_prod_signing_key:
+    external: true

--- a/deploy/backup-agent/Dockerfile
+++ b/deploy/backup-agent/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:24.15.0-alpine
+
+ARG SVA_IMAGE_REVISION
+
+LABEL org.opencontainers.image.source="https://github.com/smart-village-solutions/sva-studio"
+LABEL org.opencontainers.image.revision="${SVA_IMAGE_REVISION}"
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN apk add --no-cache aws-cli ca-certificates curl postgresql-client \
+  && aws --version \
+  && pg_dump --version \
+  && pg_restore --version
+
+COPY --chown=node:node deploy/backup-agent/agent.mjs /app/agent.mjs
+
+USER node
+
+ENTRYPOINT ["node", "/app/agent.mjs"]

--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -1,0 +1,289 @@
+import { createHash, createHmac, createPublicKey, randomUUID, timingSafeEqual, verify as verifySignature } from 'node:crypto';
+import { createServer } from 'node:http';
+import { readFile, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const requestPath = '/_ops/backup/v1/requests';
+const oidcIssuer = 'https://token.actions.githubusercontent.com';
+const jwksUrl = `${oidcIssuer}/.well-known/jwks`;
+const maxBodyBytes = 16_384;
+const maxRequestLifetimeMs = 10 * 60_000;
+
+const required = (value, name) => {
+  const result = value?.trim();
+  if (!result) throw new Error(`${name} is required`);
+  return result;
+};
+
+const readSecret = async (name) => (await readFile(required(process.env[name], name), 'utf8')).trim();
+
+const targets = {
+  staging: {
+    host: 'studio-staging.smart-village.app',
+    bucket: 'studio-db-backup-staging',
+    prefix: 'staging',
+    postgresHost: 'studio-staging_postgres',
+    postgresDatabase: process.env.BACKUP_STAGING_POSTGRES_DB || 'sva_studio',
+    postgresUser: process.env.BACKUP_STAGING_POSTGRES_USER || 'sva',
+    postgresPasswordFile: 'BACKUP_STAGING_POSTGRES_PASSWORD_FILE',
+    s3AccessKeyFile: 'BACKUP_STAGING_S3_ACCESS_KEY_FILE',
+    s3SecretKeyFile: 'BACKUP_STAGING_S3_SECRET_KEY_FILE',
+    signingKeyFile: 'BACKUP_STAGING_SIGNING_KEY_FILE',
+  },
+  prod: {
+    host: 'studio.smart-village.app',
+    bucket: 'studio-db-backup-production',
+    prefix: 'prod',
+    postgresHost: 'studio-prod_postgres',
+    postgresDatabase: process.env.BACKUP_PROD_POSTGRES_DB || 'sva_studio',
+    postgresUser: process.env.BACKUP_PROD_POSTGRES_USER || 'sva',
+    postgresPasswordFile: 'BACKUP_PROD_POSTGRES_PASSWORD_FILE',
+    s3AccessKeyFile: 'BACKUP_PROD_S3_ACCESS_KEY_FILE',
+    s3SecretKeyFile: 'BACKUP_PROD_S3_SECRET_KEY_FILE',
+    signingKeyFile: 'BACKUP_PROD_SIGNING_KEY_FILE',
+  },
+};
+
+export const canonicalRequest = (request) => JSON.stringify({
+  action: request.action,
+  deployImageDigest: request.deployImageDigest,
+  environment: request.environment,
+  expiresAt: request.expiresAt,
+  maintenanceWindowReference: request.maintenanceWindowReference ?? null,
+  requestId: request.requestId,
+  version: request.version,
+});
+
+export const validRequest = (request, now = Date.now()) => {
+  if (!request || typeof request !== 'object' || Array.isArray(request)) return false;
+  const allowedKeys = new Set(['action', 'deployImageDigest', 'environment', 'expiresAt', 'maintenanceWindowReference', 'requestId', 'version']);
+  if (Object.keys(request).some((key) => !allowedKeys.has(key))) return false;
+  if (request.version !== 1 || request.action !== 'backup-and-verify') return false;
+  if (request.environment !== 'staging' && request.environment !== 'prod') return false;
+  if (typeof request.requestId !== 'string' || !/^[a-zA-Z0-9][a-zA-Z0-9._-]{7,127}$/u.test(request.requestId)) return false;
+  if (typeof request.deployImageDigest !== 'string' || !/^sha256:[a-f0-9]{64}$/u.test(request.deployImageDigest)) return false;
+  const expiresAt = typeof request.expiresAt === 'string' ? Date.parse(request.expiresAt) : Number.NaN;
+  if (!Number.isFinite(expiresAt) || expiresAt <= now || expiresAt > now + maxRequestLifetimeMs) return false;
+  return request.environment !== 'prod'
+    || (typeof request.maintenanceWindowReference === 'string' && /^[A-Za-z0-9][A-Za-z0-9._:/# -]{2,159}$/u.test(request.maintenanceWindowReference));
+};
+
+const decodeBase64Url = (value) => Buffer.from(value, 'base64url');
+
+let jwksCache;
+const getJwks = async () => {
+  if (jwksCache && jwksCache.expiresAt > Date.now()) return jwksCache.keys;
+  const response = await fetch(jwksUrl, { signal: AbortSignal.timeout(5_000) });
+  if (!response.ok) throw new Error('oidc_jwks_unavailable');
+  const document = await response.json();
+  if (!Array.isArray(document.keys)) throw new Error('oidc_jwks_invalid');
+  jwksCache = { keys: document.keys, expiresAt: Date.now() + 5 * 60_000 };
+  return document.keys;
+};
+
+export const validateOidcClaims = (claims, environment, now = Math.floor(Date.now() / 1_000)) => {
+  if (claims.iss !== oidcIssuer || claims.aud !== required(process.env.BACKUP_AGENT_OIDC_AUDIENCE, 'BACKUP_AGENT_OIDC_AUDIENCE')) throw new Error('oidc_claims_invalid');
+  if (typeof claims.exp !== 'number' || typeof claims.nbf !== 'number' || claims.exp <= now || claims.nbf > now) throw new Error('oidc_time_invalid');
+  if (claims.repository !== required(process.env.BACKUP_AGENT_GITHUB_REPOSITORY, 'BACKUP_AGENT_GITHUB_REPOSITORY')) throw new Error('oidc_repository_invalid');
+  if (claims.environment !== environment) throw new Error('oidc_environment_invalid');
+  const allowedWorkflows = required(process.env.BACKUP_AGENT_ALLOWED_WORKFLOWS, 'BACKUP_AGENT_ALLOWED_WORKFLOWS')
+    .split(',')
+    .map((value) => `${claims.repository}/.github/workflows/${value.trim()}@refs/heads/main`);
+  const workflowReferences = [claims.workflow_ref, claims.job_workflow_ref].filter((value) => typeof value === 'string');
+  if (!workflowReferences.some((value) => allowedWorkflows.includes(value))) throw new Error('oidc_workflow_invalid');
+};
+
+const verifyOidc = async (token, environment) => {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('oidc_token_invalid');
+  const header = JSON.parse(decodeBase64Url(parts[0]).toString('utf8'));
+  const claims = JSON.parse(decodeBase64Url(parts[1]).toString('utf8'));
+  if (header.alg !== 'RS256' || typeof header.kid !== 'string') throw new Error('oidc_header_invalid');
+  const key = (await getJwks()).find((candidate) => candidate.kid === header.kid);
+  if (!key) throw new Error('oidc_key_unknown');
+  const valid = verifySignature(
+    'RSA-SHA256',
+    Buffer.from(`${parts[0]}.${parts[1]}`),
+    createPublicKey({ key, format: 'jwk' }),
+    decodeBase64Url(parts[2]),
+  );
+  if (!valid) throw new Error('oidc_signature_invalid');
+  validateOidcClaims(claims, environment);
+};
+
+const run = (command, args, options = {}) => new Promise((resolve, reject) => {
+  const child = spawn(command, args, { ...options, stdio: ['ignore', 'ignore', 'pipe'] });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-2_000); });
+  child.once('error', reject);
+  child.once('exit', (code) => code === 0 ? resolve() : reject(new Error(`${command}_failed_${String(code)}:${stderr.replaceAll(/\s+/gu, ' ')}`)));
+});
+
+const runCapture = (command, args) => new Promise((resolve, reject) => {
+  const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout = `${stdout}${chunk}`.slice(-1_000); });
+  child.stderr.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-1_000); });
+  child.once('error', reject);
+  child.once('exit', (code) => code === 0 ? resolve(stdout.trim() || stderr.trim()) : reject(new Error(`${command}_preflight_failed_${String(code)}`)));
+});
+
+const s3Env = async (target) => ({
+  ...process.env,
+  AWS_ACCESS_KEY_ID: await readSecret(target.s3AccessKeyFile),
+  AWS_SECRET_ACCESS_KEY: await readSecret(target.s3SecretKeyFile),
+  AWS_EC2_METADATA_DISABLED: 'true',
+  AWS_DEFAULT_REGION: 'us-east-1',
+});
+
+const uploadJson = async (target, key, value) => {
+  const path = join(tmpdir(), `backup-agent-${randomUUID()}.json`);
+  await writeFile(path, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+  try {
+    await run('aws', ['--endpoint-url', required(process.env.BACKUP_S3_ENDPOINT, 'BACKUP_S3_ENDPOINT'), 's3', 'cp', path, `s3://${target.bucket}/${key}`, '--only-show-errors'], { env: await s3Env(target) });
+  } finally {
+    await run('rm', ['-f', path]);
+  }
+};
+
+const objectExists = async (target, key) => {
+  try {
+    await run('aws', ['--endpoint-url', required(process.env.BACKUP_S3_ENDPOINT, 'BACKUP_S3_ENDPOINT'), 's3api', 'head-object', '--bucket', target.bucket, '--key', key], { env: await s3Env(target) });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const sha256 = async (path) => createHash('sha256').update(await readFile(path)).digest('hex');
+
+export const safeErrorCode = (error) => {
+  const message = error instanceof Error ? error.message : '';
+  if (message === 'checksum_mismatch') return message;
+  const commandFailure = /^(aws|pg_dump|pg_restore)_failed_[0-9]+/u.exec(message);
+  return commandFailure?.[0] ?? 'backup_failed';
+};
+
+let active = false;
+const terminalRequests = new Set();
+
+export const controlKeysFor = (requestId) => ({
+  request: `control/requests/${requestId}.json`,
+  result: `control/results/${requestId}.json`,
+});
+
+export const executeBackupForIntegration = async (request) => {
+  const target = targets[request.environment];
+  const workdir = join(tmpdir(), `backup-agent-${request.requestId}-${randomUUID()}`);
+  const dump = join(workdir, 'backup.dump');
+  const downloaded = join(workdir, 'backup.download');
+  const digest = request.deployImageDigest.slice('sha256:'.length);
+  const timestamp = new Date().toISOString().replaceAll(/[:.]/gu, '-');
+  const objectKey = `${target.prefix}/${timestamp}/${digest}/${request.requestId}.dump`;
+  const resultKey = controlKeysFor(request.requestId).result;
+  const steps = [];
+  const complete = (step, details = {}) => steps.push({ step, status: 'succeeded', ...details });
+  const evidence = {
+    version: 1,
+    requestId: request.requestId,
+    environment: request.environment,
+    deployImageDigest: request.deployImageDigest,
+    agentImage: required(process.env.BACKUP_AGENT_IMAGE_REF, 'BACKUP_AGENT_IMAGE_REF'),
+    tools: JSON.parse(required(process.env.BACKUP_AGENT_TOOL_VERSIONS, 'BACKUP_AGENT_TOOL_VERSIONS')),
+  };
+  try {
+    await run('mkdir', ['-p', workdir]);
+    const pgEnv = { ...process.env, PGPASSWORD: await readSecret(target.postgresPasswordFile) };
+    await run('pg_dump', ['--format=custom', '--no-owner', '--no-privileges', '--host', target.postgresHost, '--port', '5432', '--username', target.postgresUser, '--file', dump, target.postgresDatabase], { env: pgEnv });
+    complete('pg_dump');
+    const env = await s3Env(target);
+    const endpoint = required(process.env.BACKUP_S3_ENDPOINT, 'BACKUP_S3_ENDPOINT');
+    await run('aws', ['--endpoint-url', endpoint, 's3', 'cp', dump, `s3://${target.bucket}/${objectKey}`, '--only-show-errors'], { env });
+    complete('upload');
+    await run('aws', ['--endpoint-url', endpoint, 's3', 'cp', `s3://${target.bucket}/${objectKey}`, downloaded, '--only-show-errors'], { env });
+    complete('download');
+    const dumpDigest = await sha256(dump);
+    if (dumpDigest !== await sha256(downloaded)) throw new Error('checksum_mismatch');
+    const bytes = (await readFile(dump)).byteLength;
+    complete('size-and-checksum-verify', { bytes, sha256: dumpDigest });
+    await writeFile(`${dump}.sha256`, `${dumpDigest}  backup.dump\n`, { mode: 0o600 });
+    await run('aws', ['--endpoint-url', endpoint, 's3', 'cp', `${dump}.sha256`, `s3://${target.bucket}/${objectKey}.sha256`, '--only-show-errors'], { env });
+    await run('pg_restore', ['--list', downloaded]);
+    complete('archive-validate');
+    await uploadJson(target, resultKey, { ...evidence, status: 'succeeded', objectKey, bytes, sha256: dumpDigest, steps, completedAt: new Date().toISOString() });
+  } catch (error) {
+    await uploadJson(target, resultKey, { ...evidence, status: 'failed', errorCode: safeErrorCode(error), steps, completedAt: new Date().toISOString() });
+  } finally {
+    terminalRequests.add(request.requestId);
+    active = false;
+    await run('rm', ['-rf', workdir]);
+  }
+};
+
+const readBody = async (incoming) => {
+  const chunks = [];
+  let length = 0;
+  for await (const chunk of incoming) {
+    length += chunk.length;
+    if (length > maxBodyBytes) throw new Error('request_too_large');
+    chunks.push(chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+};
+
+const respond = (response, status, body) => {
+  response.writeHead(status, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+  response.end(`${JSON.stringify(body)}\n`);
+};
+
+export const createBackupAgentServer = () => createServer(async (incoming, response) => {
+  if (incoming.method === 'GET' && incoming.url === '/health/live') return respond(response, 200, { status: 'ok' });
+  if (incoming.method !== 'POST' || incoming.url !== requestPath) return respond(response, 404, { error: 'not_found' });
+  try {
+    const request = await readBody(incoming);
+    if (!validRequest(request)) return respond(response, 400, { error: 'invalid_request' });
+    if (incoming.headers.host !== targets[request.environment].host) return respond(response, 400, { error: 'invalid_request' });
+    const auth = incoming.headers.authorization;
+    if (typeof auth !== 'string' || !auth.startsWith('Bearer ')) return respond(response, 401, { error: 'unauthorized' });
+    await verifyOidc(auth.slice('Bearer '.length), request.environment);
+    const signature = incoming.headers['x-backup-request-signature'];
+    if (typeof signature !== 'string' || !/^[a-f0-9]{64}$/u.test(signature)) return respond(response, 401, { error: 'unauthorized' });
+    const key = await readSecret(targets[request.environment].signingKeyFile);
+    const actual = Buffer.from(createHmac('sha256', key).update(canonicalRequest(request)).digest('hex'), 'hex');
+    const expected = Buffer.from(signature, 'hex');
+    if (!timingSafeEqual(actual, expected)) return respond(response, 401, { error: 'unauthorized' });
+    if (active) return respond(response, 409, { error: 'agent_busy' });
+    if (terminalRequests.has(request.requestId)) return respond(response, 409, { error: 'request_replayed' });
+    active = true;
+    const target = targets[request.environment];
+    const requestKey = controlKeysFor(request.requestId).request;
+    if (await objectExists(target, requestKey)) {
+      active = false;
+      return respond(response, 409, { error: 'request_replayed' });
+    }
+    try {
+      await uploadJson(target, requestKey, request);
+    } catch (error) {
+      active = false;
+      throw error;
+    }
+    void executeBackupForIntegration(request);
+    return respond(response, 202, { requestId: request.requestId });
+  } catch {
+    return respond(response, 400, { error: 'invalid_request' });
+  }
+});
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const versions = await Promise.all([
+    runCapture('aws', ['--version']),
+    runCapture('pg_dump', ['--version']),
+    runCapture('pg_restore', ['--version']),
+  ]);
+  process.env.BACKUP_AGENT_TOOL_VERSIONS = JSON.stringify({ aws: versions[0], pgDump: versions[1], pgRestore: versions[2] });
+  createBackupAgentServer().listen(Number(process.env.BACKUP_AGENT_PORT || '3080'), '0.0.0.0');
+}

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalRequest, controlKeysFor, safeErrorCode, validateOidcClaims, validRequest } from './agent.mjs';
+
+const request = {
+  version: 1,
+  action: 'backup-and-verify',
+  requestId: 'gha-12345678',
+  environment: 'staging',
+  deployImageDigest: `sha256:${'a'.repeat(64)}`,
+  expiresAt: '2026-07-30T10:10:00.000Z',
+} as const;
+
+describe('backup agent runtime contract', () => {
+  it('binds GitHub identity to repository, environment and allowlisted main workflow', () => {
+    process.env.BACKUP_AGENT_OIDC_AUDIENCE = 'studio-backup-agent';
+    process.env.BACKUP_AGENT_GITHUB_REPOSITORY = 'smart-village-solutions/sva-studio';
+    process.env.BACKUP_AGENT_ALLOWED_WORKFLOWS = 'promote.yml,staging-backup-drill.yml';
+    const claims = {
+      aud: 'studio-backup-agent',
+      environment: 'staging',
+      exp: 1_800,
+      iss: 'https://token.actions.githubusercontent.com',
+      nbf: 900,
+      repository: 'smart-village-solutions/sva-studio',
+      workflow_ref: 'smart-village-solutions/sva-studio/.github/workflows/promote.yml@refs/heads/main',
+    };
+    expect(() => validateOidcClaims(claims, 'staging', 1_000)).not.toThrow();
+    expect(() => validateOidcClaims({ ...claims, environment: 'prod' }, 'staging', 1_000)).toThrow('oidc_environment_invalid');
+    expect(() => validateOidcClaims({ ...claims, workflow_ref: 'smart-village-solutions/sva-studio/.github/workflows/untrusted.yml@refs/heads/main' }, 'staging', 1_000)).toThrow('oidc_workflow_invalid');
+    expect(() => validateOidcClaims({
+      ...claims,
+      job_workflow_ref: claims.workflow_ref,
+      workflow_ref: 'smart-village-solutions/sva-studio/.github/workflows/build.yml@refs/heads/main',
+    }, 'staging', 1_000)).not.toThrow();
+  });
+  it('accepts only short-lived requests', () => {
+    expect(validRequest(request, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(true);
+    expect(validRequest({ ...request, expiresAt: '2026-07-30T10:10:00.001Z' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(false);
+  });
+
+  it('requires production maintenance evidence', () => {
+    expect(validRequest({ ...request, environment: 'prod' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(false);
+    expect(validRequest({ ...request, environment: 'prod', maintenanceWindowReference: 'CAB-42' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(true);
+  });
+
+  it('canonicalizes requests without accepting target overrides', () => {
+    expect(canonicalRequest(request)).not.toContain('bucket');
+    expect(canonicalRequest(request)).not.toContain('postgresHost');
+    expect(validRequest({ ...request, bucket: 'studio-db-backup-production' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(false);
+  });
+
+  it('uses persistent MinIO control keys for replay and terminal evidence', () => {
+    expect(controlKeysFor('gha-12345678')).toEqual({
+      request: 'control/requests/gha-12345678.json',
+      result: 'control/results/gha-12345678.json',
+    });
+  });
+
+  it('never propagates credentials or shell traces into terminal error codes', () => {
+    expect(safeErrorCode(new Error('aws_failed_1:https://access:secret@minio/upload shell trace'))).toBe('aws_failed_1');
+    expect(safeErrorCode(new Error('password=secret'))).toBe('backup_failed');
+  });
+});

--- a/deploy/backup-agent/compose.integration.yaml
+++ b/deploy/backup-agent/compose.integration.yaml
@@ -1,0 +1,134 @@
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: ${INTEGRATION_S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${INTEGRATION_S3_SECRET_KEY}
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  staging-db:
+    image: postgres:16.9-alpine
+    environment:
+      POSTGRES_DB: sva_studio
+      POSTGRES_PASSWORD: ${INTEGRATION_STAGING_POSTGRES_PASSWORD}
+      POSTGRES_USER: sva
+    networks:
+      default:
+        aliases: [studio-staging_postgres]
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U sva -d sva_studio']
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  production-db:
+    image: postgres:16.9-alpine
+    environment:
+      POSTGRES_DB: sva_studio
+      POSTGRES_PASSWORD: ${INTEGRATION_PRODUCTION_POSTGRES_PASSWORD}
+      POSTGRES_USER: sva
+    networks:
+      default:
+        aliases: [studio-prod_postgres]
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U sva -d sva_studio']
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: ['/bin/sh', '-ec']
+    command:
+      - |
+        mc alias set local http://minio:9000 ${INTEGRATION_S3_ACCESS_KEY} ${INTEGRATION_S3_SECRET_KEY}
+        mc mb --ignore-existing local/studio-db-backup-staging
+        mc mb --ignore-existing local/studio-db-backup-production
+
+  staging-agent-run:
+    build:
+      context: ../..
+      dockerfile: deploy/backup-agent/Dockerfile
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+      staging-db:
+        condition: service_healthy
+    entrypoint: ['node', '--input-type=module', '--eval']
+    command:
+      - |
+        process.env.BACKUP_AGENT_IMAGE_REF='integration';
+        process.env.BACKUP_AGENT_TOOL_VERSIONS='{"aws":"integration","pgDump":"integration","pgRestore":"integration"}';
+        const { executeBackupForIntegration } = await import('/app/agent.mjs');
+        await executeBackupForIntegration({version:1,action:'backup-and-verify',requestId:'integration-staging',environment:'staging',deployImageDigest:'sha256:${INTEGRATION_DIGEST}',expiresAt:'2099-01-01T00:00:00.000Z'});
+    environment: &agent-environment
+      BACKUP_S3_ENDPOINT: http://minio:9000
+      BACKUP_STAGING_POSTGRES_PASSWORD_FILE: /run/secrets/staging_postgres_password
+      BACKUP_STAGING_S3_ACCESS_KEY_FILE: /run/secrets/s3_access_key
+      BACKUP_STAGING_S3_SECRET_KEY_FILE: /run/secrets/s3_secret_key
+      BACKUP_PROD_POSTGRES_PASSWORD_FILE: /run/secrets/production_postgres_password
+      BACKUP_PROD_S3_ACCESS_KEY_FILE: /run/secrets/s3_access_key
+      BACKUP_PROD_S3_SECRET_KEY_FILE: /run/secrets/s3_secret_key
+    secrets: &agent-secrets
+      - staging_postgres_password
+      - production_postgres_password
+      - s3_access_key
+      - s3_secret_key
+
+  production-agent-run:
+    build:
+      context: ../..
+      dockerfile: deploy/backup-agent/Dockerfile
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+      production-db:
+        condition: service_healthy
+      staging-agent-run:
+        condition: service_completed_successfully
+    entrypoint: ['node', '--input-type=module', '--eval']
+    command:
+      - |
+        process.env.BACKUP_AGENT_IMAGE_REF='integration';
+        process.env.BACKUP_AGENT_TOOL_VERSIONS='{"aws":"integration","pgDump":"integration","pgRestore":"integration"}';
+        const { executeBackupForIntegration } = await import('/app/agent.mjs');
+        await executeBackupForIntegration({version:1,action:'backup-and-verify',requestId:'integration-production',environment:'prod',deployImageDigest:'sha256:${INTEGRATION_DIGEST}',expiresAt:'2099-01-01T00:00:00.000Z',maintenanceWindowReference:'integration-test'});
+    environment: *agent-environment
+    secrets: *agent-secrets
+
+  verify:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      production-agent-run:
+        condition: service_completed_successfully
+    entrypoint: ['/bin/sh', '-ec']
+    command:
+      - |
+        mc alias set local http://minio:9000 ${INTEGRATION_S3_ACCESS_KEY} ${INTEGRATION_S3_SECRET_KEY}
+        staging_result="$(mc cat local/studio-db-backup-staging/control/results/integration-staging.json)"
+        production_result="$(mc cat local/studio-db-backup-production/control/results/integration-production.json)"
+        case "$$staging_result" in *'"status":"succeeded"'*) ;; *) exit 1 ;; esac
+        case "$$production_result" in *'"status":"succeeded"'*) ;; *) exit 1 ;; esac
+        ! mc stat local/studio-db-backup-production/control/results/integration-staging.json
+        ! mc stat local/studio-db-backup-staging/control/results/integration-production.json
+
+networks:
+  default:
+
+secrets:
+  staging_postgres_password:
+    environment: INTEGRATION_STAGING_POSTGRES_PASSWORD
+  production_postgres_password:
+    environment: INTEGRATION_PRODUCTION_POSTGRES_PASSWORD
+  s3_access_key:
+    environment: INTEGRATION_S3_ACCESS_KEY
+  s3_secret_key:
+    environment: INTEGRATION_S3_SECRET_KEY

--- a/docs/adr/ADR-048-zentraler-backup-agent-mit-gehaertetem-https-trigger.md
+++ b/docs/adr/ADR-048-zentraler-backup-agent-mit-gehaertetem-https-trigger.md
@@ -1,0 +1,30 @@
+# ADR-048: Zentraler Backup-Agent mit gehärtetem HTTPS-Trigger
+
+## Status
+
+Angenommen
+
+## Kontext
+
+Der bisherige Promote-Pfad erzeugt pro Backup einen temporären Swarm-Stack. Der Pfad ist fail-closed, seine Task- und Log-Evidenz ist jedoch flüchtig. Ein dauerhafter Ausführungspunkt soll Backups für Staging und Production übernehmen, ohne eine allgemeine Remote-Shell einzuführen.
+
+## Entscheidung
+
+Ein einzelner `studio-backup-agent` wird als bewusst breite Vertrauenszone betrieben. Er ist mit den internen Staging- und Production-Netzen sowie dem bestehenden Traefik-Netz verbunden. Zwei exakte HTTPS-`POST`-Routen auf den vorhandenen Hosts lösen ausschließlich `backup-and-verify` aus.
+
+GitHub authentisiert sich mit einem kurzlebigen OIDC-Token. Der Agent bindet dessen Claims an Repository, Environment und eine Allowlist der Workflows auf `main`. Zusätzlich signieren getrennte HMAC-Schlüssel die Requests für Staging und Production. Datenbankziele, Buckets und Credentials stammen ausschließlich aus der internen Umgebungs-Allowlist.
+
+Der Agent persistiert den Request vor `202 Accepted`, verarbeitet global genau einen Auftrag und schreibt das terminale Ergebnis nach MinIO. Request-ID, Ablaufzeit, Digest und Production-Wartungsfenster werden fail-closed geprüft. Der bisherige temporäre Stack bleibt bis zur Betriebsabnahme über `BACKUP_EXECUTOR=temporary` verfügbar.
+
+## Konsequenzen
+
+- Der gemeinsame Agent vergrößert den möglichen Blast Radius und benötigt getrennte Secrets sowie strenge Request-Validierung.
+- Der HTTPS-Ingress erweitert die Angriffsfläche, ist aber auf zwei Hosts, einen exakten Pfad und `POST` begrenzt.
+- MinIO-Evidenz ersetzt flüchtige Task-Logs als autoritativen Erfolgskanal.
+- Ein automatischer Restore bleibt ausgeschlossen.
+
+## Alternativen
+
+- Polling von MinIO wurde wegen unnötiger Latenz und Last verworfen.
+- MinIO-Webhooks wurden verworfen, weil keine belastbare interne MinIO-zu-Swarm-Route nachgewiesen ist.
+- `quantum-cli exec` wurde verworfen, weil es eine allgemeine Remote-Kommandoausführung statt eines engen Backup-Vertrags eröffnet.

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -642,3 +642,7 @@ Neu hinzugekommene Bausteine im Change `add-iam-organization-management-hierarch
    - binden tenantkonfiguriertes `mapGeocoding` an normierte Host-Endpunkte unter `/api/v1/iam/map-geocoding/*`.
 3. `packages/plugin-poi/src/poi.detail-page.tsx`, `poi.detail-location-tab.tsx`, `poi.detail-media-tab.tsx`
    - orchestrieren den vollständigen POI-Editor mit Bereichs-Tabs, Geocoding-Feldern, Reverse-Geocode-Unterstützung und Host-Media-Referenzierung.
+
+## Zentraler Backup-Agent
+
+Der `studio-backup-agent` ist ein eigenständiger operativer Baustein außerhalb der App-Stacks. Sein HTTP-Port wird nicht veröffentlicht; Traefik leitet ausschließlich die beiden exakten Backup-Request-Pfade an ihn weiter. Der Baustein besitzt getrennte Staging-/Production-Secrets und leitet Datenbankhost, Bucket und Objektpräfix ausschließlich aus der validierten Zielumgebung ab.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -884,3 +884,11 @@ Fehlerpfad:
 5. Das Tool liefert ein redigiertes Ergebnis. Nach Fehlern darf es innerhalb eines festen Budgets Read-only-Evidenz ergänzen; der Primärfehler bleibt unverändert.
 
 Fehlerpfad: Auth- und Scope-Fehler werden nicht diagnostisch umgedeutet. Eine abgelaufene, wiederverwendete oder durch Zustandsänderung veraltete Challenge verlangt einen neuen Vorab-Read. Weder MCP noch Studio wiederholen Mutationen automatisch.
+
+## Backup-Agent-Laufzeit
+
+1. `Promote` bezieht ein GitHub-OIDC-Token, signiert den kurzlebigen Auftrag und sendet ihn an den Zielhost.
+2. Der Agent prüft Host, OIDC-Claims, HMAC, Schema, Ablaufzeit, Request-ID, Digest und Production-Wartungsfenster.
+3. Vor `202 Accepted` persistiert er den Auftrag unter `control/requests/`.
+4. Der einzelne Worker erzeugt einen Custom-Dump, lädt ihn hoch und wieder herunter, vergleicht Größe und SHA-256 und führt `pg_restore --list` aus.
+5. Das terminale Ergebnis unter `control/results/` entscheidet fail-closed, ob Migration, Bootstrap und Deploy fortgesetzt werden.

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -269,3 +269,7 @@ Rollout-Reihenfolge:
 Der MCP-Prozess läuft lokal beim Operator und ist kein Dienst im Studio-Swarm. Jeder Root-Realm (`studio-dev`, `studio-staging`, `sva-studio`) hält einen eigenen Client `sva-studio-mcp` mit eigenem Secret und eigener Ziel-Audience. Secrets werden nur lokal per OS-Keychain oder nicht versionierter Konfiguration verteilt; Studio validiert JWTs über OIDC/JWKS und benötigt kein MCP-Client-Secret.
 
 Der Rollout erfolgt `studio-dev` → `studio-staging` → `sva-studio`. Pro Stufe werden Read-only-Smoke, kontrollierte Testmutation, Challenge-geschützte Testmutation, Audit und OTEL geprüft. Ein Environment-Kill-Switch bleibt bis zur Freigabe aus. Rollback deaktiviert zuerst den Kill-Switch und widerruft Client/Credential; ein App-Rollback verwendet den vorherigen freigegebenen Image-Digest. Details stehen im [MCP-Betriebsleitfaden](../guides/studio-instance-mcp-betrieb.md).
+
+## Zentraler Backup-Agent im Swarm
+
+`deploy/backup-agent-stack.yaml` definiert eine Replica auf `node-005.sva`. Der Service hängt an `network-node-005`, `studio-staging_default` und `studio-prod_default`, veröffentlicht aber keinen Port. Traefik routet nur `POST /_ops/backup/v1/requests` für `studio-staging.smart-village.app` und `studio.smart-village.app` auf Port 3080. Alle acht Runtime-Secrets sind externe Swarm-Secrets.

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -600,3 +600,7 @@ Referenzen:
 - Die MCP-Create-Prozesskette korreliert HTTP-Eingang, Registry-Schritte, Queue und Keycloak-Worker über Request-, Instanz- und Run-ID im Log-Body. Stabile `step_key`-Werte benennen die technische Fehlerstufe; pro Fehler entsteht genau ein kanonisches Error-Event.
 - PostgreSQL-Logs erlauben nur SQLSTATE, Tabelle, Spalte und Constraint. Rohe Meldungen, Details, Hints, Queries, Parameter, Stacktraces und Providerantworten bleiben ebenso ausgeschlossen wie E-Mail, Passwort, Token und Connection-String.
 - Audit-Ereignisse bleiben fachlich und append-only; technische Diagnosedetails werden nicht in den Audit-Pfad verschoben. Der lokale stdio-MCP hält `stdout` für das MCP-Protokoll frei.
+
+## Backup-Sicherheitsvertrag
+
+Der Backup-Agent kombiniert GitHub-OIDC mit umgebungsspezifischen HMAC-Signaturen. OIDC ist auf Repository, Environment und freigegebene Workflows auf `main` gebunden. Requests sind höchstens zehn Minuten gültig und über ihre persistierte Request-ID vor Replay geschützt. HTTP-Antworten und terminale Fehler enthalten nur stabile Fehlercodes; Credentials, Connection-Strings, Datenbankinhalte und Shell-Traces werden nicht ausgegeben.

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -50,6 +50,7 @@ mit Bezug auf die arc42-Abschnitte.
 - [ADR-044 frontend-test-foundation mit MSW und selektivem fast-check](../adr/ADR-044-frontend-test-foundation-mit-msw-und-selektivem-fast-check.md)
 - [ADR-045 organisationsgebundene Mainserver-Credentials und policy-gesteuerte Delegation](../adr/ADR-045-organisationsgebundene-mainserver-credentials-und-policy-gesteuerte-delegation.md)
 - [ADR-046 Plattform- vs. Tenant-Rollenmodell und Legacy-Standardrollen](../adr/ADR-046-plattform-vs-tenant-rollenmodell-und-legacy-standardrollen.md)
+- [ADR-048 zentraler Backup-Agent mit gehärtetem HTTPS-Trigger](../adr/ADR-048-zentraler-backup-agent-mit-gehaertetem-https-trigger.md)
 
 ### Zuordnung zu arc42-Abschnitten
 

--- a/docs/architecture/11-risks-and-technical-debt.md
+++ b/docs/architecture/11-risks-and-technical-debt.md
@@ -445,3 +445,8 @@ Referenzen:
    - Impact: mittel (Marker-Interaktion bleibt lokal funktionsfähig, aber die Kartenansicht kann visuell degradiert sein)
    - Wahrscheinlichkeit: mittel
    - Maßnahme: Host-seitige Kill-Switch- und Observability-Pfade aktiv halten, Style-Endpoint überwachen und UI-Fallback auf manuelle Koordinatenpflege beibehalten
+
+34. Erweiterter Blast Radius des zentralen Backup-Agenten
+   - Impact: hoch (der Dienst besitzt getrennten Zugriff auf beide Datenbanken und Backup-Buckets)
+   - Wahrscheinlichkeit: niedrig
+   - Maßnahme: eine Replica, globale Serialisierung, keine allgemeine Kommandoausführung, getrennte Secrets, feste Umgebungsableitung, OIDC- und HMAC-Prüfung sowie dauerhafte MinIO-Evidenz. Bis zum erfolgreichen Staging- und Production-Nachweis bleibt der temporäre Backup-Stack als expliziter Fallback erhalten.

--- a/docs/changelog/entries/pr-768.json
+++ b/docs/changelog/entries/pr-768.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 768,
+  "body": "Backups für Staging und Produktion können nun über einen zentralen, abgesicherten Backup-Agenten ausgeführt und vollständig verifiziert werden."
+}

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -278,9 +278,29 @@ Operator-Regel:
 - Vor einem Merge muss das GitHub-Environment `staging` mit Required Reviewers geschützt sein; `QUANTUM_API_KEY` und weitere mutierende Credentials dürfen ausschließlich als Environment-Secrets vorliegen.
 - Lokale Befehle bleiben für `status`, `doctor`, `precheck`, Diagnose und Recovery zulässig, aber nicht der konkurrierende Standardweg für Staging-Rollouts.
 
+### Zentralen Backup-Agenten bereitstellen
+
+Vor dem Deploy müssen die acht externen Swarm-Secrets aus getrennten, nicht ausgegebenen Quellen angelegt sein:
+
+- je Umgebung PostgreSQL-Passwort, S3-Access-Key, S3-Secret-Key und HMAC-Signaturschlüssel
+- in den GitHub-Environments `staging` und `prod` jeweils das passende Secret `BACKUP_AGENT_SIGNING_KEY`
+- Repository- bzw. Environment-Variable `BACKUP_EXECUTOR=temporary` nur für den kontrollierten Rückfall
+
+Der Stack wird mit einer unveränderlichen Image-Referenz gerendert und ausgerollt:
+
+```bash
+IMAGE_REF='ghcr.io/smart-village-solutions/sva-studio-backup-agent@sha256:<digest>' \
+  quantum-cli stacks deploy \
+  -f deploy/backup-agent-stack.yaml \
+  --stack studio-backup-agent \
+  --endpoint sva
+```
+
+Danach müssen genau eine gesunde Replica, keine veröffentlichten Ports, alle drei Netze und die beiden exakten Traefik-Router nachgewiesen werden. Ein kontrollierter Neustart erfolgt über einen erneuten Deploy desselben Digests. Bei Störung wird `BACKUP_EXECUTOR=temporary` gesetzt; der Promote bleibt trotzdem fail-closed und führt niemals beide Executor-Pfade aus.
+
 ### Staging-Backup-Drill
 
-Der manuelle GitHub-Workflow **Staging Backup Drill** prüft den Backup-Pfad ohne Migration, Bootstrap oder App-Deployment. Er akzeptiert ausschließlich eine unveränderliche Image-Referenz und die dazugehörige Commit-Revision. Der Workflow startet einen kurzlebigen Backup-Stack im Staging-Overlay, validiert Dump, Download, Prüfsumme und Archiv und entfernt den Stack anschließend wieder.
+Der manuelle GitHub-Workflow **Staging Backup Drill** prüft den Agentenpfad ohne Migration, Bootstrap oder App-Deployment. Er akzeptiert ausschließlich eine unveränderliche Image-Referenz und die dazugehörige Commit-Revision. Der Workflow sendet einen OIDC-authentisierten und signierten Auftrag, wartet auf das passende MinIO-Ergebnis und validiert Dump, Download, Prüfsumme und Archiv. Nur mit `BACKUP_EXECUTOR=temporary` verwendet er den bisherigen kurzlebigen Stack.
 
 Ein erfolgreicher Drill hinterlässt im Bucket `studio-db-backup-staging`:
 

--- a/openspec/changes/add-central-backup-agent/design.md
+++ b/openspec/changes/add-central-backup-agent/design.md
@@ -1,0 +1,64 @@
+## Context
+
+Der aktuelle Backup-Mechanismus erzeugt für jeden mutierenden Promote einen temporären Swarm-Stack. Der Container ist nach dem Lauf entfernt; dessen Logs können abhängig vom Remote-Logkanal unvollständig sein. Der zentrale Agent schafft einen dauerhaften, überprüfbaren Ausführungspunkt für beide Umgebungen.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Ein zentraler Agent führt nur definierte Backup- und Validierungsaufträge für `staging` oder `prod` aus.
+- Der Auftrags-, Ausführungs- und Ergebnisnachweis ist unabhängig von flüchtigen Swarm-Logs dauerhaft in MinIO vorhanden.
+- Der Promote-Pfad bleibt fail-closed und nutzt ausschließlich erfolgreiche, zum Request passende Ergebnisobjekte.
+- Production bleibt manuell, imagegebunden und freigabegeschützt.
+
+### Non-Goals
+
+- Keine allgemeine Job- oder Queue-Plattform für beliebige Betriebsaufgaben.
+- Keine parallele Einführung eines zweiten Backup-Systems oder eines Restore-Automaten.
+- Keine Aufweichung der getrennten Staging-/Production-Buckets oder der bestehenden Aufbewahrung.
+
+## Decisions
+
+### Ein zentraler Agent als explizite Vertrauenszone
+
+Es gibt genau einen `studio-backup-agent` mit einer Replica. Er ist kein Teil des langlebigen Studio-App-Stacks, hat keine öffentlichen Ports und wird auf einem für operative Dienste vorgesehenen Swarm-Node platziert. Der Agent ist mit den internen Staging- und Production-Netzen verbunden und erhält getrennte Secrets für beide Datenbanken und beide Buckets.
+
+Diese breite Berechtigung ist bewusst: Der Dienst ist der zentrale operative Backup-Ausführer. Die Umgebung wird als vertrauenswürdig vorausgesetzt; dennoch darf der Prozess nur aus einem kleinen, getesteten Befehlssatz bestehen und darf niemals Credentials oder Datenbankinhalte in Logs oder Ergebnisobjekte schreiben.
+
+### Signierter, ereignisgetriebener Auftragskanal
+
+GitHub sendet einen signierten, unveränderlichen Backup-Auftrag an den dedizierten HTTPS-Endpoint der Zielumgebung: `https://studio-staging.smart-village.app/_ops/backup/v1/requests` für Staging und `https://studio.smart-village.app/_ops/backup/v1/requests` für Production. Ein separater Traefik-Router akzeptiert ausschließlich `POST` für diesen exakten Pfad und leitet ihn an den Agenten weiter. Der Agent validiert GitHub-OIDC-Identität, Request-Signatur, Schema, Ablaufzeit, Request-ID, Zielumgebung und Ziel-Digest, persistiert den Auftrag im MinIO-Control-Präfix und antwortet erst dann mit `202 Accepted`. GitHub wartet auf das terminale Ergebnisobjekt. Der Endpoint erlaubt keine beliebigen Shell-Kommandos und liefert keine operativen Details nach außen.
+
+Der Auftrag erlaubt ausschließlich `backup-and-verify`. Er enthält keine Zugangsdaten und keine frei interpretierbaren Kommandozeilen. GitHub-OIDC-Claims werden auf Repository, Workflow, Ref und Zielumgebung gebunden. Ungültige, abgelaufene oder wiederverwendete Requests werden abgelehnt und als redigierter Fehlernachweis festgehalten. Staging und Production verwenden getrennte Signaturschlüssel.
+
+### Strikte Umgebungsbindung im Agenten
+
+Die Zielumgebung ist eine geschlossene Allowlist (`staging`, `prod`). Erst nach ihrer Validierung löst der Agent daraus alle folgenden Werte ab: PostgreSQL-Host, Datenbank-Credentials, Zielbucket, Objektpräfix und Signatur-/Freigabekontext. Ein Auftrag für Staging kann daher weder Production-Postgres noch den Production-Bucket auswählen und umgekehrt.
+
+### Evidenz als autoritativer Erfolgskanal
+
+Pro Request schreibt der Agent mindestens einen Status, redigierte Schritt-Ereignisse, Objektpfad, Größe, SHA-256-Wert und Archivvalidierung. Der Ablauf bleibt: Custom-Dump → Upload → Download → Größen-/SHA-256-Vergleich → `pg_restore --list`. Ein Agent-Worker verarbeitet global nur einen Auftrag gleichzeitig. GitHub akzeptiert nur ein erfolgreiches Ergebnis mit derselben Request-ID, Umgebung und demselben Digest; sonst endet der Promote vor jeder Datenmutation.
+
+### Production-Freigabe bleibt im Kontrollpunkt
+
+Der Agent ersetzt keine GitHub-Environment-Freigabe. Der Promote-Workflow kann einen Production-Auftrag nur nach der dortigen Freigabe, mit Wartungsfenster-Verweis und nach erfolgreicher Staging-Parität erzeugen. Der Agent protokolliert den nicht-sensitiven Wartungsfenster-Verweis im Ergebnis, trifft aber keine menschliche Freigabeentscheidung.
+
+## Risks / Trade-offs
+
+- Ein zentraler Agent besitzt Zugriff auf beide Umgebungen. Die Blast-Radius-Grenze liegt daher beim Agenten statt bei zwei getrennten Services. Gegenmaßnahme sind minimales Image, kein öffentlicher Port, enge Request-Validierung, getrennte Secrets und vollständige Evidenz.
+- Der neue Ingress erweitert die Angriffsfläche. Gegenmaßnahmen sind ein exakt eingeschränkter Pfad und Methode, TLS, GitHub-OIDC-Claim-Validierung, getrennte Signaturen, Ablaufzeit, Replay-Schutz, Rate-Limits und redigierte Antworten.
+- Der Agent selbst wird zu einer kritischen Betriebsabhängigkeit. Healthcheck, Image-/Tool-Preflight, deterministisches Placement und ein dokumentierter kontrollierter Neustart sind deshalb Pflicht.
+- Bis der Agent in beiden Umgebungen abgenommen ist, muss der bestehende temporäre Backup-Pfad erhalten bleiben.
+
+## Migration Plan
+
+1. Minimalen Agenten, Swarm-Service-Spec mit gehärtetem Traefik-Ingress und signierten Request-/Result-Vertrag implementieren.
+2. Lokalen PostgreSQL-/MinIO-End-to-End-Test und Sicherheits-/Redaction-Tests etablieren.
+3. Agent in Staging bereitstellen, dessen Laufzeitvertrag prüfen und einen Staging-Backup-Drill erfolgreich durchführen.
+4. `Promote` und den Staging-Backup-Drill auf den Agenten umstellen; den temporären Pfad zunächst als kontrollierten Fallback behalten.
+5. Nach erfolgreichem, freigegebenem Staging-Nachweis Production anschließen und denselben Drill durchführen.
+6. Erst dann Task 4.3 von `add-promote-backup-production-parity` abschließen und den temporären Backup-Pfad in einem separaten Change entfernen.
+
+## Aufbewahrung
+
+Request-, Ereignis- und Ergebnisobjekte liegen getrennt unter einem `control/`-Präfix und unterliegen derselben 180-Tage-Lifecycle-Regel wie die Backup- und Diagnoseobjekte. Der Agent löscht keine Evidenzobjekte selbst.

--- a/openspec/changes/add-central-backup-agent/proposal.md
+++ b/openspec/changes/add-central-backup-agent/proposal.md
@@ -1,0 +1,29 @@
+# Change: Zentralen Backup-Agenten für Staging und Production einführen
+
+## Why
+
+Der aktuelle Promote-Pfad startet für jedes benötigte Backup einen kurzlebigen Swarm-Stack. Der Ablauf ist zwar fail-closed, aber die operative Diagnose hängt an einer flüchtigen Task- und Log-Kette. Ein dauerhafter, beobachtbarer Ausführungspunkt soll Backups für Staging und Production zuverlässig ausführen und den Promote-Pfad auf einen belegbaren Backup-Auftrag reduzieren.
+
+## What Changes
+
+- Ein einmalig betriebener, zentraler `studio-backup-agent` führt PostgreSQL-Backups für die explizit angeforderten Ziele `staging` und `prod` aus.
+- Der Agent verwendet einen signierten, ereignisgetriggerten Auftrags- und Ergebnisvertrag. GitHub übergibt Aufträge über einen dedizierten, gehärteten HTTPS-Endpoint auf den bestehenden Staging- beziehungsweise Production-Hosts; terminale Evidenz bleibt in MinIO. Der Agent akzeptiert keine beliebigen Shell-Kommandos.
+- Jeder Auftrag ist an genau eine Umgebung, eine Request-ID und einen unveränderlichen Ziel-Digest gebunden. Der Agent wählt Datenbankzugang, Bucket und Credentials ausschließlich aus dieser validierten Umgebung.
+- Der Agent erzeugt weiterhin Custom-Dumps, `.sha256`-Objekte und redigierte Schritt-Evidenz; GitHub wartet auf das Ergebnisobjekt und blockiert Migration, Bootstrap und Deploy bei jedem nicht erfolgreichen Nachweis.
+- Production-Aufträge benötigen zusätzlich den bestehenden revisionsfähigen Wartungsfenster-Verweis sowie die Freigabe des GitHub-Production-Environments.
+- Der zentrale Agent wird als bewusst breite Vertrauenszone dokumentiert: Er ist mit beiden internen Netzen sowie ausschließlich für seinen Ingress mit dem bestehenden Traefik-Netz verbunden und besitzt getrennte, jeweils umgebungsspezifische Datenbank- und MinIO-Secrets.
+- Nach erfolgreicher Betriebsabnahme ersetzt der Agent den temporären Backup-Stack im Promote-Pfad. Der bestehende temporäre Pfad bleibt bis dahin unverändert als Rückfall- und Vergleichspfad erhalten.
+
+## Non-Goals
+
+- Kein automatischer Datenbank-Restore oder Datenbank-Rollback.
+- Kein allgemeiner Remote-Shell-, SQL- oder Kommandoausführungsdienst.
+- Kein öffentlich erreichbares Backup-API und kein Ersatz für den bestehenden App- oder Migrations-Stack.
+- Kein Wechsel der 180-Tage-Lifecycle-Regel für Backup- und Diagnoseobjekte.
+
+## Impact
+
+- Affected specs: `deployment-topology`, `architecture-documentation`
+- Affected code: neuer zentraler Swarm-Service mit gehärtetem Trigger-Endpoint, Backup-Auftrags-/Ergebnisprotokoll, Traefik-Routing, `.github/workflows/promote.yml`, Staging-Backup-Drill, MinIO- und Runtime-Tests
+- Affected documentation: `docs/architecture/05-building-block-view.md`, `docs/architecture/06-runtime-view.md`, `docs/architecture/07-deployment-view.md`, `docs/architecture/08-cross-cutting-concepts.md`, `docs/architecture/09-architecture-decisions.md`, `docs/architecture/11-risks-and-technical-debt.md`, `docs/guides/swarm-deployment-runbook.md`
+- Dependencies: Ergänzt `add-promote-backup-production-parity`; dessen Task 4.3 bleibt offen, bis der Agent in Staging und anschließend Production erfolgreich nachgewiesen ist.

--- a/openspec/changes/add-central-backup-agent/specs/architecture-documentation/spec.md
+++ b/openspec/changes/add-central-backup-agent/specs/architecture-documentation/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Architektur dokumentiert die zentrale Backup-Vertrauenszone
+
+Die Architektur- und Betriebsdokumentation SHALL den zentralen Studio-Backup-Agenten, dessen umgebungsgebundenen Auftragsvertrag und seine bewusst gemeinsame Vertrauensgrenze nachvollziehbar beschreiben.
+
+#### Scenario: Operator bewertet Zugriff und Ausführungspfad
+
+- **WHEN** ein Operator den Backup-Betrieb für Staging oder Production nachvollzieht
+- **THEN** beschreiben Arc42-Baustein-, Laufzeit-, Verteilungs- und Querschnittssicht den zentralen Agenten, die beiden internen Netze, das bestehende Traefik-Netz, getrennte Secrets, GitHub-OIDC- und Signaturprüfung, MinIO-Control- und Evidenzobjekte sowie den auf einen HTTPS-`POST`-Pfad begrenzten Ingress
+- **AND** beschreibt eine ADR die Entscheidung für einen gemeinsamen Agenten gegenüber zwei umgebungsgetrennten Agenten
+- **AND** benennt das Runbook Healthcheck, kontrollierten Neustart, Störungserkennung, Staging-Drill und Production-Freigabe
+
+#### Scenario: Risiko des gemeinsamen Agents bleibt sichtbar
+
+- **WHEN** ein Team die Architektur-Risiken prüft
+- **THEN** dokumentiert die Risikobetrachtung den erweiterten Blast Radius des gemeinsamen Agenten
+- **AND** nennt sie minimale Imagefläche, keine allgemeine Kommandoausführung, signierte Aufträge, getrennte Secrets, Umgebungs-Allowlist und dauerhafte Evidenz als Gegenmaßnahmen

--- a/openspec/changes/add-central-backup-agent/specs/deployment-topology/spec.md
+++ b/openspec/changes/add-central-backup-agent/specs/deployment-topology/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Zentraler umgebungsgebundener Studio-Backup-Agent
+
+Das System SHALL einen zentralen, dauerhaft betriebenen Backup-Agenten bereitstellen, der ausschließlich signierte `backup-and-verify`-Aufträge für die expliziten Zielumgebungen `staging` und `prod` über einen gehärteten HTTPS-Endpoint ausführt.
+
+#### Scenario: Valider Staging-Auftrag erzeugt einen überprüften Dump
+
+- **WHEN** der freigegebene Staging-Promote oder -Drill einen gültig signierten und per GitHub-OIDC authentisierten Staging-Auftrag mit eindeutiger Request-ID und unveränderlichem Image-Digest an `https://studio-staging.smart-village.app/_ops/backup/v1/requests` sendet
+- **THEN** erstellt der Agent ausschließlich aus der Staging-Konfiguration einen PostgreSQL-Custom-Dump im Bucket `studio-db-backup-staging`
+- **AND** bestätigt er Upload, Download, Größe, SHA-256-Wert und `pg_restore --list` in einem terminalen redigierten Ergebnisobjekt
+- **AND** akzeptiert der Agent ausschließlich HTTPS-`POST` auf diesen Pfad, keine allgemeine Kommandoausführung und keine operativen Details in seiner HTTP-Antwort
+
+#### Scenario: Production-Auftrag bleibt an den kontrollierten Promote gebunden
+
+- **WHEN** ein Production-Promote einen per GitHub-OIDC authentisierten Backup-Auftrag an `https://studio.smart-village.app/_ops/backup/v1/requests` sendet
+- **THEN** enthält der Auftrag eine gültige Production-Umgebung, einen revisionsfähigen Wartungsfenster-Verweis und den Ziel-Digest
+- **AND** akzeptiert der Agent ausschließlich das Production-Datenbankziel und den Bucket `studio-db-backup-production`
+- **AND** blockiert der Promote Migration, Bootstrap und App-Deploy, bis das passende erfolgreiche Ergebnisobjekt vorliegt
+
+#### Scenario: Ungültige oder wiederverwendete Aufträge bleiben folgenlos
+
+- **WHEN** ein Auftrag eine ungültige Signatur, ein abgelaufenes Zeitfenster, eine unbekannte Umgebung oder eine bereits terminal verarbeitete Request-ID enthält
+- **THEN** führt der Agent kein Backup aus
+- **AND** schreibt ausschließlich redigierte Fehler-Evidenz ohne Zugangsdaten oder Datenbankinhalte
+
+#### Scenario: Umgebungsgrenzen werden innerhalb des gemeinsamen Dienstes erzwungen
+
+- **WHEN** ein formal gültiger Auftrag versucht, Bucket, Datenbankhost oder Objektpräfix einer anderen Umgebung vorzugeben
+- **THEN** verwirft der Agent den Auftrag vor jedem Datenbank- oder MinIO-Zugriff
+- **AND** leitet er alle Zielwerte ausschließlich aus der validierten Umgebungs-Allowlist ab

--- a/openspec/changes/add-central-backup-agent/tasks.md
+++ b/openspec/changes/add-central-backup-agent/tasks.md
@@ -1,0 +1,34 @@
+## 1. Auftrags- und Sicherheitsvertrag
+
+- [x] 1.1 Signiertes, versioniertes Schema für `backup-and-verify`-Requests und terminale Ergebnisobjekte definieren; GitHub-OIDC-Claims, Request-ID, Umgebung, Digest, Ablaufzeit und Wartungsfenster-Verweis für Production normativ validieren.
+- [x] 1.2 Zentrale Umgebungs-Allowlist implementieren, die Datenbankziel, Bucket, Objektpräfix und Secrets ausschließlich aus `staging` oder `prod` ableitet.
+- [x] 1.3 Replay- und globales Parallelitätsverhalten pro Request-ID fail-closed festlegen und testen.
+- [x] 1.4 Redaction-Vertrag für Request-, Ereignis- und Ergebnisobjekte testen; Zugangsdaten, URLs mit Credentials, Datenbankinhalte und Shell-Traces ausschließen.
+
+## 2. Zentraler Backup-Agent
+
+- [x] 2.1 Minimales, versioniertes Agent-Image mit `aws`, `pg_dump`, `pg_restore`, Tool-Preflight und Healthcheck erstellen.
+- [x] 2.2 Einen einmaligen Swarm-Service mit einer Replica, deterministischem Placement, internen Staging-/Production-Netzen, dem bestehenden Traefik-Netz und getrennten Secrets definieren.
+- [x] 2.3 Agent-Ausführung implementieren: Custom-Dump, Upload, Download, Größen-/SHA-256-Vergleich, Archivprüfung und redigierte Schritt-Evidenz.
+- [x] 2.4 Dauerhafte Laufzeitevidenz für Image-Digest, Tool-Versionen, Request-ID, Zielumgebung, Schrittstatus und Terminalergebnis nach MinIO schreiben.
+
+## 3. Promote- und Drill-Integration
+
+- [x] 3.1 `Promote` so umstellen, dass er vor mutierenden One-shot-Jobs über den gehärteten HTTPS-Endpoint einen signierten Agent-Auftrag erzeugt, auf das korrespondierende Ergebnis wartet und bei jedem abweichenden oder fehlenden Nachweis fail-closed endet.
+- [x] 3.2 Den manuellen Staging-Backup-Drill auf denselben Auftragsvertrag umstellen, ohne Migration, Bootstrap oder App-Deployment auszuführen.
+- [x] 3.3 Production-Aufträge an GitHub-Environment-Freigabe, Wartungsfenster und erfolgreiche Staging-Parität binden.
+- [x] 3.4 Den bisherigen temporären Backup-Stack bis zur erfolgreichen Abnahme als expliziten Fallback erhalten; seine Entfernung als separaten Folgechange dokumentieren.
+
+## 4. Tests und Betriebsabnahme
+
+- [x] 4.1 Unit-Tests für Signatur, Ablaufzeit, Umgebungsbindung, Replay-Schutz, Objektpfade und Redaction ergänzen.
+- [x] 4.2 Lokalen PostgreSQL-/MinIO-End-to-End-Test für Staging und Production-Zielauswahl ergänzen; Cross-Environment-Zugriffe müssen fehlschlagen.
+- [x] 4.3 Workflow-Contract-Tests ergänzen: ausschließlicher HTTPS-`POST` auf den gehärteten Endpoint, keine beliebigen Kommandos, Staging vor Production und fail-closed bei fehlendem Ergebnis.
+- [x] 4.4 Relevante Unit-, TypeScript-, Server-Runtime-, Workflow-, Security- und File-Placement-Gates ausführen.
+
+## 5. Dokumentation und kontrollierter Rollout
+
+- [x] 5.1 Arc42-Abschnitte 05, 06, 07, 08, 09 und 11 sowie das Swarm-Runbook aktualisieren; eine ADR für die zentrale Vertrauenszone und den gehärteten HTTPS-Kontrollkanal erstellen.
+- [ ] 5.2 Staging-Agent bereitstellen, Health-/Tool-Vertrag sowie einen erfolgreichen Backup-Drill mit Dump, Prüfsumme und Evidenz in MinIO nachweisen.
+- [ ] 5.3 Nach expliziter Production-Freigabe den Production-Agentenpfad mit demselben Nachweis abnehmen.
+- [ ] 5.4 Erst nach 5.2 und 5.3 Task 4.3 von `add-promote-backup-production-parity` schließen.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:release:studio": "pnpm test:pr && pnpm verify:runtime-artifact",
     "test:pr": "bash scripts/ci/run-workspace-node.sh --import tsx scripts/ci/run-pr-gate.ts",
     "test:integration": "tsx scripts/ci/run-integration-gate.ts --mode full",
+    "test:integration:backup-agent": "tsx scripts/ci/run-backup-agent-integration.ts",
     "test:e2e": "tsx scripts/ci/cleanup-e2e-webserver-conflicts.ts --port 3000 && env -u NO_COLOR nx run sva-studio-react:test:e2e",
     "test:acceptance:iam": "env -u NO_COLOR nx run sva-studio-react:test:acceptance",
     "test:evidence:iam": "env -u NO_COLOR nx run sva-studio-react:test:evidence",

--- a/scripts/ci/backup-agent-contract.test.ts
+++ b/scripts/ci/backup-agent-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { backupEnvironmentConfig, isValidBackupRequest, signBackupRequest, verifyBackupRequestSignature, type BackupRequest } from './backup-agent-contract.ts';
+
+const stagingRequest: BackupRequest = {
+  version: 1,
+  action: 'backup-and-verify',
+  requestId: 'gha-12345678',
+  environment: 'staging',
+  deployImageDigest: `sha256:${'a'.repeat(64)}`,
+  expiresAt: '2026-07-30T10:00:00.000Z',
+};
+
+describe('backup agent contract', () => {
+  it('derives endpoints and buckets only from the accepted environment', () => {
+    expect(backupEnvironmentConfig('staging')).toEqual({ bucket: 'studio-db-backup-staging', endpoint: 'https://studio-staging.smart-village.app/_ops/backup/v1/requests', objectPrefix: 'staging' });
+    expect(backupEnvironmentConfig('prod').bucket).toBe('studio-db-backup-production');
+  });
+
+  it('accepts valid signed requests and rejects signature changes', () => {
+    const signature = signBackupRequest(stagingRequest, 'staging-key');
+    expect(verifyBackupRequestSignature(stagingRequest, 'staging-key', signature)).toBe(true);
+    expect(verifyBackupRequestSignature(stagingRequest, 'production-key', signature)).toBe(false);
+  });
+
+  it('requires production maintenance evidence and a future expiry', () => {
+    expect(isValidBackupRequest(stagingRequest, new Date('2026-07-30T09:50:00.000Z'))).toBe(true);
+    expect(isValidBackupRequest({ ...stagingRequest, environment: 'prod' }, new Date('2026-07-30T09:50:00.000Z'))).toBe(false);
+    expect(isValidBackupRequest({ ...stagingRequest, environment: 'prod', maintenanceWindowReference: 'CAB-42' }, new Date('2026-07-30T09:50:00.000Z'))).toBe(true);
+    expect(isValidBackupRequest(stagingRequest, new Date('2026-07-30T10:00:00.000Z'))).toBe(false);
+    expect(isValidBackupRequest(stagingRequest, new Date('2026-07-30T09:49:59.999Z'))).toBe(false);
+  });
+});

--- a/scripts/ci/backup-agent-contract.ts
+++ b/scripts/ci/backup-agent-contract.ts
@@ -1,0 +1,66 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export type BackupEnvironment = 'staging' | 'prod';
+
+export type BackupRequest = Readonly<{
+  version: 1;
+  action: 'backup-and-verify';
+  requestId: string;
+  environment: BackupEnvironment;
+  deployImageDigest: string;
+  expiresAt: string;
+  maintenanceWindowReference?: string;
+}>;
+
+const environments = {
+  staging: {
+    bucket: 'studio-db-backup-staging',
+    endpoint: 'https://studio-staging.smart-village.app/_ops/backup/v1/requests',
+    objectPrefix: 'staging',
+  },
+  prod: {
+    bucket: 'studio-db-backup-production',
+    endpoint: 'https://studio.smart-village.app/_ops/backup/v1/requests',
+    objectPrefix: 'prod',
+  },
+} as const;
+
+export const backupEnvironmentConfig = (environment: BackupEnvironment) => environments[environment];
+
+export const canonicalBackupRequest = (request: BackupRequest) => JSON.stringify({
+  action: request.action,
+  deployImageDigest: request.deployImageDigest,
+  environment: request.environment,
+  expiresAt: request.expiresAt,
+  maintenanceWindowReference: request.maintenanceWindowReference ?? null,
+  requestId: request.requestId,
+  version: request.version,
+});
+
+export const signBackupRequest = (request: BackupRequest, key: string) =>
+  createHmac('sha256', key).update(canonicalBackupRequest(request)).digest('hex');
+
+export const isValidBackupRequest = (value: unknown, now = new Date()) : value is BackupRequest => {
+  if (!value || typeof value !== 'object') return false;
+  const request = value as Partial<BackupRequest>;
+  const allowedKeys = new Set(['action', 'deployImageDigest', 'environment', 'expiresAt', 'maintenanceWindowReference', 'requestId', 'version']);
+  if (Object.keys(request).some((key) => !allowedKeys.has(key))) return false;
+  if (request.version !== 1 || request.action !== 'backup-and-verify') return false;
+  if (request.environment !== 'staging' && request.environment !== 'prod') return false;
+  if (typeof request.requestId !== 'string' || !/^[a-zA-Z0-9][a-zA-Z0-9._-]{7,127}$/u.test(request.requestId)) return false;
+  if (typeof request.deployImageDigest !== 'string' || !/^sha256:[a-f0-9]{64}$/u.test(request.deployImageDigest)) return false;
+  if (
+    typeof request.expiresAt !== 'string'
+    || Number.isNaN(Date.parse(request.expiresAt))
+    || Date.parse(request.expiresAt) <= now.getTime()
+    || Date.parse(request.expiresAt) > now.getTime() + 10 * 60_000
+  ) return false;
+  return request.environment !== 'prod'
+    || (typeof request.maintenanceWindowReference === 'string' && /^[A-Za-z0-9][A-Za-z0-9._:/# -]{2,159}$/u.test(request.maintenanceWindowReference));
+};
+
+export const verifyBackupRequestSignature = (request: BackupRequest, key: string, signature: string) => {
+  const actual = Buffer.from(signBackupRequest(request, key), 'hex');
+  const expected = Buffer.from(signature, 'hex');
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+};

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -44,7 +44,10 @@ describe('Promote workflow contract', () => {
     expect(workflow).toContain('require successful staging parity for production mutation');
     expect(workflow).toContain('create database backup before one-shot jobs');
     expect(workflow).toContain('verify database backup object');
-    expect(workflow).toContain('S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object }}');
+    expect(workflow).toContain('S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object || steps.backup_fallback_job.outputs.backup_object }}');
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).toContain('submit-backup-agent-request.ts "${{ inputs.environment }}"');
+    expect(workflow).toContain("vars.BACKUP_EXECUTOR == 'temporary'");
     expect(workflow).toContain('STAGING_MUTATION: ${{ steps.gate_eval.outputs.migration_should_run == \'true\' || steps.gate_eval.outputs.bootstrap_should_run == \'true\' }}');
     expect(workflow).toContain('name: promote-staging-parity-${{ github.run_id }}-${{ github.run_attempt }}');
     expect(workflow).toContain('--expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"');
@@ -66,6 +69,8 @@ describe('Promote workflow contract', () => {
     expect(buildWorkflow).toContain('migration_mode: auto');
     expect(buildWorkflow).toContain('actions: read');
     expect(buildWorkflow).toContain('SVA_IMAGE_REVISION=${{ github.sha }}');
+    expect(buildWorkflow).toContain('file: ./deploy/backup-agent/Dockerfile');
+    expect(buildWorkflow).toContain('ghcr.io/smart-village-solutions/sva-studio-backup-agent:${{ github.sha }}');
     expect(workflow).toContain('migration_should_run');
     expect(workflow).toContain('bootstrap_should_run');
   });
@@ -73,6 +78,7 @@ describe('Promote workflow contract', () => {
   it('offers a staging-only backup drill without application mutation', () => {
     expect(backupDrillWorkflow).toContain('name: Staging Backup Drill');
     expect(backupDrillWorkflow).toContain('environment: staging');
+    expect(backupDrillWorkflow).toContain('submit-backup-agent-request.ts staging');
     expect(backupDrillWorkflow).toContain('promote-backup-job.ts staging');
     expect(backupDrillWorkflow).toContain('verify-promote-backup.ts');
     expect(backupDrillWorkflow).toContain('staging-backup-drill-${{ github.run_id }}-${{ github.run_attempt }}');

--- a/scripts/ci/run-backup-agent-integration.ts
+++ b/scripts/ci/run-backup-agent-integration.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+const secret = () => randomBytes(24).toString('hex');
+const integrationEnv = {
+  ...process.env,
+  INTEGRATION_DIGEST: 'a'.repeat(64),
+  INTEGRATION_PRODUCTION_POSTGRES_PASSWORD: secret(),
+  INTEGRATION_S3_ACCESS_KEY: `test-${randomBytes(6).toString('hex')}`,
+  INTEGRATION_S3_SECRET_KEY: secret(),
+  INTEGRATION_STAGING_POSTGRES_PASSWORD: secret(),
+};
+const cwd = new URL('../..', import.meta.url);
+const composeArgs = ['compose', '-f', 'deploy/backup-agent/compose.integration.yaml'];
+const compose = (args: string[], stdio: 'inherit' | 'pipe' = 'inherit') => spawnSync(
+  'docker',
+  [...composeArgs, ...args],
+  { cwd, env: integrationEnv, encoding: 'utf8', stdio },
+);
+
+const containerState = (service: string) => {
+  const id = compose(['ps', '--all', '--quiet', service], 'pipe').stdout.trim();
+  if (!id) return null;
+  const inspect = spawnSync('docker', ['inspect', '--format', '{{json .State}}', id], { encoding: 'utf8' });
+  return inspect.status === 0 ? JSON.parse(inspect.stdout) as { ExitCode: number; Status: string } : null;
+};
+
+const main = async () => {
+  const up = compose(['up', '--build', '--detach']);
+  let resultStatus = up.status ?? 1;
+
+  if (resultStatus === 0) {
+    const deadline = Date.now() + 120_000;
+    for (;;) {
+      const verify = containerState('verify');
+      if (verify?.Status === 'exited') {
+        resultStatus = verify.ExitCode;
+        break;
+      }
+      const failed = ['minio-init', 'staging-agent-run', 'production-agent-run']
+        .map(containerState)
+        .find((state) => state?.Status === 'exited' && state.ExitCode !== 0);
+      if (failed) {
+        resultStatus = failed.ExitCode;
+        compose(['logs', '--no-color']);
+        break;
+      }
+      if (Date.now() >= deadline) {
+        resultStatus = 124;
+        compose(['logs', '--no-color']);
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+  }
+
+  if (resultStatus !== 0) compose(['logs', '--no-color']);
+  const cleanup = compose(['down', '--volumes', '--remove-orphans']);
+
+  if (resultStatus !== 0) process.exitCode = resultStatus;
+  else if (cleanup.status !== 0) process.exitCode = cleanup.status ?? 1;
+};
+
+void main();

--- a/scripts/ci/submit-backup-agent-request.test.ts
+++ b/scripts/ci/submit-backup-agent-request.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { buildBackupAgentRequest } from './submit-backup-agent-request.ts';
+
+describe('backup agent request submission', () => {
+  it('creates a short-lived environment-bound request', () => {
+    expect(buildBackupAgentRequest({ environment: 'prod', deployImageDigest: `sha256:${'b'.repeat(64)}`, maintenanceWindowReference: 'CAB-42', now: new Date('2026-07-30T10:00:00.000Z'), requestId: 'gha-12345678' })).toMatchObject({ environment: 'prod', expiresAt: '2026-07-30T10:10:00.000Z', maintenanceWindowReference: 'CAB-42' });
+  });
+});

--- a/scripts/ci/submit-backup-agent-request.ts
+++ b/scripts/ci/submit-backup-agent-request.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+
+import { backupEnvironmentConfig, isValidBackupRequest, signBackupRequest, type BackupEnvironment, type BackupRequest } from './backup-agent-contract.ts';
+
+const required = (value: string | undefined, name: string) => {
+  const result = value?.trim();
+  if (!result) throw new Error(`${name} darf nicht leer sein.`);
+  return result;
+};
+
+const environment = (value: string | undefined): BackupEnvironment => {
+  if (value === 'staging' || value === 'prod') return value;
+  throw new Error('Der Backup-Agent akzeptiert nur staging oder prod.');
+};
+
+export const buildBackupAgentRequest = (input: {
+  deployImageDigest: string;
+  environment: BackupEnvironment;
+  now: Date;
+  requestId: string;
+  maintenanceWindowReference?: string;
+}): BackupRequest => ({
+  version: 1,
+  action: 'backup-and-verify',
+  requestId: input.requestId,
+  environment: input.environment,
+  deployImageDigest: input.deployImageDigest,
+  expiresAt: new Date(input.now.getTime() + 10 * 60_000).toISOString(),
+  ...(input.maintenanceWindowReference ? { maintenanceWindowReference: input.maintenanceWindowReference } : {}),
+});
+
+const requestOidcToken = async () => {
+  const url = new URL(required(process.env.ACTIONS_ID_TOKEN_REQUEST_URL, 'ACTIONS_ID_TOKEN_REQUEST_URL'));
+  url.searchParams.set('audience', 'studio-backup-agent');
+  const response = await fetch(url, {
+    headers: { authorization: `Bearer ${required(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN, 'ACTIONS_ID_TOKEN_REQUEST_TOKEN')}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) throw new Error(`GitHub-OIDC-Token konnte nicht bezogen werden (HTTP ${response.status}).`);
+  const document = await response.json() as { value?: unknown };
+  return required(typeof document.value === 'string' ? document.value : undefined, 'OIDC token');
+};
+
+const waitForResult = async (target: BackupEnvironment, request: BackupRequest) => {
+  const client = new S3Client({
+    endpoint: required(process.env.S3_ENDPOINT, 'S3_ENDPOINT'),
+    region: 'us-east-1',
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: required(process.env.S3_ACCESS_KEY_ID, 'S3_ACCESS_KEY_ID'),
+      secretAccessKey: required(process.env.S3_SECRET_ACCESS_KEY, 'S3_SECRET_ACCESS_KEY'),
+    },
+  });
+  const deadline = Date.now() + Number(process.env.BACKUP_AGENT_TIMEOUT_MS ?? '900000');
+  for (;;) {
+    try {
+      const response = await client.send(new GetObjectCommand({
+        Bucket: backupEnvironmentConfig(target).bucket,
+        Key: `control/results/${request.requestId}.json`,
+      }));
+      if (!response.Body) throw new Error('Das Backup-Ergebnisobjekt ist leer.');
+      const result = JSON.parse(await response.Body.transformToString()) as {
+        bytes?: unknown;
+        deployImageDigest?: unknown;
+        environment?: unknown;
+        objectKey?: unknown;
+        requestId?: unknown;
+        sha256?: unknown;
+        status?: unknown;
+        steps?: unknown;
+      };
+      if (result.requestId !== request.requestId || result.environment !== target || result.deployImageDigest !== request.deployImageDigest) {
+        throw new Error('Das Backup-Ergebnis stimmt nicht mit dem Auftrag überein.');
+      }
+      if (
+        result.status !== 'succeeded'
+        || typeof result.objectKey !== 'string'
+        || typeof result.bytes !== 'number'
+        || result.bytes <= 0
+        || typeof result.sha256 !== 'string'
+        || !/^[a-f0-9]{64}$/u.test(result.sha256)
+        || !Array.isArray(result.steps)
+      ) throw new Error('Der Backup-Agent meldet keinen vollständigen erfolgreichen Nachweis.');
+      return result;
+    } catch (error) {
+      const status = (error as { $metadata?: { httpStatusCode?: unknown } } | null)?.$metadata?.httpStatusCode;
+      if (status !== 404 && (!(error instanceof Error) || (error.name !== 'NoSuchKey' && error.name !== 'NotFound'))) throw error;
+    }
+    if (Date.now() >= deadline) throw new Error('Der Backup-Agent hat innerhalb des Timeouts kein Ergebnis geliefert.');
+    await new Promise((resolveWait) => setTimeout(resolveWait, 2_000));
+  }
+};
+
+const main = async () => {
+  const target = environment(process.argv[2]);
+  const request = buildBackupAgentRequest({
+    environment: target,
+    deployImageDigest: required(process.env.DEPLOY_IMAGE_DIGEST, 'DEPLOY_IMAGE_DIGEST'),
+    requestId: `gha-${required(process.env.GITHUB_RUN_ID, 'GITHUB_RUN_ID')}-${required(process.env.GITHUB_RUN_ATTEMPT, 'GITHUB_RUN_ATTEMPT')}`,
+    now: new Date(),
+    ...(target === 'prod' ? { maintenanceWindowReference: required(process.env.MAINTENANCE_WINDOW_REFERENCE, 'MAINTENANCE_WINDOW_REFERENCE') } : {}),
+  });
+  if (!isValidBackupRequest(request)) throw new Error('Der erzeugte Backup-Auftrag verletzt den Vertragscheck.');
+  const signature = signBackupRequest(request, required(process.env.BACKUP_AGENT_SIGNING_KEY, 'BACKUP_AGENT_SIGNING_KEY'));
+  const response = await fetch(backupEnvironmentConfig(target).endpoint, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${await requestOidcToken()}`,
+      'content-type': 'application/json',
+      'x-backup-request-signature': signature,
+    },
+    body: JSON.stringify(request),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (response.status !== 202) throw new Error(`Der Backup-Agent hat den Auftrag nicht akzeptiert (HTTP ${response.status}).`);
+  const accepted = await response.json() as { requestId?: unknown };
+  if (accepted.requestId !== request.requestId) throw new Error('Der Backup-Agent hat eine abweichende Request-ID bestätigt.');
+  const result = await waitForResult(target, request);
+  const evidencePath = resolve(process.env.RUNNER_TEMP ?? process.cwd(), `promote-backup-agent-${request.requestId}.json`);
+  writeFileSync(evidencePath, `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600 });
+  const output = resolve(process.env.GITHUB_OUTPUT ?? '/dev/null');
+  writeFileSync(output, `backup_request_id=${request.requestId}\nbackup_bucket=${backupEnvironmentConfig(target).bucket}\nbackup_object=${result.objectKey}\nbackup_evidence_path=${evidencePath}\n` , { flag: 'a', mode: 0o600 });
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error: unknown) => { console.error(error instanceof Error ? error.message : String(error)); process.exitCode = 1; });
+}


### PR DESCRIPTION
## Was sich ändert

- führt einen zentralen, einmaligen Backup-Agenten für Staging und Production ein
- exponiert einen gehärteten HTTPS-Kontrollkanal mit GitHub-OIDC, HMAC-Signatur, Replay-Schutz und fester Ziel-Allowlist
- validiert PostgreSQL-Dumps nach Upload und Download in MinIO und schreibt redigierte Evidenzobjekte
- bindet Promote und den Staging-Backup-Drill an den neuen Agenten; der temporäre Stack bleibt als expliziter Fallback erhalten
- ergänzt Swarm-Stack, separates Image, OpenSpec, ADR, Arc42- und Runbook-Dokumentation

## Warum

Der bisherige temporäre Backup-Stack setzt die Backup-Werkzeuge und Netzwerkpfade für jeden Lauf erneut voraus. Der zentrale Agent schafft einen kontrollierten, dauerhaft erreichbaren Ausführungspunkt, ohne beliebige Remote-Kommandos zuzulassen.

## Validierung

- 18 gezielte Vitest-Tests
- TypeScript- und ESLint-Gates
- Server-Runtime- und File-Placement-Gates
- strikte OpenSpec-Validierung
- lokaler PostgreSQL-/MinIO-End-to-End-Test für Staging und Production einschließlich Cross-Environment-Schutz

## Rollout

Der PR deployt den Agenten nicht automatisch. Staging-Abnahme und Production-Freigabe bleiben als getrennte OpenSpec-Aufgaben offen.