### PR TITLE
fix: allow remote smoke without local secrets

### DIFF
--- a/docs/changelog/entries/pr-790.json
+++ b/docs/changelog/entries/pr-790.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 790,
+  "body": "Remote-Smoke-Checks prüfen die laufende Umgebung, ohne lokale Kopien der Runtime-Secrets vorauszusetzen."
+}

--- a/scripts/ops/runtime/runtime-health-smoke.ts
+++ b/scripts/ops/runtime/runtime-health-smoke.ts
@@ -143,8 +143,8 @@ const assertBasicHealth = async (deps: RuntimeHealthDeps, env: NodeJS.ProcessEnv
 };
 
 const smokeRuntime = async (deps: RuntimeHealthDeps, runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) => {
-  deps.assertRuntimeEnv(runtimeProfile, env);
   const isLocalProfile = deps.getRuntimeProfileDefinition(runtimeProfile).isLocal;
+  if (isLocalProfile) deps.assertRuntimeEnv(runtimeProfile, env);
   if (!isLocalProfile) await deps.waitForRemoteSmokeWarmup(env, { runtimeProfile });
 
   await assertBasicHealth(deps, env);

--- a/scripts/ops/runtime/runtime-health.test.ts
+++ b/scripts/ops/runtime/runtime-health.test.ts
@@ -15,6 +15,68 @@ afterEach(() => {
 });
 
 describe('runtime-health helpers', () => {
+  it('requires complete local runtime variables before a local smoke', async () => {
+    const assertRuntimeEnv = vi.fn(() => {
+      throw new Error('missing local runtime variables');
+    });
+    const ops = createRuntimeHealthOps({
+      assertRuntimeEnv,
+      checkHttpHealth: vi.fn(),
+      commandExists: vi.fn(),
+      getConfiguredQuantumEndpoint: vi.fn(),
+      getConfiguredStackName: vi.fn(),
+      getRemoteAppServiceName: vi.fn(),
+      getRuntimeProfileDefinition: vi.fn(() => ({ isLocal: true })),
+      inspectRemoteServiceContract: vi.fn(),
+      isExpectedOidcRedirect: vi.fn(),
+      isMainserverCheckRequired: vi.fn(),
+      isMockAuthRuntimeProfile: vi.fn(),
+      readRemoteStackEvidence: vi.fn(),
+      resolveTenantRuntimeTargets: vi.fn(),
+      runCapture: vi.fn(),
+      runSchemaGuard: vi.fn(),
+      summarizeSchemaGuardFailures: vi.fn(),
+      toDoctorCheck: vi.fn(),
+      wait: vi.fn(),
+      waitForRemoteSmokeWarmup: vi.fn(),
+      withoutDebugEnv: vi.fn(),
+    });
+
+    await expect(ops.smokeRuntime('local-builder', {})).rejects.toThrow('missing local runtime variables');
+    expect(assertRuntimeEnv).toHaveBeenCalledWith('local-builder', {});
+  });
+
+  it('does not require local secret copies for a remote smoke', async () => {
+    const assertRuntimeEnv = vi.fn();
+    const ops = createRuntimeHealthOps({
+      assertRuntimeEnv,
+      checkHttpHealth: vi.fn(async () => ({ response: { ok: false, status: 503 } })),
+      commandExists: vi.fn(),
+      getConfiguredQuantumEndpoint: vi.fn(),
+      getConfiguredStackName: vi.fn(),
+      getRemoteAppServiceName: vi.fn(),
+      getRuntimeProfileDefinition: vi.fn(() => ({ isLocal: false })),
+      inspectRemoteServiceContract: vi.fn(),
+      isExpectedOidcRedirect: vi.fn(),
+      isMainserverCheckRequired: vi.fn(),
+      isMockAuthRuntimeProfile: vi.fn(),
+      readRemoteStackEvidence: vi.fn(),
+      resolveTenantRuntimeTargets: vi.fn(),
+      runCapture: vi.fn(),
+      runSchemaGuard: vi.fn(),
+      summarizeSchemaGuardFailures: vi.fn(),
+      toDoctorCheck: vi.fn(),
+      wait: vi.fn(),
+      waitForRemoteSmokeWarmup: vi.fn(async () => []),
+      withoutDebugEnv: vi.fn(),
+    });
+
+    await expect(
+      ops.smokeRuntime('studio', { SVA_PUBLIC_BASE_URL: 'https://studio.example.test' }),
+    ).rejects.toThrow('Live-Healthcheck fehlgeschlagen: 503');
+    expect(assertRuntimeEnv).not.toHaveBeenCalled();
+  });
+
   it('compares only explicitly configured optional live runtime flags', () => {
     expect(buildExpectedLiveRuntimeFlags('studio', {})).toEqual({
       SVA_RUNTIME_PROFILE: 'studio',


### PR DESCRIPTION
## Zusammenfassung
- lokale Runtime-Secret-Validierung bleibt für lokale Smoke-Checks bestehen
- Remote-Smoke-Checks prüfen die laufende Umgebung ohne Secret-Kopien im Runner
- Regressionstests für beide Pfade

## Tests
- `pnpm exec vitest run scripts/ops/runtime/runtime-health.test.ts scripts/ops/runtime/doctor.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`