### PR TITLE
fix: migrate historical database restores

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -184,6 +184,21 @@ jobs:
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
         run: pnpm exec tsx scripts/ci/submit-restore-agent-request.ts "${{ inputs.environment }}"
 
+      - name: migrate restored database to the selected image schema
+        id: restored_database_migration
+        env:
+          APP_CONFIG: ${{ secrets.APP_CONFIG }}
+          QUANTUM_ENDPOINT: ${{ vars.QUANTUM_ENDPOINT }}
+          SVA_COMPOSE_SOURCE_ROOT: ${{ steps.image_source.outputs.path }}
+          SVA_DEPLOY_REVISION: ${{ steps.image_contract.outputs.deploy_revision }}
+        run: |
+          set -euo pipefail
+          umask 077
+          trap 'rm -f "${SVA_COMPOSE_SOURCE_ROOT}/.env"' EXIT
+          pnpm exec tsx scripts/ci/render-compose-env.ts --output "${SVA_COMPOSE_SOURCE_ROOT}/.env"
+          printf '\nIMAGE_REF=%s\n' "${{ steps.image_contract.outputs.deploy_image_ref }}" >> "${SVA_COMPOSE_SOURCE_ROOT}/.env"
+          pnpm exec tsx scripts/ci/promote-one-shot-job.ts --kind migration --environment "${{ inputs.environment }}"
+
       - name: reconcile application database principal after restore
         id: app_principal
         env:

--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -629,6 +629,11 @@ export const extractAppliedGooseVersion = (sql) => {
   return appliedVersions.length > 0 ? Math.max(...appliedVersions) : null;
 };
 
+export const isHistoricalSchemaRestoreCompatible = (sourceGooseVersion, targetGooseVersion) =>
+  Number.isSafeInteger(sourceGooseVersion) &&
+  Number.isSafeInteger(targetGooseVersion) &&
+  sourceGooseVersion <= targetGooseVersion;
+
 const verifyArchiveSchema = async (archive) => {
   const listing = await runCapture('pg_restore', ['--list', archive], {
     maxOutputBytes: 10 * 1024 * 1024,
@@ -707,7 +712,7 @@ export const executeRestoreForIntegration = async (request) => {
         'SELECT max(version_id) FROM public.goose_db_version WHERE is_applied'
       )
     );
-    if (!Number.isSafeInteger(targetGooseVersion) || targetGooseVersion !== sourceGooseVersion)
+    if (!isHistoricalSchemaRestoreCompatible(sourceGooseVersion, targetGooseVersion))
       throw new Error('schema_version_mismatch');
     complete('schema-version-compatibility', { sourceGooseVersion, targetGooseVersion });
 

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -6,6 +6,7 @@ import {
   canonicalRestoreRequest,
   controlKeysFor,
   extractAppliedGooseVersion,
+  isHistoricalSchemaRestoreCompatible,
   isRestoreSqlLineSupported,
   minioAwsCompatibilityEnv,
   restoreControlKeysFor,
@@ -221,6 +222,12 @@ describe('backup agent runtime contract', () => {
     ].join('\n');
     expect(extractAppliedGooseVersion(sql)).toBe(2026080101);
     expect(extractAppliedGooseVersion('SELECT 1;')).toBeNull();
+  });
+
+  it('accepts historical schema versions but rejects dumps newer than the target', () => {
+    expect(isHistoricalSchemaRestoreCompatible(70, 71)).toBe(true);
+    expect(isHistoricalSchemaRestoreCompatible(71, 71)).toBe(true);
+    expect(isHistoricalSchemaRestoreCompatible(72, 71)).toBe(false);
   });
 
   it('requires both migration and IAM registry structures in the restore archive', () => {

--- a/docs/changelog/entries/pr-881.json
+++ b/docs/changelog/entries/pr-881.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 881,
+  "body": "Fehlerbehebung\n\n- Historische Datenbank-Backups mit älterem Goose-Schemastand werden vor dem Anwendungsneustart auf den Stand des freigegebenen Images migriert."
+}

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -133,8 +133,9 @@ Ablauf:
 2. Der Workflow bindet Executor-Revision und unveränderliches Image, prüft bei Production die Staging-Evidenz und setzt App sowie Provisioner auf null Replikate.
 3. Der Agent lehnt aktive App-Sessions, Replay, falsche Umgebung, falsches Präfix, abgelaufene Requests, unbekannte Felder oder eine abweichende SHA-256 vor jeder Mutation ab.
 4. Der Agent prüft `pg_restore --list` und die erforderlichen Goose-/IAM-Archiveinträge.
-5. Der Agent erzeugt einen neuen Custom-Dump, lädt ihn nach `safety-before-restore/`, lädt ihn erneut herunter und verifiziert seine SHA-256.
-6. Erst danach startet der einmalige Vollrestore. Fehler oder Timeout führen zu keinem automatischen Retry oder Gegenrestore.
+5. Der Agent akzeptiert den gleichen oder einen älteren Goose-Migrationsstand als den des Zielsystems; ein Dump mit neuerem, unbekanntem Schema wird abgelehnt.
+6. Der Agent erzeugt einen neuen Custom-Dump, lädt ihn nach `safety-before-restore/`, lädt ihn erneut herunter und verifiziert seine SHA-256.
+7. Erst danach startet der einmalige Vollrestore. Der Workflow migriert einen historischen Stand anschließend mit dem unveränderlich ausgewählten Studio-Image, bevor Principal-Reconcile und Neustart erfolgen. Fehler oder Timeout führen zu keinem automatischen Retry oder Gegenrestore.
 7. Der Agent prüft Goose-Version, IAM-Schema, App-Principal einschließlich Tabellenrechten und Registry.
 8. Nur nach erfolgreicher DB-Evidenz startet der Workflow App und Provisioner wieder und fordert HTTP 200 für `health/live` und `health/ready` sowie einen erfolgreichen Runtime-Smoke mit Tenant-Login-Redirect.
 9. Schlägt ein Schritt nach der Stilllegung fehl, deployt der Workflow den gestoppten Stackvertrag erneut. Die App bleibt bis zu einer manuellen Recovery-Entscheidung stillgelegt.

--- a/scripts/ci/database-restore-workflow-contract.test.ts
+++ b/scripts/ci/database-restore-workflow-contract.test.ts
@@ -27,4 +27,18 @@ describe('database restore workflow', () => {
     expect(workflow).not.toContain('git checkout --detach "${head}"');
     expect(workflow).toContain('SVA_COMPOSE_SOURCE_ROOT: ${{ steps.image_source.outputs.path }}');
   });
+
+  it('migrates a historical dump before reconciling and restarting the application', () => {
+    const restore = workflow.indexOf('execute database restore and database checks');
+    const migration = workflow.indexOf('migrate restored database to the selected image schema');
+    const reconcile = workflow.indexOf('reconcile application database principal after restore');
+    const restart = workflow.indexOf('restart application after successful database checks');
+
+    expect(migration).toBeGreaterThan(restore);
+    expect(reconcile).toBeGreaterThan(migration);
+    expect(restart).toBeGreaterThan(reconcile);
+    expect(workflow).toContain(
+      'pnpm exec tsx scripts/ci/promote-one-shot-job.ts --kind migration --environment "${{ inputs.environment }}"',
+    );
+  });
 });


### PR DESCRIPTION
## Problem
Der vorhandene Production-Dump hat einen älteren Goose-Migrationsstand als die inzwischen laufende Datenbank. Der Restore-Vertrag verlangte bisher exakte Gleichheit und blockierte dadurch historische Backups vor jeder Mutation.

## Lösung
- ältere oder gleiche Schemastände zulassen, Dumps mit neuerem Schema weiterhin ablehnen
- nach dem Restore den Migrations-One-shot des unveränderlich ausgewählten Studio-Images ausführen
- erst danach App-Principal reconciliieren und Anwendung neu starten
- Runbook und Changelog aktualisieren

## Tests
- `pnpm exec vitest run deploy/backup-agent/agent.test.ts scripts/ci/database-restore-workflow-contract.test.ts` (23 grün)
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`
- gezieltes ESLint und `git diff --check`

## Incident-Kontext
Der letzte Versuch `30709106226` endete mit `schema_version_mismatch` und `mutationStarted: false`; die Anwendung wurde sicher gestoppt gehalten.
