### PR TITLE
fix: keep current backup agent rollout manifest

### DIFF
--- a/.github/workflows/backup-agent-rollout.yml
+++ b/.github/workflows/backup-agent-rollout.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: bind workflow source to image revision
+      - name: verify image revision is on main
         env:
           CHANGE_HEAD: ${{ inputs.change_head }}
         run: |
@@ -40,7 +40,6 @@ jobs:
           git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
           head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
           git merge-base --is-ancestor "${head}" origin/main
-          git checkout --detach "${head}"
 
       - name: Login to GHCR
         uses: docker/login-action@v4

--- a/docs/changelog/entries/pr-870.json
+++ b/docs/changelog/entries/pr-870.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 870,
+  "body": "Interne Verbesserung\n\n- Der geschützte Backup-Agent-Rollout prüft die Image-Revision, verwendet für die Stack-Definition aber weiterhin den aktuellen Hauptbranch."
+}

--- a/scripts/ci/backup-agent-rollout-workflow-contract.test.ts
+++ b/scripts/ci/backup-agent-rollout-workflow-contract.test.ts
@@ -15,6 +15,7 @@ describe('backup agent rollout workflow', () => {
     expect(workflow).toContain('sva-studio-backup-agent@sha256:');
     expect(workflow).toContain('org.opencontainers.image.revision');
     expect(workflow).toContain('git merge-base --is-ancestor');
+    expect(workflow).not.toContain('git checkout --detach');
   });
 
   it('updates only the dedicated central stack', () => {


### PR DESCRIPTION
## Zusammenfassung
- prüft weiterhin, dass die attestierte Image-Revision auf `main` liegt
- belässt Checkout und Stack-Manifest auf dem aktuellen Hauptbranch, damit betriebliche Manifest-Korrekturen wirksam bleiben
- ergänzt den Regressionstest und Changelog

## Validierung
- `pnpm exec vitest run scripts/ci/backup-agent-rollout-workflow-contract.test.ts deploy/backup-agent-stack.test.ts`