### PR TITLE
fix: bind verified production backup secret

### DIFF
--- a/deploy/backup-agent-stack.test.ts
+++ b/deploy/backup-agent-stack.test.ts
@@ -21,6 +21,7 @@ describe('backup agent stack', () => {
     expect(source).toContain('BACKUP_PROD_POSTGRES_USER: sva');
     expect(source).toContain('BACKUP_STAGING_POSTGRES_DB: sva_studio');
     expect(source).toContain('source: backup_staging_postgres_password_v3');
+    expect(source).toContain('source: backup_prod_postgres_password_v2');
     expect(source).toContain('target: backup_staging_postgres_password');
     expect(source).toContain('BACKUP_PROD_POSTGRES_DB: sva_studio');
   });

--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -30,7 +30,8 @@ services:
       - backup_staging_s3_access_key
       - backup_staging_s3_secret_key
       - backup_staging_signing_key
-      - backup_prod_postgres_password
+      - source: backup_prod_postgres_password_v2
+        target: backup_prod_postgres_password
       - backup_prod_s3_access_key
       - backup_prod_s3_secret_key
       - backup_prod_signing_key
@@ -80,7 +81,7 @@ secrets:
     external: true
   backup_staging_signing_key:
     external: true
-  backup_prod_postgres_password:
+  backup_prod_postgres_password_v2:
     external: true
   backup_prod_s3_access_key:
     external: true

--- a/docs/changelog/entries/pr-785.json
+++ b/docs/changelog/entries/pr-785.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 785,
+  "body": "Der zentrale Backup-Agent verwendet für Production nun das verifizierte, versionierte Datenbank-Secret; die erfolgreiche Production-Abnahme ist dokumentiert."
+}

--- a/docs/reports/central-backup-agent-production-acceptance.md
+++ b/docs/reports/central-backup-agent-production-acceptance.md
@@ -1,0 +1,49 @@
+# Production-Abnahme des zentralen Backup-Agenten
+
+## Ergebnis
+
+Der zentrale Backup-Agent wurde am 31. Juli 2026 nach expliziter
+Production-Freigabe erfolgreich für die Produktionsdatenbank abgenommen. Der
+GitHub-Actions-Lauf
+[30586702874](https://github.com/smart-village-solutions/sva-studio/actions/runs/30586702874)
+endete erfolgreich.
+
+Der Auftrag `gha-30586702874-1` erzeugte im Bucket
+`studio-db-backup-production` einen PostgreSQL-Custom-Dump mit 1.771.009 Byte.
+Der Agent lud das Objekt erneut herunter und bestätigte:
+
+- Größenübereinstimmung und SHA-256-Prüfsumme,
+- ein separat persistiertes `.sha256`-Objekt,
+- ein mit `pg_restore` lesbares Archiv,
+- ein terminales, redigiertes Ergebnisobjekt mit Status `succeeded`.
+
+Der geprüfte Dump liegt unter dem Präfix `prod/2026-07-30T22-20-55-899Z/`.
+Request, Ergebnis, Dump und Prüfsummen-Sidecar wurden unabhängig über den
+S3-kompatiblen MinIO-Endpunkt verifiziert. Es handelt sich damit nicht um
+temporäre GitHub-Runner-Artefakte.
+
+## Verwendete unveränderliche Images
+
+- Anwendungs-Digest:
+  `sha256:753275384b5943c19a5e78eab1ff33adb6ad02c6f0412e43c04ecf726a170f0f`
+- Backup-Agent:
+  `ghcr.io/smart-village-solutions/sva-studio-backup-agent@sha256:65ab2ce1fc613ccdb33b7eff3955efd470d2fc4c302effd39b6b29e6e209b6b4`
+
+## Operative Korrektur
+
+Vor der erfolgreichen Abnahme wurde festgestellt, dass das eingebundene
+Production-Datenbank-Secret nicht dem laufenden Fileserver entsprach. Der Wert
+wurde ohne Ausgabe oder Protokollierung als versioniertes Swarm-Secret
+`backup_prod_postgres_password_v2` angelegt und unter dem unveränderten
+Dateinamen des Agenten eingebunden. DNS-Ziel, Datenbankname und Datenbankbenutzer
+wurden separat gegen den laufenden Production-Stack geprüft.
+
+Zugangsdaten, signierte Requests und Datenbankinhalte wurden weder in GitHub
+Actions noch in diese Dokumentation übernommen.
+
+## Noch offene Abgrenzung
+
+Diese Abnahme erfüllt Task 5.3 von `add-central-backup-agent`. Der vollständige
+Production-Promote aus Task 4.3 von `add-promote-backup-production-parity`
+bleibt separat offen; ein erfolgreicher Backup-Drill allein belegt noch keinen
+Promote einschließlich Migration, Bootstrap, Deployment und Smoke-Evidenz.

--- a/docs/staging/2026-07/zentraler-backup-agent-abnahme.md
+++ b/docs/staging/2026-07/zentraler-backup-agent-abnahme.md
@@ -61,5 +61,7 @@ Für die reale Umgebung waren drei Abweichungen zu korrigieren:
   Ausgabe als versioniertes Swarm-Secret
   `backup_staging_postgres_password_v3` gebunden.
 
-Production wurde weder gesichert noch anderweitig mutiert. Die
-Production-Abnahme bleibt bis zu einer expliziten Freigabe offen.
+Die Production-Abnahme wurde nach der expliziten Freigabe separat durchgeführt
+und ist unter
+[Production-Abnahme des zentralen Backup-Agenten](../../reports/central-backup-agent-production-acceptance.md)
+dokumentiert.

--- a/openspec/changes/add-central-backup-agent/tasks.md
+++ b/openspec/changes/add-central-backup-agent/tasks.md
@@ -30,5 +30,5 @@
 
 - [x] 5.1 Arc42-Abschnitte 05, 06, 07, 08, 09 und 11 sowie das Swarm-Runbook aktualisieren; eine ADR für die zentrale Vertrauenszone und den gehärteten HTTPS-Kontrollkanal erstellen.
 - [x] 5.2 Staging-Agent bereitstellen, Health-/Tool-Vertrag sowie einen erfolgreichen Backup-Drill mit Dump, Prüfsumme und Evidenz in MinIO nachweisen.
-- [ ] 5.3 Nach expliziter Production-Freigabe den Production-Agentenpfad mit demselben Nachweis abnehmen.
+- [x] 5.3 Nach expliziter Production-Freigabe den Production-Agentenpfad mit demselben Nachweis abnehmen.
 - [ ] 5.4 Erst nach 5.2 und 5.3 Task 4.3 von `add-promote-backup-production-parity` schließen.


### PR DESCRIPTION
## Zusammenfassung

- bindet das versionierte, gegen die laufende Production-Konfiguration verifizierte DB-Secret
- hält die Secret-Zieldatei für den Agenten stabil
- dokumentiert den erfolgreichen Production-Backup-Drill und schließt OpenSpec-Task 5.3

## Verifikation

- `pnpm exec vitest run deploy/backup-agent-stack.test.ts deploy/backup-agent/agent.test.ts`
- `openspec validate add-central-backup-agent --strict`
- `pnpm check:file-placement`
- Production Backup Drill: https://github.com/smart-village-solutions/sva-studio/actions/runs/30586702874