### PR TITLE
fix: allow production backup drill identity

### DIFF
--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -2,7 +2,7 @@ services:
   backup-agent:
     image: ${IMAGE_REF}
     environment:
-      BACKUP_AGENT_ALLOWED_WORKFLOWS: promote.yml,staging-backup-drill.yml
+      BACKUP_AGENT_ALLOWED_WORKFLOWS: promote.yml,staging-backup-drill.yml,production-backup-drill.yml
       BACKUP_AGENT_GITHUB_REPOSITORY: smart-village-solutions/sva-studio
       BACKUP_AGENT_IMAGE_REF: ${IMAGE_REF}
       BACKUP_AGENT_OIDC_AUDIENCE: studio-backup-agent

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { canonicalRequest, controlKeysFor, minioAwsCompatibilityEnv, runCommand, safeErrorCode, validateOidcClaims, validRequest, validRequestHost } from './agent.mjs';
+import {
+  canonicalRequest,
+  controlKeysFor,
+  minioAwsCompatibilityEnv,
+  runCommand,
+  safeErrorCode,
+  validateOidcClaims,
+  validRequest,
+  validRequestHost,
+} from './agent.mjs';
 
 const request = {
   version: 1,
@@ -15,7 +24,8 @@ describe('backup agent runtime contract', () => {
   it('binds GitHub identity to repository, environment and allowlisted main workflow', () => {
     process.env.BACKUP_AGENT_OIDC_AUDIENCE = 'studio-backup-agent';
     process.env.BACKUP_AGENT_GITHUB_REPOSITORY = 'smart-village-solutions/sva-studio';
-    process.env.BACKUP_AGENT_ALLOWED_WORKFLOWS = 'promote.yml,staging-backup-drill.yml';
+    process.env.BACKUP_AGENT_ALLOWED_WORKFLOWS =
+      'promote.yml,staging-backup-drill.yml,production-backup-drill.yml';
     const claims = {
       aud: 'studio-backup-agent',
       environment: 'staging',
@@ -23,31 +33,80 @@ describe('backup agent runtime contract', () => {
       iss: 'https://token.actions.githubusercontent.com',
       nbf: 900,
       repository: 'smart-village-solutions/sva-studio',
-      workflow_ref: 'smart-village-solutions/sva-studio/.github/workflows/promote.yml@refs/heads/main',
+      workflow_ref:
+        'smart-village-solutions/sva-studio/.github/workflows/promote.yml@refs/heads/main',
     };
     expect(() => validateOidcClaims(claims, 'staging', 1_000)).not.toThrow();
-    expect(() => validateOidcClaims({ ...claims, environment: 'prod' }, 'staging', 1_000)).toThrow('oidc_environment_invalid');
-    expect(() => validateOidcClaims({ ...claims, workflow_ref: 'smart-village-solutions/sva-studio/.github/workflows/untrusted.yml@refs/heads/main' }, 'staging', 1_000)).toThrow('oidc_workflow_invalid');
-    expect(() => validateOidcClaims({
-      ...claims,
-      job_workflow_ref: claims.workflow_ref,
-      workflow_ref: 'smart-village-solutions/sva-studio/.github/workflows/build.yml@refs/heads/main',
-    }, 'staging', 1_000)).not.toThrow();
+    expect(() => validateOidcClaims({ ...claims, environment: 'prod' }, 'staging', 1_000)).toThrow(
+      'oidc_environment_invalid'
+    );
+    expect(() =>
+      validateOidcClaims(
+        {
+          ...claims,
+          environment: 'prod',
+          workflow_ref:
+            'smart-village-solutions/sva-studio/.github/workflows/production-backup-drill.yml@refs/heads/main',
+        },
+        'prod',
+        1_000
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateOidcClaims(
+        {
+          ...claims,
+          workflow_ref:
+            'smart-village-solutions/sva-studio/.github/workflows/untrusted.yml@refs/heads/main',
+        },
+        'staging',
+        1_000
+      )
+    ).toThrow('oidc_workflow_invalid');
+    expect(() =>
+      validateOidcClaims(
+        {
+          ...claims,
+          job_workflow_ref: claims.workflow_ref,
+          workflow_ref:
+            'smart-village-solutions/sva-studio/.github/workflows/build.yml@refs/heads/main',
+        },
+        'staging',
+        1_000
+      )
+    ).not.toThrow();
   });
   it('accepts only short-lived requests', () => {
     expect(validRequest(request, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(true);
-    expect(validRequest({ ...request, expiresAt: '2026-07-30T10:10:00.001Z' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(false);
+    expect(
+      validRequest(
+        { ...request, expiresAt: '2026-07-30T10:10:00.001Z' },
+        Date.parse('2026-07-30T10:00:00.000Z')
+      )
+    ).toBe(false);
   });
 
   it('requires production maintenance evidence', () => {
-    expect(validRequest({ ...request, environment: 'prod' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(false);
-    expect(validRequest({ ...request, environment: 'prod', maintenanceWindowReference: 'CAB-42' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(true);
+    expect(
+      validRequest({ ...request, environment: 'prod' }, Date.parse('2026-07-30T10:00:00.000Z'))
+    ).toBe(false);
+    expect(
+      validRequest(
+        { ...request, environment: 'prod', maintenanceWindowReference: 'CAB-42' },
+        Date.parse('2026-07-30T10:00:00.000Z')
+      )
+    ).toBe(true);
   });
 
   it('canonicalizes requests without accepting target overrides', () => {
     expect(canonicalRequest(request)).not.toContain('bucket');
     expect(canonicalRequest(request)).not.toContain('postgresHost');
-    expect(validRequest({ ...request, bucket: 'studio-db-backup-production' }, Date.parse('2026-07-30T10:00:00.000Z'))).toBe(false);
+    expect(
+      validRequest(
+        { ...request, bucket: 'studio-db-backup-production' },
+        Date.parse('2026-07-30T10:00:00.000Z')
+      )
+    ).toBe(false);
   });
 
   it('accepts only the dedicated host of the requested environment', () => {
@@ -73,15 +132,15 @@ describe('backup agent runtime contract', () => {
   });
 
   it('never propagates credentials or shell traces into terminal error codes', () => {
-    expect(safeErrorCode(new Error('aws_failed_1:https://access:secret@minio/upload shell trace'))).toBe('aws_failed_1');
+    expect(
+      safeErrorCode(new Error('aws_failed_1:https://access:secret@minio/upload shell trace'))
+    ).toBe('aws_failed_1');
     expect(safeErrorCode(new Error('password=secret'))).toBe('backup_failed');
   });
 
   it('terminates an external command after its explicit deadline', async () => {
-    await expect(runCommand(
-      process.execPath,
-      ['-e', 'setTimeout(() => {}, 60_000)'],
-      { timeoutMs: 25 },
-    )).rejects.toThrow(`${process.execPath}_timeout`);
+    await expect(
+      runCommand(process.execPath, ['-e', 'setTimeout(() => {}, 60_000)'], { timeoutMs: 25 })
+    ).rejects.toThrow(`${process.execPath}_timeout`);
   });
 });

--- a/docs/changelog/entries/pr-783.json
+++ b/docs/changelog/entries/pr-783.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 783,
+  "body": "Der Production-Backup-Drill ist in der OIDC-Allowlist des Backup-Agenten freigegeben und kann damit seinen signierten Auftrag ausführen."
+}


### PR DESCRIPTION
## Ursache
Der dauerhafte Backup-Agent erlaubte den neuen Production-Drill nicht in seiner GitHub-OIDC-Workflow-Allowlist und lehnte dessen Auftrag daher vor dem Backup mit HTTP 400 ab.

## Fix
- ergänzt `production-backup-drill.yml` in der Agent-Allowlist
- testet den Production-OIDC-Pfad

## Tests
- `pnpm exec vitest run deploy/backup-agent/agent.test.ts`