### PR TITLE
Document production IAM restore recovery

### DIFF
--- a/docs/changelog/entries/pr-886.json
+++ b/docs/changelog/entries/pr-886.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 886,
+  "body": "Verbesserung des Betriebs\n\n- Der erfolgreich durchgeführte Production-IAM-Restore und der wiederholbare Recovery-Ablauf sind im Betriebsrunbook dokumentiert."
+}

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -50,18 +50,18 @@ Diese Befehle sind Diagnosewerkzeuge und starten keinen regulären Rollout.
 
 GitHub Actions führt die regulären Prüfungen aus. Für eine unabhängige Incident-Verifikation gelten mindestens:
 
-| Prüfung                   | Erwartung                                                 |
-| ------------------------- | --------------------------------------------------------- |
-| `GET /health/live`        | HTTP 200                                                  |
-| `GET /health/ready`       | HTTP 200                                                  |
-| Root-Login                | HTTP 302 zum korrekten Root-Realm                         |
-| jeder aktive Tenant-Login | HTTP 302 zum jeweiligen Tenant-Realm                      |
-| Live-Service-Image        | exakt erwarteter SHA-256-Digest                           |
-| App-Task                  | gewünschter Zustand `running`                             |
-| Netzwerke                 | internes Zielnetz und öffentliches Traefik-Netz vorhanden |
+| Prüfung                   | Erwartung                                                              |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `GET /health/live`        | HTTP 200                                                               |
+| `GET /health/ready`       | HTTP 200                                                               |
+| Root-Login                | HTTP 302 zum korrekten Root-Realm                                      |
+| jeder aktive Tenant-Login | HTTP 302 zum jeweiligen Tenant-Realm                                   |
+| Live-Service-Image        | exakt erwarteter SHA-256-Digest                                        |
+| App-Task                  | gewünschter Zustand `running`                                          |
+| Netzwerke                 | internes Zielnetz und öffentliches Traefik-Netz vorhanden              |
 | Traefik-Labels            | v1- und v2+-Regeln enthalten exakt Root- und freigegebene Tenant-Hosts |
-| TLS                       | gültiges Einzelzertifikat für jeden expliziten Host       |
-| unbekannter Tenant-Host   | kein Tenant-Inhalt und kein tenant-spezifischer Login     |
+| TLS                       | gültiges Einzelzertifikat für jeden expliziten Host                    |
+| unbekannter Tenant-Host   | kein Tenant-Inhalt und kein tenant-spezifischer Login                  |
 
 Ein Swarm-Service darf nach einem Update bis zu fünf Minuten konvergieren. Vor Ablauf dieses Fensters wird kein zusätzlicher mutierender Reparaturversuch gestartet. Bleibt ein Fehler danach bestehen, gilt der Rollout als fehlgeschlagen.
 
@@ -147,6 +147,32 @@ Ablauf:
 
 MinIO hält Request, Sicherheitsdump-Metadaten und Agent-Ergebnis getrennt unter `control/restores/`. GitHub hält zusätzlich die redigierte Workflow-Evidenz. Weder Evidenz enthält Secrets, SQL-Inhalte oder Datenbankdaten. Keycloak wird nicht verändert; erkannter Drift wird ausschließlich über die vorhandenen IAM-Reconcile-Pfade behandelt.
 
+### Wiederholbarer Restore-Ablauf für fehlende Runtime-ACLs
+
+Dieser Ablauf gilt, wenn ein fachlich korrekter Dump ohne ACLs wiederhergestellt wurde und die Anwendung anschließend beispielsweise `permission denied for schema iam`, leere `permissionActions` oder `permissionStatus: degraded` meldet:
+
+1. Exakten Dump-Objektschlüssel und die separat berechnete kleingeschriebene SHA-256 bestimmen. Zeitstempel oder Dateiname allein reichen nicht als Identität.
+2. Prüfen, welches unveränderliche App-Image aktuell im Ziel-Stack läuft, und dessen OCI-Revision als `change_head` verwenden. Der Restore-Workflow lehnt ein anderes Image vor der Mutation ab.
+3. Sicherstellen, dass der aktuelle Backup-Agent die Restore-Evidenz `runtime-principal-reconciliation` und `runtime-principal-probe` erzeugt. Ein älterer Agent kann einen ACL-losen Dump zwar einspielen, den Runtime-Zugriff aber nicht belastbar reparieren.
+4. **Controlled Database Restore** für genau eine Zielumgebung starten. Erforderlich sind `environment`, `source_object_key`, `source_sha256`, `maintenance_window`, `image_ref` und `change_head`. Eine Run-ID oder Evidenz der anderen Umgebung ist weder erforderlich noch zulässig.
+5. Das GitHub Environment der Zielumgebung freigeben und den Lauf bis einschließlich Restore, Migration, Principal-Reconciliation, Neustart, Runtime-Smoke und authentifiziertem IAM-Smoke beobachten.
+6. Abschließend mit einer bestehenden Sitzung prüfen, dass `/auth/me` HTTP 200 liefert, `permissionStatus` gleich `ok` ist und `permissionActions` nicht leer ist. Außerdem muss `/iam/me/permissions?instanceId=<instanceId-aus-auth-me>` HTTP 200 liefern.
+
+Der authentifizierte Smoke übernimmt `instanceId` aus `/auth/me`; ein Aufruf von `/iam/me/permissions` ohne diesen Queryparameter ist kein gültiger Berechtigungsnachweis.
+
+### Recovery nach fehlgeschlagener Nachprüfung
+
+Ein Fehler nach Beginn des Restores führt absichtlich erneut zum gestoppten Stackvertrag. Die grünen Einzelschritte bleiben dabei aussagekräftig: Sind Restore, Migration und Principal-Reconciliation erfolgreich und scheitert erst ein nachgelagerter HTTP-/Ingress-Smoke, darf nicht automatisch erneut restored werden.
+
+Für diesen Fall:
+
+1. Fehlerklasse und letzten erfolgreichen Schritt im Restore-Run feststellen.
+2. Bei einem ausschließlich externen Runtime-/Ingress-Fehler den bestehenden, unveränderten Live-Digest über **Promote** mit `migration_mode=assert-none` und `bootstrap_mode=assert-none` wieder ausrollen. `maintenance_window` muss auch bei diesem Recovery-Lauf mit einer nicht-sensitiven Incident-Referenz belegt sein.
+3. `health/live`, `health/ready` und den betroffenen Tenant-Host prüfen.
+4. Den fachlichen IAM-Nachweis über `/auth/me` und `/iam/me/permissions` nachholen.
+
+Wichtig: Der auf `main` laufende Restore-Smoke kann mehr explizite Tenant-Hosts kennen als ein älteres, weiterhin gebundenes Production-Image. Ein Fehler für einen solchen neuen Host widerlegt nicht die zuvor erfolgreiche Datenbank- und ACL-Reparatur. Er erfordert zunächst den beschriebenen Recovery-Promote und anschließend einen regulären Rollout des neueren Images über den kanonischen Build-/Promote-Pfad.
+
 ## DNS- und TLS-Prüfung
 
 Root- und Wildcard-DNS jeder Umgebung müssen auf denselben vorgesehenen Swarm-Ingress zeigen. Extern freigegeben sind trotzdem nur die expliziten `Host(...)`-Regeln mit konkretem Einzelzertifikat. Die Backup-Hosts müssen denselben verifizierten Ingress erreichen. DNS- oder TLS-Abweichungen werden diagnostiziert, aber nicht durch spontane Traefik-Änderungen im App-Rollout behoben.
@@ -173,3 +199,4 @@ Root- und Wildcard-DNS jeder Umgebung müssen auf denselben vorgesehenen Swarm-I
 - Backup-ADR: [`ADR-048`](../adr/ADR-048-zentraler-backup-agent-mit-gehaertetem-https-trigger.md)
 - Monitoring: [`monitoring-stack.md`](../development/monitoring-stack.md)
 - Incident Response: [`incident-response.md`](./incident-response.md)
+- Abgeschlossener Production-IAM-Restore vom 1. August 2026: [`production-iam-restore-2026-08-01.md`](../reports/production-iam-restore-2026-08-01.md)

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -142,7 +142,7 @@ Ablauf:
 7. Erst danach entfernt der Agent die anwendungseigenen Schemas `public` und `iam` vollständig und startet den einmaligen Vollrestore. Dadurch blockieren Objekte neuerer Migrationen nicht die Wiederherstellung eines älteren Dumps. Fehler oder Timeout führen zu keinem automatischen Retry oder Gegenrestore.
 8. Der Agent rekonstruiert zunächst die statischen `sva_app`-ACLs und prüft Goose-Version, IAM-Schema, `iam_app`-Mitgliedschaft, Datenbank-, Schema-, Tabellen- und Sequenzrechte sowie Registry. Alte Agent-Evidenz ohne `runtime-principal-reconciliation` und `runtime-principal-probe` wird vom Workflow abgelehnt.
 9. Der Workflow migriert einen historischen Stand anschließend mit dem unveränderlich ausgewählten Studio-Image und führt danach den allgemeinen Bootstrap als abschließendes Principal-Reconcile aus.
-10. Nur nach erfolgreicher DB-Evidenz startet der Workflow App und Provisioner wieder und fordert HTTP 200 für `health/live` und `health/ready`, einen erfolgreichen Runtime-Smoke mit Tenant-Login-Redirect sowie einen authentifizierten, nicht degradierten `/auth/me`- und `/iam/me/permissions`-Nachweis.
+10. Nur nach erfolgreicher DB-Evidenz startet der Workflow App und Provisioner wieder und fordert HTTP 200 für `health/live` und `health/ready`, einen erfolgreichen Runtime-Smoke mit Tenant-Login-Redirect sowie einen authentifizierten, nicht degradierten `/auth/me`- und `/iam/me/permissions?instanceId=<instanceId-aus-auth-me>`-Nachweis.
 11. Schlägt ein Schritt nach der Stilllegung fehl, deployt der Workflow den gestoppten Stackvertrag erneut. Die App bleibt bis zu einer manuellen Recovery-Entscheidung stillgelegt.
 
 MinIO hält Request, Sicherheitsdump-Metadaten und Agent-Ergebnis getrennt unter `control/restores/`. GitHub hält zusätzlich die redigierte Workflow-Evidenz. Weder Evidenz enthält Secrets, SQL-Inhalte oder Datenbankdaten. Keycloak wird nicht verändert; erkannter Drift wird ausschließlich über die vorhandenen IAM-Reconcile-Pfade behandelt.
@@ -167,9 +167,9 @@ Ein Fehler nach Beginn des Restores führt absichtlich erneut zum gestoppten Sta
 Für diesen Fall:
 
 1. Fehlerklasse und letzten erfolgreichen Schritt im Restore-Run feststellen.
-2. Bei einem ausschließlich externen Runtime-/Ingress-Fehler den bestehenden, unveränderten Live-Digest über **Promote** mit `migration_mode=assert-none` und `bootstrap_mode=assert-none` wieder ausrollen. `maintenance_window` muss auch bei diesem Recovery-Lauf mit einer nicht-sensitiven Incident-Referenz belegt sein.
+2. Bei einem ausschließlich externen Runtime-/Ingress-Fehler den bestehenden, unveränderten Live-Digest über **Promote** mit `migration_mode=assert-none` und `bootstrap_mode=assert-none` wieder ausrollen. `image_ref`, `change_base` und `change_head` müssen exakt aus der ursprünglichen Build-/Promote-Evidenz dieses Digests übernommen werden; `change_head` ist die attestierte OCI-Revision. Die Commit-Grenzen nicht während des Incidents raten oder aus dem aktuellen `main` ableiten. `maintenance_window` muss auch bei diesem Recovery-Lauf mit einer nicht-sensitiven Incident-Referenz belegt sein.
 3. `health/live`, `health/ready` und den betroffenen Tenant-Host prüfen.
-4. Den fachlichen IAM-Nachweis über `/auth/me` und `/iam/me/permissions` nachholen.
+4. Den fachlichen IAM-Nachweis über `/auth/me` und `/iam/me/permissions?instanceId=<instanceId-aus-auth-me>` nachholen.
 
 Wichtig: Der auf `main` laufende Restore-Smoke kann mehr explizite Tenant-Hosts kennen als ein älteres, weiterhin gebundenes Production-Image. Ein Fehler für einen solchen neuen Host widerlegt nicht die zuvor erfolgreiche Datenbank- und ACL-Reparatur. Er erfordert zunächst den beschriebenen Recovery-Promote und anschließend einen regulären Rollout des neueren Images über den kanonischen Build-/Promote-Pfad.
 

--- a/docs/reports/production-iam-restore-2026-08-01.md
+++ b/docs/reports/production-iam-restore-2026-08-01.md
@@ -1,0 +1,55 @@
+# Production-IAM-Restore vom 1. August 2026
+
+## Ergebnis
+
+Die Production-Datenbank wurde erfolgreich aus dem ausgewählten Dump wiederhergestellt und die fehlenden Runtime-ACLs wurden repariert. Nach dem abschließenden Recovery-Promote war `bb-prignitz.studio.smart-village.app` wieder erreichbar. Eine angemeldete Sitzung bestätigte anschließend:
+
+- `permissionStatus: ok`
+- fachliche Rollen und Gruppen geladen
+- `permissionActions` nicht leer
+- zugewiesene Module geladen
+
+Keycloak wurde nicht zurückgesetzt oder wiederhergestellt.
+
+## Ausgangslage und Ursache
+
+Nach einem vorherigen Restore lieferte `/auth/me` für `bb-prignitz` einen degradierten Berechtigungszustand mit leeren effektiven Rollen und Aktionen. Der verwendete PostgreSQL-Custom-Dump enthielt Schema und Daten, aber keine ACL- beziehungsweise Default-ACL-Einträge für den Runtime-Principal. Dadurch fehlte der laufenden Anwendung insbesondere der Zugriff auf das Schema `iam`.
+
+Die nachhaltige Reparatur wurde in PR [#884](https://github.com/smart-village-solutions/sva-studio/pull/884) umgesetzt: Der Backup-Agent rekonstruiert nach `pg_restore` die fest allowlisteten Rechte für `sva_app` und `iam_app` und prüft sie datenbanknah. PR [#885](https://github.com/smart-village-solutions/sva-studio/pull/885) korrigierte den authentifizierten Permission-Smoke und entkoppelte Staging- und Production-Restores vollständig voneinander.
+
+## Verwendetes Restore-Artefakt
+
+- Zielumgebung: `prod`
+- Objekt: `prod/2026-07-30T22-20-55-899Z/753275384b5943c19a5e78eab1ff33adb6ad02c6f0412e43c04ecf726a170f0f/gha-30586702874-1.dump`
+- SHA-256: `f4d61a20057aa949a70ed12ed354cf5bb3c068b8904d8bb3e2256c669cf89007`
+- Wartungsfensterreferenz: `incident-bb-prignitz-iam-acl-repair-2026-08-01`
+- Gebundenes Production-Image: `ghcr.io/smart-village-solutions/sva-studio@sha256:cef8afab475f8eb6e9b0b24b1229b7b80e2e7c09e6d9ef7eeb629866f2142312`
+- OCI-Revision des Images: `9f17413bdef95339b68de32d45baa3e719ef7d2b`
+
+## Erfolgreiche Reihenfolge
+
+1. Der aktualisierte Backup-Agent wurde ausgerollt und seine Restore-Verträge wurden geprüft.
+2. Die GitHub-Environments erhielten getrennte, nicht protokollierte Zugangsdaten für den authentifizierten Restore-Smoke.
+3. Die expliziten Tenant-Ingress-Hosts wurden auf Staging validiert. Diese Staging-Arbeit war für die Ingress-Fehleranalyse hilfreich, ist seit PR #885 aber keine Voraussetzung für einen Production-Restore.
+4. **Controlled Database Restore** wurde ausschließlich für `prod` mit exaktem Objekt, SHA-256, Wartungsfenster, Live-Image und OCI-Revision gestartet: [Run 30720498548](https://github.com/smart-village-solutions/sva-studio/actions/runs/30720498548).
+5. Im Run waren Stilllegung, Sicherheitsdump, `pg_restore`, Migration, Runtime-Principal-Reconciliation, Principal-Probe, Bootstrap und App-Neustart erfolgreich.
+6. Der allgemeine Runtime-Smoke scheiterte erst am zusätzlich erwarteten Host `bb-ahrensfelde.studio.smart-village.app`, weil das gebundene ältere Production-Image diesen neuen expliziten Host noch nicht enthielt. Der Workflow stellte Production daraufhin korrekt fail-closed wieder ab. Der authentifizierte IAM-Smoke wurde deshalb in diesem Run nicht mehr ausgeführt.
+7. Ein **Promote** desselben unveränderten Production-Images mit `migration_mode=assert-none`, `bootstrap_mode=assert-none` und derselben Wartungsfensterreferenz startete Production ohne erneute Datenbankmutation: [Run 30720914988](https://github.com/smart-village-solutions/sva-studio/actions/runs/30720914988).
+8. Der Recovery-Promote, Runtime-Verifikation und Digest-Abgleich waren erfolgreich. `health/live`, `health/ready` und der Login-Pfad von `bb-prignitz` antworteten anschließend mit HTTP 200.
+9. Die abschließende manuelle Sitzung bestätigte `permissionStatus: ok` und eine nicht leere Menge vollständig qualifizierter `permissionActions`.
+
+## Fehlversuche und ihre Bedeutung
+
+- Frühere Staging-Restore-Läufe scheiterten an fehlendem Routing eines Tenant-Hosts. Das war ein Ingress- und kein Datenbankfehler.
+- Ein Production-Restore vor PR #885 wurde vor jeder Mutation durch die damals obligatorische Staging-Evidenz blockiert. Production blieb dabei unverändert.
+- Der erfolgreiche Production-Restore-Run wurde erst nach allen Datenbankarbeiten durch einen Image-/Smoke-Versatz rot. Die erfolgreiche ACL-Reconciliation durfte deshalb nicht durch einen unnötigen zweiten Restore ersetzt werden.
+- Ein erster Recovery-Promote ohne `maintenance_window` scheiterte vor dem Deployment. Der erfolgreiche Wiederholungslauf verwendete die revisionsfähige Incident-Referenz.
+- Der lokal konfigurierte automatische IAM-Smoke konnte den vorhandenen Testzugang nicht erfolgreich durch Keycloak anmelden. Die bestehende menschliche Sitzung erbrachte den abschließenden Nachweis; Zugangsdaten wurden weder protokolliert noch in diese Dokumentation übernommen.
+
+## Wiederholung und Abbruchkriterien
+
+Der normative Ablauf steht im Abschnitt [Wiederholbarer Restore-Ablauf für fehlende Runtime-ACLs](../guides/swarm-deployment-runbook.md#wiederholbarer-restore-ablauf-für-fehlende-runtime-acls).
+
+Vor jeder Wiederholung müssen Dump, SHA-256, Zielumgebung, Live-Digest und OCI-Revision erneut bestimmt werden. Werte aus diesem Bericht dürfen nur wiederverwendet werden, wenn sie weiterhin exakt dem beabsichtigten Restore entsprechen.
+
+Ein neuer Restore ist nicht die Standardreaktion, wenn bereits `pg_restore`, Migration und Principal-Reconciliation grün waren. In diesem Zustand zuerst die nachgelagerte Fehlerklasse untersuchen und Production gegebenenfalls mit demselben Digest und ohne One-shot-Mutationen wieder hochfahren.


### PR DESCRIPTION
## Inhalt
- wiederholbaren ACL-losen Restore-Ablauf im Betriebsrunbook festhalten
- Recovery nach nachgelagertem Ingress-/Runtime-Smoke dokumentieren
- abgeschlossenen Production-Incident mit Artefaktidentität, Runs, Fehlerbildern und Erfolgskriterien protokollieren
- keine Secrets oder Zugangsdaten aufnehmen

## Validierung
- `pnpm check:file-placement`
- `pnpm exec prettier --check docs/guides/swarm-deployment-runbook.md docs/reports/production-iam-restore-2026-08-01.md`
- `git diff --check`