### PR TITLE
fix: derive remote smoke services from live contract

### DIFF
--- a/docs/changelog/entries/pr-792.json
+++ b/docs/changelog/entries/pr-792.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 792,
+  "body": "Remote-Smoke-Checks leiten optionale Dienst-Erwartungen aus dem laufenden App-Service statt aus lokalen Standardwerten ab."
+}

--- a/scripts/ops/runtime/runtime-health-smoke.ts
+++ b/scripts/ops/runtime/runtime-health-smoke.ts
@@ -112,7 +112,21 @@ const assertRemoteEvidenceHasServices = async (deps: RuntimeHealthDeps, env: Nod
 const assertAcceptanceContainerHealth = async (deps: RuntimeHealthDeps, env: NodeJS.ProcessEnv) => {
   const stackName = deps.getConfiguredStackName(env);
   const appServiceName = resolveRemoteShortServiceName(stackName, deps.getRemoteAppServiceName(env));
-  const services = resolveAcceptanceContainerServices(env, appServiceName);
+  let serviceExpectationEnv = env;
+  try {
+    const contract = await deps.inspectRemoteServiceContract(env, {
+      quantumEndpoint: deps.getConfiguredQuantumEndpoint(env),
+      serviceName: appServiceName,
+      stackName,
+    });
+    const liveOtelFlag = contract?.env.ENABLE_OTEL;
+    if (liveOtelFlag !== undefined) {
+      serviceExpectationEnv = { ...env, ENABLE_OTEL: liveOtelFlag };
+    }
+  } catch {
+    // Existing evidence fallbacks below remain available when the live contract API is unavailable.
+  }
+  const services = resolveAcceptanceContainerServices(serviceExpectationEnv, appServiceName);
 
   try {
     await assertRemoteEvidenceHasServices(deps, env, services);

--- a/scripts/ops/runtime/runtime-health.test.ts
+++ b/scripts/ops/runtime/runtime-health.test.ts
@@ -341,4 +341,53 @@ describe('runtime-health helpers', () => {
     expect(hasRunningService).toHaveBeenCalledWith('postgres');
     expect(hasRunningService).toHaveBeenCalledWith('otel-collector');
   });
+
+  it('derives the expected observability service from the live app contract', async () => {
+    const hasRunningService = vi.fn(() => true);
+    const inspectRemoteServiceContract = vi.fn(async () => ({
+      env: { ENABLE_OTEL: 'false' },
+      image: 'ghcr.io/test/studio@sha256:digest',
+      labels: {},
+      networkNames: ['internal', 'public'],
+      serviceName: 'studio-staging_studio-app',
+    }));
+    const ops = createRuntimeHealthOps({
+      assertRuntimeEnv: vi.fn(),
+      checkHttpHealth: vi.fn(),
+      commandExists: vi.fn(() => false),
+      getConfiguredQuantumEndpoint: vi.fn(() => 'sva'),
+      getConfiguredStackName: vi.fn(() => 'studio-staging'),
+      getRemoteAppServiceName: vi.fn(() => 'studio-app'),
+      getRuntimeProfileDefinition: vi.fn(() => ({ isLocal: false })),
+      inspectRemoteServiceContract,
+      isExpectedOidcRedirect: vi.fn(() => true),
+      isMainserverCheckRequired: vi.fn(() => false),
+      isMockAuthRuntimeProfile: vi.fn(() => false),
+      readRemoteStackEvidence: vi.fn(async () => ({
+        channel: 'portainer-api' as const,
+        hasRunningService,
+        summary: 'ok',
+      })),
+      resolveTenantRuntimeTargets: vi.fn(),
+      runCapture: vi.fn(),
+      runSchemaGuard: vi.fn(),
+      summarizeSchemaGuardFailures: vi.fn(),
+      toDoctorCheck: vi.fn(),
+      wait: vi.fn(),
+      waitForRemoteSmokeWarmup: vi.fn(),
+      withoutDebugEnv: vi.fn((runtimeEnv) => runtimeEnv),
+    });
+
+    await ops.assertAcceptanceContainerHealth({});
+
+    expect(inspectRemoteServiceContract).toHaveBeenCalledWith({}, {
+      quantumEndpoint: 'sva',
+      serviceName: 'studio-app',
+      stackName: 'studio-staging',
+    });
+    expect(hasRunningService).toHaveBeenCalledWith('studio-app');
+    expect(hasRunningService).toHaveBeenCalledWith('redis');
+    expect(hasRunningService).toHaveBeenCalledWith('postgres');
+    expect(hasRunningService).not.toHaveBeenCalledWith('otel-collector');
+  });
 });


### PR DESCRIPTION
## Zusammenfassung
- liest `ENABLE_OTEL` für Remote-Smokes aus dem laufenden App-Service
- erwartet den optionalen Collector nur bei aktivem Live-Flag
- bewahrt die bestehenden Portainer-, Quantum- und Docker-Fallbacks

## Tests
- `pnpm exec vitest run scripts/ops/runtime/runtime-health.test.ts scripts/ops/runtime/acceptance-command.test.ts scripts/ops/runtime/doctor.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`