### PR TITLE
fix: target verified production stack during promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -234,6 +234,10 @@ jobs:
           api-key: ${{ secrets.QUANTUM_API_KEY }}
           version: 3.2.1
 
+      - name: resolve deployment target
+        id: target
+        run: pnpm exec tsx scripts/ci/promote-target.ts "${{ inputs.environment }}"
+
       - name: capture previous live app digest
         id: previous_live_image
         if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}
@@ -363,14 +367,14 @@ jobs:
           docker compose -f compose.yaml -f ./deploy/compose.${ENVIRONMENT}.yaml config --no-normalize --format json > stack.json
           pnpm exec tsx scripts/ci/render-quantum-stack.ts --input stack.json --output stack.yaml
 
-          quantum-cli stacks deploy -f stack.yaml --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}"
+          quantum-cli stacks deploy -f stack.yaml --stack "${{ steps.target.outputs.stack_name }}" --endpoint "${QUANTUM_ENDPOINT}"
 
       - name: verify deployed runtime
         if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
-          SVA_STACK_NAME: studio-${{ inputs.environment }}
+          SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}
         run: |
           set -euo pipefail
           umask 077

--- a/docs/changelog/entries/pr-786.json
+++ b/docs/changelog/entries/pr-786.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 786,
+  "body": "Production-Promotes verwenden nun durchgängig den bestehenden, verifizierten Swarm-Stack `studio`."
+}

--- a/scripts/ci/promote-live-digest.ts
+++ b/scripts/ci/promote-live-digest.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 
 import { commandExists, runCapture } from '../ops/runtime/process.ts';
 import { inspectRemoteServiceContract } from '../ops/runtime/remote-service-spec.ts';
+import { stackNameForEnvironment } from './promote-target.ts';
 
 const rootDir = resolve(import.meta.dirname, '../..');
 
@@ -26,7 +27,7 @@ const main = async () => {
   const expectedImage = expectedFlagIndex === -1 ? undefined : required(process.argv[expectedFlagIndex + 1], '--expected');
 
   const quantumEndpoint = required(process.env.QUANTUM_ENDPOINT, 'QUANTUM_ENDPOINT');
-  const stackName = `studio-${environment}`;
+  const stackName = stackNameForEnvironment(environment);
   const contract = await inspectRemoteServiceContract(
     {
       commandExists: (command) => commandExists(rootDir, command),

--- a/scripts/ci/promote-one-shot-job.ts
+++ b/scripts/ci/promote-one-shot-job.ts
@@ -8,6 +8,7 @@ import { pickInternalNetworkName } from '../ops/runtime/internal-network.ts';
 import { runMigrationJobAgainstAcceptance } from '../ops/runtime/migration-job.ts';
 import { commandExists, run, runCapture, runCaptureDetailed, spawnBackground, wait } from '../ops/runtime/process.ts';
 import { inspectRemoteServiceContract } from '../ops/runtime/remote-service-spec.ts';
+import { stackNameForEnvironment } from './promote-target.ts';
 
 type JobKind = 'bootstrap' | 'migration';
 type PromoteEnvironment = 'dev' | 'prod' | 'staging';
@@ -52,7 +53,7 @@ const main = async () => {
   const quantumEndpoint = required(process.env.QUANTUM_ENDPOINT, 'QUANTUM_ENDPOINT');
   const runId = required(process.env.GITHUB_RUN_ID, 'GITHUB_RUN_ID');
   const attempt = required(process.env.GITHUB_RUN_ATTEMPT, 'GITHUB_RUN_ATTEMPT');
-  const sourceStackName = `studio-${environment}`;
+  const sourceStackName = stackNameForEnvironment(environment);
   const resultPath = resolve(process.env.RUNNER_TEMP ?? rootDir, `promote-${kind}-${runId}-${attempt}.json`);
   const reportId = `gha-${runId}-${attempt}`;
   const env: NodeJS.ProcessEnv = { ...process.env, QUANTUM_ENVIRONMENT: 'studio' };

--- a/scripts/ci/promote-target.test.ts
+++ b/scripts/ci/promote-target.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { stackNameForEnvironment } from './promote-target.ts';
+
+describe('stackNameForEnvironment', () => {
+  it.each([
+    ['dev', 'studio-dev'],
+    ['staging', 'studio-staging'],
+    ['prod', 'studio'],
+  ] as const)('maps %s to the verified live stack %s', (environment, expected) => {
+    expect(stackNameForEnvironment(environment)).toBe(expected);
+  });
+});

--- a/scripts/ci/promote-target.ts
+++ b/scripts/ci/promote-target.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export type PromoteEnvironment = 'dev' | 'prod' | 'staging';
+
+export const stackNameForEnvironment = (environment: PromoteEnvironment): string =>
+  environment === 'prod' ? 'studio' : `studio-${environment}`;
+
+const main = () => {
+  const environment = process.argv[2];
+  if (environment !== 'dev' && environment !== 'staging' && environment !== 'prod') {
+    throw new Error('Ungültige Zielumgebung; erwartet wird dev, staging oder prod.');
+  }
+
+  const stackName = stackNameForEnvironment(environment);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `stack_name=${stackName}\n`);
+  } else {
+    process.stdout.write(`${stackName}\n`);
+  }
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -44,7 +44,9 @@ describe('Promote workflow contract', () => {
     expect(
       workflow.match(/printf '%s\\n' "\$\{APP_CONFIG\}" > config\/runtime\/base\.vars/gu)
     ).toHaveLength(2);
-    expect(workflow).toContain('SVA_STACK_NAME: studio-${{ inputs.environment }}');
+    expect(workflow).toContain('pnpm exec tsx scripts/ci/promote-target.ts "${{ inputs.environment }}"');
+    expect(workflow).toContain('SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}');
+    expect(workflow).toContain('--stack "${{ steps.target.outputs.stack_name }}"');
     expect(workflow).toContain('QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}');
   });
 

--- a/tooling/testing/tests/deployment-contract.test.ts
+++ b/tooling/testing/tests/deployment-contract.test.ts
@@ -43,7 +43,7 @@ describe('deployment contracts', () => {
     const workflow = load('.github/workflows/promote.yml');
 
     expect(workflow).toContain(
-      'quantum-cli stacks deploy -f stack.yaml --stack "studio-${ENVIRONMENT}" --endpoint "${QUANTUM_ENDPOINT}"'
+      'quantum-cli stacks deploy -f stack.yaml --stack "${{ steps.target.outputs.stack_name }}" --endpoint "${QUANTUM_ENDPOINT}"'
     );
     expect(workflow).not.toContain('--no-pre-pull');
     expect(workflow).not.toContain('quantum_project_dir');


### PR DESCRIPTION
## Zusammenfassung

- bildet die Production-Umgebung auf den bestehenden Swarm-Stack `studio` ab
- verwendet dieselbe zentrale Zielauflösung für Live-Digest, One-shot-Jobs, Deployment und Smoke-Test
- verhindert die versehentliche Anlage eines parallelen `studio-prod`-Stacks

## Verifikation

- gezielte Vitest-Suite: 12 Tests grün
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`