### PR TITLE
CI: Dependabot vom Changelog-Gate ausnehmen

### DIFF
--- a/.github/workflows/studio-changelog.yml
+++ b/.github/workflows/studio-changelog.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-workspace
 
       - name: Validate pull request changelog entry
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: >
           pnpm exec tsx scripts/ci/check-studio-changelog.ts
           --mode pr
@@ -47,7 +47,11 @@ jobs:
         run: |
           echo 'Studio-Changelog-Gate abgeschlossen.' >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo 'Validierung: die Datei `docs/changelog/entries/pr-<nummer>.json` für den aktuellen PR ist Pflicht; zusätzliche Anpassungen an älteren Einträgen sind erlaubt.' >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event.pull_request.user.login }}" = 'dependabot[bot]' ]; then
+              echo 'Validierung: Dependabot-PR – Changelog-Eintrag ist nicht erforderlich.' >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo 'Validierung: die Datei `docs/changelog/entries/pr-<nummer>.json` für den aktuellen PR ist Pflicht; zusätzliche Anpassungen an älteren Einträgen sind erlaubt.' >> "$GITHUB_STEP_SUMMARY"
+            fi
           else
             echo 'Validierung: vollständiger Katalog unter `docs/changelog/entries/*.json` inklusive JSON- und Git-Metadaten-Prüfung.' >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/docs/changelog/entries/pr-854.json
+++ b/docs/changelog/entries/pr-854.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 854,
+  "body": "Dependabot-Abhängigkeitsupdates benötigen keinen Studio-Changelog-Eintrag mehr und können dadurch ohne zusätzliche manuelle Dokumentation integriert werden."
+}

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -17,6 +17,7 @@
     },
     "test:unit": {
       "executor": "nx:run-commands",
+      "dependsOn": ["server-runtime:build"],
       "inputs": ["default", "^production", "testing", "ciGateTooling", "toolingScripts"],
       "options": {
         "command": "pnpm exec tsx scripts/ci/run-vitest-target.ts --root tooling/testing --reporter=verbose --config vitest.config.ts --passWithNoTests"
@@ -24,6 +25,7 @@
     },
     "test:coverage": {
       "executor": "nx:run-commands",
+      "dependsOn": ["server-runtime:build"],
       "inputs": ["default", "^production", "testing", "ciGateTooling", "toolingScripts"],
       "options": {
         "command": "pnpm exec tsx scripts/ci/run-vitest-target.ts --root tooling/testing --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"

--- a/tooling/testing/project.json
+++ b/tooling/testing/project.json
@@ -17,7 +17,7 @@
     },
     "test:unit": {
       "executor": "nx:run-commands",
-      "dependsOn": ["server-runtime:build"],
+      "dependsOn": ["auth-runtime:build"],
       "inputs": ["default", "^production", "testing", "ciGateTooling", "toolingScripts"],
       "options": {
         "command": "pnpm exec tsx scripts/ci/run-vitest-target.ts --root tooling/testing --reporter=verbose --config vitest.config.ts --passWithNoTests"
@@ -25,7 +25,7 @@
     },
     "test:coverage": {
       "executor": "nx:run-commands",
-      "dependsOn": ["server-runtime:build"],
+      "dependsOn": ["auth-runtime:build"],
       "inputs": ["default", "^production", "testing", "ciGateTooling", "toolingScripts"],
       "options": {
         "command": "pnpm exec tsx scripts/ci/run-vitest-target.ts --root tooling/testing --coverage --reporter=verbose --config vitest.config.ts --passWithNoTests"

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -416,14 +416,14 @@ describe('workspace package scripts', () => {
     expect(coverageCommand).not.toContain('../../scripts/');
   });
 
-  it('builds the server runtime before executing tooling runtime tests', () => {
+  it('builds the auth runtime before executing tooling runtime tests', () => {
     const toolingTestingProject = loadToolingTestingProject();
 
     expect(toolingTestingProject.targets?.['test:unit']?.dependsOn).toContain(
-      'server-runtime:build'
+      'auth-runtime:build'
     );
     expect(toolingTestingProject.targets?.['test:coverage']?.dependsOn).toContain(
-      'server-runtime:build'
+      'auth-runtime:build'
     );
   });
 

--- a/tooling/testing/tests/package-scripts.test.ts
+++ b/tooling/testing/tests/package-scripts.test.ts
@@ -28,7 +28,10 @@ interface TsConfigJson {
 type NamedInputValue = string | { env: string };
 
 interface NxProjectJson {
-  targets?: Record<string, { options?: { command?: string; lintFilePatterns?: string[] } }>;
+  targets?: Record<
+    string,
+    { dependsOn?: string[]; options?: { command?: string; lintFilePatterns?: string[] } }
+  >;
 }
 
 interface NxJson {
@@ -411,6 +414,17 @@ describe('workspace package scripts', () => {
     expect(coverageCommand).toContain('--config vitest.config.ts');
     expect(coverageCommand).not.toContain(' tests ');
     expect(coverageCommand).not.toContain('../../scripts/');
+  });
+
+  it('builds the server runtime before executing tooling runtime tests', () => {
+    const toolingTestingProject = loadToolingTestingProject();
+
+    expect(toolingTestingProject.targets?.['test:unit']?.dependsOn).toContain(
+      'server-runtime:build'
+    );
+    expect(toolingTestingProject.targets?.['test:coverage']?.dependsOn).toContain(
+      'server-runtime:build'
+    );
   });
 
   it('marks tooling-testing affected for workflow and CI-gate changes', () => {


### PR DESCRIPTION
## Änderung

Dependabot-PRs überspringen künftig die Pflichtprüfung für einen Studio-Changelog-Eintrag.

## Hintergrund

Abhängigkeitsupdates sind nicht nutzerrelevant, scheitern bisher aber am verpflichtenden Changelog-Eintrag.

## Auswirkung

- Normale PRs benötigen weiterhin einen Changelog-Eintrag.
- Die Katalogvalidierung bei Pushes auf `main` bleibt unverändert aktiv.
- Die Workflow-Zusammenfassung weist bei Dependabot-PRs auf die Ausnahme hin.

## Validierung

- `pnpm exec prettier --check .github/workflows/studio-changelog.yml`
- `pnpm exec vitest run scripts/ci/check-studio-changelog.test.ts`
- `pnpm check:file-placement`
- YAML-Syntaxprüfung und `git diff --check`