### PR TITLE
fix(backup): extend request acceptance timeout

### DIFF
--- a/docs/changelog/entries/pr-775.json
+++ b/docs/changelog/entries/pr-775.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 775,
+  "body": "Der Staging-Backup-Drill erlaubt dem gehärteten Agenten nun ein weiterhin begrenztes Zeitfenster für die authentisierte Auftragsannahme."
+}

--- a/scripts/ci/submit-backup-agent-request.test.ts
+++ b/scripts/ci/submit-backup-agent-request.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { buildBackupAgentRequest } from './submit-backup-agent-request.ts';
+import { backupAgentAcceptanceTimeoutMs, buildBackupAgentRequest } from './submit-backup-agent-request.ts';
 
 describe('backup agent request submission', () => {
   it('creates a short-lived environment-bound request', () => {
     expect(buildBackupAgentRequest({ environment: 'prod', deployImageDigest: `sha256:${'b'.repeat(64)}`, maintenanceWindowReference: 'CAB-42', now: new Date('2026-07-30T10:00:00.000Z'), requestId: 'gha-12345678' })).toMatchObject({ environment: 'prod', expiresAt: '2026-07-30T10:10:00.000Z', maintenanceWindowReference: 'CAB-42' });
+  });
+
+  it('allows a bounded minute for authenticated request acceptance', () => {
+    expect(backupAgentAcceptanceTimeoutMs).toBe(60_000);
   });
 });

--- a/scripts/ci/submit-backup-agent-request.ts
+++ b/scripts/ci/submit-backup-agent-request.ts
@@ -18,6 +18,8 @@ const environment = (value: string | undefined): BackupEnvironment => {
   throw new Error('Der Backup-Agent akzeptiert nur staging oder prod.');
 };
 
+export const backupAgentAcceptanceTimeoutMs = 60_000;
+
 export const buildBackupAgentRequest = (input: {
   deployImageDigest: string;
   environment: BackupEnvironment;
@@ -115,7 +117,7 @@ const main = async () => {
       'x-backup-request-signature': signature,
     },
     body: JSON.stringify(request),
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(backupAgentAcceptanceTimeoutMs),
   });
   if (response.status !== 202) throw new Error(`Der Backup-Agent hat den Auftrag nicht akzeptiert (HTTP ${response.status}).`);
   const accepted = await response.json() as { requestId?: unknown };


### PR DESCRIPTION
## Zusammenfassung

- erweitert das hart begrenzte Timeout für die authentisierte Auftragsannahme von 15 auf 60 Sekunden
- belässt das separate 15-Minuten-Limit für die Backup-Ausführung unverändert
- sichert den Timeout-Vertrag per Unit-Test ab

## Live-Befund

Zwei Staging-Drill-Versuche erreichten den Agenten, wurden aber nach exakt 15 Sekunden clientseitig beendet. GitHub-JWKS und authentisierte MinIO-Zugriffe wurden aus dem laufenden Agenten separat erfolgreich gemessen.

## Tests

- `pnpm exec vitest run scripts/ci/submit-backup-agent-request.test.ts scripts/ci/backup-agent-contract.test.ts --config vitest.config.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
