### PR TITLE
fix: News-Headline-Fallback in Inhaltsprojektion wiederherstellen

### DIFF
--- a/docs/changelog/entries/pr-893.json
+++ b/docs/changelog/entries/pr-893.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 893,
+  "body": "News-Headlines wieder in der Inhaltsübersicht sichtbar\n\n- Fehlt der direkte News-Titel, verwendet die Inhaltsübersicht die Headline des ersten Content-Blocks.\n- Nur wenn weder Titel noch Headline vorhanden sind, wird weiterhin die technische News-ID angezeigt."
+}

--- a/packages/sva-mainserver/src/generated/projection-lists.ts
+++ b/packages/sva-mainserver/src/generated/projection-lists.ts
@@ -4,7 +4,7 @@ const provider = `dataProvider { id name }`;
 export const svaMainserverNewsProjectionListDocument = /* GraphQL */ `
   query SvaMainserverNewsProjectionList($limit: Int, $skip: Int, $order: NewsItemsOrder) {
     newsItems(limit: $limit, skip: $skip, order: $order) {
-      id title author createdAt updatedAt publicationDate publishedAt visible ${provider}
+      id title contentBlocks { title } author createdAt updatedAt publicationDate publishedAt visible ${provider}
     }
   }
 `;

--- a/packages/sva-mainserver/src/server/service-internals/projection-list-operations.test.ts
+++ b/packages/sva-mainserver/src/server/service-internals/projection-list-operations.test.ts
@@ -21,7 +21,14 @@ describe('projection list operations', () => {
   it('loads only allowlisted compact fields and skips invalid rows', async () => {
     const execute = vi.fn().mockResolvedValue({
       newsItems: [
-        { id: 'news-1', title: '', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+        {
+          id: 'news-1',
+          title: '',
+          contentBlocks: [{ title: 'Headline aus dem ersten Inhaltsblock' }],
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-02T00:00:00Z',
+        },
+        { id: 'news-2', title: null, contentBlocks: [{ title: null }] },
         { title: 'Ohne ID' },
       ],
     });
@@ -30,12 +37,31 @@ describe('projection list operations', () => {
     const result = await operations.listProjectionWithConfig('news.article', input, config);
 
     expect(result.data).toEqual([
-      expect.objectContaining({ id: 'news-1', title: 'news-1' }),
+      expect.objectContaining({ id: 'news-1', title: 'Headline aus dem ersten Inhaltsblock' }),
+      expect.objectContaining({ id: 'news-2', title: 'news-2' }),
     ]);
     expect(result.skippedInvalidCount).toBe(1);
     const request = execute.mock.calls[0]?.[0] as { document: string; variables: unknown };
     expect(request.variables).toEqual({ limit: 101, skip: 0, order: 'updatedAt_DESC' });
-    expect(request.document).not.toMatch(/\b(payload|contentBlocks|media|addresses)\b/);
+    expect(request.document).toMatch(/contentBlocks\s*\{\s*title\s*\}/);
+    expect(request.document).not.toMatch(/\b(payload|media|addresses)\b/);
+  });
+
+  it('prefers the news title over the first content-block headline', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      newsItems: [
+        {
+          id: 'news-1',
+          title: 'News-Titel',
+          contentBlocks: [{ title: 'Headline aus dem ersten Inhaltsblock' }],
+        },
+      ],
+    });
+    const operations = createProjectionListOperations(execute);
+
+    const result = await operations.listProjectionWithConfig('news.article', input, config);
+
+    expect(result.data[0]?.title).toBe('News-Titel');
   });
 
   it('loads surveys in one complete request without pagination variables', async () => {

--- a/packages/sva-mainserver/src/server/service-internals/projection-list-operations.ts
+++ b/packages/sva-mainserver/src/server/service-internals/projection-list-operations.ts
@@ -38,6 +38,21 @@ const mapProvider = (value: unknown): SvaMainserverProjectionListItem['dataProvi
   return id || name ? { ...(id ? { id } : {}), ...(name ? { name } : {}) } : undefined;
 };
 
+const firstContentBlockTitle = (value: unknown): string | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const firstBlock = value[0];
+  if (!firstBlock || typeof firstBlock !== 'object') return undefined;
+  return localizedTitle((firstBlock as RawItem).title);
+};
+
+const resolveTitle = (
+  source: RawItem,
+  contentType: SvaMainserverProjectionContentType,
+  titleField: 'title' | 'name'
+): string | undefined =>
+  localizedTitle(source[titleField]) ??
+  (contentType === 'news.article' ? firstContentBlockTitle(source.contentBlocks) : undefined);
+
 const mapItem = (
   value: unknown,
   contentType: SvaMainserverProjectionContentType,
@@ -49,7 +64,7 @@ const mapItem = (
   if (!id) return null;
   const createdAt = stringValue(source.createdAt) ?? stringValue(source.updatedAt) ?? new Date(0).toISOString();
   const updatedAt = stringValue(source.updatedAt) ?? createdAt;
-  const title = localizedTitle(source[titleField]) ?? id;
+  const title = resolveTitle(source, contentType, titleField) ?? id;
   const publication = stringValue(source.publishedAt) ?? stringValue(source.publicationDate);
   const provider = mapProvider(source.dataProvider);
   return {


### PR DESCRIPTION
## Zusammenfassung

- ergänzt die schlanke News-Projektionsabfrage um `contentBlocks { title }`
- verwendet den News-Titel, danach die Headline des ersten Content-Blocks und erst zuletzt die News-ID
- ergänzt Regressionstests für die vollständige Fallback-Reihenfolge

## Ursache

Der optimierte Projektionspfad ersetzte fehlende `title`-Werte unmittelbar durch die News-ID. Bestehende News können ihre sichtbare Headline jedoch im ersten Content-Block tragen.

## Auswirkung

In der Inhaltsübersicht werden betroffene News wieder mit ihrer Headline statt mit der technischen ID angezeigt. Andere Inhaltstypen bleiben unverändert.

## Verifikation

- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service-internals/projection-list-operations.test.ts`
- `pnpm nx run sva-mainserver:test:types`
- `pnpm nx run sva-mainserver:check:runtime`
- `git diff --check`