### PR TITLE
docs(backup-agent): record staging acceptance

### DIFF
--- a/deploy/backup-agent-stack.test.ts
+++ b/deploy/backup-agent-stack.test.ts
@@ -20,6 +20,8 @@ describe('backup agent stack', () => {
     expect(source).toContain('BACKUP_STAGING_POSTGRES_USER: sva');
     expect(source).toContain('BACKUP_PROD_POSTGRES_USER: sva');
     expect(source).toContain('BACKUP_STAGING_POSTGRES_DB: sva_studio');
+    expect(source).toContain('source: backup_staging_postgres_password_v3');
+    expect(source).toContain('target: backup_staging_postgres_password');
     expect(source).toContain('BACKUP_PROD_POSTGRES_DB: sva_studio');
   });
 

--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -25,7 +25,8 @@ services:
       - staging
       - production
     secrets:
-      - backup_staging_postgres_password
+      - source: backup_staging_postgres_password_v3
+        target: backup_staging_postgres_password
       - backup_staging_s3_access_key
       - backup_staging_s3_secret_key
       - backup_staging_signing_key
@@ -71,7 +72,7 @@ networks:
     name: portainer_internal
 
 secrets:
-  backup_staging_postgres_password:
+  backup_staging_postgres_password_v3:
     external: true
   backup_staging_s3_access_key:
     external: true

--- a/docs/changelog/entries/pr-779.json
+++ b/docs/changelog/entries/pr-779.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 779,
+  "body": "Der zentrale Datenbank-Backup-Dienst wurde in Staging erfolgreich abgenommen und seine Sicherungs- und Prüfnachweise dokumentiert."
+}

--- a/docs/staging/2026-07/zentraler-backup-agent-abnahme.md
+++ b/docs/staging/2026-07/zentraler-backup-agent-abnahme.md
@@ -1,0 +1,65 @@
+# Abnahme des zentralen Backup-Agenten in Staging
+
+## Ergebnis
+
+Der zentrale Backup-Agent wurde am 29. Juli 2026 auf dem Quantum-Endpoint `sva`
+im Stack `studio-backup-agent` abgenommen. Die Replica lief auf `node-005.sva`
+mit dem unveränderlichen Agent-Image:
+
+`ghcr.io/smart-village-solutions/sva-studio-backup-agent@sha256:5ade0d53dd27b621bab5b6f3bbcf1d280811b0d560bcedbbcd49c8407cd4768f`
+
+Der Staging-Endpunkt
+`https://backup-studio-staging.smart-village.app/_ops/backup/v1/requests`
+war über gültiges TLS erreichbar. Ein absichtlich ungültiger Auftrag wurde
+kontrolliert mit HTTP `400` abgewiesen.
+
+## Erfolgreicher Drill
+
+- GitHub-Actions-Lauf: `30492836842`
+- Request-ID: `gha-30492836842-1`
+- Studio-Commit: `66cd7fbc05a2bae02d8032566fc87cd3c0ad839f`
+- Studio-Image-Digest: `sha256:b7d5fd29aa2f27afb759528bbca9ed94e133024d67f736138d1e03b604886ca9`
+- Bucket: `studio-db-backup-staging`
+- Dump-Größe: `255280` Byte
+
+Der Agent meldete alle vorgeschriebenen Schritte als erfolgreich:
+
+1. PostgreSQL-Custom-Dump
+2. Upload nach MinIO
+3. erneuter Download
+4. Größen- und SHA-256-Vergleich
+5. Archivprüfung mit `pg_restore --list`
+
+Der GitHub-Workflow prüfte anschließend das Backup-Objekt unabhängig und lud
+die redigierte Laufzeitevidenz als Artifact hoch.
+
+## Unabhängig geprüfte MinIO-Nachweise
+
+Folgende Objekte wurden nach dem Workflow per `head-object` im
+Staging-Bucket bestätigt:
+
+- `control/requests/gha-30492836842-1.json`
+- `control/results/gha-30492836842-1.json`
+- `staging/2026-07-29T21-34-29-201Z/b7d5fd29aa2f27afb759528bbca9ed94e133024d67f736138d1e03b604886ca9/gha-30492836842-1.dump`
+- `staging/2026-07-29T21-34-29-201Z/b7d5fd29aa2f27afb759528bbca9ed94e133024d67f736138d1e03b604886ca9/gha-30492836842-1.dump.sha256`
+
+Das terminale Ergebnis war `succeeded`, der Prüfsummenwert hatte das erwartete
+SHA-256-Format, und die im Ergebnis gemeldete Größe stimmte mit dem
+Dump-Objekt überein. Zugangsdaten und Datenbankinhalte wurden weder in diese
+Dokumentation noch in die GitHub-Evidenz übernommen.
+
+## Operative Korrekturen
+
+Für die reale Umgebung waren drei Abweichungen zu korrigieren:
+
+- aktuelle AWS-CLI-Versionen benötigen am bestehenden MinIO-Endpunkt
+  `when_required` für optionale Request- und Response-Prüfsummen;
+- vollständige logische Dumps verwenden den PostgreSQL-Principal `sva`, weil
+  der App-Principal `sva_app` der Row-Level-Security unterliegt;
+- das lokale `POSTGRES_PASSWORD` war gegenüber dem laufenden
+  Staging-Postgres veraltet. Deshalb wurde das live gesetzte Passwort ohne
+  Ausgabe als versioniertes Swarm-Secret
+  `backup_staging_postgres_password_v3` gebunden.
+
+Production wurde weder gesichert noch anderweitig mutiert. Die
+Production-Abnahme bleibt bis zu einer expliziten Freigabe offen.

--- a/openspec/changes/add-central-backup-agent/tasks.md
+++ b/openspec/changes/add-central-backup-agent/tasks.md
@@ -29,6 +29,6 @@
 ## 5. Dokumentation und kontrollierter Rollout
 
 - [x] 5.1 Arc42-Abschnitte 05, 06, 07, 08, 09 und 11 sowie das Swarm-Runbook aktualisieren; eine ADR für die zentrale Vertrauenszone und den gehärteten HTTPS-Kontrollkanal erstellen.
-- [ ] 5.2 Staging-Agent bereitstellen, Health-/Tool-Vertrag sowie einen erfolgreichen Backup-Drill mit Dump, Prüfsumme und Evidenz in MinIO nachweisen.
+- [x] 5.2 Staging-Agent bereitstellen, Health-/Tool-Vertrag sowie einen erfolgreichen Backup-Drill mit Dump, Prüfsumme und Evidenz in MinIO nachweisen.
 - [ ] 5.3 Nach expliziter Production-Freigabe den Production-Agentenpfad mit demselben Nachweis abnehmen.
 - [ ] 5.4 Erst nach 5.2 und 5.3 Task 4.3 von `add-promote-backup-production-parity` schließen.


### PR DESCRIPTION
## Zusammenfassung
- bindet das aus dem laufenden Staging-Postgres abgeleitete versionierte Backup-Secret dauerhaft im Stack
- dokumentiert den erfolgreichen Staging-Drill und die unabhängig geprüften MinIO-Objekte
- schließt OpenSpec-Task 5.2
- lässt Production-Abnahme und Paritätsabschluss ausdrücklich offen

## Evidenz
- Staging Backup Drill: `30492836842`
- Request: `gha-30492836842-1`
- alle fünf Backup-/Prüfschritte erfolgreich

## Validierung
- Compose-Rendering
- gezielter Stack-Vertragstest
- `openspec validate add-central-backup-agent --strict`
- `pnpm check:file-placement`