### PR TITLE
fix(backup): activate production ingress router

### DIFF
--- a/deploy/backup-agent-stack.test.ts
+++ b/deploy/backup-agent-stack.test.ts
@@ -27,6 +27,8 @@ describe('backup agent stack', () => {
     expect(source).toContain('Host(`studio-staging.smart-village.app`) && Path(`/_ops/backup/v1/requests`) && Method(`POST`)');
     expect(source).toContain('Host(`studio.smart-village.app`) && Path(`/_ops/backup/v1/requests`) && Method(`POST`)');
     expect(source).toContain('backup-agent-rate-limit.ratelimit.average=2');
+    expect(source).toContain('traefik.http.routers.backup-agent-staging.tls.certresolver=default');
+    expect(source).toContain('traefik.http.routers.backup-agent-prod.tls.certresolver=default');
     expect(source).not.toContain('traefik.http.routers.backup-agent-prod.entrypoints=web,');
   });
 

--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -60,6 +60,7 @@ services:
         - 'traefik.http.routers.backup-agent-prod.priority=200'
         - 'traefik.http.routers.backup-agent-prod.middlewares=backup-agent-rate-limit'
         - 'traefik.http.routers.backup-agent-prod.tls=true'
+        - 'traefik.http.routers.backup-agent-prod.tls.certresolver=default'
         - 'traefik.http.routers.backup-agent-prod.service=backup-agent'
         - 'traefik.http.services.backup-agent.loadbalancer.server.port=3080'
         - 'traefik.http.middlewares.backup-agent-rate-limit.ratelimit.average=2'

--- a/docs/changelog/entries/pr-772.json
+++ b/docs/changelog/entries/pr-772.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 772,
+  "body": "Der zentrale Backup-Agent ist nun auch unter dem vorhandenen Produktions-DNS-Namen über den abgesicherten HTTPS-Endpunkt erreichbar."
+}


### PR DESCRIPTION
## Zusammenfassung

- konfiguriert den vorhandenen TLS-Certresolver auch für den Production-Backup-Router
- sichert die symmetrische Staging-/Production-Router-Konfiguration per Contract-Test ab

## Verifikation

- `pnpm exec vitest run deploy/backup-agent-stack.test.ts --config vitest.config.ts`
- Live-Diagnose: DNS und Ingress-Netz verifiziert; Production wurde vor dem Fix vom Studio-App-Router statt vom Backup-Agent-Router verarbeitet
