### PR TITLE
fix: pass public URL to promote checks

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -327,6 +327,7 @@ jobs:
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_PUBLIC_BASE_URL: ${{ steps.target.outputs.public_base_url }}
           SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}
         run: |
           set -euo pipefail
@@ -376,6 +377,7 @@ jobs:
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_PUBLIC_BASE_URL: ${{ steps.target.outputs.public_base_url }}
           SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}
         run: |
           set -euo pipefail

--- a/docs/changelog/entries/pr-793.json
+++ b/docs/changelog/entries/pr-793.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 793,
+  "body": "Promote-Postconditions und -Smokes erhalten die verifizierte öffentliche URL gemeinsam mit dem zentral aufgelösten Stacknamen."
+}

--- a/scripts/ci/promote-target.test.ts
+++ b/scripts/ci/promote-target.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { stackNameForEnvironment } from './promote-target.ts';
+import { publicBaseUrlForEnvironment, stackNameForEnvironment } from './promote-target.ts';
 
 describe('stackNameForEnvironment', () => {
   it.each([
@@ -9,5 +9,13 @@ describe('stackNameForEnvironment', () => {
     ['prod', 'studio'],
   ] as const)('maps %s to the verified live stack %s', (environment, expected) => {
     expect(stackNameForEnvironment(environment)).toBe(expected);
+  });
+
+  it.each([
+    ['dev', 'https://studio-dev.smart-village.app'],
+    ['staging', 'https://studio-staging.smart-village.app'],
+    ['prod', 'https://studio.smart-village.app'],
+  ] as const)('maps %s to the verified public base URL %s', (environment, expected) => {
+    expect(publicBaseUrlForEnvironment(environment)).toBe(expected);
   });
 });

--- a/scripts/ci/promote-target.ts
+++ b/scripts/ci/promote-target.ts
@@ -7,6 +7,9 @@ export type PromoteEnvironment = 'dev' | 'prod' | 'staging';
 export const stackNameForEnvironment = (environment: PromoteEnvironment): string =>
   environment === 'prod' ? 'studio' : `studio-${environment}`;
 
+export const publicBaseUrlForEnvironment = (environment: PromoteEnvironment): string =>
+  `https://${environment === 'prod' ? 'studio' : `studio-${environment}`}.smart-village.app`;
+
 const main = () => {
   const environment = process.argv[2];
   if (environment !== 'dev' && environment !== 'staging' && environment !== 'prod') {
@@ -14,10 +17,12 @@ const main = () => {
   }
 
   const stackName = stackNameForEnvironment(environment);
+  const publicBaseUrl = publicBaseUrlForEnvironment(environment);
   if (process.env.GITHUB_OUTPUT) {
     appendFileSync(process.env.GITHUB_OUTPUT, `stack_name=${stackName}\n`);
+    appendFileSync(process.env.GITHUB_OUTPUT, `public_base_url=${publicBaseUrl}\n`);
   } else {
-    process.stdout.write(`${stackName}\n`);
+    process.stdout.write(`${JSON.stringify({ publicBaseUrl, stackName })}\n`);
   }
 };
 

--- a/scripts/ci/promote-workflow-contract.test.ts
+++ b/scripts/ci/promote-workflow-contract.test.ts
@@ -47,6 +47,9 @@ describe('Promote workflow contract', () => {
     expect(
       workflow.match(/SVA_STACK_NAME: \$\{\{ steps\.target\.outputs\.stack_name \}\}/gu)
     ).toHaveLength(2);
+    expect(
+      workflow.match(/SVA_PUBLIC_BASE_URL: \$\{\{ steps\.target\.outputs\.public_base_url \}\}/gu)
+    ).toHaveLength(2);
     expect(workflow).toContain('pnpm exec tsx scripts/ci/promote-target.ts "${{ inputs.environment }}"');
     expect(workflow).toContain('SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}');
     expect(workflow).toContain('--stack "${{ steps.target.outputs.stack_name }}"');


### PR DESCRIPTION
## Zusammenfassung
- löst öffentliche URL und Stackname zentral je Umgebung auf
- übergibt die URL explizit an Postconditions und Runtime-Smoke
- verhindert einen localhost-Fallback im Production-Runner

## Tests
- `pnpm exec vitest run scripts/ci/promote-target.test.ts scripts/ci/promote-workflow-contract.test.ts scripts/ops/runtime/runtime-health.test.ts scripts/ops/runtime/doctor.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`