### PR TITLE
fix: authenticate restore image inspection

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -85,6 +85,13 @@ jobs:
       - name: setup pnpm workspace
         uses: ./.github/actions/setup-pnpm-workspace
 
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: validate image contract
         id: image_contract
         env:

--- a/docs/changelog/entries/pr-871.json
+++ b/docs/changelog/entries/pr-871.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 871,
+  "body": "Interne Verbesserung\n\n- Der kontrollierte Datenbank-Restore authentifiziert die Prüfung privater, unveränderlicher Studio-Images gegen GHCR."
+}

--- a/tooling/testing/tests/database-restore-workflow-contract.test.ts
+++ b/tooling/testing/tests/database-restore-workflow-contract.test.ts
@@ -27,6 +27,9 @@ describe('controlled database restore workflow', () => {
     expect(workflow).toContain('promote-image-contract.ts');
     expect(workflow).toContain('promote-live-digest.ts');
     expect(workflow).toContain('git merge-base --is-ancestor');
+    expect(workflow.indexOf('Login to GHCR')).toBeLessThan(
+      workflow.indexOf('validate image contract')
+    );
   });
 
   it('requires successful staging evidence before production mutation', () => {


### PR DESCRIPTION
## Zusammenfassung
- meldet den kontrollierten Restore vor der privaten OCI-Image-Prüfung an GHCR an
- ergänzt einen Regressionstest für die zwingende Reihenfolge
- dokumentiert die interne Verbesserung im Changelog

## Validierung
- `pnpm exec vitest run tooling/testing/tests/database-restore-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`