### PR TITLE
fix: use live backup agent production network

### DIFF
--- a/deploy/backup-agent-stack.test.ts
+++ b/deploy/backup-agent-stack.test.ts
@@ -12,7 +12,8 @@ describe('backup agent stack', () => {
     expect(source).toContain('      - ingress\n      - staging\n      - production');
     expect(source).toContain('name: network-node-005');
     expect(source).toContain('name: studio-staging_default');
-    expect(source).toContain('name: portainer_internal');
+    expect(source).toContain('name: studio_default');
+    expect(source).not.toContain('name: portainer_internal');
     expect(source).not.toContain('name: studio-prod_default');
   });
 

--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -81,7 +81,7 @@ networks:
     name: studio-staging_default
   production:
     external: true
-    name: portainer_internal
+    name: studio_default
 
 secrets:
   backup_staging_postgres_password_v3:

--- a/docs/changelog/entries/pr-868.json
+++ b/docs/changelog/entries/pr-868.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 868,
+  "body": "Interne Verbesserung\n\n- Der zentrale Datenbank-Backup-Agent verwendet beim geschützten Rollout das tatsächlich vorhandene Produktionsnetz."
+}

--- a/docs/changelog/entries/pr-869.json
+++ b/docs/changelog/entries/pr-869.json
@@ -1,4 +1,4 @@
 {
-  "prNumber": 868,
+  "prNumber": 869,
   "body": "Interne Verbesserung\n\n- Der zentrale Datenbank-Backup-Agent verwendet beim geschützten Rollout das tatsächlich vorhandene Produktionsnetz."
 }


### PR DESCRIPTION
## Zusammenfassung
- gleicht den versionierten Backup-Agent-Stack mit dem read-only verifizierten, tatsächlich vorhandenen Produktionsnetz `studio_default` ab
- hält die historischen, nicht vorhandenen Namen im Vertragstest ausgeschlossen

## Validierung
- `pnpm exec vitest run deploy/backup-agent-stack.test.ts scripts/ci/backup-agent-rollout-workflow-contract.test.ts`