### PR TITLE
fix(backup): allow dedicated request hosts

### DIFF
--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -22,7 +22,7 @@ const readSecret = async (name) => (await readFile(required(process.env[name], n
 
 const targets = {
   staging: {
-    host: 'studio-staging.smart-village.app',
+    host: 'backup-studio-staging.smart-village.app',
     bucket: 'studio-db-backup-staging',
     prefix: 'staging',
     postgresHost: 'studio-staging_postgres',
@@ -34,7 +34,7 @@ const targets = {
     signingKeyFile: 'BACKUP_STAGING_SIGNING_KEY_FILE',
   },
   prod: {
-    host: 'studio.smart-village.app',
+    host: 'backup-studio.smart-village.app',
     bucket: 'studio-db-backup-production',
     prefix: 'prod',
     postgresHost: 'studio-prod_postgres',
@@ -46,6 +46,8 @@ const targets = {
     signingKeyFile: 'BACKUP_PROD_SIGNING_KEY_FILE',
   },
 };
+
+export const validRequestHost = (environment, host) => targets[environment]?.host === host;
 
 export const canonicalRequest = (request) => JSON.stringify({
   action: request.action,
@@ -246,7 +248,7 @@ export const createBackupAgentServer = () => createServer(async (incoming, respo
   try {
     const request = await readBody(incoming);
     if (!validRequest(request)) return respond(response, 400, { error: 'invalid_request' });
-    if (incoming.headers.host !== targets[request.environment].host) return respond(response, 400, { error: 'invalid_request' });
+    if (!validRequestHost(request.environment, incoming.headers.host)) return respond(response, 400, { error: 'invalid_request' });
     const auth = incoming.headers.authorization;
     if (typeof auth !== 'string' || !auth.startsWith('Bearer ')) return respond(response, 401, { error: 'unauthorized' });
     await verifyOidc(auth.slice('Bearer '.length), request.environment);

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { canonicalRequest, controlKeysFor, safeErrorCode, validateOidcClaims, validRequest } from './agent.mjs';
+import { canonicalRequest, controlKeysFor, safeErrorCode, validateOidcClaims, validRequest, validRequestHost } from './agent.mjs';
 
 const request = {
   version: 1,
@@ -48,6 +48,13 @@ describe('backup agent runtime contract', () => {
     expect(canonicalRequest(request)).not.toContain('bucket');
     expect(canonicalRequest(request)).not.toContain('postgresHost');
     expect(validRequest({ ...request, bucket: 'studio-db-backup-production' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(false);
+  });
+
+  it('accepts only the dedicated host of the requested environment', () => {
+    expect(validRequestHost('staging', 'backup-studio-staging.smart-village.app')).toBe(true);
+    expect(validRequestHost('prod', 'backup-studio.smart-village.app')).toBe(true);
+    expect(validRequestHost('staging', 'backup-studio.smart-village.app')).toBe(false);
+    expect(validRequestHost('prod', 'studio.smart-village.app')).toBe(false);
   });
 
   it('uses persistent MinIO control keys for replay and terminal evidence', () => {

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -55,6 +55,7 @@ describe('backup agent runtime contract', () => {
     expect(validRequestHost('prod', 'backup-studio.smart-village.app')).toBe(true);
     expect(validRequestHost('staging', 'backup-studio.smart-village.app')).toBe(false);
     expect(validRequestHost('prod', 'studio.smart-village.app')).toBe(false);
+    expect(validRequestHost('unknown', 'backup-studio-staging.smart-village.app')).toBe(false);
   });
 
   it('uses persistent MinIO control keys for replay and terminal evidence', () => {

--- a/docs/changelog/entries/pr-774.json
+++ b/docs/changelog/entries/pr-774.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 774,
+  "body": "Der zentrale Backup-Agent akzeptiert signierte Aufträge nun ausschließlich über die neuen, umgebungsspezifischen Backup-Subdomains."
+}

--- a/scripts/ci/backup-agent-contract.test.ts
+++ b/scripts/ci/backup-agent-contract.test.ts
@@ -23,6 +23,8 @@ describe('backup agent contract', () => {
       endpoint: 'https://backup-studio.smart-village.app/_ops/backup/v1/requests',
       objectPrefix: 'prod',
     });
+    expect(backupEnvironmentConfig('staging').endpoint).not.toContain('://studio-staging.');
+    expect(backupEnvironmentConfig('prod').endpoint).not.toContain('://studio.');
   });
 
   it('accepts valid signed requests and rejects signature changes', () => {


### PR DESCRIPTION
## Zusammenfassung

- aktualisiert die Host-Allowlist des Backup-Agenten auf die dedizierten Staging- und Production-Domains
- lehnt Cross-Environment- und alte Studio-Hosts weiterhin fail-closed ab
- ergänzt einen expliziten Contract-Test für die Hostbindung

## Reproduktion

Der erste Live-Staging-Drill erreichte den Agenten, wurde aber mit `HTTP 400 invalid_request` abgelehnt, weil das bereits gebaute Agent-Image noch die alten Studio-Hosts erwartete.

## Tests

- `pnpm exec vitest run deploy/backup-agent/agent.test.ts deploy/backup-agent-stack.test.ts scripts/ci/backup-agent-contract.test.ts --config vitest.config.ts`
- `pnpm test:integration:backup-agent`
