### PR TITLE
fix: validate restore evidence before image binding

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -72,16 +72,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: bind executor source to image revision on main
-        env:
-          CHANGE_HEAD: ${{ inputs.change_head }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
-          head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
-          git merge-base --is-ancestor "${head}" origin/main
-          git checkout --detach "${head}"
-
       - name: setup pnpm workspace
         uses: ./.github/actions/setup-pnpm-workspace
 
@@ -128,6 +118,16 @@ jobs:
       - name: verify staging drill evidence for production
         if: ${{ inputs.environment == 'prod' }}
         run: pnpm exec tsx scripts/ci/verify-staging-restore-evidence.ts "${{ runner.temp }}/staging-restore-evidence"
+
+      - name: bind executor source to image revision on main
+        env:
+          CHANGE_HEAD: ${{ inputs.change_head }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
+          head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
+          git merge-base --is-ancestor "${head}" origin/main
+          git checkout --detach "${head}"
 
       - name: setup quantum-cli
         uses: hostwithquantum/setup-quantum-cli@v2.0.0

--- a/docs/changelog/entries/pr-877.json
+++ b/docs/changelog/entries/pr-877.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 877,
+  "body": "Fehlerbehebung\n\n- Die Production-Restore-Evidenz wird vor der Bindung an die Live-Image-Revision geprüft, damit der aktuelle Workflow-Validator verfügbar bleibt."
+}

--- a/scripts/ci/database-restore-workflow-contract.test.ts
+++ b/scripts/ci/database-restore-workflow-contract.test.ts
@@ -13,4 +13,12 @@ describe('database restore workflow', () => {
     expect(workflow).toContain('.path == ".github/workflows/database-restore.yml"');
     expect(workflow).not.toContain('.name == "Controlled Database Restore"');
   });
+
+  it('validates the production staging evidence before binding execution to the live image revision', () => {
+    const evidenceValidation = workflow.indexOf('verify staging drill evidence for production');
+    const imageRevisionBinding = workflow.indexOf('bind executor source to image revision on main');
+
+    expect(evidenceValidation).toBeGreaterThan(-1);
+    expect(imageRevisionBinding).toBeGreaterThan(evidenceValidation);
+  });
 });


### PR DESCRIPTION
## Änderung

- Staging-Restore-Evidenz wird vor dem Checkout auf die Live-Image-Revision validiert.
- Ein Workflow-Vertrag sichert die erforderliche Reihenfolge.

## Ursache

Der frühere Checkout auf den alten Live-Commit enthielt den inzwischen eingeführten Evidenz-Validator nicht.

## Validierung

- 
 RUN  v4.1.9 /Users/wilimzig/Documents/Projects/SVA/sva-studio


 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  17:42:21
   Duration  290ms (transform 47ms, setup 0ms, import 85ms, tests 5ms, environment 0ms)