### PR TITLE
fix: verify every Studio deployment

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -373,7 +373,6 @@ jobs:
           quantum-cli stacks deploy -f stack.yaml --stack "${{ steps.target.outputs.stack_name }}" --endpoint "${QUANTUM_ENDPOINT}"
 
       - name: verify deployed runtime
-        if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
@@ -390,7 +389,6 @@ jobs:
           pnpm exec tsx scripts/ops/runtime-env.ts smoke studio
 
       - name: verify deployed runtime image digest
-        if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}
         env:
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
         run: pnpm exec tsx scripts/ci/promote-live-digest.ts "${{ inputs.environment }}" --expected "${{ steps.image_contract.outputs.deploy_image_ref }}"

--- a/docs/changelog/entries/pr-796.json
+++ b/docs/changelog/entries/pr-796.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 796,
+  "body": "Prüft nach jedem Studio-Deployment in Dev, Staging und Production verbindlich die Runtime-Gesundheit und den tatsächlich laufenden Image-Digest."
+}

--- a/tooling/testing/tests/promote-workflow-contract.test.ts
+++ b/tooling/testing/tests/promote-workflow-contract.test.ts
@@ -4,15 +4,15 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync(
-  resolve(import.meta.dirname, '../../.github/workflows/promote.yml'),
+  resolve(import.meta.dirname, '../../../.github/workflows/promote.yml'),
   'utf8'
 );
 const backupDrillWorkflow = readFileSync(
-  resolve(import.meta.dirname, '../../.github/workflows/staging-backup-drill.yml'),
+  resolve(import.meta.dirname, '../../../.github/workflows/staging-backup-drill.yml'),
   'utf8'
 );
 const productionBackupDrillWorkflow = readFileSync(
-  resolve(import.meta.dirname, '../../.github/workflows/production-backup-drill.yml'),
+  resolve(import.meta.dirname, '../../../.github/workflows/production-backup-drill.yml'),
   'utf8'
 );
 
@@ -100,7 +100,7 @@ describe('Promote workflow contract', () => {
 
   it('uses automatic diff-based one-shot execution for main-to-Dev promotion', () => {
     const buildWorkflow = readFileSync(
-      resolve(import.meta.dirname, '../../.github/workflows/build.yml'),
+      resolve(import.meta.dirname, '../../../.github/workflows/build.yml'),
       'utf8'
     );
 
@@ -116,6 +116,11 @@ describe('Promote workflow contract', () => {
     );
     expect(workflow).toContain('migration_should_run');
     expect(workflow).toContain('bootstrap_should_run');
+  });
+
+  it('verifies runtime health and the live digest after every environment deploy', () => {
+    expect(workflow).toMatch(/- name: verify deployed runtime\n\s+env:/u);
+    expect(workflow).toMatch(/- name: verify deployed runtime image digest\n\s+env:/u);
   });
 
   it('offers a staging-only backup drill without application mutation', () => {


### PR DESCRIPTION
## Ergebnis

- Runtime-Smoke und Live-Digest-Prüfung laufen nach Dev-, Staging- und Production-Deployments
- der Workflow-Vertragstest liegt im tatsächlich ausgeführten `tooling-testing`-Scope
- die kanonische Erfolgsdefinition aus `docs/guides/studio-rollout-process.md` wird technisch durchgesetzt

## Verifikation

- `pnpm nx run tooling-testing:test:unit` (31 Dateien, 199 Tests)
- `pnpm nx run tooling-testing:lint`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:rollout-docs`
- `pnpm check:file-placement`
- Dev `/health/live` und `/health/ready`: HTTP 200