### PR TITLE
fix: target studio database in restore bootstrap

### DIFF
--- a/deploy/restore-role-bootstrap.yaml
+++ b/deploy/restore-role-bootstrap.yaml
@@ -10,7 +10,7 @@ services:
       - |
         export PGPASSWORD="$$(cat /run/secrets/postgres_admin_password)"
         restore_password="$$(cat /run/secrets/restore_postgres_password)"
-        psql --host postgres --username "$$POSTGRES_USER" --set ON_ERROR_STOP=1 --set restore_password="$$restore_password" <<'SQL'
+        psql --host postgres --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" --set ON_ERROR_STOP=1 --set restore_password="$$restore_password" <<'SQL'
         SELECT 'CREATE ROLE sva_restore LOGIN NOINHERIT'
         WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'sva_restore') \gexec
         SELECT format('ALTER ROLE sva_restore WITH LOGIN NOINHERIT PASSWORD %L', :'restore_password') \gexec

--- a/docs/changelog/entries/pr-866.json
+++ b/docs/changelog/entries/pr-866.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 866,
+  "body": "Interne Verbesserung\n\n- Der vorbereitende Rollenabgleich für kontrollierte Wiederherstellungen verbindet sich ausdrücklich mit der vorgesehenen Studio-Datenbank."
+}

--- a/scripts/ci/bootstrap-restore-role.test.ts
+++ b/scripts/ci/bootstrap-restore-role.test.ts
@@ -13,7 +13,9 @@ describe('restoreRoleSecretNames', () => {
       'utf8'
     );
 
-    expect(compose).toContain('psql --host postgres --username "$$POSTGRES_USER"');
+    expect(compose).toContain(
+      'psql --host postgres --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB"'
+    );
   });
 
   it('binds staging only to the staging restore and admin secrets', () => {


### PR DESCRIPTION
## Ursache

Nach der expliziten Benutzerwahl leitete `psql` ohne `--dbname` den Datenbanknamen weiterhin aus dem Benutzer `sva` ab. Die Ziel-Datenbank heißt `sva_studio`.

## Änderung

- `psql` erhält `POSTGRES_DB` explizit über `--dbname`
- Regressionstest deckt Benutzer und Datenbank gemeinsam ab

## Validierung

- gezielter Vitest-Run
- Compose-Rendering
- Scripts-Typecheck
- Prettier
