### PR TITLE
Speicheraktionen für lange Bearbeitungsflächen vereinheitlichen

### DIFF
--- a/apps/sva-studio-react/e2e/account-admin-ui.tenant-admin.spec.ts
+++ b/apps/sva-studio-react/e2e/account-admin-ui.tenant-admin.spec.ts
@@ -44,6 +44,6 @@ test('tenant admin mutations fail closed in the browser when the admin client co
   await navigateClientSide(page, '/admin/users/account-2');
   await page.getByRole('tab', { name: 'Verwaltung' }).click();
   await page.getByLabel('Mainserver Application-ID').fill('updated-app-id');
-  await page.getByRole('button', { name: 'Änderungen speichern' }).click();
+  await page.getByRole('button', { name: 'Änderungen speichern' }).last().click();
   await expect(page.getByText('Für diese Instanz ist noch kein Tenant-Admin-Client hinterlegt. Bitte zuerst den Instanzvertrag abgleichen.')).toBeVisible();
 });

--- a/apps/sva-studio-react/e2e/account-admin-ui.user-admin.spec.ts
+++ b/apps/sva-studio-react/e2e/account-admin-ui.user-admin.spec.ts
@@ -41,7 +41,7 @@ test('admin user list and edit page are reachable for system_admin', async ({ pa
   await page.getByRole('tab', { name: 'Verwaltung' }).click();
   await page.getByLabel('Mainserver Application-ID').fill('updated-app-id');
   await page.getByLabel('Mainserver Application-Secret').fill('new-secret');
-  await page.getByRole('button', { name: 'Änderungen speichern' }).click();
+  await page.getByRole('button', { name: 'Änderungen speichern' }).last().click();
   await expect.poll(() => updateRequestBody).toEqual(expect.objectContaining({ mainserverUserApplicationId: 'updated-app-id', mainserverUserApplicationSecret: 'new-secret' }));
   await expect(page.getByText('Nutzerdaten wurden gespeichert.')).toBeVisible();
   await page.getByRole('tab', { name: 'Berechtigungen' }).click();

--- a/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/events-poi-plugin.spec.ts
@@ -44,10 +44,10 @@ test.describe('events and POI plugins', () => {
     await page.locator('#poi-link-url-0').fill('https://example.com/poi');
     await page.locator('#poi-opening-weekday-0').selectOption('MO');
     await page.locator('#poi-opening-time-from-0').fill('09:00');
-    await page.getByRole('button', { name: /Speichern|poi\.actions\.save/ }).click();
+    await page.getByRole('button', { name: /Speichern|poi\.actions\.save/ }).last().click();
     await page.getByRole('tab', { name: /Basis|poi\.detailTabs\.basis\.title/ }).click();
     await page.locator('#poi-name').fill('Rathaus aktualisiert');
-    await page.getByRole('button', { name: /Speichern|poi\.actions\.save/ }).click();
+    await page.getByRole('button', { name: /Speichern|poi\.actions\.save/ }).last().click();
     page.once('dialog', (dialog) => dialog.accept());
     await page.getByRole('button', { name: /Löschen|poi\.actions\.delete/ }).click();
     await expectContentOverviewReady(page);
@@ -76,10 +76,10 @@ test.describe('events and POI plugins', () => {
     await page.locator('#event-city').fill('Musterhausen');
     await page.locator('#event-contact-email').fill('events@example.com');
     await page.locator('#event-url').fill('https://example.com/event');
-    await page.getByRole('button', { name: /Speichern|events\.actions\.save/ }).click();
+    await page.getByRole('button', { name: /Speichern|events\.actions\.save/ }).last().click();
     await page.getByRole('tab', { name: /Basis|events\.detailTabs\.basis\.title/ }).click();
     await page.locator('#event-title').fill('Stadtfest aktualisiert');
-    await page.getByRole('button', { name: /Speichern|events\.actions\.save/ }).click();
+    await page.getByRole('button', { name: /Speichern|events\.actions\.save/ }).last().click();
     page.once('dialog', (dialog) => dialog.accept());
     await page.getByRole('button', { name: /Löschen|events\.actions\.delete/ }).click();
     await expectContentOverviewReady(page);

--- a/apps/sva-studio-react/e2e/news-plugin.spec.ts
+++ b/apps/sva-studio-react/e2e/news-plugin.spec.ts
@@ -67,7 +67,7 @@ test.describe('news plugin', () => {
     await page.locator('#news-media-caption-0').fill('Titelbild');
     await openNewsDetailTab(page, /Einstellungen|news\.tabs\.settings/);
     await page.getByRole('radio', { name: /Entwurf|news\.publicationModes\.draft/ }).click();
-    await page.getByRole('button', { name: /Speichern|news\.actions\.save/ }).click();
+    await page.getByRole('button', { name: /Speichern|news\.actions\.save/ }).last().click();
     await expect.poll(() => newsItems.length).toBe(1);
     expect(createdBody).toMatchObject({ title: 'Erste News', author: 'Editor One', sourceUrl: { url: 'https://example.com/news/source', description: 'Quellseite' } });
     expect(createdBody?.categories).toEqual([{ name: 'Allgemein' }, { name: 'Kultur' }]);
@@ -76,7 +76,7 @@ test.describe('news plugin', () => {
     await page.getByLabel(/Titel|news\.fields\.title/).fill('Erste News aktualisiert');
     await openNewsDetailTab(page, /Einstellungen|news\.tabs\.settings/);
     await page.getByRole('radio', { name: /Sofort veröffentlichen|news\.publicationModes\.immediate/ }).click();
-    await page.getByRole('button', { name: /Speichern|news\.actions\.save/ }).click();
+    await page.getByRole('button', { name: /Speichern|news\.actions\.save/ }).last().click();
     await expect.poll(() => newsItems[0]?.title).toBe('Erste News aktualisiert');
     page.once('dialog', async (dialog) => {
       await dialog.accept();

--- a/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-create-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-create-page.test.tsx
@@ -8,7 +8,11 @@ const useLegalTextsMock = vi.fn();
 const navigateMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ to, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+  Link: ({
+    to,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
     <a href={to} {...props}>
       {children}
     </a>
@@ -79,25 +83,36 @@ describe('LegalTextCreatePage', () => {
     fireEvent.change(screen.getByLabelText('Status', { selector: '#legal-text-create-status' }), {
       target: { value: 'valid' },
     });
-    fireEvent.change(screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-create-published' }), {
-      target: { value: '2026-04-10T09:30' },
-    });
-    fireEvent.change(screen.getByLabelText('Zielrollen-IDs', { selector: '#legal-text-create-role-targets' }), {
-      target: {
-        value:
-          ' 11111111-1111-1111-1111-111111111111, 22222222-2222-2222-2222-222222222222 ,, 11111111-1111-1111-1111-111111111111 ',
-      },
-    });
-    fireEvent.change(screen.getByLabelText('Zielgruppen-IDs', { selector: '#legal-text-create-group-targets' }), {
-      target: {
-        value:
-          ' aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa, bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb ,, aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa ',
-      },
-    });
+    fireEvent.change(
+      screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-create-published' }),
+      {
+        target: { value: '2026-04-10T09:30' },
+      }
+    );
+    fireEvent.change(
+      screen.getByLabelText('Zielrollen-IDs', { selector: '#legal-text-create-role-targets' }),
+      {
+        target: {
+          value:
+            ' 11111111-1111-1111-1111-111111111111, 22222222-2222-2222-2222-222222222222 ,, 11111111-1111-1111-1111-111111111111 ',
+        },
+      }
+    );
+    fireEvent.change(
+      screen.getByLabelText('Zielgruppen-IDs', { selector: '#legal-text-create-group-targets' }),
+      {
+        target: {
+          value:
+            ' aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa, bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb ,, aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa ',
+        },
+      }
+    );
     fireEvent.change(screen.getByLabelText('Inhalt', { selector: '#legal-text-create-content' }), {
       target: { value: '<p> Rechtstext </p>' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Rechtstext anlegen' }));
+    const createButtons = screen.getAllByRole('button', { name: 'Rechtstext anlegen' });
+    expect(createButtons).toHaveLength(2);
+    fireEvent.click(createButtons[1]!);
 
     await waitFor(() => {
       expect(createLegalText).toHaveBeenCalledWith({
@@ -135,7 +150,7 @@ describe('LegalTextCreatePage', () => {
     fireEvent.change(screen.getByLabelText('Version', { selector: '#legal-text-create-version' }), {
       target: { value: '2026-05' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Rechtstext anlegen' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rechtstext anlegen' })[1]!);
 
     await waitFor(() => {
       expect(createLegalText).toHaveBeenCalled();
@@ -173,10 +188,13 @@ describe('LegalTextCreatePage', () => {
     fireEvent.change(screen.getByLabelText('Status', { selector: '#legal-text-create-status' }), {
       target: { value: 'valid' },
     });
-    fireEvent.change(screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-create-published' }), {
-      target: { value: '2026-03-29T02:30' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Rechtstext anlegen' }));
+    fireEvent.change(
+      screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-create-published' }),
+      {
+        target: { value: '2026-03-29T02:30' },
+      }
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rechtstext anlegen' })[1]!);
 
     await waitFor(() => {
       expect(createLegalText).not.toHaveBeenCalled();

--- a/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-create-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-create-page.tsx
@@ -74,7 +74,7 @@ const emptyForm = () => ({
   targetGroupIds: '',
 });
 
-export const LegalTextCreatePage = () => {
+const useLegalTextCreatePage = () => {
   const navigate = useNavigate();
   const legalTextsApi = useLegalTexts();
   const [formValues, setFormValues] = React.useState(emptyForm);
@@ -115,6 +115,13 @@ export const LegalTextCreatePage = () => {
       params: { legalTextVersionId: created.id },
     });
   };
+
+  return { formValues, legalTextsApi, onSubmit, setFormValues, validationError };
+};
+
+export const LegalTextCreatePage = () => {
+  const { formValues, legalTextsApi, onSubmit, setFormValues, validationError } =
+    useLegalTextCreatePage();
 
   return (
     <StudioDetailPageTemplate

--- a/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-create-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-create-page.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate } from '@tanstack/react-router';
+import { StudioDetailPageTemplate } from '@sva/studio-ui-react';
 import React from 'react';
 
 import { Alert, AlertDescription } from '../../../components/ui/alert';
@@ -116,53 +117,77 @@ export const LegalTextCreatePage = () => {
   };
 
   return (
-    <section className="space-y-5">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-semibold text-foreground">{t('admin.legalTexts.dialogs.createTitle')}</h1>
-          <p className="max-w-3xl text-sm text-muted-foreground">{t('admin.legalTexts.dialogs.createDescription')}</p>
-        </div>
+    <StudioDetailPageTemplate
+      title={t('admin.legalTexts.dialogs.createTitle')}
+      description={t('admin.legalTexts.dialogs.createDescription')}
+      actions={
         <Button asChild type="button" variant="outline">
           <Link to="/admin/legal-texts">{t('admin.legalTexts.detail.backToList')}</Link>
         </Button>
-      </header>
-
+      }
+      primaryAction={
+        <Button type="submit" form="legal-text-create-form">
+          {t('admin.legalTexts.actions.create')}
+        </Button>
+      }
+    >
       <Card className="space-y-4 p-4">
-        <form className="space-y-4" onSubmit={(event) => void onSubmit(event)}>
+        <form
+          id="legal-text-create-form"
+          className="space-y-4"
+          onSubmit={(event) => void onSubmit(event)}
+        >
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="legal-text-create-name">{t('admin.legalTexts.fields.name')}</Label>
               <Input
                 id="legal-text-create-name"
                 value={formValues.name}
-                onChange={(event) => setFormValues((current) => ({ ...current, name: event.target.value }))}
+                onChange={(event) =>
+                  setFormValues((current) => ({ ...current, name: event.target.value }))
+                }
                 required
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="legal-text-create-version">{t('admin.legalTexts.fields.legalTextVersion')}</Label>
+              <Label htmlFor="legal-text-create-version">
+                {t('admin.legalTexts.fields.legalTextVersion')}
+              </Label>
               <Input
                 id="legal-text-create-version"
                 value={formValues.legalTextVersion}
-                onChange={(event) => setFormValues((current) => ({ ...current, legalTextVersion: event.target.value }))}
+                onChange={(event) =>
+                  setFormValues((current) => ({ ...current, legalTextVersion: event.target.value }))
+                }
                 required
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="legal-text-create-locale">{t('admin.legalTexts.fields.locale')}</Label>
+              <Label htmlFor="legal-text-create-locale">
+                {t('admin.legalTexts.fields.locale')}
+              </Label>
               <Input
                 id="legal-text-create-locale"
                 value={formValues.locale}
-                onChange={(event) => setFormValues((current) => ({ ...current, locale: event.target.value }))}
+                onChange={(event) =>
+                  setFormValues((current) => ({ ...current, locale: event.target.value }))
+                }
                 required
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="legal-text-create-status">{t('admin.legalTexts.fields.status')}</Label>
+              <Label htmlFor="legal-text-create-status">
+                {t('admin.legalTexts.fields.status')}
+              </Label>
               <Select
                 id="legal-text-create-status"
                 value={formValues.status}
-                onChange={(event) => setFormValues((current) => ({ ...current, status: event.target.value as LegalTextStatus }))}
+                onChange={(event) =>
+                  setFormValues((current) => ({
+                    ...current,
+                    status: event.target.value as LegalTextStatus,
+                  }))
+                }
               >
                 <option value="draft">{t('admin.legalTexts.status.draft')}</option>
                 <option value="valid">{t('admin.legalTexts.status.valid')}</option>
@@ -170,30 +195,42 @@ export const LegalTextCreatePage = () => {
               </Select>
             </div>
             <div className="space-y-2 md:col-span-2">
-              <Label htmlFor="legal-text-create-published">{t('admin.legalTexts.fields.publishedAt')}</Label>
+              <Label htmlFor="legal-text-create-published">
+                {t('admin.legalTexts.fields.publishedAt')}
+              </Label>
               <Input
                 id="legal-text-create-published"
                 type="datetime-local"
                 value={formValues.publishedAt}
                 required={formValues.status === 'valid'}
-                onChange={(event) => setFormValues((current) => ({ ...current, publishedAt: event.target.value }))}
+                onChange={(event) =>
+                  setFormValues((current) => ({ ...current, publishedAt: event.target.value }))
+                }
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="legal-text-create-role-targets">{t('admin.legalTexts.fields.targetRoleIds')}</Label>
+              <Label htmlFor="legal-text-create-role-targets">
+                {t('admin.legalTexts.fields.targetRoleIds')}
+              </Label>
               <Input
                 id="legal-text-create-role-targets"
                 value={formValues.targetRoleIds}
-                onChange={(event) => setFormValues((current) => ({ ...current, targetRoleIds: event.target.value }))}
+                onChange={(event) =>
+                  setFormValues((current) => ({ ...current, targetRoleIds: event.target.value }))
+                }
                 placeholder={t('admin.legalTexts.fields.targetRoleIdsPlaceholder')}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="legal-text-create-group-targets">{t('admin.legalTexts.fields.targetGroupIds')}</Label>
+              <Label htmlFor="legal-text-create-group-targets">
+                {t('admin.legalTexts.fields.targetGroupIds')}
+              </Label>
               <Input
                 id="legal-text-create-group-targets"
                 value={formValues.targetGroupIds}
-                onChange={(event) => setFormValues((current) => ({ ...current, targetGroupIds: event.target.value }))}
+                onChange={(event) =>
+                  setFormValues((current) => ({ ...current, targetGroupIds: event.target.value }))
+                }
                 placeholder={t('admin.legalTexts.fields.targetGroupIdsPlaceholder')}
               />
             </div>
@@ -217,16 +254,17 @@ export const LegalTextCreatePage = () => {
             <Button asChild type="button" variant="outline">
               <Link to="/admin/legal-texts">{t('account.actions.cancel')}</Link>
             </Button>
-            <Button type="submit">{t('admin.legalTexts.actions.create')}</Button>
           </div>
         </form>
       </Card>
 
       {validationError || legalTextsApi.mutationError ? (
         <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-          <AlertDescription>{validationError ?? legalTextErrorMessage(legalTextsApi.mutationError)}</AlertDescription>
+          <AlertDescription>
+            {validationError ?? legalTextErrorMessage(legalTextsApi.mutationError)}
+          </AlertDescription>
         </Alert>
       ) : null}
-    </section>
+    </StudioDetailPageTemplate>
   );
 };

--- a/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-detail-page.test.tsx
@@ -8,7 +8,11 @@ const useLegalTextsMock = vi.fn();
 const navigateMock = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ to, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+  Link: ({
+    to,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
     <a href={to} {...props}>
       {children}
     </a>
@@ -111,9 +115,10 @@ describe('LegalTextDetailPage', () => {
     render(<LegalTextDetailPage legalTextVersionId="legal-1" />);
 
     await waitFor(() => {
-      expect((screen.getByLabelText('Name', { selector: '#legal-text-edit-name' }) as HTMLInputElement).value).toBe(
-        'Datenschutzhinweise'
-      );
+      expect(
+        (screen.getByLabelText('Name', { selector: '#legal-text-edit-name' }) as HTMLInputElement)
+          .value
+      ).toBe('Datenschutzhinweise');
     });
 
     fireEvent.change(screen.getByLabelText('Name', { selector: '#legal-text-edit-name' }), {
@@ -128,25 +133,36 @@ describe('LegalTextDetailPage', () => {
     fireEvent.change(screen.getByLabelText('Status', { selector: '#legal-text-edit-status' }), {
       target: { value: 'valid' },
     });
-    fireEvent.change(screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-edit-published' }), {
-      target: { value: '2026-04-10T10:45' },
-    });
-    fireEvent.change(screen.getByLabelText('Zielrollen-IDs', { selector: '#legal-text-edit-role-targets' }), {
-      target: {
-        value:
-          ' 33333333-3333-3333-3333-333333333333, 44444444-4444-4444-4444-444444444444 ,, 33333333-3333-3333-3333-333333333333 ',
-      },
-    });
-    fireEvent.change(screen.getByLabelText('Zielgruppen-IDs', { selector: '#legal-text-edit-group-targets' }), {
-      target: {
-        value:
-          ' cccccccc-cccc-cccc-cccc-cccccccccccc, dddddddd-dddd-dddd-dddd-dddddddddddd, cccccccc-cccc-cccc-cccc-cccccccccccc ',
-      },
-    });
+    fireEvent.change(
+      screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-edit-published' }),
+      {
+        target: { value: '2026-04-10T10:45' },
+      }
+    );
+    fireEvent.change(
+      screen.getByLabelText('Zielrollen-IDs', { selector: '#legal-text-edit-role-targets' }),
+      {
+        target: {
+          value:
+            ' 33333333-3333-3333-3333-333333333333, 44444444-4444-4444-4444-444444444444 ,, 33333333-3333-3333-3333-333333333333 ',
+        },
+      }
+    );
+    fireEvent.change(
+      screen.getByLabelText('Zielgruppen-IDs', { selector: '#legal-text-edit-group-targets' }),
+      {
+        target: {
+          value:
+            ' cccccccc-cccc-cccc-cccc-cccccccccccc, dddddddd-dddd-dddd-dddd-dddddddddddd, cccccccc-cccc-cccc-cccc-cccccccccccc ',
+        },
+      }
+    );
     fireEvent.change(screen.getByLabelText('Inhalt', { selector: '#legal-text-edit-content' }), {
       target: { value: '<p>Neu</p>' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Änderungen speichern' }));
+    const saveButtons = screen.getAllByRole('button', { name: 'Änderungen speichern' });
+    expect(saveButtons).toHaveLength(2);
+    fireEvent.click(saveButtons[1]!);
 
     await waitFor(() => {
       expect(updateLegalText).toHaveBeenCalledWith('legal-1', {
@@ -186,12 +202,16 @@ describe('LegalTextDetailPage', () => {
     render(<LegalTextDetailPage legalTextVersionId="legal-1" />);
 
     await waitFor(() => {
-      expect((screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-edit-published' }) as HTMLInputElement).value).toBe(
-        '2026-10-25T02:30'
-      );
+      expect(
+        (
+          screen.getByLabelText('Veröffentlicht am', {
+            selector: '#legal-text-edit-published',
+          }) as HTMLInputElement
+        ).value
+      ).toBe('2026-10-25T02:30');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Änderungen speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Änderungen speichern' })[1]!);
 
     await waitFor(() => {
       expect(updateLegalText).toHaveBeenCalledWith(
@@ -213,7 +233,9 @@ describe('LegalTextDetailPage', () => {
 
     render(<LegalTextDetailPage legalTextVersionId="missing" />);
 
-    expect(screen.getAllByText('Die angeforderte Rechtstext-Version wurde nicht gefunden.')).toHaveLength(2);
+    expect(
+      screen.getAllByText('Die angeforderte Rechtstext-Version wurde nicht gefunden.')
+    ).toHaveLength(2);
     expect(screen.getByRole('alert')).toBeTruthy();
   });
 
@@ -224,13 +246,18 @@ describe('LegalTextDetailPage', () => {
     render(<LegalTextDetailPage legalTextVersionId="legal-1" />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-edit-published' })).toBeTruthy();
+      expect(
+        screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-edit-published' })
+      ).toBeTruthy();
     });
 
-    fireEvent.change(screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-edit-published' }), {
-      target: { value: '2026-03-29T02:30' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Änderungen speichern' }));
+    fireEvent.change(
+      screen.getByLabelText('Veröffentlicht am', { selector: '#legal-text-edit-published' }),
+      {
+        target: { value: '2026-03-29T02:30' },
+      }
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: 'Änderungen speichern' })[1]!);
 
     await waitFor(() => {
       expect(updateLegalText).not.toHaveBeenCalled();

--- a/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/legal-texts/-legal-text-detail-page.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from '@tanstack/react-router';
 import { toDatetimeLocalValue } from '@sva/plugin-sdk';
+import { StudioDetailPageTemplate } from '@sva/studio-ui-react';
 import React from 'react';
 
 import { ConfirmDialog } from '../../../components/ConfirmDialog';
@@ -14,7 +15,11 @@ import { useLegalTexts } from '../../../hooks/use-legal-texts';
 import { t } from '../../../i18n';
 import { parseOptionalEditorDateTime } from '../../../lib/editor-date-time';
 import type { UpdateLegalTextPayload } from '../../../lib/iam-api';
-import { formatLegalTextDateTime, getLegalTextErrorMessage, type LegalTextStatus } from './-legal-texts-shared';
+import {
+  formatLegalTextDateTime,
+  getLegalTextErrorMessage,
+  type LegalTextStatus,
+} from './-legal-texts-shared';
 
 type LegalTextDetailPageProps = {
   readonly legalTextVersionId: string;
@@ -88,7 +93,10 @@ export const LegalTextDetailPage = ({ legalTextVersionId }: LegalTextDetailPageP
     event.preventDefault();
     setValidationError(null);
 
-    const publishedAt = parseOptionalEditorDateTime(formValues.publishedAt, selectedLegalText?.publishedAt);
+    const publishedAt = parseOptionalEditorDateTime(
+      formValues.publishedAt,
+      selectedLegalText?.publishedAt
+    );
     if (publishedAt.kind === 'invalid') {
       setValidationError(t('admin.legalTexts.validation.publishedAtInvalid'));
       return;
@@ -123,149 +131,213 @@ export const LegalTextDetailPage = ({ legalTextVersionId }: LegalTextDetailPageP
   };
 
   return (
-    <section className="space-y-5" aria-busy={legalTextsApi.isLoading}>
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-semibold text-foreground">
-            {selectedLegalText?.name ?? t('admin.legalTexts.dialogs.editTitle')}
-          </h1>
-          <p className="max-w-3xl text-sm text-muted-foreground">
-            {selectedLegalText
-              ? t('admin.legalTexts.dialogs.editDescription', {
-                  id: selectedLegalText.id,
-                  version: selectedLegalText.legalTextVersion,
-                  locale: selectedLegalText.locale,
-                })
-              : t('admin.legalTexts.dialogs.editDescriptionFallback')}
-          </p>
-        </div>
-        <Button asChild type="button" variant="outline">
-          <Link to="/admin/legal-texts">{t('admin.legalTexts.detail.backToList')}</Link>
-        </Button>
-      </header>
+    <section aria-busy={legalTextsApi.isLoading}>
+      <StudioDetailPageTemplate
+        title={selectedLegalText?.name ?? t('admin.legalTexts.dialogs.editTitle')}
+        description={
+          selectedLegalText
+            ? t('admin.legalTexts.dialogs.editDescription', {
+                id: selectedLegalText.id,
+                version: selectedLegalText.legalTextVersion,
+                locale: selectedLegalText.locale,
+              })
+            : t('admin.legalTexts.dialogs.editDescriptionFallback')
+        }
+        actions={
+          <Button asChild type="button" variant="outline">
+            <Link to="/admin/legal-texts">{t('admin.legalTexts.detail.backToList')}</Link>
+          </Button>
+        }
+        primaryAction={
+          selectedLegalText ? (
+            <Button type="submit" form="legal-text-edit-form">
+              {t('admin.legalTexts.actions.save')}
+            </Button>
+          ) : undefined
+        }
+      >
+        {!selectedLegalText && !legalTextsApi.isLoading ? (
+          <Card className="p-6 text-sm text-muted-foreground">
+            {t('admin.legalTexts.detail.notFound')}
+          </Card>
+        ) : null}
 
-      {!selectedLegalText && !legalTextsApi.isLoading ? (
-        <Card className="p-6 text-sm text-muted-foreground">{t('admin.legalTexts.detail.notFound')}</Card>
-      ) : null}
+        {selectedLegalText ? (
+          <Card className="space-y-4 p-4">
+            <form
+              id="legal-text-edit-form"
+              className="space-y-4"
+              onSubmit={(event) => void onSubmit(event)}
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="legal-text-edit-name">{t('admin.legalTexts.fields.name')}</Label>
+                  <Input
+                    id="legal-text-edit-name"
+                    value={formValues.name}
+                    onChange={(event) =>
+                      setFormValues((current) => ({ ...current, name: event.target.value }))
+                    }
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="legal-text-edit-version">
+                    {t('admin.legalTexts.fields.legalTextVersion')}
+                  </Label>
+                  <Input
+                    id="legal-text-edit-version"
+                    value={formValues.legalTextVersion}
+                    onChange={(event) =>
+                      setFormValues((current) => ({
+                        ...current,
+                        legalTextVersion: event.target.value,
+                      }))
+                    }
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="legal-text-edit-locale">
+                    {t('admin.legalTexts.fields.locale')}
+                  </Label>
+                  <Input
+                    id="legal-text-edit-locale"
+                    value={formValues.locale}
+                    onChange={(event) =>
+                      setFormValues((current) => ({ ...current, locale: event.target.value }))
+                    }
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="legal-text-edit-status">
+                    {t('admin.legalTexts.fields.status')}
+                  </Label>
+                  <Select
+                    id="legal-text-edit-status"
+                    value={formValues.status}
+                    onChange={(event) =>
+                      setFormValues((current) => ({
+                        ...current,
+                        status: event.target.value as LegalTextStatus,
+                      }))
+                    }
+                  >
+                    <option value="draft">{t('admin.legalTexts.status.draft')}</option>
+                    <option value="valid">{t('admin.legalTexts.status.valid')}</option>
+                    <option value="archived">{t('admin.legalTexts.status.archived')}</option>
+                  </Select>
+                </div>
+                <div className="space-y-2 md:col-span-2">
+                  <Label htmlFor="legal-text-edit-published">
+                    {t('admin.legalTexts.fields.publishedAt')}
+                  </Label>
+                  <Input
+                    id="legal-text-edit-published"
+                    type="datetime-local"
+                    value={formValues.publishedAt}
+                    required={formValues.status === 'valid'}
+                    onChange={(event) =>
+                      setFormValues((current) => ({ ...current, publishedAt: event.target.value }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="legal-text-edit-role-targets">
+                    {t('admin.legalTexts.fields.targetRoleIds')}
+                  </Label>
+                  <Input
+                    id="legal-text-edit-role-targets"
+                    value={formValues.targetRoleIds}
+                    onChange={(event) =>
+                      setFormValues((current) => ({
+                        ...current,
+                        targetRoleIds: event.target.value,
+                      }))
+                    }
+                    placeholder={t('admin.legalTexts.fields.targetRoleIdsPlaceholder')}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="legal-text-edit-group-targets">
+                    {t('admin.legalTexts.fields.targetGroupIds')}
+                  </Label>
+                  <Input
+                    id="legal-text-edit-group-targets"
+                    value={formValues.targetGroupIds}
+                    onChange={(event) =>
+                      setFormValues((current) => ({
+                        ...current,
+                        targetGroupIds: event.target.value,
+                      }))
+                    }
+                    placeholder={t('admin.legalTexts.fields.targetGroupIdsPlaceholder')}
+                  />
+                </div>
+              </div>
 
-      {selectedLegalText ? (
-        <Card className="space-y-4 p-4">
-          <form className="space-y-4" onSubmit={(event) => void onSubmit(event)}>
-            <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-4 rounded-lg border border-border bg-muted/40 p-4 text-sm text-muted-foreground md:grid-cols-3">
+                <p>{t('admin.legalTexts.meta.uuid', { value: selectedLegalText.id })}</p>
+                <p>
+                  {t('admin.legalTexts.meta.createdAt', {
+                    value: formatLegalTextDateTime(selectedLegalText.createdAt),
+                  })}
+                </p>
+                <p>
+                  {t('admin.legalTexts.meta.updatedAt', {
+                    value: formatLegalTextDateTime(selectedLegalText.updatedAt),
+                  })}
+                </p>
+              </div>
+
               <div className="space-y-2">
-                <Label htmlFor="legal-text-edit-name">{t('admin.legalTexts.fields.name')}</Label>
-                <Input
-                  id="legal-text-edit-name"
-                  value={formValues.name}
-                  onChange={(event) => setFormValues((current) => ({ ...current, name: event.target.value }))}
-                  required
+                <Label id="legal-text-edit-content-label" htmlFor="legal-text-edit-content">
+                  {t('admin.legalTexts.fields.contentHtml')}
+                </Label>
+                <RichTextEditor
+                  id="legal-text-edit-content"
+                  labelId="legal-text-edit-content-label"
+                  value={formValues.contentHtml}
+                  onChange={(contentHtml) =>
+                    setFormValues((current) => ({ ...current, contentHtml }))
+                  }
+                  placeholder={t('admin.legalTexts.fields.contentPlaceholder')}
+                  commands={richTextEditorCommands}
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="legal-text-edit-version">{t('admin.legalTexts.fields.legalTextVersion')}</Label>
-                <Input
-                  id="legal-text-edit-version"
-                  value={formValues.legalTextVersion}
-                  onChange={(event) => setFormValues((current) => ({ ...current, legalTextVersion: event.target.value }))}
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="legal-text-edit-locale">{t('admin.legalTexts.fields.locale')}</Label>
-                <Input
-                  id="legal-text-edit-locale"
-                  value={formValues.locale}
-                  onChange={(event) => setFormValues((current) => ({ ...current, locale: event.target.value }))}
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="legal-text-edit-status">{t('admin.legalTexts.fields.status')}</Label>
-                <Select
-                  id="legal-text-edit-status"
-                  value={formValues.status}
-                  onChange={(event) => setFormValues((current) => ({ ...current, status: event.target.value as LegalTextStatus }))}
+
+              <div className="flex justify-end gap-3">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => setDeleteConfirmOpen(true)}
                 >
-                  <option value="draft">{t('admin.legalTexts.status.draft')}</option>
-                  <option value="valid">{t('admin.legalTexts.status.valid')}</option>
-                  <option value="archived">{t('admin.legalTexts.status.archived')}</option>
-                </Select>
+                  {t('admin.legalTexts.actions.delete')}
+                </Button>
               </div>
-              <div className="space-y-2 md:col-span-2">
-                <Label htmlFor="legal-text-edit-published">{t('admin.legalTexts.fields.publishedAt')}</Label>
-                <Input
-                  id="legal-text-edit-published"
-                  type="datetime-local"
-                  value={formValues.publishedAt}
-                  required={formValues.status === 'valid'}
-                  onChange={(event) => setFormValues((current) => ({ ...current, publishedAt: event.target.value }))}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="legal-text-edit-role-targets">{t('admin.legalTexts.fields.targetRoleIds')}</Label>
-                <Input
-                  id="legal-text-edit-role-targets"
-                  value={formValues.targetRoleIds}
-                  onChange={(event) => setFormValues((current) => ({ ...current, targetRoleIds: event.target.value }))}
-                  placeholder={t('admin.legalTexts.fields.targetRoleIdsPlaceholder')}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="legal-text-edit-group-targets">{t('admin.legalTexts.fields.targetGroupIds')}</Label>
-                <Input
-                  id="legal-text-edit-group-targets"
-                  value={formValues.targetGroupIds}
-                  onChange={(event) => setFormValues((current) => ({ ...current, targetGroupIds: event.target.value }))}
-                  placeholder={t('admin.legalTexts.fields.targetGroupIdsPlaceholder')}
-                />
-              </div>
-            </div>
+            </form>
+          </Card>
+        ) : null}
 
-            <div className="grid gap-4 rounded-lg border border-border bg-muted/40 p-4 text-sm text-muted-foreground md:grid-cols-3">
-              <p>{t('admin.legalTexts.meta.uuid', { value: selectedLegalText.id })}</p>
-              <p>{t('admin.legalTexts.meta.createdAt', { value: formatLegalTextDateTime(selectedLegalText.createdAt) })}</p>
-              <p>{t('admin.legalTexts.meta.updatedAt', { value: formatLegalTextDateTime(selectedLegalText.updatedAt) })}</p>
-            </div>
+        {validationError || legalTextsApi.mutationError ? (
+          <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+            <AlertDescription>
+              {validationError ?? getLegalTextErrorMessage(legalTextsApi.mutationError)}
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
-            <div className="space-y-2">
-              <Label id="legal-text-edit-content-label" htmlFor="legal-text-edit-content">
-                {t('admin.legalTexts.fields.contentHtml')}
-              </Label>
-              <RichTextEditor
-                id="legal-text-edit-content"
-                labelId="legal-text-edit-content-label"
-                value={formValues.contentHtml}
-                onChange={(contentHtml) => setFormValues((current) => ({ ...current, contentHtml }))}
-                placeholder={t('admin.legalTexts.fields.contentPlaceholder')}
-                commands={richTextEditorCommands}
-              />
-            </div>
-
-            <div className="flex justify-end gap-3">
-              <Button type="button" variant="destructive" onClick={() => setDeleteConfirmOpen(true)}>
-                {t('admin.legalTexts.actions.delete')}
-              </Button>
-              <Button type="submit">{t('admin.legalTexts.actions.save')}</Button>
-            </div>
-          </form>
-        </Card>
-      ) : null}
-
-      {validationError || legalTextsApi.mutationError ? (
-        <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-          <AlertDescription>{validationError ?? getLegalTextErrorMessage(legalTextsApi.mutationError)}</AlertDescription>
-        </Alert>
-      ) : null}
-
-      <ConfirmDialog
-        open={deleteConfirmOpen}
-        title={t('admin.legalTexts.confirm.deleteTitle')}
-        description={t('admin.legalTexts.confirm.deleteDescription')}
-        confirmLabel={t('admin.legalTexts.actions.delete')}
-        cancelLabel={t('account.actions.cancel')}
-        onConfirm={() => void onDelete()}
-        onCancel={() => setDeleteConfirmOpen(false)}
-      />
+        <ConfirmDialog
+          open={deleteConfirmOpen}
+          title={t('admin.legalTexts.confirm.deleteTitle')}
+          description={t('admin.legalTexts.confirm.deleteDescription')}
+          confirmLabel={t('admin.legalTexts.actions.delete')}
+          cancelLabel={t('account.actions.cancel')}
+          onConfirm={() => void onDelete()}
+          onCancel={() => setDeleteConfirmOpen(false)}
+        />
+      </StudioDetailPageTemplate>
     </section>
   );
 };

--- a/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.test.tsx
@@ -75,8 +75,18 @@ describe('RoleDetailPage', () => {
           isScopeAssignable: true,
           supportedAccessScopes: ['all', 'own', 'organization'],
         },
-        { id: 'perm-3', instanceId: 'de-musterhausen', permissionKey: 'iam.configure', description: 'Konfigurieren' },
-        { id: 'perm-4', instanceId: 'de-musterhausen', permissionKey: 'news.read', description: 'News lesen' },
+        {
+          id: 'perm-3',
+          instanceId: 'de-musterhausen',
+          permissionKey: 'iam.configure',
+          description: 'Konfigurieren',
+        },
+        {
+          id: 'perm-4',
+          instanceId: 'de-musterhausen',
+          permissionKey: 'news.read',
+          description: 'News lesen',
+        },
       ],
       isLoading: false,
       error: null,
@@ -142,7 +152,9 @@ describe('RoleDetailPage', () => {
           memberCount: 3,
           syncState: 'failed',
           syncError: { code: 'IDP_UNAVAILABLE' },
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -161,11 +173,17 @@ describe('RoleDetailPage', () => {
     render(<RoleDetailPage roleId="role-2" activeTab="general" />);
 
     expect(screen.getByRole('heading', { name: 'Editor' })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'Allgemein' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Allgemein' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
     fireEvent.change(screen.getByLabelText('Anzeigename'), { target: { value: 'Content Editor' } });
-    fireEvent.change(screen.getByLabelText('Beschreibung'), { target: { value: 'Updated description' } });
+    fireEvent.change(screen.getByLabelText('Beschreibung'), {
+      target: { value: 'Updated description' },
+    });
     fireEvent.change(screen.getByLabelText('Rollenlevel'), { target: { value: '33' } });
-    fireEvent.submit(screen.getByRole('button', { name: 'Allgemeine Daten speichern' }).closest('form')!);
+    fireEvent.submit(
+      screen.getByRole('button', { name: 'Allgemeine Daten speichern' }).closest('form')!
+    );
 
     await waitFor(() => {
       expect(updateRole).toHaveBeenCalledWith('role-2', {
@@ -190,7 +208,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 20,
           memberCount: 3,
           syncState: 'synced',
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -209,14 +229,18 @@ describe('RoleDetailPage', () => {
     render(<RoleDetailPage roleId="role-2" activeTab="general" />);
 
     fireEvent.change(screen.getByLabelText('Anzeigename'), { target: { value: 'Changed name' } });
-    fireEvent.change(screen.getByLabelText('Beschreibung'), { target: { value: 'Changed description' } });
+    fireEvent.change(screen.getByLabelText('Beschreibung'), {
+      target: { value: 'Changed description' },
+    });
     fireEvent.change(screen.getByLabelText('Rollenlevel'), { target: { value: '42' } });
 
     fireEvent.click(screen.getByRole('button', { name: 'Änderungen zurücksetzen' }));
 
     await waitFor(() => {
       expect((screen.getByLabelText('Anzeigename') as HTMLInputElement).value).toBe('Editor');
-      expect((screen.getByLabelText('Beschreibung') as HTMLTextAreaElement).value).toBe('Editorial role');
+      expect((screen.getByLabelText('Beschreibung') as HTMLTextAreaElement).value).toBe(
+        'Editorial role'
+      );
       expect((screen.getByLabelText('Rollenlevel') as HTMLInputElement).value).toBe('20');
     });
   });
@@ -237,7 +261,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 20,
           memberCount: 3,
           syncState: 'synced',
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -255,10 +281,14 @@ describe('RoleDetailPage', () => {
 
     render(<RoleDetailPage roleId="role-2" activeTab="permissions" />);
 
-    expect(screen.getByRole('tab', { name: 'Berechtigungen' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Berechtigungen' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
 
     fireEvent.click(screen.getAllByLabelText(/Lesen/)[0]!);
-    fireEvent.click(screen.getByRole('button', { name: 'Rechte speichern' }));
+    const saveButtons = screen.getAllByRole('button', { name: 'Rechte speichern' });
+    expect(saveButtons).toHaveLength(2);
+    fireEvent.click(saveButtons[1]!);
 
     await waitFor(() => {
       expect(updateRole).toHaveBeenCalledWith('role-2', {
@@ -304,7 +334,7 @@ describe('RoleDetailPage', () => {
 
     render(<RoleDetailPage roleId="role-2" activeTab="permissions" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Rechte speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rechte speichern' })[1]!);
 
     await waitFor(() => {
       expect(updateRole).toHaveBeenCalledWith('role-2', {
@@ -350,8 +380,18 @@ describe('RoleDetailPage', () => {
 
     useRolePermissionsMock.mockReturnValue({
       permissions: [
-        { id: 'perm-1', instanceId: 'de-musterhausen', permissionKey: 'content.read', description: 'Lesen' },
-        { id: 'perm-5', instanceId: 'de-musterhausen', permissionKey: 'content.custom_action', description: 'Spezial' },
+        {
+          id: 'perm-1',
+          instanceId: 'de-musterhausen',
+          permissionKey: 'content.read',
+          description: 'Lesen',
+        },
+        {
+          id: 'perm-5',
+          instanceId: 'de-musterhausen',
+          permissionKey: 'content.custom_action',
+          description: 'Spezial',
+        },
       ],
       isLoading: false,
       error: null,
@@ -362,7 +402,7 @@ describe('RoleDetailPage', () => {
 
     expect(screen.getAllByText('Custom Action').length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole('button', { name: 'Sichtbare Rechte entziehen' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Rechte speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rechte speichern' })[1]!);
 
     await waitFor(() => {
       expect(updateRole).toHaveBeenCalledWith('role-2', {
@@ -398,7 +438,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 20,
           memberCount: 3,
           syncState: 'synced',
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -449,7 +491,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 90,
           memberCount: 1,
           syncState: 'synced',
-          permissions: [{ id: 'perm-3', permissionKey: 'iam.configure', description: 'System konfigurieren' }],
+          permissions: [
+            { id: 'perm-3', permissionKey: 'iam.configure', description: 'System konfigurieren' },
+          ],
         },
       ],
       isLoading: false,
@@ -468,9 +512,13 @@ describe('RoleDetailPage', () => {
     render(<RoleDetailPage roleId="role-1" activeTab="general" />);
 
     expect(
-      screen.getByText('Systemrollen bleiben schreibgeschützt, damit Baseline-Rechte konsistent und nachvollziehbar bleiben.')
+      screen.getByText(
+        'Systemrollen bleiben schreibgeschützt, damit Baseline-Rechte konsistent und nachvollziehbar bleiben.'
+      )
     ).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Allgemeine Daten speichern' }).hasAttribute('disabled')).toBe(true);
+    expect(
+      screen.getByRole('button', { name: 'Allgemeine Daten speichern' }).hasAttribute('disabled')
+    ).toBe(true);
   });
 
   it('treats legacy tenant bootstrap roles as editable when the API marks them editable', () => {
@@ -488,7 +536,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 30,
           memberCount: 2,
           syncState: 'synced',
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -507,9 +557,13 @@ describe('RoleDetailPage', () => {
     render(<RoleDetailPage roleId="role-legacy-editor" activeTab="general" />);
 
     expect(
-      screen.queryByText('Systemrollen bleiben schreibgeschützt, damit Baseline-Rechte konsistent und nachvollziehbar bleiben.')
+      screen.queryByText(
+        'Systemrollen bleiben schreibgeschützt, damit Baseline-Rechte konsistent und nachvollziehbar bleiben.'
+      )
     ).toBeNull();
-    expect(screen.getByRole('button', { name: 'Allgemeine Daten speichern' }).hasAttribute('disabled')).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Allgemeine Daten speichern' }).hasAttribute('disabled')
+    ).toBe(false);
   });
 
   it('navigates between tabs through tab buttons', () => {
@@ -526,7 +580,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 20,
           memberCount: 3,
           syncState: 'synced',
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -607,7 +663,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 20,
           memberCount: 3,
           syncState: 'synced',
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -656,7 +714,9 @@ describe('RoleDetailPage', () => {
           syncState: 'failed',
           lastSyncedAt: '2026-03-31T10:15:00.000Z',
           syncError: { code: 'IDP_UNAVAILABLE' },
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -674,7 +734,11 @@ describe('RoleDetailPage', () => {
 
     render(<RoleDetailPage roleId="role-2" activeTab="sync" />);
 
-    expect(screen.getByText('Diese Ansicht beschreibt ausschließlich den Abgleich der Studio-Rollenmetadaten mit Keycloak.')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Diese Ansicht beschreibt ausschließlich den Abgleich der Studio-Rollenmetadaten mit Keycloak.'
+      )
+    ).toBeTruthy();
     expect(
       screen.getByText(
         'Berechtigungen, Zuweisungen und lokale Rollenlevel werden im Studio gespeichert und verändern diesen Keycloak-Status nicht.'
@@ -764,7 +828,9 @@ describe('RoleDetailPage', () => {
 
     rerender(<RoleDetailPage roleId="role-missing" activeTab="general" />);
     expect(screen.getByText('Die angeforderte Rolle wurde nicht gefunden.')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Zur Rollenliste' }).getAttribute('href')).toBe('/admin/roles');
+    expect(screen.getByRole('link', { name: 'Zur Rollenliste' }).getAttribute('href')).toBe(
+      '/admin/roles'
+    );
   });
 
   it('supports keyboard tab navigation and sync actions', () => {
@@ -786,7 +852,9 @@ describe('RoleDetailPage', () => {
           syncState: 'failed',
           lastSyncedAt: null,
           syncError: null,
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -834,7 +902,9 @@ describe('RoleDetailPage', () => {
           roleLevel: 20,
           memberCount: 1,
           syncState: 'synced',
-          permissions: [{ id: 'perm-2', permissionKey: 'content.updatePayload', description: null }],
+          permissions: [
+            { id: 'perm-2', permissionKey: 'content.updatePayload', description: null },
+          ],
         },
       ],
       isLoading: false,
@@ -870,7 +940,12 @@ describe('RoleDetailPage', () => {
           isScopeAssignable: true,
           supportedAccessScopes: ['all', 'own', 'organization'],
         },
-        { id: 'perm-3', instanceId: 'de-musterhausen', permissionKey: 'iam.configure', description: 'Konfigurieren' },
+        {
+          id: 'perm-3',
+          instanceId: 'de-musterhausen',
+          permissionKey: 'iam.configure',
+          description: 'Konfigurieren',
+        },
       ],
       isLoading: false,
       error: null,
@@ -880,7 +955,7 @@ describe('RoleDetailPage', () => {
     rerender(<RoleDetailPage roleId="role-2" activeTab="permissions" />);
     fireEvent.change(screen.getByLabelText('Rechte suchen'), { target: { value: 'content' } });
     fireEvent.click(screen.getByRole('button', { name: 'Sichtbare Rechte vergeben' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Rechte speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rechte speichern' })[1]!);
 
     await waitFor(() => {
       expect(updateRole).toHaveBeenLastCalledWith('role-2', {
@@ -892,7 +967,7 @@ describe('RoleDetailPage', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Alle Rechte entziehen' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Rechte speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rechte speichern' })[1]!);
 
     await waitFor(() => {
       expect(updateRole).toHaveBeenLastCalledWith('role-2', {
@@ -956,7 +1031,9 @@ describe('RoleDetailPage', () => {
     render(<RoleDetailPage roleId="role-2" activeTab="assignments" />);
 
     expect(
-      screen.getByText('Extern verwaltete Rollen bleiben schreibgeschützt und müssen in der führenden Quelle angepasst werden.')
+      screen.getByText(
+        'Extern verwaltete Rollen bleiben schreibgeschützt und müssen in der führenden Quelle angepasst werden.'
+      )
     ).toBeTruthy();
     expect(screen.getByText('Rollen konnten nicht geladen werden.')).toBeTruthy();
     expect(screen.getByText('Die Benutzerzuweisungen konnten nicht geladen werden.')).toBeTruthy();

--- a/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/roles/-role-detail-page.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from '@tanstack/react-router';
 import {
   StudioDataTable,
   StudioDetailPageTemplate,
+  StudioFormActionBar,
   type StudioColumnDef,
 } from '@sva/studio-ui-react';
 
@@ -214,14 +215,20 @@ const buildPermissionScopeDraft = (
   ) as Record<string, PermissionAccessScope>;
   const permissionById = new Map(catalog.map((permission) => [permission.id, permission] as const));
 
-  return role.permissions.reduce<Record<string, PermissionAccessScope>>((acc, permission) => {
-    acc[permission.id] = normalizePermissionAccessScope(byAssignment[permission.id] ?? permission.accessScope ?? 'all', {
-      isScopeAssignable: permission.isScopeAssignable ?? permissionById.get(permission.id)?.isScopeAssignable,
-      supportedAccessScopes:
-        permission.supportedAccessScopes ?? permissionById.get(permission.id)?.supportedAccessScopes,
-    });
-    return acc;
-  }, { ...Object.fromEntries(catalog.map((permission) => [permission.id, 'all'] as const)) });
+  return role.permissions.reduce<Record<string, PermissionAccessScope>>(
+    (acc, permission) => {
+      acc[permission.id] = normalizePermissionAccessScope(
+        byAssignment[permission.id] ?? permission.accessScope ?? 'all',
+        {
+          isScopeAssignable: permission.isScopeAssignable ?? permissionById.get(permission.id)?.isScopeAssignable,
+          supportedAccessScopes:
+            permission.supportedAccessScopes ?? permissionById.get(permission.id)?.supportedAccessScopes,
+        }
+      );
+      return acc;
+    },
+    { ...Object.fromEntries(catalog.map((permission) => [permission.id, 'all'] as const)) }
+  );
 };
 
 export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
@@ -259,7 +266,12 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
       description: role.description ?? '',
       roleLevel: String(role.roleLevel),
     });
-    setPermissionDraft(sortPermissionIdsByCatalog(role.permissions.map((permission) => permission.id), permissionsApi.permissions));
+    setPermissionDraft(
+      sortPermissionIdsByCatalog(
+        role.permissions.map((permission) => permission.id),
+        permissionsApi.permissions
+      )
+    );
     setPermissionScopeDraft(buildPermissionScopeDraft(role, permissionsApi.permissions));
   }, [permissionsApi.permissions, role]);
 
@@ -277,9 +289,9 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
           detailLabel: summary.detailLabel,
           isAssigned: permissionDraft.includes(permission.id),
           isScopeAssignable: permission.isScopeAssignable ?? false,
-          supportedAccessScopes: normalizeSupportedAccessScopes(permission.supportedAccessScopes as
-            | readonly PermissionAccessScope[]
-            | undefined),
+          supportedAccessScopes: normalizeSupportedAccessScopes(
+            permission.supportedAccessScopes as readonly PermissionAccessScope[] | undefined
+          ),
           accessScope: normalizePermissionAccessScope(permissionScopeDraft[permission.id], permission),
         };
       }),
@@ -407,12 +419,20 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
   );
 
   const assignAllPermissions = React.useCallback(() => {
-    setPermissionDraft(sortPermissionIdsByCatalog(permissionsApi.permissions.map((permission) => permission.id), permissionsApi.permissions));
+    setPermissionDraft(
+      sortPermissionIdsByCatalog(
+        permissionsApi.permissions.map((permission) => permission.id),
+        permissionsApi.permissions
+      )
+    );
     setPermissionScopeDraft((current) =>
-      permissionsApi.permissions.reduce<Record<string, PermissionAccessScope>>((acc, permission) => {
-        acc[permission.id] = current[permission.id] ?? 'all';
-        return acc;
-      }, { ...current })
+      permissionsApi.permissions.reduce<Record<string, PermissionAccessScope>>(
+        (acc, permission) => {
+          acc[permission.id] = current[permission.id] ?? 'all';
+          return acc;
+        },
+        { ...current }
+      )
     );
   }, [permissionsApi.permissions]);
 
@@ -431,10 +451,13 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
       });
       if (nextAssigned) {
         setPermissionScopeDraft((current) =>
-          permissionIds.reduce<Record<string, PermissionAccessScope>>((acc, permissionId) => {
-            acc[permissionId] = current[permissionId] ?? 'all';
-            return acc;
-          }, { ...current })
+          permissionIds.reduce<Record<string, PermissionAccessScope>>(
+            (acc, permissionId) => {
+              acc[permissionId] = current[permissionId] ?? 'all';
+              return acc;
+            },
+            { ...current }
+          )
         );
       }
     },
@@ -527,7 +550,12 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
       return;
     }
 
-    setPermissionDraft(sortPermissionIdsByCatalog(role.permissions.map((permission) => permission.id), permissionsApi.permissions));
+    setPermissionDraft(
+      sortPermissionIdsByCatalog(
+        role.permissions.map((permission) => permission.id),
+        permissionsApi.permissions
+      )
+    );
     setPermissionScopeDraft(buildPermissionScopeDraft(role, permissionsApi.permissions));
   };
 
@@ -618,6 +646,16 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
     );
   }
 
+  const savePermissionsAction = (
+    <Button
+      type="button"
+      disabled={isReadOnly || permissionsApi.isLoading || Boolean(permissionsApi.error) || isSavingPermissions}
+      onClick={() => void onSavePermissions()}
+    >
+      {isSavingPermissions ? t('admin.roles.workspace.savingPermissions') : t('admin.roles.workspace.savePermissions')}
+    </Button>
+  );
+
   return (
     <StudioDetailPageTemplate
       title={role.roleName}
@@ -671,8 +709,16 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
               <div className="flex flex-wrap gap-2 text-xs">
                 <Badge variant="outline">{roleTypeLabel(role)}</Badge>
                 <Badge variant="outline">{roleStatusLabel(role.syncState)}</Badge>
-                <Badge variant="outline">{t('admin.roles.detail.badges.permissionCount', { count: String(role.permissions.length) })}</Badge>
-                <Badge variant="outline">{t('admin.roles.detail.badges.assignmentCount', { count: String(role.memberCount) })}</Badge>
+                <Badge variant="outline">
+                  {t('admin.roles.detail.badges.permissionCount', {
+                    count: String(role.permissions.length),
+                  })}
+                </Badge>
+                <Badge variant="outline">
+                  {t('admin.roles.detail.badges.assignmentCount', {
+                    count: String(role.memberCount),
+                  })}
+                </Badge>
               </div>
             </div>
           </CardHeader>
@@ -701,7 +747,9 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
                 aria-selected={selected}
                 aria-controls={`role-detail-panel-${tab}`}
                 className={`text-sm transition ${
-                  selected ? 'bg-primary font-semibold text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'
+                  selected
+                    ? 'bg-primary font-semibold text-primary-foreground hover:bg-primary/90'
+                    : 'text-muted-foreground'
                 }`}
                 onClick={() => onTabIntent(tab)}
                 onKeyDown={(event) => {
@@ -816,315 +864,327 @@ export const RoleDetailPage = ({ roleId, activeTab }: RoleDetailPageProps) => {
         </section>
 
         <section
-        id="role-detail-panel-permissions"
-        role="tabpanel"
-        aria-labelledby="role-detail-tab-permissions"
-        hidden={activeTab !== 'permissions'}
-        className="space-y-4"
-      >
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)]">
+          id="role-detail-panel-permissions"
+          role="tabpanel"
+          aria-labelledby="role-detail-tab-permissions"
+          hidden={activeTab !== 'permissions'}
+          className="space-y-4"
+        >
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)]">
+            <Card>
+              <CardHeader>
+                <CardTitle>{t('admin.roles.workspace.editPermissionsTitle')}</CardTitle>
+                <CardDescription>{t('admin.roles.detail.permissions.subtitle')}</CardDescription>
+              </CardHeader>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm">{t('admin.roles.workspace.sideTitle')}</CardTitle>
+                <CardDescription>{t('admin.roles.workspace.sideSubtitle')}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-xs text-muted-foreground">{t('admin.roles.detail.permissions.cockpitHint')}</p>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    aria-pressed={showTechnicalDetails}
+                    onClick={() => setShowTechnicalDetails((current) => !current)}
+                  >
+                    {showTechnicalDetails
+                      ? t('admin.roles.detail.permissions.hideTechnicalDetails')
+                      : t('admin.roles.detail.permissions.showTechnicalDetails')}
+                  </Button>
+                  <Button asChild type="button" variant="outline">
+                    <Link to="/admin/iam" search={{ tab: 'rights' }}>
+                      {t('admin.roles.workspace.openIamCta')}
+                    </Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <StudioFormActionBar position="start">{savePermissionsAction}</StudioFormActionBar>
+
+          {permissionsApi.error ? (
+            <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+              <AlertDescription>{t('admin.roles.workspace.permissionsLoadError')}</AlertDescription>
+            </Alert>
+          ) : permissionsApi.isLoading ? (
+            <p className="text-sm text-muted-foreground">{t('admin.roles.workspace.permissionsLoading')}</p>
+          ) : (
+            <StudioDataTable
+              ariaLabel={t('admin.roles.detail.permissions.table.ariaLabel')}
+              labels={studioDataTableLabels}
+              caption={t('admin.roles.detail.permissions.table.caption')}
+              data={filteredPermissionTableRows}
+              columns={permissionTableColumns}
+              getRowId={(permission) => permission.id}
+              selectionMode="none"
+              emptyState={
+                <Card className="border-none p-0 text-sm text-muted-foreground shadow-none" role="status">
+                  {t('admin.roles.detail.permissions.table.empty')}
+                </Card>
+              }
+              toolbarStart={
+                <div className="flex flex-wrap items-end gap-3">
+                  <div className="flex min-w-[16rem] flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+                    <Label htmlFor="role-permissions-search">
+                      {t('admin.roles.detail.permissions.filters.searchLabel')}
+                    </Label>
+                    <Input
+                      id="role-permissions-search"
+                      value={permissionSearch}
+                      onChange={(event) => setPermissionSearch(event.target.value)}
+                      placeholder={t('admin.roles.detail.permissions.filters.searchPlaceholder')}
+                    />
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    <Badge variant="outline">
+                      {t('admin.roles.detail.permissions.summary.visibleCount', {
+                        count: String(filteredPermissionTableRows.length),
+                      })}
+                    </Badge>
+                    <Badge variant="outline">
+                      {t('admin.roles.detail.permissions.summary.assignedCount', {
+                        count: String(permissionDraft.length),
+                      })}
+                    </Badge>
+                  </div>
+                </div>
+              }
+              toolbarEnd={
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" variant="outline" disabled={isReadOnly} onClick={assignVisiblePermissions}>
+                    {t('admin.roles.detail.permissions.bulk.assignVisible')}
+                  </Button>
+                  <Button type="button" variant="outline" disabled={isReadOnly} onClick={removeVisiblePermissions}>
+                    {t('admin.roles.detail.permissions.bulk.removeVisible')}
+                  </Button>
+                  <Button type="button" variant="outline" disabled={isReadOnly} onClick={assignAllPermissions}>
+                    {t('admin.roles.detail.permissions.bulk.assignAll')}
+                  </Button>
+                  <Button type="button" variant="outline" disabled={isReadOnly} onClick={removeAllPermissions}>
+                    {t('admin.roles.detail.permissions.bulk.removeAll')}
+                  </Button>
+                </div>
+              }
+            />
+          )}
+
+          <StudioFormActionBar>
+            {savePermissionsAction}
+            <Button type="button" variant="outline" disabled={isReadOnly} onClick={resetPermissionDraft}>
+              {t('admin.roles.workspace.resetPermissions')}
+            </Button>
+          </StudioFormActionBar>
+        </section>
+
+        <section
+          id="role-detail-panel-assignments"
+          role="tabpanel"
+          aria-labelledby="role-detail-tab-assignments"
+          hidden={activeTab !== 'assignments'}
+          className="grid gap-4 md:grid-cols-2"
+        >
           <Card>
             <CardHeader>
-              <CardTitle>{t('admin.roles.workspace.editPermissionsTitle')}</CardTitle>
-              <CardDescription>{t('admin.roles.detail.permissions.subtitle')}</CardDescription>
+              <CardTitle>{t('admin.roles.detail.assignments.summaryTitle')}</CardTitle>
+              <CardDescription>{t('admin.roles.detail.assignments.summaryBody')}</CardDescription>
             </CardHeader>
+            <CardContent className="space-y-4">
+              <dl className="grid gap-4">
+                <DetailMetaItem
+                  label={t('admin.roles.workspace.assignmentCountLabel')}
+                  value={t('admin.roles.workspace.assignmentCountValue', {
+                    count: String(role.memberCount),
+                  })}
+                />
+                <DetailMetaItem label={t('admin.roles.detail.assignments.managedBy')} value={role.managedBy} />
+              </dl>
+              <div className="grid gap-2 text-sm text-foreground">
+                <Label htmlFor="role-assignment-search">{t('admin.roles.detail.assignments.searchLabel')}</Label>
+                <Input
+                  id="role-assignment-search"
+                  value={usersApi.filters.search}
+                  onChange={(event) => usersApi.setSearch(event.target.value)}
+                  placeholder={t('admin.roles.detail.assignments.searchPlaceholder')}
+                />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="gap-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <CardTitle>{t('admin.roles.detail.assignments.managementTitle')}</CardTitle>
+                  <CardDescription>{t('admin.roles.detail.assignments.managementBody')}</CardDescription>
+                </div>
+                <Button asChild type="button" variant="outline">
+                  <Link to="/admin/users">{t('admin.roles.detail.assignments.openUsers')}</Link>
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {usersApi.error ? (
+                <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
+                  <AlertDescription>{t('admin.roles.detail.assignments.loadError')}</AlertDescription>
+                </Alert>
+              ) : null}
+
+              <div className="grid gap-4 xl:grid-cols-2">
+                <div className="space-y-2">
+                  <h3 className="text-sm font-medium text-foreground">
+                    {t('admin.roles.detail.assignments.currentTitle')}
+                  </h3>
+                  {usersApi.isLoading ? (
+                    <p className="text-sm text-muted-foreground">{t('admin.roles.detail.assignments.loading')}</p>
+                  ) : assignedUsers.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">{t('admin.roles.detail.assignments.emptyAssigned')}</p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {assignedUsers.map((user) => {
+                        const roleIds = user.roles.map((assignment) => assignment.roleId);
+                        const isBusy = isUpdatingAssignmentsForUserIds.includes(user.id);
+                        return (
+                          <li
+                            key={user.id}
+                            className="flex items-start justify-between gap-3 rounded-lg border border-border p-3"
+                          >
+                            <div className="min-w-0">
+                              <p className="font-medium text-foreground">{user.displayName}</p>
+                              <p className="text-xs text-muted-foreground">{user.email ?? user.keycloakSubject}</p>
+                            </div>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              disabled={isReadOnly || isBusy}
+                              onClick={() => void removeRoleFromUser(user.id, roleIds)}
+                            >
+                              {isBusy
+                                ? t('admin.roles.detail.assignments.updating')
+                                : t('admin.roles.detail.assignments.remove')}
+                            </Button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <h3 className="text-sm font-medium text-foreground">
+                    {t('admin.roles.detail.assignments.availableTitle')}
+                  </h3>
+                  {usersApi.isLoading ? (
+                    <p className="text-sm text-muted-foreground">{t('admin.roles.detail.assignments.loading')}</p>
+                  ) : unassignedUsers.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      {t('admin.roles.detail.assignments.emptyAvailable')}
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {unassignedUsers.map((user) => {
+                        const roleIds = user.roles.map((assignment) => assignment.roleId);
+                        const isBusy = isUpdatingAssignmentsForUserIds.includes(user.id);
+                        return (
+                          <li
+                            key={user.id}
+                            className="flex items-start justify-between gap-3 rounded-lg border border-border p-3"
+                          >
+                            <div className="min-w-0">
+                              <p className="font-medium text-foreground">{user.displayName}</p>
+                              <p className="text-xs text-muted-foreground">{user.email ?? user.keycloakSubject}</p>
+                            </div>
+                            <Button
+                              type="button"
+                              size="sm"
+                              disabled={isReadOnly || isBusy}
+                              onClick={() => void assignRoleToUser(user.id, roleIds)}
+                            >
+                              {isBusy
+                                ? t('admin.roles.detail.assignments.updating')
+                                : t('admin.roles.detail.assignments.assign')}
+                            </Button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section
+          id="role-detail-panel-sync"
+          role="tabpanel"
+          aria-labelledby="role-detail-tab-sync"
+          hidden={activeTab !== 'sync'}
+          className="grid gap-4 md:grid-cols-2"
+        >
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('admin.roles.detail.sync.title')}</CardTitle>
+              <CardDescription>{t('admin.roles.detail.sync.subtitle')}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Alert className="border-secondary/40 bg-secondary/5 text-secondary">
+                <AlertDescription>
+                  {role.managedBy === 'studio'
+                    ? t('admin.roles.detail.sync.metadataOnlyHint')
+                    : t('admin.roles.detail.sync.externalHint')}
+                </AlertDescription>
+              </Alert>
+              <dl className="grid gap-4">
+                <DetailMetaItem
+                  label={t('admin.roles.detail.sync.metadataStatus')}
+                  value={roleStatusLabel(role.syncState)}
+                />
+                <DetailMetaItem
+                  label={t('admin.roles.detail.sync.lastSyncedAt')}
+                  value={role.lastSyncedAt ?? t('admin.roles.detail.sync.notAvailable')}
+                />
+                <DetailMetaItem label={t('admin.roles.detail.sync.source')} value={role.managedBy} />
+                {role.syncError?.code ? (
+                  <DetailMetaItem label={t('admin.roles.detail.sync.errorCode')} value={role.syncError.code} />
+                ) : null}
+              </dl>
+            </CardContent>
           </Card>
           <Card>
             <CardHeader>
-              <CardTitle className="text-sm">{t('admin.roles.workspace.sideTitle')}</CardTitle>
-              <CardDescription>{t('admin.roles.workspace.sideSubtitle')}</CardDescription>
+              <CardTitle>{t('admin.roles.detail.sync.localChangesTitle')}</CardTitle>
+              <CardDescription>{t('admin.roles.detail.sync.localChangesBody')}</CardDescription>
             </CardHeader>
-            <CardContent className="space-y-3">
-              <p className="text-xs text-muted-foreground">{t('admin.roles.detail.permissions.cockpitHint')}</p>
-              <div className="flex flex-wrap gap-2">
+            <CardContent className="space-y-4">
+              <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                <li>{t('admin.roles.detail.sync.localChangeItems.permissions')}</li>
+                <li>{t('admin.roles.detail.sync.localChangeItems.assignments')}</li>
+                <li>{t('admin.roles.detail.sync.localChangeItems.roleLevel')}</li>
+              </ul>
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold text-foreground">{t('admin.roles.detail.sync.actionsTitle')}</h3>
+                <p className="text-sm text-muted-foreground">{t('admin.roles.detail.sync.actionsBody')}</p>
+              </div>
+              <div className="flex flex-wrap gap-3">
                 <Button
                   type="button"
-                  variant="outline"
-                  aria-pressed={showTechnicalDetails}
-                  onClick={() => setShowTechnicalDetails((current) => !current)}
+                  variant="secondary"
+                  disabled={role.managedBy !== 'studio'}
+                  onClick={() => void rolesApi.retryRoleSync(role.id)}
                 >
-                  {showTechnicalDetails
-                    ? t('admin.roles.detail.permissions.hideTechnicalDetails')
-                    : t('admin.roles.detail.permissions.showTechnicalDetails')}
+                  {t('admin.roles.actions.retrySync')}
                 </Button>
-                <Button asChild type="button" variant="outline">
-                  <Link to="/admin/iam" search={{ tab: 'rights' }}>
-                    {t('admin.roles.workspace.openIamCta')}
-                  </Link>
+                <Button type="button" variant="outline" onClick={() => void rolesApi.refetch()}>
+                  {t('admin.roles.actions.retry')}
                 </Button>
               </div>
             </CardContent>
           </Card>
-        </div>
-
-        {permissionsApi.error ? (
-          <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-            <AlertDescription>{t('admin.roles.workspace.permissionsLoadError')}</AlertDescription>
-          </Alert>
-        ) : permissionsApi.isLoading ? (
-          <p className="text-sm text-muted-foreground">{t('admin.roles.workspace.permissionsLoading')}</p>
-        ) : (
-          <StudioDataTable
-            ariaLabel={t('admin.roles.detail.permissions.table.ariaLabel')}
-            labels={studioDataTableLabels}
-            caption={t('admin.roles.detail.permissions.table.caption')}
-            data={filteredPermissionTableRows}
-            columns={permissionTableColumns}
-            getRowId={(permission) => permission.id}
-            selectionMode="none"
-            emptyState={
-              <Card className="border-none p-0 text-sm text-muted-foreground shadow-none" role="status">
-                {t('admin.roles.detail.permissions.table.empty')}
-              </Card>
-            }
-            toolbarStart={
-              <div className="flex flex-wrap items-end gap-3">
-                <div className="flex min-w-[16rem] flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
-                  <Label htmlFor="role-permissions-search">{t('admin.roles.detail.permissions.filters.searchLabel')}</Label>
-                  <Input
-                    id="role-permissions-search"
-                    value={permissionSearch}
-                    onChange={(event) => setPermissionSearch(event.target.value)}
-                    placeholder={t('admin.roles.detail.permissions.filters.searchPlaceholder')}
-                  />
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                  <Badge variant="outline">
-                    {t('admin.roles.detail.permissions.summary.visibleCount', {
-                      count: String(filteredPermissionTableRows.length),
-                    })}
-                  </Badge>
-                  <Badge variant="outline">
-                    {t('admin.roles.detail.permissions.summary.assignedCount', {
-                      count: String(permissionDraft.length),
-                    })}
-                  </Badge>
-                </div>
-              </div>
-            }
-            toolbarEnd={
-              <div className="flex flex-wrap gap-2">
-                <Button type="button" variant="outline" disabled={isReadOnly} onClick={assignVisiblePermissions}>
-                  {t('admin.roles.detail.permissions.bulk.assignVisible')}
-                </Button>
-                <Button type="button" variant="outline" disabled={isReadOnly} onClick={removeVisiblePermissions}>
-                  {t('admin.roles.detail.permissions.bulk.removeVisible')}
-                </Button>
-                <Button type="button" variant="outline" disabled={isReadOnly} onClick={assignAllPermissions}>
-                  {t('admin.roles.detail.permissions.bulk.assignAll')}
-                </Button>
-                <Button type="button" variant="outline" disabled={isReadOnly} onClick={removeAllPermissions}>
-                  {t('admin.roles.detail.permissions.bulk.removeAll')}
-                </Button>
-              </div>
-            }
-          />
-        )}
-
-        <div className="flex flex-wrap gap-3">
-          <Button
-            type="button"
-            disabled={isReadOnly || permissionsApi.isLoading || Boolean(permissionsApi.error) || isSavingPermissions}
-            onClick={() => void onSavePermissions()}
-          >
-            {isSavingPermissions
-              ? t('admin.roles.workspace.savingPermissions')
-              : t('admin.roles.workspace.savePermissions')}
-          </Button>
-          <Button type="button" variant="outline" disabled={isReadOnly} onClick={resetPermissionDraft}>
-            {t('admin.roles.workspace.resetPermissions')}
-          </Button>
-        </div>
-        </section>
-
-        <section
-        id="role-detail-panel-assignments"
-        role="tabpanel"
-        aria-labelledby="role-detail-tab-assignments"
-        hidden={activeTab !== 'assignments'}
-        className="grid gap-4 md:grid-cols-2"
-      >
-        <Card>
-          <CardHeader>
-            <CardTitle>{t('admin.roles.detail.assignments.summaryTitle')}</CardTitle>
-            <CardDescription>{t('admin.roles.detail.assignments.summaryBody')}</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <dl className="grid gap-4">
-              <DetailMetaItem
-                label={t('admin.roles.workspace.assignmentCountLabel')}
-                value={t('admin.roles.workspace.assignmentCountValue', { count: String(role.memberCount) })}
-              />
-              <DetailMetaItem label={t('admin.roles.detail.assignments.managedBy')} value={role.managedBy} />
-            </dl>
-            <div className="grid gap-2 text-sm text-foreground">
-              <Label htmlFor="role-assignment-search">{t('admin.roles.detail.assignments.searchLabel')}</Label>
-              <Input
-                id="role-assignment-search"
-                value={usersApi.filters.search}
-                onChange={(event) => usersApi.setSearch(event.target.value)}
-                placeholder={t('admin.roles.detail.assignments.searchPlaceholder')}
-              />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="gap-3">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <CardTitle>{t('admin.roles.detail.assignments.managementTitle')}</CardTitle>
-                <CardDescription>{t('admin.roles.detail.assignments.managementBody')}</CardDescription>
-              </div>
-              <Button asChild type="button" variant="outline">
-                <Link to="/admin/users">{t('admin.roles.detail.assignments.openUsers')}</Link>
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-
-          {usersApi.error ? (
-            <Alert className="border-destructive/40 bg-destructive/10 text-destructive">
-              <AlertDescription>{t('admin.roles.detail.assignments.loadError')}</AlertDescription>
-            </Alert>
-          ) : null}
-
-          <div className="grid gap-4 xl:grid-cols-2">
-            <div className="space-y-2">
-              <h3 className="text-sm font-medium text-foreground">{t('admin.roles.detail.assignments.currentTitle')}</h3>
-              {usersApi.isLoading ? (
-                <p className="text-sm text-muted-foreground">{t('admin.roles.detail.assignments.loading')}</p>
-              ) : assignedUsers.length === 0 ? (
-                <p className="text-sm text-muted-foreground">{t('admin.roles.detail.assignments.emptyAssigned')}</p>
-              ) : (
-                <ul className="space-y-2">
-                  {assignedUsers.map((user) => {
-                    const roleIds = user.roles.map((assignment) => assignment.roleId);
-                    const isBusy = isUpdatingAssignmentsForUserIds.includes(user.id);
-                    return (
-                      <li key={user.id} className="flex items-start justify-between gap-3 rounded-lg border border-border p-3">
-                        <div className="min-w-0">
-                          <p className="font-medium text-foreground">{user.displayName}</p>
-                          <p className="text-xs text-muted-foreground">{user.email ?? user.keycloakSubject}</p>
-                        </div>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          disabled={isReadOnly || isBusy}
-                          onClick={() => void removeRoleFromUser(user.id, roleIds)}
-                        >
-                          {isBusy
-                            ? t('admin.roles.detail.assignments.updating')
-                            : t('admin.roles.detail.assignments.remove')}
-                        </Button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <h3 className="text-sm font-medium text-foreground">{t('admin.roles.detail.assignments.availableTitle')}</h3>
-              {usersApi.isLoading ? (
-                <p className="text-sm text-muted-foreground">{t('admin.roles.detail.assignments.loading')}</p>
-              ) : unassignedUsers.length === 0 ? (
-                <p className="text-sm text-muted-foreground">{t('admin.roles.detail.assignments.emptyAvailable')}</p>
-              ) : (
-                <ul className="space-y-2">
-                  {unassignedUsers.map((user) => {
-                    const roleIds = user.roles.map((assignment) => assignment.roleId);
-                    const isBusy = isUpdatingAssignmentsForUserIds.includes(user.id);
-                    return (
-                      <li key={user.id} className="flex items-start justify-between gap-3 rounded-lg border border-border p-3">
-                        <div className="min-w-0">
-                          <p className="font-medium text-foreground">{user.displayName}</p>
-                          <p className="text-xs text-muted-foreground">{user.email ?? user.keycloakSubject}</p>
-                        </div>
-                        <Button
-                          type="button"
-                          size="sm"
-                          disabled={isReadOnly || isBusy}
-                          onClick={() => void assignRoleToUser(user.id, roleIds)}
-                        >
-                          {isBusy
-                            ? t('admin.roles.detail.assignments.updating')
-                            : t('admin.roles.detail.assignments.assign')}
-                        </Button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
-          </div>
-          </CardContent>
-        </Card>
-        </section>
-
-        <section
-        id="role-detail-panel-sync"
-        role="tabpanel"
-        aria-labelledby="role-detail-tab-sync"
-        hidden={activeTab !== 'sync'}
-        className="grid gap-4 md:grid-cols-2"
-      >
-        <Card>
-          <CardHeader>
-            <CardTitle>{t('admin.roles.detail.sync.title')}</CardTitle>
-            <CardDescription>{t('admin.roles.detail.sync.subtitle')}</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Alert className="border-secondary/40 bg-secondary/5 text-secondary">
-              <AlertDescription>
-                {role.managedBy === 'studio'
-                  ? t('admin.roles.detail.sync.metadataOnlyHint')
-                  : t('admin.roles.detail.sync.externalHint')}
-              </AlertDescription>
-            </Alert>
-            <dl className="grid gap-4">
-              <DetailMetaItem label={t('admin.roles.detail.sync.metadataStatus')} value={roleStatusLabel(role.syncState)} />
-              <DetailMetaItem
-                label={t('admin.roles.detail.sync.lastSyncedAt')}
-                value={role.lastSyncedAt ?? t('admin.roles.detail.sync.notAvailable')}
-              />
-              <DetailMetaItem label={t('admin.roles.detail.sync.source')} value={role.managedBy} />
-              {role.syncError?.code ? (
-                <DetailMetaItem label={t('admin.roles.detail.sync.errorCode')} value={role.syncError.code} />
-              ) : null}
-            </dl>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>{t('admin.roles.detail.sync.localChangesTitle')}</CardTitle>
-            <CardDescription>{t('admin.roles.detail.sync.localChangesBody')}</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
-              <li>{t('admin.roles.detail.sync.localChangeItems.permissions')}</li>
-              <li>{t('admin.roles.detail.sync.localChangeItems.assignments')}</li>
-              <li>{t('admin.roles.detail.sync.localChangeItems.roleLevel')}</li>
-            </ul>
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-foreground">{t('admin.roles.detail.sync.actionsTitle')}</h3>
-              <p className="text-sm text-muted-foreground">{t('admin.roles.detail.sync.actionsBody')}</p>
-            </div>
-            <div className="flex flex-wrap gap-3">
-              <Button
-                type="button"
-                variant="secondary"
-                disabled={role.managedBy !== 'studio'}
-                onClick={() => void rolesApi.retryRoleSync(role.id)}
-              >
-                {t('admin.roles.actions.retrySync')}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => void rolesApi.refetch()}>
-                {t('admin.roles.actions.retry')}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
         </section>
       </section>
     </StudioDetailPageTemplate>

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.test.tsx
@@ -58,7 +58,15 @@ describe('UserEditPage', () => {
     notes: '',
     avatarUrl: 'https://example.com/avatar.png',
     roles: [{ roleId: 'role-1', roleName: 'system_admin', roleLevel: 90 }],
-    groups: [{ groupId: 'group-1', groupKey: 'admins', displayName: 'Admins', groupType: 'role_bundle', origin: 'manual' as const }],
+    groups: [
+      {
+        groupId: 'group-1',
+        groupKey: 'admins',
+        displayName: 'Admins',
+        groupType: 'role_bundle',
+        origin: 'manual' as const,
+      },
+    ],
     organizationMemberships: [
       {
         organizationId: 'org-1',
@@ -148,8 +156,18 @@ describe('UserEditPage', () => {
     });
     useRolePermissionsMock.mockReturnValue({
       permissions: [
-        { id: 'perm-read', instanceId: 'de-musterhausen', permissionKey: 'content.read', description: 'Inhalte lesen' },
-        { id: 'perm-write', instanceId: 'de-musterhausen', permissionKey: 'content.updatePayload', description: 'Inhalte bearbeiten' },
+        {
+          id: 'perm-read',
+          instanceId: 'de-musterhausen',
+          permissionKey: 'content.read',
+          description: 'Inhalte lesen',
+        },
+        {
+          id: 'perm-write',
+          instanceId: 'de-musterhausen',
+          permissionKey: 'content.updatePayload',
+          description: 'Inhalte bearbeiten',
+        },
       ],
       isLoading: false,
       error: null,
@@ -269,7 +287,9 @@ describe('UserEditPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Passwort-Einladung erneut senden' }));
 
     await waitFor(() => expect(resendPasswordSetupEmail).toHaveBeenCalledTimes(1));
-    expect(screen.getByText('Die Einladungs-E-Mail zum Passwort setzen wurde versendet.')).toBeTruthy();
+    expect(
+      screen.getByText('Die Einladungs-E-Mail zum Passwort setzen wurde versendet.')
+    ).toBeTruthy();
   });
 
   it('reprovisions mainserver data and shows a success notice', async () => {
@@ -329,8 +349,20 @@ describe('UserEditPage', () => {
 
   it('builds group membership lookups by group id once for constant-time access', () => {
     const membershipById = buildGroupMembershipById([
-      { groupId: 'group-1', groupKey: 'admins', displayName: 'Admins', groupType: 'role_bundle', origin: 'manual' as const },
-      { groupId: 'group-2', groupKey: 'authors', displayName: 'Authors', groupType: 'role_bundle', origin: 'sync' as const },
+      {
+        groupId: 'group-1',
+        groupKey: 'admins',
+        displayName: 'Admins',
+        groupType: 'role_bundle',
+        origin: 'manual' as const,
+      },
+      {
+        groupId: 'group-2',
+        groupKey: 'authors',
+        displayName: 'Authors',
+        groupType: 'role_bundle',
+        origin: 'sync' as const,
+      },
     ]);
 
     expect(membershipById.get('group-1')).toMatchObject({ displayName: 'Admins' });
@@ -471,10 +503,14 @@ describe('UserEditPage', () => {
     expect(screen.getAllByText('content.read').length).toBeGreaterThan(0);
 
     fireEvent.keyDown(screen.getByRole('tab', { name: 'Berechtigungen' }), { key: 'ArrowRight' });
-    expect(screen.getByRole('tab', { name: 'Historie' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Historie' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
 
     fireEvent.keyDown(screen.getByRole('tab', { name: 'Historie' }), { key: 'Home' });
-    expect(screen.getByRole('tab', { name: 'Persönliche Daten' }).getAttribute('aria-selected')).toBe('true');
+    expect(
+      screen.getByRole('tab', { name: 'Persönliche Daten' }).getAttribute('aria-selected')
+    ).toBe('true');
   });
 
   it('renders effective and inactive permission traces in the permissions tab', () => {
@@ -698,8 +734,12 @@ describe('UserEditPage', () => {
     });
     expect(setSearch).toHaveBeenLastCalledWith('');
 
-    fireEvent.change(screen.getByLabelText('Sichtbarkeit für Musterstadt'), { target: { value: 'external' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Mitgliedschaft für Musterstadt aktualisieren' }));
+    fireEvent.change(screen.getByLabelText('Sichtbarkeit für Musterstadt'), {
+      target: { value: 'external' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Mitgliedschaft für Musterstadt aktualisieren' })
+    );
 
     await waitFor(() => {
       expect(updateMembership).toHaveBeenCalledWith('org-1', 'user-1', {
@@ -750,10 +790,12 @@ describe('UserEditPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Organisation auswählen' }));
     fireEvent.click(screen.getByRole('option', { name: 'Stadtwerke (stadtwerke)' }));
 
-    expect(screen.getByRole('button', { name: 'Organisation auswählen' }).textContent).toContain('Stadtwerke');
-    expect((screen.getByRole('button', { name: 'Organisation zuweisen' }) as HTMLButtonElement).disabled).toBe(
-      false
+    expect(screen.getByRole('button', { name: 'Organisation auswählen' }).textContent).toContain(
+      'Stadtwerke'
     );
+    expect(
+      (screen.getByRole('button', { name: 'Organisation zuweisen' }) as HTMLButtonElement).disabled
+    ).toBe(false);
 
     useUserMock.mockReturnValue({
       user: secondUser,
@@ -769,9 +811,9 @@ describe('UserEditPage', () => {
     expect(screen.getByRole('button', { name: 'Organisation auswählen' }).textContent).toContain(
       'Organisation für neue Zuordnung auswählen'
     );
-    expect((screen.getByRole('button', { name: 'Organisation zuweisen' }) as HTMLButtonElement).disabled).toBe(
-      true
-    );
+    expect(
+      (screen.getByRole('button', { name: 'Organisation zuweisen' }) as HTMLButtonElement).disabled
+    ).toBe(true);
   });
 
   it('loads unified history entries and renders role validity windows', async () => {
@@ -930,7 +972,9 @@ describe('UserEditPage', () => {
     const notesField = document.querySelector('textarea');
     expect(notesField).toBeTruthy();
     fireEvent.change(notesField as HTMLTextAreaElement, { target: { value: 'saved note' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Änderungen speichern' }));
+    const saveButtons = screen.getAllByRole('button', { name: 'Änderungen speichern' });
+    expect(saveButtons).toHaveLength(2);
+    fireEvent.click(saveButtons[1]!);
 
     await waitFor(() => {
       expect(save).toHaveBeenCalledTimes(1);
@@ -980,7 +1024,7 @@ describe('UserEditPage', () => {
       expect(editorCheckbox.checked).toBe(true);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Änderungen speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Änderungen speichern' })[1]!);
 
     await waitFor(() => {
       expect(save).toHaveBeenCalledWith({
@@ -1014,7 +1058,12 @@ describe('UserEditPage', () => {
 
     useRolesMock.mockReturnValue({
       roles: [
-        { id: 'role-1', roleName: 'system_admin', roleKey: 'system_admin', externalRoleName: 'system_admin' },
+        {
+          id: 'role-1',
+          roleName: 'system_admin',
+          roleKey: 'system_admin',
+          externalRoleName: 'system_admin',
+        },
         {
           id: 'role-root',
           roleName: 'instance_registry_admin',
@@ -1110,12 +1159,18 @@ describe('UserEditPage', () => {
     render(<UserEditPage userId="user-1" />);
 
     fireEvent.click(screen.getByRole('tab', { name: 'Verwaltung' }));
-    expect((screen.getByLabelText('Mainserver Application-ID') as HTMLInputElement).value).toBe('app-id-1');
+    expect((screen.getByLabelText('Mainserver Application-ID') as HTMLInputElement).value).toBe(
+      'app-id-1'
+    );
     expect(screen.getByText('Ein Secret ist bereits hinterlegt.')).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText('Mainserver Application-ID'), { target: { value: 'updated-app-id' } });
-    fireEvent.change(screen.getByPlaceholderText('Neues Secret eingeben'), { target: { value: 'new-secret' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Änderungen speichern' }));
+    fireEvent.change(screen.getByLabelText('Mainserver Application-ID'), {
+      target: { value: 'updated-app-id' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Neues Secret eingeben'), {
+      target: { value: 'new-secret' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Änderungen speichern' })[1]!);
 
     await waitFor(() => {
       expect(save).toHaveBeenCalledWith({
@@ -1180,7 +1235,9 @@ describe('UserEditPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Verwerfen und wechseln' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: 'Historie' }).getAttribute('aria-selected')).toBe('true');
+      expect(screen.getByRole('tab', { name: 'Historie' }).getAttribute('aria-selected')).toBe(
+        'true'
+      );
       expect(screen.getByText('Keine Historieneinträge vorhanden.')).toBeTruthy();
     });
   }, 15000);
@@ -1217,7 +1274,9 @@ describe('UserEditPage', () => {
     expect(screen.getByRole('alert').textContent).toContain(
       'Die Verbindung zu Keycloak ist derzeit nicht verfügbar. Bitte später erneut versuchen.'
     );
-    expect(screen.getByRole('alert').textContent).not.toContain('Nutzer konnten nicht geladen werden.');
+    expect(screen.getByRole('alert').textContent).not.toContain(
+      'Nutzer konnten nicht geladen werden.'
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Erneut versuchen' }));
 
@@ -1254,15 +1313,23 @@ describe('UserEditPage', () => {
     expect(screen.getByRole('alert').textContent).toContain(
       'Technischer Fehler bei der Nutzeraktion: Einladungs-E-Mail zum Passwort setzen konnte nicht gesendet werden.'
     );
-    expect(screen.getByRole('alert').textContent).not.toContain('Technischer Fehler beim Laden der Nutzer');
+    expect(screen.getByRole('alert').textContent).not.toContain(
+      'Technischer Fehler beim Laden der Nutzer'
+    );
   });
 
   it.each([
     ['invalid_request', 'Die Nutzeraktion konnte nicht abgeschlossen werden.'],
     ['forbidden', 'Unzureichende Berechtigungen für diese Nutzeraktion.'],
-    ['csrf_validation_failed', 'Sicherheitsprüfung fehlgeschlagen. Bitte Seite neu laden und erneut versuchen.'],
+    [
+      'csrf_validation_failed',
+      'Sicherheitsprüfung fehlgeschlagen. Bitte Seite neu laden und erneut versuchen.',
+    ],
     ['rate_limited', 'Zu viele Anfragen in kurzer Zeit. Bitte kurz warten und erneut versuchen.'],
-    ['conflict', 'Die Nutzeränderung steht in Konflikt mit dem aktuellen Zustand. Bitte aktualisieren und erneut versuchen.'],
+    [
+      'conflict',
+      'Die Nutzeränderung steht in Konflikt mit dem aktuellen Zustand. Bitte aktualisieren und erneut versuchen.',
+    ],
     [
       'tenant_admin_client_not_configured',
       'Für diese Instanz ist noch kein Tenant-Admin-Client hinterlegt. Bitte zuerst den Instanzvertrag abgleichen.',
@@ -1271,8 +1338,14 @@ describe('UserEditPage', () => {
       'tenant_admin_client_secret_missing',
       'Für diese Instanz fehlt noch das Tenant-Admin-Client-Secret. Bitte zuerst den Instanzvertrag abgleichen.',
     ],
-    ['keycloak_unavailable', 'Die Verbindung zu Keycloak ist derzeit nicht verfügbar. Bitte später erneut versuchen.'],
-    ['database_unavailable', 'Die IAM-Datenbank ist derzeit nicht erreichbar. Bitte später erneut versuchen.'],
+    [
+      'keycloak_unavailable',
+      'Die Verbindung zu Keycloak ist derzeit nicht verfügbar. Bitte später erneut versuchen.',
+    ],
+    [
+      'database_unavailable',
+      'Die IAM-Datenbank ist derzeit nicht erreichbar. Bitte später erneut versuchen.',
+    ],
     [
       'mainserver_configuration_incomplete',
       'Die Mainserver-Integration ist unvollständig konfiguriert. Bitte die Schnittstellen-Konfiguration prüfen.',
@@ -1297,8 +1370,14 @@ describe('UserEditPage', () => {
       'mainserver_provisioning_failed',
       'Die Aktualisierung der Mainserver-Daten ist am Mainserver fehlgeschlagen. Bitte die Mainserver-Integration prüfen und erneut versuchen.',
     ],
-    ['last_admin_protection', 'Der letzte aktive System-Administrator kann nicht entfernt oder deaktiviert werden.'],
-    ['self_protection', 'Das aktuell angemeldete Konto kann nicht auf diese Weise deaktiviert werden.'],
+    [
+      'last_admin_protection',
+      'Der letzte aktive System-Administrator kann nicht entfernt oder deaktiviert werden.',
+    ],
+    [
+      'self_protection',
+      'Das aktuell angemeldete Konto kann nicht auf diese Weise deaktiviert werden.',
+    ],
   ])('maps %s save errors to the localized alert message', (code, expectedMessage) => {
     useUserMock.mockReturnValue({
       user: baseUser,
@@ -1330,13 +1409,18 @@ describe('UserEditPage', () => {
 
   it('falls back to the generic message for null and unknown errors', () => {
     expect(userErrorMessage(null)).toBe('Nutzer konnten nicht geladen werden.');
-    expect(userErrorMessage(null, 'mutation')).toBe('Die Nutzeraktion konnte nicht abgeschlossen werden.');
+    expect(userErrorMessage(null, 'mutation')).toBe(
+      'Die Nutzeraktion konnte nicht abgeschlossen werden.'
+    );
     expect(
-      userErrorMessage({
-        status: 400,
-        code: 'invalid_request',
-        message: 'invalid payload',
-      } as never, 'mutation')
+      userErrorMessage(
+        {
+          status: 400,
+          code: 'invalid_request',
+          message: 'invalid payload',
+        } as never,
+        'mutation'
+      )
     ).toBe('Die Nutzeraktion konnte nicht abgeschlossen werden.');
     expect(
       userErrorMessage({
@@ -1353,18 +1437,24 @@ describe('UserEditPage', () => {
       } as never)
     ).toBe('Technischer Fehler beim Laden der Nutzer: Failed to fetch');
     expect(
-      userErrorMessage({
-        status: 0,
-        code: 'non_json_response',
-        message: 'upstream proxy text',
-      } as never, 'mutation')
+      userErrorMessage(
+        {
+          status: 0,
+          code: 'non_json_response',
+          message: 'upstream proxy text',
+        } as never,
+        'mutation'
+      )
     ).toBe('Technischer Fehler bei der Nutzeraktion: upstream proxy text');
     expect(
-      userErrorMessage({
-        status: 500,
-        code: 'internal_error',
-        message: '   ',
-      } as never, 'mutation')
+      userErrorMessage(
+        {
+          status: 500,
+          code: 'internal_error',
+          message: '   ',
+        } as never,
+        'mutation'
+      )
     ).toBe('Die Nutzeraktion konnte nicht abgeschlossen werden.');
     expect(
       userErrorMessage({
@@ -1373,7 +1463,9 @@ describe('UserEditPage', () => {
         message: 'reconcile',
         classification: 'keycloak_reconcile',
       } as never)
-    ).toBe('Der Benutzerabgleich mit Keycloak ist fehlgeschlagen oder erfordert manuelle Nacharbeit. Bitte den Reconcile-Befund prüfen.');
+    ).toBe(
+      'Der Benutzerabgleich mit Keycloak ist fehlgeschlagen oder erfordert manuelle Nacharbeit. Bitte den Reconcile-Befund prüfen.'
+    );
     expect(
       userErrorMessage({
         status: 503,
@@ -1390,11 +1482,14 @@ describe('UserEditPage', () => {
       } as never)
     ).toBe('Nutzer konnten nicht geladen werden.');
     expect(
-      userErrorMessage({
-        status: 500,
-        code: 'unknown_error',
-        message: 'unexpected failure',
-      } as never, 'mutation')
+      userErrorMessage(
+        {
+          status: 500,
+          code: 'unknown_error',
+          message: 'unexpected failure',
+        } as never,
+        'mutation'
+      )
     ).toBe('Die Nutzeraktion konnte nicht abgeschlossen werden.');
   });
 
@@ -1429,7 +1524,7 @@ describe('UserEditPage', () => {
 
     fireEvent.change(systemAdminCheckbox, { target: { checked: true } });
     fireEvent.change(systemAdminCheckbox, { target: { checked: true } });
-    fireEvent.click(screen.getByRole('button', { name: 'Änderungen speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Änderungen speichern' })[1]!);
 
     await waitFor(() => {
       expect(save).toHaveBeenCalledWith(

--- a/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
+++ b/apps/sva-studio-react/src/routes/admin/users/-user-edit-page.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { StudioFormActionBar } from '@sva/studio-ui-react';
 
 import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { Alert, AlertDescription } from '../../../components/ui/alert';
@@ -52,24 +53,34 @@ const PermissionTraceEntryCard = ({
   runtimeScopeText,
   scopeText,
 }: PermissionTraceEntryCardProps) => (
-  <li className={`rounded-lg border border-border bg-background p-3 ${dashed ? 'border-dashed' : ''}`}>
+  <li
+    className={`rounded-lg border border-border bg-background p-3 ${dashed ? 'border-dashed' : ''}`}
+  >
     <div className="flex flex-wrap items-start justify-between gap-3">
       <div>
         <p className="font-medium text-foreground">{entry.permissionKey}</p>
         <p className="mt-1 text-sm text-muted-foreground">{describePermissionTraceSource(entry)}</p>
       </div>
       <div className="flex flex-wrap gap-2">
-        <Badge variant="outline">{t(userEditTranslationKeys.permissionTraceStatus[entry.status])}</Badge>
+        <Badge variant="outline">
+          {t(userEditTranslationKeys.permissionTraceStatus[entry.status])}
+        </Badge>
         {runtimeScopeText ? <Badge variant="outline">{runtimeScopeText}</Badge> : null}
       </div>
     </div>
     {scopeText !== undefined ? (
       <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
-        <span>{t('admin.users.edit.permissionTrace.resourceType', { value: entry.resourceType })}</span>
+        <span>
+          {t('admin.users.edit.permissionTrace.resourceType', { value: entry.resourceType })}
+        </span>
         {entry.organizationId ? (
-          <span>{t('admin.users.edit.permissionTrace.organization', { value: entry.organizationId })}</span>
+          <span>
+            {t('admin.users.edit.permissionTrace.organization', { value: entry.organizationId })}
+          </span>
         ) : null}
-        {scopeText ? <span>{t('admin.users.edit.permissionTrace.scope', { value: scopeText })}</span> : null}
+        {scopeText ? (
+          <span>{t('admin.users.edit.permissionTrace.scope', { value: scopeText })}</span>
+        ) : null}
       </div>
     ) : null}
     {detailLines.length > 0 ? (
@@ -82,7 +93,11 @@ const PermissionTraceEntryCard = ({
   </li>
 );
 
-export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage }: UserEditPageProps) => {
+export const UserEditPage = ({
+  userId,
+  invitationStatus,
+  invitationErrorMessage,
+}: UserEditPageProps) => {
   const {
     activeTab,
     closeUnsavedDialog,
@@ -143,7 +158,10 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
       return {
         value: selectedAssignableOrganization.id,
         label: `${selectedAssignableOrganization.displayName} (${selectedAssignableOrganization.organizationKey})`,
-        keywords: [selectedAssignableOrganization.displayName, selectedAssignableOrganization.organizationKey],
+        keywords: [
+          selectedAssignableOrganization.displayName,
+          selectedAssignableOrganization.organizationKey,
+        ],
       };
     }
 
@@ -156,7 +174,11 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
       label: organizationAssignment.organizationLabel,
       keywords: [organizationAssignment.organizationLabel],
     };
-  }, [organizationAssignment.organizationId, organizationAssignment.organizationLabel, selectedAssignableOrganization]);
+  }, [
+    organizationAssignment.organizationId,
+    organizationAssignment.organizationLabel,
+    selectedAssignableOrganization,
+  ]);
 
   if (userApi.isLoading) {
     return (
@@ -205,14 +227,18 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
               {t('account.fields.username')}: {userApi.user.username ?? '-'}
             </p>
             <div className="mt-2 flex flex-wrap gap-2 text-xs">
-              <Badge variant="outline">{t(userEditTranslationKeys.status[userApi.user.status])}</Badge>
+              <Badge variant="outline">
+                {t(userEditTranslationKeys.status[userApi.user.status])}
+              </Badge>
               {userApi.user.roles.map((role) => {
                 const validityLabel = formatRoleValidity(role);
                 return (
                   <Badge key={role.roleId} variant="outline" className="h-auto items-start py-1">
                     <span className="block">{role.roleName}</span>
                     {validityLabel ? (
-                      <span className="block text-[11px] text-muted-foreground">{validityLabel}</span>
+                      <span className="block text-[11px] text-muted-foreground">
+                        {validityLabel}
+                      </span>
                     ) : null}
                   </Badge>
                 );
@@ -255,7 +281,17 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
         </div>
       </Card>
 
-      <Card role="tablist" aria-label={t('admin.users.edit.tabsAriaLabel')} className="flex overflow-x-auto p-1">
+      <StudioFormActionBar position="start">
+        <Button type="submit" form="user-edit-form" disabled={isSaving}>
+          {isSaving ? t('account.actions.saving') : t('admin.users.edit.save')}
+        </Button>
+      </StudioFormActionBar>
+
+      <Card
+        role="tablist"
+        aria-label={t('admin.users.edit.tabsAriaLabel')}
+        className="flex overflow-x-auto p-1"
+      >
         {USER_EDIT_TABS.map((tab, index) => {
           const selected = tab.key === activeTab;
           return (
@@ -281,7 +317,7 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
         })}
       </Card>
 
-      <form className="space-y-4" onSubmit={onSave}>
+      <form id="user-edit-form" className="space-y-4" onSubmit={onSave}>
         <section
           id="user-edit-panel-personal"
           role="tabpanel"
@@ -291,14 +327,21 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
         >
           <div className="grid gap-2 text-sm text-foreground">
             <Label htmlFor="user-username">{t('account.fields.username')}</Label>
-            <Input id="user-username" value={userApi.user.username ?? ''} readOnly aria-readonly="true" />
+            <Input
+              id="user-username"
+              value={userApi.user.username ?? ''}
+              readOnly
+              aria-readonly="true"
+            />
           </div>
           <div className="grid gap-2 text-sm text-foreground">
             <Label htmlFor="user-first-name">{t('account.fields.firstName')}</Label>
             <Input
               id="user-first-name"
               value={formValues.firstName}
-              onChange={(event) => setFormValues((current) => ({ ...current, firstName: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, firstName: event.target.value }))
+              }
             />
           </div>
           <div className="grid gap-2 text-sm text-foreground">
@@ -306,7 +349,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
             <Input
               id="user-last-name"
               value={formValues.lastName}
-              onChange={(event) => setFormValues((current) => ({ ...current, lastName: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, lastName: event.target.value }))
+              }
             />
           </div>
           <div className="grid gap-2 text-sm text-foreground">
@@ -314,7 +359,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
             <Input
               id="user-display-name"
               value={formValues.displayName}
-              onChange={(event) => setFormValues((current) => ({ ...current, displayName: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, displayName: event.target.value }))
+              }
             />
           </div>
           <div className="grid gap-2 text-sm text-foreground">
@@ -323,7 +370,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
               id="user-email"
               type="email"
               value={formValues.email}
-              onChange={(event) => setFormValues((current) => ({ ...current, email: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, email: event.target.value }))
+              }
             />
           </div>
           <div className="grid gap-2 text-sm text-foreground md:col-span-2">
@@ -331,7 +380,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
             <Input
               id="user-phone"
               value={formValues.phone}
-              onChange={(event) => setFormValues((current) => ({ ...current, phone: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, phone: event.target.value }))
+              }
             />
           </div>
         </section>
@@ -366,7 +417,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
             <Input
               id="user-language"
               value={formValues.preferredLanguage}
-              onChange={(event) => setFormValues((current) => ({ ...current, preferredLanguage: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, preferredLanguage: event.target.value }))
+              }
             />
           </div>
           <div className="grid gap-2 text-sm text-foreground">
@@ -374,7 +427,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
             <Input
               id="user-timezone"
               value={formValues.timezone}
-              onChange={(event) => setFormValues((current) => ({ ...current, timezone: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, timezone: event.target.value }))
+              }
             />
           </div>
           <fieldset className="flex flex-col gap-2 text-sm text-foreground md:col-span-2">
@@ -411,7 +466,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
               {selectableGroups.map((group) => {
                 const selected = formValues.groupIds.includes(group.id);
                 const currentMembership = groupMembershipById.get(group.id);
-                const membershipValidity = currentMembership ? formatTraceValidity(currentMembership) : null;
+                const membershipValidity = currentMembership
+                  ? formatTraceValidity(currentMembership)
+                  : null;
                 return (
                   <Label
                     key={group.id}
@@ -447,7 +504,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
             </div>
           </fieldset>
           <div className="grid gap-2 text-sm text-foreground md:col-span-2">
-            <Label htmlFor="user-mainserver-app-id">{t('admin.users.edit.mainserverApplicationIdLabel')}</Label>
+            <Label htmlFor="user-mainserver-app-id">
+              {t('admin.users.edit.mainserverApplicationIdLabel')}
+            </Label>
             <Input
               id="user-mainserver-app-id"
               value={formValues.mainserverUserApplicationId}
@@ -460,7 +519,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
             />
           </div>
           <div className="grid gap-2 text-sm text-foreground md:col-span-2">
-            <Label htmlFor="user-mainserver-app-secret">{t('admin.users.edit.mainserverApplicationSecretLabel')}</Label>
+            <Label htmlFor="user-mainserver-app-secret">
+              {t('admin.users.edit.mainserverApplicationSecretLabel')}
+            </Label>
             <Input
               id="user-mainserver-app-secret"
               type="password"
@@ -489,7 +550,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
               id="user-notes"
               value={formValues.notes}
               maxLength={2000}
-              onChange={(event) => setFormValues((current) => ({ ...current, notes: event.target.value }))}
+              onChange={(event) =>
+                setFormValues((current) => ({ ...current, notes: event.target.value }))
+              }
             />
             <span className="text-xs text-muted-foreground">
               {t('admin.users.edit.notesCounter', { count: formValues.notes.length })}
@@ -505,13 +568,19 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
           className="space-y-4 rounded-xl border border-border bg-card p-4 shadow-shell"
         >
           <div className="space-y-2">
-            <h2 className="text-lg font-semibold text-foreground">{t('admin.users.edit.permissionTrace.title')}</h2>
-            <p className="text-sm text-muted-foreground">{t('admin.users.edit.permissionTrace.description')}</p>
+            <h2 className="text-lg font-semibold text-foreground">
+              {t('admin.users.edit.permissionTrace.title')}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {t('admin.users.edit.permissionTrace.description')}
+            </p>
           </div>
 
           {effectivePermissionTrace.length > 0 ? (
             <div className="space-y-3">
-              <h3 className="text-sm font-medium text-foreground">{t('admin.users.edit.permissionTrace.effectiveTitle')}</h3>
+              <h3 className="text-sm font-medium text-foreground">
+                {t('admin.users.edit.permissionTrace.effectiveTitle')}
+              </h3>
               <ul className="grid gap-3">
                 {effectivePermissionTrace.map((entry, index) => {
                   const scopeText = formatScope(entry.scope);
@@ -533,7 +602,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
 
           {inactivePermissionTrace.length > 0 ? (
             <div className="space-y-3">
-              <h3 className="text-sm font-medium text-foreground">{t('admin.users.edit.permissionTrace.inactiveTitle')}</h3>
+              <h3 className="text-sm font-medium text-foreground">
+                {t('admin.users.edit.permissionTrace.inactiveTitle')}
+              </h3>
               <ul className="grid gap-3">
                 {inactivePermissionTrace.map((entry, index) => {
                   const detailLines = buildPermissionTraceDetails(entry);
@@ -558,7 +629,10 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
           userApi.user.permissions.length > 0 ? (
             <ul className="grid gap-2 text-sm text-foreground sm:grid-cols-2">
               {userApi.user.permissions.map((permission) => (
-                <li key={permission} className="rounded border border-border bg-background px-3 py-2">
+                <li
+                  key={permission}
+                  className="rounded border border-border bg-background px-3 py-2"
+                >
                   {permission}
                 </li>
               ))}
@@ -568,7 +642,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
           {effectivePermissionTrace.length === 0 &&
           inactivePermissionTrace.length === 0 &&
           (!userApi.user.permissions || userApi.user.permissions.length === 0) ? (
-            <p className="text-sm text-muted-foreground">{t('admin.users.edit.permissionsEmpty')}</p>
+            <p className="text-sm text-muted-foreground">
+              {t('admin.users.edit.permissionsEmpty')}
+            </p>
           ) : null}
         </section>
 
@@ -580,8 +656,12 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
           className="space-y-4 rounded-xl border border-border bg-card p-4 shadow-shell"
         >
           <div className="space-y-2">
-            <h2 className="text-lg font-semibold text-foreground">{t('admin.users.edit.organizations.title')}</h2>
-            <p className="text-sm text-muted-foreground">{t('admin.users.edit.organizations.description')}</p>
+            <h2 className="text-lg font-semibold text-foreground">
+              {t('admin.users.edit.organizations.title')}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {t('admin.users.edit.organizations.description')}
+            </p>
           </div>
 
           <div className="grid gap-3 rounded-lg border border-border bg-background p-3 md:grid-cols-2">
@@ -614,16 +694,26 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
                   }))
                 }
               >
-                <option value="internal">{t('admin.users.edit.organizations.visibility.internal')}</option>
-                <option value="external">{t('admin.users.edit.organizations.visibility.external')}</option>
+                <option value="internal">
+                  {t('admin.users.edit.organizations.visibility.internal')}
+                </option>
+                <option value="external">
+                  {t('admin.users.edit.organizations.visibility.external')}
+                </option>
               </Select>
             </div>
-            <Label htmlFor="user-organization-default" className="flex items-center gap-2 text-sm text-foreground">
+            <Label
+              htmlFor="user-organization-default"
+              className="flex items-center gap-2 text-sm text-foreground"
+            >
               <Checkbox
                 id="user-organization-default"
                 checked={organizationAssignment.isDefaultContext}
                 onChange={(event) =>
-                  setOrganizationAssignment((current) => ({ ...current, isDefaultContext: event.target.checked }))
+                  setOrganizationAssignment((current) => ({
+                    ...current,
+                    isDefaultContext: event.target.checked,
+                  }))
                 }
               />
               <span>{t('admin.users.edit.organizations.assignDefaultLabel')}</span>
@@ -656,12 +746,16 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
                       <p className="font-medium text-foreground">{membership.displayName}</p>
                       <p className="text-xs text-muted-foreground">{membership.organizationKey}</p>
                       <p className="text-xs text-muted-foreground">
-                        {t('admin.users.edit.organizations.createdAt', { value: formatDateTime(membership.createdAt) })}
+                        {t('admin.users.edit.organizations.createdAt', {
+                          value: formatDateTime(membership.createdAt),
+                        })}
                       </p>
                     </div>
                     <div className="grid gap-1 text-sm text-foreground">
                       <Label htmlFor={`organization-visibility-${membership.organizationId}`}>
-                        {t('admin.users.edit.organizations.membershipVisibilityLabel', { name: membership.displayName })}
+                        {t('admin.users.edit.organizations.membershipVisibilityLabel', {
+                          name: membership.displayName,
+                        })}
                       </Label>
                       <Select
                         id={`organization-visibility-${membership.organizationId}`}
@@ -672,8 +766,12 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
                           })
                         }
                       >
-                        <option value="internal">{t('admin.users.edit.organizations.visibility.internal')}</option>
-                        <option value="external">{t('admin.users.edit.organizations.visibility.external')}</option>
+                        <option value="internal">
+                          {t('admin.users.edit.organizations.visibility.internal')}
+                        </option>
+                        <option value="external">
+                          {t('admin.users.edit.organizations.visibility.external')}
+                        </option>
                       </Select>
                     </div>
                     <Label
@@ -697,14 +795,18 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
                         variant="outline"
                         onClick={() => void saveOrganizationMembership(membership.organizationId)}
                       >
-                        {t('admin.users.edit.organizations.updateAction', { name: membership.displayName })}
+                        {t('admin.users.edit.organizations.updateAction', {
+                          name: membership.displayName,
+                        })}
                       </Button>
                       <Button
                         type="button"
                         variant="destructive"
                         onClick={() => void removeOrganizationMembership(membership.organizationId)}
                       >
-                        {t('admin.users.edit.organizations.removeAction', { name: membership.displayName })}
+                        {t('admin.users.edit.organizations.removeAction', {
+                          name: membership.displayName,
+                        })}
                       </Button>
                     </div>
                   </li>
@@ -712,7 +814,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
               })}
             </ul>
           ) : (
-            <p className="text-sm text-muted-foreground">{t('admin.users.edit.organizations.empty')}</p>
+            <p className="text-sm text-muted-foreground">
+              {t('admin.users.edit.organizations.empty')}
+            </p>
           )}
         </section>
 
@@ -728,7 +832,12 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
               <AlertDescription className="flex flex-col gap-3">
                 <span>{timelineError}</span>
                 <div>
-                  <Button type="button" size="sm" variant="outline" onClick={() => void reloadTimeline()}>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void reloadTimeline()}
+                  >
                     {t('admin.users.edit.historyRetry')}
                   </Button>
                 </div>
@@ -757,8 +866,16 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
                       </div>
                     </div>
                     <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
-                      <span>{t('admin.users.edit.historyOccurredAt', { value: formatDateTime(entry.occurredAt) })}</span>
-                      {metadataText ? <span>{t('admin.users.edit.historyMetadata', { value: metadataText })}</span> : null}
+                      <span>
+                        {t('admin.users.edit.historyOccurredAt', {
+                          value: formatDateTime(entry.occurredAt),
+                        })}
+                      </span>
+                      {metadataText ? (
+                        <span>
+                          {t('admin.users.edit.historyMetadata', { value: metadataText })}
+                        </span>
+                      ) : null}
                     </div>
                   </li>
                 );
@@ -779,7 +896,9 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
         ) : null}
         {invitationStatus === 'failed' ? (
           <Alert className="border-secondary/40 bg-secondary/10 text-secondary" role="status">
-            <AlertDescription>{invitationErrorMessage ?? t('admin.users.edit.invitationWarning')}</AlertDescription>
+            <AlertDescription>
+              {invitationErrorMessage ?? t('admin.users.edit.invitationWarning')}
+            </AlertDescription>
           </Alert>
         ) : null}
         {saveSuccess ? (
@@ -794,18 +913,20 @@ export const UserEditPage = ({ userId, invitationStatus, invitationErrorMessage 
         ) : null}
         {mainserverReprovisionSuccess ? (
           <Alert className="border-primary/40 bg-primary/10 text-primary" role="status">
-            <AlertDescription>{t('admin.users.edit.mainserverReprovisionSuccess')}</AlertDescription>
+            <AlertDescription>
+              {t('admin.users.edit.mainserverReprovisionSuccess')}
+            </AlertDescription>
           </Alert>
         ) : null}
 
-        <div className="flex flex-wrap justify-end gap-3">
+        <StudioFormActionBar>
           <Button type="button" variant="outline" onClick={resetFormValues}>
             {t('account.actions.cancel')}
           </Button>
           <Button type="submit" disabled={isSaving}>
             {isSaving ? t('account.actions.saving') : t('admin.users.edit.save')}
           </Button>
-        </div>
+        </StudioFormActionBar>
       </form>
 
       <ConfirmDialog

--- a/apps/sva-studio-react/src/routes/content/-content-editor-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/content/-content-editor-page.test.tsx
@@ -10,7 +10,11 @@ const useContentAccessMock = vi.fn();
 const invalidatePermissionsMock = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, to, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+  Link: ({
+    children,
+    to,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
     <a href={to} {...props}>
       {children}
     </a>
@@ -130,10 +134,12 @@ describe('ContentEditorPage', () => {
     render(<ContentEditorPage mode="create" />);
 
     expect(screen.getByRole('combobox', { name: 'Inhaltsbereiche' })).toBeTruthy();
-    expect((screen.getByRole('combobox', { name: 'Inhaltsbereiche' }) as HTMLSelectElement).value).toBe('general');
-    expect(screen.getByRole('tabpanel', { name: /Allgemeine Angaben/i }).firstElementChild?.className).toContain(
-      'bg-[rgb(var(--waste-panel-surface))]'
-    );
+    expect(
+      (screen.getByRole('combobox', { name: 'Inhaltsbereiche' }) as HTMLSelectElement).value
+    ).toBe('general');
+    expect(
+      screen.getByRole('tabpanel', { name: /Allgemeine Angaben/i }).firstElementChild?.className
+    ).toContain('bg-[rgb(var(--waste-panel-surface))]');
 
     fireEvent.change(screen.getByLabelText('Titel'), {
       target: { value: 'Landing Page' },
@@ -142,10 +148,14 @@ describe('ContentEditorPage', () => {
       target: { value: '{"hero":' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Inhalt anlegen' }));
+    const createButtons = screen.getAllByRole('button', { name: 'Inhalt anlegen' });
+    expect(createButtons).toHaveLength(2);
+    fireEvent.click(createButtons[1]!);
 
     await waitFor(() => {
-      expect(screen.getByRole('alert').textContent).toContain('Die Payload muss gültiges JSON sein.');
+      expect(screen.getByRole('alert').textContent).toContain(
+        'Die Payload muss gültiges JSON sein.'
+      );
     });
 
     expect(document.activeElement).toBe(screen.getByLabelText('Payload (JSON)'));
@@ -154,7 +164,7 @@ describe('ContentEditorPage', () => {
     fireEvent.change(screen.getByLabelText('Payload (JSON)'), {
       target: { value: '{"hero":"Willkommen"}' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Inhalt anlegen' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Inhalt anlegen' })[1]!);
 
     await waitFor(() => {
       expect(createdPayload).toEqual({
@@ -205,7 +215,9 @@ describe('ContentEditorPage', () => {
     expect(screen.getByRole('heading', { name: 'Inhalt bearbeiten', level: 1 })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Startseite', level: 2 })).toBeTruthy();
     expect(screen.getByRole('combobox', { name: 'Inhaltsbereiche' })).toBeTruthy();
-    expect((screen.getByRole('combobox', { name: 'Inhaltsbereiche' }) as HTMLSelectElement).value).toBe('general');
+    expect(
+      (screen.getByRole('combobox', { name: 'Inhaltsbereiche' }) as HTMLSelectElement).value
+    ).toBe('general');
     expect(screen.getByText('Editor')).toBeTruthy();
     expect(screen.getAllByRole('button', { name: 'Änderungen speichern' })).toHaveLength(2);
 
@@ -214,7 +226,9 @@ describe('ContentEditorPage', () => {
     });
 
     await waitFor(() => {
-      expect((screen.getByRole('combobox', { name: 'Inhaltsbereiche' }) as HTMLSelectElement).value).toBe('history');
+      expect(
+        (screen.getByRole('combobox', { name: 'Inhaltsbereiche' }) as HTMLSelectElement).value
+      ).toBe('history');
     });
 
     const historyPanel = screen.getByRole('tabpanel', { name: /Historie/i });
@@ -269,7 +283,7 @@ describe('ContentEditorPage', () => {
     fireEvent.change(screen.getByLabelText('Status'), {
       target: { value: 'published' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Inhalt anlegen' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Inhalt anlegen' })[1]!);
 
     await waitFor(() => {
       expect(createRequests).toBe(0);
@@ -279,19 +293,25 @@ describe('ContentEditorPage', () => {
     });
 
     expect(document.activeElement).toBe(screen.getByLabelText('Veröffentlichungsdatum'));
-    expect(screen.getByLabelText('Veröffentlichungsdatum').getAttribute('aria-invalid')).toBe('true');
+    expect(screen.getByLabelText('Veröffentlichungsdatum').getAttribute('aria-invalid')).toBe(
+      'true'
+    );
 
     fireEvent.change(screen.getByLabelText('Veröffentlichungsdatum'), {
       target: { value: '2026-03-22T12:00' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Inhalt anlegen' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Inhalt anlegen' })[1]!);
 
     await waitFor(() => {
       expect(createRequests).toBe(1);
     });
 
     expect(navigateMock).not.toHaveBeenCalled();
-    expect(screen.getByText('Die Inhaltsdaten konnten wegen eines Datenbankproblems nicht verarbeitet werden.')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Die Inhaltsdaten konnten wegen eines Datenbankproblems nicht verarbeitet werden.'
+      )
+    ).toBeTruthy();
   });
 
   it('blocks saving when a non-empty publication date is invalid in Europe/Berlin', async () => {
@@ -426,7 +446,9 @@ describe('ContentEditorPage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Änderungen speichern' })[1]!);
 
     await waitFor(() => {
-      expect(screen.getByText('Der Inhalt enthält ungültige oder unvollständige Daten.')).toBeTruthy();
+      expect(
+        screen.getByText('Der Inhalt enthält ungültige oder unvollständige Daten.')
+      ).toBeTruthy();
     });
   });
 
@@ -453,10 +475,14 @@ describe('ContentEditorPage', () => {
     fireEvent.change(screen.getByLabelText('Payload (JSON)'), {
       target: { value: '{"hero":"Willkommen"}' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Inhalt anlegen' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Inhalt anlegen' })[1]!);
 
     await waitFor(() => {
-      expect(screen.getByText('Zu viele Anfragen in kurzer Zeit. Bitte kurz warten und erneut versuchen.')).toBeTruthy();
+      expect(
+        screen.getByText(
+          'Zu viele Anfragen in kurzer Zeit. Bitte kurz warten und erneut versuchen.'
+        )
+      ).toBeTruthy();
     });
   });
 
@@ -482,7 +508,11 @@ describe('ContentEditorPage', () => {
         'Aktionen bleiben deaktiviert, bis die erforderlichen Berechtigungen im aktuellen Kontext vorliegen.'
       )
     ).toBeTruthy();
-    expect((screen.getByRole('button', { name: 'Inhalt anlegen' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      screen
+        .getAllByRole('button', { name: 'Inhalt anlegen' })
+        .every((button) => (button as HTMLButtonElement).disabled)
+    ).toBe(true);
   });
 
   it('renders edit mode as read only when content access forbids updates', async () => {
@@ -518,10 +548,15 @@ describe('ContentEditorPage', () => {
     });
 
     expect(
-      screen.getAllByText('Der Inhalt ist im aktuellen Kontext nur lesbar. Felder und Speichern bleiben deaktiviert.')
-        .length
+      screen.getAllByText(
+        'Der Inhalt ist im aktuellen Kontext nur lesbar. Felder und Speichern bleiben deaktiviert.'
+      ).length
     ).toBeGreaterThan(0);
-    expect(screen.getAllByRole('button', { name: 'Änderungen speichern' }).every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
+    expect(
+      screen
+        .getAllByRole('button', { name: 'Änderungen speichern' })
+        .every((button) => (button as HTMLButtonElement).disabled)
+    ).toBe(true);
     expect((screen.getByLabelText('Titel') as HTMLInputElement).disabled).toBe(true);
     expect(screen.getByText('Nur lesbar')).toBeTruthy();
   });

--- a/apps/sva-studio-react/src/routes/content/-content-editor-page.tsx
+++ b/apps/sva-studio-react/src/routes/content/-content-editor-page.tsx
@@ -1,6 +1,11 @@
 import { Link, useNavigate } from '@tanstack/react-router';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { GENERIC_CONTENT_TYPE, withServerDeniedContentAccess, type IamContentAccessSummary, type IamContentStatus } from '@sva/core';
+import {
+  GENERIC_CONTENT_TYPE,
+  withServerDeniedContentAccess,
+  type IamContentAccessSummary,
+  type IamContentStatus,
+} from '@sva/core';
 import { FilePenLine, History } from 'lucide-react';
 import {
   StudioDetailPageTemplate,
@@ -30,7 +35,11 @@ import { useContentAccess } from '../../hooks/use-content-access';
 import { useContentDetail, useCreateContent } from '../../hooks/use-contents';
 import { t } from '../../i18n';
 import { formatContentAuthor } from '../../lib/content-author';
-import { formatEditorDateTime, parseOptionalEditorDateTime, toDatetimeLocalValue } from '../../lib/editor-date-time';
+import {
+  formatEditorDateTime,
+  parseOptionalEditorDateTime,
+  toDatetimeLocalValue,
+} from '../../lib/editor-date-time';
 import type { CreateContentPayload, IamHttpError, UpdateContentPayload } from '../../lib/iam-api';
 
 type ContentEditorPageProps = {
@@ -145,7 +154,9 @@ const historyActionLabelKey = {
   status_changed: 'content.history.actions.statusChanged',
 } as const;
 
-const parseContentPayload = (payloadText: string): { ok: true; payload: unknown } | { ok: false; message: string } => {
+const parseContentPayload = (
+  payloadText: string
+): { ok: true; payload: unknown } | { ok: false; message: string } => {
   try {
     return { ok: true, payload: JSON.parse(payloadText) };
   } catch {
@@ -192,7 +203,9 @@ const createContentFormSchema = (originalPublishedAt?: string) =>
       }
     });
 
-const toDeniedAccess = (errorCode: IamHttpError['code'] | undefined): IamContentAccessSummary | null =>
+const toDeniedAccess = (
+  errorCode: IamHttpError['code'] | undefined
+): IamContentAccessSummary | null =>
   errorCode === 'forbidden' ? withServerDeniedContentAccess(undefined) : null;
 
 const resolveActiveAccess = ({
@@ -269,10 +282,14 @@ const renderContentHistory = ({
       {history.map((entry) => (
         <li key={entry.id} className="rounded-lg border border-border p-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-sm font-medium text-foreground">{t(historyActionLabelKey[entry.action])}</span>
+            <span className="text-sm font-medium text-foreground">
+              {t(historyActionLabelKey[entry.action])}
+            </span>
             <span className="text-xs text-muted-foreground">{formatDateTime(entry.createdAt)}</span>
           </div>
-          <p className="mt-1 text-sm text-muted-foreground">{t('content.history.byline', { actor: entry.actor })}</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t('content.history.byline', { actor: entry.actor })}
+          </p>
           {entry.summary ? <p className="mt-2 text-sm text-foreground">{entry.summary}</p> : null}
           {entry.changedFields.length > 0 ? (
             <p className="mt-2 text-xs text-muted-foreground">
@@ -303,11 +320,18 @@ const contentEditorTabBodyKeyMap = {
   history: 'content.tabs.historyDescription',
 } as const satisfies Record<ContentEditorTabId, string>;
 
-export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: ContentEditorPageProps) => {
+export const ContentEditorPage = ({
+  mode,
+  contentId,
+  activeTab,
+  onTabChange,
+}: ContentEditorPageProps) => {
   const navigate = useNavigate();
-  const [internalActiveTab, setInternalActiveTab] = React.useState<ContentEditorTabId>(activeTab ?? 'general');
+  const [internalActiveTab, setInternalActiveTab] = React.useState<ContentEditorTabId>(
+    activeTab ?? 'general'
+  );
   const createApi = useCreateContent();
-  const detailApi = useContentDetail(mode === 'edit' ? contentId ?? null : null);
+  const detailApi = useContentDetail(mode === 'edit' ? (contentId ?? null) : null);
   const contentAccessApi = useContentAccess();
   const formSchema = React.useMemo(
     () => createContentFormSchema(detailApi.content?.publishedAt),
@@ -344,7 +368,8 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
     activeErrorCode: activeError?.code,
   });
 
-  const isReadOnly = mode === 'edit' && activeAccess?.canRead === true && activeAccess.canUpdate === false;
+  const isReadOnly =
+    mode === 'edit' && activeAccess?.canRead === true && activeAccess.canUpdate === false;
 
   const actionsDisabled = isEditorActionDisabled({
     mode,
@@ -373,24 +398,37 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
     id: 'content-payload',
     error: errors.payloadText,
   });
-  const summaryErrors = collectSummaryErrors([titleField, contentTypeField, statusField, publishedAtField, payloadField]);
+  const summaryErrors = collectSummaryErrors([
+    titleField,
+    contentTypeField,
+    statusField,
+    publishedAtField,
+    payloadField,
+  ]);
   const formId = React.useId();
-  const primaryActionLabel = mode === 'create' ? t('content.actions.createNow') : t('content.actions.save');
-  const submitDisabled = actionsDisabled || isSubmitting || isLoading || (mode === 'edit' && !content);
+  const primaryActionLabel =
+    mode === 'create' ? t('content.actions.createNow') : t('content.actions.save');
+  const submitDisabled =
+    actionsDisabled || isSubmitting || isLoading || (mode === 'edit' && !content);
   const showEditorTabs = mode === 'create' || Boolean(content);
   const resolvedActiveTab = activeTab ?? internalActiveTab;
   const visibleTabs = React.useMemo<readonly ContentEditorTabId[]>(
     () => (mode === 'edit' ? ['general', 'history'] : ['general']),
     [mode]
   );
-  const [visitedTabs, setVisitedTabs] = React.useState<readonly ContentEditorTabId[]>([resolvedActiveTab]);
+  const [visitedTabs, setVisitedTabs] = React.useState<readonly ContentEditorTabId[]>([
+    resolvedActiveTab,
+  ]);
 
   const submitCreate = async (values: ContentFormState): Promise<void> => {
     const parsedPayload = parseContentPayload(values.payloadText);
     if (!parsedPayload.ok) {
       return;
     }
-    const publishedAt = parseOptionalEditorDateTime(values.publishedAt, detailApi.content?.publishedAt);
+    const publishedAt = parseOptionalEditorDateTime(
+      values.publishedAt,
+      detailApi.content?.publishedAt
+    );
     if (publishedAt.kind === 'invalid') {
       return;
     }
@@ -416,7 +454,10 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
     if (!parsedPayload.ok) {
       return;
     }
-    const publishedAt = parseOptionalEditorDateTime(values.publishedAt, detailApi.content?.publishedAt);
+    const publishedAt = parseOptionalEditorDateTime(
+      values.publishedAt,
+      detailApi.content?.publishedAt
+    );
     if (publishedAt.kind === 'invalid') {
       return;
     }
@@ -452,7 +493,9 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
   }, [activeTab]);
 
   React.useEffect(() => {
-    setVisitedTabs((current) => (current.includes(resolvedActiveTab) ? current : [...current, resolvedActiveTab]));
+    setVisitedTabs((current) =>
+      current.includes(resolvedActiveTab) ? current : [...current, resolvedActiveTab]
+    );
   }, [resolvedActiveTab]);
 
   const warmTab = React.useCallback((tabId: ContentEditorTabId) => {
@@ -473,9 +516,17 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
   const renderGeneralTabPanel = () => (
     <div className="space-y-5">
       <form id={formId} className="space-y-4" onSubmit={submitForm} noValidate>
-        <StudioFormSummaryErrors errors={summaryErrors} title={t('account.messages.validationSummary')} />
+        <StudioFormSummaryErrors
+          errors={summaryErrors}
+          title={t('account.messages.validationSummary')}
+        />
         <StudioFieldGroup columns={2}>
-          <StudioField {...titleField} label={t('content.fields.title')} required className="md:col-span-2">
+          <StudioField
+            {...titleField}
+            label={t('content.fields.title')}
+            required
+            className="md:col-span-2"
+          >
             <Input {...register('title')} disabled={actionsDisabled} />
           </StudioField>
           <StudioField {...contentTypeField} label={t('content.fields.contentType')}>
@@ -490,7 +541,11 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
               <option value="archived">{t('content.status.archived')}</option>
             </FieldSelect>
           </StudioField>
-          <StudioField {...publishedAtField} label={t('content.fields.publishedAt')} className="md:col-span-2">
+          <StudioField
+            {...publishedAtField}
+            label={t('content.fields.publishedAt')}
+            className="md:col-span-2"
+          >
             <Input
               {...register('publishedAt')}
               type="datetime-local"
@@ -498,7 +553,11 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
               required={statusValue === 'published'}
             />
           </StudioField>
-          <StudioField {...payloadField} label={t('content.fields.payload')} className="md:col-span-2">
+          <StudioField
+            {...payloadField}
+            label={t('content.fields.payload')}
+            className="md:col-span-2"
+          >
             <Textarea
               {...register('payloadText')}
               disabled={actionsDisabled}
@@ -507,14 +566,6 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
           </StudioField>
         </StudioFieldGroup>
       </form>
-      <div className="flex flex-wrap gap-3 border-t border-border/60 pt-4">
-        <Button asChild variant="outline">
-          <Link to="/admin/content">{t('content.actions.cancel')}</Link>
-        </Button>
-        <Button type="submit" form={formId} disabled={submitDisabled}>
-          {primaryActionLabel}
-        </Button>
-      </div>
     </div>
   );
 
@@ -528,16 +579,15 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
 
       <StudioDetailPageTemplate
         title={mode === 'create' ? t('content.editor.createTitle') : t('content.editor.editTitle')}
-        description={mode === 'create' ? t('content.editor.createSubtitle') : t('content.editor.editSubtitle')}
-        actions={
-          mode === 'edit' ? (
-            <Button type="submit" form={formId} disabled={submitDisabled}>
-              {primaryActionLabel}
-            </Button>
-          ) : undefined
+        description={
+          mode === 'create' ? t('content.editor.createSubtitle') : t('content.editor.editSubtitle')
+        }
+        primaryAction={
+          <Button type="submit" form={formId} disabled={submitDisabled}>
+            {primaryActionLabel}
+          </Button>
         }
       >
-
         {detailApi.error && mode === 'edit' ? (
           <Alert className="border-destructive/40 bg-destructive/5 text-destructive">
             <AlertDescription>{contentErrorMessage(detailApi.error)}</AlertDescription>
@@ -563,12 +613,28 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
         {mode === 'edit' && content ? (
           <StudioResourceHeader
             title={resolveResourceTitle(content)}
-            status={<Badge variant={statusVariantByValue[content.status]}>{t(statusLabelKeyByValue[content.status])}</Badge>}
+            status={
+              <Badge variant={statusVariantByValue[content.status]}>
+                {t(statusLabelKeyByValue[content.status])}
+              </Badge>
+            }
             description={content.contentType}
             metadata={[
-              { id: 'author', label: t('content.meta.author'), value: formatContentAuthor(content.author) },
-              { id: 'createdAt', label: t('content.meta.createdAt'), value: formatDateTime(content.createdAt) },
-              { id: 'updatedAt', label: t('content.meta.updatedAt'), value: formatDateTime(content.updatedAt) },
+              {
+                id: 'author',
+                label: t('content.meta.author'),
+                value: formatContentAuthor(content.author),
+              },
+              {
+                id: 'createdAt',
+                label: t('content.meta.createdAt'),
+                value: formatDateTime(content.createdAt),
+              },
+              {
+                id: 'updatedAt',
+                label: t('content.meta.updatedAt'),
+                value: formatDateTime(content.updatedAt),
+              },
               { id: 'contentId', label: t('content.meta.id'), value: content.id },
               {
                 id: 'access',
@@ -592,7 +658,9 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
                   aria-label={t('content.tabs.ariaLabel')}
                   className="h-11 rounded-xl border-border/70 bg-card"
                   value={resolvedActiveTab}
-                  onChange={(event) => handleTabChange(normalizeContentEditorTab(event.target.value))}
+                  onChange={(event) =>
+                    handleTabChange(normalizeContentEditorTab(event.target.value))
+                  }
                 >
                   {visibleTabs.map((tabId) => (
                     <option key={tabId} value={tabId}>
@@ -602,7 +670,10 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
                 </StudioSelect>
               </label>
 
-              <TabsList aria-label={t('content.tabs.ariaLabel')} className="ml-[10px] hidden gap-10 md:flex">
+              <TabsList
+                aria-label={t('content.tabs.ariaLabel')}
+                className="ml-[10px] hidden gap-10 md:flex"
+              >
                 {visibleTabs.map((tabId) => {
                   const TabIcon = contentEditorTabIconMap[tabId];
                   const isActive = tabId === resolvedActiveTab;
@@ -614,7 +685,9 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
                       onMouseEnter={() => warmTab(tabId)}
                       onFocus={() => warmTab(tabId)}
                       className={`relative z-10 gap-2 rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none ${
-                        isActive ? 'mb-[-1px] border-primary text-primary' : 'border-transparent text-muted-foreground'
+                        isActive
+                          ? 'mb-[-1px] border-primary text-primary'
+                          : 'border-transparent text-muted-foreground'
                       }`}
                     >
                       <span className="inline-flex items-center gap-2">
@@ -627,7 +700,8 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
               </TabsList>
 
               {visibleTabs.map((tabId) => {
-                const shouldKeepMounted = visitedTabs.includes(tabId) && tabId !== resolvedActiveTab;
+                const shouldKeepMounted =
+                  visitedTabs.includes(tabId) && tabId !== resolvedActiveTab;
 
                 return (
                   <TabsContent
@@ -642,7 +716,9 @@ export const ContentEditorPage = ({ mode, contentId, activeTab, onTabChange }: C
                         className="flex flex-col gap-3 border-0 bg-transparent p-0 lg:flex-row lg:items-start lg:justify-between"
                       >
                         <div className="space-y-1">
-                          <h2 className="text-base font-semibold text-foreground">{t(contentEditorTabLabelKeyMap[tabId])}</h2>
+                          <h2 className="text-base font-semibold text-foreground">
+                            {t(contentEditorTabLabelKeyMap[tabId])}
+                          </h2>
                           <p className="text-sm leading-relaxed text-muted-foreground">
                             {t(contentEditorTabBodyKeyMap[tabId])}
                           </p>

--- a/docs/changelog/entries/pr-878.json
+++ b/docs/changelog/entries/pr-878.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 878,
+  "body": "Verbesserung der Bearbeitung\n\n- Lange Bearbeitungsflächen bieten ihre globale Speichern- oder Anlegen-Aktion jetzt am Seitenanfang und am Seitenende an.\n- Das gemeinsame Pattern gilt für Inhalte, Benutzer, Rollenberechtigungen und Rechtstexte und ist für neue Plugins dokumentiert."
+}

--- a/docs/development/studio-uebersichts-und-detailseiten-standard.md
+++ b/docs/development/studio-uebersichts-und-detailseiten-standard.md
@@ -77,7 +77,7 @@ Der Ausnahmefall ist eine Plugin-Custom-View. Sie ist zulässig, wenn die Fachob
 Das Package startet mit einem bewusst kleinen, aber verbindlichen Umfang. Der erste umgesetzte MVP enthält die UI-Boundary, Basiscontrols, Page-/Form-/State-Primitives und `plugin-news` als Referenzverbraucher.
 
 - umgesetzt im MVP: `Button`, `Input`, `Textarea`, `Select`, `Checkbox`, `Badge`, `Alert`, `Dialog`, `AlertDialog`, `Tabs`
-- umgesetzt im MVP: `StudioPageHeader`, `StudioOverviewPageTemplate`, `StudioDetailPageTemplate`
+- umgesetzt im MVP: `StudioPageHeader`, `StudioOverviewPageTemplate`, `StudioDetailPageTemplate`, `StudioFormActionBar`
 - umgesetzt im MVP: `StudioField`, `StudioFieldGroup`, `StudioFormSummary`
 - umgesetzt im MVP: `StudioStateBlock`, `StudioLoadingState`, `StudioEmptyState`, `StudioErrorState`
 - Folgeumfang: Ressourcen-Header, Detail-Tabs, Sektionen, Editierflächen und Aktionsmenüs nach konkretem Host- oder Plugin-Bedarf
@@ -167,6 +167,27 @@ Detailseiten verwenden dieselbe Grundstruktur:
 - aktiver Arbeitsbereich mit fachlichen Sektionen
 - optionale Historie, Aktivität oder Audit-Information
 
+### Primäraktion auf langen Bearbeitungsflächen
+
+Wenn eine Erstellungs- oder Bearbeitungsseite mehrere Viewport-Höhen, Tabs, umfangreiche Sektionen, Rich Text, Tabellen oder Listen umfasst, wird ihre globale Primäraktion an zwei Stellen angeboten:
+
+1. im Seitenkopf vor Beginn der Arbeitsfläche
+2. nach der Arbeitsfläche als Abschluss der Seite
+
+Beide Positionen repräsentieren dieselbe Aktion. Sie verwenden dieselbe Beschriftung, denselben Submit- oder Mutationspfad und dieselben Berechtigungs-, Lade- und Disabled-Zustände. Insbesondere darf der Button im Seitenkopf nicht nur den aktiven Tab speichern: Eine globale Primäraktion speichert die gesamte Bearbeitungsfläche unabhängig vom aktuellen Tab.
+
+Das Pattern gilt fachübergreifend. Dazu zählen Inhalte wie News, Events, FAQ, POI, Umfragen und generische Inhalte ebenso wie Benutzerbearbeitung, Rollenberechtigungen sowie die Anlage und Bearbeitung von Rechtstexten.
+
+Technischer Standard:
+
+- Detailseiten übergeben die Aktion einmalig als `primaryAction` an `StudioDetailPageTemplate`; das Template platziert sie oben und unten.
+- Seiten ohne dieses Template verwenden `StudioFormActionBar` mit `position="start"` und `position="end"`.
+- Formularbasierte Aktionen referenzieren an beiden Positionen dieselbe Formular-ID über das native `form`-Attribut.
+- Sekundäre oder destruktive Aktionen werden nicht automatisch verdoppelt.
+- Kurze Formulare und Dialoge ohne relevanten Scrollweg bleiben bei einer einzelnen Abschlusszone.
+
+Damit ist das Muster eine Eigenschaft langer Bearbeitungsflächen und keine Sonderregel für Content-Plugins.
+
 ## Kanonisches Standardmuster: Fokussierte Erstellungs-/Bearbeitungsseite
 
 Das primäre Zielbild für neue Detailseiten ist eine ruhige, fokussierte Arbeitsseite mit genau einem dominanten Arbeitsauftrag. Visuell ist nicht entscheidend, ob die technische Umsetzung später als Route, Dialog, Drawer oder Template-Komposition erfolgt. Maßgeblich ist der finale wahrnehmbare Aufbau.
@@ -186,7 +207,7 @@ Diese Referenzen sind deshalb geeignet, weil sie ohne zusätzliche Verwaltungsum
 4. zentrale Arbeitsfläche
 5. logisch gruppierte Felder oder Sektionen
 6. optionale Inline-Hinweise oder Fehlerzusammenfassung
-7. eindeutige Abschlusszone mit `Abbrechen` und Primäraktion
+7. eindeutige Abschlusszone mit `Abbrechen` und Primäraktion; bei langen Bearbeitungsflächen zusätzlich dieselbe Primäraktion im Seitenkopf
 
 ### Zielbild
 

--- a/docs/guides/plugin-development.md
+++ b/docs/guides/plugin-development.md
@@ -244,6 +244,65 @@ Ein abgelehntes Plugin erscheint nicht teilweise im Snapshot.
 
 Plugin-Custom-Views sind zulässig, wenn sie die Host-Shell, hostseitige Guards und den Routing-Vertrag respektieren. Wiederverwendbare Studio-UI kommt ausschließlich aus `@sva/studio-ui-react`.
 
+### Design-Pattern für lange Bearbeitungsflächen
+
+Lange Erstellungs- und Bearbeitungsseiten bieten ihre eine fachliche Primäraktion sowohl im Seitenkopf als auch nach der Arbeitsfläche an. Das gilt nicht nur für klassische Inhalte wie News, Events, FAQ, POI, Umfragen oder generische Inhalte, sondern für jede lange Bearbeitungsfläche, beispielsweise Benutzer, Rollenberechtigungen oder Rechtstexte.
+
+Das Pattern ist anzuwenden, wenn mindestens eines dieser Merkmale vorliegt:
+
+- Tabs oder mehrere fachliche Sektionen verteilen die Eingaben.
+- Rich-Text-, Medien-, Tabellen- oder Listenbearbeitung macht die Seite lang.
+- Die Arbeitsfläche überschreitet typischerweise mehrere Viewport-Höhen.
+- Speichern schließt Änderungen aus mehreren Bereichen gemeinsam ab.
+
+Kurze Formulare und Dialoge, bei denen die Abschlusszone ohne Scrollen sichtbar bleibt, benötigen keine doppelte Primäraktion. Tab-spezifische Aktionen werden nicht in dieses Pattern aufgenommen. Die wiederholte Aktion speichert immer die gesamte Bearbeitungsfläche und bleibt deshalb unabhängig vom aktiven Tab.
+
+Für Detailseiten ist `primaryAction` von `StudioDetailPageTemplate` der Standard. Das Template rendert dieselbe Aktion im Kopf und am Seitenende:
+
+```tsx
+import { Button, StudioDetailPageTemplate } from '@sva/studio-ui-react';
+import React from 'react';
+
+export function ExampleDetailPage() {
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const save = async () => {
+    setIsSaving(true);
+    try {
+      await saveAllSections();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <StudioDetailPageTemplate
+      title={pt('editor.title')}
+      description={pt('editor.description')}
+      primaryAction={
+        <Button type="button" disabled={isSaving} onClick={() => void save()}>
+          {pt('actions.save')}
+        </Button>
+      }
+    >
+      <ExampleEditor />
+    </StudioDetailPageTemplate>
+  );
+}
+```
+
+Bei nativen Formularen verweist die Aktion mit `type="submit"` und `form` auf genau dasselbe Formular. Beide sichtbaren Buttons müssen denselben Handler, Lade-/Disabled-Zustand, Berechtigungszustand und dieselbe Beschriftung verwenden. Es darf keine getrennte Kopf- und Fuß-Speicherlogik geben.
+
+Wenn eine Seite das Detailseiten-Template nicht verwenden kann, wird `StudioFormActionBar` explizit vor und nach der langen Arbeitsfläche eingebunden. `position="start"` kennzeichnet den oberen und `position="end"` den unteren Abschlussbereich.
+
+Review-Checkliste:
+
+- Ist die Primäraktion fachlich global und nicht tab-spezifisch?
+- Lösen beide Positionen exakt dieselbe Mutation beziehungsweise dasselbe Formular aus?
+- Sind Beschriftung, Berechtigung, Lade- und Disabled-Zustand identisch?
+- Bleiben Abbrechen, Löschen und andere sekundäre Aktionen bewusst getrennt?
+- Prüft mindestens ein UI-Test beide Positionen und eine Ausführung über die untere Aktion?
+
 Erlaubt:
 
 ```tsx
@@ -328,7 +387,14 @@ export const pluginNews: PluginDefinition = {
   displayName: 'News',
   permissions: newsPermissions,
   routes: [{ id: 'news.list', path: '/plugins/news', guard: 'news.read', component: NewsListPage }],
-  navigation: [{ id: 'news.navigation', to: '/plugins/news', titleKey: 'news.navigation.title', requiredAction: 'news.read' }],
+  navigation: [
+    {
+      id: 'news.navigation',
+      to: '/plugins/news',
+      titleKey: 'news.navigation.title',
+      requiredAction: 'news.read',
+    },
+  ],
   translations: {},
 };
 ```

--- a/openspec/changes/add-content-editor-footer-save-actions/design.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/design.md
@@ -1,0 +1,52 @@
+## Context
+
+Die spezialisierten Inhaltseditoren besitzen unterschiedliche fachliche Formularmodelle, verwenden aber überwiegend `StudioDetailPageTemplate` und eine formularweite Primäraktion im Seitenkopf. Vergleichbare lange Arbeitsflächen existieren in der Benutzerbearbeitung, der Rechtstextverwaltung und der Rollenberechtigungsmatrix. Die relevante Primäraktion gehört jeweils zur gesamten Formular- oder Teilflächengrenze und nicht zu einem einzelnen Tab, Feld oder Tabellenabschnitt.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Speichern ohne Zurückscrollen ermöglichen
+  - identisches Verhalten in langen Bearbeitungsflächen sicherstellen
+  - Layout-Ownership für wiederholte Primäraktionen in `studio-ui-react` bündeln
+  - vorhandene fachliche Submit-Logik unverändert wiederverwenden
+  - neuen Plugins ein dokumentiertes und ausführbares Golden-Path-Pattern geben
+- Non-Goals:
+  - kein Speichern einzelner Tabs
+  - keine Änderung an Validierung, Persistenz oder Berechtigungen
+  - keine Verdopplung destruktiver, navigierender oder zurücksetzender Sekundäraktionen
+  - keine sticky oder schwebende Aktionsleiste
+
+## Decisions
+
+- Decision: `StudioDetailPageTemplate` erhält einen semantischen `primaryAction`-Vertrag und rendert diese Aktion bei seitengroßen Bearbeitungsflächen im Kopfbereich und nach dem Seiteninhalt.
+  - Rationale: Das Template besitzt bereits die Layout-Ownership für Detailseiten. Der semantische Vertrag verhindert, dass neue Plugins die zweite Position versehentlich auslassen, und trennt die wiederholte Commit-Aktion von ausschließlich oben sichtbaren Navigations- oder Löschaktionen.
+
+- Decision: Eingebettete lange Teilflächen verwenden eine gemeinsame `StudioFormActionBar` oberhalb und unterhalb ihres fachlichen Inhalts.
+  - Rationale: Die Rollenberechtigungsmatrix besitzt eine eigene Mutationsgrenze innerhalb einer größeren Detailseite und darf nicht an eine globale Seitenspeicherung gekoppelt werden.
+
+- Decision: Die wiederholte Primäraktion wird nicht anhand des aktiven Tabs ausgeblendet.
+  - Rationale: Die Aktion speichert das gesamte Formular und ist daher auch im Historien-Tab fachlich gültig.
+
+- Decision: Das Pattern gilt für Tabs, Rich-Text-Flächen, lange Listen oder Tabellen und Bearbeitungsflächen über mehrere Bildschirmhöhen; kurze Dialoge und kompakte Einzelformulare bleiben ausgenommen.
+  - Rationale: Eine allgemeine Verdopplung aller Submit-Buttons würde visuelles Rauschen erzeugen und wäre für kurze Interaktionen ohne Scrollproblem nicht hilfreich.
+
+- Decision: Der Plugin-Guide enthält ein vollständiges TypeScript-Beispiel und eine Review-Checkliste.
+  - Rationale: Gemeinsame Komponenten sichern den ausführbaren Pfad, während Einsatzgrenzen, Accessibility und Ownership-Regeln für Plugin-Autoren normativ auffindbar bleiben müssen.
+
+## Risks / Trade-offs
+
+- Zwei gleich benannte Buttons erfordern Tests, die bewusst zwischen oberer und unterer Aktion unterscheiden. Die zugängliche Beschriftung bleibt identisch, weil beide Aktionen semantisch dasselbe ausführen.
+- Zwei Positionen dürfen nicht zu auseinanderlaufenden Zuständen oder doppelten gleichzeitigen Submits führen. Gemeinsame Handler- und Statusquellen sowie Template-, Action-Bar- und Fachseitentests sichern dies ab.
+- Die Migration bestehender Seiten auf gemeinsame Layout-Primitives darf deren Formulargrenzen, Validierung, Berechtigungen oder Unsaved-Changes-Verhalten nicht verändern.
+
+## Migration Plan
+
+1. `primaryAction` im gemeinsamen Detailseiten-Template und die gemeinsame `StudioFormActionBar` ergänzen und testen.
+2. Die sechs spezialisierten Inhaltseditoren und den Kern-Inhaltseditor migrieren.
+3. Benutzerbearbeitung, Rollenberechtigungsmatrix sowie Rechtstexterstellung und -bearbeitung migrieren.
+4. Plugin- und Detailseiten-Guides um das verbindliche Pattern ergänzen.
+5. Gezielte Unit- und Type-Gates ausführen.
+
+## Open Questions
+
+Keine.

--- a/openspec/changes/add-content-editor-footer-save-actions/proposal.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/proposal.md
@@ -1,0 +1,25 @@
+# Change: Primäraktion bei langen Bearbeitungsflächen oben und unten anbieten
+
+## Why
+
+Lange, tab-basierte oder listenorientierte Bearbeitungsflächen zeigen ihre Speichern-Aktion derzeit häufig nur an einem Ende der Arbeitsfläche. Redakteurinnen, Redakteure und Administratoren müssen deshalb nach der Bearbeitung unnötig scrollen, obwohl die Primäraktion für die gesamte jeweilige Formular- oder Teilflächengrenze gilt.
+
+## What Changes
+
+- News, Events, FAQs, POIs, Umfragen und generische Inhalte zeigen die formularweite Speichern- beziehungsweise Anlegen-Aktion sowohl im Seitenkopf als auch direkt unterhalb der Tabs.
+- Beide Aktionen lösen denselben Submit-Pfad aus und teilen Beschriftung, Lade-, Disabled- und Berechtigungszustände.
+- Die untere Aktion bleibt in jedem Tab sichtbar, einschließlich des schreibgeschützten Historien-Tabs.
+- Die Benutzerbearbeitung zeigt ihre formularweite Speichern-Aktion oberhalb der Benutzer-Tabs und am Formularende.
+- Die Rollenberechtigungen zeigen ihre eigene Speichern-Aktion oberhalb und unterhalb der Berechtigungsmatrix, ohne andere Rollen-Teilflächen einzubeziehen.
+- Rechtstexterstellung und Rechtstextbearbeitung zeigen ihre Primäraktion oberhalb der Eingabefläche und unterhalb des Rich-Text-Editors.
+- `StudioDetailPageTemplate` erhält einen semantischen `primaryAction`-Vertrag für seitengroße Bearbeitungsflächen; eingebettete Teilflächen verwenden eine gemeinsame `StudioFormActionBar`.
+- Der bestehende generische Kern-Inhaltseditor wird auf denselben gemeinsamen Layoutpfad vereinheitlicht.
+- Der Plugin-Entwicklungsleitfaden dokumentiert das Pattern „lange Bearbeitungsfläche“ mit Einsatzkriterien, Referenzkomposition und Review-Checkliste für neue Plugins.
+
+## Impact
+
+- Affected specs: `content-management`, `account-ui`, `iam-access-control`, `ui-layout-shell`, `architecture-documentation`
+- Affected code: `packages/studio-ui-react`, `packages/plugin-news`, `packages/plugin-events`, `packages/plugin-faq`, `packages/plugin-poi`, `packages/plugin-surveys`, `packages/plugin-generic-items`, `apps/sva-studio-react`
+- Affected arc42 sections: keine; bestehende Paket- und Verantwortungsgrenzen bleiben unverändert
+- Required documentation updates: `docs/guides/plugin-development.md` und `docs/development/studio-uebersichts-und-detailseiten-standard.md`
+- Required tests: gemeinsame Template-/Action-Bar-Tests sowie betroffene Editor-, Benutzer-, Rollen- und Rechtstext-Unit-Tests für zwei gleichwertige Primäraktionen

--- a/openspec/changes/add-content-editor-footer-save-actions/specs/account-ui/spec.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/specs/account-ui/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Wiederholte Primäraktion in Benutzer- und Rechtstextbearbeitung
+
+Das System SHALL bei langen Benutzer- und Rechtstextformularen dieselbe formularweite Speichern- beziehungsweise Anlegen-Aktion oberhalb und unterhalb der bearbeitbaren Inhalte anbieten.
+
+#### Scenario: Administrator bearbeitet einen Benutzer über mehrere Tabs
+
+- **GIVEN** ein berechtigter Administrator bearbeitet einen Benutzer in der tab-basierten Benutzerbearbeitung
+- **WHEN** die Bearbeitungsseite gerendert wird
+- **THEN** steht dieselbe Speichern-Aktion oberhalb der Tabs und am Formularende bereit
+- **AND** beide Positionen verwenden denselben Submit-, Lade- und Disabled-Zustand
+
+#### Scenario: Administrator erstellt oder bearbeitet einen Rechtstext
+
+- **GIVEN** ein berechtigter Administrator öffnet die lange Rechtstexterstellung oder Rechtstextbearbeitung
+- **WHEN** die Eingabefläche einschließlich Rich-Text-Editor gerendert wird
+- **THEN** steht dieselbe Primäraktion oberhalb der Felder und unterhalb des Rich-Text-Editors bereit
+- **AND** beide Positionen speichern dasselbe vollständige Rechtstextformular

--- a/openspec/changes/add-content-editor-footer-save-actions/specs/architecture-documentation/spec.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/specs/architecture-documentation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Plugin-Guide dokumentiert lange Bearbeitungsflächen
+
+Die Entwicklungsdokumentation SHALL das Pattern „lange Bearbeitungsfläche“ für Host- und Plugin-Views mit Einsatzkriterien, gemeinsamen Studio-UI-Verträgen, einem vollständigen TypeScript-Beispiel, Ausnahmen und einer Review-Checkliste beschreiben.
+
+#### Scenario: Plugin-Entwickler implementiert einen langen Editor
+
+- **WHEN** ein Plugin-Entwickler den Plugin-Entwicklungsleitfaden liest
+- **THEN** erkennt er, wann eine Primäraktion oben und unten erforderlich ist
+- **AND** kann er den Golden Path mit `StudioDetailPageTemplate`, `StudioDetailTabs` und den gemeinsamen Aktionsverträgen übernehmen
+- **AND** erkennt er, dass kurze Dialoge und kompakte Einzelformulare ausgenommen sind
+
+#### Scenario: Reviewer prüft eine neue lange Bearbeitungsfläche
+
+- **WHEN** ein PR eine lange Host- oder Plugin-Bearbeitungsfläche einführt
+- **THEN** kann der Reviewer prüfen, ob Formulargrenze, Primäraktion, Zustände, Accessibility und Sekundäraktionen dem dokumentierten Pattern entsprechen

--- a/openspec/changes/add-content-editor-footer-save-actions/specs/content-management/spec.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/specs/content-management/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Formularweite Speichern-Aktion am Anfang und Ende von Inhaltseditoren
+
+Das System SHALL in tab-basierten Inhaltseditoren die formularweite Speichern- beziehungsweise Anlegen-Aktion sowohl im Seitenkopf als auch direkt unterhalb der Editor-Tabs anbieten. Beide Aktionen SHALL denselben Submit-Pfad, dieselbe Beschriftung sowie dieselben Lade-, Disabled- und Berechtigungszustände verwenden.
+
+#### Scenario: Redaktion speichert am Ende eines langen Editor-Tabs
+
+- **GIVEN** eine berechtigte Person bearbeitet News, Events, FAQs, POIs, Umfragen, generische Inhalte oder einen Kern-Inhalt
+- **WHEN** sie die Aktion unterhalb der Tabs auslöst
+- **THEN** speichert das System das gesamte Formular über denselben Pfad wie die Aktion im Seitenkopf
+- **AND** es wird kein tab-spezifischer Speichervorgang erzeugt
+
+#### Scenario: Speichern bleibt im Historien-Tab erreichbar
+
+- **GIVEN** ein Inhaltseditor besitzt einen schreibgeschützten Historien-Tab
+- **WHEN** die Person diesen Tab öffnet
+- **THEN** bleiben die formularweiten Speichern-Aktionen im Seitenkopf und unterhalb der Tabs sichtbar
+- **AND** zuvor vorgenommene Änderungen aus anderen Tabs können weiterhin gespeichert werden
+
+#### Scenario: Speichern ist nicht erlaubt oder läuft bereits
+
+- **GIVEN** die formularweite Speichern-Aktion ist durch Berechtigungen, Validierungszustand oder einen laufenden Submit deaktiviert
+- **WHEN** der Editor beide Aktionspositionen rendert
+- **THEN** spiegeln beide Positionen denselben Disabled- und Ladezustand wider

--- a/openspec/changes/add-content-editor-footer-save-actions/specs/iam-access-control/spec.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/specs/iam-access-control/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Wiederholte Primäraktion für Rollenberechtigungen
+
+Das System SHALL die Primäraktion der langen Rollenberechtigungsmatrix oberhalb und unterhalb der Matrix anbieten, ohne sie mit anderen speicherbaren Rollen-Teilflächen zu vermischen.
+
+#### Scenario: Administrator speichert eine lange Berechtigungsauswahl
+
+- **GIVEN** ein berechtigter Administrator bearbeitet die Berechtigungen einer Rolle
+- **WHEN** die Berechtigungsmatrix gerendert wird
+- **THEN** steht dieselbe Aktion zum Speichern der Berechtigungen oberhalb und unterhalb der Matrix bereit
+- **AND** beide Positionen verwenden denselben Handler sowie denselben Berechtigungs-, Lade- und Disabled-Zustand
+- **AND** allgemeine Rollendaten oder andere Rollen-Tabs werden dadurch nicht gespeichert

--- a/openspec/changes/add-content-editor-footer-save-actions/specs/ui-layout-shell/spec.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/specs/ui-layout-shell/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Wiederholte Primäraktionen für lange Bearbeitungsflächen
+
+Das Studio SHALL gemeinsame UI-Verträge bereitstellen, mit denen lange seitengroße oder eingebettete Bearbeitungsflächen dieselbe Primäraktion oberhalb und unterhalb ihres fachlichen Inhalts anzeigen. Die Verträge SHALL einheitliche Abstände, Ausrichtung und visuelle Trennung verwenden, ohne fachliche Aktionslogik zu besitzen.
+
+#### Scenario: Detailseite stellt eine Primäraktion bereit
+
+- **GIVEN** eine lange Detailseite übergibt eine Primäraktion
+- **WHEN** das gemeinsame Detailseiten-Template gerendert wird
+- **THEN** erscheint dieselbe Primäraktion im Seitenkopf und nach dem Seiteninhalt
+- **AND** ausschließlich für den Seitenkopf bestimmte Sekundäraktionen werden nicht automatisch wiederholt
+
+#### Scenario: Eingebettete Bearbeitungsfläche besitzt eine eigene Mutationsgrenze
+
+- **GIVEN** eine lange Tabelle, Liste oder Teilfläche wird unabhängig von der umgebenden Detailseite gespeichert
+- **WHEN** die gemeinsame Formular-Aktionsleiste verwendet wird
+- **THEN** erscheint dieselbe Primäraktion oberhalb und unterhalb dieser Teilfläche
+- **AND** die Aktion bleibt an deren eigenen Handler und Zustand gebunden
+
+#### Scenario: Detailseite besitzt keine wiederholte Primäraktion
+
+- **GIVEN** eine Detailseite übergibt keine Primäraktion
+- **WHEN** das gemeinsame Detailseiten-Template gerendert wird
+- **THEN** erzeugt das Template keine leere untere Aktionsfläche

--- a/openspec/changes/add-content-editor-footer-save-actions/tasks.md
+++ b/openspec/changes/add-content-editor-footer-save-actions/tasks.md
@@ -1,0 +1,31 @@
+## 1. Gemeinsames Pattern ergänzen
+
+- [x] 1.1 `StudioDetailPageTemplate` um den semantischen `primaryAction`-Vertrag erweitern
+- [x] 1.2 Gemeinsame `StudioFormActionBar` für eingebettete lange Bearbeitungsflächen ergänzen
+- [x] 1.3 Darstellung, Abwesenheit und gemeinsame Zustände beider Primitives mit Unit-Tests absichern
+
+## 2. Inhaltseditoren migrieren
+
+- [x] 2.1 News, Events und POIs auf dieselbe obere und untere Speichern-Aktion umstellen
+- [x] 2.2 FAQs, Umfragen und generische Inhalte auf dieselbe obere und untere Speichern-Aktion umstellen
+- [x] 2.3 Kern-Inhaltseditor auf den gemeinsamen Seitenabschluss-Slot vereinheitlichen
+- [x] 2.4 Sicherstellen, dass beide Aktionen in jedem Tab einschließlich Historie sichtbar bleiben
+
+## 3. Weitere lange Bearbeitungsflächen migrieren
+
+- [x] 3.1 Benutzerbearbeitung mit identischer Primäraktion oberhalb der Tabs und am Formularende ausstatten
+- [x] 3.2 Rollenberechtigungen mit identischer Primäraktion oberhalb und unterhalb der Berechtigungsmatrix ausstatten
+- [x] 3.3 Rechtstexterstellung und Rechtstextbearbeitung mit identischer Primäraktion oberhalb und unterhalb der langen Eingabefläche ausstatten
+- [x] 3.4 Bestehende Formulargrenzen, Berechtigungen, Loading-Zustände und Unsaved-Changes-Verhalten unverändert erhalten
+
+## 4. Design-Pattern dokumentieren
+
+- [x] 4.1 `docs/guides/plugin-development.md` um das verbindliche Pattern „lange Bearbeitungsfläche“ ergänzen
+- [x] 4.2 TypeScript-Golden-Path, Einsatzkriterien, Ausnahmen und Review-Checkliste dokumentieren
+- [x] 4.3 `docs/development/studio-uebersichts-und-detailseiten-standard.md` auf denselben Komponentenvertrag aktualisieren
+
+## 5. Qualitätsnachweise
+
+- [x] 5.1 Betroffene Unit-Tests für zwei Aktionen und Submit über die untere Aktion ergänzen beziehungsweise anpassen
+- [x] 5.2 Betroffene Unit- und Type-Targets über Nx ausführen
+- [x] 5.3 `openspec validate add-content-editor-footer-save-actions --strict` erfolgreich ausführen

--- a/packages/plugin-events/src/events.detail-page.tsx
+++ b/packages/plugin-events/src/events.detail-page.tsx
@@ -72,7 +72,14 @@ type EventsMediaPickerAsset = StudioMediaPickerAssetDetail;
 type EventsTabIconProps = Readonly<{ className?: string }>;
 
 const EventsTabBasisIcon = ({ className }: EventsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <path d="M7 4.75h7.5L19 9.25v9A1.75 1.75 0 0 1 17.25 20h-10.5A1.75 1.75 0 0 1 5 18.25v-11.5A1.75 1.75 0 0 1 6.75 5Z" />
     <path d="M14 4.75v4.5h4.5" />
     <path d="M8.5 12h7" />
@@ -81,7 +88,14 @@ const EventsTabBasisIcon = ({ className }: EventsTabIconProps) => (
 );
 
 const EventsTabContentIcon = ({ className }: EventsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <rect x="4.5" y="5" width="15" height="14" rx="2" />
     <path d="m8 14 2.5-2.5 2 2 2.5-3 3 4.5" />
     <circle cx="9" cy="9.5" r="1.2" />
@@ -89,7 +103,14 @@ const EventsTabContentIcon = ({ className }: EventsTabIconProps) => (
 );
 
 const EventsTabSettingsIcon = ({ className }: EventsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <path d="M4 7h10" />
     <path d="M4 17h16" />
     <circle cx="17" cy="7" r="2.5" />
@@ -98,7 +119,14 @@ const EventsTabSettingsIcon = ({ className }: EventsTabIconProps) => (
 );
 
 const EventsTabHistoryIcon = ({ className }: EventsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <path d="M4.5 12a7.5 7.5 0 1 0 2.2-5.3" />
     <path d="M4.5 5.5v3.7h3.7" />
     <path d="M12 8.5v4l2.5 1.5" />
@@ -112,8 +140,11 @@ const eventsTabIconMap = {
   history: EventsTabHistoryIcon,
 } as const satisfies Record<EventsDetailTabId, (props: EventsTabIconProps) => React.JSX.Element>;
 
-const errorMessage = (pt: ReturnType<typeof usePluginTranslation>, error: unknown, fallbackKey: string) =>
-  error instanceof EventsApiError ? error.message : pt(fallbackKey);
+const errorMessage = (
+  pt: ReturnType<typeof usePluginTranslation>,
+  error: unknown,
+  fallbackKey: string
+) => (error instanceof EventsApiError ? error.message : pt(fallbackKey));
 
 const parseDateOnlyInput = (value: string) => {
   if (value.trim().length === 0) {
@@ -127,7 +158,9 @@ const parseDateOnlyInput = (value: string) => {
   };
 };
 
-const toEventsMediaPickerSummary = (asset: HostMediaAssetListItem): StudioMediaPickerAssetSummary => ({
+const toEventsMediaPickerSummary = (
+  asset: HostMediaAssetListItem
+): StudioMediaPickerAssetSummary => ({
   id: asset.id,
   title: readAssetTitle(asset),
   fileName: readAssetFileName(asset),
@@ -254,7 +287,10 @@ export function EventsDetailPage({
   const [mediaAssets, setMediaAssets] = React.useState<readonly HostMediaAssetListItem[]>([]);
   const [dateStartInput, setDateStartInput] = React.useState('');
   const [dateEndInput, setDateEndInput] = React.useState('');
-  const [invalidDateInputs, setInvalidDateInputs] = React.useState({ dateStart: false, dateEnd: false });
+  const [invalidDateInputs, setInvalidDateInputs] = React.useState({
+    dateStart: false,
+    dateEnd: false,
+  });
   const [activeTab, setActiveTab] = React.useState<EventsDetailTabId>('basis');
   const [visitedTabs, setVisitedTabs] = React.useState<readonly EventsDetailTabId[]>(['basis']);
   const [categoryOptions, setCategoryOptions] = React.useState<readonly EventCategoryOption[]>([]);
@@ -268,7 +304,10 @@ export function EventsDetailPage({
 
   const refreshMediaAssets = React.useCallback(async () => {
     try {
-      const assets = await listHostMediaAssets({ fetch: globalThis.fetch.bind(globalThis), visibility: 'public' });
+      const assets = await listHostMediaAssets({
+        fetch: globalThis.fetch.bind(globalThis),
+        visibility: 'public',
+      });
       mediaAssetsRef.current = assets;
       setMediaAssets(assets);
       return assets;
@@ -279,27 +318,30 @@ export function EventsDetailPage({
     }
   }, []);
 
-  const isAssetSelectable = React.useCallback((asset: EventsMediaPickerAsset) => {
-    const nextMedia = mediaContentFromAsset({
-      id: asset.id,
-      fileName: asset.fileName,
-      metadata: asset.metadata,
-      visibility: asset.visibility,
-      mimeType: asset.mimeType,
-      previewUrl: asset.previewUrl,
-    });
-    if (!nextMedia) {
-      return false;
-    }
+  const isAssetSelectable = React.useCallback(
+    (asset: EventsMediaPickerAsset) => {
+      const nextMedia = mediaContentFromAsset({
+        id: asset.id,
+        fileName: asset.fileName,
+        metadata: asset.metadata,
+        visibility: asset.visibility,
+        mimeType: asset.mimeType,
+        previewUrl: asset.previewUrl,
+      });
+      if (!nextMedia) {
+        return false;
+      }
 
-    const existingUrls = new Set(
-      (methods.getValues('content.mediaContents') ?? [])
-        .map((entry) => entry.sourceUrl?.url?.trim() ?? '')
-        .filter((value) => value.length > 0)
-    );
-    const nextUrl = nextMedia.sourceUrl?.url?.trim() ?? '';
-    return existingUrls.has(nextUrl) === false;
-  }, [methods]);
+      const existingUrls = new Set(
+        (methods.getValues('content.mediaContents') ?? [])
+          .map((entry) => entry.sourceUrl?.url?.trim() ?? '')
+          .filter((value) => value.length > 0)
+      );
+      const nextUrl = nextMedia.sourceUrl?.url?.trim() ?? '';
+      return existingUrls.has(nextUrl) === false;
+    },
+    [methods]
+  );
 
   const mediaPicker = useStudioMediaPickerOverlay<EventsMediaPickerAsset>({
     onAccept: (asset) => {
@@ -420,7 +462,10 @@ export function EventsDetailPage({
       })
       .catch((loadError) => {
         if (active) {
-          setStatus({ kind: 'error', text: errorMessage(pt, loadError, 'messages.missingContent') });
+          setStatus({
+            kind: 'error',
+            text: errorMessage(pt, loadError, 'messages.missingContent'),
+          });
           setLoading(false);
         }
       });
@@ -448,11 +493,9 @@ export function EventsDetailPage({
     (field: 'dateStart' | 'dateEnd', nextValue: string) => {
       const currentDate = methods.getValues('content.dates.0') ?? {};
       const { isInvalid, normalizedValue } = parseDateOnlyInput(nextValue);
-      methods.setValue(
-        'content.dates',
-        [{ ...currentDate, [field]: normalizedValue }],
-        { shouldDirty: true }
-      );
+      methods.setValue('content.dates', [{ ...currentDate, [field]: normalizedValue }], {
+        shouldDirty: true,
+      });
       setInvalidDateInputs((current) => ({ ...current, [field]: isInvalid }));
       if (field === 'dateStart') {
         setDateStartInput(nextValue);
@@ -478,14 +521,28 @@ export function EventsDetailPage({
         methods.setFocus('content.dates.0.dateStart');
         setActiveTab('content');
       } else if (validationErrors.includes('geoLocation')) {
-        if ((payload.addresses ?? []).some((address) => hasInvalidGeoLocation(address.geoLocation))) {
-          methods.setError('content.addresses.0.geoLocation.latitude', { type: 'manual', message: 'geoLocation' });
-          methods.setError('content.addresses.0.geoLocation.longitude', { type: 'manual', message: 'geoLocation' });
+        if (
+          (payload.addresses ?? []).some((address) => hasInvalidGeoLocation(address.geoLocation))
+        ) {
+          methods.setError('content.addresses.0.geoLocation.latitude', {
+            type: 'manual',
+            message: 'geoLocation',
+          });
+          methods.setError('content.addresses.0.geoLocation.longitude', {
+            type: 'manual',
+            message: 'geoLocation',
+          });
           methods.setFocus('content.addresses.0.geoLocation.latitude');
         }
         if (hasInvalidGeoLocation(payload.organizer?.address?.geoLocation)) {
-          methods.setError('content.organizer.address.geoLocation.latitude', { type: 'manual', message: 'geoLocation' });
-          methods.setError('content.organizer.address.geoLocation.longitude', { type: 'manual', message: 'geoLocation' });
+          methods.setError('content.organizer.address.geoLocation.latitude', {
+            type: 'manual',
+            message: 'geoLocation',
+          });
+          methods.setError('content.organizer.address.geoLocation.longitude', {
+            type: 'manual',
+            message: 'geoLocation',
+          });
           methods.setFocus('content.organizer.address.geoLocation.latitude');
         }
         setActiveTab('content');
@@ -502,8 +559,14 @@ export function EventsDetailPage({
     }
 
     try {
-      const saved = mode === 'create' ? await createEvent(payload) : await updateEvent(contentId as string, payload);
-      setStatus({ kind: 'success', text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess') });
+      const saved =
+        mode === 'create'
+          ? await createEvent(payload)
+          : await updateEvent(contentId as string, payload);
+      setStatus({
+        kind: 'success',
+        text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess'),
+      });
       if (mode === 'create') {
         await navigate({ to: '/admin/events/$id', params: { id: saved.id } });
       }
@@ -533,7 +596,14 @@ export function EventsDetailPage({
     <FormProvider {...methods}>
       <StudioDetailPageTemplate
         title={mode === 'create' ? pt('detail.createTitle') : pt('detail.editTitle')}
-        description={mode === 'create' ? pt('detail.createDescription') : pt('detail.editDescription')}
+        description={
+          mode === 'create' ? pt('detail.createDescription') : pt('detail.editDescription')
+        }
+        primaryAction={
+          <Button type="submit" form={formId}>
+            {pt('actions.save')}
+          </Button>
+        }
         actions={
           <div className="flex flex-wrap gap-2">
             <Button asChild variant="outline">
@@ -544,9 +614,6 @@ export function EventsDetailPage({
                 {pt('actions.delete')}
               </Button>
             ) : null}
-            <Button type="submit" form={formId}>
-              {pt('actions.save')}
-            </Button>
           </div>
         }
       >
@@ -578,7 +645,9 @@ export function EventsDetailPage({
           onClose={mediaPicker.close}
           onConfirmSelection={() => void mediaPicker.confirmSelection()}
           onMetadataChange={(key, value) => mediaPicker.updateMetadataField(key, value)}
-          onOpenMediaManagement={(assetId) => void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })}
+          onOpenMediaManagement={(assetId) =>
+            void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })
+          }
           onSearchValueChange={mediaPicker.setSearchValue}
           onSelectAsset={(asset) => void mediaPicker.selectAsset(asset)}
           onUploadFile={(file) => void mediaPicker.uploadFile(file)}
@@ -590,7 +659,11 @@ export function EventsDetailPage({
         />
         <form id={formId} onSubmit={(event) => void submit(event)} className="space-y-5">
           {status ? <StudioFormSummary kind={status.kind}>{status.text}</StudioFormSummary> : null}
-          <Tabs value={activeTab} onValueChange={(value) => handleTabChange(value as EventsDetailTabId)} className="space-y-0">
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => handleTabChange(value as EventsDetailTabId)}
+            className="space-y-0"
+          >
             <label className="block md:hidden">
               <span className="sr-only">{pt('tabs.mobileLabel')}</span>
               <Select
@@ -619,7 +692,9 @@ export function EventsDetailPage({
                     onMouseEnter={() => warmTab(tab.id)}
                     onFocus={() => warmTab(tab.id)}
                     className={`relative z-10 gap-2 rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none ${
-                      isActive ? 'mb-[-1px] border-primary text-primary' : 'border-transparent text-muted-foreground'
+                      isActive
+                        ? 'mb-[-1px] border-primary text-primary'
+                        : 'border-transparent text-muted-foreground'
                     }`}
                   >
                     <span className="inline-flex items-center gap-2">
@@ -647,21 +722,23 @@ export function EventsDetailPage({
                     >
                       <div className="space-y-1">
                         <h2 className="text-base font-semibold text-foreground">{tab.title}</h2>
-                        <p className="text-sm leading-relaxed text-muted-foreground">{tab.description}</p>
+                        <p className="text-sm leading-relaxed text-muted-foreground">
+                          {tab.description}
+                        </p>
                       </div>
                     </section>
                     {tab.id === 'basis' ? (
-        <EventsDetailBasisTab
-          availableCategories={categoryOptions}
-          availablePois={poiOptions}
-          categoryOptionsError={categoryOptionsError}
-          categoryOptionsLoading={categoryOptionsLoading}
-          loadedItem={loadedItem}
-          mode={mode}
-          poiOptionsError={poiOptionsError}
-          poiOptionsLoading={poiOptionsLoading}
-          pt={pt}
-        />
+                      <EventsDetailBasisTab
+                        availableCategories={categoryOptions}
+                        availablePois={poiOptions}
+                        categoryOptionsError={categoryOptionsError}
+                        categoryOptionsLoading={categoryOptionsLoading}
+                        loadedItem={loadedItem}
+                        mode={mode}
+                        poiOptionsError={poiOptionsError}
+                        poiOptionsLoading={poiOptionsLoading}
+                        pt={pt}
+                      />
                     ) : null}
                     {tab.id === 'content' ? (
                       <EventsDetailContentTab
@@ -669,9 +746,13 @@ export function EventsDetailPage({
                         dateInputsInvalid={invalidDateInputs}
                         dateStartInput={dateStartInput}
                         onDateEndInputChange={(nextValue) => updateDateField('dateEnd', nextValue)}
-                        onDateStartInputChange={(nextValue) => updateDateField('dateStart', nextValue)}
+                        onDateStartInputChange={(nextValue) =>
+                          updateDateField('dateStart', nextValue)
+                        }
                         onOpenMediaPicker={(pickerMode) =>
-                          pickerMode === 'upload' ? mediaPicker.openUpload() : mediaPicker.openLibrary()
+                          pickerMode === 'upload'
+                            ? mediaPicker.openUpload()
+                            : mediaPicker.openLibrary()
                         }
                         pt={pt}
                       />

--- a/packages/plugin-events/tests/events.detail-page.test.tsx
+++ b/packages/plugin-events/tests/events.detail-page.test.tsx
@@ -43,7 +43,8 @@ vi.mock('@sva/plugin-sdk', async () => {
 });
 
 vi.mock('@sva/studio-ui-react', async () => {
-  const actual = await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
+  const actual =
+    await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
   return {
     ...actual,
     RichTextHtmlEditor: ({
@@ -264,7 +265,7 @@ describe('EventsDetailPage', () => {
   it('renders a global save action and a history placeholder for events', async () => {
     render(<EventsDetailPage mode="create" />);
 
-    expect(await screen.findByRole('button', { name: 'Speichern' })).toBeTruthy();
+    expect(await screen.findAllByRole('button', { name: 'Speichern' })).toHaveLength(2);
     fireEvent.click(screen.getByRole('tab', { name: 'Historie' }));
     await waitFor(() => {
       expect(screen.getByText('Noch keine Historie verfügbar.')).toBeTruthy();
@@ -310,8 +311,10 @@ describe('EventsDetailPage', () => {
 
     fireEvent.click(await screen.findByRole('tab', { name: 'Inhalt' }));
     fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: 'invalid-date' } });
-    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'http://example.com/events' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'http://example.com/events' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createEvent)).not.toHaveBeenCalled();
@@ -323,7 +326,7 @@ describe('EventsDetailPage', () => {
   it('keeps the basis tab active when the title is missing', async () => {
     render(<EventsDetailPage mode="create" />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Speichern' }));
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Speichern' }))[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createEvent)).not.toHaveBeenCalled();
@@ -337,8 +340,10 @@ describe('EventsDetailPage', () => {
 
     fireEvent.change(await screen.findByLabelText('Titel'), { target: { value: 'Neues Event' } });
     fireEvent.click(screen.getByRole('tab', { name: 'Inhalt' }));
-    fireEvent.change(await screen.findByLabelText('URL'), { target: { value: 'http://invalid.example' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.change(await screen.findByLabelText('URL'), {
+      target: { value: 'http://invalid.example' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createEvent)).not.toHaveBeenCalled();
@@ -351,7 +356,12 @@ describe('EventsDetailPage', () => {
       id: 'event-1',
       title: 'Stadtfest',
       description: 'Innenstadt',
-      mediaContents: [{ sourceUrl: { url: 'https://example.com/header.jpg', description: 'Header' }, captionText: 'Headerbild' }],
+      mediaContents: [
+        {
+          sourceUrl: { url: 'https://example.com/header.jpg', description: 'Header' },
+          captionText: 'Headerbild',
+        },
+      ],
       dates: [{ dateStart: '2026-06-11T10:00:00.000Z' }],
       addresses: [{ street: 'Marktplatz 1', city: 'Musterhausen' }],
       urls: [{ url: 'https://example.com/events' }],
@@ -367,7 +377,7 @@ describe('EventsDetailPage', () => {
       expect(screen.getByDisplayValue('Stadtfest')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(updateEvent)).toHaveBeenCalledTimes(1);
@@ -465,8 +475,12 @@ describe('EventsDetailPage', () => {
       id: 'event-created',
       title: 'Neues Event',
     } as never);
-    vi.mocked(listEventCategories).mockResolvedValueOnce([{ id: 'cat-1', name: 'Kultur' }] as never);
-    vi.mocked(listPoiForEventSelection).mockResolvedValue([{ id: 'poi-7', name: 'Rathaus' }] as never);
+    vi.mocked(listEventCategories).mockResolvedValueOnce([
+      { id: 'cat-1', name: 'Kultur' },
+    ] as never);
+    vi.mocked(listPoiForEventSelection).mockResolvedValue([
+      { id: 'poi-7', name: 'Rathaus' },
+    ] as never);
 
     render(<EventsDetailPage mode="create" />);
 
@@ -487,7 +501,7 @@ describe('EventsDetailPage', () => {
     fireEvent.click(screen.getByText('Rathaus').closest('button') as HTMLButtonElement);
     fireEvent.click(screen.getByRole('tab', { name: 'Einstellungen' }));
     fireEvent.change(screen.getByLabelText('Externe ID'), { target: { value: 'event-ext-1' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createEvent)).toHaveBeenCalledTimes(1);
@@ -501,7 +515,10 @@ describe('EventsDetailPage', () => {
           visible: true,
         })
       );
-      expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/events/$id', params: { id: 'event-created' } });
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/admin/events/$id',
+        params: { id: 'event-created' },
+      });
     });
   });
 
@@ -520,7 +537,7 @@ describe('EventsDetailPage', () => {
     render(<EventsDetailPage mode="create" />);
 
     fireEvent.change(await screen.findByLabelText('Titel'), { target: { value: 'Neues Event' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(screen.getByText('events.messages.saveError')).toBeTruthy();
@@ -533,7 +550,10 @@ describe('EventsDetailPage', () => {
       title: 'Stadtfest',
       dates: [{ dateStart: '2026-06-11T10:00:00.000Z' }],
     } as never);
-    vi.stubGlobal('confirm', vi.fn(() => false));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => false)
+    );
 
     render(<EventsDetailPage mode="edit" contentId="event-1" />);
 
@@ -554,7 +574,10 @@ describe('EventsDetailPage', () => {
       dates: [{ dateStart: '2026-06-11T10:00:00.000Z' }],
     } as never);
     vi.mocked(deleteEvent).mockRejectedValueOnce(new Error('delete boom'));
-    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true)
+    );
 
     render(<EventsDetailPage mode="edit" contentId="event-1" />);
 
@@ -587,7 +610,7 @@ describe('EventsDetailPage', () => {
       expect(screen.getByDisplayValue('Stadtfest')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(updateEvent)).toHaveBeenCalledTimes(1);
@@ -600,7 +623,10 @@ describe('EventsDetailPage', () => {
       title: 'Stadtfest',
       dates: [{ dateStart: '2026-06-11T10:00:00.000Z' }],
     } as never);
-    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true)
+    );
 
     render(<EventsDetailPage mode="edit" contentId="event-1" />);
 

--- a/packages/plugin-events/tests/events.pages.test.tsx
+++ b/packages/plugin-events/tests/events.pages.test.tsx
@@ -6,7 +6,8 @@ import { createEvent, getEvent, listEvents, updateEvent } from '../src/events.ap
 import { EventsCreatePage, EventsEditPage, EventsListPage } from '../src/events.pages.js';
 
 vi.mock('@sva/studio-ui-react', async () => {
-  const actual = await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
+  const actual =
+    await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
   return {
     ...actual,
     RichTextHtmlEditor: ({
@@ -41,7 +42,10 @@ vi.mock('../src/events.api.js', () => ({
     data: [],
     pagination: { page: 1, pageSize: 25, hasNextPage: false },
   })),
-  listEventCategories: vi.fn(async () => [{ id: 'cat-1', name: 'Kultur' }, { id: 'cat-2', name: 'Open Air' }]),
+  listEventCategories: vi.fn(async () => [
+    { id: 'cat-1', name: 'Kultur' },
+    { id: 'cat-2', name: 'Open Air' },
+  ]),
   listPoiForEventSelection: vi.fn(async () => []),
   getEvent: vi.fn(async () => ({
     id: 'event-1',
@@ -141,7 +145,8 @@ describe('EventsListPage', () => {
         'events.detail.createTitle': 'Event anlegen',
         'events.detail.createDescription': 'Erstellen Sie einen neuen Veranstaltungseintrag.',
         'events.detail.editTitle': 'Event bearbeiten',
-        'events.detail.editDescription': 'Aktualisieren oder löschen Sie den Veranstaltungseintrag.',
+        'events.detail.editDescription':
+          'Aktualisieren oder löschen Sie den Veranstaltungseintrag.',
         'events.detailTabs.basis.title': 'Basis',
         'events.detailTabs.content.title': 'Inhalt',
         'events.detailTabs.settings.title': 'Einstellungen',
@@ -165,15 +170,18 @@ describe('EventsListPage', () => {
         'events.cards.content.poi.title': 'POI-Verknüpfung',
         'events.cards.content.poi.description': 'Zuordnung zu einem bestehenden POI.',
         'events.cards.content.media.title': 'Medien',
-        'events.cards.content.media.description': 'Galerie, Upload oder manuelle Medienangaben für das Event.',
+        'events.cards.content.media.description':
+          'Galerie, Upload oder manuelle Medienangaben für das Event.',
         'events.history.empty.title': 'Noch keine Historie verfügbar.',
-        'events.history.empty.description': 'Historienereignisse für Events werden in einem späteren Schritt angebunden.',
+        'events.history.empty.description':
+          'Historienereignisse für Events werden in einem späteren Schritt angebunden.',
         'events.actions.addCategory': 'Kategorie hinzufügen',
         'events.actions.removeCategory': 'Kategorie {{name}} entfernen',
         'events.editor.createTitle': 'Event anlegen',
         'events.editor.createDescription': 'Erstellen Sie einen neuen Veranstaltungseintrag.',
         'events.editor.editTitle': 'Event bearbeiten',
-        'events.editor.editDescription': 'Aktualisieren oder löschen Sie den Veranstaltungseintrag.',
+        'events.editor.editDescription':
+          'Aktualisieren oder löschen Sie den Veranstaltungseintrag.',
         'events.validation.title': 'Der Titel ist erforderlich.',
         'events.validation.dates': 'Datumswerte müssen gültig sein.',
         'events.validation.urls': 'URLs müssen mit https:// beginnen.',
@@ -183,7 +191,9 @@ describe('EventsListPage', () => {
       };
       return labels[key] ?? key;
     });
-    vi.mocked(listHostMediaAssets).mockResolvedValue([{ id: 'asset-header', metadata: { title: 'Header Asset' } }]);
+    vi.mocked(listHostMediaAssets).mockResolvedValue([
+      { id: 'asset-header', metadata: { title: 'Header Asset' } },
+    ]);
   });
 
   afterEach(() => {
@@ -238,16 +248,22 @@ describe('EventsListPage', () => {
     fireEvent.change(screen.getByLabelText('Titel'), { target: { value: 'Konzertabend' } });
     fireEvent.click(await screen.findByRole('tab', { name: 'Inhalt' }));
 
-    fireEvent.change(await screen.findByLabelText('Beschreibung'), { target: { value: 'Live im Stadtpark' } });
+    fireEvent.change(await screen.findByLabelText('Beschreibung'), {
+      target: { value: 'Live im Stadtpark' },
+    });
     fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-04-14' } });
-    fireEvent.change(screen.getByLabelText('Web-URL'), { target: { value: 'https://example.com/events' } });
+    fireEvent.change(screen.getByLabelText('Web-URL'), {
+      target: { value: 'https://example.com/events' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Manuell hinzufügen' }));
-    fireEvent.change(await screen.findByLabelText('Bildunterschrift'), { target: { value: 'Bühne' } });
+    fireEvent.change(await screen.findByLabelText('Bildunterschrift'), {
+      target: { value: 'Bühne' },
+    });
     fireEvent.change(screen.getByLabelText('Copyright'), { target: { value: 'Stadt' } });
     fireEvent.change(await screen.findByLabelText('Web-URL', { selector: '#event-media-url-0' }), {
       target: { value: 'https://example.com/event.jpg' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(createEvent).toHaveBeenCalledWith(
@@ -267,7 +283,10 @@ describe('EventsListPage', () => {
       );
     });
 
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/events/$id', params: { id: 'event-created' } });
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/admin/events/$id',
+      params: { id: 'event-created' },
+    });
   }, 10_000);
 
   it('ignores impossible browser date values and still submits with the remaining valid input', async () => {
@@ -283,7 +302,7 @@ describe('EventsListPage', () => {
       expect(screen.getByLabelText('Startdatum')).toBeTruthy();
     });
     fireEvent.change(screen.getByLabelText('Startdatum'), { target: { value: '2026-02-31' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(createEvent).toHaveBeenCalledWith(
@@ -304,7 +323,12 @@ describe('EventsListPage', () => {
       title: 'Bestehendes Event',
       description: 'Beschreibung',
       categoryName: 'Kultur',
-      mediaContents: [{ sourceUrl: { url: 'https://example.com/header.jpg', description: 'Header Asset' }, captionText: 'Header' }],
+      mediaContents: [
+        {
+          sourceUrl: { url: 'https://example.com/header.jpg', description: 'Header Asset' },
+          captionText: 'Header',
+        },
+      ],
       dates: [{ dateStart: '2026-04-14T09:30:00.000Z' }],
       addresses: [{ street: 'Markt 1', city: 'Musterhausen' }],
       urls: [{ url: 'https://example.com/events' }],
@@ -321,7 +345,7 @@ describe('EventsListPage', () => {
       expect(screen.getByDisplayValue('Header')).toBeTruthy();
     });
     fireEvent.click(screen.getByRole('button', { name: 'Medium entfernen' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(updateEvent).toHaveBeenCalledWith(

--- a/packages/plugin-faq/src/faq.pages.tsx
+++ b/packages/plugin-faq/src/faq.pages.tsx
@@ -17,24 +17,46 @@ import { FaqListPage } from './faq-list-page.js';
 import { faqFormSchema } from './faq.model.js';
 import type { FaqFormValues } from './faq.types.js';
 
-const defaultValues: FaqFormValues = { question: '', answer: '', languageCode: 'de', sortWeight: 0, visible: true };
+const defaultValues: FaqFormValues = {
+  question: '',
+  answer: '',
+  languageCode: 'de',
+  sortWeight: 0,
+  visible: true,
+};
 
-const FaqEditorActions = ({ deletePending, mode, onDelete, onSave, saving, pt }: Readonly<{
+const FaqEditorActions = ({
+  deletePending,
+  mode,
+  onDelete,
+  pt,
+}: Readonly<{
   deletePending: boolean;
   mode: 'create' | 'edit';
   onDelete: () => Promise<void>;
-  onSave: () => Promise<void>;
   pt: (key: string) => string;
-  saving: boolean;
 }>) => (
   <div className="flex flex-wrap gap-2">
-    <Button asChild variant="outline"><Link to="/admin/content">{pt('actions.back')}</Link></Button>
-    {mode === 'edit' ? <Button type="button" variant="destructive" disabled={deletePending} onClick={() => void onDelete()}>{pt('actions.delete')}</Button> : null}
-    <Button type="button" disabled={saving || deletePending} onClick={() => void onSave()}>{pt('actions.save')}</Button>
+    <Button asChild variant="outline">
+      <Link to="/admin/content">{pt('actions.back')}</Link>
+    </Button>
+    {mode === 'edit' ? (
+      <Button
+        type="button"
+        variant="destructive"
+        disabled={deletePending}
+        onClick={() => void onDelete()}
+      >
+        {pt('actions.delete')}
+      </Button>
+    ) : null}
   </div>
 );
 
-const FaqEditorPage = ({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; contentId?: string }>) => {
+const FaqEditorPage = ({
+  mode,
+  contentId,
+}: Readonly<{ mode: 'create' | 'edit'; contentId?: string }>) => {
   const pt = usePluginTranslation('faq');
   const navigate = useNavigate();
   const form = useForm<FaqFormValues>({ defaultValues, resolver: zodResolver(faqFormSchema) });
@@ -43,8 +65,14 @@ const FaqEditorPage = ({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; 
   const onInvalid = () => setSaveErrorMessage(pt('messages.validationError'));
   const { existingPayload, loadError, loading } = useFaqEditorLoader({ contentId, form, mode });
   const { deletePending, onDelete, onSubmit } = useFaqEditorActions({
-    contentId, existingPayload, mode, navigate, pt, setSaveErrorMessage,
+    contentId,
+    existingPayload,
+    mode,
+    navigate,
+    pt,
+    setSaveErrorMessage,
   });
+  const save = form.handleSubmit(onSubmit, onInvalid);
 
   if (loading) return <StudioLoadingState>{pt('messages.loading')}</StudioLoadingState>;
   if (loadError) return <StudioErrorState>{pt('messages.loadError')}</StudioErrorState>;
@@ -52,11 +80,31 @@ const FaqEditorPage = ({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; 
   return (
     <StudioDetailPageTemplate
       title={pt(mode === 'create' ? 'editor.createTitle' : 'editor.editTitle')}
-      actions={<FaqEditorActions deletePending={deletePending} mode={mode} onDelete={onDelete} onSave={form.handleSubmit(onSubmit, onInvalid)} pt={pt} saving={form.formState.isSubmitting} />}
+      actions={
+        <FaqEditorActions deletePending={deletePending} mode={mode} onDelete={onDelete} pt={pt} />
+      }
+      primaryAction={
+        <Button
+          type="button"
+          disabled={form.formState.isSubmitting || deletePending}
+          onClick={() => void save()}
+        >
+          {pt('actions.save')}
+        </Button>
+      }
     >
       <FormProvider {...form}>
-        {saveErrorMessage ? <StudioFormSummary kind="error">{saveErrorMessage}</StudioFormSummary> : null}
-        <FaqEditorTabs activeTab={activeTab} contentId={contentId} form={form} mode={mode} onTabChange={setActiveTab} pt={pt} />
+        {saveErrorMessage ? (
+          <StudioFormSummary kind="error">{saveErrorMessage}</StudioFormSummary>
+        ) : null}
+        <FaqEditorTabs
+          activeTab={activeTab}
+          contentId={contentId}
+          form={form}
+          mode={mode}
+          onTabChange={setActiveTab}
+          pt={pt}
+        />
       </FormProvider>
     </StudioDetailPageTemplate>
   );
@@ -65,7 +113,10 @@ const FaqEditorPage = ({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; 
 export const FaqCreatePage = () => <FaqEditorPage mode="create" />;
 
 export const FaqEditPage = () => {
-  const params = useParams({ strict: false }) as { readonly contentId?: string; readonly id?: string };
+  const params = useParams({ strict: false }) as {
+    readonly contentId?: string;
+    readonly id?: string;
+  };
   return <FaqEditorPage mode="edit" contentId={params.contentId ?? params.id} />;
 };
 

--- a/packages/plugin-faq/tests/faq.pages.test.tsx
+++ b/packages/plugin-faq/tests/faq.pages.test.tsx
@@ -17,7 +17,10 @@ vi.mock('../src/faq.api.js', () => ({
   getFaq: state.getFaqMock,
   updateFaq: state.updateFaqMock,
   FaqApiError: class FaqApiError extends Error {
-    public constructor(public readonly code: string, message = code) {
+    public constructor(
+      public readonly code: string,
+      message = code
+    ) {
       super(message);
       this.name = 'FaqApiError';
     }
@@ -27,7 +30,10 @@ vi.mock('../src/faq.api.js', () => ({
 vi.mock('@sva/plugin-sdk', () => ({
   usePluginTranslation: () =>
     ((key: string, values?: Record<string, unknown>) =>
-      typeof values?.page === 'number' ? `${key}:${values.page}` : key) as (key: string, values?: Record<string, unknown>) => string,
+      typeof values?.page === 'number' ? `${key}:${values.page}` : key) as (
+      key: string,
+      values?: Record<string, unknown>
+    ) => string,
 }));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -57,7 +63,7 @@ describe('faq editor pages', () => {
     fireEvent.change(screen.getByLabelText('fields.answer'), { target: { value: 'Eine Antwort' } });
     fireEvent.change(screen.getByLabelText('fields.languageCode'), { target: { value: 'en-us' } });
     fireEvent.change(screen.getByLabelText('fields.sortWeight'), { target: { value: '7' } });
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() =>
       expect(state.createFaqMock).toHaveBeenCalledWith({
@@ -94,10 +100,12 @@ describe('faq editor pages', () => {
     render(<FaqEditPage />);
 
     await screen.findByDisplayValue('Bestehende Frage');
-    fireEvent.change(screen.getByLabelText('fields.answer'), { target: { value: 'Aktualisierte Antwort' } });
+    fireEvent.change(screen.getByLabelText('fields.answer'), {
+      target: { value: 'Aktualisierte Antwort' },
+    });
     fireEvent.change(screen.getByLabelText('fields.languageCode'), { target: { value: 'fr' } });
     fireEvent.click(screen.getByLabelText('fields.visible'));
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() => expect(state.updateFaqMock).toHaveBeenCalledTimes(1));
     expect(state.updateFaqMock).toHaveBeenCalledWith('faq-1', {
@@ -121,7 +129,7 @@ describe('faq editor pages', () => {
     state.createFaqMock.mockRejectedValueOnce(new Error('save failed'));
     fireEvent.change(screen.getByLabelText('fields.question'), { target: { value: 'Neue Frage' } });
     fireEvent.change(screen.getByLabelText('fields.answer'), { target: { value: 'Eine Antwort' } });
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() => expect(state.updateFaqMock).not.toHaveBeenCalled());
     await screen.findByText('messages.saveError');
@@ -142,17 +150,25 @@ describe('faq editor pages', () => {
 
     fireEvent.change(screen.getByLabelText('fields.question'), { target: { value: 'Neue Frage' } });
     fireEvent.change(screen.getByLabelText('fields.answer'), { target: { value: 'Eine Antwort' } });
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'actions.save' }).hasAttribute('disabled')).toBe(true)
+      expect(
+        screen
+          .getAllByRole('button', { name: 'actions.save' })
+          .every((button) => button.hasAttribute('disabled'))
+      ).toBe(true)
     );
 
     rejectRequest?.(new FaqApiError('forbidden', 'Nicht erlaubt.'));
 
     await screen.findByText('messages.saveErrorWithReason');
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'actions.save' }).hasAttribute('disabled')).toBe(false)
+      expect(
+        screen
+          .getAllByRole('button', { name: 'actions.save' })
+          .every((button) => !button.hasAttribute('disabled'))
+      ).toBe(true)
     );
   });
 
@@ -166,7 +182,16 @@ describe('faq editor pages', () => {
   });
 
   it('deletes an existing faq and returns to the content overview', async () => {
-    state.getFaqMock.mockResolvedValue({ id: 'faq-1', title: 'Frage', genericType: 'FAQ', contentBlocks: [{ body: 'Antwort' }], payload: { languageCode: 'de', sortWeight: 0 }, visible: true, createdAt: '', updatedAt: '' });
+    state.getFaqMock.mockResolvedValue({
+      id: 'faq-1',
+      title: 'Frage',
+      genericType: 'FAQ',
+      contentBlocks: [{ body: 'Antwort' }],
+      payload: { languageCode: 'de', sortWeight: 0 },
+      visible: true,
+      createdAt: '',
+      updatedAt: '',
+    });
     state.deleteFaqMock.mockResolvedValue(undefined);
     const { FaqEditPage } = await import('../src/faq.pages.js');
     render(<FaqEditPage />);
@@ -184,7 +209,7 @@ describe('faq editor pages', () => {
     fireEvent.change(screen.getByLabelText('fields.question'), { target: { value: 'Neue Frage' } });
     fireEvent.change(screen.getByLabelText('fields.answer'), { target: { value: 'Eine Antwort' } });
     fireEvent.change(screen.getByLabelText('fields.sortWeight'), { target: { value: '1.5' } });
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await screen.findByText('validation.sortWeight');
     expect(state.createFaqMock).not.toHaveBeenCalled();

--- a/packages/plugin-generic-items/src/generic-items.detail-page.tsx
+++ b/packages/plugin-generic-items/src/generic-items.detail-page.tsx
@@ -43,7 +43,10 @@ import {
   type StatusMessage,
 } from './generic-items.detail-page.logic.js';
 import { GenericItemsDetailTabs } from './generic-items.detail-page.tabs.js';
-import { genericItemsDetailFormSchema, type GenericItemsDetailFormValues } from './generic-items.validation.js';
+import {
+  genericItemsDetailFormSchema,
+  type GenericItemsDetailFormValues,
+} from './generic-items.validation.js';
 
 const genericItemsListLink = {
   to: '/admin/content',
@@ -58,9 +61,13 @@ const getFieldErrorMessage = (error: unknown): string | undefined => {
   return typeof error.message === 'string' && error.message.length > 0 ? error.message : undefined;
 };
 
-const createSummaryErrors = (errors: ReturnType<typeof useForm<GenericItemsDetailFormValues>>['formState']['errors']) => {
+const createSummaryErrors = (
+  errors: ReturnType<typeof useForm<GenericItemsDetailFormValues>>['formState']['errors']
+) => {
   const entries = [
-    getFieldErrorMessage(errors.title) ? { field: 'generic-item-title', message: getFieldErrorMessage(errors.title) } : null,
+    getFieldErrorMessage(errors.title)
+      ? { field: 'generic-item-title', message: getFieldErrorMessage(errors.title) }
+      : null,
     getFieldErrorMessage(errors.genericType)
       ? { field: 'generic-item-type', message: getFieldErrorMessage(errors.genericType) }
       : null,
@@ -77,7 +84,9 @@ const createSummaryErrors = (errors: ReturnType<typeof useForm<GenericItemsDetai
 
 type GenericItemsMediaPickerAsset = StudioMediaPickerAssetDetail;
 
-const toGenericItemsMediaPickerSummary = (asset: Parameters<typeof readAssetTitle>[0]): StudioMediaPickerAssetSummary => ({
+const toGenericItemsMediaPickerSummary = (
+  asset: Parameters<typeof readAssetTitle>[0]
+): StudioMediaPickerAssetSummary => ({
   id: asset.id,
   title: readAssetTitle(asset),
   fileName: readAssetFileName(asset),
@@ -189,14 +198,12 @@ const DetailPageActions = ({
   mode,
   deleting,
   onDelete,
-  onSubmit,
   pt,
 }: Readonly<{
   disableActions: boolean;
   deleting: boolean;
   mode: 'create' | 'edit';
   onDelete: () => Promise<void>;
-  onSubmit: () => Promise<void>;
   pt: (key: string) => string;
 }>) => (
   <div className="flex gap-2">
@@ -204,13 +211,15 @@ const DetailPageActions = ({
       <Link {...genericItemsListLink}>{pt('actions.back')}</Link>
     </Button>
     {mode === 'edit' ? (
-      <Button type="button" variant="outline" disabled={disableActions || deleting} onClick={() => void onDelete()}>
+      <Button
+        type="button"
+        variant="outline"
+        disabled={disableActions || deleting}
+        onClick={() => void onDelete()}
+      >
         {pt('actions.delete')}
       </Button>
     ) : null}
-    <Button type="button" disabled={disableActions} onClick={() => void onSubmit()}>
-      {mode === 'create' ? pt('actions.create') : pt('actions.update')}
-    </Button>
   </div>
 );
 
@@ -229,40 +238,48 @@ export function GenericItemsDetailPage({
     resolver: zodResolver(genericItemsDetailFormSchema),
     defaultValues: createDefaultGenericItemsDetailFormValues(),
   });
-  const summaryErrors = React.useMemo(() => createSummaryErrors(methods.formState.errors), [methods.formState.errors]);
+  const summaryErrors = React.useMemo(
+    () => createSummaryErrors(methods.formState.errors),
+    [methods.formState.errors]
+  );
   const [status, setStatus] = React.useState<StatusMessage | null>(null);
   const { mediaAssets, refreshMediaAssets } = useGenericItemsMediaAssets();
   const mediaAssetsRef = React.useRef(mediaAssets);
-  const { categoryOptions, categoryOptionsError, categoryOptionsLoading } = useGenericItemsCategoryOptions(pt);
+  const { categoryOptions, categoryOptionsError, categoryOptionsLoading } =
+    useGenericItemsCategoryOptions(pt);
   const loading = useGenericItemsDetailLoader({ contentId, methods, mode, pt, setStatus });
-  const { activeTab, deleting, handleDelete, onSubmit, setActiveTab } = useGenericItemsDetailActions({
-    contentId,
-    methods,
-    mode,
-    navigate,
-    pt,
-    setStatus,
-  });
-  const isAssetSelectable = React.useCallback((asset: GenericItemsMediaPickerAsset) => {
-    const nextMedia = mediaContentFromAsset({
-      id: asset.id,
-      fileName: asset.fileName,
-      metadata: asset.metadata,
-      visibility: asset.visibility,
-      mimeType: asset.mimeType,
-      previewUrl: asset.previewUrl,
+  const { activeTab, deleting, handleDelete, onSubmit, setActiveTab } =
+    useGenericItemsDetailActions({
+      contentId,
+      methods,
+      mode,
+      navigate,
+      pt,
+      setStatus,
     });
-    if (!nextMedia) {
-      return false;
-    }
+  const isAssetSelectable = React.useCallback(
+    (asset: GenericItemsMediaPickerAsset) => {
+      const nextMedia = mediaContentFromAsset({
+        id: asset.id,
+        fileName: asset.fileName,
+        metadata: asset.metadata,
+        visibility: asset.visibility,
+        mimeType: asset.mimeType,
+        previewUrl: asset.previewUrl,
+      });
+      if (!nextMedia) {
+        return false;
+      }
 
-    const existingSources = new Set(
-      (methods.getValues('mediaContents') ?? [])
-        .map((entry) => entry.sourceUrl?.url?.trim() ?? '')
-        .filter((value) => value.length > 0)
-    );
-    return existingSources.has(nextMedia.sourceUrl?.url?.trim() ?? '') === false;
-  }, [methods]);
+      const existingSources = new Set(
+        (methods.getValues('mediaContents') ?? [])
+          .map((entry) => entry.sourceUrl?.url?.trim() ?? '')
+          .filter((value) => value.length > 0)
+      );
+      return existingSources.has(nextMedia.sourceUrl?.url?.trim() ?? '') === false;
+    },
+    [methods]
+  );
 
   const mediaPicker = useStudioMediaPickerOverlay<GenericItemsMediaPickerAsset>({
     onAccept: (asset) => {
@@ -334,7 +351,8 @@ export function GenericItemsDetailPage({
     mediaAssetsRef.current = mediaAssets;
   }, [mediaAssets]);
   const mediaPickerFeedback = React.useMemo(
-    () => resolveGenericItemsMediaPickerFeedback(pt, mediaPicker.errorCode, mediaPicker.uploadPhase),
+    () =>
+      resolveGenericItemsMediaPickerFeedback(pt, mediaPicker.errorCode, mediaPicker.uploadPhase),
     [mediaPicker.errorCode, mediaPicker.uploadPhase, pt]
   );
 
@@ -346,14 +364,24 @@ export function GenericItemsDetailPage({
     <FormProvider {...methods}>
       <StudioDetailPageTemplate
         title={mode === 'create' ? pt('editor.createTitle') : pt('editor.editTitle')}
-        description={mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')}
+        description={
+          mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')
+        }
+        primaryAction={
+          <Button
+            type="button"
+            disabled={methods.formState.isSubmitting}
+            onClick={() => void onSubmit()}
+          >
+            {mode === 'create' ? pt('actions.create') : pt('actions.update')}
+          </Button>
+        }
         actions={
           <DetailPageActions
             disableActions={methods.formState.isSubmitting}
             deleting={deleting}
             mode={mode}
             onDelete={handleDelete}
-            onSubmit={onSubmit}
             pt={pt}
           />
         }
@@ -386,7 +414,9 @@ export function GenericItemsDetailPage({
           onClose={mediaPicker.close}
           onConfirmSelection={() => void mediaPicker.confirmSelection()}
           onMetadataChange={(key, value) => mediaPicker.updateMetadataField(key, value)}
-          onOpenMediaManagement={(assetId) => void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })}
+          onOpenMediaManagement={(assetId) =>
+            void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })
+          }
           onSearchValueChange={mediaPicker.setSearchValue}
           onSelectAsset={(asset) => void mediaPicker.selectAsset(asset)}
           onUploadFile={(file) => void mediaPicker.uploadFile(file)}

--- a/packages/plugin-generic-items/tests/generic-items.detail-page.test.tsx
+++ b/packages/plugin-generic-items/tests/generic-items.detail-page.test.tsx
@@ -3,7 +3,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { registerPluginTranslationResolver } from '@sva/plugin-sdk';
 
-import { createGenericItem, deleteGenericItem, updateGenericItem } from '../src/generic-items.api.js';
+import {
+  createGenericItem,
+  deleteGenericItem,
+  updateGenericItem,
+} from '../src/generic-items.api.js';
 import { GenericItemsDetailPage } from '../src/generic-items.detail-page.js';
 
 const navigateMock = vi.fn();
@@ -48,7 +52,9 @@ vi.mock('@tanstack/react-router', () => ({
     children: React.ReactNode;
     to: string;
     search?: Record<string, string>;
-  }) => <a href={search?.type ? `${to}?type=${encodeURIComponent(search.type)}` : to}>{children}</a>,
+  }) => (
+    <a href={search?.type ? `${to}?type=${encodeURIComponent(search.type)}` : to}>{children}</a>
+  ),
   useNavigate: () => navigateMock,
 }));
 
@@ -57,7 +63,10 @@ vi.mock('@sva/plugin-sdk', async () => {
   return {
     ...actual,
     listHostMediaAssets: vi.fn(async () => []),
-    uploadHostMediaFile: vi.fn(async () => ({ assetId: 'uploaded-asset', uploadSessionId: 'upload-1' })),
+    uploadHostMediaFile: vi.fn(async () => ({
+      assetId: 'uploaded-asset',
+      uploadSessionId: 'upload-1',
+    })),
   };
 });
 
@@ -65,7 +74,10 @@ describe('GenericItemsDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     navigateMock.mockReset();
-    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true)
+    );
     registerPluginTranslationResolver((key) => {
       const map: Record<string, string> = {
         'genericItems.editor.createTitle': 'Generic Item anlegen',
@@ -263,15 +275,19 @@ describe('GenericItemsDetailPage', () => {
         'genericItems.richText.linkInput': 'Link-URL',
         'genericItems.messages.imagePickerEmpty': 'Keine passenden Bilder gefunden.',
         'genericItems.messages.categoryOptionsLoading': 'Kategorien werden geladen.',
-        'genericItems.messages.categoryOptionsLoadError': 'Kategorien konnten nicht geladen werden.',
+        'genericItems.messages.categoryOptionsLoadError':
+          'Kategorien konnten nicht geladen werden.',
         'genericItems.messages.mediaUploadInitializing': 'Upload wird vorbereitet.',
         'genericItems.messages.mediaUploadUploading': 'Bild wird hochgeladen.',
         'genericItems.messages.mediaUploadFinalizing': 'Bild wird eingebunden.',
         'genericItems.messages.mediaUploadSuccess': 'Bild wurde hinzugefügt.',
         'genericItems.messages.mediaUploadError': 'Bild konnte nicht hochgeladen werden.',
-        'genericItems.messages.mediaUploadUnsupportedType': 'Dieser Dateityp wird nicht unterstützt.',
-        'genericItems.messages.mediaUploadUnavailableUrl': 'Dieses Medium hat keine öffentliche URL.',
-        'genericItems.validation.categories': 'Kategorien benötigen einen Namen mit maximal 128 Zeichen.',
+        'genericItems.messages.mediaUploadUnsupportedType':
+          'Dieser Dateityp wird nicht unterstützt.',
+        'genericItems.messages.mediaUploadUnavailableUrl':
+          'Dieses Medium hat keine öffentliche URL.',
+        'genericItems.validation.categories':
+          'Kategorien benötigen einen Namen mit maximal 128 Zeichen.',
         'genericItems.validation.priceInformations': 'Preisangaben müssen valide Zahlen enthalten.',
         'genericItems.validation.webUrls': 'URLs müssen mit https:// beginnen.',
       };
@@ -293,14 +309,19 @@ describe('GenericItemsDetailPage', () => {
 
     fireEvent.change(screen.getByLabelText('Titel'), { target: { value: 'Freier Eintrag' } });
     fireEvent.change(screen.getByLabelText('Generic-Type'), { target: { value: 'faq' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Generic Item anlegen' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Generic Item anlegen' })[1]!);
 
     await waitFor(() => {
-      expect(createGenericItem).toHaveBeenCalledWith(expect.objectContaining({ title: 'Freier Eintrag', genericType: 'faq' }));
+      expect(createGenericItem).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Freier Eintrag', genericType: 'faq' })
+      );
     });
 
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/generic-items/$id', params: { id: 'created' } });
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/admin/generic-items/$id',
+        params: { id: 'created' },
+      });
     });
   });
 
@@ -318,7 +339,7 @@ describe('GenericItemsDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Kategorie Rathaus entfernen' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Generic Item anlegen' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Generic Item anlegen' })[1]!);
 
     await waitFor(() => {
       expect(createGenericItem).toHaveBeenCalledWith(
@@ -340,7 +361,7 @@ describe('GenericItemsDetailPage', () => {
     });
 
     fireEvent.change(screen.getByLabelText('Titel'), { target: { value: 'Aktualisiert' } });
-    fireEvent.click(screen.getByText('Änderungen speichern'));
+    fireEvent.click(screen.getAllByText('Änderungen speichern')[1]!);
 
     await waitFor(() => {
       expect(updateGenericItem).toHaveBeenCalledWith(

--- a/packages/plugin-news/src/news.detail-page.tsx
+++ b/packages/plugin-news/src/news.detail-page.tsx
@@ -73,14 +73,18 @@ type StatusMessage = Readonly<{
   text: string;
 }>;
 
-type PluginTranslator = (key: string, variables?: Readonly<Record<string, string | number>>) => string;
+type PluginTranslator = (
+  key: string,
+  variables?: Readonly<Record<string, string | number>>
+) => string;
 
 const errorMessageTranslationKeys: Record<string, string> = {
   config_not_found: 'messages.errors.configNotFound',
   integration_disabled: 'messages.errors.integrationDisabled',
   invalid_config: 'messages.errors.invalidConfig',
   missing_credentials: 'messages.errors.missingCredentials',
-  organization_mainserver_credentials_missing: 'messages.errors.organizationMainserverCredentialsMissing',
+  organization_mainserver_credentials_missing:
+    'messages.errors.organizationMainserverCredentialsMissing',
   token_request_failed: 'messages.errors.tokenRequestFailed',
   unauthorized: 'messages.errors.unauthorized',
   forbidden: 'messages.errors.forbidden',
@@ -157,7 +161,9 @@ const parseDatetimeLocalInput = (value: string, referenceValue?: string) => {
 
 type NewsMediaPickerAsset = StudioMediaPickerAssetDetail;
 
-const toNewsMediaPickerSummary = (asset: HostMediaAssetListItem): StudioMediaPickerAssetSummary => ({
+const toNewsMediaPickerSummary = (
+  asset: HostMediaAssetListItem
+): StudioMediaPickerAssetSummary => ({
   id: asset.id,
   title: readAssetTitle(asset),
   fileName: readAssetFileName(asset),
@@ -269,7 +275,14 @@ const isDirtyFieldTree = (
 type NewsTabIconProps = Readonly<{ className?: string }>;
 
 const NewsTabBasisIcon = ({ className }: NewsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <path d="M7 4.75h7.5L19 9.25v9A1.75 1.75 0 0 1 17.25 20h-10.5A1.75 1.75 0 0 1 5 18.25v-11.5A1.75 1.75 0 0 1 6.75 5Z" />
     <path d="M14 4.75v4.5h4.5" />
     <path d="M8.5 12h7" />
@@ -278,7 +291,14 @@ const NewsTabBasisIcon = ({ className }: NewsTabIconProps) => (
 );
 
 const NewsTabContentIcon = ({ className }: NewsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <rect x="4.5" y="5" width="15" height="14" rx="2" />
     <path d="m8 14 2.5-2.5 2 2 2.5-3 3 4.5" />
     <circle cx="9" cy="9.5" r="1.2" />
@@ -286,7 +306,14 @@ const NewsTabContentIcon = ({ className }: NewsTabIconProps) => (
 );
 
 const NewsTabSettingsIcon = ({ className }: NewsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <path d="M4 7h10" />
     <path d="M4 17h16" />
     <circle cx="17" cy="7" r="2.5" />
@@ -295,7 +322,14 @@ const NewsTabSettingsIcon = ({ className }: NewsTabIconProps) => (
 );
 
 const NewsTabHistoryIcon = ({ className }: NewsTabIconProps) => (
-  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    className={className}
+  >
     <path d="M4.5 12a7.5 7.5 0 1 0 2.2-5.3" />
     <path d="M4.5 5.5v3.7h3.7" />
     <path d="M12 8.5v4l2.5 1.5" />
@@ -333,7 +367,8 @@ export const NewsDetailPage = ({
   const [deletePending, setDeletePending] = React.useState(false);
   const [loadedItem, setLoadedItem] = React.useState<NewsContentItem | null>(null);
   const [scheduledPublicationInput, setScheduledPublicationInput] = React.useState('');
-  const [invalidScheduledPublicationInput, setInvalidScheduledPublicationInput] = React.useState(false);
+  const [invalidScheduledPublicationInput, setInvalidScheduledPublicationInput] =
+    React.useState(false);
   const [categoryOptions, setCategoryOptions] = React.useState<readonly NewsCategoryOption[]>([]);
   const [categoryOptionsLoading, setCategoryOptionsLoading] = React.useState(true);
   const [categoryOptionsError, setCategoryOptionsError] = React.useState<string | null>(null);
@@ -348,15 +383,14 @@ export const NewsDetailPage = ({
     defaultValues: createDefaultNewsDetailFormValues(resolvedInitialAuthor),
     resolver: newsDetailFormResolver,
   });
-  const {
-    formState,
-    reset,
-    setValue,
-  } = methods;
+  const { formState, reset, setValue } = methods;
 
   const refreshMediaAssets = React.useCallback(async () => {
     try {
-      const assets = await listHostMediaAssets({ fetch: globalThis.fetch.bind(globalThis), visibility: 'public' });
+      const assets = await listHostMediaAssets({
+        fetch: globalThis.fetch.bind(globalThis),
+        visibility: 'public',
+      });
       mediaAssetsRef.current = assets;
       setMediaAssets(assets);
       return assets;
@@ -368,22 +402,27 @@ export const NewsDetailPage = ({
   }, []);
   const mediaPickerLabels = React.useMemo(() => createNewsMediaPickerLabels(pt), [pt]);
 
-  const isAssetSelectable = React.useCallback((asset: NewsMediaPickerAsset) => {
-    const nextMedia = mediaContentFromAsset({
-      id: asset.id,
-      fileName: asset.fileName,
-      metadata: asset.metadata,
-      visibility: asset.visibility,
-      mimeType: asset.mimeType,
-      previewUrl: asset.previewUrl,
-    });
-    if (!nextMedia) {
-      return false;
-    }
+  const isAssetSelectable = React.useCallback(
+    (asset: NewsMediaPickerAsset) => {
+      const nextMedia = mediaContentFromAsset({
+        id: asset.id,
+        fileName: asset.fileName,
+        metadata: asset.metadata,
+        visibility: asset.visibility,
+        mimeType: asset.mimeType,
+        previewUrl: asset.previewUrl,
+      });
+      if (!nextMedia) {
+        return false;
+      }
 
-    const existingSources = new Set((methods.getValues('contentMedia') ?? []).map(mediaContentSourceKey).filter(Boolean));
-    return existingSources.has(mediaContentSourceKey(nextMedia)) === false;
-  }, [methods]);
+      const existingSources = new Set(
+        (methods.getValues('contentMedia') ?? []).map(mediaContentSourceKey).filter(Boolean)
+      );
+      return existingSources.has(mediaContentSourceKey(nextMedia)) === false;
+    },
+    [methods]
+  );
 
   const mediaPicker = useStudioMediaPickerOverlay<NewsMediaPickerAsset>({
     onAccept: (asset) => {
@@ -492,7 +531,9 @@ export const NewsDetailPage = ({
           return;
         }
         setCategoryOptions([]);
-        setCategoryOptionsError(resolveNewsErrorMessage(pt, error, 'messages.categoryOptionsLoadError'));
+        setCategoryOptionsError(
+          resolveNewsErrorMessage(pt, error, 'messages.categoryOptionsLoadError')
+        );
       })
       .finally(() => {
         if (active) {
@@ -537,7 +578,10 @@ export const NewsDetailPage = ({
       })
       .catch((error: unknown) => {
         if (active && requestId === editLoadRequestIdRef.current) {
-          setStatusMessage({ kind: 'error', text: resolveNewsErrorMessage(pt, error, 'messages.loadError') });
+          setStatusMessage({
+            kind: 'error',
+            text: resolveNewsErrorMessage(pt, error, 'messages.loadError'),
+          });
         }
       })
       .finally(() => {
@@ -551,41 +595,50 @@ export const NewsDetailPage = ({
     };
   }, [contentId, mode, pt, reset]);
 
-  const saveCurrentItem = methods.handleSubmit(async (values) => {
-    setStatusMessage(null);
+  const saveCurrentItem = methods.handleSubmit(
+    async (values) => {
+      setStatusMessage(null);
 
-    if (mode === 'edit' && !contentId) {
-      setStatusMessage({ kind: 'error', text: pt('messages.missingContent') });
-      return;
-    }
-
-    try {
-      const saved = await saveNewsEditorItem({
-        contentId,
-        values,
-        existingItem: loadedItem ?? null,
-      }, {
-        createNews,
-        updateNews,
-      });
-
-      if (mode === 'create') {
-        await navigate({ to: '/admin/content' });
+      if (mode === 'edit' && !contentId) {
+        setStatusMessage({ kind: 'error', text: pt('messages.missingContent') });
         return;
       }
 
-      const nextValues = mapNewsItemToDetailFormValues(saved);
-      reset(nextValues);
-      setLoadedItem(saved);
-      setScheduledPublicationInput(toDatetimeLocalValue(nextValues.scheduledPublicationAt));
-      setInvalidScheduledPublicationInput(false);
-      setStatusMessage({ kind: 'success', text: pt('messages.updateSuccess') });
-    } catch (error) {
-      setStatusMessage({ kind: 'error', text: resolveNewsErrorMessage(pt, error, 'messages.saveError') });
+      try {
+        const saved = await saveNewsEditorItem(
+          {
+            contentId,
+            values,
+            existingItem: loadedItem ?? null,
+          },
+          {
+            createNews,
+            updateNews,
+          }
+        );
+
+        if (mode === 'create') {
+          await navigate({ to: '/admin/content' });
+          return;
+        }
+
+        const nextValues = mapNewsItemToDetailFormValues(saved);
+        reset(nextValues);
+        setLoadedItem(saved);
+        setScheduledPublicationInput(toDatetimeLocalValue(nextValues.scheduledPublicationAt));
+        setInvalidScheduledPublicationInput(false);
+        setStatusMessage({ kind: 'success', text: pt('messages.updateSuccess') });
+      } catch (error) {
+        setStatusMessage({
+          kind: 'error',
+          text: resolveNewsErrorMessage(pt, error, 'messages.saveError'),
+        });
+      }
+    },
+    () => {
+      setStatusMessage({ kind: 'error', text: pt('messages.validationError') });
     }
-  }, () => {
-    setStatusMessage({ kind: 'error', text: pt('messages.validationError') });
-  });
+  );
 
   const onDelete = async () => {
     if (!contentId || deletePending) {
@@ -602,7 +655,10 @@ export const NewsDetailPage = ({
       await deleteNews(contentId);
       await navigate({ to: '/admin/content' });
     } catch (error) {
-      setStatusMessage({ kind: 'error', text: resolveNewsErrorMessage(pt, error, 'messages.deleteError') });
+      setStatusMessage({
+        kind: 'error',
+        text: resolveNewsErrorMessage(pt, error, 'messages.deleteError'),
+      });
     } finally {
       setDeletePending(false);
     }
@@ -706,12 +762,16 @@ export const NewsDetailPage = ({
   return (
     <StudioDetailPageTemplate
       title={mode === 'create' ? pt('editor.createTitle') : pt('editor.editTitle')}
-      description={mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')}
+      description={
+        mode === 'create' ? pt('editor.createDescription') : pt('editor.editDescription')
+      }
+      primaryAction={
+        <Button type="submit" form={formId}>
+          {headerSaveLabel}
+        </Button>
+      }
       actions={
         <div className="flex flex-wrap gap-3">
-          <Button type="submit" form={formId}>
-            {headerSaveLabel}
-          </Button>
           <Button asChild variant="outline">
             <Link to="/admin/content">{pt('actions.back')}</Link>
           </Button>
@@ -752,7 +812,9 @@ export const NewsDetailPage = ({
           onClose={mediaPicker.close}
           onConfirmSelection={() => void mediaPicker.confirmSelection()}
           onMetadataChange={(key, value) => mediaPicker.updateMetadataField(key, value)}
-          onOpenMediaManagement={(assetId) => void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })}
+          onOpenMediaManagement={(assetId) =>
+            void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })
+          }
           onSearchValueChange={mediaPicker.setSearchValue}
           onSelectAsset={(asset) => void mediaPicker.selectAsset(asset)}
           onUploadFile={(file) => void mediaPicker.uploadFile(file)}
@@ -769,8 +831,14 @@ export const NewsDetailPage = ({
             void saveCurrentItem();
           }}
         >
-          {statusMessage ? <StudioFormSummary kind={statusMessage.kind}>{statusMessage.text}</StudioFormSummary> : null}
-          <Tabs value={activeTab} onValueChange={(value) => handleTabChange(value as NewsDetailTabId)} className="space-y-0">
+          {statusMessage ? (
+            <StudioFormSummary kind={statusMessage.kind}>{statusMessage.text}</StudioFormSummary>
+          ) : null}
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => handleTabChange(value as NewsDetailTabId)}
+            className="space-y-0"
+          >
             <label className="block md:hidden">
               <span className="sr-only">{pt('tabs.mobileLabel')}</span>
               <Select
@@ -798,14 +866,18 @@ export const NewsDetailPage = ({
                     onMouseEnter={() => warmTab(tab.id)}
                     onFocus={() => warmTab(tab.id)}
                     className={`relative z-10 gap-2 rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none ${
-                      isActive ? 'mb-[-1px] border-primary text-primary' : 'border-transparent text-muted-foreground'
+                      isActive
+                        ? 'mb-[-1px] border-primary text-primary'
+                        : 'border-transparent text-muted-foreground'
                     }`}
                   >
                     <span className="inline-flex items-center gap-2">
                       <TabIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
                       <span>{tab.label}</span>
                       {tab.hasChanges && tab.changeLabel ? (
-                        <span className="text-xs font-medium text-foreground">{tab.changeLabel}</span>
+                        <span className="text-xs font-medium text-foreground">
+                          {tab.changeLabel}
+                        </span>
                       ) : null}
                     </span>
                   </TabsTrigger>
@@ -828,12 +900,20 @@ export const NewsDetailPage = ({
                       className="flex flex-col gap-3 border-0 bg-transparent p-0 lg:flex-row lg:items-start lg:justify-between"
                     >
                       <div className="space-y-1">
-                        <h2 className="text-base font-semibold text-foreground">{tab.title ?? tab.label}</h2>
+                        <h2 className="text-base font-semibold text-foreground">
+                          {tab.title ?? tab.label}
+                        </h2>
                         {tab.description ? (
-                          <p className="text-sm leading-relaxed text-muted-foreground">{tab.description}</p>
+                          <p className="text-sm leading-relaxed text-muted-foreground">
+                            {tab.description}
+                          </p>
                         ) : null}
                       </div>
-                      {tab.actions ? <div className="flex shrink-0 flex-wrap items-start justify-end gap-2">{tab.actions}</div> : null}
+                      {tab.actions ? (
+                        <div className="flex shrink-0 flex-wrap items-start justify-end gap-2">
+                          {tab.actions}
+                        </div>
+                      ) : null}
                     </section>
                     {tab.panel}
                   </div>

--- a/packages/plugin-news/tests/news.detail-page.test.tsx
+++ b/packages/plugin-news/tests/news.detail-page.test.tsx
@@ -16,7 +16,8 @@ import { listNewsCategories } from '../src/news.api.js';
 import { NewsDetailPage } from '../src/news.detail-page.js';
 
 vi.mock('@sva/studio-ui-react', async () => {
-  const actual = await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
+  const actual =
+    await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
   return {
     ...actual,
     RichTextHtmlEditor: ({
@@ -213,14 +214,12 @@ describe('NewsDetailPage', () => {
     cleanup();
   });
 
-  it('renders exactly one save button in the page header', async () => {
+  it('renders the same save action in the page header and after the editor', async () => {
     render(<NewsDetailPage mode="create" initialAuthor="Redaktion" />);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Speichern' })).toBeTruthy();
+      expect(screen.getAllByRole('button', { name: 'Speichern' })).toHaveLength(2);
     });
-
-    expect(screen.getAllByRole('button', { name: 'Speichern' })).toHaveLength(1);
   });
 
   it('uses the upload response url when the refreshed news asset still has no preview url', async () => {
@@ -283,7 +282,9 @@ describe('NewsDetailPage', () => {
 
     render(<NewsDetailPage mode="create" initialAuthor="Redaktion" />);
 
-    fireEvent.change(await screen.findByLabelText('Bereich auswählen'), { target: { value: 'content' } });
+    fireEvent.change(await screen.findByLabelText('Bereich auswählen'), {
+      target: { value: 'content' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Bild hochladen' }));
     fireEvent.change(screen.getByTestId('media-upload-input'), {
       target: {
@@ -299,7 +300,12 @@ describe('NewsDetailPage', () => {
   });
 
   it('renders the author as a fixed readonly field when authorship is fixed', async () => {
-    render(<NewsDetailPage mode="create" authorControl={{ kind: 'fixed', value: 'Stadt Musterhausen' }} />);
+    render(
+      <NewsDetailPage
+        mode="create"
+        authorControl={{ kind: 'fixed', value: 'Stadt Musterhausen' }}
+      />
+    );
 
     const authorInput = await screen.findByLabelText('Autor');
     expect((authorInput as HTMLInputElement).value).toBe('Stadt Musterhausen');
@@ -323,10 +329,9 @@ describe('NewsDetailPage', () => {
 
     const authorSelect = await screen.findByRole('combobox', { name: 'Autor' });
     expect((authorSelect as HTMLSelectElement).value).toBe('Stadt Musterhausen');
-    expect(Array.from((authorSelect as HTMLSelectElement).options).map((option) => option.textContent)).toEqual([
-      'Stadt Musterhausen',
-      'Max Mustermann',
-    ]);
+    expect(
+      Array.from((authorSelect as HTMLSelectElement).options).map((option) => option.textContent)
+    ).toEqual(['Stadt Musterhausen', 'Max Mustermann']);
   });
 
   it('keeps the author editable when no author policy is provided', async () => {
@@ -343,9 +348,16 @@ describe('NewsDetailPage', () => {
   it('applies a later author policy update while the author field is still pristine', async () => {
     const { rerender } = render(<NewsDetailPage mode="create" initialAuthor="Max Mustermann" />);
 
-    expect((await screen.findByLabelText('Autor') as HTMLInputElement).value).toBe('Max Mustermann');
+    expect(((await screen.findByLabelText('Autor')) as HTMLInputElement).value).toBe(
+      'Max Mustermann'
+    );
 
-    rerender(<NewsDetailPage mode="create" authorControl={{ kind: 'fixed', value: 'Stadt Musterhausen' }} />);
+    rerender(
+      <NewsDetailPage
+        mode="create"
+        authorControl={{ kind: 'fixed', value: 'Stadt Musterhausen' }}
+      />
+    );
 
     await waitFor(() => {
       expect((screen.getByLabelText('Autor') as HTMLInputElement).value).toBe('Stadt Musterhausen');
@@ -389,7 +401,9 @@ describe('NewsDetailPage', () => {
     expect(source).toContain('aria-describedby={`publication-mode-${option}-description`}');
     expect(source).toContain('htmlFor={`publication-mode-${option}`}');
     expect(source).toContain('{pt(`publicationModes.${option}.label`)}');
-    expect(source).toContain('<p id={`publication-mode-${option}-description`} className="text-muted-foreground">');
+    expect(source).toContain(
+      '<p id={`publication-mode-${option}-description`} className="text-muted-foreground">'
+    );
     expect(source).toContain('<label');
   });
 

--- a/packages/plugin-news/tests/news.pages.test.tsx
+++ b/packages/plugin-news/tests/news.pages.test.tsx
@@ -19,7 +19,8 @@ import {
 import { NEWS_CONTENT_TYPE } from '../src/plugin.js';
 
 vi.mock('@sva/studio-ui-react', async () => {
-  const actual = await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
+  const actual =
+    await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
   return {
     ...actual,
     RichTextHtmlEditor: ({
@@ -79,30 +80,35 @@ vi.mock('../src/news.api.js', async () => {
     id: 'news-1',
   }));
   const deleteNewsMock = vi.fn(async () => undefined);
-  const saveNewsEditorItemMock = vi.fn(async (input: {
-    contentId?: string;
-    values: Parameters<typeof mapNewsDetailFormValuesToMutation>[0];
-    existingItem?: Record<string, unknown> | null;
-  }) => {
-    const mutation = mapNewsDetailFormValuesToMutation(input.values, input.contentId ? 'edit' : 'create');
-    const saved = input.contentId
-      ? await updateNewsMock(input.contentId, mutation)
-      : await createNewsMock(mutation);
+  const saveNewsEditorItemMock = vi.fn(
+    async (input: {
+      contentId?: string;
+      values: Parameters<typeof mapNewsDetailFormValuesToMutation>[0];
+      existingItem?: Record<string, unknown> | null;
+    }) => {
+      const mutation = mapNewsDetailFormValuesToMutation(
+        input.values,
+        input.contentId ? 'edit' : 'create'
+      );
+      const saved = input.contentId
+        ? await updateNewsMock(input.contentId, mutation)
+        : await createNewsMock(mutation);
 
-    return {
-      ...(input.existingItem ?? {}),
-      id: input.contentId ?? 'news-created',
-      contentType: NEWS_CONTENT_TYPE,
-      payload: {},
-      status: 'published',
-      author: mutation.author ?? '',
-      publishedAt: mutation.publishedAt,
-      publicationDate: mutation.publicationDate,
-      ...saved,
-      ...mutation,
-      visible: input.values.publicationMode !== 'draft',
-    };
-  });
+      return {
+        ...(input.existingItem ?? {}),
+        id: input.contentId ?? 'news-created',
+        contentType: NEWS_CONTENT_TYPE,
+        payload: {},
+        status: 'published',
+        author: mutation.author ?? '',
+        publishedAt: mutation.publishedAt,
+        publicationDate: mutation.publicationDate,
+        ...saved,
+        ...mutation,
+        visible: input.values.publicationMode !== 'draft',
+      };
+    }
+  );
 
   return {
     ...actual,
@@ -120,7 +126,9 @@ vi.mock('../src/news.api.js', async () => {
     listNewsCategories: listNewsCategoriesMock,
     saveNewsEditorItem: saveNewsEditorItemMock,
     updateNews: updateNewsMock,
-    updateNewsPartial: vi.fn(async (contentId: string, input: unknown) => updateNewsMock(contentId, input)),
+    updateNewsPartial: vi.fn(async (contentId: string, input: unknown) =>
+      updateNewsMock(contentId, input)
+    ),
     deleteNews: deleteNewsMock,
   };
 });
@@ -163,7 +171,10 @@ const createDeferred = <T,>() => {
   return { promise, resolve, reject };
 };
 
-const actResolve = async <T,>(deferred: { resolve: (value: T) => void; promise: Promise<T> }, value: T) => {
+const actResolve = async <T,>(
+  deferred: { resolve: (value: T) => void; promise: Promise<T> },
+  value: T
+) => {
   await act(async () => {
     deferred.resolve(value);
     await deferred.promise;
@@ -216,8 +227,10 @@ const waitForCategoryControls = async () => {
 };
 
 const clickPrimaryAction = (label: string) => {
-  const targetLabel = label === 'News anlegen' || label === 'Änderungen speichern' ? 'Speichern' : label;
-  fireEvent.click(screen.getByRole('button', { name: targetLabel }));
+  const targetLabel =
+    label === 'News anlegen' || label === 'Änderungen speichern' ? 'Speichern' : label;
+  const actions = screen.getAllByRole('button', { name: targetLabel });
+  fireEvent.click(actions.at(-1)!);
 };
 
 describe('News editor pages', () => {
@@ -254,7 +267,8 @@ describe('News editor pages', () => {
       const labels: Record<string, string> = {
         'news.messages.loading': 'News werden geladen.',
         'news.messages.loadError': 'News konnten nicht geladen werden.',
-        'news.messages.missingContent': 'Der angeforderte News-Eintrag konnte nicht geladen werden.',
+        'news.messages.missingContent':
+          'Der angeforderte News-Eintrag konnte nicht geladen werden.',
         'news.messages.saveError': 'News konnten nicht gespeichert werden.',
         'news.messages.validationError': 'Bitte korrigieren Sie die markierten Felder.',
         'news.messages.validationSummary': 'Bitte prüfen Sie die folgenden Felder:',
@@ -264,22 +278,28 @@ describe('News editor pages', () => {
         'news.messages.deleteError': 'News-Eintrag konnte nicht gelöscht werden.',
         'news.messages.categoryOptionsLoading': 'Kategorien werden geladen.',
         'news.messages.categoryOptionsLoadError': 'Die Kategorien konnten nicht geladen werden.',
-        'news.messages.unsavedTabChanges': 'Bitte speichern Sie die Änderungen im aktuellen Tab, bevor Sie den Bereich wechseln.',
+        'news.messages.unsavedTabChanges':
+          'Bitte speichern Sie die Änderungen im aktuellen Tab, bevor Sie den Bereich wechseln.',
         'news.messages.errors.forbidden': 'Keine Berechtigung für Mainserver-News.',
         'news.messages.errors.graphqlError': 'Der Mainserver hat die News-Anfrage abgelehnt.',
-        'news.messages.errors.integrationDisabled': 'Die Mainserver-Integration ist für diese Instanz deaktiviert.',
+        'news.messages.errors.integrationDisabled':
+          'Die Mainserver-Integration ist für diese Instanz deaktiviert.',
         'news.messages.errors.invalidRequest': 'Die News-Daten sind unvollständig oder ungültig.',
         'news.messages.errors.invalidConfig': 'Die Mainserver-Konfiguration für News ist ungültig.',
         'news.messages.errors.details': 'Details: {{message}}',
-        'news.messages.errors.invalidResponse': 'Der Mainserver hat eine ungültige News-Antwort geliefert.',
+        'news.messages.errors.invalidResponse':
+          'Der Mainserver hat eine ungültige News-Antwort geliefert.',
         'news.messages.errors.organizationMainserverCredentialsMissing':
           'Für die aktive Organisation fehlen Mainserver-Credentials.',
-        'news.messages.errors.configNotFound': 'Für diese Instanz ist keine Mainserver-Konfiguration hinterlegt.',
+        'news.messages.errors.configNotFound':
+          'Für diese Instanz ist keine Mainserver-Konfiguration hinterlegt.',
         'news.messages.errors.missingCredentials': 'Mainserver-Credentials fehlen.',
         'news.messages.errors.missingInstance': 'Kein Instanzkontext vorhanden.',
         'news.messages.errors.networkError': 'Der Mainserver ist nicht erreichbar.',
-        'news.messages.errors.tokenRequestFailed': 'Die Authentifizierung am Mainserver ist fehlgeschlagen.',
-        'news.messages.errors.unauthorized': 'Die Sitzung ist nicht mehr gültig. Bitte erneut anmelden.',
+        'news.messages.errors.tokenRequestFailed':
+          'Die Authentifizierung am Mainserver ist fehlgeschlagen.',
+        'news.messages.errors.unauthorized':
+          'Die Sitzung ist nicht mehr gültig. Bitte erneut anmelden.',
         'news.empty.title': 'Noch keine News vorhanden',
         'news.empty.description': 'Legen Sie den ersten News-Eintrag an.',
         'news.pagination.ariaLabel': 'News-Pagination',
@@ -354,7 +374,8 @@ describe('News editor pages', () => {
         'news.tabs.changeLabel': 'Ungespeichert',
         'news.tabs.basis.label': 'Basis',
         'news.tabs.basis.title': 'Basisdaten',
-        'news.tabs.basis.description': 'Metadaten, Veröffentlichung und redaktionelle Kerndaten des News-Eintrags.',
+        'news.tabs.basis.description':
+          'Metadaten, Veröffentlichung und redaktionelle Kerndaten des News-Eintrags.',
         'news.tabs.basis.metaSummaryTitle': 'Aktuelle Metadaten',
         'news.tabs.basis.metaSummaryInline': 'Veröffentlicht: {{publishedAt}}',
         'news.tabs.content.label': 'Inhalte',
@@ -362,10 +383,12 @@ describe('News editor pages', () => {
         'news.tabs.content.description': 'Textinhalt, Medien und Quelle der News.',
         'news.tabs.settings.label': 'Einstellungen',
         'news.tabs.settings.title': 'Einstellungen',
-        'news.tabs.settings.description': 'Push-Benachrichtigung und redaktionelle Veröffentlichungslogik.',
+        'news.tabs.settings.description':
+          'Push-Benachrichtigung und redaktionelle Veröffentlichungslogik.',
         'news.tabs.history.label': 'Historie',
         'news.tabs.history.title': 'Historie',
-        'news.tabs.history.description': 'Nachvollziehbare Änderungen und Statuswechsel dieses News-Eintrags.',
+        'news.tabs.history.description':
+          'Nachvollziehbare Änderungen und Statuswechsel dieses News-Eintrags.',
         'news.cards.basis.titleCategories.title': 'Titel & Kategorien',
         'news.cards.basis.titleCategories.description': 'Titel und Kategorien.',
         'news.cards.basis.authorMeta.title': 'Autor & Metadaten',
@@ -429,12 +452,14 @@ describe('News editor pages', () => {
         'news.actions.addMediaManual': 'Link manuell eintragen',
         'news.actions.remove': 'Entfernen',
         'news.actions.removeImage': 'Bild entfernen',
-        'news.validation.contentBlocks': 'Mindestens ein Inhaltsblock benötigt Inhalt und darf maximal 50.000 Zeichen haben.',
+        'news.validation.contentBlocks':
+          'Mindestens ein Inhaltsblock benötigt Inhalt und darf maximal 50.000 Zeichen haben.',
         'news.validation.contentBody': 'Der Inhalt ist erforderlich.',
         'news.validation.sourceUrl': 'Die Quell-URL muss mit https:// beginnen.',
         'news.validation.publishedAt': 'Das Veröffentlichungsdatum ist erforderlich.',
         'news.validation.publicationDate': 'Das Publikationsdatum muss gültig sein.',
-        'news.validation.scheduledPublicationAt': 'Der geplante Veröffentlichungszeitpunkt ist ungültig.',
+        'news.validation.scheduledPublicationAt':
+          'Der geplante Veröffentlichungszeitpunkt ist ungültig.',
         'news.fields.mediaUrlDescription': 'Bildquelle',
         'news.fields.mediaCopyright': 'Copyright',
         'news.fields.mediaWidth': 'Breite',
@@ -461,7 +486,9 @@ describe('News editor pages', () => {
     await openContentTab();
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: ' ' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -490,7 +517,9 @@ describe('News editor pages', () => {
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p><br></p>' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -527,18 +556,26 @@ describe('News editor pages', () => {
 
     fireEvent.change(screen.getByLabelText('Titel'), { target: { value: 'Neue News' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-03-29T02:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-03-29T02:30' },
+    });
     await openContentTab();
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Body</p>' } });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
-      expect(screen.getAllByText('Der geplante Veröffentlichungszeitpunkt ist ungültig.').length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText('Der geplante Veröffentlichungszeitpunkt ist ungültig.').length
+      ).toBeGreaterThan(0);
     });
 
-    expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('value')).toBe('2026-03-29T02:30');
-    expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('aria-invalid')).toBe('true');
+    expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('value')).toBe(
+      '2026-03-29T02:30'
+    );
+    expect(
+      screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('aria-invalid')
+    ).toBe('true');
   });
 
   it('navigates back to the shared content list after creating a news entry', async () => {
@@ -549,7 +586,9 @@ describe('News editor pages', () => {
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Body</p>' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -570,12 +609,18 @@ describe('News editor pages', () => {
     await openContentTab();
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Body</p>' } });
-    fireEvent.change(screen.getByLabelText('Quell-URL'), { target: { value: 'https://example.com/news' } });
+    fireEvent.change(screen.getByLabelText('Quell-URL'), {
+      target: { value: 'https://example.com/news' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Link manuell eintragen' }));
-    fireEvent.change(screen.getByLabelText('Medien-URL'), { target: { value: 'https://example.com/image.jpg' } });
+    fireEvent.change(screen.getByLabelText('Medien-URL'), {
+      target: { value: 'https://example.com/image.jpg' },
+    });
     fireEvent.change(screen.getByLabelText('Bildunterschrift'), { target: { value: 'Bild' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -587,13 +632,14 @@ describe('News editor pages', () => {
             expect.objectContaining({
               intro: 'Kurztext',
               body: '<p>Body</p>',
-              mediaContents: [expect.objectContaining({ sourceUrl: { url: 'https://example.com/image.jpg' } })],
+              mediaContents: [
+                expect.objectContaining({ sourceUrl: { url: 'https://example.com/image.jpg' } }),
+              ],
             }),
           ],
         })
       );
     });
-
   });
 
   it('submits the simplified editorial model while preserving hidden legacy omissions on create', async () => {
@@ -613,14 +659,20 @@ describe('News editor pages', () => {
     expect(screen.getByText('Rathaus')).toBeTruthy();
     await openReleaseTab();
     fireEvent.click(screen.getByRole('checkbox', { name: /Push-Benachrichtigung senden/ }));
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     await openContentTab();
-    fireEvent.change(screen.getByLabelText('Quell-URL'), { target: { value: 'https://example.com/news' } });
+    fireEvent.change(screen.getByLabelText('Quell-URL'), {
+      target: { value: 'https://example.com/news' },
+    });
     fireEvent.change(screen.getByLabelText('Quellbeschreibung'), { target: { value: 'Quelle' } });
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Inhalt</p>' } });
     fireEvent.click(screen.getByRole('button', { name: 'Link manuell eintragen' }));
-    fireEvent.change(screen.getByLabelText('Medien-URL'), { target: { value: 'https://example.com/image.jpg' } });
+    fireEvent.change(screen.getByLabelText('Medien-URL'), {
+      target: { value: 'https://example.com/image.jpg' },
+    });
     fireEvent.change(screen.getByLabelText('Bildunterschrift'), { target: { value: 'Bild' } });
     clickPrimaryAction('News anlegen');
 
@@ -630,13 +682,18 @@ describe('News editor pages', () => {
       expect(createPayload.title).toBe('Volle News');
       expect(createPayload.author).toBe('Redaktion');
       expect(createPayload.categories).toEqual([{ name: 'Allgemein' }, { name: 'Rathaus' }]);
-      expect(createPayload.sourceUrl).toEqual({ url: 'https://example.com/news', description: 'Quelle' });
+      expect(createPayload.sourceUrl).toEqual({
+        url: 'https://example.com/news',
+        description: 'Quelle',
+      });
       expect(createPayload.contentBlocks).toEqual([
         expect.objectContaining({
           title: 'Volle News',
           intro: 'Kurztext',
           body: '<p>Inhalt</p>',
-          mediaContents: [expect.objectContaining({ sourceUrl: { url: 'https://example.com/image.jpg' } })],
+          mediaContents: [
+            expect.objectContaining({ sourceUrl: { url: 'https://example.com/image.jpg' } }),
+          ],
         }),
       ]);
       expect(createPayload).not.toHaveProperty('payload');
@@ -659,7 +716,9 @@ describe('News editor pages', () => {
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Body</p>' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -681,7 +740,9 @@ describe('News editor pages', () => {
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Body</p>' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -705,7 +766,9 @@ describe('News editor pages', () => {
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Body</p>' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -729,7 +792,9 @@ describe('News editor pages', () => {
     fireEvent.change(screen.getByLabelText('Teaser'), { target: { value: 'Kurztext' } });
     fireEvent.change(screen.getByLabelText('Inhalt'), { target: { value: '<p>Body</p>' } });
     await openReleaseTab();
-    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), { target: { value: '2026-04-14T09:30' } });
+    fireEvent.change(screen.getByLabelText('Zeitpunkt der Veröffentlichung'), {
+      target: { value: '2026-04-14T09:30' },
+    });
     clickPrimaryAction('News anlegen');
 
     await waitFor(() => {
@@ -755,7 +820,9 @@ describe('News editor pages', () => {
     render(<NewsEditPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Der angeforderte News-Eintrag konnte nicht geladen werden.')).toBeTruthy();
+      expect(
+        screen.getByText('Der angeforderte News-Eintrag konnte nicht geladen werden.')
+      ).toBeTruthy();
       expect(screen.queryByText('News werden geladen.')).toBeNull();
     });
 
@@ -840,7 +907,7 @@ describe('News editor pages', () => {
         'news-1',
         expect.objectContaining({
           title: 'Aktualisierte News',
-        }),
+        })
       );
       expect(screen.getByText('News-Eintrag wurde aktualisiert.')).toBeTruthy();
     });
@@ -960,7 +1027,7 @@ describe('News editor pages', () => {
     });
   });
 
-  it('keeps Historie read-only and free of save actions', async () => {
+  it('keeps Historie read-only without adding a tab-specific save action', async () => {
     vi.mocked(fetchIamContentHistory).mockResolvedValueOnce([
       {
         id: 'history-1',
@@ -1044,7 +1111,11 @@ describe('News editor pages', () => {
       ],
       pointOfInterestId: 'poi-7',
       dataProvider: { id: 'dp-1', name: 'Datenquelle' },
-      settings: { alwaysRecreateOnImport: 'false', displayOnlySummary: 'true', onlySummaryLinkText: 'Mehr' },
+      settings: {
+        alwaysRecreateOnImport: 'false',
+        displayOnlySummary: 'true',
+        onlySummaryLinkText: 'Mehr',
+      },
       announcements: [{ id: 'announcement-1', title: 'Hinweis' }],
       likeCount: 3,
       likedByMe: false,
@@ -1132,7 +1203,11 @@ describe('News editor pages', () => {
         'news-1',
         expect.objectContaining({
           sourceUrl: { url: 'https://example.com/source', description: 'Quelle' },
-          address: expect.objectContaining({ street: 'Markt 1', zip: '12345', city: 'Musterhausen' }),
+          address: expect.objectContaining({
+            street: 'Markt 1',
+            zip: '12345',
+            city: 'Musterhausen',
+          }),
           pointOfInterestId: 'poi-7',
           contentBlocks: [
             expect.objectContaining({
@@ -1257,7 +1332,9 @@ describe('News editor pages', () => {
     await openSettingsTab();
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('value')).toBe('2026-08-14T11:30');
+      expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('value')).toBe(
+        '2026-08-14T11:30'
+      );
     });
   });
 
@@ -1283,7 +1360,9 @@ describe('News editor pages', () => {
     fireEvent.click(screen.getByRole('radio', { name: /Zeitgesteuert/ }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('value')).toBe('');
+      expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('value')).toBe(
+        ''
+      );
     });
   });
 });

--- a/packages/plugin-poi/src/poi.detail-page.tsx
+++ b/packages/plugin-poi/src/poi.detail-page.tsx
@@ -29,7 +29,14 @@ import {
   useStudioMediaPickerOverlay,
 } from '@sva/studio-ui-react';
 
-import { createPoi, deletePoi, getPoi, listPoiCategories, PoiApiError, updatePoi } from './poi.api.js';
+import {
+  createPoi,
+  deletePoi,
+  getPoi,
+  listPoiCategories,
+  PoiApiError,
+  updatePoi,
+} from './poi.api.js';
 import { PoiDetailBasisTab } from './poi.detail-basis-tab.js';
 import { PoiDetailContentTab } from './poi.detail-content-tab.js';
 import {
@@ -60,8 +67,11 @@ type StatusMessage = Readonly<{
 
 type PoiMediaPickerAsset = StudioMediaPickerAssetDetail;
 
-const errorMessage = (pt: ReturnType<typeof usePluginTranslation>, error: unknown, fallbackKey: string) =>
-  error instanceof PoiApiError ? error.message : pt(fallbackKey);
+const errorMessage = (
+  pt: ReturnType<typeof usePluginTranslation>,
+  error: unknown,
+  fallbackKey: string
+) => (error instanceof PoiApiError ? error.message : pt(fallbackKey));
 
 const renderPoiTabPanel = ({
   title,
@@ -79,7 +89,9 @@ const renderPoiTabPanel = ({
     >
       <div className="space-y-1">
         <h2 className="text-base font-semibold text-foreground">{title}</h2>
-        {description ? <p className="text-sm leading-relaxed text-muted-foreground">{description}</p> : null}
+        {description ? (
+          <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>
+        ) : null}
       </div>
     </section>
     {panel}
@@ -230,7 +242,11 @@ export function PoiDetailPage({
 
   const refreshMediaAssets = React.useCallback(async () => {
     try {
-      const assets = await listHostMediaAssets({ fetch: globalThis.fetch.bind(globalThis), instanceId, visibility: 'public' });
+      const assets = await listHostMediaAssets({
+        fetch: globalThis.fetch.bind(globalThis),
+        instanceId,
+        visibility: 'public',
+      });
       mediaAssetsRef.current = assets;
       setMediaAssets(assets);
       return assets;
@@ -241,22 +257,29 @@ export function PoiDetailPage({
     }
   }, [instanceId]);
 
-  const isAssetSelectable = React.useCallback((asset: PoiMediaPickerAsset) => {
-    const nextMedia = mediaContentFromAsset({
-      id: asset.id,
-      fileName: asset.fileName,
-      metadata: asset.metadata,
-      visibility: asset.visibility,
-      mimeType: asset.mimeType,
-      previewUrl: asset.previewUrl,
-    });
-    if (!nextMedia) {
-      return false;
-    }
+  const isAssetSelectable = React.useCallback(
+    (asset: PoiMediaPickerAsset) => {
+      const nextMedia = mediaContentFromAsset({
+        id: asset.id,
+        fileName: asset.fileName,
+        metadata: asset.metadata,
+        visibility: asset.visibility,
+        mimeType: asset.mimeType,
+        previewUrl: asset.previewUrl,
+      });
+      if (!nextMedia) {
+        return false;
+      }
 
-    const existingSources = new Set((methods.getValues('content.mediaContents') ?? []).map(mediaContentSourceKey).filter(Boolean));
-    return existingSources.has(mediaContentSourceKey(nextMedia)) === false;
-  }, [methods]);
+      const existingSources = new Set(
+        (methods.getValues('content.mediaContents') ?? [])
+          .map(mediaContentSourceKey)
+          .filter(Boolean)
+      );
+      return existingSources.has(mediaContentSourceKey(nextMedia)) === false;
+    },
+    [methods]
+  );
 
   const mediaPicker = useStudioMediaPickerOverlay<PoiMediaPickerAsset>({
     onAccept: (asset) => {
@@ -273,7 +296,9 @@ export function PoiDetailPage({
       }
 
       const currentMedia = methods.getValues('content.mediaContents') ?? [];
-      methods.setValue('content.mediaContents', [...currentMedia, nextMedia], { shouldDirty: true });
+      methods.setValue('content.mediaContents', [...currentMedia, nextMedia], {
+        shouldDirty: true,
+      });
       void refreshMediaAssets();
     },
     canAcceptAsset: isAssetSelectable,
@@ -352,7 +377,10 @@ export function PoiDetailPage({
       })
       .catch((loadError) => {
         if (active) {
-          setStatus({ kind: 'error', text: errorMessage(pt, loadError, 'messages.missingContent') });
+          setStatus({
+            kind: 'error',
+            text: errorMessage(pt, loadError, 'messages.missingContent'),
+          });
           setLoading(false);
         }
       });
@@ -424,15 +452,24 @@ export function PoiDetailPage({
         focusFieldById('poi-contact-url');
       }
       if (validationErrors.includes('addresses')) {
-        methods.setError('content.addresses.0.geoLocation.latitude', { type: 'manual', message: 'addresses' });
+        methods.setError('content.addresses.0.geoLocation.latitude', {
+          type: 'manual',
+          message: 'addresses',
+        });
         setActiveTab('content');
       }
       if (validationErrors.includes('location')) {
-        methods.setError('content.location.geoLocation.latitude', { type: 'manual', message: 'location' });
+        methods.setError('content.location.geoLocation.latitude', {
+          type: 'manual',
+          message: 'location',
+        });
         setActiveTab('content');
       }
       if (validationErrors.includes('priceInformations')) {
-        methods.setError('content.prices.0.amount', { type: 'manual', message: 'priceInformations' });
+        methods.setError('content.prices.0.amount', {
+          type: 'manual',
+          message: 'priceInformations',
+        });
         setActiveTab('content');
       }
       if (validationErrors.includes('mediaContents')) {
@@ -441,7 +478,10 @@ export function PoiDetailPage({
           return url.length > 0 && isHttpsUrl(url) === false;
         });
         const mediaIndex = invalidMediaIndex >= 0 ? invalidMediaIndex : 0;
-        methods.setError(`content.mediaContents.${mediaIndex}.sourceUrl.url`, { type: 'manual', message: 'webUrls' });
+        methods.setError(`content.mediaContents.${mediaIndex}.sourceUrl.url`, {
+          type: 'manual',
+          message: 'webUrls',
+        });
         setActiveTab('content');
         focusFieldById(`poi-media-url-${mediaIndex}`);
       }
@@ -469,8 +509,14 @@ export function PoiDetailPage({
     }
 
     try {
-      const saved = mode === 'create' ? await createPoi(mutation) : await updatePoi(contentId as string, mutation);
-      setStatus({ kind: 'success', text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess') });
+      const saved =
+        mode === 'create'
+          ? await createPoi(mutation)
+          : await updatePoi(contentId as string, mutation);
+      setStatus({
+        kind: 'success',
+        text: mode === 'create' ? pt('messages.createSuccess') : pt('messages.updateSuccess'),
+      });
       if (mode === 'create') {
         await navigate({ to: '/admin/poi/$id', params: { id: saved.id } });
       }
@@ -523,7 +569,14 @@ export function PoiDetailPage({
     <FormProvider {...methods}>
       <StudioDetailPageTemplate
         title={mode === 'create' ? pt('detail.createTitle') : pt('detail.editTitle')}
-        description={mode === 'create' ? pt('detail.createDescription') : pt('detail.editDescription')}
+        description={
+          mode === 'create' ? pt('detail.createDescription') : pt('detail.editDescription')
+        }
+        primaryAction={
+          <Button type="submit" form={formId}>
+            {pt('actions.save')}
+          </Button>
+        }
         actions={
           <div className="flex flex-wrap gap-2">
             <Button asChild variant="outline">
@@ -534,9 +587,6 @@ export function PoiDetailPage({
                 {pt('actions.delete')}
               </Button>
             ) : null}
-            <Button type="submit" form={formId}>
-              {pt('actions.save')}
-            </Button>
           </div>
         }
       >
@@ -568,7 +618,9 @@ export function PoiDetailPage({
           onClose={mediaPicker.close}
           onConfirmSelection={() => void mediaPicker.confirmSelection()}
           onMetadataChange={(key, value) => mediaPicker.updateMetadataField(key, value)}
-          onOpenMediaManagement={(assetId) => void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })}
+          onOpenMediaManagement={(assetId) =>
+            void navigate({ to: '/admin/media/$mediaId', params: { mediaId: assetId } })
+          }
           onSearchValueChange={mediaPicker.setSearchValue}
           onSelectAsset={(asset) => void mediaPicker.selectAsset(asset)}
           onUploadFile={(file) => void mediaPicker.uploadFile(file)}
@@ -580,7 +632,11 @@ export function PoiDetailPage({
         />
         <form id={formId} onSubmit={(event) => void submit(event)} className="space-y-5" noValidate>
           {status ? <StudioFormSummary kind={status.kind}>{status.text}</StudioFormSummary> : null}
-          <Tabs value={activeTab} onValueChange={(value) => handleTabChange(value as PoiDetailTabId)} className="space-y-0">
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => handleTabChange(value as PoiDetailTabId)}
+            className="space-y-0"
+          >
             <label className="block md:hidden">
               <span className="sr-only">{pt('tabs.mobileLabel')}</span>
               <Select
@@ -607,7 +663,9 @@ export function PoiDetailPage({
                     onMouseEnter={() => warmTab(tab.id)}
                     onFocus={() => warmTab(tab.id)}
                     className={`relative z-10 rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none ${
-                      isActive ? 'mb-[-1px] border-primary text-primary' : 'border-transparent text-muted-foreground'
+                      isActive
+                        ? 'mb-[-1px] border-primary text-primary'
+                        : 'border-transparent text-muted-foreground'
                     }`}
                   >
                     <PoiTabTriggerLabel label={tab.label} />

--- a/packages/plugin-poi/src/poi.pages.test.tsx
+++ b/packages/plugin-poi/src/poi.pages.test.tsx
@@ -11,7 +11,11 @@ const listHostMediaAssetsMock = vi.hoisted(() => vi.fn());
 const paramsMock = vi.hoisted(() => vi.fn(() => ({})));
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, to, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { readonly to: string }) => (
+  Link: ({
+    children,
+    to,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { readonly to: string }) => (
     <a href={to} {...props}>
       {children}
     </a>
@@ -66,11 +70,19 @@ describe('PoiCreatePage', () => {
     fireEvent.change(screen.getByLabelText('fields.url'), {
       target: { value: 'http://invalid.example' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() => {
-      expect(screen.getAllByRole('alert').some((element) => element.textContent?.includes('validation.name'))).toBe(true);
-      expect(screen.getAllByRole('alert').some((element) => element.textContent?.includes('validation.webUrls'))).toBe(true);
+      expect(
+        screen
+          .getAllByRole('alert')
+          .some((element) => element.textContent?.includes('validation.name'))
+      ).toBe(true);
+      expect(
+        screen
+          .getAllByRole('alert')
+          .some((element) => element.textContent?.includes('validation.webUrls'))
+      ).toBe(true);
     });
 
     const urlInput = screen.getByLabelText('fields.url');
@@ -108,14 +120,20 @@ describe('PoiCreatePage', () => {
       target: { value: 'x'.repeat(129) },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() => {
-      expect(screen.getAllByRole('alert').some((element) => element.textContent?.includes('validation.categories'))).toBe(true);
+      expect(
+        screen
+          .getAllByRole('alert')
+          .some((element) => element.textContent?.includes('validation.categories'))
+      ).toBe(true);
     });
 
     expect(screen.queryByRole('button', { name: 'actions.addCategory' })).toBeNull();
-    expect(screen.getByLabelText('fields.categoriesSearch').closest('section')?.textContent).toContain('validation.categories');
+    expect(
+      screen.getByLabelText('fields.categoriesSearch').closest('section')?.textContent
+    ).toContain('validation.categories');
     expect(createPoiMock).not.toHaveBeenCalled();
   });
 
@@ -142,10 +160,14 @@ describe('PoiCreatePage', () => {
       target: { value: '{"hero":' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() => {
-      expect(screen.getAllByRole('alert').some((element) => element.textContent?.includes('validation.payload'))).toBe(true);
+      expect(
+        screen
+          .getAllByRole('alert')
+          .some((element) => element.textContent?.includes('validation.payload'))
+      ).toBe(true);
     });
 
     const payloadInput = screen.getByLabelText('fields.payload');
@@ -155,7 +177,7 @@ describe('PoiCreatePage', () => {
     fireEvent.change(payloadInput, {
       target: { value: '{"hero":"Willkommen"}' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
 
     await waitFor(() => {
       expect(createPoiMock).toHaveBeenCalledWith(

--- a/packages/plugin-poi/tests/poi.detail-page.test.tsx
+++ b/packages/plugin-poi/tests/poi.detail-page.test.tsx
@@ -61,30 +61,35 @@ vi.mock('@sva/plugin-sdk', async () => {
       };
     }),
     listHostMediaAssets: vi.fn(async () => []),
-    updateHostMediaAsset: vi.fn(async ({ assetId, metadata }: { assetId: string; metadata: Record<string, string> }) => {
-      const asset = resolveMockMediaAsset(assetId);
-      return {
-        id: assetId,
-        instanceId: 'instance-1',
-        storageKey: `media/${asset.fileName}`,
-        mediaType: 'image',
-        mimeType: 'image/jpeg',
-        byteSize: 2048,
-        visibility: 'public',
-        uploadStatus: 'processed',
-        processingStatus: 'ready',
-        metadata: {
-          title: metadata.title ?? asset.title,
-          altText: metadata.altText ?? '',
-          description: metadata.description ?? '',
-          copyright: metadata.copyright ?? 'Stadt Musterhausen',
-          license: metadata.license ?? '',
-        },
-        technical: {},
-        previewUrl: asset.previewUrl,
-      };
-    }),
-    uploadHostMediaFile: vi.fn(async () => ({ assetId: 'uploaded-asset', uploadSessionId: 'upload-1' })),
+    updateHostMediaAsset: vi.fn(
+      async ({ assetId, metadata }: { assetId: string; metadata: Record<string, string> }) => {
+        const asset = resolveMockMediaAsset(assetId);
+        return {
+          id: assetId,
+          instanceId: 'instance-1',
+          storageKey: `media/${asset.fileName}`,
+          mediaType: 'image',
+          mimeType: 'image/jpeg',
+          byteSize: 2048,
+          visibility: 'public',
+          uploadStatus: 'processed',
+          processingStatus: 'ready',
+          metadata: {
+            title: metadata.title ?? asset.title,
+            altText: metadata.altText ?? '',
+            description: metadata.description ?? '',
+            copyright: metadata.copyright ?? 'Stadt Musterhausen',
+            license: metadata.license ?? '',
+          },
+          technical: {},
+          previewUrl: asset.previewUrl,
+        };
+      }
+    ),
+    uploadHostMediaFile: vi.fn(async () => ({
+      assetId: 'uploaded-asset',
+      uploadSessionId: 'upload-1',
+    })),
   };
 });
 
@@ -141,7 +146,10 @@ describe('PoiDetailPage', () => {
     vi.mocked(getHostMediaAsset).mockReset();
     vi.mocked(updateHostMediaAsset).mockReset();
     vi.mocked(uploadHostMediaFile).mockReset();
-    vi.mocked(uploadHostMediaFile).mockResolvedValue({ assetId: 'uploaded-asset', uploadSessionId: 'upload-1' } as never);
+    vi.mocked(uploadHostMediaFile).mockResolvedValue({
+      assetId: 'uploaded-asset',
+      uploadSessionId: 'upload-1',
+    } as never);
     vi.unstubAllGlobals();
     registerPluginTranslationResolver((key) => {
       const labels: Record<string, string> = {
@@ -171,7 +179,8 @@ describe('PoiDetailPage', () => {
         'poi.cards.prices.entries.title': 'Preise',
         'poi.cards.prices.entries.description': 'Preisangaben',
         'poi.cards.media.entries.title': 'Medieninhalte',
-        'poi.cards.media.entries.description': 'Quellen und Metadaten der übertragenen Medien pflegen.',
+        'poi.cards.media.entries.description':
+          'Quellen und Metadaten der übertragenen Medien pflegen.',
         'poi.cards.settings.media.title': 'Bilder',
         'poi.cards.settings.media.description': 'Bilder des Ortes verwalten',
         'poi.cards.advanced.payload.title': 'Zusatzdaten',
@@ -230,8 +239,10 @@ describe('PoiDetailPage', () => {
         'poi.messages.mediaUploadFinalizing': 'Upload wird abgeschlossen.',
         'poi.messages.mediaUploadSuccess': 'Medium wurde hochgeladen und zugeordnet.',
         'poi.messages.mediaUploadError': 'Das Medium konnte nicht hochgeladen werden.',
-        'poi.messages.mediaUploadUnsupportedType': 'Nur JPG, PNG und WebP können hochgeladen werden.',
-        'poi.messages.mediaUploadUnavailableUrl': 'Für dieses Medium ist keine öffentliche URL verfügbar.',
+        'poi.messages.mediaUploadUnsupportedType':
+          'Nur JPG, PNG und WebP können hochgeladen werden.',
+        'poi.messages.mediaUploadUnavailableUrl':
+          'Für dieses Medium ist keine öffentliche URL verfügbar.',
         'poi.messages.mediaPickerTitle': 'Medium hinzufügen',
         'poi.messages.mediaPickerUseMedia': 'Medium übernehmen',
         'poi.messages.mediaPickerAssetLoadError': 'Das Medium konnte nicht geladen werden.',
@@ -293,7 +304,9 @@ describe('PoiDetailPage', () => {
       expect(screen.getByLabelText('Wochentag')).toBeTruthy();
       expect(screen.getAllByLabelText('URL').length).toBeGreaterThan(1);
       expect(screen.getByText('Medieninhalte')).toBeTruthy();
-      expect(screen.getByText('Quellen und Metadaten der übertragenen Medien pflegen.')).toBeTruthy();
+      expect(
+        screen.getByText('Quellen und Metadaten der übertragenen Medien pflegen.')
+      ).toBeTruthy();
       expect(screen.getByLabelText('Preiskategorie')).toBeTruthy();
       expect(screen.getByLabelText('Preisbeschreibung')).toBeTruthy();
       expect(screen.queryByLabelText('Medienbeschriftung')).toBeNull();
@@ -303,8 +316,12 @@ describe('PoiDetailPage', () => {
     const libraryAction = within(mediaSection as HTMLElement).getByText('Aus Mediathek auswählen');
     const uploadAction = within(mediaSection as HTMLElement).getByText('Medium hochladen');
     const manualAction = within(mediaSection as HTMLElement).getByText('Manuell hinzufügen');
-    expect(libraryAction.compareDocumentPosition(uploadAction) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(uploadAction.compareDocumentPosition(manualAction) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      libraryAction.compareDocumentPosition(uploadAction) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      uploadAction.compareDocumentPosition(manualAction) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 
   it('manages poi mediaContents in the content tab through the media library overlay', async () => {
@@ -316,7 +333,10 @@ describe('PoiDetailPage', () => {
         {
           captionText: 'Rathaus außen',
           contentType: 'image/jpeg',
-          sourceUrl: { url: 'https://cdn.example.test/rathaus-aussen.jpg', description: 'rathaus-aussen.jpg' },
+          sourceUrl: {
+            url: 'https://cdn.example.test/rathaus-aussen.jpg',
+            description: 'rathaus-aussen.jpg',
+          },
         },
       ],
     } as never);
@@ -374,7 +394,9 @@ describe('PoiDetailPage', () => {
       expect(screen.getByLabelText('Dateiname filtern')).toBeTruthy();
     });
 
-    fireEvent.change(screen.getByLabelText('Dateiname filtern'), { target: { value: 'stadtpark' } });
+    fireEvent.change(screen.getByLabelText('Dateiname filtern'), {
+      target: { value: 'stadtpark' },
+    });
     const dialog = screen.getByRole('dialog');
     expect(within(dialog).queryByText('Rathaus außen')).toBeNull();
     expect(within(dialog).getByText('Stadtpark')).toBeTruthy();
@@ -423,7 +445,7 @@ describe('PoiDetailPage', () => {
   it('renders a global save action and a history placeholder for poi', async () => {
     render(<PoiDetailPage mode="create" />);
 
-    expect(await screen.findByRole('button', { name: 'Speichern' })).toBeTruthy();
+    expect(await screen.findAllByRole('button', { name: 'Speichern' })).toHaveLength(2);
     switchSection('history');
     expect(screen.getByText('Noch keine Historie verfügbar.')).toBeTruthy();
   });
@@ -476,7 +498,7 @@ describe('PoiDetailPage', () => {
     });
     switchSection('settings');
     fireEvent.change(screen.getByLabelText('Payload'), { target: { value: '{' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).not.toHaveBeenCalled();
@@ -488,7 +510,7 @@ describe('PoiDetailPage', () => {
   it('keeps the basis tab active when the name is missing', async () => {
     render(<PoiDetailPage mode="create" />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Speichern' }));
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Speichern' }))[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).not.toHaveBeenCalled();
@@ -508,7 +530,7 @@ describe('PoiDetailPage', () => {
     const categoryInput = screen.getByLabelText('Kategorien suchen');
     fireEvent.change(categoryInput, { target: { value: 'Verwaltung' } });
     fireEvent.blur(categoryInput);
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).toHaveBeenCalledWith(
@@ -530,7 +552,7 @@ describe('PoiDetailPage', () => {
       target: { value: 'http://invalid.example' },
     });
     switchSection('basis');
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).not.toHaveBeenCalled();
@@ -543,18 +565,22 @@ describe('PoiDetailPage', () => {
 
     fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Neuer POI' } });
     switchSection('content');
-    fireEvent.change(screen.getByLabelText('Name des Betreibers'), { target: { value: 'Stadtwerke' } });
+    fireEvent.change(screen.getByLabelText('Name des Betreibers'), {
+      target: { value: 'Stadtwerke' },
+    });
     fireEvent.change(document.getElementById('poi-operator-url') as HTMLInputElement, {
       target: { value: 'http://invalid.example/operator' },
     });
     switchSection('basis');
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).not.toHaveBeenCalled();
       expect(document.activeElement).toBe(document.getElementById('poi-operator-url'));
       expect(screen.getByText('URLs müssen mit https:// beginnen.')).toBeTruthy();
-      expect(document.getElementById('poi-operator-url')?.getAttribute('aria-invalid')).toBe('true');
+      expect(document.getElementById('poi-operator-url')?.getAttribute('aria-invalid')).toBe(
+        'true'
+      );
     });
   });
 
@@ -567,7 +593,7 @@ describe('PoiDetailPage', () => {
       target: { value: 'http://invalid.example/contact' },
     });
     switchSection('basis');
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).not.toHaveBeenCalled();
@@ -587,7 +613,7 @@ describe('PoiDetailPage', () => {
       target: { value: 'http://invalid.example/media.jpg' },
     });
     switchSection('basis');
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).not.toHaveBeenCalled();
@@ -615,7 +641,7 @@ describe('PoiDetailPage', () => {
     });
 
     switchSection('content');
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(updatePoi)).not.toHaveBeenCalled();
@@ -630,7 +656,9 @@ describe('PoiDetailPage', () => {
 
     fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Neuer POI' } });
     switchSection('content');
-    fireEvent.change(screen.getByLabelText('Name des Betreibers'), { target: { value: 'Stadtwerke' } });
+    fireEvent.change(screen.getByLabelText('Name des Betreibers'), {
+      target: { value: 'Stadtwerke' },
+    });
     fireEvent.change(document.getElementById('poi-operator-latitude') as HTMLInputElement, {
       target: { value: '91' },
     });
@@ -638,14 +666,20 @@ describe('PoiDetailPage', () => {
       target: { value: '13' },
     });
     switchSection('basis');
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).not.toHaveBeenCalled();
       expect(document.activeElement).toBe(document.getElementById('poi-operator-latitude'));
-      expect(screen.getAllByText('Koordinaten müssen gültige Breiten- und Längengrade sein.')).toHaveLength(2);
-      expect(document.getElementById('poi-operator-latitude')?.getAttribute('aria-invalid')).toBe('true');
-      expect(document.getElementById('poi-operator-longitude')?.getAttribute('aria-invalid')).toBe('true');
+      expect(
+        screen.getAllByText('Koordinaten müssen gültige Breiten- und Längengrade sein.')
+      ).toHaveLength(2);
+      expect(document.getElementById('poi-operator-latitude')?.getAttribute('aria-invalid')).toBe(
+        'true'
+      );
+      expect(document.getElementById('poi-operator-longitude')?.getAttribute('aria-invalid')).toBe(
+        'true'
+      );
     });
   });
 
@@ -707,7 +741,10 @@ describe('PoiDetailPage', () => {
         {
           captionText: 'Rathaus außen',
           contentType: 'image/jpeg',
-          sourceUrl: { url: 'https://cdn.example.test/rathaus-aussen.jpg', description: 'rathaus-aussen.jpg' },
+          sourceUrl: {
+            url: 'https://cdn.example.test/rathaus-aussen.jpg',
+            description: 'rathaus-aussen.jpg',
+          },
         },
       ],
       payload: { source: 'test' },
@@ -723,7 +760,7 @@ describe('PoiDetailPage', () => {
       expect(screen.getByDisplayValue('Rathaus')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(updatePoi)).toHaveBeenCalledWith(
@@ -771,7 +808,7 @@ describe('PoiDetailPage', () => {
       expect(screen.getByDisplayValue('service,amt')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(updatePoi)).toHaveBeenCalledWith(
@@ -853,7 +890,7 @@ describe('PoiDetailPage', () => {
       expect(screen.queryByRole('dialog')).toBeNull();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(updatePoi)).toHaveBeenCalledWith(
@@ -899,10 +936,13 @@ describe('PoiDetailPage', () => {
       expect(screen.getByRole('button', { name: 'Entfernen' })).toBeTruthy();
     });
     fireEvent.click(screen.getByRole('button', { name: 'Entfernen' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
-      expect(vi.mocked(updatePoi)).toHaveBeenCalledWith('poi-1', expect.objectContaining({ mediaContents: [] }));
+      expect(vi.mocked(updatePoi)).toHaveBeenCalledWith(
+        'poi-1',
+        expect.objectContaining({ mediaContents: [] })
+      );
     });
   });
 
@@ -915,11 +955,14 @@ describe('PoiDetailPage', () => {
     render(<PoiDetailPage mode="create" />);
 
     fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Neuer POI' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).toHaveBeenCalledTimes(1);
-      expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/poi/$id', params: { id: 'poi-created' } });
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/admin/poi/$id',
+        params: { id: 'poi-created' },
+      });
     });
   });
 
@@ -968,7 +1011,7 @@ describe('PoiDetailPage', () => {
       expect(screen.getByDisplayValue('https://cdn.example.test/rathaus-aussen.jpg')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).toHaveBeenCalledWith(
@@ -1017,7 +1060,9 @@ describe('PoiDetailPage', () => {
     fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Neuer POI' } });
     switchSection('content');
     fireEvent.click(screen.getByRole('button', { name: 'Medium hochladen' }));
-    fireEvent.change(screen.getByTestId('media-upload-input'), { target: { files: [uploadedFile] } });
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [uploadedFile] },
+    });
 
     await waitFor(() => {
       expect(vi.mocked(uploadHostMediaFile)).toHaveBeenCalledWith({
@@ -1036,7 +1081,7 @@ describe('PoiDetailPage', () => {
       expect(screen.getByDisplayValue('https://cdn.example.test/upload-rathaus.webp')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(vi.mocked(createPoi)).toHaveBeenCalledWith(
@@ -1090,7 +1135,9 @@ describe('PoiDetailPage', () => {
     fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Neuer POI' } });
     switchSection('content');
     fireEvent.click(screen.getByRole('button', { name: 'Medium hochladen' }));
-    fireEvent.change(screen.getByTestId('media-upload-input'), { target: { files: [uploadedFile] } });
+    fireEvent.change(screen.getByTestId('media-upload-input'), {
+      target: { files: [uploadedFile] },
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Das Medium konnte nicht geladen werden.')).toBeTruthy();
@@ -1114,7 +1161,7 @@ describe('PoiDetailPage', () => {
     render(<PoiDetailPage mode="create" />);
 
     fireEvent.change(await screen.findByLabelText('Name'), { target: { value: 'Neuer POI' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(screen.getByText('poi.messages.saveError')).toBeTruthy();
@@ -1127,7 +1174,10 @@ describe('PoiDetailPage', () => {
       name: 'Rathaus',
       payload: {},
     } as never);
-    vi.stubGlobal('confirm', vi.fn(() => false));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => false)
+    );
 
     render(<PoiDetailPage mode="edit" contentId="poi-1" />);
 
@@ -1148,7 +1198,10 @@ describe('PoiDetailPage', () => {
       payload: {},
     } as never);
     vi.mocked(deletePoi).mockRejectedValueOnce(new Error('delete boom'));
-    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true)
+    );
 
     render(<PoiDetailPage mode="edit" contentId="poi-1" />);
 
@@ -1170,7 +1223,10 @@ describe('PoiDetailPage', () => {
       name: 'Rathaus',
       payload: {},
     } as never);
-    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true)
+    );
 
     render(<PoiDetailPage mode="edit" contentId="poi-1" />);
 

--- a/packages/plugin-poi/tests/poi.pages.test.tsx
+++ b/packages/plugin-poi/tests/poi.pages.test.tsx
@@ -11,7 +11,8 @@ import { createPoi, getPoi, listPoi, listPoiCategories, updatePoi } from '../src
 import { PoiCreatePage, PoiEditPage, PoiListPage } from '../src/poi.pages.js';
 
 vi.mock('@sva/studio-ui-react', async () => {
-  const actual = await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
+  const actual =
+    await vi.importActual<typeof import('@sva/studio-ui-react')>('@sva/studio-ui-react');
   return {
     ...actual,
     RichTextHtmlEditor: ({
@@ -50,7 +51,9 @@ vi.mock('../src/poi.api.js', () => ({
     addresses: [{ street: 'Markt 2', city: 'Musterhausen' }],
     webUrls: [{ url: 'https://example.com/poi' }],
     openingHours: [{ weekday: 'Montag', timeFrom: '09:00' }],
-    mediaContents: [{ captionText: 'Bibliothek', sourceUrl: { url: 'https://example.com/poi/library.jpg' } }],
+    mediaContents: [
+      { captionText: 'Bibliothek', sourceUrl: { url: 'https://example.com/poi/library.jpg' } },
+    ],
     payload: { source: 'legacy' },
   })),
   listPoiCategories: vi.fn(async () => []),
@@ -132,7 +135,10 @@ describe('PoiListPage', () => {
   const getEditableNameInput = () =>
     screen
       .getAllByLabelText('Name')
-      .find((element): element is HTMLInputElement => element instanceof HTMLInputElement && element.readOnly === false);
+      .find(
+        (element): element is HTMLInputElement =>
+          element instanceof HTMLInputElement && element.readOnly === false
+      );
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -225,7 +231,8 @@ describe('PoiListPage', () => {
         'poi.cards.advanced.payload.title': 'Zusatzdaten',
         'poi.cards.advanced.payload.description': 'Zusätzliche Mainserver-Daten als JSON.',
         'poi.history.empty.title': 'Noch keine Historie verfügbar.',
-        'poi.history.empty.description': 'Historienereignisse für Orte werden in einem späteren Schritt angebunden.',
+        'poi.history.empty.description':
+          'Historienereignisse für Orte werden in einem späteren Schritt angebunden.',
         'poi.editor.createTitle': 'Ort anlegen',
         'poi.editor.createDescription': 'Erstellen Sie einen neuen Ort.',
         'poi.editor.editTitle': 'Ort bearbeiten',
@@ -338,7 +345,7 @@ describe('PoiListPage', () => {
       expect(screen.queryByRole('dialog')).toBeNull();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(createPoi).toHaveBeenCalledWith(
@@ -360,7 +367,10 @@ describe('PoiListPage', () => {
           ],
         })
       );
-      expect(navigateMock).toHaveBeenCalledWith({ to: '/admin/poi/$id', params: { id: 'poi-created' } });
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/admin/poi/$id',
+        params: { id: 'poi-created' },
+      });
     });
   }, 10_000);
 
@@ -383,8 +393,10 @@ describe('PoiListPage', () => {
     });
     const nameInput = getEditableNameInput();
     expect(nameInput).toBeTruthy();
-    fireEvent.change(nameInput as HTMLInputElement, { target: { value: 'Aktualisierte Stadtbibliothek' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.change(nameInput as HTMLInputElement, {
+      target: { value: 'Aktualisierte Stadtbibliothek' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(updatePoi).toHaveBeenCalledWith(
@@ -408,7 +420,7 @@ describe('PoiListPage', () => {
       expect(screen.getByDisplayValue('Stadtbibliothek')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(screen.getByText('Der Ort wurde aktualisiert.')).toBeTruthy();
@@ -421,7 +433,7 @@ describe('PoiListPage', () => {
     fireEvent.change(document.getElementById('poi-link-url-0') as HTMLInputElement, {
       target: { value: 'http://invalid.example' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Speichern' })[1]!);
 
     await waitFor(() => {
       expect(screen.queryByText('Der Ort wurde aktualisiert.')).toBeNull();

--- a/packages/plugin-surveys/src/surveys.editor.actions.tsx
+++ b/packages/plugin-surveys/src/surveys.editor.actions.tsx
@@ -4,6 +4,20 @@ import { Button } from '@sva/studio-ui-react';
 import { type SurveyEditorMode } from './surveys.editor.shared.js';
 
 export function SurveyEditorActions({
+  pt,
+}: Readonly<{
+  pt: (key: string) => string;
+}>) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button asChild variant="outline">
+        <Link to="/admin/content">{pt('actions.back')}</Link>
+      </Button>
+    </div>
+  );
+}
+
+export function SurveyEditorPrimaryAction({
   mode,
   formId,
   pt,
@@ -13,13 +27,8 @@ export function SurveyEditorActions({
   pt: (key: string) => string;
 }>) {
   return (
-    <div className="flex flex-wrap gap-2">
-      <Button asChild variant="outline">
-        <Link to="/admin/content">{pt('actions.back')}</Link>
-      </Button>
-      <Button type="submit" form={formId}>
-        {pt(mode === 'create' ? 'actions.create' : 'actions.update')}
-      </Button>
-    </div>
+    <Button type="submit" form={formId}>
+      {pt(mode === 'create' ? 'actions.create' : 'actions.update')}
+    </Button>
   );
 }

--- a/packages/plugin-surveys/src/surveys.editor.tsx
+++ b/packages/plugin-surveys/src/surveys.editor.tsx
@@ -2,10 +2,18 @@ import React from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { FormProvider, useForm } from 'react-hook-form';
 import { usePluginTranslation } from '@sva/plugin-sdk';
-import { StudioDetailPageTemplate, StudioDetailTabs, StudioFormSummary, StudioLoadingState } from '@sva/studio-ui-react';
+import {
+  StudioDetailPageTemplate,
+  StudioDetailTabs,
+  StudioFormSummary,
+  StudioLoadingState,
+} from '@sva/studio-ui-react';
 
-import { createDefaultSurveyDetailFormValues, type SurveyDetailFormValues } from './surveys.detail-form.js';
-import { SurveyEditorActions } from './surveys.editor.actions.js';
+import {
+  createDefaultSurveyDetailFormValues,
+  type SurveyDetailFormValues,
+} from './surveys.detail-form.js';
+import { SurveyEditorActions, SurveyEditorPrimaryAction } from './surveys.editor.actions.js';
 import { useSurveyEditorController } from './surveys.editor-logic.js';
 import {
   createSurveyEditorTabs,
@@ -22,7 +30,9 @@ export const SurveyEditorPage = ({
   const pt = usePluginTranslation('surveys');
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = React.useState<SurveyEditorTabId>('basis');
-  const methods = useForm<SurveyDetailFormValues>({ defaultValues: createDefaultSurveyDetailFormValues() });
+  const methods = useForm<SurveyDetailFormValues>({
+    defaultValues: createDefaultSurveyDetailFormValues(),
+  });
   const { isLoading, loadedItem, status, submit } = useSurveyEditorController({
     mode,
     contentId,
@@ -30,7 +40,10 @@ export const SurveyEditorPage = ({
     pt,
     navigateToContentList: () => navigate({ to: '/admin/content' }),
   });
-  const tabs = React.useMemo(() => createSurveyEditorTabs(pt, mode, loadedItem, contentId), [contentId, loadedItem, mode, pt]);
+  const tabs = React.useMemo(
+    () => createSurveyEditorTabs(pt, mode, loadedItem, contentId),
+    [contentId, loadedItem, mode, pt]
+  );
 
   if (isLoading) {
     return <StudioLoadingState>{pt('messages.editorLoading')}</StudioLoadingState>;
@@ -40,7 +53,8 @@ export const SurveyEditorPage = ({
     <StudioDetailPageTemplate
       title={pt(mode === 'create' ? 'pages.createTitle' : 'pages.editTitle')}
       description={pt(mode === 'create' ? 'pages.createDescription' : 'pages.editDescription')}
-      actions={<SurveyEditorActions mode={mode} formId={formId} pt={pt} />}
+      actions={<SurveyEditorActions pt={pt} />}
+      primaryAction={<SurveyEditorPrimaryAction mode={mode} formId={formId} pt={pt} />}
     >
       <FormProvider {...methods}>
         <form
@@ -52,7 +66,13 @@ export const SurveyEditorPage = ({
           className="space-y-5"
         >
           {status ? <StudioFormSummary kind={status.kind}>{status.text}</StudioFormSummary> : null}
-          <StudioDetailTabs ariaLabel={pt('tabs.ariaLabel')} tabs={tabs} value={activeTab} onValueChange={setActiveTab} keepMounted />
+          <StudioDetailTabs
+            ariaLabel={pt('tabs.ariaLabel')}
+            tabs={tabs}
+            value={activeTab}
+            onValueChange={setActiveTab}
+            keepMounted
+          />
         </form>
       </FormProvider>
     </StudioDetailPageTemplate>

--- a/packages/studio-ui-react/src/index.ts
+++ b/packages/studio-ui-react/src/index.ts
@@ -40,9 +40,17 @@ export {
   type MediaReferenceFieldOption,
   type MediaReferenceFieldProps,
 } from './media-reference-field.js';
-export { MediaIntakePanel, type MediaIntakePanelPhase, type MediaIntakePanelProps } from './media-intake-panel.js';
+export {
+  MediaIntakePanel,
+  type MediaIntakePanelPhase,
+  type MediaIntakePanelProps,
+} from './media-intake-panel.js';
 export { Select } from './select.js';
-export { StudioFormSummaryErrors, getStudioFieldError, getStudioFormFieldProps } from './studio-form-bridge.js';
+export {
+  StudioFormSummaryErrors,
+  getStudioFieldError,
+  getStudioFormFieldProps,
+} from './studio-form-bridge.js';
 export type {
   GetStudioFormFieldPropsOptions,
   StudioFormFieldBindings,
@@ -64,6 +72,7 @@ export {
   StudioErrorState,
   StudioField,
   StudioFieldGroup,
+  StudioFormActionBar,
   StudioFormSummary,
   StudioJobSummaryCard,
   StudioLoadingState,
@@ -77,6 +86,7 @@ export {
   type StudioFieldGroupProps,
   type StudioFieldControlProps,
   type StudioFieldProps,
+  type StudioFormActionBarProps,
   type StudioFormSummaryProps,
   type StudioJobSummaryCardProps,
   type StudioListPageAction,

--- a/packages/studio-ui-react/src/studio-primitives.test.tsx
+++ b/packages/studio-ui-react/src/studio-primitives.test.tsx
@@ -36,6 +36,7 @@ import {
   StudioField,
   type StudioFieldControlProps,
   StudioFieldGroup,
+  StudioFormActionBar,
   StudioFormSummary,
   StudioJobSummaryCard,
   StudioListPageTemplate,
@@ -65,7 +66,12 @@ describe('studio-ui-react primitives', () => {
 
   it('renders overview pages with header, action and content regions', () => {
     render(
-      <StudioOverviewPageTemplate title="News" description="Verwalten" primaryAction={<button type="button">Anlegen</button>} toolbar={<span>Werkzeuge</span>}>
+      <StudioOverviewPageTemplate
+        title="News"
+        description="Verwalten"
+        primaryAction={<button type="button">Anlegen</button>}
+        toolbar={<span>Werkzeuge</span>}
+      >
         <p>Inhalt</p>
       </StudioOverviewPageTemplate>
     );
@@ -108,9 +114,13 @@ describe('studio-ui-react primitives', () => {
       />
     );
 
-    expect(screen.getByRole('tab', { name: 'Abholorte' }).getAttribute('data-state')).toBe('active');
+    expect(screen.getByRole('tab', { name: 'Abholorte' }).getAttribute('data-state')).toBe(
+      'active'
+    );
     expect(screen.getByText('Abholorte-Inhalt')).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'Ausweichtermine' }).getAttribute('data-state')).toBe('inactive');
+    expect(screen.getByRole('tab', { name: 'Ausweichtermine' }).getAttribute('data-state')).toBe(
+      'inactive'
+    );
   });
 
   it('renders tab lists with an explicit accessible name when the title is not a plain string', () => {
@@ -167,7 +177,11 @@ describe('studio-ui-react primitives', () => {
 
   it('renders detail pages, grouped fields and form summaries', () => {
     render(
-      <StudioDetailPageTemplate title="Detail" description="Beschreibung" actions={<Button>Speichern</Button>}>
+      <StudioDetailPageTemplate
+        title="Detail"
+        description="Beschreibung"
+        actions={<Button>Speichern</Button>}
+      >
         <StudioFieldGroup columns={2}>
           <StudioField id="summary-title" label="Titel">
             <Input id="summary-title" />
@@ -187,6 +201,40 @@ describe('studio-ui-react primitives', () => {
     expect(screen.getByLabelText('Text')).toBeTruthy();
     expect(screen.getByText('Gespeichert')).toBeTruthy();
     expect(screen.getByText('Fehler')).toBeTruthy();
+  });
+
+  it('renders the same detail-page primary action in the header and after the content', () => {
+    render(
+      <StudioDetailPageTemplate
+        title="Langer Editor"
+        actions={<Button variant="outline">Zurück</Button>}
+        primaryAction={<Button disabled>Speichern</Button>}
+      >
+        <p>Editorinhalt</p>
+      </StudioDetailPageTemplate>
+    );
+
+    expect(screen.getByRole('button', { name: 'Zurück' })).toBeTruthy();
+    const saveActions = screen.getAllByRole('button', { name: 'Speichern' });
+    expect(saveActions).toHaveLength(2);
+    expect(saveActions.every((action) => (action as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  it('renders form action bars at the requested boundary positions', () => {
+    render(
+      <div>
+        <StudioFormActionBar position="start">
+          <Button>Oben speichern</Button>
+        </StudioFormActionBar>
+        <p>Bearbeitungsfläche</p>
+        <StudioFormActionBar>
+          <Button>Unten speichern</Button>
+        </StudioFormActionBar>
+      </div>
+    );
+
+    expect(screen.getByRole('button', { name: 'Oben speichern' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Unten speichern' })).toBeTruthy();
   });
 
   it('keeps field label, description and error relationships explicit', () => {
@@ -219,7 +267,13 @@ describe('studio-ui-react primitives', () => {
     };
 
     render(
-      <StudioField id="title" label="Titel" description="Pflichtfeld" error="Titel fehlt" controlProps={controlProps}>
+      <StudioField
+        id="title"
+        label="Titel"
+        description="Pflichtfeld"
+        error="Titel fehlt"
+        controlProps={controlProps}
+      >
         <Input {...controlProps} aria-describedby="hint-extra" />
       </StudioField>
     );
@@ -269,7 +323,10 @@ describe('studio-ui-react primitives', () => {
         label="Titel"
         description="Pflichtfeld"
         error="Titel fehlt"
-        controlProps={{ id: 'resolved-id', 'aria-describedby': 'resolved-id-description resolved-id-error' }}
+        controlProps={{
+          id: 'resolved-id',
+          'aria-describedby': 'resolved-id-description resolved-id-error',
+        }}
       >
         <Input id="base-id" />
       </StudioField>
@@ -281,11 +338,7 @@ describe('studio-ui-react primitives', () => {
 
   it('keeps label htmlFor on base id when children cannot be cloned', () => {
     render(
-      <StudioField
-        id="fallback-id"
-        label="Titel"
-        controlProps={{ id: 'overridden-id' }}
-      >
+      <StudioField id="fallback-id" label="Titel" controlProps={{ id: 'overridden-id' }}>
         {'plain-text-child'}
       </StudioField>
     );
@@ -366,7 +419,11 @@ describe('studio-ui-react primitives', () => {
             items={[
               { id: 'save', label: 'Speichern', onSelect },
               { id: 'disabled', label: 'Gesperrt', disabled: true, onSelect },
-              { id: 'custom', label: 'Custom', render: <button type="button">Eigene Aktion</button> },
+              {
+                id: 'custom',
+                label: 'Custom',
+                render: <button type="button">Eigene Aktion</button>,
+              },
             ]}
           />
         </StudioEditSurface>
@@ -397,14 +454,30 @@ describe('studio-ui-react primitives', () => {
         labels={tableLabels}
         data={data}
         getRowId={(row) => row.id}
-        columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title, sortable: true, sortValue: (row) => row.title }]}
+        columns={[
+          {
+            id: 'title',
+            header: 'Titel',
+            cell: (row) => row.title,
+            sortable: true,
+            sortValue: (row) => row.title,
+          },
+        ]}
         emptyState={<p>Keine Daten</p>}
-        bulkActions={[{ id: 'archive', label: 'Archivieren', onClick: ({ selectedRows }) => onBulk(selectedRows) }]}
+        bulkActions={[
+          {
+            id: 'archive',
+            label: 'Archivieren',
+            onClick: ({ selectedRows }) => onBulk(selectedRows),
+          },
+        ]}
       />
     );
 
     fireEvent.click(screen.getByLabelText('News a auswählen'));
-    expect((screen.getByLabelText('Alle News auswählen') as HTMLInputElement).indeterminate).toBe(true);
+    expect((screen.getByLabelText('Alle News auswählen') as HTMLInputElement).indeterminate).toBe(
+      true
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Archivieren' }));
 
     expect(screen.getAllByText('Alpha')).toHaveLength(2);
@@ -428,13 +501,21 @@ describe('studio-ui-react primitives', () => {
         columns={[{ id: 'title', header: 'Titel', cell: (row) => row.title }]}
         emptyState={<p>Keine Daten</p>}
         canSelectRow={(row) => row.selectable}
-        bulkActions={[{ id: 'delete', label: 'Löschen', onClick: ({ selectedRows }) => onBulk(selectedRows) }]}
+        bulkActions={[
+          { id: 'delete', label: 'Löschen', onClick: ({ selectedRows }) => onBulk(selectedRows) },
+        ]}
       />
     );
 
-    const holidayCheckbox = screen.getByLabelText('Ausweichtermine holiday-1 auswählen') as HTMLInputElement;
-    const globalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
-    const tourCheckbox = screen.getByLabelText('Ausweichtermine tour-1 auswählen') as HTMLInputElement;
+    const holidayCheckbox = screen.getByLabelText(
+      'Ausweichtermine holiday-1 auswählen'
+    ) as HTMLInputElement;
+    const globalCheckbox = screen.getByLabelText(
+      'Ausweichtermine global-1 auswählen'
+    ) as HTMLInputElement;
+    const tourCheckbox = screen.getByLabelText(
+      'Ausweichtermine tour-1 auswählen'
+    ) as HTMLInputElement;
 
     expect(holidayCheckbox.disabled).toBe(true);
     expect(globalCheckbox.disabled).toBe(false);
@@ -471,7 +552,9 @@ describe('studio-ui-react primitives', () => {
       />
     );
 
-    const globalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
+    const globalCheckbox = screen.getByLabelText(
+      'Ausweichtermine global-1 auswählen'
+    ) as HTMLInputElement;
     fireEvent.click(globalCheckbox);
     expect(globalCheckbox.checked).toBe(true);
 
@@ -486,7 +569,9 @@ describe('studio-ui-react primitives', () => {
       />
     );
 
-    expect((screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement).checked).toBe(true);
+    expect(
+      (screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement).checked
+    ).toBe(true);
   });
 
   it('prunes selected rows when an unchanged row id becomes non-selectable', () => {
@@ -507,7 +592,9 @@ describe('studio-ui-react primitives', () => {
       />
     );
 
-    const globalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
+    const globalCheckbox = screen.getByLabelText(
+      'Ausweichtermine global-1 auswählen'
+    ) as HTMLInputElement;
     fireEvent.click(globalCheckbox);
     expect(globalCheckbox.checked).toBe(true);
 
@@ -526,7 +613,9 @@ describe('studio-ui-react primitives', () => {
       />
     );
 
-    const updatedGlobalCheckbox = screen.getByLabelText('Ausweichtermine global-1 auswählen') as HTMLInputElement;
+    const updatedGlobalCheckbox = screen.getByLabelText(
+      'Ausweichtermine global-1 auswählen'
+    ) as HTMLInputElement;
     expect(updatedGlobalCheckbox.checked).toBe(false);
     expect(updatedGlobalCheckbox.disabled).toBe(true);
   });
@@ -566,7 +655,12 @@ describe('studio-ui-react primitives', () => {
         footer={<span>Seitenfuß</span>}
         rowActions={(row) => <Button>Öffnen {row.title}</Button>}
         bulkActions={[
-          { id: 'custom', label: 'Custom', render: <button type="button">Sonderaktion</button>, onClick: vi.fn() },
+          {
+            id: 'custom',
+            label: 'Custom',
+            render: <button type="button">Sonderaktion</button>,
+            onClick: vi.fn(),
+          },
           {
             id: 'archive',
             label: 'Archivieren',
@@ -600,7 +694,9 @@ describe('studio-ui-react primitives', () => {
     expect(screen.getByRole('button', { name: 'Archivieren' }).hasAttribute('disabled')).toBe(true);
     const table = screen.getByRole('table', { name: 'News' });
     const footer = screen.getByText('Seitenfuß');
-    expect(Boolean(table.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(table.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(
+      true
+    );
   });
 
   it('keeps desktop table rows height-stable on hover', () => {
@@ -738,7 +834,10 @@ describe('studio-ui-react primitives', () => {
       constructor(private readonly callback: ResizeObserverCallback) {}
 
       observe() {
-        this.callback([{ contentRect: { width: 320 } as DOMRectReadOnly }] as ResizeObserverEntry[], this as ResizeObserver);
+        this.callback(
+          [{ contentRect: { width: 320 } as DOMRectReadOnly }] as ResizeObserverEntry[],
+          this as ResizeObserver
+        );
       }
 
       unobserve = vi.fn();
@@ -759,7 +858,9 @@ describe('studio-ui-react primitives', () => {
       );
 
       fireEvent.click(screen.getByLabelText('News a in Kartenansicht auswählen'));
-      expect((screen.getByLabelText('News a in Kartenansicht auswählen') as HTMLInputElement).checked).toBe(true);
+      expect(
+        (screen.getByLabelText('News a in Kartenansicht auswählen') as HTMLInputElement).checked
+      ).toBe(true);
       unmount();
     } finally {
       globalThis.ResizeObserver = originalResizeObserver;
@@ -776,7 +877,10 @@ describe('studio-ui-react primitives', () => {
       constructor(private readonly callback: ResizeObserverCallback) {}
 
       observe() {
-        this.callback([{ contentRect: { width: 320 } as DOMRectReadOnly }] as ResizeObserverEntry[], this as ResizeObserver);
+        this.callback(
+          [{ contentRect: { width: 320 } as DOMRectReadOnly }] as ResizeObserverEntry[],
+          this as ResizeObserver
+        );
       }
 
       unobserve = vi.fn();
@@ -800,8 +904,20 @@ describe('studio-ui-react primitives', () => {
         />
       );
 
-      expect((screen.getByLabelText('Ausweichtermine holiday-1 in Kartenansicht auswählen') as HTMLInputElement).disabled).toBe(true);
-      expect((screen.getByLabelText('Ausweichtermine tour-1 in Kartenansicht auswählen') as HTMLInputElement).disabled).toBe(false);
+      expect(
+        (
+          screen.getByLabelText(
+            'Ausweichtermine holiday-1 in Kartenansicht auswählen'
+          ) as HTMLInputElement
+        ).disabled
+      ).toBe(true);
+      expect(
+        (
+          screen.getByLabelText(
+            'Ausweichtermine tour-1 in Kartenansicht auswählen'
+          ) as HTMLInputElement
+        ).disabled
+      ).toBe(false);
       unmount();
     } finally {
       globalThis.ResizeObserver = originalResizeObserver;
@@ -839,7 +955,9 @@ describe('studio-ui-react primitives', () => {
       </>
     );
 
-    expect(callbackRef).toHaveBeenCalledWith(screen.getByRole('checkbox', { name: 'Callback-Checkbox' }));
+    expect(callbackRef).toHaveBeenCalledWith(
+      screen.getByRole('checkbox', { name: 'Callback-Checkbox' })
+    );
     expect(objectRef.current).toBe(screen.getByRole('checkbox', { name: 'Objekt-Checkbox' }));
     expect(objectRef.current?.indeterminate).toBe(true);
   });
@@ -943,7 +1061,14 @@ describe('studio-ui-react primitives', () => {
   it('renders optional primitive variants without auxiliary content', () => {
     render(
       <>
-        <StudioOverviewPageTemplate title="Minimal" primaryAction={<Button asChild><a href="/new">Neu</a></Button>}>
+        <StudioOverviewPageTemplate
+          title="Minimal"
+          primaryAction={
+            <Button asChild>
+              <a href="/new">Neu</a>
+            </Button>
+          }
+        >
           <p>Minimaler Inhalt</p>
         </StudioOverviewPageTemplate>
         <StudioDetailPageTemplate title="Detail minimal">
@@ -964,7 +1089,9 @@ describe('studio-ui-react primitives', () => {
           <AlertTitle>Titel</AlertTitle>
           <AlertDescription>Beschreibung</AlertDescription>
         </Alert>
-        <Button variant="destructive" size="sm">Löschen</Button>
+        <Button variant="destructive" size="sm">
+          Löschen
+        </Button>
       </>
     );
 

--- a/packages/studio-ui-react/src/studio-primitives.tsx
+++ b/packages/studio-ui-react/src/studio-primitives.tsx
@@ -23,14 +23,24 @@ export type StudioPageHeaderProps = Readonly<{
   className?: string;
 }>;
 
-export function StudioPageHeader({ title, titleId, description, actions, className }: StudioPageHeaderProps) {
+export function StudioPageHeader({
+  title,
+  titleId,
+  description,
+  actions,
+  className,
+}: StudioPageHeaderProps) {
   return (
-    <header className={cn('flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between', className)}>
+    <header
+      className={cn('flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between', className)}
+    >
       <div className="space-y-2">
         <h1 id={titleId} className="text-3xl font-semibold text-foreground">
           {title}
         </h1>
-        {description ? <p className="max-w-3xl text-sm text-muted-foreground">{description}</p> : null}
+        {description ? (
+          <p className="max-w-3xl text-sm text-muted-foreground">{description}</p>
+        ) : null}
       </div>
       {actions ? <div className="flex shrink-0 items-start gap-2">{actions}</div> : null}
     </header>
@@ -98,7 +108,12 @@ const renderStudioListPageAction = (action: StudioListPageAction) => {
   }
 
   return (
-    <Button type="button" onClick={action.onClick} disabled={action.disabled} variant={action.variant ?? 'default'}>
+    <Button
+      type="button"
+      onClick={action.onClick}
+      disabled={action.disabled}
+      variant={action.variant ?? 'default'}
+    >
       {action.icon}
       {action.label}
     </Button>
@@ -142,7 +157,9 @@ export function StudioListPageTemplate({
           </TabsList>
           {tabs.map((tab) => (
             <TabsContent key={tab.id} value={tab.id} className="space-y-3">
-              {tab.description ? <p className="text-sm text-muted-foreground">{tab.description}</p> : null}
+              {tab.description ? (
+                <p className="text-sm text-muted-foreground">{tab.description}</p>
+              ) : null}
               {tab.content}
             </TabsContent>
           ))}
@@ -158,21 +175,56 @@ export type StudioDetailPageTemplateProps = Readonly<{
   title: React.ReactNode;
   description?: React.ReactNode;
   actions?: React.ReactNode;
+  primaryAction?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
 }>;
+
+export type StudioFormActionBarProps = Readonly<{
+  children: React.ReactNode;
+  position?: 'start' | 'end';
+  className?: string;
+}>;
+
+export function StudioFormActionBar({
+  children,
+  position = 'end',
+  className,
+}: StudioFormActionBarProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center justify-end gap-3 border-border/60',
+        position === 'start' ? 'border-b pb-4' : 'border-t pt-4',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
 
 export function StudioDetailPageTemplate({
   title,
   description,
   actions,
+  primaryAction,
   children,
   className,
 }: StudioDetailPageTemplateProps) {
+  const headerActions =
+    actions || primaryAction ? (
+      <>
+        {actions}
+        {primaryAction}
+      </>
+    ) : undefined;
+
   return (
     <section className={cn('space-y-6', className)}>
-      <StudioPageHeader title={title} description={description} actions={actions} />
+      <StudioPageHeader title={title} description={description} actions={headerActions} />
       <div className="space-y-5">{children}</div>
+      {primaryAction ? <StudioFormActionBar>{primaryAction}</StudioFormActionBar> : null}
     </section>
   );
 }
@@ -197,7 +249,9 @@ export type StudioFieldControlProps = Readonly<{
 }>;
 
 const mergeDescribedBy = (currentValue: string | undefined, nextValue: string | undefined) => {
-  const tokens = [...(currentValue?.split(/\s+/) ?? []), ...(nextValue?.split(/\s+/) ?? [])].filter(Boolean);
+  const tokens = [...(currentValue?.split(/\s+/) ?? []), ...(nextValue?.split(/\s+/) ?? [])].filter(
+    Boolean
+  );
   return tokens.length > 0 ? Array.from(new Set(tokens)).join(' ') : undefined;
 };
 
@@ -289,7 +343,11 @@ export type StudioFieldGroupProps = Readonly<{
 }>;
 
 export function StudioFieldGroup({ children, columns = 1, className }: StudioFieldGroupProps) {
-  return <div className={cn(columns === 2 ? 'grid gap-4 md:grid-cols-2' : 'grid gap-4', className)}>{children}</div>;
+  return (
+    <div className={cn(columns === 2 ? 'grid gap-4 md:grid-cols-2' : 'grid gap-4', className)}>
+      {children}
+    </div>
+  );
 }
 
 export type StudioFormSummaryProps = Readonly<{
@@ -360,12 +418,13 @@ export function StudioConfirmDialog({
 
 export type StudioTechnicalStatusTone = 'neutral' | 'success' | 'warning' | 'error';
 
-const technicalStatusBadgeVariantByTone: Record<StudioTechnicalStatusTone, BadgeProps['variant']> = {
-  neutral: 'outline',
-  success: 'default',
-  warning: 'secondary',
-  error: 'destructive',
-};
+const technicalStatusBadgeVariantByTone: Record<StudioTechnicalStatusTone, BadgeProps['variant']> =
+  {
+    neutral: 'outline',
+    success: 'default',
+    warning: 'secondary',
+    error: 'destructive',
+  };
 
 export type StudioTechnicalStatusMetaItem = Readonly<{
   id: string;
@@ -409,7 +468,9 @@ const StudioStatusCardBody = ({
         ))}
       </div>
     ) : null}
-    {!metadata?.length && emptyState ? <div className="text-sm text-muted-foreground">{emptyState}</div> : null}
+    {!metadata?.length && emptyState ? (
+      <div className="text-sm text-muted-foreground">{emptyState}</div>
+    ) : null}
     {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
   </>
 );
@@ -501,7 +562,11 @@ export function StudioStateBlock({
   const ariaLive = role === 'alert' ? 'assertive' : role === 'status' ? 'polite' : undefined;
 
   return (
-    <div role={role} aria-live={ariaLive} className={cn('rounded-lg border border-border bg-card p-6', className)}>
+    <div
+      role={role}
+      aria-live={ariaLive}
+      className={cn('rounded-lg border border-border bg-card p-6', className)}
+    >
       {title ? <h2 className="text-lg font-medium text-foreground">{title}</h2> : null}
       {description ? <p className="mt-2 text-sm text-muted-foreground">{description}</p> : null}
       {children ? <div className="mt-4">{children}</div> : null}


### PR DESCRIPTION
## Zusammenfassung

- führt `StudioDetailPageTemplate.primaryAction` und `StudioFormActionBar` als gemeinsames Pattern für lange Bearbeitungsflächen ein
- zeigt die globale Speichern-/Anlegen-Aktion oben und unten in News, Events, FAQ, POI, Umfragen, generischen Inhalten und dem Kern-Inhaltseditor
- überträgt das Pattern auf Benutzerbearbeitung, Rollenberechtigungen sowie Rechtstext-Neuanlage und -Bearbeitung
- dokumentiert Einsatzkriterien, Ausnahmen, Golden Path und Review-Checkliste für neue Plugins
- ergänzt und erfüllt den OpenSpec-Change `add-content-editor-footer-save-actions`

## Motivation

Bei langen oder tab-basierten Bearbeitungsflächen war die globale Speichern-Aktion häufig nur am Seitenanfang oder -ende erreichbar. Die Änderung macht sie an beiden Positionen verfügbar. Beide Buttons verwenden denselben Submit-/Mutationspfad und bleiben unabhängig vom aktiven Tab.

Closes #868

## Validierung

- betroffene Unit-Tests der sieben UI-/Plugin-Projekte
- gezielte Route-Tests für Kern-Inhaltseditor, Benutzer, Rollen und Rechtstexte
- TypeScript-Targets für acht betroffene Projekte
- betroffene Lint-Targets ohne Fehler
- `openspec validate add-content-editor-footer-save-actions --strict`
- `pnpm check:file-placement`
- `pnpm check:plugin-ui-boundary`
- `git diff --check`

Der gemessene breite affected-Unit-Scope umfasst elf Projekte und wurde gemäß den lokalen Entwicklungsregeln nicht zusätzlich als Standard-Shift-left-Lauf ausgeführt.