### PR TITLE
fix: reset schemas for historical restore

### DIFF
--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -634,6 +634,9 @@ export const isHistoricalSchemaRestoreCompatible = (sourceGooseVersion, targetGo
   Number.isSafeInteger(targetGooseVersion) &&
   sourceGooseVersion <= targetGooseVersion;
 
+export const restoreSchemaResetSql = (appUser) =>
+  `SET ROLE ${appUser}; DROP SCHEMA IF EXISTS iam CASCADE; DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public AUTHORIZATION ${appUser}; CREATE SCHEMA iam AUTHORIZATION ${appUser};`;
+
 const verifyArchiveSchema = async (archive) => {
   const listing = await runCapture('pg_restore', ['--list', archive], {
     maxOutputBytes: 10 * 1024 * 1024,
@@ -776,6 +779,8 @@ export const executeRestoreForIntegration = async (request) => {
     complete('safety-backup', { objectKey: safetyObjectKey, sha256: safetySha256 });
 
     mutationStarted = true;
+    await runSql(target, pgEnv, restoreSchemaResetSql(target.appUser));
+    complete('application-schema-reset');
     await runCommand(
       'pg_restore',
       [

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -10,6 +10,7 @@ import {
   isRestoreSqlLineSupported,
   minioAwsCompatibilityEnv,
   restoreControlKeysFor,
+  restoreSchemaResetSql,
   runCommand,
   safeErrorCode,
   targets,
@@ -228,6 +229,12 @@ describe('backup agent runtime contract', () => {
     expect(isHistoricalSchemaRestoreCompatible(70, 71)).toBe(true);
     expect(isHistoricalSchemaRestoreCompatible(71, 71)).toBe(true);
     expect(isHistoricalSchemaRestoreCompatible(72, 71)).toBe(false);
+  });
+
+  it('resets application-owned schemas before applying a historical dump', () => {
+    expect(restoreSchemaResetSql('sva')).toBe(
+      'SET ROLE sva; DROP SCHEMA IF EXISTS iam CASCADE; DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public AUTHORIZATION sva; CREATE SCHEMA iam AUTHORIZATION sva;'
+    );
   });
 
   it('requires both migration and IAM registry structures in the restore archive', () => {

--- a/docs/changelog/entries/pr-882.json
+++ b/docs/changelog/entries/pr-882.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 882,
+  "body": "Fehlerbehebung\n\n- Der historische Datenbank-Restore entfernt vor dem Import vollständig die anwendungseigenen Schemas, damit neuere Constraints den älteren Dump nicht blockieren."
+}

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -135,7 +135,7 @@ Ablauf:
 4. Der Agent prüft `pg_restore --list` und die erforderlichen Goose-/IAM-Archiveinträge.
 5. Der Agent akzeptiert den gleichen oder einen älteren Goose-Migrationsstand als den des Zielsystems; ein Dump mit neuerem, unbekanntem Schema wird abgelehnt.
 6. Der Agent erzeugt einen neuen Custom-Dump, lädt ihn nach `safety-before-restore/`, lädt ihn erneut herunter und verifiziert seine SHA-256.
-7. Erst danach startet der einmalige Vollrestore. Der Workflow migriert einen historischen Stand anschließend mit dem unveränderlich ausgewählten Studio-Image, bevor Principal-Reconcile und Neustart erfolgen. Fehler oder Timeout führen zu keinem automatischen Retry oder Gegenrestore.
+7. Erst danach entfernt der Agent die anwendungseigenen Schemas `public` und `iam` vollständig und startet den einmaligen Vollrestore. Dadurch blockieren Objekte neuerer Migrationen nicht die Wiederherstellung eines älteren Dumps. Der Workflow migriert den historischen Stand anschließend mit dem unveränderlich ausgewählten Studio-Image, bevor Principal-Reconcile und Neustart erfolgen. Fehler oder Timeout führen zu keinem automatischen Retry oder Gegenrestore.
 7. Der Agent prüft Goose-Version, IAM-Schema, App-Principal einschließlich Tabellenrechten und Registry.
 8. Nur nach erfolgreicher DB-Evidenz startet der Workflow App und Provisioner wieder und fordert HTTP 200 für `health/live` und `health/ready` sowie einen erfolgreichen Runtime-Smoke mit Tenant-Login-Redirect.
 9. Schlägt ein Schritt nach der Stilllegung fehl, deployt der Workflow den gestoppten Stackvertrag erneut. Die App bleibt bis zu einer manuellen Recovery-Entscheidung stillgelegt.


### PR DESCRIPTION
## Problem
Der historische Dump passiert den Versions-Gate, aber `--clean` kann neuere, im Dump unbekannte Abhängigkeiten nicht entfernen. Production meldete konkret `cannot drop constraint instances_pkey ... because other objects depend on it` und brach mit `psql_failed_3` ab.

## Lösung
- nach dem verifizierten Sicherheitsbackup `public` und `iam` als anwendungseigene Schemas vollständig zurücksetzen
- erst danach den verifizierten historischen Dump anwenden
- Schema-Reset als eigener Evidenzschritt erfassen
- Runbook und Changelog aktualisieren

## Tests
- `pnpm exec vitest run deploy/backup-agent/agent.test.ts scripts/ci/database-restore-workflow-contract.test.ts` (24 grün)
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- gezieltes ESLint
- `pnpm check:file-placement`
- `git diff --check`

## Incident-Kontext
Run `30709932664` wurde nach dem SQL-Fehler sicher mit gestoppter Anwendung beendet. Der nächste Versuch führt einen vollständigen Schema-Neuimport aus und kann daher den teilweise bereinigten Stand ersetzen.
