### PR TITLE
fix(backup-agent): configure AWS CLI for MinIO

### DIFF
--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -12,6 +12,10 @@ const jwksUrl = `${oidcIssuer}/.well-known/jwks`;
 const maxBodyBytes = 16_384;
 const maxRequestLifetimeMs = 10 * 60_000;
 const acceptanceCommandTimeoutMs = 10_000;
+export const minioAwsCompatibilityEnv = {
+  AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required',
+  AWS_RESPONSE_CHECKSUM_VALIDATION: 'when_required',
+};
 
 const required = (value, name) => {
   const result = value?.trim();
@@ -158,6 +162,7 @@ const s3Env = async (target) => ({
   AWS_DEFAULT_REGION: 'us-east-1',
   AWS_MAX_ATTEMPTS: '2',
   AWS_RETRY_MODE: 'standard',
+  ...minioAwsCompatibilityEnv,
 });
 
 const uploadJson = async (target, key, value) => {

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { canonicalRequest, controlKeysFor, runCommand, safeErrorCode, validateOidcClaims, validRequest, validRequestHost } from './agent.mjs';
+import { canonicalRequest, controlKeysFor, minioAwsCompatibilityEnv, runCommand, safeErrorCode, validateOidcClaims, validRequest, validRequestHost } from './agent.mjs';
 
 const request = {
   version: 1,
@@ -62,6 +62,13 @@ describe('backup agent runtime contract', () => {
     expect(controlKeysFor('gha-12345678')).toEqual({
       request: 'control/requests/gha-12345678.json',
       result: 'control/results/gha-12345678.json',
+    });
+  });
+
+  it('uses checksum settings compatible with the deployed MinIO endpoint', () => {
+    expect(minioAwsCompatibilityEnv).toEqual({
+      AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required',
+      AWS_RESPONSE_CHECKSUM_VALIDATION: 'when_required',
     });
   });
 

--- a/docs/architecture/07-deployment-view.md
+++ b/docs/architecture/07-deployment-view.md
@@ -273,3 +273,5 @@ Der Rollout erfolgt `studio-dev` → `studio-staging` → `sva-studio`. Pro Stuf
 ## Zentraler Backup-Agent im Swarm
 
 `deploy/backup-agent-stack.yaml` definiert eine Replica auf `node-005.sva`. Der Service hängt an den gegen den laufenden Swarm verifizierten Netzen `network-node-005`, `studio-staging_default` und `portainer_internal`, veröffentlicht aber keinen Port. Traefik routet nur `POST /_ops/backup/v1/requests` für `backup-studio-staging.smart-village.app` und `backup-studio.smart-village.app` auf Port 3080. Alle acht Runtime-Secrets sind externe Swarm-Secrets.
+
+Für S3-Uploads setzt der Agent die AWS-CLI-Prüfsummenberechnung und -validierung auf `when_required`. Das verhindert mit aktuellen AWS-CLI-Versionen inkompatible optionale Prüfsummen-Header am bestehenden MinIO-Endpunkt; die eigene SHA-256-Prüfung des Backup-Artefakts bleibt davon unberührt.

--- a/docs/changelog/entries/pr-777.json
+++ b/docs/changelog/entries/pr-777.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 777,
+  "body": "Der zentrale Datenbank-Backup-Dienst ist jetzt mit dem bestehenden MinIO-Dateiserver kompatibel und kann Backup-Aufträge zuverlässig speichern."
+}


### PR DESCRIPTION
## Zusammenfassung
- setzt die AWS-CLI-Prüfsummenberechnung und -validierung für den bestehenden MinIO-Endpunkt auf `when_required`
- behält die unabhängige SHA-256-Prüfung des Backup-Dumps unverändert bei
- dokumentiert die MinIO-Kompatibilitätsentscheidung

## Reproduktion
AWS CLI 2.32.7 aus dem Agent-Image verlor beim Upload ohne diese Einstellung die Verbindung. Derselbe Image-Client lud mit `when_required` erfolgreich hoch; das Diagnoseobjekt wurde anschließend gelöscht.

## Validierung
- gezielte Vitest-Suite: 18/18
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- gezieltes ESLint
- `pnpm test:integration:backup-agent`
- `openspec validate add-central-backup-agent --strict`