### PR TITLE
ci: scope Studio release tenant smoke

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -329,6 +329,7 @@ jobs:
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
           SVA_PUBLIC_BASE_URL: ${{ steps.target.outputs.public_base_url }}
           SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}
+          SVA_ACCEPTANCE_RELEASE_MODE: ${{ inputs.environment }}
         run: |
           set -euo pipefail
           umask 077
@@ -378,6 +379,7 @@ jobs:
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
           SVA_PUBLIC_BASE_URL: ${{ steps.target.outputs.public_base_url }}
           SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}
+          SVA_ACCEPTANCE_RELEASE_MODE: ${{ inputs.environment }}
         run: |
           set -euo pipefail
           umask 077

--- a/docs/changelog/entries/pr-856.json
+++ b/docs/changelog/entries/pr-856.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 856,
+  "body": "Production-Rollouts prüfen nur noch den verbindlichen Studio-Referenz-Tenant. Störungen weiterer Mandanten bleiben sichtbar, blockieren aber keine Studio-Auslieferung."
+}

--- a/docs/guides/studio-rollout-process.md
+++ b/docs/guides/studio-rollout-process.md
@@ -94,11 +94,11 @@ Docker-Swarm-Dienste dürfen nach einem Update bis zu fünf Minuten benötigen, 
 
 1. Ein unmittelbar nach dem Deploy fehlschlagender Smoke wird nicht durch weitere Mutationen „repariert“.
 2. Zuerst Service-Update und Tasks prüfen und bis zu fünf Minuten ab dem abgeschlossenen Update konvergieren lassen.
-3. Danach `health/live`, `health/ready`, alle aktiven Tenant-Login-Redirects und den Live-Digest erneut prüfen.
+3. Danach `health/live`, `health/ready`, den Release-Blocking-Tenant-Login-Redirect (`de-studio-sandbox`) und den Live-Digest erneut prüfen. Weitere Tenant-Redirects bleiben operativ überwacht, blockieren den Release aber nicht.
 4. Bleibt ein Fehler bestehen, ist der Rollout rot und wird diagnostiziert oder auf den vorherigen Digest zurückgeführt.
 5. Ein Workflow-Retry ist erst nach dokumentierter Ursache beziehungsweise bestätigtem reinen Konvergenzfehler zulässig.
 
-Ein regulärer Rollout ist nur erfolgreich, wenn der GitHub-Workflow grün ist, der erwartete Digest live läuft, `live` und `ready` HTTP 200 liefern und alle aktiven Tenant-Smokes bestanden sind. Abweichende Einzelfallfreigaben sind Incident-Entscheidungen, keine neue Prozessregel.
+Ein regulärer Rollout ist nur erfolgreich, wenn der GitHub-Workflow grün ist, der erwartete Digest live läuft, `live` und `ready` HTTP 200 liefern und der Release-Blocking-Tenant-Smoke für `de-studio-sandbox` bestanden ist. Weitere Tenant-Smokes sind operative Signale und keine Release-Blocker.
 
 ## Backup- und Rollback-Grenzen
 


### PR DESCRIPTION
## Änderung
- Kennzeichnet Postconditions und Runtime-Smoke als Studio-Release-Prüfung.
- Dadurch ist ausschließlich `de-studio-sandbox` ein Release-blockierender Tenant; `hb-meinquartier` wird nicht mehr im Promote-Smoke geprüft.
- Aktualisiert den kanonischen Rollout-Guide.

## Verifikation
- `pnpm nx run tooling-testing:test:unit --testFiles=../../scripts/ops/runtime-env.test.ts`
- `pnpm check:rollout-docs`