### PR TITLE
fix: pass deployment target to promote postconditions

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -326,6 +326,8 @@ jobs:
         if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}
         run: |
           set -euo pipefail
           umask 077

--- a/docs/changelog/entries/pr-787.json
+++ b/docs/changelog/entries/pr-787.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 787,
+  "body": "Das Promote-Postcondition-Gate prüft nun den aufgelösten Ziel-Stack über den konfigurierten Quantum-Endpoint."
+}

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -44,6 +44,9 @@ describe('Promote workflow contract', () => {
     expect(
       workflow.match(/printf '%s\\n' "\$\{APP_CONFIG\}" > config\/runtime\/base\.vars/gu)
     ).toHaveLength(2);
+    expect(
+      workflow.match(/SVA_STACK_NAME: \$\{\{ steps\.target\.outputs\.stack_name \}\}/gu)
+    ).toHaveLength(2);
     expect(workflow).toContain('pnpm exec tsx scripts/ci/promote-target.ts "${{ inputs.environment }}"');
     expect(workflow).toContain('SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}');
     expect(workflow).toContain('--stack "${{ steps.target.outputs.stack_name }}"');


### PR DESCRIPTION
## Zusammenfassung

- übergibt dem Remote-Doctor den bereits aufgelösten Stacknamen
- übergibt den konfigurierten Quantum-Endpoint explizit
- hält das Postcondition-Gate für Staging und Production fail-closed

## Verifikation

- Promote-Workflow-Vertrag: 6 Tests grün
- Deployment-Vertrag: 11 Tests grün
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`

Gefunden im kontrollierten Staging-Promote 30615332227; Backup, Migration und Bootstrap waren erfolgreich, der App-Deploy wurde korrekt blockiert.