### PR TITLE
fix: skip local secret gate for remote smoke

### DIFF
--- a/docs/changelog/entries/pr-791.json
+++ b/docs/changelog/entries/pr-791.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 791,
+  "body": "Der Remote-Command-Dispatcher führt Smoke-Checks ohne lokale Kopien der Runtime-Secrets aus."
+}

--- a/scripts/ops/runtime/acceptance-command.test.ts
+++ b/scripts/ops/runtime/acceptance-command.test.ts
@@ -18,6 +18,44 @@ const createCheck = (status: DoctorCheck['status'], message: string): DoctorChec
 });
 
 describe('createAcceptanceCommandRunner', () => {
+  it('runs a remote smoke without requiring local copies of runtime secrets', async () => {
+    const env = { SVA_PUBLIC_BASE_URL: 'https://studio.example.test', SVA_STACK_NAME: 'studio' };
+    const assertRuntimeEnv = vi.fn();
+    const smokeRuntime = vi.fn();
+    const runAcceptanceCommand = createAcceptanceCommandRunner({
+      applyCliOptionEnvOverrides: vi.fn((profileEnv) => profileEnv),
+      assertDangerousOperationApproved: vi.fn(),
+      assertDeterministicRemoteMutationContext: vi.fn(),
+      assertRuntimeEnv,
+      buildProfileEnv: vi.fn(() => env),
+      cliOptions: {},
+      doctorRuntime: vi.fn(async () => createDoctorReport()),
+      getConfiguredStackName: vi.fn(() => 'studio'),
+      getRuntimeStatusExecutionMode: () => 'remote',
+      migrateAcceptance: vi.fn(),
+      precheckAcceptance: vi.fn(async () => createDoctorReport()),
+      printDoctorReport: vi.fn(),
+      readRemoteStackEvidence: vi.fn(async () => ({ summary: 'ok' })),
+      resetAcceptance: vi.fn(),
+      resolveRemoteDangerousApprovalRequirement: vi.fn(),
+      rootDir: '/repo',
+      run: vi.fn(),
+      runAcceptanceDeploy: vi.fn(),
+      runSchemaGuard: vi.fn(() => ({ ok: true })),
+      runtimeDoctorDbCheckOps: {
+        buildInstanceHostnameMappingCheck: vi.fn(),
+        runSchemaGuard: vi.fn(() => ({ ok: true })),
+      },
+      smokeRuntime,
+      summarizeSchemaGuardFailures: vi.fn(),
+    });
+
+    await runAcceptanceCommand('studio', 'smoke');
+
+    expect(smokeRuntime).toHaveBeenCalledWith('studio', env);
+    expect(assertRuntimeEnv).not.toHaveBeenCalled();
+  });
+
   it('verifies hostname mappings after reset before reporting success', async () => {
     const buildInstanceHostnameMappingCheck = vi.fn(async () => createCheck('ok', 'ok'));
     const runSchemaGuard = vi.fn(() => ({ ok: true }));

--- a/scripts/ops/runtime/acceptance-command.ts
+++ b/scripts/ops/runtime/acceptance-command.ts
@@ -157,7 +157,6 @@ export const createAcceptanceCommandRunner = (deps: AcceptanceCommandDeps) => {
         await deps.runAcceptanceDeploy(runtimeProfile, env);
       },
       smoke: async () => {
-        deps.assertRuntimeEnv(runtimeProfile, env);
         await deps.smokeRuntime(runtimeProfile, env);
         console.log(`Smoke-Checks fuer ${runtimeProfile} erfolgreich.`);
       },


### PR DESCRIPTION
## Zusammenfassung
- entfernt die lokale Secret-Vollständigkeitsprüfung aus dem Remote-Smoke-Dispatcher
- belässt die eigentlichen Remote-Laufzeit- und HTTP-Prüfungen unverändert
- ergänzt einen Regressionstest für den Command-Pfad

## Tests
- `pnpm exec vitest run scripts/ops/runtime/acceptance-command.test.ts scripts/ops/runtime/runtime-health.test.ts scripts/ops/runtime/doctor.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`