### PR TITLE
fix: use production postgres swarm host

### DIFF
--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -25,7 +25,7 @@ const required = (value, name) => {
 
 const readSecret = async (name) => (await readFile(required(process.env[name], name), 'utf8')).trim();
 
-const targets = {
+export const targets = {
   staging: {
     host: 'backup-studio-staging.smart-village.app',
     bucket: 'studio-db-backup-staging',
@@ -42,7 +42,7 @@ const targets = {
     host: 'backup-studio.smart-village.app',
     bucket: 'studio-db-backup-production',
     prefix: 'prod',
-    postgresHost: 'studio-prod_postgres',
+    postgresHost: 'studio_postgres',
     postgresDatabase: process.env.BACKUP_PROD_POSTGRES_DB || 'sva_studio',
     postgresUser: process.env.BACKUP_PROD_POSTGRES_USER || 'sva',
     postgresPasswordFile: 'BACKUP_PROD_POSTGRES_PASSWORD_FILE',

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -6,6 +6,7 @@ import {
   minioAwsCompatibilityEnv,
   runCommand,
   safeErrorCode,
+  targets,
   validateOidcClaims,
   validRequest,
   validRequestHost,
@@ -115,6 +116,11 @@ describe('backup agent runtime contract', () => {
     expect(validRequestHost('staging', 'backup-studio.smart-village.app')).toBe(false);
     expect(validRequestHost('prod', 'studio.smart-village.app')).toBe(false);
     expect(validRequestHost('unknown', 'backup-studio-staging.smart-village.app')).toBe(false);
+  });
+
+  it('uses the verified Swarm DNS names for both database stacks', () => {
+    expect(targets.staging.postgresHost).toBe('studio-staging_postgres');
+    expect(targets.prod.postgresHost).toBe('studio_postgres');
   });
 
   it('uses persistent MinIO control keys for replay and terminal evidence', () => {

--- a/docs/changelog/entries/pr-784.json
+++ b/docs/changelog/entries/pr-784.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 784,
+  "body": "Production-Backups verwenden nun den verifizierten Swarm-DNS-Namen der Produktionsdatenbank."
+}


### PR DESCRIPTION
## Ursache
Der Backup-Agent verwendete `studio-prod_postgres`, der live verifizierte Production-Stack heißt jedoch `studio`; der Swarm-DNS-Service ist daher `studio_postgres`.

## Fix
- korrigiert ausschließlich den Production-PostgreSQL-Host
- ergänzt einen Regressionstest für beide verifizierten Swarm-DNS-Namen

## Tests
- `pnpm exec vitest run deploy/backup-agent/agent.test.ts`