### PR TITLE
ci: add protected backup agent rollout

### DIFF
--- a/.github/workflows/backup-agent-rollout.yml
+++ b/.github/workflows/backup-agent-rollout.yml
@@ -1,0 +1,82 @@
+name: Backup Agent Rollout
+run-name: Roll out backup agent ${{ inputs.image_ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: 'Immutable backup-agent image reference'
+        required: true
+        type: string
+      change_head:
+        description: 'Commit revision represented by the image'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: backup-agent-rollout
+  cancel-in-progress: false
+
+jobs:
+  rollout:
+    name: roll out shared backup agent
+    environment: prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: bind workflow source to image revision
+        env:
+          CHANGE_HEAD: ${{ inputs.change_head }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
+          head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
+          git merge-base --is-ancestor "${head}" origin/main
+          git checkout --detach "${head}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: validate immutable agent image
+        env:
+          CHANGE_HEAD: ${{ inputs.change_head }}
+          IMAGE_REF: ${{ inputs.image_ref }}
+        run: |
+          set -euo pipefail
+          [[ "${IMAGE_REF}" =~ ^ghcr\.io/smart-village-solutions/sva-studio-backup-agent@sha256:[0-9a-f]{64}$ ]]
+          revision="$(docker buildx imagetools inspect "${IMAGE_REF}" --format '{{json .Image.Config.Labels}}' | jq -er '."org.opencontainers.image.revision"')"
+          test "${revision}" = "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
+
+      - name: setup quantum-cli
+        uses: hostwithquantum/setup-quantum-cli@v2.0.0
+        with:
+          api-key: ${{ secrets.QUANTUM_API_KEY }}
+          version: 3.2.1
+
+      - name: deploy shared backup agent
+        env:
+          IMAGE_REF: ${{ inputs.image_ref }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          quantum-cli stacks deploy \
+            --file deploy/backup-agent-stack.yaml \
+            --stack studio-backup-agent \
+            --endpoint "${QUANTUM_ENDPOINT}"
+
+      - name: capture converged service state
+        env:
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+        run: quantum-cli show --endpoint "${QUANTUM_ENDPOINT}" --stack studio-backup-agent --service backup-agent --all

--- a/docs/changelog/entries/pr-867.json
+++ b/docs/changelog/entries/pr-867.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 867,
+  "body": "Interne Verbesserung\n\n- Der gemeinsam betriebene Datenbank-Backup-Agent kann über einen geschützten, revisionsgebundenen Workflow mit einem unveränderlichen Image ausgerollt werden."
+}

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -72,6 +72,8 @@ Der zentrale Service `studio-backup-agent` ist mit den aktuellen internen Netzen
 - `POST https://backup-studio-staging.smart-village.app/_ops/restore/v1/requests`
 - `POST https://backup-studio.smart-village.app/_ops/restore/v1/requests`
 
+Da der Agent beide Umgebungen bedient, erfolgt sein Image-Rollout ausschließlich über den manuell gestarteten Workflow **Backup Agent Rollout** und das geschützte GitHub Environment `prod`. Der Workflow akzeptiert nur den unveränderlichen Digest des Backup-Agent-Images, bindet ihn an dessen Git-Revision und aktualisiert ausschließlich den Stack `studio-backup-agent`. Ein erfolgreicher Staging-Backup-Drill weist anschließend den tatsächlich laufenden Agent-Digest nach.
+
 Ein erfolgreicher Auftrag erzeugt dauerhaft in MinIO:
 
 - das Request-Objekt unter `control/requests/`,

--- a/scripts/ci/backup-agent-rollout-workflow-contract.test.ts
+++ b/scripts/ci/backup-agent-rollout-workflow-contract.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(resolve(import.meta.dirname, '../../.github/workflows/backup-agent-rollout.yml'), 'utf8');
+
+describe('backup agent rollout workflow', () => {
+  it('uses the production approval gate for the shared service', () => {
+    expect(workflow).toContain('environment: prod');
+    expect(workflow).toContain('group: backup-agent-rollout');
+  });
+
+  it('accepts only the immutable repository image and binds its revision', () => {
+    expect(workflow).toContain('sva-studio-backup-agent@sha256:');
+    expect(workflow).toContain('org.opencontainers.image.revision');
+    expect(workflow).toContain('git merge-base --is-ancestor');
+  });
+
+  it('updates only the dedicated central stack', () => {
+    expect(workflow).toContain('--file deploy/backup-agent-stack.yaml');
+    expect(workflow).toContain('--stack studio-backup-agent');
+    expect(workflow).toContain('--service backup-agent');
+  });
+});


### PR DESCRIPTION
## Zusammenfassung
- ergänzt einen manuellen, durch das `prod`-Environment geschützten Rollout für den gemeinsam betriebenen Backup-Agenten
- akzeptiert ausschließlich einen immutablem GHCR-Digest und bindet ihn an die OCI-/Git-Revision
- begrenzt den Deploy auf `studio-backup-agent` und dokumentiert den Betriebsvertrag

## Validierung
- `pnpm exec vitest run scripts/ci/backup-agent-rollout-workflow-contract.test.ts deploy/backup-agent-stack.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`