### PR TITLE
fix(rollout): narrow migration risk detection

### DIFF
--- a/docs/changelog/entries/pr-852.json
+++ b/docs/changelog/entries/pr-852.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 852,
+  "body": "Der Studio-Promote erkennt Migrationsrisiken anhand konkreter Migrations-, Schema- und Deploy-Änderungen. Reine Änderungen an der Anwendungslogik lösen keinen unnötigen Migrationslauf mehr aus."
+}

--- a/openspec/specs/deployment-topology/spec.md
+++ b/openspec/specs/deployment-topology/spec.md
@@ -195,6 +195,7 @@ Das System SHALL stateful Services, Secrets, Configs, Migrationen, Bootstrap und
 
 - **WHEN** ein Merge einen Push nach `main` auslöst und `Promote` für `dev` im Modus `auto` startet
 - **THEN** klassifiziert der Workflow Migration und Bootstrap anhand des konkreten Commit-Diffs unabhängig
+- **AND** markiert er Änderungen an Anwendungslogik nicht allein wegen ihres Package-Pfads als migrationsrelevant, sondern nur bei konkreten Migrationsartefakten oder Änderungen am Datenbank- beziehungsweise Deploy-Vertrag
 - **AND** führt er jeden erforderlichen One-shot-Job vor dem App-Deploy aus
 - **AND** überspringt er nicht erforderliche Jobs
 - **AND** aktualisiert er den Dev-App-Stack nur, wenn alle erforderlichen Jobs und der Build erfolgreich sind

--- a/scripts/ci/promote-deploy-gates.test.ts
+++ b/scripts/ci/promote-deploy-gates.test.ts
@@ -52,6 +52,27 @@ describe('promote-deploy-gates', () => {
     expect(result.migration.riskFiles).toEqual(['packages/data/migrations/0010_add_role.sql']);
   });
 
+  it('fails migration assert-none when the deployed Goose runner changes', () => {
+    const result = evaluatePromoteDeployGates({
+      bootstrapMode: 'assert-none',
+      changedFiles: [
+        'packages/data/goose.config.json',
+        'packages/data/scripts/goosew.sh',
+      ],
+      migrationMode: 'assert-none',
+    });
+
+    expect(result.migration).toMatchObject({
+      ok: false,
+      result: 'blocked-risk',
+      riskDetected: true,
+    });
+    expect(result.migration.riskFiles).toEqual([
+      'packages/data/goose.config.json',
+      'packages/data/scripts/goosew.sh',
+    ]);
+  });
+
   it('treats application changes outside migration artifacts as safe for assert-none', () => {
     const result = evaluatePromoteDeployGates({
       bootstrapMode: 'assert-none',

--- a/scripts/ci/promote-deploy-gates.test.ts
+++ b/scripts/ci/promote-deploy-gates.test.ts
@@ -52,6 +52,29 @@ describe('promote-deploy-gates', () => {
     expect(result.migration.riskFiles).toEqual(['packages/data/migrations/0010_add_role.sql']);
   });
 
+  it('treats application changes outside migration artifacts as safe for assert-none', () => {
+    const result = evaluatePromoteDeployGates({
+      bootstrapMode: 'assert-none',
+      changedFiles: [
+        'packages/core/src/actions.ts',
+        'packages/data/src/news.ts',
+        'packages/data-repositories/src/news-repository.ts',
+        'packages/sva-mainserver/src/server/news-route.test.ts',
+        'packages/sva-mainserver/src/server/news-route.ts',
+        'packages/sva-mainserver/src/server/service-internals/news-operations.ts',
+        'packages/sva-mainserver/src/server/service.test.ts',
+      ],
+      migrationMode: 'assert-none',
+    });
+
+    expect(result.migration).toMatchObject({
+      ok: true,
+      result: 'asserted-clean',
+      riskDetected: false,
+      riskFiles: [],
+    });
+  });
+
   it('fails bootstrap assert-none when provisioning-risk files changed', () => {
     const result = evaluatePromoteDeployGates({
       bootstrapMode: 'assert-none',

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -39,6 +39,8 @@ const migrationRiskPatterns = [
   /^packages\/.+\/migrations\//u,
   /(?:^|\/)migrations\//u,
   /^migrate-entrypoint\.sh$/u,
+  /^packages\/data\/goose\.config\.json$/u,
+  /^packages\/data\/scripts\/goosew\.sh$/u,
   /^docs\/development\/studio-db-schema-final\.sql$/u,
   /^docs\/development\/studio-db-schema\.md$/u,
 ];

--- a/scripts/ci/promote-deploy-gates.ts
+++ b/scripts/ci/promote-deploy-gates.ts
@@ -41,7 +41,6 @@ const migrationRiskPatterns = [
   /^migrate-entrypoint\.sh$/u,
   /^docs\/development\/studio-db-schema-final\.sql$/u,
   /^docs\/development\/studio-db-schema\.md$/u,
-  /^packages\/(?:data|data-repositories|core|sva-mainserver)\/.+/u,
 ];
 const bootstrapRiskPatterns = [
   /^compose\.yaml$/u,


### PR DESCRIPTION
## Was ändert sich?

Das Migrations-Gate bewertet nicht länger jede Änderung unter `packages/data`, `packages/data-repositories`, `packages/core` oder `packages/sva-mainserver` pauschal als Migrationsrisiko.

## Warum?

Eine reine News-Route einschließlich Tests hat dadurch den Staging-Promote blockiert, obwohl weder Migration noch Datenbankvertrag geändert wurden.

## Wirkung

`assert-none` bleibt bei konkreten Migrationsartefakten, Schema-Snapshots und Compose-Änderungen fail-closed. Reguläre Anwendungslogik kann ohne unnötigen One-shot-Migrationslauf promotet werden.

## Validierung

- `pnpm exec vitest --root tooling/testing run tests ../../scripts/ci/promote-deploy-gates.test.ts --reporter=verbose --config vitest.config.ts --passWithNoTests` (32 Dateien, 205 Tests)
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`