### PR TITLE
fix: grant build workflow OIDC permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  id-token: write
   packages: write
 
 jobs:

--- a/docs/changelog/entries/pr-769.json
+++ b/docs/changelog/entries/pr-769.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 769,
+  "body": "Der zentrale Backup-Agent kann nun im Main-Build mit der erforderlichen OIDC-Berechtigung gebaut und für Deployments vorbereitet werden."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -68,6 +68,7 @@ describe('Promote workflow contract', () => {
     expect(buildWorkflow).toContain('bootstrap_mode: auto');
     expect(buildWorkflow).toContain('migration_mode: auto');
     expect(buildWorkflow).toContain('actions: read');
+    expect(buildWorkflow).toContain('id-token: write');
     expect(buildWorkflow).toContain('SVA_IMAGE_REVISION=${{ github.sha }}');
     expect(buildWorkflow).toContain('file: ./deploy/backup-agent/Dockerfile');
     expect(buildWorkflow).toContain('ghcr.io/smart-village-solutions/sva-studio-backup-agent:${{ github.sha }}');


### PR DESCRIPTION
## Problem

Der Main-`Build`-Workflow scheitert vor Jobstart, weil der wiederverwendete Promote-Workflow `id-token: write` für den Backup-Agent-Auftrag benötigt, der aufrufende Workflow diese Berechtigung aber nicht gewährt.

## Änderung

- gewährt `id-token: write` im aufrufenden Build-Workflow
- erweitert den Workflow-Contract-Test um diese Berechtigungsgrenze

## Validierung

- gezielter Vitest-Contract-Test
- TypeScript
- ESLint
- `git diff --check`