### PR TITLE
fix: wait for restore health convergence

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -202,8 +202,8 @@ jobs:
           mkdir -p config/runtime
           printf '%s\n' "${APP_CONFIG}" > config/runtime/base.vars
           : > config/runtime/studio.vars
-          curl --fail --silent --show-error --retry 12 --retry-delay 5 "${SVA_PUBLIC_BASE_URL}/health/live" >/dev/null
-          curl --fail --silent --show-error --retry 12 --retry-delay 5 "${SVA_PUBLIC_BASE_URL}/health/ready" >/dev/null
+          curl --fail --silent --show-error --retry 60 --retry-delay 5 --retry-all-errors "${SVA_PUBLIC_BASE_URL}/health/live" >/dev/null
+          curl --fail --silent --show-error --retry 60 --retry-delay 5 --retry-all-errors "${SVA_PUBLIC_BASE_URL}/health/ready" >/dev/null
           pnpm exec tsx scripts/ops/runtime-env.ts smoke studio
 
       - name: write successful workflow evidence

--- a/docs/changelog/entries/pr-872.json
+++ b/docs/changelog/entries/pr-872.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 872,
+  "body": "Interne Verbesserung\n\n- Der kontrollierte Datenbank-Restore berücksichtigt bei den abschließenden Health-Prüfungen das zulässige Konvergenzfenster des Swarm-Services."
+}

--- a/tooling/testing/tests/database-restore-workflow-contract.test.ts
+++ b/tooling/testing/tests/database-restore-workflow-contract.test.ts
@@ -50,6 +50,7 @@ describe('controlled database restore workflow', () => {
     expect(workflow).toContain('restore-stack-stopped.yaml');
     expect(workflow).toContain('/health/live');
     expect(workflow).toContain('/health/ready');
+    expect(workflow).toContain('--retry 60 --retry-delay 5 --retry-all-errors');
     expect(workflow).toContain('runtime-env.ts smoke studio');
   });
 


### PR DESCRIPTION
## Zusammenfassung
- behandelt vorübergehende HTTP-404/5xx während der zulässigen Swarm-Konvergenz als retryfähig
- wartet bis zu fünf Minuten auf Live und Ready, bevor der Restore fail-closed bleibt
- ergänzt Regressionstest und Changelog

## Validierung
- `pnpm exec vitest run tooling/testing/tests/database-restore-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`

## Betriebszustand
Staging App/Provisioner bleiben nach dem fail-closed Restore-Run bewusst gestoppt. Recovery erfolgt ausschließlich durch einen neuen, freigegebenen Restore-Run nach Merge.