### PR TITLE
fix: accept staging backup evidence bundle

### DIFF
--- a/docs/changelog/entries/pr-782.json
+++ b/docs/changelog/entries/pr-782.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 782,
+  "body": "Der Production-Backup-Drill erkennt den vollständigen Staging-Nachweis nun zuverlässig und bleibt bei mehrdeutigen Agent-Ergebnissen weiterhin gesperrt."
+}

--- a/scripts/ci/verify-staging-promote-evidence.test.ts
+++ b/scripts/ci/verify-staging-promote-evidence.test.ts
@@ -8,6 +8,7 @@ import {
   matchesSuccessfulStagingBackupEvidence,
   matchesSuccessfulStagingEvidence,
   selectEvidenceJsonFile,
+  selectStagingBackupEvidenceJsonFile,
 } from './verify-staging-promote-evidence.ts';
 
 describe('staging parity evidence', () => {
@@ -123,6 +124,22 @@ describe('staging parity evidence', () => {
     expect(selectEvidenceJsonFile('evidence.json\n')).toBe('evidence.json');
     expect(selectEvidenceJsonFile('evidence.json\nmetadata.json\n')).toBeUndefined();
     expect(selectEvidenceJsonFile('README.md\n')).toBeUndefined();
+  });
+
+  it('selects the unique agent result when a staging drill artifact contains verification evidence', () => {
+    const archiveEntries = [
+      'promote-backup-agent-gha-30512741172-1.json',
+      'promote-backup-verification-30512741172-1.json',
+    ].join('\n');
+
+    expect(selectStagingBackupEvidenceJsonFile(archiveEntries)).toBe(
+      'promote-backup-agent-gha-30512741172-1.json'
+    );
+    expect(
+      selectStagingBackupEvidenceJsonFile(
+        `${archiveEntries}\npromote-backup-agent-gha-duplicate.json\n`
+      )
+    ).toBeUndefined();
   });
 
   it('downloads parity artifacts through gh api without unsupported output flags', () => {

--- a/scripts/ci/verify-staging-promote-evidence.ts
+++ b/scripts/ci/verify-staging-promote-evidence.ts
@@ -59,6 +59,13 @@ export const selectEvidenceJsonFile = (archiveEntries: string) => {
   const files = archiveEntries.split('\n').filter((entry) => entry.endsWith('.json'));
   return files.length === 1 ? files[0] : undefined;
 };
+
+export const selectStagingBackupEvidenceJsonFile = (archiveEntries: string) => {
+  const files = archiveEntries
+    .split('\n')
+    .filter((entry) => /(^|\/)promote-backup-agent-[^/]+\.json$/u.test(entry));
+  return files.length === 1 ? files[0] : undefined;
+};
 const required = (value: string | undefined, name: string) => {
   const trimmed = value?.trim();
   if (!trimmed) throw new Error(`${name} darf nicht leer sein.`);
@@ -109,9 +116,11 @@ const main = () => {
           env: { ...process.env, GH_TOKEN: required(process.env.GITHUB_TOKEN, 'GITHUB_TOKEN') },
         })
       );
-      const evidenceFile = selectEvidenceJsonFile(
-        execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf8' })
-      );
+      const archiveEntries = execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf8' });
+      const evidenceFile =
+        evidenceKind === 'promote'
+          ? selectEvidenceJsonFile(archiveEntries)
+          : selectStagingBackupEvidenceJsonFile(archiveEntries);
       if (!evidenceFile) continue;
       const evidence = JSON.parse(
         execFileSync('unzip', ['-p', zipPath, evidenceFile], { encoding: 'utf8' })


### PR DESCRIPTION
## Ursache
Der Staging-Drill lädt sowohl das Agent-Ergebnis als auch die Objektverifikation als JSON hoch. Der Production-Paritätsprüfer verlangte irrtümlich genau eine JSON-Datei und verwarf deshalb den gültigen Nachweis.

## Fix
- wählt für Backup-Drills ausschließlich das eindeutig benannte Agent-Ergebnis
- bleibt bei fehlenden oder doppelten Agent-Ergebnissen fail-closed
- ergänzt den reproduzierenden Test

## Tests
- `pnpm exec vitest run scripts/ci/verify-staging-promote-evidence.test.ts scripts/ci/promote-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`