### PR TITLE
feat: add production backup drill workflow

### DIFF
--- a/.github/workflows/production-backup-drill.yml
+++ b/.github/workflows/production-backup-drill.yml
@@ -1,0 +1,102 @@
+name: Production Backup Drill
+run-name: Production backup drill ${{ inputs.image_ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: 'Immutable Studio image reference to bind to the backup'
+        required: true
+        type: string
+      change_head:
+        description: 'Commit revision represented by the immutable image'
+        required: true
+        type: string
+      maintenance_window:
+        description: 'Non-sensitive, revisionable maintenance-window reference'
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  packages: read
+
+jobs:
+  backup:
+    name: backup production database
+    environment: prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: bind executor source to image revision
+        env:
+          CHANGE_HEAD: ${{ inputs.change_head }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
+          head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
+          git merge-base --is-ancestor "${head}" origin/main
+          git checkout --detach "${head}"
+
+      - name: setup pnpm workspace
+        uses: ./.github/actions/setup-pnpm-workspace
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: validate image contract
+        id: image_contract
+        env:
+          IMAGE_INPUT: ${{ inputs.image_ref }}
+          CHANGE_HEAD: ${{ inputs.change_head }}
+        run: |
+          set -euo pipefail
+          pnpm exec tsx scripts/ci/promote-image-contract.ts \
+            --environment prod \
+            --image "${IMAGE_INPUT}" \
+            --expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
+
+      - name: require successful staging backup parity
+        env:
+          DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm exec tsx scripts/ci/verify-staging-promote-evidence.ts backup-drill
+
+      - name: create and verify production database backup
+        id: backup_job
+        env:
+          BACKUP_AGENT_SIGNING_KEY: ${{ secrets.BACKUP_AGENT_SIGNING_KEY }}
+          DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
+          MAINTENANCE_WINDOW_REFERENCE: ${{ inputs.maintenance_window }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_ENDPOINT: https://fileserver.smart-village.app
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: pnpm exec tsx scripts/ci/submit-backup-agent-request.ts prod
+
+      - name: verify production database backup object
+        env:
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket }}
+          S3_ENDPOINT: https://fileserver.smart-village.app
+          S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object }}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: pnpm exec tsx scripts/ci/verify-promote-backup.ts
+
+      - name: upload production backup drill evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-backup-drill-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/promote-backup-*.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/changelog/entries/pr-781.json
+++ b/docs/changelog/entries/pr-781.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 781,
+  "body": "Ein neuer, freigabegeschützter Production-Backup-Drill sichert und verifiziert die Produktionsdatenbank ohne Migration, Bootstrap oder App-Deployment."
+}

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -313,6 +313,7 @@ Bei einem Fehler ist zuerst die Diagnosedatei in MinIO auszuwerten. Fehlt sie we
 Prod-Hinweis:
 
 - Für Produktion verlangt `Promote` bei beiden `run`-Modi ein revisionsfähiges Wartungsfenster sowie ein erfolgreiches Artifact eines abgeschlossenen mutierenden Staging-Pfads für exakt dasselbe Image-Digest. Ein App-only-Staging-Deploy genügt nicht. Fehlt einer dieser Nachweise, blockiert der Lauf vor Backup und Mutation.
+- Der manuelle Workflow `Production Backup Drill` führt ausschließlich ein Production-Backup ohne Migration, Bootstrap oder App-Deployment aus. Er läuft im geschützten GitHub-Environment `prod`, verlangt einen nicht-sensitiven Wartungsfenster-Verweis und akzeptiert nur einen erfolgreichen `Staging Backup Drill` für exakt dasselbe Image-Digest als Paritätsnachweis.
 - Vor produktiven Schema- oder Reconcile-Eingriffen müssen aktuelles Backup, Restore-Pfad und Rollback-Entscheidung vorliegen; ein grüner App-Build ersetzt diese Freigabe nicht.
 
 ### Image-Versionierung im Promote-Pfad

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -23,20 +23,20 @@ Der Stack besteht aus:
 
 ### Zielwerte
 
-| Bereich | Zielwert |
-|---|---|
-| App + Monitoring | `RTO <= 2h` |
+| Bereich               | Zielwert     |
+| --------------------- | ------------ |
+| App + Monitoring      | `RTO <= 2h`  |
 | IAM-Daten in Postgres | `RPO <= 24h` |
 
 Die Zielwerte sind bewusst als operative Mindestziele formuliert. Sie ersetzen kein vollständiges Backup- oder HA-Konzept, sondern definieren den erwarteten Wiederanlauf- und Datenverlustrahmen für das aktuelle Referenzprofil.
 
 ### Eskalationspfad
 
-| Fall | Primärer Kanal | Zusätzlicher Kanal |
-|---|---|---|
-| Betriebsstörung ohne Sensitive Data | `operations@smart-village.app` | GitHub Issue für Nachverfolgung |
-| Sicherheitsvorfall oder DSGVO-Bezug | `security@smart-village.app` | `operations@smart-village.app` |
-| Reine Produkt-/Doku-Nacharbeit ohne Sensitivität | GitHub Issue | - |
+| Fall                                             | Primärer Kanal                 | Zusätzlicher Kanal              |
+| ------------------------------------------------ | ------------------------------ | ------------------------------- |
+| Betriebsstörung ohne Sensitive Data              | `operations@smart-village.app` | GitHub Issue für Nachverfolgung |
+| Sicherheitsvorfall oder DSGVO-Bezug              | `security@smart-village.app`   | `operations@smart-village.app`  |
+| Reine Produkt-/Doku-Nacharbeit ohne Sensitivität | GitHub Issue                   | -                               |
 
 Regel:
 
@@ -57,15 +57,15 @@ Regel:
 
 ## Dateien
 
-| Datei | Zweck |
-|---|---|
-| `deploy/portainer/docker-compose.yml` | Swarm-Stack-Definition |
-| `deploy/portainer/Dockerfile` | Build-Definition für das App-Image |
-| `deploy/portainer/entrypoint.sh` | Validiert und normalisiert Runtime-Variablen vor dem App-Start |
-| `deploy/portainer/otel-bootstrap.mjs` | Initialisiert OTEL vor dem Nitro-Entry im Node-Prozess |
-| `deploy/portainer/monitoring/` | Swarm-spezifische Monitoring-Konfigurationen |
+| Datei                                      | Zweck                                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `deploy/portainer/docker-compose.yml`      | Swarm-Stack-Definition                                                               |
+| `deploy/portainer/Dockerfile`              | Build-Definition für das App-Image                                                   |
+| `deploy/portainer/entrypoint.sh`           | Validiert und normalisiert Runtime-Variablen vor dem App-Start                       |
+| `deploy/portainer/otel-bootstrap.mjs`      | Initialisiert OTEL vor dem Nitro-Entry im Node-Prozess                               |
+| `deploy/portainer/monitoring/`             | Swarm-spezifische Monitoring-Konfigurationen                                         |
 | `deploy/portainer/monitoring-config-init/` | Build-Kontext für das Init-Image, das Monitoring-Konfigurationen in Volumes schreibt |
-| `deploy/portainer/.env.example` | Referenz aller Konfigurationsvariablen |
+| `deploy/portainer/.env.example`            | Referenz aller Konfigurationsvariablen                                               |
 
 ## Schritt 1: Stack-Variablen konfigurieren
 
@@ -73,48 +73,48 @@ Das Referenzprofil `studio` wird env-only betrieben. Sowohl nicht-sensitive als 
 
 ### Pflicht-Variablen
 
-| Variable | Beispiel |
-|---|---|
-| `POSTGRES_PASSWORD` | `***` |
-| `APP_DB_PASSWORD` | `***` |
-| `REDIS_PASSWORD` | `***` |
-| `SVA_AUTH_CLIENT_SECRET` | `***` |
-| `SVA_AUTH_STATE_SECRET` | `***` |
-| `KEYCLOAK_ADMIN_CLIENT_SECRET` | `***` |
-| `ENCRYPTION_KEY` | `***` |
-| `IAM_PII_KEYRING_JSON` | `{"k1":"***"}` |
-| `SVA_PUBLIC_BASE_URL` | `https://studio.smart-village.app` |
-| `SVA_PUBLIC_HOST` | `studio.smart-village.app` |
-| `SVA_DB_ADMIN_HOST` | `studio-db.smart-village.app` |
-| `SVA_AUTH_REDIRECT_URI` | `https://studio.smart-village.app/auth/callback` |
-| `SVA_AUTH_POST_LOGOUT_REDIRECT_URI` | `https://studio.smart-village.app/` |
-| `SVA_PARENT_DOMAIN` | `studio.smart-village.app` |
-| `IAM_CSRF_ALLOWED_ORIGINS` | `https://studio.smart-village.app` |
+| Variable                            | Beispiel                                         |
+| ----------------------------------- | ------------------------------------------------ |
+| `POSTGRES_PASSWORD`                 | `***`                                            |
+| `APP_DB_PASSWORD`                   | `***`                                            |
+| `REDIS_PASSWORD`                    | `***`                                            |
+| `SVA_AUTH_CLIENT_SECRET`            | `***`                                            |
+| `SVA_AUTH_STATE_SECRET`             | `***`                                            |
+| `KEYCLOAK_ADMIN_CLIENT_SECRET`      | `***`                                            |
+| `ENCRYPTION_KEY`                    | `***`                                            |
+| `IAM_PII_KEYRING_JSON`              | `{"k1":"***"}`                                   |
+| `SVA_PUBLIC_BASE_URL`               | `https://studio.smart-village.app`               |
+| `SVA_PUBLIC_HOST`                   | `studio.smart-village.app`                       |
+| `SVA_DB_ADMIN_HOST`                 | `studio-db.smart-village.app`                    |
+| `SVA_AUTH_REDIRECT_URI`             | `https://studio.smart-village.app/auth/callback` |
+| `SVA_AUTH_POST_LOGOUT_REDIRECT_URI` | `https://studio.smart-village.app/`              |
+| `SVA_PARENT_DOMAIN`                 | `studio.smart-village.app`                       |
+| `IAM_CSRF_ALLOWED_ORIGINS`          | `https://studio.smart-village.app`               |
 
 ### Optionale Variablen
 
-| Variable | Default | Beschreibung |
-|---|---|---|
-| `SVA_REGISTRY` | `ghcr.io/smart-village-solutions` | Container-Registry für das App-Image |
-| `SVA_IMAGE_REPOSITORY` | `sva-studio` | Repository-Name des App-Images |
-| `SVA_MONITORING_REGISTRY` | `ghcr.io/smart-village-solutions` | Container-Registry für das Monitoring-Init-Image |
-| `SVA_IMAGE_TAG` | `0.0.0-dev` | Image-Tag oder Digest; für Produktion Digest oder unveränderlichen Tag verwenden |
-| `SVA_IMAGE_DIGEST` | kein Default | Verbindlicher SHA256-Digest für produktionsnahe Releases |
-| `SVA_IMAGE_REF` | kein Default | Vollständige Image-Referenz `${SVA_REGISTRY}/${SVA_IMAGE_REPOSITORY}@${SVA_IMAGE_DIGEST}` |
-| `SVA_MONITORING_CONFIG_INIT_IMAGE_TAG` | `0.0.0-dev` | Image-Tag des Monitoring-Init-Images; für Produktion Digest oder unveränderlichen Tag verwenden |
-| `SVA_ALLOWED_INSTANCE_IDS` | leer | Nur lokaler oder migrierender Fallback; im Registry-Betrieb keine führende Freigabequelle |
-| `SVA_TENANT_SCOPE_INSTANCE_IDS` | leer | Optionaler Override für Tenant-Smokes und Doctor-Scopes; ohne Wert werden Remote-Scopes aus der Registry abgeleitet |
-| `ENABLE_OTEL` | `true` | OpenTelemetry für lokale Deaktivierungsfälle in Development; im produktionsnahen Betrieb bleibt OTEL verpflichtend |
-| `OTEL_SERVICE_NAME` | `sva-studio` | Service-Name für OTEL Resource Attributes |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://otel-collector:4318` | Interner OTLP-HTTP-Endpoint |
-| `GF_SECURITY_ADMIN_PASSWORD` | kein Default | Pflichtwert für den internen Grafana-Login |
-| `IAM_UI_ENABLED` | `false` | IAM-Account-UI |
-| `IAM_ADMIN_ENABLED` | `false` | IAM-Admin-UI |
-| `IAM_BULK_ENABLED` | `false` | IAM-Bulk-Operationen |
-| `SVA_DOCTOR_KEYCLOAK_SUBJECT` | leer | optionaler Actor-Override für `env:doctor:studio` |
-| `SVA_DOCTOR_INSTANCE_ID` | kein Default | überschreibt die Zielinstanz für den Doctor-Lauf; für tiefe Actor-Diagnose explizit setzen |
-| `SVA_DOCTOR_SESSION_ROLES` | leer | kommagetrennte Session-Rollen für Rollen-Diagnose |
-| `SVA_DB_ADMIN_BASIC_AUTH` | kein Default | htpasswd-String für vorgeschalteten Adminer-Basic-Auth |
+| Variable                               | Default                           | Beschreibung                                                                                                        |
+| -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `SVA_REGISTRY`                         | `ghcr.io/smart-village-solutions` | Container-Registry für das App-Image                                                                                |
+| `SVA_IMAGE_REPOSITORY`                 | `sva-studio`                      | Repository-Name des App-Images                                                                                      |
+| `SVA_MONITORING_REGISTRY`              | `ghcr.io/smart-village-solutions` | Container-Registry für das Monitoring-Init-Image                                                                    |
+| `SVA_IMAGE_TAG`                        | `0.0.0-dev`                       | Image-Tag oder Digest; für Produktion Digest oder unveränderlichen Tag verwenden                                    |
+| `SVA_IMAGE_DIGEST`                     | kein Default                      | Verbindlicher SHA256-Digest für produktionsnahe Releases                                                            |
+| `SVA_IMAGE_REF`                        | kein Default                      | Vollständige Image-Referenz `${SVA_REGISTRY}/${SVA_IMAGE_REPOSITORY}@${SVA_IMAGE_DIGEST}`                           |
+| `SVA_MONITORING_CONFIG_INIT_IMAGE_TAG` | `0.0.0-dev`                       | Image-Tag des Monitoring-Init-Images; für Produktion Digest oder unveränderlichen Tag verwenden                     |
+| `SVA_ALLOWED_INSTANCE_IDS`             | leer                              | Nur lokaler oder migrierender Fallback; im Registry-Betrieb keine führende Freigabequelle                           |
+| `SVA_TENANT_SCOPE_INSTANCE_IDS`        | leer                              | Optionaler Override für Tenant-Smokes und Doctor-Scopes; ohne Wert werden Remote-Scopes aus der Registry abgeleitet |
+| `ENABLE_OTEL`                          | `true`                            | OpenTelemetry für lokale Deaktivierungsfälle in Development; im produktionsnahen Betrieb bleibt OTEL verpflichtend  |
+| `OTEL_SERVICE_NAME`                    | `sva-studio`                      | Service-Name für OTEL Resource Attributes                                                                           |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`          | `http://otel-collector:4318`      | Interner OTLP-HTTP-Endpoint                                                                                         |
+| `GF_SECURITY_ADMIN_PASSWORD`           | kein Default                      | Pflichtwert für den internen Grafana-Login                                                                          |
+| `IAM_UI_ENABLED`                       | `false`                           | IAM-Account-UI                                                                                                      |
+| `IAM_ADMIN_ENABLED`                    | `false`                           | IAM-Admin-UI                                                                                                        |
+| `IAM_BULK_ENABLED`                     | `false`                           | IAM-Bulk-Operationen                                                                                                |
+| `SVA_DOCTOR_KEYCLOAK_SUBJECT`          | leer                              | optionaler Actor-Override für `env:doctor:studio`                                                                   |
+| `SVA_DOCTOR_INSTANCE_ID`               | kein Default                      | überschreibt die Zielinstanz für den Doctor-Lauf; für tiefe Actor-Diagnose explizit setzen                          |
+| `SVA_DOCTOR_SESSION_ROLES`             | leer                              | kommagetrennte Session-Rollen für Rollen-Diagnose                                                                   |
+| `SVA_DB_ADMIN_BASIC_AUTH`              | kein Default                      | htpasswd-String für vorgeschalteten Adminer-Basic-Auth                                                              |
 
 Die vollständige Variablenliste inklusive Keycloak-Admin- und Rollenabgleich-Optionen steht in `deploy/portainer/.env.example`.
 Für produktionsnahe Acceptance-Deployments ist `SVA_IMAGE_DIGEST` verpflichtend; `SVA_IMAGE_REF` muss auf genau dieses Artefakt zeigen. `SVA_IMAGE_TAG` bleibt nur ergänzende Metadaten für Lesbarkeit und Rückverfolgung. Wenn App- und Monitoring-Image aus unterschiedlichen Registries bezogen werden, müssen `SVA_REGISTRY` und `SVA_MONITORING_REGISTRY` konsistent gesetzt sein.
@@ -171,18 +171,18 @@ curl -I https://hb-meinquartier.studio.smart-village.app
 
 ### Ressourcenlimits des Referenzprofils
 
-| Service | CPU-Limit |
-|---|---|
-| `app` | `1.0` |
-| `postgres` | `0.5` |
-| `redis` | `0.25` |
-| `monitoring-config-init` | `0.10` |
-| `otel-collector` | `0.25` |
-| `loki` | `0.75` |
-| `prometheus` | `1.0` |
-| `grafana` | `0.5` |
-| `promtail` | `0.25` |
-| `alertmanager` | `0.25` |
+| Service                  | CPU-Limit |
+| ------------------------ | --------- |
+| `app`                    | `1.0`     |
+| `postgres`               | `0.5`     |
+| `redis`                  | `0.25`    |
+| `monitoring-config-init` | `0.10`    |
+| `otel-collector`         | `0.25`    |
+| `loki`                   | `0.75`    |
+| `prometheus`             | `1.0`     |
+| `grafana`                | `0.5`     |
+| `promtail`               | `0.25`    |
+| `alertmanager`           | `0.25`    |
 
 ## Schritt 2: Datenbank initialisieren
 
@@ -371,6 +371,7 @@ Interpretationshilfe:
 - in diesem Fall zuerst Live-Service und Smokes als Wahrheitsebene prüfen, dann den Reportpfad debuggen
 - wenn `migrate` grün ist, `bootstrap` aber rot, zuerst den Bootstrap-SQL-Vertrag gegen die zuletzt eingezogenen Schema-Pflichtfelder prüfen; ein pauschaler Retry des Gesamtdeploys hilft dann meist nicht
 - wenn der Cutover technisch durch ist, aber die ersten externen Health-/Tenant-Probes kurz `404` liefern, ist das zuerst als mögliche Post-Cutover-Settling-Phase zu behandeln und nicht sofort als belastbare Regression
+
 8. Schreiben eines Deploy-Reports unter `artifacts/runtime/deployments/`
 
 Read-only Betriebsregel:
@@ -524,17 +525,17 @@ Stabile Diagnosecodes umfassen unter anderem:
 - `database_connection_failed`
 - `keycloak_dependency_failed`
 
-| Prüfung | Erwartung |
-|---|---|
-| `GET https://<SVA_PARENT_DOMAIN>/health/live` | HTTP 200 |
-| `GET https://<SVA_PARENT_DOMAIN>/health/ready` | HTTP 200, Redis + DB + Keycloak bereit |
-| `GET https://<SVA_PARENT_DOMAIN>/auth/login` | Redirect zum OIDC-Provider |
-| `GET https://<aktive-instance>.<SVA_PARENT_DOMAIN>/` | HTTP 200 ohne neues Deployment |
-| `GET https://unknown.<SVA_PARENT_DOMAIN>/` | fail-closed, ohne tenant-spezifische Detailoffenlegung |
-| `GET https://<suspendierte-instance>.<SVA_PARENT_DOMAIN>/auth/me` | gleiches fail-closed-Verhalten wie unbekannter Host |
-| App in Portainer | Status: `healthy` |
-| Monitoring-Services in Portainer | `otel-collector`, `loki`, `prometheus`, `grafana`, `promtail`, `alertmanager` laufen |
-| `app-db-principal` in `doctor`/`precheck` | `ok`, `APP_DB_USER` sieht `db=true`, `redis=true`, `keycloak=true` |
+| Prüfung                                                           | Erwartung                                                                            |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `GET https://<SVA_PARENT_DOMAIN>/health/live`                     | HTTP 200                                                                             |
+| `GET https://<SVA_PARENT_DOMAIN>/health/ready`                    | HTTP 200, Redis + DB + Keycloak bereit                                               |
+| `GET https://<SVA_PARENT_DOMAIN>/auth/login`                      | Redirect zum OIDC-Provider                                                           |
+| `GET https://<aktive-instance>.<SVA_PARENT_DOMAIN>/`              | HTTP 200 ohne neues Deployment                                                       |
+| `GET https://unknown.<SVA_PARENT_DOMAIN>/`                        | fail-closed, ohne tenant-spezifische Detailoffenlegung                               |
+| `GET https://<suspendierte-instance>.<SVA_PARENT_DOMAIN>/auth/me` | gleiches fail-closed-Verhalten wie unbekannter Host                                  |
+| App in Portainer                                                  | Status: `healthy`                                                                    |
+| Monitoring-Services in Portainer                                  | `otel-collector`, `loki`, `prometheus`, `grafana`, `promtail`, `alertmanager` laufen |
+| `app-db-principal` in `doctor`/`precheck`                         | `ok`, `APP_DB_USER` sieht `db=true`, `redis=true`, `keycloak=true`                   |
 
 Für IAM-Abnahmen zusätzlich:
 
@@ -592,10 +593,10 @@ Direkte Portainer-Eingriffe bleiben Incident-Recovery und sind nicht der kanonis
 
 ## Persistenz
 
-| Service | Volume | Placement |
-|---|---|---|
+| Service  | Volume          | Placement              |
+| -------- | --------------- | ---------------------- |
 | Postgres | `postgres-data` | `node.role == manager` |
-| Redis | `redis-data` | `node.role == manager` |
+| Redis    | `redis-data`    | `node.role == manager` |
 
 Die Placement-Constraints stellen sicher, dass Volumes auf demselben Node bleiben. Bei Cluster-Erweiterung müssen die Constraints ggf. angepasst werden.
 

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -3,8 +3,18 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-const workflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/promote.yml'), 'utf8');
-const backupDrillWorkflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/staging-backup-drill.yml'), 'utf8');
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/promote.yml'),
+  'utf8'
+);
+const backupDrillWorkflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/staging-backup-drill.yml'),
+  'utf8'
+);
+const productionBackupDrillWorkflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/production-backup-drill.yml'),
+  'utf8'
+);
 
 describe('Promote workflow contract', () => {
   it('runs staging phases in the required fail-closed order', () => {
@@ -25,16 +35,24 @@ describe('Promote workflow contract', () => {
     expect(offsets.every((offset) => offset >= 0)).toBe(true);
     expect(offsets).toEqual([...offsets].sort((left, right) => left - right));
     expect(workflow).toMatch(/- name: deploy\s+id: deploy/u);
-    expect(workflow.indexOf('Login to GHCR')).toBeLessThan(workflow.indexOf('validate image contract'));
-    expect(workflow).toContain("trap 'rm -f .env config/runtime/base.vars config/runtime/studio.vars' EXIT");
-    expect(workflow.match(/printf '%s\\n' "\$\{APP_CONFIG\}" > config\/runtime\/base\.vars/gu)).toHaveLength(2);
+    expect(workflow.indexOf('Login to GHCR')).toBeLessThan(
+      workflow.indexOf('validate image contract')
+    );
+    expect(workflow).toContain(
+      "trap 'rm -f .env config/runtime/base.vars config/runtime/studio.vars' EXIT"
+    );
+    expect(
+      workflow.match(/printf '%s\\n' "\$\{APP_CONFIG\}" > config\/runtime\/base\.vars/gu)
+    ).toHaveLength(2);
     expect(workflow).toContain('SVA_STACK_NAME: studio-${{ inputs.environment }}');
     expect(workflow).toContain('QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}');
   });
 
   it('requires a maintenance reference and guards production mutations with staging parity', () => {
     expect(workflow).toContain('maintenance_window');
-    expect(workflow).toContain("'maintenance_window' must be a non-sensitive, revisionable reference");
+    expect(workflow).toContain(
+      "'maintenance_window' must be a non-sensitive, revisionable reference"
+    );
     expect(workflow).toContain('--environment "${ENVIRONMENT}"');
     expect(workflow).toContain('upload redacted one-shot evidence');
     expect(workflow).toContain('if-no-files-found: ignore');
@@ -44,26 +62,39 @@ describe('Promote workflow contract', () => {
     expect(workflow).toContain('require successful staging parity for production mutation');
     expect(workflow).toContain('create database backup before one-shot jobs');
     expect(workflow).toContain('verify database backup object');
-    expect(workflow).toContain('S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object || steps.backup_fallback_job.outputs.backup_object }}');
+    expect(workflow).toContain(
+      'S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object || steps.backup_fallback_job.outputs.backup_object }}'
+    );
     expect(workflow).toContain('id-token: write');
     expect(workflow).toContain('submit-backup-agent-request.ts "${{ inputs.environment }}"');
     expect(workflow).toContain("vars.BACKUP_EXECUTOR == 'temporary'");
-    expect(workflow).toContain('STAGING_MUTATION: ${{ steps.gate_eval.outputs.migration_should_run == \'true\' || steps.gate_eval.outputs.bootstrap_should_run == \'true\' }}');
-    expect(workflow).toContain('name: promote-staging-parity-${{ github.run_id }}-${{ github.run_attempt }}');
-    expect(workflow).toContain('--expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"');
+    expect(workflow).toContain(
+      "STAGING_MUTATION: ${{ steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true' }}"
+    );
+    expect(workflow).toContain(
+      'name: promote-staging-parity-${{ github.run_id }}-${{ github.run_attempt }}'
+    );
+    expect(workflow).toContain(
+      '--expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"'
+    );
   });
 
   it('runs backups only for staging or production mutations and blocks production deploys behind parity', () => {
     expect(workflow).toContain("inputs.environment == 'staging' || inputs.environment == 'prod'");
-    expect(workflow).toContain("inputs.environment == 'prod' && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true')");
-    expect(workflow).toContain('require successful staging parity for production mutation');
-    expect(workflow.indexOf('require successful staging parity for production mutation')).toBeLessThan(
-      workflow.indexOf('create database backup before one-shot jobs'),
+    expect(workflow).toContain(
+      "inputs.environment == 'prod' && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true')"
     );
+    expect(workflow).toContain('require successful staging parity for production mutation');
+    expect(
+      workflow.indexOf('require successful staging parity for production mutation')
+    ).toBeLessThan(workflow.indexOf('create database backup before one-shot jobs'));
   });
 
   it('uses automatic diff-based one-shot execution for main-to-Dev promotion', () => {
-    const buildWorkflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/build.yml'), 'utf8');
+    const buildWorkflow = readFileSync(
+      resolve(import.meta.dirname, '../../.github/workflows/build.yml'),
+      'utf8'
+    );
 
     expect(buildWorkflow).toContain('bootstrap_mode: auto');
     expect(buildWorkflow).toContain('migration_mode: auto');
@@ -71,7 +102,9 @@ describe('Promote workflow contract', () => {
     expect(buildWorkflow).toContain('id-token: write');
     expect(buildWorkflow).toContain('SVA_IMAGE_REVISION=${{ github.sha }}');
     expect(buildWorkflow).toContain('file: ./deploy/backup-agent/Dockerfile');
-    expect(buildWorkflow).toContain('ghcr.io/smart-village-solutions/sva-studio-backup-agent:${{ github.sha }}');
+    expect(buildWorkflow).toContain(
+      'ghcr.io/smart-village-solutions/sva-studio-backup-agent:${{ github.sha }}'
+    );
     expect(workflow).toContain('migration_should_run');
     expect(workflow).toContain('bootstrap_should_run');
   });
@@ -82,8 +115,24 @@ describe('Promote workflow contract', () => {
     expect(backupDrillWorkflow).toContain('submit-backup-agent-request.ts staging');
     expect(backupDrillWorkflow).toContain('promote-backup-job.ts staging');
     expect(backupDrillWorkflow).toContain('verify-promote-backup.ts');
-    expect(backupDrillWorkflow).toContain('staging-backup-drill-${{ github.run_id }}-${{ github.run_attempt }}');
+    expect(backupDrillWorkflow).toContain(
+      'staging-backup-drill-${{ github.run_id }}-${{ github.run_attempt }}'
+    );
     expect(backupDrillWorkflow).not.toContain('promote-one-shot-job.ts');
     expect(backupDrillWorkflow).not.toContain('quantum-cli stacks deploy');
+  });
+
+  it('offers an approved production backup drill without application mutation', () => {
+    expect(productionBackupDrillWorkflow).toContain('name: Production Backup Drill');
+    expect(productionBackupDrillWorkflow).toContain('environment: prod');
+    expect(productionBackupDrillWorkflow).toContain('maintenance_window');
+    expect(productionBackupDrillWorkflow).toContain('require successful staging backup parity');
+    expect(productionBackupDrillWorkflow).toContain(
+      'verify-staging-promote-evidence.ts backup-drill'
+    );
+    expect(productionBackupDrillWorkflow).toContain('submit-backup-agent-request.ts prod');
+    expect(productionBackupDrillWorkflow).toContain('verify-promote-backup.ts');
+    expect(productionBackupDrillWorkflow).not.toContain('promote-one-shot-job.ts');
+    expect(productionBackupDrillWorkflow).not.toContain('quantum-cli stacks deploy');
   });
 });

--- a/scripts/ci/verify-staging-promote-evidence.test.ts
+++ b/scripts/ci/verify-staging-promote-evidence.test.ts
@@ -3,32 +3,117 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildArtifactDownloadArgs,
   isSuccessfulPromoteWorkflowRun,
+  isSuccessfulStagingBackupWorkflowRun,
   listArtifacts,
+  matchesSuccessfulStagingBackupEvidence,
   matchesSuccessfulStagingEvidence,
   selectEvidenceJsonFile,
 } from './verify-staging-promote-evidence.ts';
 
 describe('staging parity evidence', () => {
   it('accepts only successful staging evidence for the exact target digest', () => {
-    expect(matchesSuccessfulStagingEvidence({ digest: 'sha256:expected', environment: 'staging', mutation: 'completed', postflight: 'passed' }, 'sha256:expected')).toBe(true);
-    expect(matchesSuccessfulStagingEvidence({ digest: 'sha256:expected', environment: 'staging', postflight: 'passed' }, 'sha256:expected')).toBe(false);
-    expect(matchesSuccessfulStagingEvidence({ digest: 'sha256:other', environment: 'staging', mutation: 'completed', postflight: 'passed' }, 'sha256:expected')).toBe(false);
-    expect(matchesSuccessfulStagingEvidence({ digest: 'sha256:expected', environment: 'prod', mutation: 'completed', postflight: 'passed' }, 'sha256:expected')).toBe(false);
-    expect(matchesSuccessfulStagingEvidence({ digest: 'sha256:expected', environment: 'staging', mutation: 'completed', postflight: 'failed' }, 'sha256:expected')).toBe(false);
+    expect(
+      matchesSuccessfulStagingEvidence(
+        {
+          digest: 'sha256:expected',
+          environment: 'staging',
+          mutation: 'completed',
+          postflight: 'passed',
+        },
+        'sha256:expected'
+      )
+    ).toBe(true);
+    expect(
+      matchesSuccessfulStagingEvidence(
+        { digest: 'sha256:expected', environment: 'staging', postflight: 'passed' },
+        'sha256:expected'
+      )
+    ).toBe(false);
+    expect(
+      matchesSuccessfulStagingEvidence(
+        {
+          digest: 'sha256:other',
+          environment: 'staging',
+          mutation: 'completed',
+          postflight: 'passed',
+        },
+        'sha256:expected'
+      )
+    ).toBe(false);
+    expect(
+      matchesSuccessfulStagingEvidence(
+        {
+          digest: 'sha256:expected',
+          environment: 'prod',
+          mutation: 'completed',
+          postflight: 'passed',
+        },
+        'sha256:expected'
+      )
+    ).toBe(false);
+    expect(
+      matchesSuccessfulStagingEvidence(
+        {
+          digest: 'sha256:expected',
+          environment: 'staging',
+          mutation: 'completed',
+          postflight: 'failed',
+        },
+        'sha256:expected'
+      )
+    ).toBe(false);
+  });
+
+  it('accepts only a successful staging backup drill for the exact target digest', () => {
+    expect(
+      matchesSuccessfulStagingBackupEvidence(
+        {
+          deployImageDigest: 'sha256:expected',
+          environment: 'staging',
+          status: 'succeeded',
+        },
+        'sha256:expected'
+      )
+    ).toBe(true);
+    expect(
+      matchesSuccessfulStagingBackupEvidence(
+        {
+          deployImageDigest: 'sha256:other',
+          environment: 'staging',
+          status: 'succeeded',
+        },
+        'sha256:expected'
+      )
+    ).toBe(false);
+    expect(
+      matchesSuccessfulStagingBackupEvidence(
+        {
+          deployImageDigest: 'sha256:expected',
+          environment: 'prod',
+          status: 'succeeded',
+        },
+        'sha256:expected'
+      )
+    ).toBe(false);
   });
 
   it('reads paginated artifact responses before filtering parity evidence', () => {
     const firstPage = Array.from({ length: 100 }, (_, index) => ({ id: index + 1 }));
-    const artifacts = listArtifacts((page) => page === 1
-      ? { artifacts: firstPage, total_count: 101 }
-      : { artifacts: [{ id: 101, name: 'promote-staging-parity-101' }], total_count: 101 });
+    const artifacts = listArtifacts((page) =>
+      page === 1
+        ? { artifacts: firstPage, total_count: 101 }
+        : { artifacts: [{ id: 101, name: 'promote-staging-parity-101' }], total_count: 101 }
+    );
 
     expect(artifacts).toHaveLength(101);
     expect(artifacts.at(-1)).toMatchObject({ name: 'promote-staging-parity-101' });
   });
 
   it('limits artifact pagination to ten pages', () => {
-    const readPage = vi.fn(() => ({ artifacts: Array.from({ length: 100 }, () => ({})), total_count: 2_000 }));
+    const readPage = vi.fn(() => ({
+      artifacts: Array.from({ length: 100 }, () => ({})),
+      total_count: 2_000,
+    }));
 
     expect(listArtifacts(readPage)).toHaveLength(1_000);
     expect(readPage).toHaveBeenCalledTimes(10);
@@ -48,17 +133,44 @@ describe('staging parity evidence', () => {
   });
 
   it('accepts artifacts only from successful Promote workflow runs', () => {
-    expect(isSuccessfulPromoteWorkflowRun({
-      conclusion: 'success',
-      path: '.github/workflows/promote.yml',
-    })).toBe(true);
-    expect(isSuccessfulPromoteWorkflowRun({
-      conclusion: 'failure',
-      path: '.github/workflows/promote.yml',
-    })).toBe(false);
-    expect(isSuccessfulPromoteWorkflowRun({
-      conclusion: 'success',
-      path: '.github/workflows/build.yml',
-    })).toBe(false);
+    expect(
+      isSuccessfulPromoteWorkflowRun({
+        conclusion: 'success',
+        path: '.github/workflows/promote.yml',
+      })
+    ).toBe(true);
+    expect(
+      isSuccessfulPromoteWorkflowRun({
+        conclusion: 'failure',
+        path: '.github/workflows/promote.yml',
+      })
+    ).toBe(false);
+    expect(
+      isSuccessfulPromoteWorkflowRun({
+        conclusion: 'success',
+        path: '.github/workflows/build.yml',
+      })
+    ).toBe(false);
+  });
+
+  it('accepts staging backup evidence only from successful staging drill runs', () => {
+    expect(
+      isSuccessfulStagingBackupWorkflowRun({
+        conclusion: 'success',
+        path: '.github/workflows/staging-backup-drill.yml',
+      })
+    ).toBe(true);
+    expect(
+      isSuccessfulStagingBackupWorkflowRun({
+        conclusion: 'failure',
+        path: '.github/workflows/staging-backup-drill.yml',
+      })
+    ).toBe(false);
+    expect(
+      isSuccessfulStagingBackupWorkflowRun({
+        conclusion: 'success',
+        path: '.github/workflows/promote.yml',
+      })
+    ).toBe(false);
   });
 });

--- a/scripts/ci/verify-staging-promote-evidence.ts
+++ b/scripts/ci/verify-staging-promote-evidence.ts
@@ -7,11 +7,29 @@ import { pathToFileURL } from 'node:url';
 
 type Artifact = { expired?: boolean; id?: number; name?: string; workflow_run?: { id?: number } };
 type ArtifactPage = { artifacts?: Artifact[]; total_count?: number };
-type StagingEvidence = { digest?: string; environment?: string; mutation?: string; postflight?: string };
+type StagingEvidence = {
+  deployImageDigest?: string;
+  digest?: string;
+  environment?: string;
+  mutation?: string;
+  postflight?: string;
+  status?: string;
+};
 type WorkflowRun = { conclusion?: string; path?: string };
 
 export const matchesSuccessfulStagingEvidence = (evidence: StagingEvidence, targetDigest: string) =>
-  evidence.environment === 'staging' && evidence.mutation === 'completed' && evidence.postflight === 'passed' && evidence.digest === targetDigest;
+  evidence.environment === 'staging' &&
+  evidence.mutation === 'completed' &&
+  evidence.postflight === 'passed' &&
+  evidence.digest === targetDigest;
+
+export const matchesSuccessfulStagingBackupEvidence = (
+  evidence: StagingEvidence,
+  targetDigest: string
+) =>
+  evidence.environment === 'staging' &&
+  evidence.status === 'succeeded' &&
+  evidence.deployImageDigest === targetDigest;
 
 export const listArtifacts = (readPage: (page: number) => ArtifactPage): Artifact[] => {
   const artifacts: Artifact[] = [];
@@ -19,7 +37,8 @@ export const listArtifacts = (readPage: (page: number) => ArtifactPage): Artifac
     const payload = readPage(page);
     const pageArtifacts = payload.artifacts ?? [];
     artifacts.push(...pageArtifacts);
-    if (pageArtifacts.length < 100 || artifacts.length >= (payload.total_count ?? artifacts.length)) break;
+    if (pageArtifacts.length < 100 || artifacts.length >= (payload.total_count ?? artifacts.length))
+      break;
   }
   return artifacts;
 };
@@ -32,6 +51,10 @@ export const buildArtifactDownloadArgs = (repo: string, artifactId: number) => [
 export const isSuccessfulPromoteWorkflowRun = (workflowRun: WorkflowRun) =>
   workflowRun.conclusion === 'success' && workflowRun.path === '.github/workflows/promote.yml';
 
+export const isSuccessfulStagingBackupWorkflowRun = (workflowRun: WorkflowRun) =>
+  workflowRun.conclusion === 'success' &&
+  workflowRun.path === '.github/workflows/staging-backup-drill.yml';
+
 export const selectEvidenceJsonFile = (archiveEntries: string) => {
   const files = archiveEntries.split('\n').filter((entry) => entry.endsWith('.json'));
   return files.length === 1 ? files[0] : undefined;
@@ -42,32 +65,75 @@ const required = (value: string | undefined, name: string) => {
   return trimmed;
 };
 const main = () => {
+  const evidenceKind = process.argv[2] ?? 'promote';
+  if (evidenceKind !== 'promote' && evidenceKind !== 'backup-drill') {
+    throw new Error('Der Evidenztyp muss promote oder backup-drill sein.');
+  }
   const targetDigest = required(process.env.DEPLOY_IMAGE_DIGEST, 'DEPLOY_IMAGE_DIGEST');
   const repo = required(process.env.GITHUB_REPOSITORY, 'GITHUB_REPOSITORY');
-  const api = (path: string) => execFileSync('gh', ['api', path], { encoding: 'utf8', env: { ...process.env, GH_TOKEN: required(process.env.GITHUB_TOKEN, 'GITHUB_TOKEN') } });
-  const candidates = listArtifacts((page) => JSON.parse(api(`repos/${repo}/actions/artifacts?per_page=100&page=${page}`)) as ArtifactPage)
-    .filter((artifact) => !artifact.expired && artifact.id && artifact.name?.startsWith('promote-staging-parity-'));
+  const api = (path: string) =>
+    execFileSync('gh', ['api', path], {
+      encoding: 'utf8',
+      env: { ...process.env, GH_TOKEN: required(process.env.GITHUB_TOKEN, 'GITHUB_TOKEN') },
+    });
+  const candidates = listArtifacts(
+    (page) =>
+      JSON.parse(api(`repos/${repo}/actions/artifacts?per_page=100&page=${page}`)) as ArtifactPage
+  ).filter(
+    (artifact) =>
+      !artifact.expired &&
+      artifact.id &&
+      artifact.name?.startsWith(
+        evidenceKind === 'promote' ? 'promote-staging-parity-' : 'staging-backup-drill-'
+      )
+  );
   const workdir = mkdtempSync(resolve(tmpdir(), 'sva-staging-parity-'));
   try {
     for (const artifact of candidates) {
       const artifactId = artifact.id;
       const workflowRunId = artifact.workflow_run?.id;
       if (!artifactId || !workflowRunId) continue;
-      const workflowRun = JSON.parse(api(`repos/${repo}/actions/runs/${workflowRunId}`)) as WorkflowRun;
-      if (!isSuccessfulPromoteWorkflowRun(workflowRun)) continue;
+      const workflowRun = JSON.parse(
+        api(`repos/${repo}/actions/runs/${workflowRunId}`)
+      ) as WorkflowRun;
+      if (
+        evidenceKind === 'promote'
+          ? !isSuccessfulPromoteWorkflowRun(workflowRun)
+          : !isSuccessfulStagingBackupWorkflowRun(workflowRun)
+      )
+        continue;
       const zipPath = resolve(workdir, `${artifactId}.zip`);
-      writeFileSync(zipPath, execFileSync('gh', buildArtifactDownloadArgs(repo, artifactId), {
-        env: { ...process.env, GH_TOKEN: required(process.env.GITHUB_TOKEN, 'GITHUB_TOKEN') },
-      }));
-      const evidenceFile = selectEvidenceJsonFile(execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf8' }));
+      writeFileSync(
+        zipPath,
+        execFileSync('gh', buildArtifactDownloadArgs(repo, artifactId), {
+          env: { ...process.env, GH_TOKEN: required(process.env.GITHUB_TOKEN, 'GITHUB_TOKEN') },
+        })
+      );
+      const evidenceFile = selectEvidenceJsonFile(
+        execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf8' })
+      );
       if (!evidenceFile) continue;
-      const evidence = JSON.parse(execFileSync('unzip', ['-p', zipPath, evidenceFile], { encoding: 'utf8' })) as StagingEvidence;
-      if (matchesSuccessfulStagingEvidence(evidence, targetDigest)) return;
+      const evidence = JSON.parse(
+        execFileSync('unzip', ['-p', zipPath, evidenceFile], { encoding: 'utf8' })
+      ) as StagingEvidence;
+      if (
+        evidenceKind === 'promote'
+          ? matchesSuccessfulStagingEvidence(evidence, targetDigest)
+          : matchesSuccessfulStagingBackupEvidence(evidence, targetDigest)
+      )
+        return;
     }
     throw new Error(`Kein erfolgreicher Staging-Paritätsnachweis für ${targetDigest} gefunden.`);
-  } finally { rmSync(workdir, { force: true, recursive: true }); }
+  } finally {
+    rmSync(workdir, { force: true, recursive: true });
+  }
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  try { main(); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exitCode = 1; }
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Zusammenfassung
- ergänzt einen geschützten Production-Backup-Drill ohne Deployment oder One-shot-Mutationen
- bindet den Lauf an Wartungsfenster, exakten Image-Digest und erfolgreichen Staging-Drill
- ergänzt Vertrags- und Evidenztests sowie das Runbook

## Tests
- `pnpm exec vitest run scripts/ci/promote-workflow-contract.test.ts scripts/ci/verify-staging-promote-evidence.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `openspec validate add-central-backup-agent --strict`
- `pnpm check:file-placement`