### PR TITLE
fix: back up before every protected deploy

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -207,7 +207,7 @@ jobs:
           QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
           SVA_PUBLIC_BASE_URL: ${{ steps.target.outputs.public_base_url }}
           SVA_STACK_NAME: ${{ steps.target.outputs.stack_name }}
-          SVA_ACCEPTANCE_RELEASE_MODE: ${{ inputs.environment }}
+          SVA_ACCEPTANCE_RELEASE_MODE: ${{ inputs.environment == 'prod' && 'prod' || '' }}
         run: |
           set -euo pipefail
           umask 077

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -252,9 +252,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm exec tsx scripts/ci/verify-staging-promote-evidence.ts
 
-      - name: create database backup before one-shot jobs
+      - name: create database backup before deployment
         id: backup_job
-        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') && vars.BACKUP_EXECUTOR != 'temporary' }}
+        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && vars.BACKUP_EXECUTOR != 'temporary' }}
         env:
           BACKUP_AGENT_SIGNING_KEY: ${{ secrets.BACKUP_AGENT_SIGNING_KEY }}
           DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: create temporary database backup fallback
         id: backup_fallback_job
-        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') && vars.BACKUP_EXECUTOR == 'temporary' }}
+        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && vars.BACKUP_EXECUTOR == 'temporary' }}
         env:
           APP_CONFIG: ${{ secrets.APP_CONFIG }}
           DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
@@ -283,7 +283,7 @@ jobs:
           pnpm exec tsx scripts/ci/promote-backup-job.ts "${{ inputs.environment }}"
 
       - name: verify database backup object
-        if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true') }}
+        if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}
         env:
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           S3_BUCKET: ${{ steps.backup_job.outputs.backup_bucket || steps.backup_fallback_job.outputs.backup_bucket }}

--- a/docs/changelog/entries/pr-874.json
+++ b/docs/changelog/entries/pr-874.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 874,
+  "body": "Interne Verbesserung\n\n- Staging- und Production-Deployments sichern die Datenbank jetzt immer vor dem Rollout.\n- Der Restore-Smoke verwendet den Production-Tenant-Gate nur in Production."
+}

--- a/docs/guides/studio-rollout-process.md
+++ b/docs/guides/studio-rollout-process.md
@@ -12,7 +12,7 @@ Dieses Dokument ist die einzige normative Bedienanleitung für reguläre Studio-
 - Staging wird vor Production mit demselben Digest vollständig verifiziert.
 - Production wird ausschließlich manuell über das geschützte GitHub-Environment `prod` freigegeben.
 - `auto` ist ausschließlich in Dev zulässig. Staging und Production verwenden `assert-none` oder `run`.
-- Bei Migration oder Bootstrap in Staging oder Production muss vor der ersten Datenmutation ein erfolgreich verifiziertes PostgreSQL-Backup vorliegen.
+- Vor jedem Deployment nach Staging oder Production muss ein erfolgreich verifiziertes PostgreSQL-Backup vorliegen.
 - Backup, Migration, Bootstrap, Postconditions und Verifikation sind fail-closed: Ein Fehler blockiert alle nachfolgenden mutierenden Phasen.
 - Secrets kommen ausschließlich aus dem jeweiligen GitHub-Environment. Sie werden weder in Workflow-Inputs noch in Logs, Reports oder Dokumentation geschrieben.
 - Direkte Portainer-Änderungen, Docker-Service-Updates, rohe `quantum-cli stacks deploy/update`-Aufrufe und `env:release:studio:local` sind kein regulärer Rolloutpfad.
@@ -22,8 +22,8 @@ Dieses Dokument ist die einzige normative Bedienanleitung für reguläre Studio-
 | Umgebung | Stack | Root-URL | Auslösung | Modi | Backup |
 | --- | --- | --- | --- | --- | --- |
 | Dev | `studio-dev` | `https://studio-dev.smart-village.app` | automatisch nach erfolgreichem Build auf `main` | `migration_mode=auto`, `bootstrap_mode=auto` | kein Promote-Backup |
-| Staging | `studio-staging` | `https://studio-staging.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `staging` | `assert-none` oder `run` | verpflichtend, sobald Migration oder Bootstrap ausgeführt wird |
-| Production | `studio` | `https://studio.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `prod` | `assert-none` oder `run` | verpflichtend, sobald Migration oder Bootstrap ausgeführt wird |
+| Staging | `studio-staging` | `https://studio-staging.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `staging` | `assert-none` oder `run` | vor jedem Deployment verpflichtend |
+| Production | `studio` | `https://studio.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `prod` | `assert-none` oder `run` | vor jedem Deployment verpflichtend |
 
 Die Backup-Endpunkte und Buckets sind fest an die Zielumgebung gebunden:
 
@@ -60,7 +60,7 @@ Der manuelle Workflow [Promote](../../.github/workflows/promote.yml) erhält:
 
 `assert-none` ist kein Skip: Sobald der Diff ein entsprechendes Risiko enthält, bricht das Gate ab. Dann muss der betreffende Modus bewusst auf `run` gesetzt werden.
 
-Wenn mindestens ein One-shot-Job läuft, ist die Reihenfolge unveränderlich:
+Die Reihenfolge ist unveränderlich; nicht angeforderte One-shot-Jobs und deren Postconditions werden übersprungen:
 
 1. Inputs, Git-Bindung, Image-Digest und OCI-Revision validieren.
 2. Vorherigen Live-Digest erfassen.
@@ -86,7 +86,7 @@ Production verwendet denselben Workflow und denselben bereits in Staging geprüf
 
 Danach gilt dieselbe Reihenfolge wie in Staging: Backup → Migration → Bootstrap → Postconditions → App-Deploy → Runtime-Smoke → Digest-Prüfung.
 
-Ein reines App-Deployment mit beiden Modi `assert-none` führt kein Datenbank-Backup aus. Das ist nur zulässig, wenn die Diff-Gates belastbar bestätigen, dass weder Migration noch Bootstrap erforderlich sind.
+Auch ein reines App-Deployment mit beiden Modi `assert-none` beginnt mit einem erfolgreich verifizierten Datenbank-Backup.
 
 ## Konvergenz und Erfolgsdefinition
 

--- a/tooling/testing/tests/database-restore-workflow-contract.test.ts
+++ b/tooling/testing/tests/database-restore-workflow-contract.test.ts
@@ -8,6 +8,12 @@ const workflow = readFileSync(
 );
 
 describe('controlled database restore workflow', () => {
+  it('uses the production-only release-blocking tenant scope', () => {
+    expect(workflow).toContain(
+      "SVA_ACCEPTANCE_RELEASE_MODE: ${{ inputs.environment == 'prod' && 'prod' || '' }}"
+    );
+  });
+
   it('is manually dispatched, environment-protected and globally serialized per target', () => {
     expect(workflow).toContain('workflow_dispatch:');
     expect(workflow).toContain('environment: ${{ inputs.environment }}');

--- a/tooling/testing/tests/promote-workflow-contract.test.ts
+++ b/tooling/testing/tests/promote-workflow-contract.test.ts
@@ -21,7 +21,7 @@ describe('Promote workflow contract', () => {
     const phases = [
       'bind executor source to promoted change head',
       'capture previous live app digest',
-      'create database backup before one-shot jobs',
+      'create database backup before deployment',
       'verify database backup object',
       'run migration one-shot job',
       'run bootstrap one-shot job',
@@ -68,7 +68,7 @@ describe('Promote workflow contract', () => {
     expect(workflow).toContain('packages: read');
     expect(workflow).toContain('actions: read');
     expect(workflow).toContain('require successful staging parity for production mutation');
-    expect(workflow).toContain('create database backup before one-shot jobs');
+    expect(workflow).toContain('create database backup before deployment');
     expect(workflow).toContain('verify database backup object');
     expect(workflow).toContain(
       'S3_OBJECT_KEY: ${{ steps.backup_job.outputs.backup_object || steps.backup_fallback_job.outputs.backup_object }}'
@@ -87,7 +87,7 @@ describe('Promote workflow contract', () => {
     );
   });
 
-  it('runs backups only for staging or production mutations and blocks production deploys behind parity', () => {
+  it('runs backups before every staging or production deployment and blocks production mutations behind parity', () => {
     expect(workflow).toContain("inputs.environment == 'staging' || inputs.environment == 'prod'");
     expect(workflow).toContain(
       "inputs.environment == 'prod' && (steps.gate_eval.outputs.migration_should_run == 'true' || steps.gate_eval.outputs.bootstrap_should_run == 'true')"
@@ -95,7 +95,16 @@ describe('Promote workflow contract', () => {
     expect(workflow).toContain('require successful staging parity for production mutation');
     expect(
       workflow.indexOf('require successful staging parity for production mutation')
-    ).toBeLessThan(workflow.indexOf('create database backup before one-shot jobs'));
+    ).toBeLessThan(workflow.indexOf('create database backup before deployment'));
+    expect(workflow).toContain(
+      "if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && vars.BACKUP_EXECUTOR != 'temporary' }}"
+    );
+    expect(workflow).toContain(
+      "if: ${{ (inputs.environment == 'staging' || inputs.environment == 'prod') && vars.BACKUP_EXECUTOR == 'temporary' }}"
+    );
+    expect(workflow).toContain(
+      "if: ${{ inputs.environment == 'staging' || inputs.environment == 'prod' }}"
+    );
   });
 
   it('uses automatic diff-based one-shot execution for main-to-Dev promotion', () => {


### PR DESCRIPTION
## Zusammenfassung
- erzwingt ein verifiziertes Datenbank-Backup vor jedem Staging- und Production-Deployment
- beschränkt den release-blockierenden Tenant-Smoke beim Restore auf Production
- aktualisiert Workflow-Verträge, Rollout-Dokumentation und Changelog

## Tests
- `pnpm exec vitest run tooling/testing/tests/database-restore-workflow-contract.test.ts tooling/testing/tests/promote-workflow-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`