### PR TITLE
fix: ignore unset optional live runtime flags

### DIFF
--- a/docs/changelog/entries/pr-789.json
+++ b/docs/changelog/entries/pr-789.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 789,
+  "body": "Der Live-Runtime-Check vergleicht optionale Flags nur noch, wenn dafür ein expliziter Sollwert konfiguriert ist."
+}

--- a/scripts/ops/runtime/runtime-health-doctor-checks.ts
+++ b/scripts/ops/runtime/runtime-health-doctor-checks.ts
@@ -66,6 +66,17 @@ const probeOidcClientSecret = async (probe: OidcClientSecretProbe): Promise<Oidc
   return evaluateOidcClientSecretProbeResponse(probe, response, await readJsonResponse(response));
 };
 
+export const buildExpectedLiveRuntimeFlags = (
+  runtimeProfile: RemoteRuntimeProfile,
+  env: NodeJS.ProcessEnv,
+): Partial<LiveRuntimeFlags> => ({
+  ...(env.ENABLE_OTEL?.trim() ? { ENABLE_OTEL: env.ENABLE_OTEL.trim() } : {}),
+  ...(env.SVA_ENABLE_SERVER_CONSOLE_LOGS?.trim()
+    ? { SVA_ENABLE_SERVER_CONSOLE_LOGS: env.SVA_ENABLE_SERVER_CONSOLE_LOGS.trim() }
+    : {}),
+  SVA_RUNTIME_PROFILE: runtimeProfile,
+});
+
 const buildLiveRuntimeEnvCheck = async (
   deps: RuntimeHealthDeps,
   runtimeProfile: RemoteRuntimeProfile,
@@ -73,11 +84,7 @@ const buildLiveRuntimeEnvCheck = async (
 ): Promise<DoctorCheck> => {
   try {
     const liveFlags = await readLiveRuntimeFlags(deps, env);
-    const expectedFlags = {
-      ENABLE_OTEL: env.ENABLE_OTEL?.trim() || '',
-      SVA_ENABLE_SERVER_CONSOLE_LOGS: env.SVA_ENABLE_SERVER_CONSOLE_LOGS?.trim() || '',
-      SVA_RUNTIME_PROFILE: runtimeProfile,
-    };
+    const expectedFlags = buildExpectedLiveRuntimeFlags(runtimeProfile, env);
     const mismatches = Object.entries(expectedFlags)
       .filter(([key, expectedValue]) => liveFlags[key as keyof LiveRuntimeFlags] !== expectedValue)
       .map(([key, expectedValue]) => ({ actual: liveFlags[key as keyof LiveRuntimeFlags], expected: expectedValue, key }));

--- a/scripts/ops/runtime/runtime-health.test.ts
+++ b/scripts/ops/runtime/runtime-health.test.ts
@@ -8,12 +8,27 @@ import {
   resolveRemoteShortServiceName,
   resolveRemoteStackServiceName,
 } from './runtime-health.ts';
+import { buildExpectedLiveRuntimeFlags } from './runtime-health-doctor-checks.ts';
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe('runtime-health helpers', () => {
+  it('compares only explicitly configured optional live runtime flags', () => {
+    expect(buildExpectedLiveRuntimeFlags('studio', {})).toEqual({
+      SVA_RUNTIME_PROFILE: 'studio',
+    });
+    expect(buildExpectedLiveRuntimeFlags('studio', {
+      ENABLE_OTEL: 'false',
+      SVA_ENABLE_SERVER_CONSOLE_LOGS: 'true',
+    })).toEqual({
+      ENABLE_OTEL: 'false',
+      SVA_ENABLE_SERVER_CONSOLE_LOGS: 'true',
+      SVA_RUNTIME_PROFILE: 'studio',
+    });
+  });
+
   it('builds all configured oidc client-secret probes', () => {
     expect(
       buildOidcClientSecretProbes({


### PR DESCRIPTION
## Zusammenfassung

- vergleicht optionale Live-Runtime-Flags nur bei explizitem Sollwert
- hält `SVA_RUNTIME_PROFILE` weiterhin strikt
- verhindert, dass ein fehlender CI-Sollwert fälschlich als erwarteter Leerstring gilt

## Verifikation

- Runtime-Health-, Doctor- und Smoke-Tests: 17 Tests grün
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`

Gefunden im Staging-Promote 30617725610: Live-Contract meldete ausschließlich `ENABLE_OTEL`: erwartet leer, live `false`; alle operativen Checks waren grün.