### PR TITLE
fix: use verified production backup network

### DIFF
--- a/deploy/backup-agent-stack.test.ts
+++ b/deploy/backup-agent-stack.test.ts
@@ -10,6 +10,10 @@ describe('backup agent stack', () => {
     expect(source).not.toMatch(/^\s+ports:/mu);
     expect(source).toContain("replicas: 1");
     expect(source).toContain("      - ingress\n      - staging\n      - production");
+    expect(source).toContain('name: network-node-005');
+    expect(source).toContain('name: studio-staging_default');
+    expect(source).toContain('name: portainer_internal');
+    expect(source).not.toContain('name: studio-prod_default');
   });
 
   it('uses the application database principal from both live Studio stacks', () => {

--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -74,7 +74,7 @@ networks:
     name: studio-staging_default
   production:
     external: true
-    name: studio-prod_default
+    name: portainer_internal
 
 secrets:
   backup_staging_postgres_password:

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -272,4 +272,4 @@ Der Rollout erfolgt `studio-dev` → `studio-staging` → `sva-studio`. Pro Stuf
 
 ## Zentraler Backup-Agent im Swarm
 
-`deploy/backup-agent-stack.yaml` definiert eine Replica auf `node-005.sva`. Der Service hängt an `network-node-005`, `studio-staging_default` und `studio-prod_default`, veröffentlicht aber keinen Port. Traefik routet nur `POST /_ops/backup/v1/requests` für `studio-staging.smart-village.app` und `studio.smart-village.app` auf Port 3080. Alle acht Runtime-Secrets sind externe Swarm-Secrets.
+`deploy/backup-agent-stack.yaml` definiert eine Replica auf `node-005.sva`. Der Service hängt an den gegen den laufenden Swarm verifizierten Netzen `network-node-005`, `studio-staging_default` und `portainer_internal`, veröffentlicht aber keinen Port. Traefik routet nur `POST /_ops/backup/v1/requests` für `studio-staging.smart-village.app` und `studio.smart-village.app` auf Port 3080. Alle acht Runtime-Secrets sind externe Swarm-Secrets.

--- a/docs/changelog/entries/pr-771.json
+++ b/docs/changelog/entries/pr-771.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 771,
+  "body": "Der zentrale Backup-Agent verwendet nun die verifizierten Swarm-Netzwerke für Staging, Produktion und Traefik."
+}


### PR DESCRIPTION
## Problem

Der erste Backup-Agent-Deploy wurde vor der Service-Erstellung abgelehnt, weil das angenommene externe Netz `studio-prod_default` im Swarm nicht existiert.

Die Live-Inventur auf Endpoint `sva` zeigt:

- `studio-staging_postgres` → `studio-staging_default`
- `studio_postgres` → `portainer_internal`
- beide App-Services → `network-node-005` für Traefik

## Änderung

- verwendet `portainer_internal` als verifiziertes Production-DB-Netz
- sichert alle drei Netzwerknamen im Stack-Contract-Test ab
- korrigiert die Arc42-Deployment-Dokumentation

## Validierung

- `docker stack config` mit unveränderlichem Agent-Digest
- gezielter Vitest-Contract-Test
- ESLint
- File Placement
- strikte OpenSpec-Validierung