### PR TITLE
fix: Deployment-Smoke-Warmup auf 50 Versuche erweitern

### DIFF
--- a/.github/agents/rollout-operator.agent.md
+++ b/.github/agents/rollout-operator.agent.md
@@ -93,7 +93,7 @@ Nicht benötigte One-shot-Phasen werden durch die Gate-Auswertung übersprungen;
 
 ## Konvergenz
 
-Nach einem Swarm-Update bis zu fünf Minuten ab abgeschlossenem Service-Update zulassen. Während dieses Fensters keine zusätzliche Mutation starten. Danach erneut prüfen:
+Nach einem Swarm-Update bis zu 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden ab abgeschlossenem Service-Update zulassen. Während dieses Fensters keine zusätzliche Mutation starten. Danach erneut prüfen:
 
 - App-Task läuft,
 - `/health/live` und `/health/ready` liefern 200,
@@ -111,7 +111,7 @@ Wenn ein App-Rollback nötig ist:
 1. vorherigen Live-Digest aus der Promote-Evidenz nehmen,
 2. Datenbankschema-Kompatibilität prüfen,
 3. Recovery auf den expliziten App-Service und Zielstack begrenzen,
-4. fünf Minuten Konvergenz berücksichtigen,
+4. bis zu 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden berücksichtigen,
 5. vollständige Health-, Tenant- und Digest-Verifikation ausführen,
 6. Incident-Report unter `docs/reports/` anlegen,
 7. Zustand anschließend durch den kanonischen Promote-Pfad reconciliieren.

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -58,7 +58,7 @@ Dieser Abschnitt beschreibt messbare Qualitätsziele auf aktuellem Stand.
   - Vor jeder Staging-/Production-Migration oder jedem Bootstrap muss das umgebungsgebundene PostgreSQL-Backup erfolgreich und das MinIO-Objekt unabhängig verifiziert sein.
   - Mutierende Production-Läufe müssen Environment-Freigabe und erfolgreiche mutierende Staging-Parität exakt desselben Digests nachweisen; ein Wartungsfenster-Verweis ist nicht erforderlich.
   - Migration, Bootstrap, Postconditions, App-Deploy, Runtime-Smoke und Digest-Prüfung müssen fail-closed in dieser Reihenfolge laufen.
-  - Öffentliche Smoke-Probes gegen `/health/live`, `/health/ready`, Root-Login und alle aktiven Tenant-Logins dürfen nach bis zu fünf Minuten Swarm-Konvergenz keinen stabilen Fehler liefern.
+  - Öffentliche Smoke-Probes gegen `/health/live`, `/health/ready`, Root-Login und alle aktiven Tenant-Logins dürfen nach bis zu 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden keinen stabilen Fehler liefern.
   - GitHub-Step-Summary und Action-Artefakte müssen Digest, Stack, Phasenstatus, Backup-Referenz, Jobstatus und Verifikation redigiert dokumentieren; Secrets, `.env`, `APP_CONFIG`, PII und unredigierte Remote-Logs bleiben ausgeschlossen.
   - Lokale `artifacts/runtime/deployments/`-Reports und `env:feedback:studio` gehören ausschließlich zum genehmigten Incident-Recovery-Pfad.
 - Lokale Runtime-Drift-Reparatur:

--- a/docs/changelog/entries/pr-892.json
+++ b/docs/changelog/entries/pr-892.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 892,
+  "body": "Robusterer Deployment-Smoke bei langsamer Konvergenz\n\n- Der Runtime-Smoke wartet bei vorübergehenden Erreichbarkeitsfehlern standardmäßig bis zu 50 Versuche im Abstand von zehn Sekunden ab.\n- Dauerhafte Fehler bleiben blockierend und werden nach dem erweiterten Warmup weiterhin klar gemeldet."
+}

--- a/docs/development/runtime-profile-betrieb.md
+++ b/docs/development/runtime-profile-betrieb.md
@@ -307,7 +307,7 @@ Der Container-Entrypoint kennt zusätzlich nur noch einen expliziten Legacy-Reco
 - Wenn das Ziel-Digest bereits live auf `app` läuft, darf das Parity-Gate die Live-Evidenz desselben Digests wiederverwenden. Voraussetzung sind grüne Nachweise für Ingress-Konsistenz, `app-db-principal`, Tenant-Auth-Proof und Live-Runtime-Flags.
 - Ein lokaler Kandidatencontainer ersetzt fuer `studio` keinen echten Swarm-/Ingress-/Private-DNS-Nachweis. Kann der Remote-Hostvertrag lokal nicht realistisch abgebildet werden, bleibt nur die dokumentierte Live-Paritaet desselben Digests oder ein echter Remote-Rollout im kanonischen Pfad.
 - Erkenntnis aus dem Studio-Release vom 28. April 2026: `migrate` und `bootstrap` bleiben harte Freigabegates, weil Schema-Pflichtfelder und Bootstrap-Reconcile gemeinsam betrachtet werden müssen.
-- Erkenntnis aus realen Studio-Rollouts: externe Health- und Tenant-Probes direkt nach dem Stack-Cutover können kurzzeitige Fehler liefern; der kanonische Prozess berücksichtigt bis zu fünf Minuten Konvergenzzeit, bevor ein stabiler Fehler bewertet wird.
+- Erkenntnis aus realen Studio-Rollouts: externe Health- und Tenant-Probes direkt nach dem Stack-Cutover können kurzzeitige Fehler liefern; der kanonische Prozess berücksichtigt bis zu 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden, bevor ein stabiler Fehler bewertet wird.
 - Erkenntnis aus dem Studio-Release vom 28. April 2026: eine erfolgreich in GitHub gelaufene `Studio Image Verify`-Evidenz ist fachlich gleichwertig zu lokal erzeugten Verify-Artefakten; ein reiner Lookup auf `artifacts/runtime/image-verify` erzeugt sonst Warnrauschen.
 
 ### `smoke`
@@ -337,7 +337,7 @@ Zusatzprüfungen:
 - Remote: zusätzlich `/api/v1/iam/instances`
 - Remote: mindestens ein aktiver Tenant-Host und ein negativer Host-Fall gegen dieselbe App-Instanz
 - Remote: `doctor` und `precheck` muessen `app-db-principal` fuer denselben Runtime-User wie die laufende App als `ok` ausweisen
-- Lokale Remote-Recovery: Wenn die erste externe Probe direkt nach einem `app-only`-Reconcile fehlschlägt, gilt dieselbe Konvergenzzeit von bis zu fünf Minuten wie im kanonischen Rollout, bevor ein stabiler `health`-Fehler gewertet wird
+- Lokale Remote-Recovery: Wenn die erste externe Probe direkt nach einem `app-only`-Reconcile fehlschlägt, gelten dieselben maximal 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden wie im kanonischen Rollout, bevor ein stabiler `health`-Fehler gewertet wird
 
 Im Profil `studio` prüfen die externen Smokes zusätzlich tenant-spezifische OIDC-Redirects. Der Scope kommt bevorzugt aus der Instanz-Registry; `SVA_ALLOWED_INSTANCE_IDS` bleibt nur lokaler oder migrationsbezogener Fallback, und `SVA_TENANT_SCOPE_INSTANCE_IDS` kann den Scope für gezielte Operator-Läufe explizit übersteuern.
 
@@ -473,7 +473,7 @@ Für den produktionsnahen `studio`-Betrieb gilt:
 - bei lokalen Profilwechseln nie zwei Profile parallel auf Port `3000` betreiben
 - für serverseitige Details, Secrets und Portainer-Bedienung bleibt `../guides/swarm-deployment-runbook.md` die Referenz
 - `config/runtime/studio.local.vars` ist ausschließlich lokale Diagnose-/Recovery-Konfiguration und keine Quelle für GitHub-Environment-Secrets
-- Der Recovery-Pfad für `app 1/1`, aber externen `502`, lautet: Render-Compose prüfen, Live-Service-Spec prüfen, bis zu fünf Minuten Konvergenz berücksichtigen, bei Bedarf kontrollierten App-Reconcile ausführen und danach `status`, `smoke` und `precheck` wiederholen.
+- Der Recovery-Pfad für `app 1/1`, aber externen `502`, lautet: Render-Compose prüfen, Live-Service-Spec prüfen, bis zu 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden berücksichtigen, bei Bedarf kontrollierten App-Reconcile ausführen und danach `status`, `smoke` und `precheck` wiederholen.
 
 ## Typische Fehlerbilder
 

--- a/docs/guides/deployment-overview.md
+++ b/docs/guides/deployment-overview.md
@@ -25,7 +25,7 @@ main → Build → Dev → manuelles Staging → manuell freigegebenes Productio
 - Production akzeptiert bei Datenmutationen nur denselben erfolgreich in Staging geprüften Digest.
 - Ein erfolgreich verifiziertes Datenbank-Backup liegt vor jeder Migration oder jedem Bootstrap in Staging und Production.
 - Die GitHub-Environments `staging` und `prod` bilden die Freigabe- und Secret-Grenzen.
-- Nach einem Swarm-Update wird eine Konvergenzzeit von bis zu fünf Minuten berücksichtigt.
+- Nach einem Swarm-Update werden zur Konvergenz bis zu 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden berücksichtigt.
 
 Die vollständige Reihenfolge, Eingaben, Stacknamen, Domains, Buckets und Erfolgskriterien stehen ausschließlich im [kanonischen Studio-Rollout](./studio-rollout-process.md).
 

--- a/docs/guides/studio-rollout-process.md
+++ b/docs/guides/studio-rollout-process.md
@@ -99,10 +99,10 @@ Migrationen, Bootstraps und Backups benötigen keinen Wartungsfenster-Verweis. D
 
 ## Konvergenz und Erfolgsdefinition
 
-Docker-Swarm-Dienste dürfen nach einem Update bis zu fünf Minuten benötigen, bis alle Probes stabil sind. Deshalb gilt:
+Docker-Swarm-Dienste dürfen nach einem Update längere Zeit benötigen, bis alle Probes stabil sind. Der Runtime-Smoke prüft die Erreichbarkeit deshalb standardmäßig bis zu 50-mal im Abstand von zehn Sekunden. Deshalb gilt:
 
 1. Ein unmittelbar nach dem Deploy fehlschlagender Smoke wird nicht durch weitere Mutationen „repariert“.
-2. Zuerst Service-Update und Tasks prüfen und bis zu fünf Minuten ab dem abgeschlossenen Update konvergieren lassen.
+2. Zuerst Service-Update und Tasks prüfen und bis zum Abschluss der maximal 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden konvergieren lassen.
 3. In Production danach `health/live`, `health/ready`, den Release-Blocking-Tenant-Login-Redirect (`de-studio-sandbox`) und den Live-Digest erneut prüfen. Weitere Tenant-Redirects bleiben operativ überwacht, blockieren aber nicht. Staging verwendet den allgemeinen Runtime-Smoke ohne verpflichtenden Tenant-Scope.
 4. Bleibt ein Fehler bestehen, ist der Rollout rot und wird diagnostiziert oder auf den vorherigen Digest zurückgeführt.
 5. Ein Workflow-Retry ist erst nach dokumentierter Ursache beziehungsweise bestätigtem reinen Konvergenzfehler zulässig.

--- a/docs/guides/studio-rollout-process.md
+++ b/docs/guides/studio-rollout-process.md
@@ -99,7 +99,7 @@ Migrationen, Bootstraps und Backups benötigen keinen Wartungsfenster-Verweis. D
 
 ## Konvergenz und Erfolgsdefinition
 
-Docker-Swarm-Dienste dürfen nach einem Update längere Zeit benötigen, bis alle Probes stabil sind. Der Runtime-Smoke prüft die Erreichbarkeit deshalb standardmäßig bis zu 50-mal im Abstand von zehn Sekunden. Deshalb gilt:
+Docker-Swarm-Dienste dürfen nach einem Update längere Zeit benötigen, bis alle Probes stabil sind. Die bisherige Warmup-Grenze von bis zu fünf Minuten reicht dafür nicht immer aus. Der Runtime-Smoke prüft die Erreichbarkeit deshalb standardmäßig bis zu 50-mal im Abstand von zehn Sekunden. Deshalb gilt:
 
 1. Ein unmittelbar nach dem Deploy fehlschlagender Smoke wird nicht durch weitere Mutationen „repariert“.
 2. Zuerst Service-Update und Tasks prüfen und bis zum Abschluss der maximal 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden konvergieren lassen.

--- a/docs/guides/swarm-deployment-runbook.md
+++ b/docs/guides/swarm-deployment-runbook.md
@@ -63,7 +63,7 @@ GitHub Actions führt die regulären Prüfungen aus. Für eine unabhängige Inci
 | TLS                       | gültiges Einzelzertifikat für jeden expliziten Host                    |
 | unbekannter Tenant-Host   | kein Tenant-Inhalt und kein tenant-spezifischer Login                  |
 
-Ein Swarm-Service darf nach einem Update bis zu fünf Minuten konvergieren. Vor Ablauf dieses Fensters wird kein zusätzlicher mutierender Reparaturversuch gestartet. Bleibt ein Fehler danach bestehen, gilt der Rollout als fehlgeschlagen.
+Ein Swarm-Service darf nach einem Update bis zum Abschluss der maximal 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden konvergieren. Vor Ablauf dieses Fensters wird kein zusätzlicher mutierender Reparaturversuch gestartet. Bleibt ein Fehler danach bestehen, gilt der Rollout als fehlgeschlagen.
 
 ## Backup-Agent
 
@@ -97,7 +97,7 @@ Die Workflows **Staging Backup Drill** und **Production Backup Drill** testen de
 
 1. Zielstack, erwarteten Digest und Zeitpunkt festhalten.
 2. Service-Spec, Taskzustände, Netzwerke und Traefik-Labels read-only prüfen.
-3. Bis zu fünf Minuten Konvergenzzeit ab dem abgeschlossenen Service-Update berücksichtigen.
+3. Bis zu 50 Erreichbarkeitsprüfungen im Abstand von zehn Sekunden ab dem abgeschlossenen Service-Update berücksichtigen.
 4. Root-, alle expliziten Tenant-, Zertifikats- und Unknown-Host-Probes erneut ausführen.
 5. Bei anhaltendem Fehler den vorherigen Digest als Recovery-Ziel festlegen.
 6. Eine notwendige direkte Mutation auf genau den App-Service des Zielstacks begrenzen.

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -30,6 +30,9 @@ type ExternalSmokeWarmupOptions = {
   readonly shouldRetry?: (probes: readonly AcceptanceProbeResult[]) => boolean;
 };
 
+const defaultExternalSmokeMaxAttempts = 50;
+const defaultExternalSmokeRetryDelayMs = 10_000;
+
 const defaultRuntimeProfile = (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv) =>
   deps.parseRuntimeProfile(env.SVA_RUNTIME_PROFILE as RuntimeProfile | undefined) ?? 'local-keycloak';
 
@@ -147,9 +150,12 @@ const runExternalSmoke = async (deps: RuntimeSmokeDeps, runtimeProfile: RuntimeP
 };
 
 const runExternalSmokeWithWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv, options?: ExternalSmokeWarmupOptions) => {
-  const retryDelayMs = options?.retryDelayMs ?? Number(env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS ?? '15000');
-  const warmupWindowMs = Number(env.SVA_EXTERNAL_SMOKE_WARMUP_WINDOW_MS ?? '300000');
-  const maxAttempts = options?.maxAttempts ?? Number(env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS ?? String(Math.max(1, Math.floor(warmupWindowMs / Math.max(retryDelayMs, 1)) + 1)));
+  const retryDelayMs = options?.retryDelayMs ?? Number(env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS ?? String(defaultExternalSmokeRetryDelayMs));
+  const configuredWarmupWindowMs = env.SVA_EXTERNAL_SMOKE_WARMUP_WINDOW_MS;
+  const maxAttemptsFromWarmupWindow = configuredWarmupWindowMs === undefined
+    ? defaultExternalSmokeMaxAttempts
+    : Math.max(1, Math.floor(Number(configuredWarmupWindowMs) / Math.max(retryDelayMs, 1)) + 1);
+  const maxAttempts = options?.maxAttempts ?? Number(env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS ?? String(maxAttemptsFromWarmupWindow));
   const shouldRetry = options?.shouldRetry ?? shouldRetryExternalSmoke;
   const runtimeProfile = options?.runtimeProfile ?? defaultRuntimeProfile(deps, env);
   const runner = options?.runner ?? ((currentEnv: NodeJS.ProcessEnv) => runExternalSmoke(deps, runtimeProfile, currentEnv));

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -33,6 +33,11 @@ type ExternalSmokeWarmupOptions = {
 const defaultExternalSmokeMaxAttempts = 50;
 const defaultExternalSmokeRetryDelayMs = 10_000;
 
+const parsePositiveInteger = (value: number | string | undefined): number | undefined => {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+};
+
 const defaultRuntimeProfile = (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv) =>
   deps.parseRuntimeProfile(env.SVA_RUNTIME_PROFILE as RuntimeProfile | undefined) ?? 'local-keycloak';
 
@@ -150,12 +155,14 @@ const runExternalSmoke = async (deps: RuntimeSmokeDeps, runtimeProfile: RuntimeP
 };
 
 const runExternalSmokeWithWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv, options?: ExternalSmokeWarmupOptions) => {
-  const retryDelayMs = options?.retryDelayMs ?? Number(env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS ?? String(defaultExternalSmokeRetryDelayMs));
-  const configuredWarmupWindowMs = env.SVA_EXTERNAL_SMOKE_WARMUP_WINDOW_MS;
+  const retryDelayMs = parsePositiveInteger(options?.retryDelayMs ?? env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS)
+    ?? defaultExternalSmokeRetryDelayMs;
+  const configuredWarmupWindowMs = parsePositiveInteger(env.SVA_EXTERNAL_SMOKE_WARMUP_WINDOW_MS);
   const maxAttemptsFromWarmupWindow = configuredWarmupWindowMs === undefined
     ? defaultExternalSmokeMaxAttempts
-    : Math.max(1, Math.floor(Number(configuredWarmupWindowMs) / Math.max(retryDelayMs, 1)) + 1);
-  const maxAttempts = options?.maxAttempts ?? Number(env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS ?? String(maxAttemptsFromWarmupWindow));
+    : Math.max(1, Math.floor(configuredWarmupWindowMs / retryDelayMs) + 1);
+  const maxAttempts = parsePositiveInteger(options?.maxAttempts ?? env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS)
+    ?? maxAttemptsFromWarmupWindow;
   const shouldRetry = options?.shouldRetry ?? shouldRetryExternalSmoke;
   const runtimeProfile = options?.runtimeProfile ?? defaultRuntimeProfile(deps, env);
   const runner = options?.runner ?? ((currentEnv: NodeJS.ProcessEnv) => runExternalSmoke(deps, runtimeProfile, currentEnv));

--- a/scripts/ops/runtime/smoke-runtime.ts
+++ b/scripts/ops/runtime/smoke-runtime.ts
@@ -38,6 +38,9 @@ const parsePositiveInteger = (value: number | string | undefined): number | unde
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 };
 
+const parseNonNegativeInteger = (value: number | undefined): number | undefined =>
+  value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
+
 const defaultRuntimeProfile = (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv) =>
   deps.parseRuntimeProfile(env.SVA_RUNTIME_PROFILE as RuntimeProfile | undefined) ?? 'local-keycloak';
 
@@ -155,12 +158,13 @@ const runExternalSmoke = async (deps: RuntimeSmokeDeps, runtimeProfile: RuntimeP
 };
 
 const runExternalSmokeWithWarmup = async (deps: RuntimeSmokeDeps, env: NodeJS.ProcessEnv, options?: ExternalSmokeWarmupOptions) => {
-  const retryDelayMs = parsePositiveInteger(options?.retryDelayMs ?? env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS)
-    ?? defaultExternalSmokeRetryDelayMs;
+  const retryDelayMs = options?.retryDelayMs === undefined
+    ? parsePositiveInteger(env.SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS) ?? defaultExternalSmokeRetryDelayMs
+    : parseNonNegativeInteger(options.retryDelayMs) ?? defaultExternalSmokeRetryDelayMs;
   const configuredWarmupWindowMs = parsePositiveInteger(env.SVA_EXTERNAL_SMOKE_WARMUP_WINDOW_MS);
   const maxAttemptsFromWarmupWindow = configuredWarmupWindowMs === undefined
     ? defaultExternalSmokeMaxAttempts
-    : Math.max(1, Math.floor(configuredWarmupWindowMs / retryDelayMs) + 1);
+    : Math.max(1, Math.floor(configuredWarmupWindowMs / Math.max(retryDelayMs, 1)) + 1);
   const maxAttempts = parsePositiveInteger(options?.maxAttempts ?? env.SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS)
     ?? maxAttemptsFromWarmupWindow;
   const shouldRetry = options?.shouldRetry ?? shouldRetryExternalSmoke;

--- a/scripts/ops/runtime/smoke.test.ts
+++ b/scripts/ops/runtime/smoke.test.ts
@@ -29,6 +29,37 @@ const createDoctorReport = (overrides: Partial<DoctorReport>): DoctorReport => (
 });
 
 describe('smoke helpers', () => {
+  it('fails a persistent root 404 only after 50 attempts every 10 seconds by default', async () => {
+    const wait = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue();
+    const runner = vi.fn<(env: NodeJS.ProcessEnv) => Promise<readonly AcceptanceProbeResult[]>>()
+      .mockResolvedValue([
+        createProbe({
+          message: 'Erwartet HTTP 200, erhalten 404.',
+          name: 'public-home',
+          status: 'error',
+        }),
+      ]);
+    const ops = createRuntimeSmokeOps({
+      buildSwarmAppTaskProbe: () => createProbe({ scope: 'internal' }),
+      buildSwarmServicePresenceProbe: () => createProbe({ scope: 'internal' }),
+      doctorRuntime: async () => createDoctorReport({}),
+      isExpectedOidcRedirect: () => true,
+      parseRuntimeProfile: (value) => value,
+      resolveTenantRuntimeTargets: async () => ({ source: 'registry', targets: [] }),
+      runHttpProbe: async (input) => createProbe({ name: input.name, target: input.target }),
+      selectSmokeTenantTargets: (_runtimeProfile, tenantTargets) => tenantTargets,
+      shouldUseStudioReleaseBlockingTenantScope: () => true,
+      wait,
+    });
+
+    await expect(ops.waitForRemoteSmokeWarmup({}, { runner, runtimeProfile: 'studio' }))
+      .rejects.toThrow('public-home: Erwartet HTTP 200, erhalten 404.');
+
+    expect(runner).toHaveBeenCalledTimes(50);
+    expect(wait).toHaveBeenCalledTimes(49);
+    expect(wait).toHaveBeenCalledWith(10_000);
+  });
+
   it('probes every explicit ingress host and an unknown host for the selected environment', async () => {
     const targets: string[] = [];
     const names: string[] = [];

--- a/scripts/ops/runtime/smoke.test.ts
+++ b/scripts/ops/runtime/smoke.test.ts
@@ -57,7 +57,40 @@ describe('smoke helpers', () => {
 
     expect(runner).toHaveBeenCalledTimes(50);
     expect(wait).toHaveBeenCalledTimes(49);
-    expect(wait).toHaveBeenCalledWith(10_000);
+    expect(wait.mock.calls).toEqual(Array.from({ length: 49 }, () => [10_000]));
+  });
+
+  it.each([
+    { SVA_EXTERNAL_SMOKE_MAX_ATTEMPTS: 'abc', SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS: 'abc' },
+    { SVA_EXTERNAL_SMOKE_RETRY_DELAY_MS: 'abc', SVA_EXTERNAL_SMOKE_WARMUP_WINDOW_MS: 'abc' },
+  ])('falls back to safe defaults for invalid external warmup settings', async (env) => {
+    const wait = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue();
+    const transientFailure = createProbe({
+      message: 'Erwartet HTTP 200, erhalten 404.',
+      name: 'public-home',
+      status: 'error',
+    });
+    const runner = vi.fn<(env: NodeJS.ProcessEnv) => Promise<readonly AcceptanceProbeResult[]>>()
+      .mockResolvedValueOnce([transientFailure])
+      .mockResolvedValueOnce([createProbe({ name: 'public-home' })]);
+    const ops = createRuntimeSmokeOps({
+      buildSwarmAppTaskProbe: () => createProbe({ scope: 'internal' }),
+      buildSwarmServicePresenceProbe: () => createProbe({ scope: 'internal' }),
+      doctorRuntime: async () => createDoctorReport({}),
+      isExpectedOidcRedirect: () => true,
+      parseRuntimeProfile: (value) => value,
+      resolveTenantRuntimeTargets: async () => ({ source: 'registry', targets: [] }),
+      runHttpProbe: async (input) => createProbe({ name: input.name, target: input.target }),
+      selectSmokeTenantTargets: (_runtimeProfile, tenantTargets) => tenantTargets,
+      shouldUseStudioReleaseBlockingTenantScope: () => true,
+      wait,
+    });
+
+    await expect(ops.runExternalSmokeWithWarmup(env, { runner, runtimeProfile: 'studio' }))
+      .resolves.toEqual([expect.objectContaining({ name: 'public-home', status: 'ok' })]);
+
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledExactlyOnceWith(10_000);
   });
 
   it('probes every explicit ingress host and an unknown host for the selected environment', async () => {


### PR DESCRIPTION
## Was ändert sich?

- Der externe Deployment-Smoke prüft vor einem stabilen Fehler standardmäßig bis zu 50-mal.
- Zwischen den Versuchen liegen zehn Sekunden.
- Der Root-Endpunkt `public-home` bleibt Teil der release-blockierenden Warmup-Prüfung.
- Der verbindliche Rollout-Prozess sowie Architektur- und Betriebsdokumentation beschreiben denselben Konvergenzvertrag.

## Warum?

Nach einem Swarm-Neustart kann die Studio-Anwendung erst verzögert erreichbar sein. Der bisherige Standard leitete aus fünf Minuten und 15 Sekunden Abstand nur 21 Versuche ab. Temporäre HTTP-404-Antworten konnten dadurch den Promote-Lauf beenden, obwohl die Anwendung kurz darauf verfügbar war.

Die zentrale Smoke-Logik gilt für Dev, Staging und Production. Bewusste Overrides über `SVA_EXTERNAL_SMOKE_*` bleiben erhalten. Definitive, nicht als Warmup klassifizierte Fehler bleiben fail-fast.

## Validierung

- `pnpm exec vitest run scripts/ops/runtime-env.test.ts scripts/ops/runtime/smoke.test.ts scripts/ops/runtime/runtime-health.test.ts` — 83 Tests bestanden
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm exec eslint scripts/ops/runtime/smoke-runtime.ts scripts/ops/runtime/smoke.test.ts`
- `pnpm check:file-placement`
- `git diff --cached --check`