### PR TITLE
fix: validate restore staging drill workflow

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${STAGING_DRILL_RUN_ID}" \
-            --jq 'select(.name == "Controlled Database Restore" and .event == "workflow_dispatch" and .head_branch == "main" and .conclusion == "success") | .id' \
+            --jq 'select(.path == ".github/workflows/database-restore.yml" and .event == "workflow_dispatch" and .head_branch == "main" and .conclusion == "success") | .id' \
             | grep -Eq "^${STAGING_DRILL_RUN_ID}$"
 
       - name: verify staging drill evidence for production

--- a/docs/changelog/entries/pr-876.json
+++ b/docs/changelog/entries/pr-876.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 876,
+  "body": "Fehlerbehebung\n\n- Die Produktionsfreigabe eines Datenbank-Restores erkennt erfolgreiche Staging-Drills nun über die stabile Workflow-Datei statt über einen dynamischen Laufnamen."
+}

--- a/scripts/ci/database-restore-workflow-contract.test.ts
+++ b/scripts/ci/database-restore-workflow-contract.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/database-restore.yml'),
+  'utf8',
+);
+
+describe('database restore workflow', () => {
+  it('identifies a successful staging drill by its stable workflow path, not its dynamic run name', () => {
+    expect(workflow).toContain('.path == ".github/workflows/database-restore.yml"');
+    expect(workflow).not.toContain('.name == "Controlled Database Restore"');
+  });
+});


### PR DESCRIPTION
## Änderung

Der Production-Restore akzeptiert den erfolgreichen Staging-Drill jetzt anhand des stabilen Workflow-Pfads statt des dynamischen Anzeigenamens.

## Ursache

GitHub setzt für manuell ausgelöste Runs den dynamischen `run-name`; die bisherige Prüfung auf `Controlled Database Restore` hat daher jeden gültigen Staging-Drill abgewiesen.

## Prüfung

- `pnpm exec vitest run scripts/ci/database-restore-workflow-contract.test.ts scripts/ci/verify-staging-restore-evidence.test.ts`