### PR TITLE
fix(ci): Dependabot von automatischer Zuweisung ausnehmen

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -27,12 +27,14 @@ jobs:
             const pull_number = pr.number;
             const author = pr.user.login;
 
-            await github.rest.issues.addAssignees({
-              owner,
-              repo,
-              issue_number: pull_number,
-              assignees: [author],
-            });
+            if (author !== 'dependabot[bot]') {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: pull_number,
+                assignees: [author],
+              });
+            }
 
             try {
               await github.rest.pulls.requestReviewers({

--- a/docs/changelog/entries/pr-855.json
+++ b/docs/changelog/entries/pr-855.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 855,
+  "body": "Interne Verbesserungen\n\n- Dependabot-Updates werden nicht mehr fälschlich als PR-Assignee eingetragen."
+}


### PR DESCRIPTION
## Zusammenfassung

- Überspringt die automatische Autorenzuweisung für `dependabot[bot]`.
- Führt die optionale Copilot-Review-Anfrage weiterhin aus.

## Ursache

GitHub lehnt die Zuweisung von `dependabot[bot]` als Assignee mit HTTP 403 ab; dadurch schlug der Check **Auto Assignment** für Dependabot-PRs fehl.

## Validierung

- `pnpm exec prettier --check .github/workflows/pr-automation.yml`
- `git diff --check`
