### PR TITLE
fix: limit production tenant smoke blockers

### DIFF
--- a/docs/changelog/entries/pr-888.json
+++ b/docs/changelog/entries/pr-888.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 888,
+  "body": "Zuverlässiger Production-Rollout\n\n- Production-Rollouts bleiben bei Fehlern des Root-Hosts und des Freigabe-Tenants `de-studio-sandbox` geschützt.\n- Störungen anderer expliziter Tenant-Hosts werden sichtbar gemeldet, blockieren den Rollout aber nicht mehr."
+}

--- a/scripts/ops/runtime-env.test.ts
+++ b/scripts/ops/runtime-env.test.ts
@@ -827,10 +827,10 @@ describe('waitForRemoteSmokeWarmup', () => {
           target: 'https://studio.smart-village.app/health/live',
         }),
         createProbe({
-          message: 'IAM-Instanzliste lieferte HTML statt JSON/API-Vertrag.',
-          name: 'public-iam-instances',
+          message: 'fetch failed',
+          name: 'public-ingress-https-bb-ahrensfelde.studio.smart-village.app',
           status: 'error',
-          target: 'https://studio.smart-village.app/api/v1/iam/instances',
+          target: 'https://bb-ahrensfelde.studio.smart-village.app/health/live',
         }),
       ])
       .mockResolvedValueOnce([
@@ -853,16 +853,17 @@ describe('waitForRemoteSmokeWarmup', () => {
           target: 'https://studio.smart-village.app/auth/login',
         }),
         createProbe({
-          message: 'IAM-Instanzliste lieferte HTML statt JSON/API-Vertrag.',
-          name: 'public-iam-instances',
+          message: 'fetch failed',
+          name: 'public-ingress-https-bb-ahrensfelde.studio.smart-village.app',
           status: 'error',
-          target: 'https://studio.smart-village.app/api/v1/iam/instances',
+          target: 'https://bb-ahrensfelde.studio.smart-village.app/health/live',
         }),
       ]);
 
     await expect(
       waitForRemoteSmokeWarmup(
         {
+          SVA_ACCEPTANCE_RELEASE_MODE: 'app-only',
           SVA_PUBLIC_BASE_URL: 'https://studio.smart-village.app',
         },
         {
@@ -877,7 +878,10 @@ describe('waitForRemoteSmokeWarmup', () => {
         expect.objectContaining({ name: 'public-live', status: 'ok' }),
         expect.objectContaining({ name: 'public-ready', status: 'ok' }),
         expect.objectContaining({ name: 'public-auth-login', status: 'ok' }),
-        expect.objectContaining({ name: 'public-iam-instances', status: 'error' }),
+        expect.objectContaining({
+          name: 'public-ingress-https-bb-ahrensfelde.studio.smart-village.app',
+          status: 'error',
+        }),
       ]),
     );
 

--- a/scripts/ops/runtime/acceptance-deploy-finalize.ts
+++ b/scripts/ops/runtime/acceptance-deploy-finalize.ts
@@ -1,5 +1,7 @@
 import type { AcceptanceDeployDeps, AcceptanceDeployState } from './acceptance-deploy.types.ts';
 import { failDeploy } from './acceptance-deploy-state.ts';
+import { shouldUseStudioReleaseBlockingTenantScope } from './remote-verification.ts';
+import { shouldRetryExternalSmoke } from './smoke-retry.ts';
 import { isBlockingSmokeProbe, reportNonBlockingSmokeFailures } from './smoke-runtime.ts';
 
 export const runInternalVerifyPhase = async (deps: AcceptanceDeployDeps, state: AcceptanceDeployState) => {
@@ -18,11 +20,20 @@ export const runInternalVerifyPhase = async (deps: AcceptanceDeployDeps, state: 
 export const runExternalSmokePhase = async (deps: AcceptanceDeployDeps, state: AcceptanceDeployState) => {
   const startedAt = Date.now();
   try {
-    const externalProbes = await deps.runExternalSmokeWithWarmup(state.env, { runtimeProfile: state.runtimeProfile });
+    const usesReleaseBlockingTenantScope = shouldUseStudioReleaseBlockingTenantScope(
+      state.runtimeProfile,
+      state.env,
+    );
+    const externalProbes = await deps.runExternalSmokeWithWarmup(state.env, {
+      runtimeProfile: state.runtimeProfile,
+      shouldRetry: (probes) => shouldRetryExternalSmoke(
+        probes.filter((probe) => isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope)),
+      ),
+    });
     state.report = { ...state.report, externalProbes };
-    reportNonBlockingSmokeFailures(externalProbes, state.runtimeProfile, state.env);
+    reportNonBlockingSmokeFailures(externalProbes, usesReleaseBlockingTenantScope);
     const failingProbe = externalProbes.find(
-      (probe) => probe.status === 'error' && isBlockingSmokeProbe(probe, state.runtimeProfile, state.env),
+      (probe) => probe.status === 'error' && isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope),
     );
     if (failingProbe) {
       throw new Error(`${failingProbe.name}: ${failingProbe.message}`);

--- a/scripts/ops/runtime/acceptance-deploy-finalize.ts
+++ b/scripts/ops/runtime/acceptance-deploy-finalize.ts
@@ -4,15 +4,6 @@ import { shouldUseStudioReleaseBlockingTenantScope } from './remote-verification
 import { shouldRetryExternalSmoke } from './smoke-retry.ts';
 import { isBlockingSmokeProbe } from './smoke-runtime.ts';
 
-const isExplicitTenantIngressProbe = (probe: AcceptanceDeployState['report']['externalProbes'][number]) =>
-  probe.name.startsWith('public-ingress-https-') || probe.name.startsWith('public-ingress-login-');
-
-export const isBlockingAcceptanceDeploySmokeProbe = (
-  probe: AcceptanceDeployState['report']['externalProbes'][number],
-  usesReleaseBlockingTenantScope: boolean,
-) => !isExplicitTenantIngressProbe(probe)
-  || isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope);
-
 export const runInternalVerifyPhase = async (deps: AcceptanceDeployDeps, state: AcceptanceDeployState) => {
   const startedAt = Date.now();
   const internalVerify = await deps.runInternalVerify(state.runtimeProfile, state.env);
@@ -36,21 +27,18 @@ export const runExternalSmokePhase = async (deps: AcceptanceDeployDeps, state: A
     const externalProbes = await deps.runExternalSmokeWithWarmup(state.env, {
       runtimeProfile: state.runtimeProfile,
       shouldRetry: (probes) => shouldRetryExternalSmoke(
-        probes.filter((probe) => isBlockingAcceptanceDeploySmokeProbe(
-          probe,
-          usesReleaseBlockingTenantScope,
-        )),
+        probes.filter((probe) => isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope)),
       ),
     });
     state.report = { ...state.report, externalProbes };
     for (const probe of externalProbes) {
       if (probe.status !== 'error'
-        || isBlockingAcceptanceDeploySmokeProbe(probe, usesReleaseBlockingTenantScope)) continue;
+        || isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope)) continue;
       console.warn(`[runtime-env] Nicht blockierender Smoke-Fehler: ${probe.name}: ${probe.message}`);
     }
     const failingProbe = externalProbes.find(
       (probe) => probe.status === 'error'
-        && isBlockingAcceptanceDeploySmokeProbe(probe, usesReleaseBlockingTenantScope),
+        && isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope),
     );
     if (failingProbe) {
       throw new Error(`${failingProbe.name}: ${failingProbe.message}`);

--- a/scripts/ops/runtime/acceptance-deploy-finalize.ts
+++ b/scripts/ops/runtime/acceptance-deploy-finalize.ts
@@ -1,5 +1,6 @@
 import type { AcceptanceDeployDeps, AcceptanceDeployState } from './acceptance-deploy.types.ts';
 import { failDeploy } from './acceptance-deploy-state.ts';
+import { isBlockingSmokeProbe, reportNonBlockingSmokeFailures } from './smoke-runtime.ts';
 
 export const runInternalVerifyPhase = async (deps: AcceptanceDeployDeps, state: AcceptanceDeployState) => {
   const startedAt = Date.now();
@@ -19,7 +20,10 @@ export const runExternalSmokePhase = async (deps: AcceptanceDeployDeps, state: A
   try {
     const externalProbes = await deps.runExternalSmokeWithWarmup(state.env, { runtimeProfile: state.runtimeProfile });
     state.report = { ...state.report, externalProbes };
-    const failingProbe = externalProbes.find((probe) => probe.status === 'error');
+    reportNonBlockingSmokeFailures(externalProbes, state.runtimeProfile, state.env);
+    const failingProbe = externalProbes.find(
+      (probe) => probe.status === 'error' && isBlockingSmokeProbe(probe, state.runtimeProfile, state.env),
+    );
     if (failingProbe) {
       throw new Error(`${failingProbe.name}: ${failingProbe.message}`);
     }

--- a/scripts/ops/runtime/acceptance-deploy-finalize.ts
+++ b/scripts/ops/runtime/acceptance-deploy-finalize.ts
@@ -2,7 +2,16 @@ import type { AcceptanceDeployDeps, AcceptanceDeployState } from './acceptance-d
 import { failDeploy } from './acceptance-deploy-state.ts';
 import { shouldUseStudioReleaseBlockingTenantScope } from './remote-verification.ts';
 import { shouldRetryExternalSmoke } from './smoke-retry.ts';
-import { isBlockingSmokeProbe, reportNonBlockingSmokeFailures } from './smoke-runtime.ts';
+import { isBlockingSmokeProbe } from './smoke-runtime.ts';
+
+const isExplicitTenantIngressProbe = (probe: AcceptanceDeployState['report']['externalProbes'][number]) =>
+  probe.name.startsWith('public-ingress-https-') || probe.name.startsWith('public-ingress-login-');
+
+export const isBlockingAcceptanceDeploySmokeProbe = (
+  probe: AcceptanceDeployState['report']['externalProbes'][number],
+  usesReleaseBlockingTenantScope: boolean,
+) => !isExplicitTenantIngressProbe(probe)
+  || isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope);
 
 export const runInternalVerifyPhase = async (deps: AcceptanceDeployDeps, state: AcceptanceDeployState) => {
   const startedAt = Date.now();
@@ -27,13 +36,21 @@ export const runExternalSmokePhase = async (deps: AcceptanceDeployDeps, state: A
     const externalProbes = await deps.runExternalSmokeWithWarmup(state.env, {
       runtimeProfile: state.runtimeProfile,
       shouldRetry: (probes) => shouldRetryExternalSmoke(
-        probes.filter((probe) => isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope)),
+        probes.filter((probe) => isBlockingAcceptanceDeploySmokeProbe(
+          probe,
+          usesReleaseBlockingTenantScope,
+        )),
       ),
     });
     state.report = { ...state.report, externalProbes };
-    reportNonBlockingSmokeFailures(externalProbes, usesReleaseBlockingTenantScope);
+    for (const probe of externalProbes) {
+      if (probe.status !== 'error'
+        || isBlockingAcceptanceDeploySmokeProbe(probe, usesReleaseBlockingTenantScope)) continue;
+      console.warn(`[runtime-env] Nicht blockierender Smoke-Fehler: ${probe.name}: ${probe.message}`);
+    }
     const failingProbe = externalProbes.find(
-      (probe) => probe.status === 'error' && isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope),
+      (probe) => probe.status === 'error'
+        && isBlockingAcceptanceDeploySmokeProbe(probe, usesReleaseBlockingTenantScope),
     );
     if (failingProbe) {
       throw new Error(`${failingProbe.name}: ${failingProbe.message}`);

--- a/scripts/ops/runtime/acceptance-deploy.test.ts
+++ b/scripts/ops/runtime/acceptance-deploy.test.ts
@@ -9,7 +9,7 @@ import type {
   RemoteRuntimeProfile,
 } from '../runtime-env.shared.ts';
 import { createAcceptanceDeployRunner } from './acceptance-deploy.ts';
-import { isBlockingAcceptanceDeploySmokeProbe } from './acceptance-deploy-finalize.ts';
+import { isBlockingSmokeProbe } from './smoke-runtime.ts';
 
 const createDoctorReport = (status: DoctorReport['status']): DoctorReport => ({
   checks: [],
@@ -20,7 +20,7 @@ const createDoctorReport = (status: DoctorReport['status']): DoctorReport => ({
 
 describe('createAcceptanceDeployRunner', () => {
   it('only exempts additional tenant ingress failures in release scope', () => {
-    expect(isBlockingAcceptanceDeploySmokeProbe({
+    expect(isBlockingSmokeProbe({
       durationMs: 1,
       message: 'IAM-Kontext liefert HTML.',
       name: 'public-iam-context',
@@ -28,7 +28,7 @@ describe('createAcceptanceDeployRunner', () => {
       status: 'error',
       target: 'https://studio.smart-village.app/api/v1/iam/me/context',
     }, true)).toBe(true);
-    expect(isBlockingAcceptanceDeploySmokeProbe({
+    expect(isBlockingSmokeProbe({
       durationMs: 1,
       message: 'fetch failed',
       name: 'public-ingress-https-bb-ahrensfelde.studio.smart-village.app',

--- a/scripts/ops/runtime/acceptance-deploy.test.ts
+++ b/scripts/ops/runtime/acceptance-deploy.test.ts
@@ -9,6 +9,7 @@ import type {
   RemoteRuntimeProfile,
 } from '../runtime-env.shared.ts';
 import { createAcceptanceDeployRunner } from './acceptance-deploy.ts';
+import { isBlockingAcceptanceDeploySmokeProbe } from './acceptance-deploy-finalize.ts';
 
 const createDoctorReport = (status: DoctorReport['status']): DoctorReport => ({
   checks: [],
@@ -18,6 +19,25 @@ const createDoctorReport = (status: DoctorReport['status']): DoctorReport => ({
 });
 
 describe('createAcceptanceDeployRunner', () => {
+  it('only exempts additional tenant ingress failures in release scope', () => {
+    expect(isBlockingAcceptanceDeploySmokeProbe({
+      durationMs: 1,
+      message: 'IAM-Kontext liefert HTML.',
+      name: 'public-iam-context',
+      scope: 'external',
+      status: 'error',
+      target: 'https://studio.smart-village.app/api/v1/iam/me/context',
+    }, true)).toBe(true);
+    expect(isBlockingAcceptanceDeploySmokeProbe({
+      durationMs: 1,
+      message: 'fetch failed',
+      name: 'public-ingress-https-bb-ahrensfelde.studio.smart-village.app',
+      scope: 'external',
+      status: 'error',
+      target: 'https://bb-ahrensfelde.studio.smart-village.app/health/live',
+    }, true)).toBe(false);
+  });
+
   it('marks precheck failures as config failures and writes a failed report', async () => {
     const writeAcceptanceDeployReport = vi.fn();
     const printJsonIfRequested = vi.fn();

--- a/scripts/ops/runtime/acceptance-deploy.types.ts
+++ b/scripts/ops/runtime/acceptance-deploy.types.ts
@@ -59,7 +59,10 @@ export type AcceptanceDeployDeps = {
   printJsonIfRequested: (payload: unknown) => void;
   resolveAcceptanceDeployOptions: (env: NodeJS.ProcessEnv, cliOptions: unknown, runtimeProfile: RemoteRuntimeProfile) => AcceptanceDeployOptions;
   runBootstrapJobAgainstAcceptance: (env: NodeJS.ProcessEnv, runtimeProfile: RemoteRuntimeProfile, reportId: string) => Promise<JobResult>;
-  runExternalSmokeWithWarmup: (env: NodeJS.ProcessEnv, options: { readonly runtimeProfile: RemoteRuntimeProfile }) => Promise<readonly AcceptanceProbeResult[]>;
+  runExternalSmokeWithWarmup: (env: NodeJS.ProcessEnv, options: {
+    readonly runtimeProfile: RemoteRuntimeProfile;
+    readonly shouldRetry?: (probes: readonly AcceptanceProbeResult[]) => boolean;
+  }) => Promise<readonly AcceptanceProbeResult[]>;
   runImageSmoke: (env: NodeJS.ProcessEnv, options: AcceptanceDeployOptions, reportId: string) => Promise<readonly AcceptanceProbeResult[]>;
   runInternalVerify: (runtimeProfile: RemoteRuntimeProfile, env: NodeJS.ProcessEnv) => Promise<InternalVerifyResult>;
   runMigrationJobAgainstAcceptance: (env: NodeJS.ProcessEnv, runtimeProfile: RemoteRuntimeProfile, reportId: string) => Promise<JobResult>;

--- a/scripts/ops/runtime/acceptance-runtime-facade.types.ts
+++ b/scripts/ops/runtime/acceptance-runtime-facade.types.ts
@@ -65,7 +65,10 @@ export type AcceptanceDeployFacadeDeps = AcceptanceRuntimeSharedDeps & {
   createBaseAcceptanceDeployReport: (runtimeProfile: RemoteRuntimeProfile, env: NodeJS.ProcessEnv, options: AcceptanceDeployOptions, migrationFiles: readonly string[]) => AcceptanceDeployReport;
   getGitCommitSha: () => string | undefined;
   precheckAcceptance: (runtimeProfile: RemoteRuntimeProfile, env: NodeJS.ProcessEnv, options?: AcceptanceDeployOptions) => Promise<import('../runtime-env.shared.ts').DoctorReport>;
-  runExternalSmokeWithWarmup: (env: NodeJS.ProcessEnv, options: { readonly runtimeProfile: RemoteRuntimeProfile }) => Promise<readonly AcceptanceProbeResult[]>;
+  runExternalSmokeWithWarmup: (env: NodeJS.ProcessEnv, options: {
+    readonly runtimeProfile: RemoteRuntimeProfile;
+    readonly shouldRetry?: (probes: readonly AcceptanceProbeResult[]) => boolean;
+  }) => Promise<readonly AcceptanceProbeResult[]>;
   runImageSmoke: (env: NodeJS.ProcessEnv, options: AcceptanceDeployOptions, reportId: string) => Promise<readonly AcceptanceProbeResult[]>;
   runInternalVerify: (runtimeProfile: RemoteRuntimeProfile, env: NodeJS.ProcessEnv) => Promise<{ doctorReport: import('../runtime-env.shared.ts').DoctorReport; probes: readonly AcceptanceProbeResult[] }>;
   waitForPostDeployStabilization: (env: NodeJS.ProcessEnv) => Promise<number>;

--- a/scripts/ops/runtime/remote-verification.ts
+++ b/scripts/ops/runtime/remote-verification.ts
@@ -137,7 +137,7 @@ const selectReleaseBlockingTenantTargets = (
     ? tenantTargets.filter((target) => target.instanceId === 'de-studio-sandbox')
     : tenantTargets;
 
-const shouldUseStudioReleaseBlockingTenantScope = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) =>
+export const shouldUseStudioReleaseBlockingTenantScope = (runtimeProfile: RuntimeProfile, env: NodeJS.ProcessEnv) =>
   runtimeProfile === 'studio' && (env.SVA_ACCEPTANCE_RELEASE_MODE?.trim().length ?? 0) > 0;
 
 const selectSmokeTenantTargets = (

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -174,7 +174,7 @@ export const isBlockingSmokeProbe = (
 
   const isExplicitIngressProbe = probe.name.startsWith('public-ingress-https-')
     || probe.name.startsWith('public-ingress-login-');
-  if (!isExplicitIngressProbe) return false;
+  if (!isExplicitIngressProbe) return true;
   if (!usesReleaseBlockingTenantScope) return true;
 
   return probe.name.startsWith('public-ingress-https-de-studio-sandbox.')

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -174,7 +174,7 @@ export const isBlockingSmokeProbe = (
 
   const isExplicitIngressProbe = probe.name.startsWith('public-ingress-https-')
     || probe.name.startsWith('public-ingress-login-');
-  if (!isExplicitIngressProbe) return true;
+  if (!isExplicitIngressProbe) return false;
   if (!usesReleaseBlockingTenantScope) return true;
 
   return probe.name.startsWith('public-ingress-https-de-studio-sandbox.')

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -165,21 +165,34 @@ const runExternalSmokeWithWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.Pr
   return lastProbes;
 };
 
-const isBlockingSmokeProbe = (
-  deps: RuntimeSmokeDeps,
+export const isBlockingSmokeProbe = (
   probe: AcceptanceProbeResult,
   runtimeProfile: RuntimeProfile,
   env: NodeJS.ProcessEnv,
 ) => {
-  if (['public-live', 'public-ready', 'public-auth-login', 'public-ingress-unknown-host'].includes(probe.name)) return true;
+  if (['public-home', 'public-live', 'public-ready', 'public-auth-login', 'public-ingress-unknown-host'].includes(probe.name)) return true;
   if (probe.name.startsWith('public-auth-login-')) return true;
 
   const isExplicitIngressProbe = probe.name.startsWith('public-ingress-https-')
     || probe.name.startsWith('public-ingress-login-');
   if (!isExplicitIngressProbe) return false;
-  if (!deps.shouldUseStudioReleaseBlockingTenantScope(runtimeProfile, env)) return true;
+  const usesReleaseBlockingTenantScope = runtimeProfile === 'studio'
+    && (env.SVA_ACCEPTANCE_RELEASE_MODE?.trim().length ?? 0) > 0;
+  if (!usesReleaseBlockingTenantScope) return true;
 
-  return probe.name.includes('de-studio-sandbox.studio.smart-village.app');
+  return probe.name.startsWith('public-ingress-https-de-studio-sandbox.')
+    || probe.name.startsWith('public-ingress-login-de-studio-sandbox.');
+};
+
+export const reportNonBlockingSmokeFailures = (
+  probes: readonly AcceptanceProbeResult[],
+  runtimeProfile: RuntimeProfile,
+  env: NodeJS.ProcessEnv,
+) => {
+  for (const probe of probes) {
+    if (probe.status !== 'error' || isBlockingSmokeProbe(probe, runtimeProfile, env)) continue;
+    console.warn(`[runtime-env] Nicht blockierender Smoke-Fehler: ${probe.name}: ${probe.message}`);
+  }
 };
 
 const waitForRemoteSmokeWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv, options?: ExternalSmokeWarmupOptions) => {
@@ -190,11 +203,12 @@ const waitForRemoteSmokeWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.Proc
     runtimeProfile,
     runner: options?.runner,
     shouldRetry: (candidateProbes) => shouldRetryExternalSmoke(
-      candidateProbes.filter((probe) => isBlockingSmokeProbe(deps, probe, runtimeProfile, env)),
+      candidateProbes.filter((probe) => isBlockingSmokeProbe(probe, runtimeProfile, env)),
     ),
   });
+  reportNonBlockingSmokeFailures(probes, runtimeProfile, env);
   const failingProbe = probes.find(
-    (probe) => probe.status === 'error' && isBlockingSmokeProbe(deps, probe, runtimeProfile, env),
+    (probe) => probe.status === 'error' && isBlockingSmokeProbe(probe, runtimeProfile, env),
   );
   if (failingProbe) throw new Error(`${failingProbe.name}: ${failingProbe.message}`);
   return probes;

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -165,11 +165,22 @@ const runExternalSmokeWithWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.Pr
   return lastProbes;
 };
 
-const isBlockingSmokeProbe = (probe: AcceptanceProbeResult) =>
-  ['public-live', 'public-ready', 'public-auth-login', 'public-ingress-unknown-host'].includes(probe.name)
-  || probe.name.startsWith('public-auth-login-')
-  || probe.name.startsWith('public-ingress-https-')
-  || probe.name.startsWith('public-ingress-login-');
+const isBlockingSmokeProbe = (
+  deps: RuntimeSmokeDeps,
+  probe: AcceptanceProbeResult,
+  runtimeProfile: RuntimeProfile,
+  env: NodeJS.ProcessEnv,
+) => {
+  if (['public-live', 'public-ready', 'public-auth-login', 'public-ingress-unknown-host'].includes(probe.name)) return true;
+  if (probe.name.startsWith('public-auth-login-')) return true;
+
+  const isExplicitIngressProbe = probe.name.startsWith('public-ingress-https-')
+    || probe.name.startsWith('public-ingress-login-');
+  if (!isExplicitIngressProbe) return false;
+  if (!deps.shouldUseStudioReleaseBlockingTenantScope(runtimeProfile, env)) return true;
+
+  return probe.name.includes('de-studio-sandbox.studio.smart-village.app');
+};
 
 const waitForRemoteSmokeWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv, options?: ExternalSmokeWarmupOptions) => {
   const runtimeProfile = options?.runtimeProfile ?? defaultRuntimeProfile(deps, env);
@@ -178,9 +189,13 @@ const waitForRemoteSmokeWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.Proc
     retryDelayMs: options?.retryDelayMs,
     runtimeProfile,
     runner: options?.runner,
-    shouldRetry: (candidateProbes) => shouldRetryExternalSmoke(candidateProbes.filter(isBlockingSmokeProbe)),
+    shouldRetry: (candidateProbes) => shouldRetryExternalSmoke(
+      candidateProbes.filter((probe) => isBlockingSmokeProbe(deps, probe, runtimeProfile, env)),
+    ),
   });
-  const failingProbe = probes.find((probe) => probe.status === 'error' && isBlockingSmokeProbe(probe));
+  const failingProbe = probes.find(
+    (probe) => probe.status === 'error' && isBlockingSmokeProbe(deps, probe, runtimeProfile, env),
+  );
   if (failingProbe) throw new Error(`${failingProbe.name}: ${failingProbe.message}`);
   return probes;
 };

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -167,8 +167,7 @@ const runExternalSmokeWithWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.Pr
 
 export const isBlockingSmokeProbe = (
   probe: AcceptanceProbeResult,
-  runtimeProfile: RuntimeProfile,
-  env: NodeJS.ProcessEnv,
+  usesReleaseBlockingTenantScope: boolean,
 ) => {
   if (['public-home', 'public-live', 'public-ready', 'public-auth-login', 'public-ingress-unknown-host'].includes(probe.name)) return true;
   if (probe.name.startsWith('public-auth-login-')) return true;
@@ -176,8 +175,6 @@ export const isBlockingSmokeProbe = (
   const isExplicitIngressProbe = probe.name.startsWith('public-ingress-https-')
     || probe.name.startsWith('public-ingress-login-');
   if (!isExplicitIngressProbe) return false;
-  const usesReleaseBlockingTenantScope = runtimeProfile === 'studio'
-    && (env.SVA_ACCEPTANCE_RELEASE_MODE?.trim().length ?? 0) > 0;
   if (!usesReleaseBlockingTenantScope) return true;
 
   return probe.name.startsWith('public-ingress-https-de-studio-sandbox.')
@@ -186,29 +183,29 @@ export const isBlockingSmokeProbe = (
 
 export const reportNonBlockingSmokeFailures = (
   probes: readonly AcceptanceProbeResult[],
-  runtimeProfile: RuntimeProfile,
-  env: NodeJS.ProcessEnv,
+  usesReleaseBlockingTenantScope: boolean,
 ) => {
   for (const probe of probes) {
-    if (probe.status !== 'error' || isBlockingSmokeProbe(probe, runtimeProfile, env)) continue;
+    if (probe.status !== 'error' || isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope)) continue;
     console.warn(`[runtime-env] Nicht blockierender Smoke-Fehler: ${probe.name}: ${probe.message}`);
   }
 };
 
 const waitForRemoteSmokeWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv, options?: ExternalSmokeWarmupOptions) => {
   const runtimeProfile = options?.runtimeProfile ?? defaultRuntimeProfile(deps, env);
+  const usesReleaseBlockingTenantScope = deps.shouldUseStudioReleaseBlockingTenantScope(runtimeProfile, env);
   const probes = await runExternalSmokeWithWarmup(deps, env, {
     maxAttempts: options?.maxAttempts,
     retryDelayMs: options?.retryDelayMs,
     runtimeProfile,
     runner: options?.runner,
     shouldRetry: (candidateProbes) => shouldRetryExternalSmoke(
-      candidateProbes.filter((probe) => isBlockingSmokeProbe(probe, runtimeProfile, env)),
+      candidateProbes.filter((probe) => isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope)),
     ),
   });
-  reportNonBlockingSmokeFailures(probes, runtimeProfile, env);
+  reportNonBlockingSmokeFailures(probes, usesReleaseBlockingTenantScope);
   const failingProbe = probes.find(
-    (probe) => probe.status === 'error' && isBlockingSmokeProbe(probe, runtimeProfile, env),
+    (probe) => probe.status === 'error' && isBlockingSmokeProbe(probe, usesReleaseBlockingTenantScope),
   );
   if (failingProbe) throw new Error(`${failingProbe.name}: ${failingProbe.message}`);
   return probes;

--- a/scripts/ops/runtime/smoke.test.ts
+++ b/scripts/ops/runtime/smoke.test.ts
@@ -143,6 +143,7 @@ describe('smoke helpers', () => {
 
   it.each([
     'public-home',
+    'public-iam-context',
     'public-ingress-https-de-studio-sandbox.studio-staging.smart-village.app',
   ])('keeps %s release-blocking', async (name) => {
     const ops = createRuntimeSmokeOps({

--- a/scripts/ops/runtime/smoke.test.ts
+++ b/scripts/ops/runtime/smoke.test.ts
@@ -108,6 +108,36 @@ describe('smoke helpers', () => {
     }), null)).toBeNull();
   });
 
+  it('does not block production releases on non-release tenant ingress failures', async () => {
+    const ops = createRuntimeSmokeOps({
+      buildSwarmAppTaskProbe: () => createProbe({ scope: 'internal' }),
+      buildSwarmServicePresenceProbe: () => createProbe({ scope: 'internal' }),
+      doctorRuntime: async () => createDoctorReport({}),
+      isExpectedOidcRedirect: () => true,
+      parseRuntimeProfile: (value) => value,
+      resolveTenantRuntimeTargets: async () => ({ source: 'registry', targets: [] }),
+      runHttpProbe: async (input) => createProbe({ name: input.name, target: input.target }),
+      selectSmokeTenantTargets: (_runtimeProfile, tenantTargets) => tenantTargets,
+      shouldUseStudioReleaseBlockingTenantScope: (runtimeProfile, env) =>
+        runtimeProfile === 'studio' && env.SVA_ACCEPTANCE_RELEASE_MODE === 'prod',
+      wait: async () => undefined,
+    });
+    const nonBlockingFailure = createProbe({
+      message: 'fetch failed',
+      name: 'public-ingress-https-bb-ahrensfelde.studio.smart-village.app',
+      status: 'error',
+    });
+
+    await expect(ops.waitForRemoteSmokeWarmup({
+      SVA_ACCEPTANCE_RELEASE_MODE: 'prod',
+      SVA_RUNTIME_PROFILE: 'studio',
+    }, {
+      maxAttempts: 1,
+      runner: async () => [nonBlockingFailure],
+      runtimeProfile: 'studio',
+    })).resolves.toEqual([nonBlockingFailure]);
+  });
+
   it('returns no ingress contract for an invalid base URL', () => {
     expect(resolveStudioIngressContract('https://')).toBeNull();
   });

--- a/scripts/ops/runtime/smoke.test.ts
+++ b/scripts/ops/runtime/smoke.test.ts
@@ -143,7 +143,6 @@ describe('smoke helpers', () => {
 
   it.each([
     'public-home',
-    'public-iam-context',
     'public-ingress-https-de-studio-sandbox.studio-staging.smart-village.app',
   ])('keeps %s release-blocking', async (name) => {
     const ops = createRuntimeSmokeOps({

--- a/scripts/ops/runtime/smoke.test.ts
+++ b/scripts/ops/runtime/smoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { AcceptanceProbeResult, DoctorReport } from '../runtime-env.shared.ts';
 import {
@@ -109,6 +109,7 @@ describe('smoke helpers', () => {
   });
 
   it('does not block production releases on non-release tenant ingress failures', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const ops = createRuntimeSmokeOps({
       buildSwarmAppTaskProbe: () => createProbe({ scope: 'internal' }),
       buildSwarmServicePresenceProbe: () => createProbe({ scope: 'internal' }),
@@ -119,7 +120,7 @@ describe('smoke helpers', () => {
       runHttpProbe: async (input) => createProbe({ name: input.name, target: input.target }),
       selectSmokeTenantTargets: (_runtimeProfile, tenantTargets) => tenantTargets,
       shouldUseStudioReleaseBlockingTenantScope: (runtimeProfile, env) =>
-        runtimeProfile === 'studio' && env.SVA_ACCEPTANCE_RELEASE_MODE === 'prod',
+        runtimeProfile === 'studio' && (env.SVA_ACCEPTANCE_RELEASE_MODE?.trim().length ?? 0) > 0,
       wait: async () => undefined,
     });
     const nonBlockingFailure = createProbe({
@@ -129,13 +130,43 @@ describe('smoke helpers', () => {
     });
 
     await expect(ops.waitForRemoteSmokeWarmup({
-      SVA_ACCEPTANCE_RELEASE_MODE: 'prod',
+      SVA_ACCEPTANCE_RELEASE_MODE: 'app-only',
       SVA_RUNTIME_PROFILE: 'studio',
     }, {
       maxAttempts: 1,
       runner: async () => [nonBlockingFailure],
       runtimeProfile: 'studio',
     })).resolves.toEqual([nonBlockingFailure]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(nonBlockingFailure.name));
+    warn.mockRestore();
+  });
+
+  it.each([
+    'public-home',
+    'public-ingress-https-de-studio-sandbox.studio-staging.smart-village.app',
+  ])('keeps %s release-blocking', async (name) => {
+    const ops = createRuntimeSmokeOps({
+      buildSwarmAppTaskProbe: () => createProbe({ scope: 'internal' }),
+      buildSwarmServicePresenceProbe: () => createProbe({ scope: 'internal' }),
+      doctorRuntime: async () => createDoctorReport({}),
+      isExpectedOidcRedirect: () => true,
+      parseRuntimeProfile: (value) => value,
+      resolveTenantRuntimeTargets: async () => ({ source: 'registry', targets: [] }),
+      runHttpProbe: async (input) => createProbe({ name: input.name, target: input.target }),
+      selectSmokeTenantTargets: (_runtimeProfile, tenantTargets) => tenantTargets,
+      shouldUseStudioReleaseBlockingTenantScope: () => true,
+      wait: async () => undefined,
+    });
+    const blockingFailure = createProbe({ message: 'fetch failed', name, status: 'error' });
+
+    await expect(ops.waitForRemoteSmokeWarmup({
+      SVA_ACCEPTANCE_RELEASE_MODE: 'app-only',
+      SVA_RUNTIME_PROFILE: 'studio',
+    }, {
+      maxAttempts: 1,
+      runner: async () => [blockingFailure],
+      runtimeProfile: 'studio',
+    })).rejects.toThrow(name);
   });
 
   it('returns no ingress contract for an invalid base URL', () => {


### PR DESCRIPTION
## Ursache
Der Production-Promote von PR #887 war nach erfolgreichem Backup, Migration und Stack-Update am nicht eingerichteten Tenant-Host `bb-ahrensfelde` rot. Der allgemeine Ingress-Smoke behandelte sämtliche expliziten Production-Hosts als release-blockierend, obwohl der kanonische Rollout-Vertrag ausschließlich `de-studio-sandbox` als tenantseitigen Release-Blocker definiert.

## Änderung
- Root-, Live-, Ready-, Unknown-Host- und `de-studio-sandbox`-Prüfungen bleiben blockierend.
- Andere explizite Production-Tenant-Hosts bleiben im Smoke sichtbar, brechen den Release aber nicht mehr ab.
- Außerhalb des Production-Release-Scope bleibt das bisherige strikte Verhalten unverändert.

## Verifikation
- `pnpm exec vitest run scripts/ops/runtime/smoke.test.ts` (13/13)
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:rollout-docs`

## Rollout-Kontext
Follow-up zu #887 und Production-Run 30747084325. Nach Merge wird ein neues Image gebaut und regulär über Dev/Staging/Production promotet.