### PR TITLE
fix: use database admin for restore bootstrap

### DIFF
--- a/deploy/restore-role-bootstrap.yaml
+++ b/deploy/restore-role-bootstrap.yaml
@@ -10,7 +10,7 @@ services:
       - |
         export PGPASSWORD="$$(cat /run/secrets/postgres_admin_password)"
         restore_password="$$(cat /run/secrets/restore_postgres_password)"
-        psql --host postgres --set ON_ERROR_STOP=1 --set restore_password="$$restore_password" <<'SQL'
+        psql --host postgres --username "$$POSTGRES_USER" --set ON_ERROR_STOP=1 --set restore_password="$$restore_password" <<'SQL'
         SELECT 'CREATE ROLE sva_restore LOGIN NOINHERIT'
         WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'sva_restore') \gexec
         SELECT format('ALTER ROLE sva_restore WITH LOGIN NOINHERIT PASSWORD %L', :'restore_password') \gexec

--- a/docs/changelog/entries/pr-865.json
+++ b/docs/changelog/entries/pr-865.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 865,
+  "body": "Interne Verbesserung\n\n- Der vorbereitende Datenbank-Rollenabgleich für kontrollierte Wiederherstellungen verwendet zuverlässig den vorgesehenen Datenbankadministrator."
+}

--- a/scripts/ci/bootstrap-restore-role.test.ts
+++ b/scripts/ci/bootstrap-restore-role.test.ts
@@ -1,9 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { buildMigrationJobComposeDocument } from '../ops/runtime/migration-job.ts';
 import { restoreRoleSecretNames } from './bootstrap-restore-role.ts';
 
 describe('restoreRoleSecretNames', () => {
+  it('connects psql with the configured database administrator instead of the container user', () => {
+    const compose = readFileSync(
+      resolve(import.meta.dirname, '../../deploy/restore-role-bootstrap.yaml'),
+      'utf8'
+    );
+
+    expect(compose).toContain('psql --host postgres --username "$$POSTGRES_USER"');
+  });
+
   it('binds staging only to the staging restore and admin secrets', () => {
     expect(restoreRoleSecretNames('staging')).toEqual({
       admin: 'backup_staging_postgres_password_v3',


### PR DESCRIPTION
## Ursache

Der temporäre Restore-Rollen-Job setzte `POSTGRES_USER=sva`, übergab den Wert aber nicht an `psql`. libpq fiel deshalb auf den Container-Benutzer `root` zurück und die Authentifizierung schlug fehl.

## Änderung

- `psql` erhält den fest konfigurierten Administrator explizit über `--username`
- Regressionstest verhindert den OS-Benutzer-Fallback

## Validierung

- gezielter Vitest-Run
- Compose-Rendering
- Scripts-Typecheck
- Prettier
