### PR TITLE
fix: reconcile app principal after restore

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -180,6 +180,20 @@ jobs:
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
         run: pnpm exec tsx scripts/ci/submit-restore-agent-request.ts "${{ inputs.environment }}"
 
+      - name: reconcile application database principal after restore
+        id: app_principal
+        env:
+          APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_DEPLOY_REVISION: ${{ steps.image_contract.outputs.deploy_revision }}
+        run: |
+          set -euo pipefail
+          umask 077
+          trap 'rm -f .env' EXIT
+          pnpm exec tsx scripts/ci/render-compose-env.ts --output .env
+          printf '\nIMAGE_REF=%s\n' "${{ steps.image_contract.outputs.deploy_image_ref }}" >> .env
+          pnpm exec tsx scripts/ci/promote-one-shot-job.ts --kind bootstrap --environment "${{ inputs.environment }}"
+
       - name: restart application after successful database checks
         id: restart
         env:
@@ -239,7 +253,7 @@ jobs:
           retention-days: 90
 
       - name: keep application stopped after any restore, post-check or evidence failure
-        if: ${{ always() && steps.maintenance.outputs.active == 'true' && (steps.external_verify.outcome != 'success' || steps.workflow_evidence.outcome != 'success' || steps.evidence_upload.outcome != 'success') }}
+        if: ${{ always() && steps.maintenance.outputs.active == 'true' && (steps.app_principal.outcome != 'success' || steps.external_verify.outcome != 'success' || steps.workflow_evidence.outcome != 'success' || steps.evidence_upload.outcome != 'success') }}
         env:
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
         run: quantum-cli stacks deploy -f "${RUNNER_TEMP}/restore-stack-stopped.yaml" --stack "${{ steps.target.outputs.stack_name }}" --endpoint "${QUANTUM_ENDPOINT}"

--- a/docs/changelog/entries/pr-873.json
+++ b/docs/changelog/entries/pr-873.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 873,
+  "body": "Interne Verbesserung\n\n- Der kontrollierte Datenbank-Restore stellt vor dem Neustart der Anwendung die Rechte des App-Datenbank-Principals über den bestehenden Bootstrap-Pfad wieder her."
+}

--- a/tooling/testing/tests/database-restore-workflow-contract.test.ts
+++ b/tooling/testing/tests/database-restore-workflow-contract.test.ts
@@ -54,6 +54,17 @@ describe('controlled database restore workflow', () => {
     expect(workflow).toContain('runtime-env.ts smoke studio');
   });
 
+  it('reconciles the application database principal before restarting writers', () => {
+    expect(workflow).toContain('promote-one-shot-job.ts --kind bootstrap');
+    expect(workflow.indexOf('reconcile application database principal after restore')).toBeGreaterThan(
+      workflow.indexOf('execute database restore and database checks')
+    );
+    expect(workflow.indexOf('reconcile application database principal after restore')).toBeLessThan(
+      workflow.indexOf('restart application after successful database checks')
+    );
+    expect(workflow).toContain("steps.app_principal.outcome != 'success'");
+  });
+
   it('uses only the dedicated restore contract and emits redacted evidence', () => {
     expect(workflow).toContain('RESTORE_AGENT_SIGNING_KEY');
     expect(workflow).toContain('database-restore-workflow-');


### PR DESCRIPTION
## Zusammenfassung
- führt nach erfolgreichem Restore bei weiterhin gestoppten Writern den bestehenden Bootstrap-One-shot aus
- stellt damit die Rechte von `sva_app` deterministisch wieder her, bevor App und Provisioner starten
- hält Staging bei Bootstrap-, Postcheck- oder Evidenzfehlern weiterhin fail-closed

## Validierung
- `pnpm exec vitest run tooling/testing/tests/database-restore-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`

## Laufzeitevidenz
Der Restore selbst sowie Sicherheitsdump und DB-Postchecks waren erfolgreich. Die Readiness-Diagnose wies ausschließlich `permission denied for schema iam` für `sva_app` aus; der bestehende Bootstrap plus reiner App-Promote stellte Staging wieder vollständig auf Live/Ready 200 her.