### PR TITLE
fix(news): allow delayed push notifications

### DIFF
--- a/docs/changelog/entries/pr-799.json
+++ b/docs/changelog/entries/pr-799.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 799,
+  "body": "Push-Benachrichtigungen können für bestehende News nachträglich aktiviert werden, solange noch kein Push versendet wurde. Beim Speichern wird die vollständige News mit dem Push-Flag an den Mainserver übertragen."
+}

--- a/packages/plugin-news/README.md
+++ b/packages/plugin-news/README.md
@@ -38,6 +38,7 @@ Fachlich deckt das Paket derzeit insbesondere folgende Integrationspunkte ab:
 - zweckgebundene Media-Picker für Teaser- und Header-Bilder
 - CRUD-Zugriffe auf `/api/v1/mainserver/news`
 - formularnahe Validierung für Datumswerte, Kategorien, HTTPS-URLs und Inhaltsblöcke
+- einmalige Push-Benachrichtigung beim Erstellen oder bei einer späteren vollständigen Aktualisierung, solange noch kein Push versendet wurde
 
 ## Projektstruktur
 

--- a/packages/plugin-news/src/news.api.ts
+++ b/packages/plugin-news/src/news.api.ts
@@ -56,7 +56,7 @@ const newsClient = createMainserverCrudClient<NewsContentItem, NewsFormInput, Ne
     pagination: response.pagination,
   }),
   createBody: (input) => toMutationBody(input, { includePushNotification: true }),
-  updateBody: (input) => toMutationBody(input, { includePushNotification: false }),
+  updateBody: (input) => toMutationBody(input, { includePushNotification: true }),
   createHeaders: () =>
     createMainserverJsonRequestHeaders({
       'Idempotency-Key': createIdempotencyKey(),

--- a/packages/plugin-news/tests/news.api.test.ts
+++ b/packages/plugin-news/tests/news.api.test.ts
@@ -204,7 +204,11 @@ describe('news api', () => {
       '/api/v1/mainserver/news/news-1',
       expect.objectContaining({ method: 'PATCH' })
     );
-    expect(JSON.parse(vi.mocked(fetch).mock.calls[0]?.[1]?.body as string)).not.toHaveProperty('pushNotification');
+    expect(JSON.parse(vi.mocked(fetch).mock.calls[0]?.[1]?.body as string)).toEqual(
+      expect.objectContaining({
+        pushNotification: true,
+      })
+    );
     expect(fetch).toHaveBeenNthCalledWith(
       2,
       '/api/v1/mainserver/news/news-1',

--- a/packages/sva-mainserver/src/server/news-route.test.ts
+++ b/packages/sva-mainserver/src/server/news-route.test.ts
@@ -566,7 +566,7 @@ describe('dispatchSvaMainserverNewsRequest', () => {
     expect(state.updateSvaMainserverNews).not.toHaveBeenCalled();
   });
 
-  it('rejects legacy payload, invalid visibility, read-only fields and update push notifications before GraphQL', async () => {
+  it('rejects legacy payload, invalid visibility and read-only fields before GraphQL', async () => {
     state.withAuthenticatedUser.mockImplementation((_request, handler) => handler(ctx));
     state.validateCsrf.mockReturnValue(null);
     state.authorizeContentPrimitiveForUser.mockResolvedValue({
@@ -599,14 +599,21 @@ describe('dispatchSvaMainserverNewsRequest', () => {
     );
     expect(invalidVisibility?.status).toBe(400);
 
+    state.updateSvaMainserverNews.mockResolvedValue({ id: 'news-1' });
+
     const pushOnUpdate = await dispatchSvaMainserverNewsRequest(
       createRequest('https://studio.test/api/v1/mainserver/news/news-1', {
         method: 'PATCH',
         body: JSON.stringify(newsInput),
       })
     );
-    expect(pushOnUpdate?.status).toBe(400);
-    expect(state.updateSvaMainserverNews).not.toHaveBeenCalled();
+    expect(pushOnUpdate?.status).toBe(200);
+    expect(state.updateSvaMainserverNews).toHaveBeenCalledWith(
+      expect.objectContaining({
+        newsId: 'news-1',
+        news: expect.objectContaining(newsInput),
+      })
+    );
   });
 
   it('deletes news via mainserver hard delete', async () => {

--- a/packages/sva-mainserver/src/server/news-route.ts
+++ b/packages/sva-mainserver/src/server/news-route.ts
@@ -688,7 +688,7 @@ const handleItemUpdate = async (
     route,
     action: 'news.update',
     requestId,
-    parse: async (inputRequest) => await parseNewsInput(inputRequest, { allowPushNotification: false }),
+    parse: async (inputRequest) => await parseNewsInput(inputRequest, { allowPushNotification: true }),
     execute: async (actor, parsed) => {
       let response: Response;
       try {

--- a/packages/sva-mainserver/src/server/service-internals/news-operations.ts
+++ b/packages/sva-mainserver/src/server/service-internals/news-operations.ts
@@ -74,7 +74,7 @@ const buildNewsMutationVariables = (input: {
   ...(input.newsId ? { id: input.newsId } : {}),
   ...(input.forceCreate === undefined ? {} : { forceCreate: input.forceCreate }),
   title: input.news.title,
-  ...(input.newsId ? {} : { pushNotification: input.news.pushNotification ?? false }),
+  ...(input.news.pushNotification === undefined ? {} : { pushNotification: input.news.pushNotification }),
   ...(input.news.author ? { author: input.news.author } : {}),
   ...(input.news.keywords ? { keywords: input.news.keywords } : {}),
   ...(input.news.externalId ? { externalId: input.news.externalId } : {}),

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -506,6 +506,7 @@ describe('createSvaMainserverService', () => {
       publishedAt: item.publishedAt,
       categoryName: 'Allgemein',
       contentBlocks: [{ intro: 'Kurztext', body: '<p>Body</p>' }],
+      pushNotification: true,
     };
 
     await expect(service.listNews({ ...connection, page: 1, pageSize: 25 })).resolves.toEqual({
@@ -527,7 +528,15 @@ describe('createSvaMainserverService', () => {
     });
     expect(requestBodies[2]).toMatchObject({
       operationName: 'SvaMainserverCreateNews',
-      variables: { id: 'news-1', forceCreate: false, categoryName: 'Allgemein' },
+      variables: {
+        id: 'news-1',
+        forceCreate: false,
+        title: 'News',
+        publishedAt: '2026-04-14T09:30:00.000Z',
+        categoryName: 'Allgemein',
+        contentBlocks: [{ intro: 'Kurztext', body: '<p>Body</p>' }],
+        pushNotification: true,
+      },
     });
     expect(requestBodies[3]).toMatchObject({
       operationName: 'SvaMainserverDestroyNews',


### PR DESCRIPTION
## Änderung

Erlaubt das nachträgliche Auslösen einer Push-Benachrichtigung für bestehende News, indem das Flag bei einer vollständigen News-Aktualisierung bis zur Mainserver-GraphQL-Mutation weitergereicht wird.

## Ursache

Das News-Plugin, die Studio-Route und der GraphQL-Variablen-Mapper unterdrückten `pushNotification` bei Updates, obwohl `createNewsItem` mit `id` dieses Argument im Schema unterstützt.

## Auswirkung

Redaktionen können den bereits vorhandenen Push-Schalter für eine noch nicht benachrichtigte News nachträglich aktivieren. Titel, Veröffentlichungsdaten, Kategorien, Medien und Inhaltsblöcke werden dabei erneut übertragen.

## Validierung

- `pnpm test:pr`
- `pnpm nx run plugin-news:test:unit`
- `pnpm nx run sva-mainserver:test:unit`
- `pnpm nx run plugin-news:test:types`
- `pnpm nx run sva-mainserver:test:types`
- `pnpm nx run sva-mainserver:check:runtime`