### PR TITLE
fix: verify live runtime contract for remote doctor

### DIFF
--- a/docs/changelog/entries/pr-788.json
+++ b/docs/changelog/entries/pr-788.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 788,
+  "body": "Remote-Doctor und Smoke prüfen nun den laufenden Service-Vertrag, ohne lokale Kopien produktiver Swarm-Secrets zu verlangen."
+}

--- a/scripts/ops/runtime/doctor.test.ts
+++ b/scripts/ops/runtime/doctor.test.ts
@@ -108,6 +108,8 @@ describe('createRuntimeDoctorOps', () => {
     } satisfies AcceptanceDeployOptions);
 
     expect(remoteReport.checks.map((check) => check.name)).toContain('acceptance-service');
+    expect(remoteReport.checks.map((check) => check.name)).toContain('runtime-env-live');
+    expect(remoteReport.checks.map((check) => check.name)).not.toContain('runtime-env');
     expect(remoteReport.checks.map((check) => check.name)).not.toContain('otel');
     expect(localBuilderReport.checks.map((check) => check.name)).toContain('otel');
     expect(localKeycloakReport.checks.map((check) => check.name)).toContain('actor-diagnosis');

--- a/scripts/ops/runtime/doctor.ts
+++ b/scripts/ops/runtime/doctor.ts
@@ -181,7 +181,11 @@ const doctorRuntime = async (
   env: NodeJS.ProcessEnv,
 ): Promise<DoctorReport> => {
   const checks: DoctorCheck[] = [];
-  addRuntimeEnvCheck(deps, checks, runtimeProfile, env, 'Runtime-Profil ist nicht vollstaendig konfiguriert.');
+  if (deps.isRemoteRuntimeProfile(runtimeProfile)) {
+    checks.push(await deps.buildLiveRuntimeEnvCheck(runtimeProfile, env));
+  } else {
+    addRuntimeEnvCheck(deps, checks, runtimeProfile, env, 'Runtime-Profil ist nicht vollstaendig konfiguriert.');
+  }
   checks.push(deps.buildLocalProvisioningWorkerCheck(runtimeProfile, deps.readLocalWorkerState(deps.localWorkerStateFile)));
   await addEndpointChecks(deps, checks, env.SVA_PUBLIC_BASE_URL ?? 'http://localhost:3000');
   await addAuthChecks(deps, checks, runtimeProfile, env);


### PR DESCRIPTION
## Zusammenfassung

- validiert Remote-Profile anhand des laufenden Service-Vertrags
- verlangt keine lokalen Kopien von Swarm-Secrets für Remote-Doctor und Smoke
- behält die strikte Variablenvalidierung für lokale Profile bei

## Verifikation

- Doctor-, Smoke- und Promote-Vertrag: 13 Tests grün
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`

Gefunden im Staging-Promote 30616629782: Live, Ready, DB, Redis, Keycloak, Migration und Bootstrap waren grün; ausschließlich die lokale Secret-Vollständigkeitsprüfung blockierte.