### PR TITLE
Kanonischen Permission-Katalog und additiven Tenant-Reconcile einführen

### DIFF
--- a/deploy/portainer/bootstrap-entrypoint.sh
+++ b/deploy/portainer/bootstrap-entrypoint.sh
@@ -32,7 +32,29 @@ cleanup() {
 }
 trap cleanup EXIT
 
-node <<'NODE' >"${tmp_sql}"
+node --input-type=module <<'NODE' >"${tmp_sql}"
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const resolveWorkspacePackage = (packageName) => {
+  const packagePath = packageName.replace('@sva/', '');
+  const candidates = [
+    resolve('node_modules/@sva', packagePath, 'dist/index.js'),
+    resolve('apps/sva-studio-react/node_modules/@sva', packagePath, 'dist/index.js'),
+  ];
+  const entrypoint = candidates.find((candidate) => existsSync(candidate));
+  if (!entrypoint) {
+    throw new Error(`Bootstrap-Package nicht gefunden: ${packageName}`);
+  }
+  return import(pathToFileURL(entrypoint).href);
+};
+
+const [{ resolvesSystemAdminGrant }, { studioPermissionCatalog }] = await Promise.all([
+  resolveWorkspacePackage('@sva/core'),
+  resolveWorkspacePackage('@sva/studio-module-iam'),
+]);
+
 const appDbPassword = process.env.APP_DB_PASSWORD?.trim() ?? '';
 const appDbUser = process.env.APP_DB_USER?.trim() || 'sva_app';
 const instanceIds = (process.env.SVA_ALLOWED_INSTANCE_IDS ?? '')
@@ -272,6 +294,124 @@ SET
   auth_client_id = EXCLUDED.auth_client_id,
   tenant_admin_client_id = COALESCE(NULLIF(iam.instances.tenant_admin_client_id, ''), EXCLUDED.tenant_admin_client_id),
   updated_at = NOW();`,
+  );
+  const activePermissionCatalog = studioPermissionCatalog.filter(
+    (definition) => definition.availability.kind !== 'root' && definition.lifecycle !== 'deprecated',
+  );
+  const permissionCatalogRows = activePermissionCatalog
+    .map((definition) => {
+      const moduleId = definition.availability.kind === 'module'
+        ? sqlLiteral(definition.availability.moduleId)
+        : 'NULL';
+      return `(${sqlLiteral(definition.key)}, ${sqlLiteral(definition.description)}, ${sqlLiteral(definition.resourceType)}, ${moduleId}, ${resolvesSystemAdminGrant(definition) ? 'TRUE' : 'FALSE'})`;
+    })
+    .join(',\n        ');
+  statements.push(
+    `DO $permission_catalog_reconcile$
+DECLARE
+  target_instance_id text;
+  permissions_changed integer;
+  grants_inserted integer;
+BEGIN
+  FOR target_instance_id IN
+    SELECT id FROM iam.instances WHERE id IN (${instanceIdList}) ORDER BY id
+  LOOP
+    WITH catalog(permission_key, description, resource_type, module_id, system_admin_grant) AS (
+      VALUES
+        ${permissionCatalogRows}
+    )
+    INSERT INTO iam.permissions (
+      id, instance_id, permission_key, action, resource_type, resource_id, scope, description
+    )
+    SELECT
+      gen_random_uuid(), target_instance_id, catalog.permission_key, catalog.permission_key,
+      catalog.resource_type, NULL, '{}'::jsonb, catalog.description
+    FROM catalog
+    WHERE catalog.module_id IS NULL
+       OR EXISTS (
+         SELECT 1
+         FROM iam.instance_modules instance_module
+         WHERE instance_module.instance_id = target_instance_id
+           AND instance_module.module_id = catalog.module_id
+       )
+    ON CONFLICT (instance_id, permission_key) DO UPDATE
+    SET
+      action = EXCLUDED.action,
+      resource_type = EXCLUDED.resource_type,
+      resource_id = EXCLUDED.resource_id,
+      scope = EXCLUDED.scope,
+      description = EXCLUDED.description,
+      updated_at = NOW()
+    WHERE (iam.permissions.action, iam.permissions.resource_type, iam.permissions.resource_id, iam.permissions.scope, iam.permissions.description)
+      IS DISTINCT FROM (EXCLUDED.action, EXCLUDED.resource_type, EXCLUDED.resource_id, EXCLUDED.scope, EXCLUDED.description);
+    GET DIAGNOSTICS permissions_changed = ROW_COUNT;
+
+    INSERT INTO iam.roles (
+      id, instance_id, role_key, role_name, display_name, external_role_name, description,
+      is_system_role, role_level, managed_by, sync_state, last_synced_at, last_error_code
+    )
+    VALUES (
+      gen_random_uuid(), target_instance_id, 'system_admin', 'system_admin', 'System Administrator',
+      'system_admin', 'Geschützte Systemrolle System Administrator', TRUE, 100, 'studio', 'pending', NOW(), NULL
+    )
+    ON CONFLICT (instance_id, role_key) DO UPDATE
+    SET
+      role_name = EXCLUDED.role_name,
+      display_name = EXCLUDED.display_name,
+      external_role_name = EXCLUDED.external_role_name,
+      description = EXCLUDED.description,
+      is_system_role = TRUE,
+      role_level = EXCLUDED.role_level,
+      updated_at = NOW();
+
+    WITH catalog(permission_key, description, resource_type, module_id, system_admin_grant) AS (
+      VALUES
+        ${permissionCatalogRows}
+    )
+    INSERT INTO iam.role_permissions (
+      instance_id, role_id, permission_id, grant_origin_kind, grant_origin_module_id
+    )
+    SELECT
+      target_instance_id,
+      role.id,
+      permission.id,
+      CASE WHEN catalog.module_id IS NULL THEN 'bootstrap' ELSE 'module_sync' END,
+      catalog.module_id
+    FROM catalog
+    JOIN iam.roles role
+      ON role.instance_id = target_instance_id
+     AND role.role_key = 'system_admin'
+    JOIN iam.permissions permission
+      ON permission.instance_id = target_instance_id
+     AND permission.permission_key = catalog.permission_key
+    WHERE catalog.system_admin_grant = TRUE
+      AND (
+        catalog.module_id IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM iam.instance_modules instance_module
+          WHERE instance_module.instance_id = target_instance_id
+            AND instance_module.module_id = catalog.module_id
+        )
+      )
+    ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
+    GET DIAGNOSTICS grants_inserted = ROW_COUNT;
+
+    INSERT INTO iam.instance_audit_events (instance_id, event_type, actor_id, request_id, details)
+    VALUES (
+      target_instance_id,
+      'instance_permission_catalog_reconciled',
+      'runtime-bootstrap',
+      NULL,
+      jsonb_build_object(
+        'permissionsChanged', permissions_changed,
+        'grantsInserted', grants_inserted,
+        'outcome', 'reconciled'
+      )
+    );
+  END LOOP;
+END
+$permission_catalog_reconcile$;`,
   );
   statements.push(
     `UPDATE iam.instance_hostnames

--- a/docs/adr/ADR-049-kanonischer-permission-katalog-und-additiver-reconcile.md
+++ b/docs/adr/ADR-049-kanonischer-permission-katalog-und-additiver-reconcile.md
@@ -1,0 +1,29 @@
+# ADR-049: Kanonischer Permission-Katalog und additiver Reconcile
+
+- Status: Accepted
+- Datum: 2026-08-02
+
+## Kontext
+
+Core-Permissions, Modul-Permissions und Grants der geschützten Tenant-Rolle `system_admin` wurden bislang in Seeds, Runtime-Baselines und einzelnen Migrationen parallel gepflegt. Dadurch konnte ein später angelegter Tenant trotz ausgeführter Migration unvollständig sein, wie bei `iam.accounts.delete`.
+
+## Entscheidung
+
+`@sva/core` führt die typsicheren Core-Definitionen einschließlich Availability, Lifecycle und Default-Grant. `@sva/studio-module-iam` komponiert daraus und aus den bestehenden Modulverträgen die validierte Gesamtsicht `studioPermissionCatalog`.
+
+Aktive tenantweite Permissions und Permissions zugewiesener Module werden standardmäßig an `system_admin` vergeben. Abweichungen sind explizit als `systemAdminGrant: false` beziehungsweise `systemAdminPermissionExclusions` zu deklarieren. Root-Permissions sind von diesem Default ausgeschlossen.
+
+Der Tenant-Reconcile verwendet `(instance_id, permission_key)` als natürliche Identität, legt fehlende Definitionen und verwaltete Grants idempotent an und aktualisiert fachliche Metadaten. Katalogentfernung oder Deprecation löschen weder Permission-Zeilen noch manuelle Grants oder Custom-Rollen. Ein destruktiver Cleanup benötigt einen eigenen Change und eine eigene Migration.
+
+Moduldeaktivierung darf ausschließlich eindeutig als `module_sync` markierte Grants entfernen; die Permission-Definition bleibt erhalten. Schema-Migrationen bleiben von der additiven Katalogdatenpflege getrennt.
+
+## Konsequenzen
+
+- Eine neue tenantweite Permission benötigt nur Katalogeintrag, Tests, Review und den kontrollierten Reconcile im regulären Rollout.
+- Neue und bestehende Tenants verwenden dieselbe fachliche Quelle.
+- Reconcile-Auditdaten weisen sichere Zähler für eingefügte, aktualisierte und unveränderte Definitionen und Grants aus.
+- Deprecated Daten bleiben absichtlich erhalten, bis ein explizit freigegebener Cleanup erfolgt.
+
+## Alternativen
+
+Handgeschriebene SQL-Migrationen pro Permission verhindern keine Drift zukünftiger Runtime-Baselines. Generierte Migrationen würden einen zweiten Snapshotzustand schaffen. Beide Varianten wurden daher für normale additive Katalogänderungen verworfen.

--- a/docs/adr/ADR-049-kanonischer-permission-katalog-und-additiver-reconcile.md
+++ b/docs/adr/ADR-049-kanonischer-permission-katalog-und-additiver-reconcile.md
@@ -15,11 +15,13 @@ Aktive tenantweite Permissions und Permissions zugewiesener Module werden standa
 
 Der Tenant-Reconcile verwendet `(instance_id, permission_key)` als natürliche Identität, legt fehlende Definitionen und verwaltete Grants idempotent an und aktualisiert fachliche Metadaten. Katalogentfernung oder Deprecation löschen weder Permission-Zeilen noch manuelle Grants oder Custom-Rollen. Ein destruktiver Cleanup benötigt einen eigenen Change und eine eigene Migration.
 
+Die scoped Runtime- beziehungsweise CLI-Grenze besitzt die Transaktion. Repository-Methoden starten oder beenden keine eigene Transaktion, damit der transaktionslokale Tenant-Kontext für RLS bis zum Ende der gesamten Operation erhalten bleibt. Der Release-Bootstrap lädt die kompilierte `studioPermissionCatalog`-Sicht aus demselben Image und wendet sie auf die explizit erlaubten Tenants an. Damit entstehen für den Rollout weder eine zweite handgepflegte Permission-Liste noch freie SQL- oder Permission-Payloads.
+
 Moduldeaktivierung darf ausschließlich eindeutig als `module_sync` markierte Grants entfernen; die Permission-Definition bleibt erhalten. Schema-Migrationen bleiben von der additiven Katalogdatenpflege getrennt.
 
 ## Konsequenzen
 
-- Eine neue tenantweite Permission benötigt nur Katalogeintrag, Tests, Review und den kontrollierten Reconcile im regulären Rollout.
+- Eine neue tenantweite Permission benötigt nur Katalogeintrag, Tests, Review und den kontrollierten Bootstrap-Reconcile im regulären Rollout.
 - Neue und bestehende Tenants verwenden dieselbe fachliche Quelle.
 - Reconcile-Auditdaten weisen sichere Zähler für eingefügte, aktualisierte und unveränderte Definitionen und Grants aus.
 - Deprecated Daten bleiben absichtlich erhalten, bis ein explizit freigegebener Cleanup erfolgt.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,6 +74,7 @@ Architecture Decision Records dokumentieren **wichtige technische Entscheidungen
 | 044 | Frontend-Test-Foundation mit MSW und selektivem fast-check | ✅ | 2026-05-22 | Frontend / Testing / Governance |
 | 046 | Plattform- vs. Tenant-Rollenmodell und Legacy-Standardrollen | ✅ | 2026-07-12 | IAM / Authorization |
 | 047 | Keycloak-Service-Accounts für die lokale MCP-Control-Plane | ✅ | 2026-07-13 | MCP / IAM / Security / Betrieb |
+| 049 | Kanonischer Permission-Katalog und additiver Reconcile | ✅ | 2026-08-02 | IAM / Authorization / Betrieb |
 
 ### Kanonischer Ablageort
 

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -211,3 +211,7 @@ Referenzen:
 ### Ergänzung 2026-07: Policy-gesteuerter MCP-Zugang
 
 Die Instanz-Control-Plane wird über einen dünnen lokalen MCP-Adapter wiederverwendet. Keycloak-Service-Tokens werden serverseitig gegen Issuer, Audience, Zeitbindung und vollständig qualifizierte Action-IDs geprüft. Lesen, kontrollierte Mutationen und kritische Mutationen bilden drei feste Risikostufen. Kritische Aktionen verwenden einen serverseitig erzwungenen Zwei-Schritt-Vertrag aus aktuellem Read/Plan und einer kurzlebigen, einmaligen, zustandsgebundenen Confirmation-Challenge. Der MCP führt keine automatische Reparatur aus und reicht ausschließlich redigierte strukturierte Ergebnisse weiter.
+
+### Ergänzung 2026-08: Kanonischer Permission-Katalog
+
+Core- und Modul-Permissions werden in einer typsicheren, validierten Katalogsicht zusammengeführt. Tenantweite und aktivierte Modul-Permissions erhalten standardmäßig einen verwalteten `system_admin`-Grant; Root-Permissions bleiben isoliert. Der Reconcile ist idempotent und additiv, während Löschungen ausschließlich über separate, ausdrücklich freigegebene Changes erfolgen.

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -681,3 +681,10 @@ Für Waste liest der Agent das kanonische Inventar aus `iam.instance_waste_provi
 - `@sva/sva-mainserver/server` stellt neben den unveränderten Fachadaptern schlanke Projection-List-Operationen bereit. Sie lesen ausschließlich Identität, Titel, Zeitpunkte, Sichtbarkeit, Status und Datenprovider; fachliche Payloads bleiben außerhalb des Projektionspfads.
 - Die Studio-Server-Runtime orchestriert pro Instanz, Account, Organisation und Inhaltstyp eine Hot-Phase und eine deduplizierte Reconciliation. Persistierte Pages sind sofort lesbar.
 - `iam.content_list_projection_sync_state` hält Generation, Phase, Page-Fortschritt, verfügbare Zeilen, Finalität und Fehlerzustand. Damit liegt die Konkurrenzkontrolle dauerhaft in PostgreSQL und nicht nur im Prozessspeicher.
+
+### Ergänzung 2026-08: Permission-Katalog und Reconcile
+
+- `@sva/core` besitzt Katalogtypen, Core-Definitionen, Availability, Lifecycle und Default-Grant-Regeln.
+- `@sva/studio-module-iam` komponiert die bestehenden Modulverträge zur validierten Gesamtsicht `studioPermissionCatalog`.
+- `@sva/data-repositories` materialisiert Definitionen und verwaltete Grants additiv und liefert sichere Änderungszähler.
+- `@sva/instance-registry` bindet denselben Vertrag an Tenant-Bootstrap, Modul-Lifecycle und explizites `seedIamBaseline`.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -936,5 +936,7 @@ Fehlerpfad: Auth- und Scope-Fehler werden nicht diagnostisch umgedeutet. Eine ab
 1. Der Registry-Service liest den Tenant und seine zugewiesenen Module.
 2. Er selektiert aktive tenantweite Katalogdefinitionen und Beiträge der aktiven Module.
 3. Das Repository führt idempotente Upserts über `(instance_id, permission_key)` aus und ergänzt fehlende verwaltete `system_admin`-Grants.
-4. Bei Moduldeaktivierung entfernt es nur eindeutig als `module_sync` markierte Grants; Definitionen, Custom-Rollen und manuelle Grants bleiben erhalten.
-5. Der Service invalidiert den Tenant-Permission-Snapshot und persistiert Audit-Evidenz mit sicheren Reconcile-Zählern.
+4. Die aufrufende scoped Runtime- oder CLI-Grenze besitzt die Datenbanktransaktion; das Repository öffnet und beendet keine verschachtelte Transaktion und behält dadurch den gesetzten Tenant-Kontext bis zum Abschluss der Operation.
+5. Katalogentfernung und explizite Grant-Ausnahmen wirken additiv: Bereits materialisierte Definitionen und Grants eines weiterhin aktiven Moduls bleiben bestehen. Bei echter Moduldeaktivierung entfernt das Repository ausschließlich eindeutig als `module_sync` markierte Grants des deaktivierten Moduls.
+6. Der Service invalidiert den Tenant-Permission-Snapshot und persistiert Audit-Evidenz mit sicheren Reconcile-Zählern.
+7. Der kontrollierte Bootstrap eines Releases liest dieselbe kompilierte Katalogsicht aus dem Image und reconciliiert Core-Permissions sowie die Beiträge der in `iam.instance_modules` zugewiesenen Module für alle erlaubten Tenants. Er führt keine katalogbedingten Löschungen aus.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -930,3 +930,11 @@ Fehlerpfad: Auth- und Scope-Fehler werden nicht diagnostisch umgedeutet. Eine ab
 7. Nach dem App-Neustart prüft der Workflow zusätzlich zum allgemeinen Runtime-Smoke authentifiziert `/auth/me` auf `permissionStatus: ok` und `/iam/me/permissions` auf HTTP 200. Erst danach entsteht erfolgreiche Workflow-Evidenz.
 8. Erst nach erfolgreicher DB-Evidenz startet der Workflow App und Provisioner. HTTP-Liveness, Readiness und Tenant-Login müssen erfolgreich sein; andernfalls deployt der Workflow erneut den gestoppten Stackvertrag.
 9. Keycloak bleibt unverändert. Externer Drift wird nur über die getrennten IAM-Reconcile-Pfade behandelt.
+
+### Permission-Katalog-Reconcile
+
+1. Der Registry-Service liest den Tenant und seine zugewiesenen Module.
+2. Er selektiert aktive tenantweite Katalogdefinitionen und Beiträge der aktiven Module.
+3. Das Repository führt idempotente Upserts über `(instance_id, permission_key)` aus und ergänzt fehlende verwaltete `system_admin`-Grants.
+4. Bei Moduldeaktivierung entfernt es nur eindeutig als `module_sync` markierte Grants; Definitionen, Custom-Rollen und manuelle Grants bleiben erhalten.
+5. Der Service invalidiert den Tenant-Permission-Snapshot und persistiert Audit-Evidenz mit sicheren Reconcile-Zählern.

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -630,3 +630,11 @@ Waste-Fachdaten werden in einer eigenen Datenbank pro Studio-Instanz und nicht i
 - Ein Datensatz ohne stabile Quell-ID wird übersprungen und gezählt. Transportfehler, fehlende Page-Metadaten und strukturell ungültige Pages stoppen nur den betroffenen Typ.
 - Browser-Revalidation läuft nur für laufende, partielle oder veraltete Zustände, pausiert bei unsichtbarem Dokument, verwendet Backoff und beendet sich nach Finalisierung. Filter, Auswahl, Fokus, lokale Seite und Scrollposition bleiben Browserzustand.
 - Rollback-Schalter ändern nur neue Läufe und Reads; additive Sync-State-Spalten bleiben erhalten.
+
+### Permission-Katalog-Governance
+
+- Permission-Keys bleiben vollständig qualifiziert und global eindeutig.
+- Root-, Tenant- und Modul-Availability werden vor Deployment validiert; Modul-Keys müssen im Namespace ihres Moduls liegen.
+- `systemAdminGrant` ist für Tenant- und Modul-Permissions standardmäßig `true`, für Root-Permissions immer `false`.
+- Deprecation ist rein deklarativ und niemals ein Löschsignal. Destruktive Datenpflege benötigt eine eigene Migration und Freigabe.
+- Auditdaten enthalten nur IDs, Request-Korrelation und Zählwerte, keine freien Permission- oder Account-Payloads.

--- a/docs/architecture/09-architecture-decisions.md
+++ b/docs/architecture/09-architecture-decisions.md
@@ -527,3 +527,4 @@ Zuordnung:
 Zuordnung:
 
 - Abschnitt 06/07/08/09/11: ADR-048 und OpenSpec-Change `add-controlled-database-restore`
+- Abschnitt 04/05/06/08/09: ADR-049 und OpenSpec-Change `add-canonical-permission-catalog`

--- a/docs/changelog/entries/pr-897.json
+++ b/docs/changelog/entries/pr-897.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 897,
+  "body": "Zuverlässige Berechtigungen für Systemadministratoren\n\n- Neue tenantweite Berechtigungen werden zentral definiert und standardmäßig automatisch an die geschützte Rolle System Admin vergeben.\n- Modulberechtigungen werden bei Aktivierung ergänzt; bestehende Berechtigungen bleiben bei späteren Katalogänderungen erhalten.\n- Bestehende und zukünftige Tenants erhalten über Bootstrap und IAM-Abgleich denselben nachvollziehbaren Berechtigungsstand."
+}

--- a/docs/development/iam-baseline-seeding.md
+++ b/docs/development/iam-baseline-seeding.md
@@ -8,7 +8,8 @@ Dieses Dokument beschreibt den Entwicklungs- und Testpfad für das modulbezogene
 
 - `iam.instances` enthält die Instanz
 - `iam.instance_modules` enthält den kanonischen Modulsatz
-- `@sva/plugin-sdk` liefert den deklarativen Modul-IAM-Vertrag
+- `@sva/core` liefert den kanonischen Katalog tenantweiter Core-Permissions
+- `@sva/studio-module-iam` liefert die Modulbeiträge und die validierte Gesamtsicht
 
 ## Lokaler Ablauf
 
@@ -43,13 +44,15 @@ pnpm nx run data:db:seed
 
 - Modulverträge dürfen nur über `plugin.moduleIam` eingebracht werden.
 - unbekannte Module werden serverseitig abgewiesen
-- Entzug entfernt modulbezogene Rechte hart
+- Entzug entfernt nur eindeutig als `module_sync` verwaltete Grants; Permission-Definitionen bleiben erhalten
 - `seedIamBaseline` verändert keine Rollenmitgliedschaften des aufrufenden Benutzers
+- Tenant- und aktive Modul-Permissions werden standardmäßig an `system_admin` vergeben; Ausnahmen sind explizit zu deklarieren
+- Katalogentfernung oder Deprecation löst keine automatische Löschung aus
 
 ## Relevante Checks
 
 ```bash
-openspec validate add-instance-module-activation --strict
+openspec validate add-canonical-permission-catalog --strict
 pnpm check:server-runtime
 pnpm nx run-many --target=test:unit --projects=plugin-sdk,instance-registry,data-repositories,data,routing,sva-studio-react --parallel=4
 ```

--- a/docs/guides/iam-autorisierungsmodell-zielbild.md
+++ b/docs/guides/iam-autorisierungsmodell-zielbild.md
@@ -195,6 +195,9 @@ Die genaue fachliche Spezifikation eines expliziten Ownership-Transfers folgt sp
 - Der vollständige Zugriff wird durch einen deterministischen Permission-Sync hergestellt.
 - Neue tenant-relevante Permissions und Modul-Permissions müssen automatisch oder über ein verbindliches Gate in die `System Admin`-Rolle aufgenommen werden.
 - Root-only Permissions bleiben außerhalb des tenant-lokalen `System Admin`.
+- Führend ist der typsichere Katalog in `@sva/core`; die validierte Gesamtsicht `studioPermissionCatalog` ergänzt die bestehenden Modul-IAM-Verträge.
+- Ohne explizite Ausnahme erhält `system_admin` jede aktive tenantweite Permission und jede Permission eines aktivierten Moduls.
+- Entfernte oder deprecated Katalogeinträge werden nicht automatisch aus der Datenbank oder aus manuellen Rollenbindungen gelöscht.
 
 ## Sichtbare Autorenanzeige
 

--- a/docs/guides/keycloak-tenant-realm-bootstrap.md
+++ b/docs/guides/keycloak-tenant-realm-bootstrap.md
@@ -202,6 +202,8 @@ Begründung:
 - `system_admin` reicht für die tenant-lokalen Admin-Funktionen wie Benutzer-, Rollen- und Gruppenverwaltung
 - `instance_registry_admin` ist eine Plattformrolle für globale Instanzmutationen und soll nicht automatisch an Tenant-Admins gehen
 - Tenant-Zugriffe werden fachlich über Permissions entschieden; `system_admin` ist nur die kanonische Bootstrap-Rolle, nicht das alleinige technische Zugriffsmodell
+- Der IAM-Baseline-Reconcile materialisiert alle aktiven tenantweiten Katalogeinträge sowie die Permissions der zugewiesenen Module und bindet sie standardmäßig additiv an `system_admin`.
+- Der Reconcile akzeptiert keine freien Permission-Payloads und löscht weder Custom-Rollen noch manuelle Grants; nach Katalogerweiterungen läuft derselbe Vertrag im regulären Studio-Rollout für bestehende Tenants.
 - der Root-Host-Provisioning-Pfad unter `/admin/instances` stellt den Tenant-Admin nicht nur in Keycloak sicher, sondern bindet den konfigurierten Bootstrap-User auch lokal in Studio direkt an die Sonderrolle `system_admin`
 - derselbe Root-Follow-up-Pfad synchronisiert nur `system_admin` und die IAM-Basis der aktivierten Module; Gruppen wie `admins`, Rollen wie `core_admin` oder modulbezogene `*_admin`-Standardrollen werden dabei nicht mehr automatisch angelegt
 

--- a/docs/guides/studio-rollout-process.md
+++ b/docs/guides/studio-rollout-process.md
@@ -19,11 +19,11 @@ Dieses Dokument ist die einzige normative Bedienanleitung für reguläre Studio-
 
 ## Umgebungsvertrag
 
-| Umgebung   | Stack            | Root-URL                                   | Auslösung                                                         | Modi                                         | Backup                             |
-| ---------- | ---------------- | ------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------------- | ---------------------------------- |
-| Dev        | `studio-dev`     | `https://studio-dev.smart-village.app`     | automatisch nach erfolgreichem Build auf `main`                   | `migration_mode=auto`, `bootstrap_mode=auto` | kein Promote-Backup                |
-| Staging    | `studio-staging` | `https://studio-staging.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `staging` | `assert-none` oder `run`                     | vor jedem Deployment verpflichtend |
-| Production | `studio`         | `https://studio.smart-village.app`         | manuell über `Promote`, geschützt durch das Environment `prod`    | `assert-none` oder `run`                     | vor jedem Deployment verpflichtend |
+| Umgebung | Stack | Root-URL | Auslösung | Modi | Backup |
+| --- | --- | --- | --- | --- | --- |
+| Dev | `studio-dev` | `https://studio-dev.smart-village.app` | automatisch nach erfolgreichem Build auf `main` | `migration_mode=auto`, `bootstrap_mode=auto` | kein Promote-Backup |
+| Staging | `studio-staging` | `https://studio-staging.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `staging` | `assert-none` oder `run` | vor jedem Deployment verpflichtend |
+| Production | `studio` | `https://studio.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `prod` | `assert-none` oder `run` | vor jedem Deployment verpflichtend |
 
 ## Explizite Tenant-Hostfreigabe
 

--- a/docs/guides/studio-rollout-process.md
+++ b/docs/guides/studio-rollout-process.md
@@ -21,9 +21,9 @@ Dieses Dokument ist die einzige normative Bedienanleitung für reguläre Studio-
 
 | Umgebung   | Stack            | Root-URL                                   | Auslösung                                                         | Modi                                         | Backup                             |
 | ---------- | ---------------- | ------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------------- | ---------------------------------- |
-| Dev | `studio-dev` | `https://studio-dev.smart-village.app` | automatisch nach erfolgreichem Build auf `main` | `migration_mode=auto`, `bootstrap_mode=auto` | kein Promote-Backup |
-| Staging | `studio-staging` | `https://studio-staging.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `staging` | `assert-none` oder `run` | vor jedem Deployment verpflichtend |
-| Production | `studio` | `https://studio.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `prod` | `assert-none` oder `run` | vor jedem Deployment verpflichtend |
+| Dev        | `studio-dev`     | `https://studio-dev.smart-village.app`     | automatisch nach erfolgreichem Build auf `main`                   | `migration_mode=auto`, `bootstrap_mode=auto` | kein Promote-Backup                |
+| Staging    | `studio-staging` | `https://studio-staging.smart-village.app` | manuell über `Promote`, geschützt durch das Environment `staging` | `assert-none` oder `run`                     | vor jedem Deployment verpflichtend |
+| Production | `studio`         | `https://studio.smart-village.app`         | manuell über `Promote`, geschützt durch das Environment `prod`    | `assert-none` oder `run`                     | vor jedem Deployment verpflichtend |
 
 ## Explizite Tenant-Hostfreigabe
 
@@ -81,6 +81,8 @@ Die Reihenfolge ist unveränderlich; nicht angeforderte One-shot-Jobs und deren 
 8. App-Stack `studio-staging` aktualisieren.
 9. Runtime-Smoke für Root-Host, alle expliziten Tenant-Hosts, deren konkrete TLS-Zertifikate und einen unbekannten Host sowie den Live-Digest verifizieren.
 10. Redigierte Staging-Paritätsevidenz für genau diesen Digest schreiben.
+
+Der Bootstrap-Reconcile liest den im Release-Image kompilierten kanonischen Permission-Katalog. Für jeden Tenant aus `SVA_ALLOWED_INSTANCE_IDS` legt er fehlende aktive Core-Permissions sowie Permissions der bereits zugewiesenen Module an und ergänzt die standardmäßig vorgesehenen `system_admin`-Grants. Der Pfad ist additiv: Er löscht weder Permission-Definitionen noch Grants aufgrund einer Katalogentfernung. Die erfolgreiche Ausführung erzeugt pro Tenant das Audit-Ereignis `instance_permission_catalog_reconciled`; dessen Zähler sind Bestandteil der Rollout-Evidenz.
 
 Nur ein insgesamt erfolgreicher mutierender Staging-Lauf erzeugt die für eine mutierende Production-Promotion gültige Paritätsevidenz.
 

--- a/openspec/changes/add-canonical-permission-catalog/design.md
+++ b/openspec/changes/add-canonical-permission-catalog/design.md
@@ -1,0 +1,152 @@
+## Context
+
+SVA Studio persistiert Permissions instanzgebunden in Postgres. Neue Core-Rechte, Modulrechte und Grants für die geschützte Tenant-Rolle `system_admin` gelangen heute über mehrere Pfade in die Datenbank. Die Quellen sind nicht vollständig gekoppelt: Eine Migration kann bestehende Tenants korrigieren, während ein später angelegter Tenant aus einer veralteten Runtime-Baseline erneut unvollständig entsteht.
+
+Der aktuelle Vorfall zeigt dieses Muster bei `iam.accounts.delete`: Die katalogisierte Seed-Basis und Migration kennen die Permission, die separat gepflegte Runtime-Baseline jedoch nicht.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Genau eine fachliche Quelle für bekannte Permission-Definitionen schaffen.
+- Neue und bestehende Tenants über denselben idempotenten Vertrag auf den additiven Sollstand bringen.
+- Tenantweite Permissions standardmäßig an `system_admin` vergeben, sofern keine explizite Ausnahme definiert ist.
+- Modul-Permissions spätestens bei Modulaktivierung materialisieren und an `system_admin` binden.
+- Persistierte Permissions und Grants niemals allein aufgrund einer Katalogentfernung automatisch löschen.
+- Root-/Tenant-Grenzen, Custom-Rollen und manuelle Grants unverändert schützen.
+- Den Soll-/Ist-Abgleich beobachtbar, testbar und über den kanonischen Rollout wiederholbar machen.
+
+### Non-Goals
+
+- Keine frei editierbare Permission-Verwaltung über die Studio-UI.
+- Keine automatische Löschung oder Umbenennung bestehender Permissions.
+- Keine automatische Migration von Custom-Rollen auf neue Permissions.
+- Kein Runtime-Bypass für `system_admin`; Autorisierung bleibt permission-zentriert.
+- Kein zweiter Deployment- oder Datenbank-Reparaturpfad neben dem kanonischen Rollout.
+
+## Decisions
+
+### Decision: Typsicherer Katalog ist die einzige fachliche Definitionsquelle
+
+Der Katalog liegt in einem framework- und persistenzunabhängigen Workspace-Package. Ein Eintrag enthält mindestens:
+
+```ts
+type PermissionDefinition = {
+  readonly key: PermissionKey;
+  readonly description: string;
+  readonly resourceType: string;
+  readonly availability:
+    | { readonly kind: 'root' }
+    | { readonly kind: 'tenant' }
+    | { readonly kind: 'module'; readonly moduleId: StudioModuleId };
+  readonly systemAdminGrant?: boolean;
+  readonly lifecycle?: 'active' | 'deprecated';
+};
+```
+
+Der effektive Default für `systemAdminGrant` ist für `tenant` und `module` `true`, für `root` immer `false`. Eine widersprüchliche Root-Definition wird bei Build oder Test abgewiesen.
+
+Stabile Datenbank-IDs sind kein fachliches Merkmal des Katalogs. Runtime-Reconcile verwendet `(instance_id, permission_key)` als natürliche idempotente Identität und erzeugt IDs in der Datenbank. Deterministische IDs bestehender statischer Testseeds bleiben auf den jeweiligen Fixture-/Seed-Kontext begrenzt.
+
+### Decision: Core- und Modulbeiträge werden zu einer validierten Katalogsicht komponiert
+
+Core-Permissions werden zentral deklariert. Modul-Permissions stammen weiterhin aus der kanonischen Modul-IAM-Vertragsfamilie, werden aber durch denselben Katalog-Validator normalisiert. Dadurch entsteht keine zweite Plugin- oder Modulliste.
+
+Die Komposition schlägt bei doppelten Keys, unbekannten Modul-IDs, fremden Namespaces, ungültigen Ressourcentypen oder widersprüchlichen Availability-Angaben fehl.
+
+### Decision: Reconcile ist additiv und idempotent
+
+Der Reconcile berechnet pro Tenant:
+
+1. alle aktiven tenantweiten Definitionen;
+2. alle aktiven Definitionen der zugewiesenen Module;
+3. die daraus folgenden verwalteten `system_admin`-Grants.
+
+Er führt Upserts für `iam.permissions` und fehlende verwaltete `iam.role_permissions` aus. Er verändert keine Account-Rollenzuweisungen, Custom-Rollen, manuellen Grants oder Grants anderer Rollen.
+
+Er löscht keine Permission-Zeile, wenn ein Eintrag aus dem Katalog entfernt oder auf `deprecated` gesetzt wurde. Destruktive Bereinigung benötigt eine eigene, explizite Migration mit eigener Freigabe.
+
+### Decision: Modul-Lifecycle trennt Definition und Wirksamkeit
+
+Eine Modul-Permission muss spätestens bei Aktivierung des Moduls im Tenant materialisiert werden. Bereits vorher oder nach einer Deaktivierung vorhandene Permission-Zeilen sind zulässig.
+
+Bei Moduldeaktivierung darf der bestehende, klar modulverwaltete Grant an `system_admin` entsprechend dem bisherigen Modulentzugsvertrag entfernt werden. Die Permission-Definition selbst bleibt erhalten. Manuelle Grants und Custom-Rollen bleiben unberührt.
+
+### Decision: Reconcile wird in bestehende kontrollierte Abläufe integriert
+
+Der Katalog-Reconcile läuft bei:
+
+- initialem Tenant-Baseline-Seed;
+- Modulaktivierung und Moduldeaktivierung;
+- explizitem, wiederholbarem IAM-Baseline-Reconcile;
+- dem kontrollierten Nachziehschritt des kanonischen Rollout-Prozesses für bestehende Tenants.
+
+Der Reconcile invalidiert nur betroffene Instanz-Snapshots und erzeugt ein Audit-Ergebnis mit Zählwerten für eingefügte, aktualisierte, unveränderte und übersprungene Definitionen beziehungsweise Grants. Freie Permission-Payloads oder freie SQL-Eingaben sind nicht Teil des Operatorvertrags.
+
+### Decision: Schema-Migrationen und Katalogdaten bleiben getrennte Verantwortungen
+
+Goose-Migrationen bleiben für Schema, Constraints und ausdrücklich freigegebene destruktive Datenänderungen zuständig. Normales Hinzufügen einer Permission erfordert künftig:
+
+1. einen Katalogeintrag;
+2. Tests und Review;
+3. den additiven Reconcile im Rollout.
+
+Damit wirkt eine neue Permission auf bestehende und zukünftige Tenants, ohne pro Permission handgeschriebene SQL-Backfills zu verlangen.
+
+## Alternatives considered
+
+### Handgeschriebene SQL-Migration pro Permission
+
+Gut auditierbar, aber sie korrigiert nur zum Ausführungszeitpunkt vorhandene Tenants und verhindert keine veralteten Runtime-Baselines. Deshalb bleibt sie nur für Sonderfälle bestehen.
+
+### SQL-Migrationen automatisch aus dem Katalog generieren
+
+Dies erzeugt zusätzliche Snapshots und Generatorzustände, die ebenfalls driften können. Außerdem vermischt es additive Referenzdatenpflege mit Schemahistorie. Ein kontrollierter Reconcile ist direkter und wiederholbar.
+
+### Sämtliche Modul-Permissions in jedem Tenant vorab materialisieren
+
+Technisch möglich, aber unnötig groß und weniger transparent. Aktivierungsgebundene Materialisierung hält die fachlich relevante Basis klein, ohne bereits vorhandene Zeilen zu verbieten.
+
+## Risks / Trade-offs
+
+- Ein fehlerhafter Katalogeintrag könnte viele Tenants betreffen. Gegenmaßnahme: strikte Typen, Validatoren, Diff-/Dry-Run-Evidenz und kontrollierter Rollout.
+- Additive Semantik hinterlässt deprecated Daten. Gegenmaßnahme: Lifecycle-Metadaten und separate, explizite Cleanup-Changes.
+- Moduldeaktivierung benötigt klare Grant-Provenance. Gegenmaßnahme: nur eindeutig system-/modulverwaltete Grants dürfen automatisch entzogen werden.
+- Eine neue zentrale Package-Abhängigkeit könnte Zyklen erzeugen. Gegenmaßnahme: Katalogtypen und Core-Definitionen liegen in einer neutralen Schicht; Persistenz und Registry konsumieren sie nur in eine Richtung.
+
+## Migration Plan
+
+1. Katalogtypen, Core-Definitionen und Validatoren einführen.
+2. Bestehende Modul-IAM-Verträge in die validierte Katalogsicht integrieren.
+3. Seed-Plan und Runtime-Baseline auf den Katalog umstellen; Parallelarrays entfernen.
+4. Additiven Repository-Reconcile mit Transaktion, Audit-Zählwerten und Snapshot-Invalidierung implementieren.
+5. Tenant-Erstellung, Modul-Lifecycle und expliziten Baseline-Pfad anbinden.
+6. Dry-Run beziehungsweise Plan-Evidenz für bestehende Tenants prüfen.
+7. Über den kanonischen Staging-Rollout reconciliieren und `de-studio-sandbox` über `/iam/me/permissions` verifizieren.
+8. Production mit demselben Image-Digest promoten und Reconcile-/IAM-Smokes auswerten.
+
+Rollback entfernt nur die neue Codeausführung. Additiv angelegte Permission-Definitionen und Grants werden nicht automatisch zurückgerollt; ein Entzug benötigt eine eigene fachlich freigegebene Migration.
+
+## Verification
+
+- Katalog-Eindeutigkeit und Root-/Tenant-Isolation
+- Default-Grant an `system_admin` und explizite Opt-outs
+- Core-Permission für neue und bestehende Tenants
+- Modul-Permission bei Aktivierung und keine Definition-Löschung bei Deaktivierung
+- Keine Änderung an Custom-Rollen, manuellen Grants oder Account-Rollenzuweisungen
+- Wiederholter Reconcile ohne Dubletten oder unnötige Änderungen
+- Gezielte Snapshot-Invalidierung und Audit-Evidenz
+- Regression: `iam.accounts.delete` ist nach Baseline-Reconcile für `system_admin` effektiv
+- Server-Runtime-, Unit-, Type-, Integrations-, Migrations- und PR-Gates gemäß Repository-Regeln
+
+## Documentation
+
+- ADR für Katalog und additiven Reconcile
+- arc42 04, 05, 06, 08 und 09
+- IAM-Autorisierungsmodell und Tenant-Bootstrap-Guide
+- Studio-Rollout-Prozess nur ergänzen, wenn der Reconcile dort als Schritt des bestehenden kanonischen Pfads präzisiert werden muss; kein alternativer Deploypfad
+
+## Open Questions
+
+- Keine offenen fachlichen Fragen. Tenantweite Permissions erhalten standardmäßig `system_admin`; Moduldefinitionen werden spätestens bei Aktivierung materialisiert; Katalogentfernung ist nicht destruktiv.
+

--- a/openspec/changes/add-canonical-permission-catalog/proposal.md
+++ b/openspec/changes/add-canonical-permission-catalog/proposal.md
@@ -1,0 +1,28 @@
+# Change: Kanonischen Permission-Katalog und additiven Tenant-Reconcile einführen
+
+## Why
+
+Permission-Definitionen und Grants für `system_admin` werden derzeit in Seed-Plänen, Runtime-Baselines und einzelnen SQL-Migrationen mehrfach gepflegt. Diese Parallelquellen können auseinanderlaufen: Neu angelegte Tenants erhalten dann nicht zwingend dieselben Rechte wie bereits migrierte Tenants.
+
+Das System benötigt eine einzige einsehbare und typsichere Quelle, aus der neue Tenant-Baselines, Modulaktivierungen und kontrollierte Nachziehläufe für bestehende Tenants deterministisch abgeleitet werden.
+
+## What Changes
+
+- Ein kanonischer Permission-Katalog beschreibt Key, Beschreibung, Ressourcentyp, Verfügbarkeit (`root`, `tenant` oder `module`) und Lifecycle einer Permission.
+- Tenantweite Permissions und Permissions aktivierter Module erhalten standardmäßig einen Grant an `system_admin`; Ausnahmen müssen explizit im Katalog stehen.
+- Neue Tenants, Modulaktivierungen und Baseline-Reconcile verwenden dieselbe Katalogauswertung statt lokaler Parallelarrays.
+- Ein idempotenter, additiver Reconcile ergänzt Definitionen und verwaltete Grants für bestehende Tenants und invalidiert betroffene Permission-Snapshots.
+- Fehlende Katalogeinträge oder auf `deprecated` gesetzte Permissions führen niemals automatisch zum Löschen persistierter Permission-Daten oder manueller Grants.
+- Modul-Permissions müssen spätestens bei Modulaktivierung materialisiert werden; bereits vorhandene Definitionen bleiben auch ohne aktive Modulzuweisung zulässig.
+- `iam.accounts.delete` wird über den Katalog und den kontrollierten Reconcile für bestehende Tenants einschließlich `de-studio-sandbox` nachgezogen.
+- Drift-, Eindeutigkeits-, Root-/Tenant-Isolations- und Idempotenztests sichern den Katalog und seine Verbraucher ab.
+
+## Impact
+
+- Affected specs: `iam-access-control`, `instance-provisioning`
+- Affected code: `packages/core`, `packages/data-repositories`, `packages/instance-registry`, `packages/studio-module-iam`, IAM-Seeds und Migrations-/Rollout-Gates
+- Affected data: `iam.permissions`, `iam.role_permissions`, Permission-Snapshot-Invalidierung
+- Affected arc42 sections: `docs/architecture/04-solution-strategy.md`, `docs/architecture/05-building-block-view.md`, `docs/architecture/06-runtime-view.md`, `docs/architecture/08-cross-cutting-concepts.md`, `docs/architecture/09-architecture-decisions.md`
+- ADR required: kanonischer Permission-Katalog und additiver Reconcile als neues IAM-Pattern
+- Rollout: ausschließlich über `docs/guides/studio-rollout-process.md`; kein manueller SQL-Fix als Standardpfad
+

--- a/openspec/changes/add-canonical-permission-catalog/specs/iam-access-control/spec.md
+++ b/openspec/changes/add-canonical-permission-catalog/specs/iam-access-control/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Kanonischer Permission-Katalog ist die einzige fachliche Definitionsquelle
+
+Das System MUST bekannte Core- und Modul-Permissions in einer typsicheren, validierten Katalogsicht zusammenführen. Seed-, Bootstrap-, Reconcile-, Diagnose- und Testpfade MUST ihre Permission-Definitionen aus dieser Katalogsicht ableiten und dürfen keine unabhängigen fachlichen Parallelkataloge pflegen.
+
+#### Scenario: Neue tenantweite Permission wird einmalig deklariert
+
+- **WHEN** eine neue tenantweite Permission in den kanonischen Katalog aufgenommen wird
+- **THEN** verwenden neue Tenant-Baselines und Reconcile-Läufe für bestehende Tenants dieselbe Definition
+- **AND** ist keine zusätzliche handgeschriebene Permission-Liste im Runtime-Bootstrap erforderlich
+
+#### Scenario: Ungültiger oder doppelter Katalogeintrag
+
+- **WHEN** der zusammengesetzte Katalog doppelte Keys, unbekannte Module, fremde Namespaces oder widersprüchliche Root-/Tenant-Metadaten enthält
+- **THEN** schlägt die Validierung vor Deployment fehl
+- **AND** es wird kein partieller Katalogzustand persistiert
+
+### Requirement: Tenant-Permissions gewähren system_admin standardmäßig Vollzugriff
+
+Das System MUST aktive tenantweite Permissions und aktive Permissions zugewiesener Module standardmäßig als verwalteten Grant an die geschützte Tenant-Rolle `system_admin` binden. Abweichungen MUST pro Permission explizit im Katalog definiert sein. Root-Permissions dürfen niemals durch diesen Default an `system_admin` gebunden werden.
+
+#### Scenario: Tenant-Permission ohne explizite Ausnahme
+
+- **WHEN** eine aktive tenantweite Permission keinen expliziten `systemAdminGrant`-Wert definiert
+- **THEN** behandelt der Katalog den Wert als `true`
+- **AND** ergänzt der Reconcile den fehlenden Grant an `system_admin`
+
+#### Scenario: Explizite Ausnahme vom Default-Grant
+
+- **WHEN** eine tenantweite oder modulbezogene Permission `systemAdminGrant=false` definiert
+- **THEN** erzeugt der Reconcile für diese Permission keinen automatischen `system_admin`-Grant
+- **AND** bleibt die Ausnahme im Katalog nachvollziehbar
+
+#### Scenario: Root-Permission bleibt isoliert
+
+- **WHEN** eine Permission als `root` klassifiziert ist
+- **THEN** darf der Tenant-Reconcile sie weder materialisieren noch an `system_admin` vergeben
+
+### Requirement: Permission-Reconcile arbeitet additiv und nicht destruktiv
+
+Das System MUST einen idempotenten, instanzgebundenen Permission-Reconcile bereitstellen, der fehlende aktive Definitionen und katalogverwaltete Grants ergänzt. Das Fehlen oder Deprecaten eines Katalogeintrags darf keine persistierte Permission, keinen manuellen Grant und keine Custom-Rollen-Zuordnung automatisch löschen.
+
+#### Scenario: Bestehender Tenant erhält neue Permission
+
+- **WHEN** der Reconcile für einen bestehenden Tenant nach Erweiterung des Katalogs ausgeführt wird
+- **THEN** wird die fehlende Permission idempotent angelegt oder aktualisiert
+- **AND** wird ein vorgesehener fehlender `system_admin`-Grant ergänzt
+- **AND** wird der betroffene Permission-Snapshot invalidiert
+
+#### Scenario: Wiederholter Reconcile
+
+- **WHEN** derselbe Katalogstand wiederholt für denselben Tenant reconciled wird
+- **THEN** entstehen keine doppelten Permission- oder Rollen-Permission-Datensätze
+- **AND** bleiben Custom-Rollen, manuelle Grants und Account-Rollenzuweisungen unverändert
+
+#### Scenario: Katalogeintrag wurde entfernt oder deprecated
+
+- **WHEN** eine persistierte Permission nicht mehr als aktiv im Katalog enthalten ist
+- **THEN** löscht der additive Reconcile weder die Permission noch bestehende manuelle Grants
+- **AND** benötigt eine destruktive Bereinigung einen separaten expliziten Change
+
+### Requirement: Modul-Permissions werden aktivierungsgebunden materialisiert
+
+Das System MUST Definitionen eines zugewiesenen Moduls spätestens bei dessen Aktivierung materialisieren und vorgesehene verwaltete Grants herstellen. Bereits vorhandene Modul-Permission-Definitionen dürfen vor Aktivierung oder nach Deaktivierung bestehen bleiben.
+
+#### Scenario: Modul wird aktiviert
+
+- **WHEN** ein Modul einer Instanz zugewiesen wird
+- **THEN** materialisiert der Reconcile seine aktiven Permission-Definitionen
+- **AND** bindet er sie standardmäßig an `system_admin`, sofern keine explizite Ausnahme definiert ist
+
+#### Scenario: Modul wird deaktiviert
+
+- **WHEN** ein Modul einer Instanz entzogen wird
+- **THEN** darf der eindeutig modulverwaltete `system_admin`-Grant gemäß Modulentzugsvertrag unwirksam gemacht werden
+- **AND** bleibt die Permission-Definition erhalten
+- **AND** bleiben manuelle Grants und Custom-Rollen unverändert
+

--- a/openspec/changes/add-canonical-permission-catalog/specs/instance-provisioning/spec.md
+++ b/openspec/changes/add-canonical-permission-catalog/specs/instance-provisioning/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Tenant-Baseline und Rollout reconciliieren den kanonischen Permission-Katalog
+
+Das System MUST bei Tenant-Erstellung, explizitem IAM-Baseline-Reconcile und kontrolliertem Rollout für bestehende Tenants denselben kanonischen Permission-Katalog additiv anwenden. Der Operatorvertrag darf keine freien Permission-Payloads oder freien SQL-Eingaben akzeptieren.
+
+#### Scenario: Neuer Tenant erhält vollständige Core-Basis
+
+- **WHEN** ein neuer Tenant mit `system_admin` initialisiert wird
+- **THEN** materialisiert der Baseline-Reconcile alle aktiven tenantweiten Katalog-Permissions
+- **AND** erhält `system_admin` alle standardmäßig vorgesehenen Grants
+
+#### Scenario: Bestehende Tenants werden nach Katalogerweiterung aktualisiert
+
+- **WHEN** ein Release einen erweiterten Permission-Katalog enthält
+- **THEN** führt der kanonische Rollout einen kontrollierten additiven Reconcile für die Zielumgebung aus
+- **AND** sind Ergebnis, Request-ID, betroffene Instanzen und sichere Änderungszähler nachvollziehbar
+- **AND** führt ein wiederholter Lauf nicht zu Dubletten
+
+#### Scenario: Reconcile schlägt für eine Instanz fehl
+
+- **WHEN** der Permission-Reconcile für eine Zielinstanz nicht vollständig abgeschlossen werden kann
+- **THEN** wird die Instanz als nicht erfolgreich reconciled ausgewiesen
+- **AND** wird der Fehler ohne freie SQL-Reparatur über den bestehenden Diagnose- und Rollout-Vertrag behandelt
+

--- a/openspec/changes/add-canonical-permission-catalog/tasks.md
+++ b/openspec/changes/add-canonical-permission-catalog/tasks.md
@@ -1,0 +1,39 @@
+## 1. Katalog und Verträge
+
+- [x] 1.1 Kanonische Permission-Typen, Availability- und Lifecycle-Metadaten in einer neutralen Workspace-Schicht definieren
+- [x] 1.2 Core-Permissions in den Katalog überführen und lokale Parallelkataloge entfernen
+- [x] 1.3 Modul-IAM-Beiträge über die bestehende Modulvertragsfamilie in die Katalogsicht integrieren
+- [x] 1.4 Validatoren für Eindeutigkeit, Namespaces, Root-/Tenant-Isolation, Module und Default-Grants ergänzen
+
+## 2. Persistenz und Reconcile
+
+- [x] 2.1 Additiven, transaktionalen Repository-Reconcile für Permission-Definitionen und verwaltete `system_admin`-Grants implementieren
+- [x] 2.2 Reconcile-Ergebnis mit sicheren Zählwerten und Audit-Evidenz modellieren
+- [x] 2.3 Gezielte Permission-Snapshot-Invalidierung nach tatsächlichen Änderungen sicherstellen
+- [x] 2.4 Automatische Löschungen sowie Änderungen an Custom-Rollen, manuellen Grants und Account-Rollenzuweisungen ausschließen
+
+## 3. Lifecycle-Integration
+
+- [x] 3.1 Tenant-Baseline und initialen Admin-Bootstrap an den Katalog-Reconcile anbinden
+- [x] 3.2 Modulaktivierung und -deaktivierung an katalogisierte Definitionen und verwaltete Grants anbinden
+- [x] 3.3 Expliziten IAM-Baseline-Reconcile für bestehende Tenants auf dieselbe Logik umstellen
+- [x] 3.4 Veraltete direkte Permission-Arrays und redundante Seed-Definitionen entfernen
+
+## 4. Tests und Gates
+
+- [x] 4.1 Unit-Tests für Katalogvalidierung, Default-Grant und explizite Ausnahmen ergänzen
+- [x] 4.2 Repository-Integrationstests für additive Upserts, Idempotenz und Non-Deletion ergänzen
+- [x] 4.3 Lifecycle-Tests für neue Tenants, Modulaktivierung, Moduldeaktivierung und Re-Seed ergänzen
+- [x] 4.4 Regressionstest für `iam.accounts.delete` auf `system_admin` ergänzen
+- [x] 4.5 Betroffene Unit- und Type-Targets nach jedem Änderungsblock ausführen
+- [x] 4.6 `pnpm check:server-runtime`, DB-Schema-/Migrationschecks und den kleinsten relevanten PR-Gate-Pfad ausführen
+
+## 5. Dokumentation und Rollout
+
+- [x] 5.1 ADR für kanonischen Permission-Katalog und additiven Reconcile erstellen
+- [x] 5.2 Arc42-Abschnitte 04, 05, 06, 08 und 09 aktualisieren
+- [x] 5.3 IAM-Autorisierungsmodell und Tenant-Bootstrap-Guide aktualisieren
+- [x] 5.4 Katalogänderungs- und Deprecation-Verfahren dokumentieren
+- [ ] 5.5 Staging über den kanonischen Rollout aktualisieren und den Reconcile für `de-studio-sandbox` ausführen
+- [ ] 5.6 Effektive Permission `iam.accounts.delete`, Benutzer-Löschgate und Audit-/Snapshot-Evidenz live verifizieren
+- [ ] 5.7 Production mit demselben Image-Digest promoten und Reconcile-/IAM-Smokes dokumentieren

--- a/packages/core/src/iam/permission-catalog.test.ts
+++ b/packages/core/src/iam/permission-catalog.test.ts
@@ -77,4 +77,37 @@ describe('permission catalog', () => {
       composePermissionCatalog([], [{ moduleId: 'news', permissionIds: ['events.read'] }])
     ).toThrow('module_permission_namespace_mismatch:events.read');
   });
+
+  it('rejects incomplete definitions and unknown module grant exclusions', () => {
+    const tenantDefinition = {
+      key: 'iam.example.read',
+      description: 'Example',
+      resourceType: 'iam',
+      availability: { kind: 'tenant' as const },
+    };
+
+    expect(() =>
+      validatePermissionCatalog([{ ...tenantDefinition, description: ' ' }])
+    ).toThrow('invalid_permission_catalog_description:iam.example.read');
+    expect(() =>
+      validatePermissionCatalog([{ ...tenantDefinition, resourceType: '' }])
+    ).toThrow('invalid_permission_catalog_resource_type:iam.example.read');
+    expect(() =>
+      validatePermissionCatalog([
+        {
+          ...tenantDefinition,
+          availability: { kind: 'module', moduleId: '' },
+        },
+      ])
+    ).toThrow('invalid_permission_catalog_module_id:iam.example.read');
+    expect(() =>
+      composePermissionCatalog([], [
+        {
+          moduleId: 'news',
+          permissionIds: ['news.read'],
+          systemAdminPermissionExclusions: ['news.delete'],
+        },
+      ])
+    ).toThrow('unknown_system_admin_permission_exclusion:news:news.delete');
+  });
 });

--- a/packages/core/src/iam/permission-catalog.test.ts
+++ b/packages/core/src/iam/permission-catalog.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  composePermissionCatalog,
+  corePermissionCatalog,
+  resolvesSystemAdminGrant,
+  tenantCoreSystemAdminPermissionKeys,
+  validatePermissionCatalog,
+} from './permission-catalog.js';
+
+describe('permission catalog', () => {
+  it('grants active tenant permissions to system_admin by default', () => {
+    expect(tenantCoreSystemAdminPermissionKeys).toContain('iam.accounts.delete');
+    expect(
+      resolvesSystemAdminGrant({
+        key: 'iam.example.read',
+        description: 'Example',
+        resourceType: 'iam',
+        availability: { kind: 'tenant' },
+      })
+    ).toBe(true);
+  });
+
+  it('honors explicit opt-outs and never grants root permissions to system_admin', () => {
+    expect(
+      resolvesSystemAdminGrant({
+        key: 'iam.example.write',
+        description: 'Example',
+        resourceType: 'iam',
+        availability: { kind: 'tenant' },
+        systemAdminGrant: false,
+      })
+    ).toBe(false);
+    expect(corePermissionCatalog.find((entry) => entry.key === 'instance.registry.manage')).toMatchObject({
+      availability: { kind: 'root' },
+      systemAdminGrant: false,
+    });
+  });
+
+  it('composes module permissions and applies the tenant default grant', () => {
+    const catalog = composePermissionCatalog(corePermissionCatalog, [
+      { moduleId: 'surveys', permissionIds: ['surveys.read', 'surveys.export'] },
+    ]);
+    expect(catalog.find((entry) => entry.key === 'surveys.export')).toMatchObject({
+      availability: { kind: 'module', moduleId: 'surveys' },
+    });
+    expect(resolvesSystemAdminGrant(catalog.find((entry) => entry.key === 'surveys.export')!)).toBe(true);
+  });
+
+  it('rejects duplicate keys, root grants and module namespace drift', () => {
+    expect(() => validatePermissionCatalog([corePermissionCatalog[0], corePermissionCatalog[0]])).toThrow(
+      'duplicate_permission_catalog_key:iam.user.read'
+    );
+    expect(() =>
+      validatePermissionCatalog([
+        {
+          key: 'instance.example',
+          description: 'Example',
+          resourceType: 'instance',
+          availability: { kind: 'root' },
+          systemAdminGrant: true,
+        },
+      ])
+    ).toThrow('root_permission_system_admin_grant:instance.example');
+    expect(() => composePermissionCatalog([], [{ moduleId: 'news', permissionIds: ['events.read'] }])).toThrow(
+      'module_permission_namespace_mismatch:events.read'
+    );
+  });
+});

--- a/packages/core/src/iam/permission-catalog.test.ts
+++ b/packages/core/src/iam/permission-catalog.test.ts
@@ -31,7 +31,9 @@ describe('permission catalog', () => {
         systemAdminGrant: false,
       })
     ).toBe(false);
-    expect(corePermissionCatalog.find((entry) => entry.key === 'instance.registry.manage')).toMatchObject({
+    expect(
+      corePermissionCatalog.find((entry) => entry.key === 'instance.registry.manage')
+    ).toMatchObject({
       availability: { kind: 'root' },
       systemAdminGrant: false,
     });
@@ -39,18 +41,27 @@ describe('permission catalog', () => {
 
   it('composes module permissions and applies the tenant default grant', () => {
     const catalog = composePermissionCatalog(corePermissionCatalog, [
-      { moduleId: 'surveys', permissionIds: ['surveys.read', 'surveys.export'] },
+      {
+        moduleId: 'surveys',
+        permissionIds: ['surveys.read', 'surveys.export'],
+        systemAdminPermissionExclusions: ['surveys.export'],
+      },
     ]);
     expect(catalog.find((entry) => entry.key === 'surveys.export')).toMatchObject({
       availability: { kind: 'module', moduleId: 'surveys' },
     });
-    expect(resolvesSystemAdminGrant(catalog.find((entry) => entry.key === 'surveys.export')!)).toBe(true);
+    expect(resolvesSystemAdminGrant(catalog.find((entry) => entry.key === 'surveys.read')!)).toBe(
+      true
+    );
+    expect(resolvesSystemAdminGrant(catalog.find((entry) => entry.key === 'surveys.export')!)).toBe(
+      false
+    );
   });
 
   it('rejects duplicate keys, root grants and module namespace drift', () => {
-    expect(() => validatePermissionCatalog([corePermissionCatalog[0], corePermissionCatalog[0]])).toThrow(
-      'duplicate_permission_catalog_key:iam.user.read'
-    );
+    expect(() =>
+      validatePermissionCatalog([corePermissionCatalog[0], corePermissionCatalog[0]])
+    ).toThrow('duplicate_permission_catalog_key:iam.user.read');
     expect(() =>
       validatePermissionCatalog([
         {
@@ -62,8 +73,8 @@ describe('permission catalog', () => {
         },
       ])
     ).toThrow('root_permission_system_admin_grant:instance.example');
-    expect(() => composePermissionCatalog([], [{ moduleId: 'news', permissionIds: ['events.read'] }])).toThrow(
-      'module_permission_namespace_mismatch:events.read'
-    );
+    expect(() =>
+      composePermissionCatalog([], [{ moduleId: 'news', permissionIds: ['events.read'] }])
+    ).toThrow('module_permission_namespace_mismatch:events.read');
   });
 });

--- a/packages/core/src/iam/permission-catalog.ts
+++ b/packages/core/src/iam/permission-catalog.ts
@@ -17,6 +17,7 @@ export type PermissionDefinition = Readonly<{
 export type ModulePermissionCatalogContribution = Readonly<{
   moduleId: string;
   permissionIds: readonly string[];
+  systemAdminPermissionExclusions?: readonly string[];
 }>;
 
 const tenantPermission = <const TKey extends string>(
@@ -121,23 +122,33 @@ export const composePermissionCatalog = (
 ): readonly PermissionDefinition[] =>
   validatePermissionCatalog([
     ...coreDefinitions,
-    ...moduleContributions.flatMap((contribution) =>
-      contribution.permissionIds.map((key): PermissionDefinition => ({
+    ...moduleContributions.flatMap((contribution) => {
+      const exclusions = new Set(contribution.systemAdminPermissionExclusions ?? []);
+      for (const exclusion of exclusions) {
+        if (!contribution.permissionIds.includes(exclusion)) {
+          throw new Error(
+            `unknown_system_admin_permission_exclusion:${contribution.moduleId}:${exclusion}`
+          );
+        }
+      }
+      return contribution.permissionIds.map((key): PermissionDefinition => ({
         key,
         description: `Module permission ${key}`,
         resourceType: key.split('.')[0] ?? key,
         availability: { kind: 'module', moduleId: contribution.moduleId },
-      }))
-    ),
+        ...(exclusions.has(key) ? { systemAdminGrant: false } : {}),
+      }));
+    }),
   ]);
 
 export const tenantCorePermissionCatalog = validatePermissionCatalog(corePermissionCatalog).filter(
   (definition) => definition.availability.kind === 'tenant' && definition.lifecycle !== 'deprecated'
 );
 
-export const tenantCoreSystemAdminPermissionKeys: readonly CorePermissionKey[] = tenantCorePermissionCatalog
-  .filter(resolvesSystemAdminGrant)
-  .map((definition) => definition.key as CorePermissionKey);
+export const tenantCoreSystemAdminPermissionKeys: readonly CorePermissionKey[] =
+  tenantCorePermissionCatalog
+    .filter(resolvesSystemAdminGrant)
+    .map((definition) => definition.key as CorePermissionKey);
 
 export const rootPermissionCatalog = corePermissionCatalog.filter(
   (definition) => definition.availability.kind === 'root' && definition.lifecycle !== 'deprecated'

--- a/packages/core/src/iam/permission-catalog.ts
+++ b/packages/core/src/iam/permission-catalog.ts
@@ -1,0 +1,144 @@
+export type PermissionAvailability =
+  | { readonly kind: 'root' }
+  | { readonly kind: 'tenant' }
+  | { readonly kind: 'module'; readonly moduleId: string };
+
+export type PermissionLifecycle = 'active' | 'deprecated';
+
+export type PermissionDefinition = Readonly<{
+  key: string;
+  description: string;
+  resourceType: string;
+  availability: PermissionAvailability;
+  systemAdminGrant?: boolean;
+  lifecycle?: PermissionLifecycle;
+}>;
+
+export type ModulePermissionCatalogContribution = Readonly<{
+  moduleId: string;
+  permissionIds: readonly string[];
+}>;
+
+const tenantPermission = <const TKey extends string>(
+  key: TKey,
+  description: string
+): PermissionDefinition & { readonly key: TKey } => ({
+  key,
+  description,
+  resourceType: key.split('.')[0] ?? key,
+  availability: { kind: 'tenant' },
+});
+
+export const corePermissionCatalog = [
+  tenantPermission('iam.user.read', 'Read account data'),
+  tenantPermission('iam.user.write', 'Modify account data'),
+  tenantPermission('iam.role.read', 'Read role assignments'),
+  tenantPermission('iam.role.write', 'Modify role assignments'),
+  tenantPermission('iam.org.read', 'Read organization data'),
+  tenantPermission('iam.org.write', 'Modify organization data'),
+  tenantPermission('iam.legalText.read', 'Read legal text administration data'),
+  tenantPermission('iam.legalText.write', 'Modify legal text administration data'),
+  tenantPermission('iam.governance.read', 'Read governance workflows and audit trails'),
+  tenantPermission('iam.governance.write', 'Execute governance workflows and decisions'),
+  tenantPermission('iam.governance.export', 'Export governance and legal consent evidence'),
+  tenantPermission('iam.dsr.read', 'Read tenant data-subject-rights cases'),
+  tenantPermission('iam.dsr.write', 'Process tenant data-subject-rights cases'),
+  tenantPermission('iam.dsr.export', 'Export tenant data-subject-rights payloads'),
+  tenantPermission('iam.deletionRules.read', 'Read tenant deletion rules'),
+  tenantPermission('iam.deletionRules.write', 'Modify tenant deletion rules'),
+  tenantPermission('iam.monitoring.read', 'Read IAM monitoring and plugin operation status'),
+  tenantPermission('iam.monitoring.write', 'Run IAM monitoring and plugin operations'),
+  tenantPermission('iam.accounts.delete', 'Delete tenant accounts physically'),
+  tenantPermission('experimental.read', 'Enable experimental shell features and placeholders'),
+  tenantPermission('app.read', 'Show the app link in the sidebar'),
+  tenantPermission('cockpit.read', 'Show the cockpit link in the sidebar'),
+  tenantPermission('content.read', 'Read content'),
+  tenantPermission('content.create', 'Create content'),
+  tenantPermission('content.updateMetadata', 'Update content metadata'),
+  tenantPermission('content.updatePayload', 'Update content payload'),
+  tenantPermission('content.changeStatus', 'Change content status'),
+  tenantPermission('content.publish', 'Publish content'),
+  tenantPermission('content.archive', 'Archive content'),
+  tenantPermission('content.restore', 'Restore content'),
+  tenantPermission('content.readHistory', 'Read content history'),
+  tenantPermission('content.manageRevisions', 'Manage content revisions'),
+  tenantPermission('content.delete', 'Delete content'),
+  tenantPermission('integration.manage', 'Manage integrations'),
+  tenantPermission('feature.toggle', 'Toggle feature flags'),
+  {
+    key: 'instance.registry.manage',
+    description: 'Manage instance registry and provisioning',
+    resourceType: 'instance',
+    availability: { kind: 'root' },
+    systemAdminGrant: false,
+    lifecycle: 'active',
+  },
+] as const satisfies readonly PermissionDefinition[];
+
+export type CorePermissionKey = (typeof corePermissionCatalog)[number]['key'];
+
+export const resolvesSystemAdminGrant = (definition: PermissionDefinition): boolean => {
+  if (definition.availability.kind === 'root') {
+    return false;
+  }
+  return definition.systemAdminGrant ?? true;
+};
+
+const assertNonBlank = (value: string, field: string, key: string): void => {
+  if (value.trim().length === 0) {
+    throw new Error(`invalid_permission_catalog_${field}:${key}`);
+  }
+};
+
+export const validatePermissionCatalog = (
+  definitions: readonly PermissionDefinition[]
+): readonly PermissionDefinition[] => {
+  const keys = new Set<string>();
+  for (const definition of definitions) {
+    assertNonBlank(definition.key, 'key', definition.key);
+    assertNonBlank(definition.description, 'description', definition.key);
+    assertNonBlank(definition.resourceType, 'resource_type', definition.key);
+    if (keys.has(definition.key)) {
+      throw new Error(`duplicate_permission_catalog_key:${definition.key}`);
+    }
+    keys.add(definition.key);
+    if (definition.availability.kind === 'root' && definition.systemAdminGrant === true) {
+      throw new Error(`root_permission_system_admin_grant:${definition.key}`);
+    }
+    if (definition.availability.kind === 'module') {
+      assertNonBlank(definition.availability.moduleId, 'module_id', definition.key);
+      if (!definition.key.startsWith(`${definition.availability.moduleId}.`)) {
+        throw new Error(`module_permission_namespace_mismatch:${definition.key}`);
+      }
+    }
+  }
+  return definitions;
+};
+
+export const composePermissionCatalog = (
+  coreDefinitions: readonly PermissionDefinition[],
+  moduleContributions: readonly ModulePermissionCatalogContribution[]
+): readonly PermissionDefinition[] =>
+  validatePermissionCatalog([
+    ...coreDefinitions,
+    ...moduleContributions.flatMap((contribution) =>
+      contribution.permissionIds.map((key): PermissionDefinition => ({
+        key,
+        description: `Module permission ${key}`,
+        resourceType: key.split('.')[0] ?? key,
+        availability: { kind: 'module', moduleId: contribution.moduleId },
+      }))
+    ),
+  ]);
+
+export const tenantCorePermissionCatalog = validatePermissionCatalog(corePermissionCatalog).filter(
+  (definition) => definition.availability.kind === 'tenant' && definition.lifecycle !== 'deprecated'
+);
+
+export const tenantCoreSystemAdminPermissionKeys: readonly CorePermissionKey[] = tenantCorePermissionCatalog
+  .filter(resolvesSystemAdminGrant)
+  .map((definition) => definition.key as CorePermissionKey);
+
+export const rootPermissionCatalog = corePermissionCatalog.filter(
+  (definition) => definition.availability.kind === 'root' && definition.lifecycle !== 'deprecated'
+);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,20 @@
 export const coreVersion = '0.0.1';
+export {
+  composePermissionCatalog,
+  corePermissionCatalog,
+  resolvesSystemAdminGrant,
+  rootPermissionCatalog,
+  tenantCorePermissionCatalog,
+  tenantCoreSystemAdminPermissionKeys,
+  validatePermissionCatalog,
+} from './iam/permission-catalog.js';
+export type {
+  CorePermissionKey,
+  ModulePermissionCatalogContribution,
+  PermissionAvailability,
+  PermissionDefinition,
+  PermissionLifecycle,
+} from './iam/permission-catalog.js';
 export { isPlausibleEmailAddress } from './email-address.js';
 export {
   iamContentAccessReasonCodes,

--- a/packages/data-repositories/src/iam/seed-plan.permissions.ts
+++ b/packages/data-repositories/src/iam/seed-plan.permissions.ts
@@ -1,60 +1,65 @@
+import {
+  corePermissionCatalog,
+  rootPermissionCatalog,
+  tenantCoreSystemAdminPermissionKeys,
+  type CorePermissionKey,
+} from '@sva/core';
+
 import type { PermissionKey } from './types.js';
 
-export const iamSeedPermissions = [
-  ['40111111-1111-1111-1111-111111111111', 'iam.user.read', 'Read account data'],
-  ['40111111-1111-1111-1111-111111111112', 'iam.user.write', 'Modify account data'],
-  ['40111111-1111-1111-1111-111111111113', 'iam.role.read', 'Read role assignments'],
-  ['40111111-1111-1111-1111-111111111114', 'iam.role.write', 'Modify role assignments'],
-  ['40111111-1111-1111-1111-111111111115', 'iam.org.read', 'Read organization data'],
-  ['40111111-1111-1111-1111-111111111116', 'iam.org.write', 'Modify organization data'],
-  ['40111111-1111-1111-1111-111111111151', 'iam.legalText.read', 'Read legal text administration data'],
-  ['40111111-1111-1111-1111-111111111152', 'iam.legalText.write', 'Modify legal text administration data'],
-  ['40111111-1111-1111-1111-111111111153', 'iam.governance.read', 'Read governance workflows and audit trails'],
-  ['40111111-1111-1111-1111-111111111154', 'iam.governance.write', 'Execute governance workflows and decisions'],
-  ['40111111-1111-1111-1111-111111111155', 'iam.governance.export', 'Export governance and legal consent evidence'],
-  ['40111111-1111-1111-1111-111111111156', 'iam.dsr.read', 'Read tenant data-subject-rights cases'],
-  ['40111111-1111-1111-1111-111111111157', 'iam.dsr.write', 'Process tenant data-subject-rights cases'],
-  ['40111111-1111-1111-1111-111111111158', 'iam.dsr.export', 'Export tenant data-subject-rights payloads'],
-  ['40111111-1111-1111-1111-111111111159', 'iam.deletionRules.read', 'Read tenant deletion rules'],
-  ['40111111-1111-1111-1111-111111111160', 'iam.deletionRules.write', 'Modify tenant deletion rules'],
-  ['40111111-1111-1111-1111-111111111161', 'iam.monitoring.read', 'Read IAM monitoring and plugin operation status'],
-  ['40111111-1111-1111-1111-111111111162', 'iam.monitoring.write', 'Run IAM monitoring and plugin operations'],
-  ['40111111-1111-1111-1111-111111111163', 'experimental.read', 'Enable experimental shell features and placeholders'],
-  ['40111111-1111-1111-1111-111111111168', 'iam.accounts.delete', 'Delete tenant accounts physically'],
-  ['40111111-1111-1111-1111-111111111117', 'content.read', 'Read content'],
-  ['40111111-1111-1111-1111-111111111118', 'content.create', 'Create content'],
-  ['40111111-1111-1111-1111-111111111119', 'content.updateMetadata', 'Update content metadata'],
-  ['40111111-1111-1111-1111-111111111120', 'content.publish', 'Publish content'],
-  ['40111111-1111-1111-1111-111111111121', 'content.manageRevisions', 'Manage content revisions'],
-  ['40111111-1111-1111-1111-111111111122', 'integration.manage', 'Manage integrations'],
-  ['40111111-1111-1111-1111-111111111123', 'feature.toggle', 'Toggle feature flags'],
-  ['40111111-1111-1111-1111-111111111149', 'app.read', 'Show the app link in the sidebar'],
-  ['40111111-1111-1111-1111-111111111150', 'cockpit.read', 'Show the cockpit link in the sidebar'],
-  ['40111111-1111-1111-1111-111111111124', 'instance.registry.manage', 'Manage instance registry and provisioning'],
-  ['40111111-1111-1111-1111-111111111125', 'content.updatePayload', 'Update content payload'],
-  ['40111111-1111-1111-1111-111111111126', 'content.changeStatus', 'Change content status'],
-  ['40111111-1111-1111-1111-111111111127', 'content.archive', 'Archive content'],
-  ['40111111-1111-1111-1111-111111111128', 'content.restore', 'Restore content'],
-  ['40111111-1111-1111-1111-111111111129', 'content.readHistory', 'Read content history'],
-  ['40111111-1111-1111-1111-111111111130', 'content.delete', 'Delete content'],
-  ['40111111-1111-1111-1111-111111111143', 'media.read', 'Read media'],
-  ['40111111-1111-1111-1111-111111111144', 'media.create', 'Create media'],
-  ['40111111-1111-1111-1111-111111111145', 'media.update', 'Update media'],
-  ['40111111-1111-1111-1111-111111111146', 'media.reference.manage', 'Manage media references'],
-  ['40111111-1111-1111-1111-111111111147', 'media.delete', 'Delete media'],
-  ['40111111-1111-1111-1111-111111111148', 'media.deliver.protected', 'Deliver protected media'],
-] as const satisfies readonly [string, PermissionKey, string][];
+const permissionIds = {
+  'iam.user.read': '40111111-1111-1111-1111-111111111111',
+  'iam.user.write': '40111111-1111-1111-1111-111111111112',
+  'iam.role.read': '40111111-1111-1111-1111-111111111113',
+  'iam.role.write': '40111111-1111-1111-1111-111111111114',
+  'iam.org.read': '40111111-1111-1111-1111-111111111115',
+  'iam.org.write': '40111111-1111-1111-1111-111111111116',
+  'content.read': '40111111-1111-1111-1111-111111111117',
+  'content.create': '40111111-1111-1111-1111-111111111118',
+  'content.updateMetadata': '40111111-1111-1111-1111-111111111119',
+  'content.publish': '40111111-1111-1111-1111-111111111120',
+  'content.manageRevisions': '40111111-1111-1111-1111-111111111121',
+  'integration.manage': '40111111-1111-1111-1111-111111111122',
+  'feature.toggle': '40111111-1111-1111-1111-111111111123',
+  'instance.registry.manage': '40111111-1111-1111-1111-111111111124',
+  'content.updatePayload': '40111111-1111-1111-1111-111111111125',
+  'content.changeStatus': '40111111-1111-1111-1111-111111111126',
+  'content.archive': '40111111-1111-1111-1111-111111111127',
+  'content.restore': '40111111-1111-1111-1111-111111111128',
+  'content.readHistory': '40111111-1111-1111-1111-111111111129',
+  'content.delete': '40111111-1111-1111-1111-111111111130',
+  'app.read': '40111111-1111-1111-1111-111111111149',
+  'cockpit.read': '40111111-1111-1111-1111-111111111150',
+  'iam.legalText.read': '40111111-1111-1111-1111-111111111151',
+  'iam.legalText.write': '40111111-1111-1111-1111-111111111152',
+  'iam.governance.read': '40111111-1111-1111-1111-111111111153',
+  'iam.governance.write': '40111111-1111-1111-1111-111111111154',
+  'iam.governance.export': '40111111-1111-1111-1111-111111111155',
+  'iam.dsr.read': '40111111-1111-1111-1111-111111111156',
+  'iam.dsr.write': '40111111-1111-1111-1111-111111111157',
+  'iam.dsr.export': '40111111-1111-1111-1111-111111111158',
+  'iam.deletionRules.read': '40111111-1111-1111-1111-111111111159',
+  'iam.deletionRules.write': '40111111-1111-1111-1111-111111111160',
+  'iam.monitoring.read': '40111111-1111-1111-1111-111111111161',
+  'iam.monitoring.write': '40111111-1111-1111-1111-111111111162',
+  'experimental.read': '40111111-1111-1111-1111-111111111163',
+  'iam.accounts.delete': '40111111-1111-1111-1111-111111111168',
+} as const satisfies Readonly<Record<CorePermissionKey, string>>;
 
-export const rootOnlySeedPermissionKeys = ['instance.registry.manage'] as const satisfies readonly PermissionKey[];
+export const iamSeedPermissions = corePermissionCatalog.map((definition) => [
+  permissionIds[definition.key],
+  definition.key,
+  definition.description,
+] as const) satisfies readonly [string, PermissionKey, string][];
 
-const rootOnlySeedPermissionKeySet: ReadonlySet<PermissionKey> = new Set(rootOnlySeedPermissionKeys);
+export const rootOnlySeedPermissionKeys = rootPermissionCatalog.map(
+  (definition) => definition.key
+) satisfies readonly PermissionKey[];
 
-export const tenantBootstrapPermissionKeys = iamSeedPermissions
-  .map(([, key]) => key)
-  .filter((key): key is PermissionKey => !rootOnlySeedPermissionKeySet.has(key));
+export const tenantBootstrapPermissionKeys = tenantCoreSystemAdminPermissionKeys satisfies readonly PermissionKey[];
 
-export const experimentalShellPermissionKeys = ['experimental.read'] as const;
-export const applicationReadPermissionKeys = ['app.read', 'cockpit.read'] as const;
+export const experimentalShellPermissionKeys = ['experimental.read'] as const satisfies readonly PermissionKey[];
+export const applicationReadPermissionKeys = ['app.read', 'cockpit.read'] as const satisfies readonly PermissionKey[];
 export const mediaReadPermissionKeys = ['media.read'] as const;
 export const mediaManagePermissionKeys = [
   'media.read',

--- a/packages/data-repositories/src/iam/seed-plan.test.ts
+++ b/packages/data-repositories/src/iam/seed-plan.test.ts
@@ -17,7 +17,6 @@ describe('iam seed plan', () => {
     expect(iamSeedPlan.permissions.find((permission) => permission.key === 'content.publish')?.resourceType).toBe(
       'content'
     );
-    expect(iamSeedPlan.permissions.find((permission) => permission.key === 'media.read')?.resourceType).toBe('media');
     expect(iamSeedPlan.permissions.find((permission) => permission.key === 'app.read')?.resourceType).toBe('app');
     expect(iamSeedPlan.permissions.find((permission) => permission.key === 'experimental.read')?.resourceType).toBe(
       'experimental'
@@ -44,8 +43,6 @@ describe('iam seed plan', () => {
         'content.updatePayload',
         'content.changeStatus',
         'content.delete',
-        'media.create',
-        'media.reference.manage',
       ]),
     });
     expect(() => getPersonaSeed('instance_registry_admin' as never)).toThrow(

--- a/packages/data-repositories/src/iam/types.permissions.ts
+++ b/packages/data-repositories/src/iam/types.permissions.ts
@@ -1,45 +1,10 @@
-type PermissionKey =
-  | 'iam.user.read'
-  | 'iam.user.write'
-  | 'iam.role.read'
-  | 'iam.role.write'
-  | 'iam.org.read'
-  | 'iam.org.write'
-  | 'iam.legalText.read'
-  | 'iam.legalText.write'
-  | 'iam.governance.read'
-  | 'iam.governance.write'
-  | 'iam.governance.export'
-  | 'iam.dsr.read'
-  | 'iam.dsr.write'
-  | 'iam.dsr.export'
-  | 'iam.deletionRules.read'
-  | 'iam.deletionRules.write'
-  | 'iam.accounts.delete'
-  | 'iam.monitoring.read'
-  | 'iam.monitoring.write'
-  | 'experimental.read'
-  | 'app.read'
-  | 'cockpit.read'
-  | 'content.read'
-  | 'content.create'
-  | 'content.updateMetadata'
-  | 'content.updatePayload'
-  | 'content.changeStatus'
-  | 'content.publish'
-  | 'content.archive'
-  | 'content.restore'
-  | 'content.readHistory'
-  | 'content.manageRevisions'
-  | 'content.delete'
+import type { CorePermissionKey } from '@sva/core';
+
+export type PermissionKey =
+  | CorePermissionKey
   | 'media.read'
   | 'media.create'
   | 'media.update'
   | 'media.reference.manage'
   | 'media.delete'
-  | 'media.deliver.protected'
-  | 'integration.manage'
-  | 'feature.toggle'
-  | 'instance.registry.manage';
-
-export type { PermissionKey };
+  | 'media.deliver.protected';

--- a/packages/data-repositories/src/index.ts
+++ b/packages/data-repositories/src/index.ts
@@ -39,6 +39,7 @@ export type {
   InstanceIntegrationRecord,
   InstanceIntegrationRepository,
   InstanceRegistryRepository,
+  PermissionCatalogReconcileResult,
   IntegrationProviderKey,
   MediaAssetListFilter,
   MediaAssetRecord,

--- a/packages/data-repositories/src/instance-registry/index.ts
+++ b/packages/data-repositories/src/instance-registry/index.ts
@@ -8,6 +8,7 @@ import type {
   InstanceConfirmationChallengeRecord,
   InstanceModuleIamContractRecord,
   InstanceRegistryRepository,
+  PermissionCatalogReconcileResult,
   ProtectedSystemRolePermissionBundleRecord,
   PrepareInstanceConfirmationChallengeInput,
 } from './repository-contract.js';
@@ -23,6 +24,7 @@ export type {
   InstanceConfirmationChallengeRecord,
   InstanceModuleIamContractRecord,
   InstanceRegistryRepository,
+  PermissionCatalogReconcileResult,
   ProtectedSystemRolePermissionBundleRecord,
   PrepareInstanceConfirmationChallengeInput,
 };

--- a/packages/data-repositories/src/instance-registry/repository-contract.ts
+++ b/packages/data-repositories/src/instance-registry/repository-contract.ts
@@ -73,6 +73,7 @@ export type ProtectedSystemRolePermissionBundleRecord = {
     readonly description: string;
     readonly resourceType: string;
   }[];
+  readonly grantPermissionKeys: readonly string[];
 };
 
 export type PermissionCatalogReconcileResult = {
@@ -85,8 +86,12 @@ export type PermissionCatalogReconcileResult = {
 
 export type InstanceRegistryRepository = {
   readonly requestWasteProvisioning: (instanceId: string) => Promise<WasteTenantProvisioningRecord>;
-  readonly getWasteProvisioning: (instanceId: string) => Promise<WasteTenantProvisioningRecord | null>;
-  readonly disableWasteProvisioning: (instanceId: string) => Promise<WasteTenantProvisioningRecord | null>;
+  readonly getWasteProvisioning: (
+    instanceId: string
+  ) => Promise<WasteTenantProvisioningRecord | null>;
+  readonly disableWasteProvisioning: (
+    instanceId: string
+  ) => Promise<WasteTenantProvisioningRecord | null>;
   readonly claimWasteProvisioning: (input: {
     instanceId: string;
     jobId: string;
@@ -115,7 +120,9 @@ export type InstanceRegistryRepository = {
   readonly prepareConfirmationChallenge: (
     input: PrepareInstanceConfirmationChallengeInput
   ) => Promise<InstanceConfirmationChallengeRecord>;
-  readonly consumeConfirmationChallenge: (input: ConsumeInstanceConfirmationChallengeInput) => Promise<boolean>;
+  readonly consumeConfirmationChallenge: (
+    input: ConsumeInstanceConfirmationChallengeInput
+  ) => Promise<boolean>;
   readonly listInstances: (input?: {
     search?: string;
     status?: InstanceStatus;
@@ -138,7 +145,9 @@ export type InstanceRegistryRepository = {
   readonly getTenantAdminClientSecretCiphertext: (instanceId: string) => Promise<string | null>;
   readonly resolveHostname: (hostname: string) => Promise<InstanceRegistryRecord | null>;
   readonly resolvePrimaryHostname: (hostname: string) => Promise<InstanceRegistryRecord | null>;
-  readonly listProvisioningRuns: (instanceId: string) => Promise<readonly InstanceProvisioningRun[]>;
+  readonly listProvisioningRuns: (
+    instanceId: string
+  ) => Promise<readonly InstanceProvisioningRun[]>;
   readonly listLatestProvisioningRuns: (
     instanceIds: readonly string[]
   ) => Promise<Readonly<Record<string, InstanceProvisioningRun | undefined>>>;

--- a/packages/data-repositories/src/instance-registry/repository-contract.ts
+++ b/packages/data-repositories/src/instance-registry/repository-contract.ts
@@ -45,6 +45,11 @@ export type ConsumeInstanceConfirmationChallengeInput = {
 export type InstanceModuleIamContractRecord = {
   readonly moduleId: string;
   readonly permissionIds: readonly string[];
+  readonly permissions: readonly {
+    readonly key: string;
+    readonly description: string;
+    readonly resourceType: string;
+  }[];
   readonly tenantBootstrapRoles?: readonly {
     readonly roleName: string;
     readonly permissionIds: readonly string[];
@@ -63,7 +68,19 @@ export type ProtectedSystemRolePermissionBundleRecord = {
   readonly roleKey: string;
   readonly displayName: string;
   readonly roleLevel: number;
-  readonly permissionKeys: readonly string[];
+  readonly permissions: readonly {
+    readonly key: string;
+    readonly description: string;
+    readonly resourceType: string;
+  }[];
+};
+
+export type PermissionCatalogReconcileResult = {
+  readonly permissionsInserted: number;
+  readonly permissionsUpdated: number;
+  readonly permissionsUnchanged: number;
+  readonly grantsInserted: number;
+  readonly grantsUnchanged: number;
 };
 
 export type InstanceRegistryRepository = {
@@ -111,11 +128,11 @@ export type InstanceRegistryRepository = {
     instanceId: string;
     managedModuleIds: readonly string[];
     contracts: readonly InstanceModuleIamContractRecord[];
-  }) => Promise<void>;
+  }) => Promise<PermissionCatalogReconcileResult | void>;
   readonly syncProtectedSystemRolePermissions: (input: {
     instanceId: string;
     role: ProtectedSystemRolePermissionBundleRecord;
-  }) => Promise<void>;
+  }) => Promise<PermissionCatalogReconcileResult | void>;
   readonly countLocalSystemAdminAssignments: (instanceId: string) => Promise<number>;
   readonly getAuthClientSecretCiphertext: (instanceId: string) => Promise<string | null>;
   readonly getTenantAdminClientSecretCiphertext: (instanceId: string) => Promise<string | null>;

--- a/packages/data-repositories/src/instance-registry/repository-module-iam-shared.ts
+++ b/packages/data-repositories/src/instance-registry/repository-module-iam-shared.ts
@@ -12,8 +12,11 @@ export type RolePermissionPair = {
   permissionId: string;
 };
 
-export const buildManagedPermissionKeys = (contracts: readonly InstanceModuleIamContractRecord[]): readonly string[] =>
-  Array.from(new Set(contracts.flatMap((contract) => contract.permissionIds))).sort(compareAlphabetically);
+export const buildManagedPermissions = (
+  contracts: readonly InstanceModuleIamContractRecord[]
+): readonly InstanceModuleIamContractRecord['permissions'][number][] =>
+  [...new Map(contracts.flatMap((contract) => contract.permissions).map((permission) => [permission.key, permission])).values()]
+    .sort((left, right) => compareAlphabetically(left.key, right.key));
 
 export const buildRolePermissionPairs = (
   contracts: readonly InstanceModuleIamContractRecord[]
@@ -31,16 +34,15 @@ export const buildRolePermissionPairs = (
 export const upsertPermission = async (
   executor: SqlExecutor,
   instanceId: string,
-  permissionKey: string,
-  description: string
-): Promise<void> => {
-  await executor.execute(
+  definition: { readonly key: string; readonly description: string; readonly resourceType: string }
+): Promise<'inserted' | 'updated' | 'unchanged'> => {
+  const result = await executor.execute<{ readonly inserted: boolean }>(
     statement(
       `
 INSERT INTO iam.permissions (
   id, instance_id, permission_key, action, resource_type, resource_id, scope, description
 )
-VALUES (gen_random_uuid(), $1, $2, $2, split_part($2, '.', 1), NULL, '{}'::jsonb, $3)
+VALUES (gen_random_uuid(), $1, $2, $2, $3, NULL, '{}'::jsonb, $4)
 ON CONFLICT (instance_id, permission_key) DO UPDATE
 SET
   action = EXCLUDED.action,
@@ -48,19 +50,26 @@ SET
   resource_id = EXCLUDED.resource_id,
   scope = EXCLUDED.scope,
   description = EXCLUDED.description,
-  updated_at = NOW();
+  updated_at = NOW()
+WHERE (iam.permissions.action, iam.permissions.resource_type, iam.permissions.resource_id, iam.permissions.scope, iam.permissions.description)
+  IS DISTINCT FROM (EXCLUDED.action, EXCLUDED.resource_type, EXCLUDED.resource_id, EXCLUDED.scope, EXCLUDED.description)
+RETURNING (xmax = 0) AS inserted;
 `,
-      [instanceId, permissionKey, description]
+      [instanceId, definition.key, definition.resourceType, definition.description]
     )
   );
+  if (result.rowCount === 0) {
+    return 'unchanged';
+  }
+  return result.rows[0]?.inserted ? 'inserted' : 'updated';
 };
 
 export const insertModuleRolePermission = async (
   executor: SqlExecutor,
   instanceId: string,
   pair: RolePermissionPair
-): Promise<void> => {
-  await executor.execute(
+): Promise<boolean> => {
+  const result = await executor.execute(
     statement(
       `
 INSERT INTO iam.role_permissions (instance_id, role_id, permission_id, grant_origin_kind, grant_origin_module_id)
@@ -76,6 +85,7 @@ ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
       [instanceId, pair.roleName, pair.permissionId, 'module_sync', pair.moduleId]
     )
   );
+  return result.rowCount > 0;
 };
 
 export const cleanupModuleRolePermissions = async (
@@ -112,33 +122,6 @@ WHERE role_permission.instance_id = $1
   );
 };
 
-export const cleanupModulePermissions = async (
-  executor: SqlExecutor,
-  instanceId: string,
-  managedModuleIds: readonly string[],
-  permissionKeys: readonly string[]
-): Promise<void> => {
-  if (managedModuleIds.length === 0) {
-    return;
-  }
-  const managedPrefixConditions = managedModuleIds
-    .map((moduleId) => `permission_key LIKE ${quoteSqlLiteral(`${moduleId}.%`)}`)
-    .join(' OR ');
-  const desiredPermissionFilter =
-    permissionKeys.length > 0 ? `AND permission_key NOT IN (${createTextList(permissionKeys)})` : '';
-  await executor.execute(
-    statement(
-      `
-DELETE FROM iam.permissions
-WHERE instance_id = $1
-  ${desiredPermissionFilter}
-  AND (${managedPrefixConditions});
-`,
-      [instanceId]
-    )
-  );
-};
-
 export const upsertProtectedRole = async (
   executor: SqlExecutor,
   instanceId: string,
@@ -167,42 +150,13 @@ SET
   );
 };
 
-export const cleanupProtectedRolePermissions = async (
-  executor: SqlExecutor,
-  instanceId: string,
-  roleKey: string,
-  permissionKeys: readonly string[]
-): Promise<void> => {
-  await executor.execute(
-    statement(
-      `
-DELETE FROM iam.role_permissions role_permission
-WHERE role_permission.instance_id = $1
-  AND role_permission.role_id = (
-    SELECT id FROM iam.roles WHERE instance_id = $1 AND role_key = $2 LIMIT 1
-  )
-  AND role_permission.grant_origin_kind = 'bootstrap'
-  AND role_permission.grant_origin_module_id IS NULL
-  AND NOT EXISTS (
-    SELECT 1
-    FROM iam.permissions permission
-    WHERE permission.instance_id = role_permission.instance_id
-      AND permission.id = role_permission.permission_id
-      AND permission.permission_key = ANY($3::text[])
-  );
-`,
-      [instanceId, roleKey, permissionKeys]
-    )
-  );
-};
-
 export const insertProtectedRolePermission = async (
   executor: SqlExecutor,
   instanceId: string,
   roleKey: string,
   permissionKey: string
-): Promise<void> => {
-  await executor.execute(
+): Promise<boolean> => {
+  const result = await executor.execute(
     statement(
       `
 INSERT INTO iam.role_permissions (instance_id, role_id, permission_id, grant_origin_kind, grant_origin_module_id)
@@ -218,4 +172,5 @@ ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING;
       [instanceId, roleKey, permissionKey]
     )
   );
+  return result.rowCount > 0;
 };

--- a/packages/data-repositories/src/instance-registry/repository-module-iam-shared.ts
+++ b/packages/data-repositories/src/instance-registry/repository-module-iam-shared.ts
@@ -4,7 +4,7 @@ import type {
   InstanceModuleIamContractRecord,
   ProtectedSystemRolePermissionBundleRecord,
 } from './repository-contract.js';
-import { compareAlphabetically, createTextList, quoteSqlLiteral, statement } from './repository-shared.js';
+import { compareAlphabetically, createTextList, statement } from './repository-shared.js';
 
 export type RolePermissionPair = {
   moduleId: string;
@@ -15,8 +15,13 @@ export type RolePermissionPair = {
 export const buildManagedPermissions = (
   contracts: readonly InstanceModuleIamContractRecord[]
 ): readonly InstanceModuleIamContractRecord['permissions'][number][] =>
-  [...new Map(contracts.flatMap((contract) => contract.permissions).map((permission) => [permission.key, permission])).values()]
-    .sort((left, right) => compareAlphabetically(left.key, right.key));
+  [
+    ...new Map(
+      contracts
+        .flatMap((contract) => contract.permissions)
+        .map((permission) => [permission.key, permission])
+    ).values(),
+  ].sort((left, right) => compareAlphabetically(left.key, right.key));
 
 export const buildRolePermissionPairs = (
   contracts: readonly InstanceModuleIamContractRecord[]
@@ -92,17 +97,15 @@ export const cleanupModuleRolePermissions = async (
   executor: SqlExecutor,
   instanceId: string,
   managedModuleIds: readonly string[],
-  rolePermissionPairs: readonly RolePermissionPair[]
+  activeModuleIds: readonly string[]
 ): Promise<void> => {
   if (managedModuleIds.length === 0) {
     return;
   }
-  const desiredPairSql =
-    rolePermissionPairs.length > 0
-      ? rolePermissionPairs
-          .map((pair) => `(${quoteSqlLiteral(pair.moduleId)}, ${quoteSqlLiteral(pair.roleName)}, ${quoteSqlLiteral(pair.permissionId)})`)
-          .join(', ')
-      : null;
+  const activeModuleFilter =
+    activeModuleIds.length > 0
+      ? `AND role_permission.grant_origin_module_id NOT IN (${createTextList(activeModuleIds)})`
+      : '';
   await executor.execute(
     statement(
       `
@@ -115,7 +118,7 @@ WHERE role_permission.instance_id = $1
   AND permission.id = role_permission.permission_id
   AND role_permission.grant_origin_kind = 'module_sync'
   AND role_permission.grant_origin_module_id IN (${createTextList(managedModuleIds)})
-  ${desiredPairSql ? `AND (role_permission.grant_origin_module_id, role.role_key, permission.permission_key) NOT IN (${desiredPairSql})` : ''};
+  ${activeModuleFilter};
 `,
       [instanceId]
     )
@@ -145,7 +148,13 @@ SET
   role_level = EXCLUDED.role_level,
   updated_at = NOW();
 `,
-      [instanceId, role.roleKey, role.displayName, `Geschützte Systemrolle ${role.displayName}`, role.roleLevel]
+      [
+        instanceId,
+        role.roleKey,
+        role.displayName,
+        `Geschützte Systemrolle ${role.displayName}`,
+        role.roleLevel,
+      ]
     )
   );
 };

--- a/packages/data-repositories/src/instance-registry/repository-module-iam.test.ts
+++ b/packages/data-repositories/src/instance-registry/repository-module-iam.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { SqlExecutor, SqlStatement } from '../iam/repositories/types.js';
 import { createInstanceRegistryRepository } from './index.js';
 import { createQueuedExecutor } from './test-support.js';
 
@@ -22,12 +23,18 @@ describe('instance registry repository module iam', () => {
         managedModuleIds: [],
         contracts: [],
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({
+      permissionsInserted: 0,
+      permissionsUpdated: 0,
+      permissionsUnchanged: 0,
+      grantsInserted: 0,
+      grantsUnchanged: 0,
+    });
 
     expect(statements).toEqual([]);
   });
 
-  it('cleans up stale module permissions and role grants when desired sets are empty', async () => {
+  it('cleans up stale module grants but preserves materialized permission definitions', async () => {
     const { executor, statements } = createQueuedExecutor([[]]);
     const repository = createInstanceRegistryRepository(executor);
 
@@ -39,16 +46,19 @@ describe('instance registry repository module iam', () => {
           {
             moduleId: 'news',
             permissionIds: [],
+            permissions: [],
             tenantBootstrapRoles: [{ roleName: 'news_admin', permissionIds: [] }],
           },
         ],
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ permissionsUnchanged: 0, grantsUnchanged: 0 });
 
-    expect(statements).toHaveLength(2);
-    expect(statements[0]?.text).toContain("role_permission.grant_origin_module_id IN ('news')");
-    expect(statements[1]?.text).toContain("permission_key LIKE 'news.%'");
-    expect(statements[1]?.text).not.toContain('permission_key NOT IN (');
+    expect(statements.map((entry) => entry.text.trim())).toEqual([
+      'BEGIN;',
+      expect.stringContaining("role_permission.grant_origin_module_id IN ('news')"),
+      'COMMIT;',
+    ]);
+    expect(statements.some((statement) => statement.text.includes('DELETE FROM iam.permissions'))).toBe(false);
   });
 
   it('tags module-synced role grants with ownership metadata and cleans up only module-owned rows', async () => {
@@ -63,11 +73,12 @@ describe('instance registry repository module iam', () => {
           {
             moduleId: 'news',
             permissionIds: ['news.read'],
+            permissions: [{ key: 'news.read', description: 'Read news', resourceType: 'news' }],
             tenantBootstrapRoles: [{ roleName: 'system_admin', permissionIds: ['news.read'] }],
           },
         ],
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ permissionsUnchanged: 1, grantsUnchanged: 1 });
 
     const rolePermissionInsert = statements.find((statement) => statement.text.includes('grant_origin_kind'));
     expect(rolePermissionInsert?.text).toContain('grant_origin_kind');
@@ -94,6 +105,10 @@ describe('instance registry repository module iam', () => {
           {
             moduleId: 'news',
             permissionIds: ['z.permission', 'ä.permission'],
+            permissions: [
+              { key: 'z.permission', description: 'Z permission', resourceType: 'z' },
+              { key: 'ä.permission', description: 'Ä permission', resourceType: 'ä' },
+            ],
             tenantBootstrapRoles: [
               { roleName: 'z-role', permissionIds: ['z.permission'] },
               { roleName: 'ä-role', permissionIds: ['ä.permission'] },
@@ -101,12 +116,10 @@ describe('instance registry repository module iam', () => {
           },
         ],
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ permissionsUnchanged: 2, grantsUnchanged: 2 });
 
-    const permissionCleanup = statements.find((statement) => statement.text.includes('DELETE FROM iam.permissions'));
     const permissionUpserts = statements.filter((statement) => statement.text.includes('INSERT INTO iam.permissions'));
 
-    expect(permissionCleanup?.text).toContain("permission_key NOT IN ('ä.permission', 'z.permission')");
     expect(permissionUpserts.map((statement) => statement.values[1])).toEqual(['ä.permission', 'z.permission']);
   });
 
@@ -121,10 +134,13 @@ describe('instance registry repository module iam', () => {
           roleKey: 'system_admin',
           displayName: 'System Administrator',
           roleLevel: 100,
-          permissionKeys: ['cockpit.read', 'iam.user.read'],
+          permissions: [
+            { key: 'cockpit.read', description: 'Read cockpit', resourceType: 'cockpit' },
+            { key: 'iam.user.read', description: 'Read accounts', resourceType: 'iam' },
+          ],
         },
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ permissionsUnchanged: 2, grantsUnchanged: 2 });
 
     const roleUpsert = statements.find(
       (statement) =>
@@ -143,7 +159,7 @@ describe('instance registry repository module iam', () => {
         statement.text.includes('DELETE FROM iam.role_permissions role_permission') &&
         statement.text.includes("role_permission.grant_origin_kind = 'bootstrap'")
     );
-    expect(bootstrapCleanup?.values).toEqual(['tenant-a', 'system_admin', ['cockpit.read', 'iam.user.read']]);
+    expect(bootstrapCleanup).toBeUndefined();
 
     const rolePermissionInserts = statements.filter(
       (statement) =>
@@ -155,6 +171,38 @@ describe('instance registry repository module iam', () => {
     expect(rolePermissionInserts.map((statement) => statement.values)).toEqual([
       ['tenant-a', 'system_admin', 'cockpit.read'],
       ['tenant-a', 'system_admin', 'iam.user.read'],
+    ]);
+  });
+
+  it('rolls back the permission reconcile transaction when a write fails', async () => {
+    const statements: SqlStatement[] = [];
+    const executor: SqlExecutor = {
+      async execute<TRow>(statement: SqlStatement) {
+        statements.push(statement);
+        if (statement.text.includes('INSERT INTO iam.permissions')) {
+          throw new Error('permission_write_failed');
+        }
+        return { rowCount: 0, rows: [] as readonly TRow[] };
+      },
+    };
+    const repository = createInstanceRegistryRepository(executor);
+
+    await expect(
+      repository.syncProtectedSystemRolePermissions({
+        instanceId: 'tenant-a',
+        role: {
+          roleKey: 'system_admin',
+          displayName: 'System Administrator',
+          roleLevel: 100,
+          permissions: [{ key: 'iam.user.read', description: 'Read accounts', resourceType: 'iam' }],
+        },
+      })
+    ).rejects.toThrow('permission_write_failed');
+
+    expect(statements.map((statement) => statement.text.trim())).toEqual([
+      'BEGIN;',
+      expect.stringContaining('INSERT INTO iam.permissions'),
+      'ROLLBACK;',
     ]);
   });
 });

--- a/packages/data-repositories/src/instance-registry/repository-module-iam.test.ts
+++ b/packages/data-repositories/src/instance-registry/repository-module-iam.test.ts
@@ -42,23 +42,34 @@ describe('instance registry repository module iam', () => {
       repository.syncAssignedModuleIam({
         instanceId: 'tenant-a',
         managedModuleIds: ['news'],
-        contracts: [
-          {
-            moduleId: 'news',
-            permissionIds: [],
-            permissions: [],
-            tenantBootstrapRoles: [{ roleName: 'news_admin', permissionIds: [] }],
-          },
-        ],
+        contracts: [],
       })
     ).resolves.toMatchObject({ permissionsUnchanged: 0, grantsUnchanged: 0 });
 
-    expect(statements.map((entry) => entry.text.trim())).toEqual([
-      'BEGIN;',
-      expect.stringContaining("role_permission.grant_origin_module_id IN ('news')"),
-      'COMMIT;',
-    ]);
-    expect(statements.some((statement) => statement.text.includes('DELETE FROM iam.permissions'))).toBe(false);
+    expect(statements).toHaveLength(1);
+    expect(statements[0]?.text).toContain("role_permission.grant_origin_module_id IN ('news')");
+    expect(
+      statements.some((statement) => statement.text.includes('DELETE FROM iam.permissions'))
+    ).toBe(false);
+  });
+
+  it('does not revoke grants merely because an active module removed a catalog entry', async () => {
+    const { executor, statements } = createQueuedExecutor([[]]);
+    const repository = createInstanceRegistryRepository(executor);
+
+    await repository.syncAssignedModuleIam({
+      instanceId: 'tenant-a',
+      managedModuleIds: ['news'],
+      contracts: [{ moduleId: 'news', permissionIds: [], permissions: [] }],
+    });
+
+    const cleanup = statements.find((statement) =>
+      statement.text.includes('DELETE FROM iam.role_permissions')
+    );
+    expect(cleanup?.text).toContain("grant_origin_module_id NOT IN ('news')");
+    expect(
+      statements.some((statement) => statement.text.includes('DELETE FROM iam.permissions'))
+    ).toBe(false);
   });
 
   it('tags module-synced role grants with ownership metadata and cleans up only module-owned rows', async () => {
@@ -80,16 +91,31 @@ describe('instance registry repository module iam', () => {
       })
     ).resolves.toMatchObject({ permissionsUnchanged: 1, grantsUnchanged: 1 });
 
-    const rolePermissionInsert = statements.find((statement) => statement.text.includes('grant_origin_kind'));
+    const rolePermissionInsert = statements.find((statement) =>
+      statement.text.includes('grant_origin_kind')
+    );
     expect(rolePermissionInsert?.text).toContain('grant_origin_kind');
     expect(rolePermissionInsert?.text).toContain('grant_origin_module_id');
-    expect(rolePermissionInsert?.values).toEqual(['tenant-a', 'system_admin', 'news.read', 'module_sync', 'news']);
+    expect(rolePermissionInsert?.values).toEqual([
+      'tenant-a',
+      'system_admin',
+      'news.read',
+      'module_sync',
+      'news',
+    ]);
 
     const rolePermissionCleanup = statements.find((statement) =>
       statement.text.includes('DELETE FROM iam.role_permissions role_permission')
     );
-    expect(rolePermissionCleanup?.text).toContain("role_permission.grant_origin_kind = 'module_sync'");
-    expect(rolePermissionCleanup?.text).toContain("role_permission.grant_origin_module_id IN ('news', 'events')");
+    expect(rolePermissionCleanup?.text).toContain(
+      "role_permission.grant_origin_kind = 'module_sync'"
+    );
+    expect(rolePermissionCleanup?.text).toContain(
+      "role_permission.grant_origin_module_id IN ('news', 'events')"
+    );
+    expect(rolePermissionCleanup?.text).toContain(
+      "role_permission.grant_origin_module_id NOT IN ('news')"
+    );
     expect(rolePermissionCleanup?.text).not.toContain('role.role_key IN');
   });
 
@@ -118,9 +144,14 @@ describe('instance registry repository module iam', () => {
       })
     ).resolves.toMatchObject({ permissionsUnchanged: 2, grantsUnchanged: 2 });
 
-    const permissionUpserts = statements.filter((statement) => statement.text.includes('INSERT INTO iam.permissions'));
+    const permissionUpserts = statements.filter((statement) =>
+      statement.text.includes('INSERT INTO iam.permissions')
+    );
 
-    expect(permissionUpserts.map((statement) => statement.values[1])).toEqual(['ä.permission', 'z.permission']);
+    expect(permissionUpserts.map((statement) => statement.values[1])).toEqual([
+      'ä.permission',
+      'z.permission',
+    ]);
   });
 
   it('syncs protected system-role permissions without relying on bootstrap groups', async () => {
@@ -136,15 +167,18 @@ describe('instance registry repository module iam', () => {
           roleLevel: 100,
           permissions: [
             { key: 'cockpit.read', description: 'Read cockpit', resourceType: 'cockpit' },
+            { key: 'iam.optout.read', description: 'Read opt-out data', resourceType: 'iam' },
             { key: 'iam.user.read', description: 'Read accounts', resourceType: 'iam' },
           ],
+          grantPermissionKeys: ['cockpit.read', 'iam.user.read'],
         },
       })
-    ).resolves.toMatchObject({ permissionsUnchanged: 2, grantsUnchanged: 2 });
+    ).resolves.toMatchObject({ permissionsUnchanged: 3, grantsUnchanged: 2 });
 
     const roleUpsert = statements.find(
       (statement) =>
-        statement.text.includes('INSERT INTO iam.roles') && statement.text.includes('is_system_role = TRUE')
+        statement.text.includes('INSERT INTO iam.roles') &&
+        statement.text.includes('is_system_role = TRUE')
     );
     expect(roleUpsert?.values).toEqual([
       'tenant-a',
@@ -174,7 +208,7 @@ describe('instance registry repository module iam', () => {
     ]);
   });
 
-  it('rolls back the permission reconcile transaction when a write fails', async () => {
+  it('leaves transaction ownership to the scoped runtime boundary', async () => {
     const statements: SqlStatement[] = [];
     const executor: SqlExecutor = {
       async execute<TRow>(statement: SqlStatement) {
@@ -194,15 +228,15 @@ describe('instance registry repository module iam', () => {
           roleKey: 'system_admin',
           displayName: 'System Administrator',
           roleLevel: 100,
-          permissions: [{ key: 'iam.user.read', description: 'Read accounts', resourceType: 'iam' }],
+          permissions: [
+            { key: 'iam.user.read', description: 'Read accounts', resourceType: 'iam' },
+          ],
+          grantPermissionKeys: ['iam.user.read'],
         },
       })
     ).rejects.toThrow('permission_write_failed');
 
-    expect(statements.map((statement) => statement.text.trim())).toEqual([
-      'BEGIN;',
-      expect.stringContaining('INSERT INTO iam.permissions'),
-      'ROLLBACK;',
-    ]);
+    expect(statements).toHaveLength(1);
+    expect(statements[0]?.text).toContain('INSERT INTO iam.permissions');
   });
 });

--- a/packages/data-repositories/src/instance-registry/repository-module-iam.ts
+++ b/packages/data-repositories/src/instance-registry/repository-module-iam.ts
@@ -38,18 +38,6 @@ const recordPermissionOutcome = (
   permissionsUnchanged: result.permissionsUnchanged + (outcome === 'unchanged' ? 1 : 0),
 });
 
-const inTransaction = async <T>(executor: SqlExecutor, work: () => Promise<T>): Promise<T> => {
-  await executor.execute(statement('BEGIN;', []));
-  try {
-    const result = await work();
-    await executor.execute(statement('COMMIT;', []));
-    return result;
-  } catch (error) {
-    await executor.execute(statement('ROLLBACK;', []));
-    throw error;
-  }
-};
-
 export const createModuleIamRepository = (executor: SqlExecutor): ModuleIamRepository => ({
   async assignModule(instanceId, moduleId) {
     const result = await executor.execute(
@@ -82,52 +70,64 @@ WHERE instance_id = $1
   async syncAssignedModuleIam({ instanceId, managedModuleIds, contracts }) {
     const permissions = buildManagedPermissions(contracts);
     const rolePermissionPairs = buildRolePermissionPairs(contracts);
-    if (permissions.length === 0 && rolePermissionPairs.length === 0 && managedModuleIds.length === 0) {
+    if (
+      permissions.length === 0 &&
+      rolePermissionPairs.length === 0 &&
+      managedModuleIds.length === 0
+    ) {
       return emptyReconcileResult();
     }
-    return inTransaction(executor, async () => {
-      let reconcileResult = emptyReconcileResult();
-      for (const permission of permissions) {
-        reconcileResult = recordPermissionOutcome(
-          reconcileResult,
-          await upsertPermission(executor, instanceId, permission)
-        );
-      }
-      for (const pair of rolePermissionPairs) {
-        const inserted = await insertModuleRolePermission(executor, instanceId, pair);
-        reconcileResult = {
-          ...reconcileResult,
-          grantsInserted: reconcileResult.grantsInserted + (inserted ? 1 : 0),
-          grantsUnchanged: reconcileResult.grantsUnchanged + (inserted ? 0 : 1),
-        };
-      }
-      await cleanupModuleRolePermissions(executor, instanceId, managedModuleIds, rolePermissionPairs);
-      return reconcileResult;
-    });
+    let reconcileResult = emptyReconcileResult();
+    for (const permission of permissions) {
+      reconcileResult = recordPermissionOutcome(
+        reconcileResult,
+        await upsertPermission(executor, instanceId, permission)
+      );
+    }
+    for (const pair of rolePermissionPairs) {
+      const inserted = await insertModuleRolePermission(executor, instanceId, pair);
+      reconcileResult = {
+        ...reconcileResult,
+        grantsInserted: reconcileResult.grantsInserted + (inserted ? 1 : 0),
+        grantsUnchanged: reconcileResult.grantsUnchanged + (inserted ? 0 : 1),
+      };
+    }
+    await cleanupModuleRolePermissions(
+      executor,
+      instanceId,
+      managedModuleIds,
+      contracts.map((contract) => contract.moduleId)
+    );
+    return reconcileResult;
   },
 
   async syncProtectedSystemRolePermissions({ instanceId, role }) {
-    const permissions = [...new Map(role.permissions.map((permission) => [permission.key, permission])).values()].sort(
-      (left, right) => compareAlphabetically(left.key, right.key)
-    );
-    return inTransaction(executor, async () => {
-      let reconcileResult = emptyReconcileResult();
-      for (const permission of permissions) {
-        reconcileResult = recordPermissionOutcome(
-          reconcileResult,
-          await upsertPermission(executor, instanceId, permission)
-        );
-      }
-      await upsertProtectedRole(executor, instanceId, role);
-      for (const permission of permissions) {
-        const inserted = await insertProtectedRolePermission(executor, instanceId, role.roleKey, permission.key);
-        reconcileResult = {
-          ...reconcileResult,
-          grantsInserted: reconcileResult.grantsInserted + (inserted ? 1 : 0),
-          grantsUnchanged: reconcileResult.grantsUnchanged + (inserted ? 0 : 1),
-        };
-      }
-      return reconcileResult;
-    });
+    const permissions = [
+      ...new Map(role.permissions.map((permission) => [permission.key, permission])).values(),
+    ].sort((left, right) => compareAlphabetically(left.key, right.key));
+    let reconcileResult = emptyReconcileResult();
+    for (const permission of permissions) {
+      reconcileResult = recordPermissionOutcome(
+        reconcileResult,
+        await upsertPermission(executor, instanceId, permission)
+      );
+    }
+    await upsertProtectedRole(executor, instanceId, role);
+    for (const permissionKey of [...new Set(role.grantPermissionKeys)].sort(
+      compareAlphabetically
+    )) {
+      const inserted = await insertProtectedRolePermission(
+        executor,
+        instanceId,
+        role.roleKey,
+        permissionKey
+      );
+      reconcileResult = {
+        ...reconcileResult,
+        grantsInserted: reconcileResult.grantsInserted + (inserted ? 1 : 0),
+        grantsUnchanged: reconcileResult.grantsUnchanged + (inserted ? 0 : 1),
+      };
+    }
+    return reconcileResult;
   },
 });

--- a/packages/data-repositories/src/instance-registry/repository-module-iam.ts
+++ b/packages/data-repositories/src/instance-registry/repository-module-iam.ts
@@ -38,36 +38,10 @@ const recordPermissionOutcome = (
   permissionsUnchanged: result.permissionsUnchanged + (outcome === 'unchanged' ? 1 : 0),
 });
 
-export const createModuleIamRepository = (executor: SqlExecutor): ModuleIamRepository => ({
-  async assignModule(instanceId, moduleId) {
-    const result = await executor.execute(
-      statement(
-        `
-INSERT INTO iam.instance_modules (instance_id, module_id)
-VALUES ($1, $2)
-ON CONFLICT (instance_id, module_id) DO NOTHING;
-`,
-        [instanceId, moduleId]
-      )
-    );
-    return result.rowCount > 0;
-  },
-
-  async revokeModule(instanceId, moduleId) {
-    const result = await executor.execute(
-      statement(
-        `
-DELETE FROM iam.instance_modules
-WHERE instance_id = $1
-  AND module_id = $2;
-`,
-        [instanceId, moduleId]
-      )
-    );
-    return result.rowCount > 0;
-  },
-
-  async syncAssignedModuleIam({ instanceId, managedModuleIds, contracts }) {
+const createSyncAssignedModuleIam = (
+  executor: SqlExecutor
+): InstanceRegistryRepository['syncAssignedModuleIam'] =>
+  async ({ instanceId, managedModuleIds, contracts }) => {
     const permissions = buildManagedPermissions(contracts);
     const rolePermissionPairs = buildRolePermissionPairs(contracts);
     if (
@@ -99,9 +73,12 @@ WHERE instance_id = $1
       contracts.map((contract) => contract.moduleId)
     );
     return reconcileResult;
-  },
+  };
 
-  async syncProtectedSystemRolePermissions({ instanceId, role }) {
+const createSyncProtectedSystemRolePermissions = (
+  executor: SqlExecutor
+): InstanceRegistryRepository['syncProtectedSystemRolePermissions'] =>
+  async ({ instanceId, role }) => {
     const permissions = [
       ...new Map(role.permissions.map((permission) => [permission.key, permission])).values(),
     ].sort((left, right) => compareAlphabetically(left.key, right.key));
@@ -129,5 +106,37 @@ WHERE instance_id = $1
       };
     }
     return reconcileResult;
+  };
+
+export const createModuleIamRepository = (executor: SqlExecutor): ModuleIamRepository => ({
+  async assignModule(instanceId, moduleId) {
+    const result = await executor.execute(
+      statement(
+        `
+INSERT INTO iam.instance_modules (instance_id, module_id)
+VALUES ($1, $2)
+ON CONFLICT (instance_id, module_id) DO NOTHING;
+`,
+        [instanceId, moduleId]
+      )
+    );
+    return result.rowCount > 0;
   },
+
+  async revokeModule(instanceId, moduleId) {
+    const result = await executor.execute(
+      statement(
+        `
+DELETE FROM iam.instance_modules
+WHERE instance_id = $1
+  AND module_id = $2;
+`,
+        [instanceId, moduleId]
+      )
+    );
+    return result.rowCount > 0;
+  },
+
+  syncAssignedModuleIam: createSyncAssignedModuleIam(executor),
+  syncProtectedSystemRolePermissions: createSyncProtectedSystemRolePermissions(executor),
 });

--- a/packages/data-repositories/src/instance-registry/repository-module-iam.ts
+++ b/packages/data-repositories/src/instance-registry/repository-module-iam.ts
@@ -2,13 +2,12 @@ import type { SqlExecutor } from '../iam/repositories/types.js';
 
 import type {
   InstanceRegistryRepository,
+  PermissionCatalogReconcileResult,
 } from './repository-contract.js';
 import {
-  buildManagedPermissionKeys,
+  buildManagedPermissions,
   buildRolePermissionPairs,
-  cleanupModulePermissions,
   cleanupModuleRolePermissions,
-  cleanupProtectedRolePermissions,
   insertModuleRolePermission,
   insertProtectedRolePermission,
   upsertPermission,
@@ -20,6 +19,36 @@ type ModuleIamRepository = Pick<
   InstanceRegistryRepository,
   'assignModule' | 'revokeModule' | 'syncAssignedModuleIam' | 'syncProtectedSystemRolePermissions'
 >;
+
+const emptyReconcileResult = (): PermissionCatalogReconcileResult => ({
+  permissionsInserted: 0,
+  permissionsUpdated: 0,
+  permissionsUnchanged: 0,
+  grantsInserted: 0,
+  grantsUnchanged: 0,
+});
+
+const recordPermissionOutcome = (
+  result: PermissionCatalogReconcileResult,
+  outcome: 'inserted' | 'updated' | 'unchanged'
+): PermissionCatalogReconcileResult => ({
+  ...result,
+  permissionsInserted: result.permissionsInserted + (outcome === 'inserted' ? 1 : 0),
+  permissionsUpdated: result.permissionsUpdated + (outcome === 'updated' ? 1 : 0),
+  permissionsUnchanged: result.permissionsUnchanged + (outcome === 'unchanged' ? 1 : 0),
+});
+
+const inTransaction = async <T>(executor: SqlExecutor, work: () => Promise<T>): Promise<T> => {
+  await executor.execute(statement('BEGIN;', []));
+  try {
+    const result = await work();
+    await executor.execute(statement('COMMIT;', []));
+    return result;
+  } catch (error) {
+    await executor.execute(statement('ROLLBACK;', []));
+    throw error;
+  }
+};
 
 export const createModuleIamRepository = (executor: SqlExecutor): ModuleIamRepository => ({
   async assignModule(instanceId, moduleId) {
@@ -51,32 +80,54 @@ WHERE instance_id = $1
   },
 
   async syncAssignedModuleIam({ instanceId, managedModuleIds, contracts }) {
-    const permissionKeys = buildManagedPermissionKeys(contracts);
+    const permissions = buildManagedPermissions(contracts);
     const rolePermissionPairs = buildRolePermissionPairs(contracts);
-    for (const permissionKey of permissionKeys) {
-      await upsertPermission(executor, instanceId, permissionKey, `Modulberechtigung ${permissionKey}`);
+    if (permissions.length === 0 && rolePermissionPairs.length === 0 && managedModuleIds.length === 0) {
+      return emptyReconcileResult();
     }
-    for (const pair of rolePermissionPairs) {
-      await insertModuleRolePermission(executor, instanceId, pair);
-    }
-    await cleanupModuleRolePermissions(executor, instanceId, managedModuleIds, rolePermissionPairs);
-    await cleanupModulePermissions(executor, instanceId, managedModuleIds, permissionKeys);
+    return inTransaction(executor, async () => {
+      let reconcileResult = emptyReconcileResult();
+      for (const permission of permissions) {
+        reconcileResult = recordPermissionOutcome(
+          reconcileResult,
+          await upsertPermission(executor, instanceId, permission)
+        );
+      }
+      for (const pair of rolePermissionPairs) {
+        const inserted = await insertModuleRolePermission(executor, instanceId, pair);
+        reconcileResult = {
+          ...reconcileResult,
+          grantsInserted: reconcileResult.grantsInserted + (inserted ? 1 : 0),
+          grantsUnchanged: reconcileResult.grantsUnchanged + (inserted ? 0 : 1),
+        };
+      }
+      await cleanupModuleRolePermissions(executor, instanceId, managedModuleIds, rolePermissionPairs);
+      return reconcileResult;
+    });
   },
 
   async syncProtectedSystemRolePermissions({ instanceId, role }) {
-    const permissionKeys = Array.from(new Set(role.permissionKeys)).sort(compareAlphabetically);
-    for (const permissionKey of permissionKeys) {
-      await upsertPermission(
-        executor,
-        instanceId,
-        permissionKey,
-        `Geschützte Systemrolle ${role.roleKey}: ${permissionKey}`
-      );
-    }
-    await upsertProtectedRole(executor, instanceId, role);
-    await cleanupProtectedRolePermissions(executor, instanceId, role.roleKey, permissionKeys);
-    for (const permissionKey of permissionKeys) {
-      await insertProtectedRolePermission(executor, instanceId, role.roleKey, permissionKey);
-    }
+    const permissions = [...new Map(role.permissions.map((permission) => [permission.key, permission])).values()].sort(
+      (left, right) => compareAlphabetically(left.key, right.key)
+    );
+    return inTransaction(executor, async () => {
+      let reconcileResult = emptyReconcileResult();
+      for (const permission of permissions) {
+        reconcileResult = recordPermissionOutcome(
+          reconcileResult,
+          await upsertPermission(executor, instanceId, permission)
+        );
+      }
+      await upsertProtectedRole(executor, instanceId, role);
+      for (const permission of permissions) {
+        const inserted = await insertProtectedRolePermission(executor, instanceId, role.roleKey, permission.key);
+        reconcileResult = {
+          ...reconcileResult,
+          grantsInserted: reconcileResult.grantsInserted + (inserted ? 1 : 0),
+          grantsUnchanged: reconcileResult.grantsUnchanged + (inserted ? 0 : 1),
+        };
+      }
+      return reconcileResult;
+    });
   },
 });

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -3,7 +3,10 @@
   "license": "EUPL-1.2",
   "version": "0.0.1",
   "type": "module",
-  "svaPackageRoles": ["db-operations", "compat"],
+  "svaPackageRoles": [
+    "db-operations",
+    "compat"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
@@ -18,9 +21,11 @@
     }
   },
   "dependencies": {
+    "@sva/core": "workspace:*",
     "@sva/data-client": "workspace:*",
     "@sva/data-repositories": "workspace:*",
     "@sva/server-runtime": "workspace:*",
+    "@sva/studio-module-iam": "workspace:*",
     "pg": "^8.22.0"
   },
   "devDependencies": {

--- a/packages/data/src/iam/seed-plan.test.ts
+++ b/packages/data/src/iam/seed-plan.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { getPersonaSeed, iamSeedPlan, rootOnlySeedPermissionKeys, tenantBootstrapPermissionKeys } from './seed-plan';
+import {
+  getPersonaSeed,
+  iamSeedPlan,
+  resolveFixturePermissionId,
+  rootOnlySeedPermissionKeys,
+  tenantBootstrapPermissionKeys,
+} from './seed-plan';
+import type { PermissionKey } from './types';
 
 describe('iam seed plan', () => {
   it('contains exactly one tenant bootstrap persona', () => {
@@ -79,5 +86,11 @@ describe('iam seed plan', () => {
 
   it('throws for unknown persona keys', () => {
     expect(() => getPersonaSeed('unknown' as never)).toThrowError(/Unknown persona key: unknown/);
+  });
+
+  it('fails clearly when a catalog permission has no stable fixture ID', () => {
+    expect(() => resolveFixturePermissionId(new Map(), 'iam.user.read' as PermissionKey)).toThrowError(
+      /Missing fixture permission ID: iam\.user\.read/
+    );
   });
 });

--- a/packages/data/src/iam/seed-plan.ts
+++ b/packages/data/src/iam/seed-plan.ts
@@ -117,8 +117,11 @@ const permissionIdFixtures = [
   ['40111111-1111-1111-1111-111111111167', 'categories.delete', 'Delete categories plugin content'],
 ] as const satisfies readonly [string, PermissionKey, string][];
 const fixturePermissionIds = new Map(permissionIdFixtures.map(([id, key]) => [key, id] as const));
-const getFixturePermissionId = (key: PermissionKey): string => {
-  const id = fixturePermissionIds.get(key);
+export const resolveFixturePermissionId = (
+  permissionIds: ReadonlyMap<PermissionKey, string>,
+  key: PermissionKey
+): string => {
+  const id = permissionIds.get(key);
   if (!id) throw new Error(`Missing fixture permission ID: ${key}`);
   return id;
 };
@@ -208,7 +211,7 @@ export const iamSeedPlan: IamSeedPlan & { readonly seedFiles: typeof iamSeedFile
   ],
   personas,
   permissions: fixturePermissionCatalog.map((definition) => ({
-    id: getFixturePermissionId(definition.key),
+      id: resolveFixturePermissionId(fixturePermissionIds, definition.key),
     key: definition.key,
     action: definition.key,
     resourceType: definition.resourceType,

--- a/packages/data/src/iam/seed-plan.ts
+++ b/packages/data/src/iam/seed-plan.ts
@@ -1,26 +1,78 @@
+import { resolvesSystemAdminGrant } from '@sva/core';
+import { studioPermissionCatalog } from '@sva/studio-module-iam';
+
 import type { IamSeedPlan, PermissionKey, PersonaSeed } from './types.js';
 
-const permissions = [
-  ['40111111-1111-1111-1111-111111111168', 'iam.accounts.delete', 'Delete tenant accounts physically'],
+// IDs bleiben ausschließlich für reproduzierbare SQL-Fixtures stabil; fachliche Metadaten stammen aus dem Katalog.
+const permissionIdFixtures = [
+  [
+    '40111111-1111-1111-1111-111111111168',
+    'iam.accounts.delete',
+    'Delete tenant accounts physically',
+  ],
   ['40111111-1111-1111-1111-111111111111', 'iam.user.read', 'Read account data'],
   ['40111111-1111-1111-1111-111111111112', 'iam.user.write', 'Modify account data'],
   ['40111111-1111-1111-1111-111111111113', 'iam.role.read', 'Read role assignments'],
   ['40111111-1111-1111-1111-111111111114', 'iam.role.write', 'Modify role assignments'],
   ['40111111-1111-1111-1111-111111111115', 'iam.org.read', 'Read organization data'],
   ['40111111-1111-1111-1111-111111111116', 'iam.org.write', 'Modify organization data'],
-  ['40111111-1111-1111-1111-111111111151', 'iam.legalText.read', 'Read legal text administration data'],
-  ['40111111-1111-1111-1111-111111111152', 'iam.legalText.write', 'Modify legal text administration data'],
-  ['40111111-1111-1111-1111-111111111153', 'iam.governance.read', 'Read governance workflows and audit trails'],
-  ['40111111-1111-1111-1111-111111111154', 'iam.governance.write', 'Execute governance workflows and decisions'],
-  ['40111111-1111-1111-1111-111111111155', 'iam.governance.export', 'Export governance and legal consent evidence'],
+  [
+    '40111111-1111-1111-1111-111111111151',
+    'iam.legalText.read',
+    'Read legal text administration data',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111152',
+    'iam.legalText.write',
+    'Modify legal text administration data',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111153',
+    'iam.governance.read',
+    'Read governance workflows and audit trails',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111154',
+    'iam.governance.write',
+    'Execute governance workflows and decisions',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111155',
+    'iam.governance.export',
+    'Export governance and legal consent evidence',
+  ],
   ['40111111-1111-1111-1111-111111111156', 'iam.dsr.read', 'Read tenant data-subject-rights cases'],
-  ['40111111-1111-1111-1111-111111111157', 'iam.dsr.write', 'Process tenant data-subject-rights cases'],
-  ['40111111-1111-1111-1111-111111111158', 'iam.dsr.export', 'Export tenant data-subject-rights payloads'],
+  [
+    '40111111-1111-1111-1111-111111111157',
+    'iam.dsr.write',
+    'Process tenant data-subject-rights cases',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111158',
+    'iam.dsr.export',
+    'Export tenant data-subject-rights payloads',
+  ],
   ['40111111-1111-1111-1111-111111111159', 'iam.deletionRules.read', 'Read tenant deletion rules'],
-  ['40111111-1111-1111-1111-111111111160', 'iam.deletionRules.write', 'Modify tenant deletion rules'],
-  ['40111111-1111-1111-1111-111111111161', 'iam.monitoring.read', 'Read IAM monitoring and plugin operation status'],
-  ['40111111-1111-1111-1111-111111111162', 'iam.monitoring.write', 'Run IAM monitoring and plugin operations'],
-  ['40111111-1111-1111-1111-111111111163', 'experimental.read', 'Enable experimental shell features and placeholders'],
+  [
+    '40111111-1111-1111-1111-111111111160',
+    'iam.deletionRules.write',
+    'Modify tenant deletion rules',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111161',
+    'iam.monitoring.read',
+    'Read IAM monitoring and plugin operation status',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111162',
+    'iam.monitoring.write',
+    'Run IAM monitoring and plugin operations',
+  ],
+  [
+    '40111111-1111-1111-1111-111111111163',
+    'experimental.read',
+    'Enable experimental shell features and placeholders',
+  ],
   ['40111111-1111-1111-1111-111111111117', 'content.read', 'Read content'],
   ['40111111-1111-1111-1111-111111111118', 'content.create', 'Create content'],
   ['40111111-1111-1111-1111-111111111119', 'content.updateMetadata', 'Update content metadata'],
@@ -30,7 +82,11 @@ const permissions = [
   ['40111111-1111-1111-1111-111111111123', 'feature.toggle', 'Toggle feature flags'],
   ['40111111-1111-1111-1111-111111111149', 'app.read', 'Show the app link in the sidebar'],
   ['40111111-1111-1111-1111-111111111150', 'cockpit.read', 'Show the cockpit link in the sidebar'],
-  ['40111111-1111-1111-1111-111111111124', 'instance.registry.manage', 'Manage instance registry and provisioning'],
+  [
+    '40111111-1111-1111-1111-111111111124',
+    'instance.registry.manage',
+    'Manage instance registry and provisioning',
+  ],
   ['40111111-1111-1111-1111-111111111125', 'content.updatePayload', 'Update content payload'],
   ['40111111-1111-1111-1111-111111111126', 'content.changeStatus', 'Change content status'],
   ['40111111-1111-1111-1111-111111111127', 'content.archive', 'Archive content'],
@@ -60,11 +116,27 @@ const permissions = [
   ['40111111-1111-1111-1111-111111111166', 'categories.update', 'Update categories plugin content'],
   ['40111111-1111-1111-1111-111111111167', 'categories.delete', 'Delete categories plugin content'],
 ] as const satisfies readonly [string, PermissionKey, string][];
-export const rootOnlySeedPermissionKeys = ['instance.registry.manage'] as const satisfies readonly PermissionKey[];
-const rootOnlySeedPermissionKeySet: ReadonlySet<PermissionKey> = new Set(rootOnlySeedPermissionKeys);
-export const tenantBootstrapPermissionKeys = permissions
-  .map(([, key]) => key)
-  .filter((key): key is PermissionKey => !rootOnlySeedPermissionKeySet.has(key));
+const fixturePermissionIds = new Map(permissionIdFixtures.map(([id, key]) => [key, id] as const));
+const getFixturePermissionId = (key: PermissionKey): string => {
+  const id = fixturePermissionIds.get(key);
+  if (!id) throw new Error(`Missing fixture permission ID: ${key}`);
+  return id;
+};
+const fixturePermissionCatalog = studioPermissionCatalog.filter(
+  (definition): definition is typeof definition & { readonly key: PermissionKey } =>
+    fixturePermissionIds.has(definition.key as PermissionKey)
+);
+export const rootOnlySeedPermissionKeys = fixturePermissionCatalog
+  .filter((definition) => definition.availability.kind === 'root')
+  .map((definition) => definition.key);
+export const tenantBootstrapPermissionKeys = fixturePermissionCatalog
+  .filter(
+    (definition) =>
+      definition.availability.kind !== 'root' &&
+      definition.lifecycle !== 'deprecated' &&
+      resolvesSystemAdminGrant(definition)
+  )
+  .map((definition) => definition.key);
 const personas: readonly PersonaSeed[] = [
   {
     personaKey: 'system_admin',
@@ -124,7 +196,10 @@ export const iamSeedPlan: IamSeedPlan & { readonly seedFiles: typeof iamSeedFile
       displayName: 'Seed District',
       organizationType: 'district',
       parentOrganizationId: '22333333-3333-3333-3333-333333333333',
-      hierarchyPath: ['22222222-2222-2222-2222-222222222222', '22333333-3333-3333-3333-333333333333'],
+      hierarchyPath: [
+        '22222222-2222-2222-2222-222222222222',
+        '22333333-3333-3333-3333-333333333333',
+      ],
       depth: 2,
       contentAuthorPolicy: 'org_only',
       isActive: true,
@@ -132,13 +207,13 @@ export const iamSeedPlan: IamSeedPlan & { readonly seedFiles: typeof iamSeedFile
     },
   ],
   personas,
-  permissions: permissions.map(([id, key, description]) => ({
-    id,
-    key,
-    action: key,
-    resourceType: key.replace(/\..*$/, ''),
+  permissions: fixturePermissionCatalog.map((definition) => ({
+    id: getFixturePermissionId(definition.key),
+    key: definition.key,
+    action: definition.key,
+    resourceType: definition.resourceType,
     scope: {},
-    description,
+    description: definition.description,
   })),
 };
 export const getPersonaSeed = (personaKey: PersonaSeed['personaKey']): PersonaSeed => {

--- a/packages/data/tsconfig.lib.json
+++ b/packages/data/tsconfig.lib.json
@@ -12,7 +12,8 @@
       "@sva/data-client": ["packages/data-client/dist/index.d.ts"],
       "@sva/data-repositories": ["packages/data-repositories/dist/index.d.ts"],
       "@sva/data-repositories/server": ["packages/data-repositories/dist/server.d.ts"],
-      "@sva/server-runtime": ["packages/server-runtime/dist/index.d.ts"]
+      "@sva/server-runtime": ["packages/server-runtime/dist/index.d.ts"],
+      "@sva/studio-module-iam": ["packages/studio-module-iam/dist/index.d.ts"]
     }
   },
   "include": ["src/**/*.ts"]

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -17,27 +17,37 @@ const WASTE_MANAGEMENT_MODULE_ID = 'waste-management';
 const categoriesCompanionSourceModuleIds = new Set(['news', 'events', 'poi']);
 
 const withRequiredCompanionModules = (moduleIds: readonly string[]): string[] => {
-  const normalizedModuleIds = Array.from(new Set(moduleIds.map((moduleId) => moduleId.trim()).filter(Boolean)));
+  const normalizedModuleIds = Array.from(
+    new Set(moduleIds.map((moduleId) => moduleId.trim()).filter(Boolean))
+  );
 
   if (normalizedModuleIds.some((moduleId) => categoriesCompanionSourceModuleIds.has(moduleId))) {
     normalizedModuleIds.push(CATEGORIES_MODULE_ID);
   }
 
-  return Array.from(new Set(normalizedModuleIds)).sort((left, right) => left.localeCompare(right, 'de'));
+  return Array.from(new Set(normalizedModuleIds)).sort((left, right) =>
+    left.localeCompare(right, 'de')
+  );
 };
 
-const syncProtectedSystemAdminPermissions = async (deps: InstanceRegistryServiceDeps, instanceId: string) => {
+const syncProtectedSystemAdminPermissions = async (
+  deps: InstanceRegistryServiceDeps,
+  instanceId: string
+) => {
   return deps.repository.syncProtectedSystemRolePermissions({
     instanceId,
     role: {
       roleKey: SYSTEM_ADMIN_ROLE_KEY,
       displayName: SYSTEM_ADMIN_DISPLAY_NAME,
       roleLevel: SYSTEM_ADMIN_ROLE_LEVEL,
-      permissions: tenantCorePermissionCatalog.filter(resolvesSystemAdminGrant).map((permission) => ({
+      permissions: tenantCorePermissionCatalog.map((permission) => ({
         key: permission.key,
         description: permission.description,
         resourceType: permission.resourceType,
       })),
+      grantPermissionKeys: tenantCorePermissionCatalog
+        .filter(resolvesSystemAdminGrant)
+        .map(({ key }) => key),
     },
   });
 };
@@ -71,7 +81,11 @@ const createModuleAssignRollbackError = (
   rollbackError: unknown
 ): Error => {
   const message =
-    syncError instanceof Error ? syncError.message : typeof syncError === 'string' ? syncError : 'instance_module_sync_failed';
+    syncError instanceof Error
+      ? syncError.message
+      : typeof syncError === 'string'
+        ? syncError
+        : 'instance_module_sync_failed';
   const combined = new Error(message) as Error & {
     cause?: {
       rollbackError: unknown;
@@ -94,7 +108,11 @@ const createBootstrapAssignRollbackError = (
   rollbackError: unknown
 ): Error => {
   const message =
-    syncError instanceof Error ? syncError.message : typeof syncError === 'string' ? syncError : 'instance_module_sync_failed';
+    syncError instanceof Error
+      ? syncError.message
+      : typeof syncError === 'string'
+        ? syncError
+        : 'instance_module_sync_failed';
   const combined = new Error(message) as Error & {
     cause?: {
       rollbackError: unknown;
@@ -132,7 +150,9 @@ export const createAssignModuleHandler =
     let permissionReconcile: PermissionCatalogReconcileResult | void;
     const newlyAssignedModuleIds = [input.moduleId];
     try {
-      const assignedAfterPrimaryInsert = await deps.repository.listAssignedModules(input.instanceId);
+      const assignedAfterPrimaryInsert = await deps.repository.listAssignedModules(
+        input.instanceId
+      );
       const desiredAssignedModuleIds = withRequiredCompanionModules(assignedAfterPrimaryInsert);
 
       for (const moduleId of desiredAssignedModuleIds) {
@@ -144,7 +164,9 @@ export const createAssignModuleHandler =
         }
       }
 
-      assignedModuleIds = withRequiredCompanionModules(await deps.repository.listAssignedModules(input.instanceId));
+      assignedModuleIds = withRequiredCompanionModules(
+        await deps.repository.listAssignedModules(input.instanceId)
+      );
       permissionReconcile = await deps.repository.syncAssignedModuleIam({
         instanceId: input.instanceId,
         managedModuleIds: [...registry.keys()],
@@ -156,7 +178,12 @@ export const createAssignModuleHandler =
           await deps.repository.revokeModule(input.instanceId, moduleId);
         }
       } catch (rollbackError) {
-        throw createModuleAssignRollbackError(input.instanceId, input.moduleId, error, rollbackError);
+        throw createModuleAssignRollbackError(
+          input.instanceId,
+          input.moduleId,
+          error,
+          rollbackError
+        );
       }
       throw error;
     }
@@ -197,7 +224,9 @@ export const createBootstrapAdminStructureHandler =
       return { ok: false, reason: 'unknown_module' };
     }
 
-    const currentAssignedModuleIds = new Set(await deps.repository.listAssignedModules(input.instanceId));
+    const currentAssignedModuleIds = new Set(
+      await deps.repository.listAssignedModules(input.instanceId)
+    );
     const newlyAssignedModuleIds: string[] = [];
     for (const moduleId of requestedModuleIds) {
       if (!currentAssignedModuleIds.has(moduleId)) {
@@ -222,22 +251,35 @@ export const createBootstrapAdminStructureHandler =
         for (const moduleId of [...newlyAssignedModuleIds].reverse()) {
           const removed = await deps.repository.revokeModule(input.instanceId, moduleId);
           if (!removed) {
-            const rollbackRevokeError = new Error(`rollback_revoke_failed:${moduleId}`) as Error & { cause?: unknown };
+            const rollbackRevokeError = new Error(`rollback_revoke_failed:${moduleId}`) as Error & {
+              cause?: unknown;
+            };
             rollbackRevokeError.cause = error;
             throw rollbackRevokeError;
           }
         }
       } catch (rollbackError) {
-        throw createBootstrapAssignRollbackError(input.instanceId, newlyAssignedModuleIds, error, rollbackError);
+        throw createBootstrapAssignRollbackError(
+          input.instanceId,
+          newlyAssignedModuleIds,
+          error,
+          rollbackError
+        );
       }
       throw error;
     }
 
     let bootstrapCompleted = false;
     try {
-      const corePermissionReconcile = await syncProtectedSystemAdminPermissions(deps, input.instanceId);
+      const corePermissionReconcile = await syncProtectedSystemAdminPermissions(
+        deps,
+        input.instanceId
+      );
       bootstrapCompleted = true;
-      modulePermissionReconcile = mergeReconcileResults(modulePermissionReconcile, corePermissionReconcile);
+      modulePermissionReconcile = mergeReconcileResults(
+        modulePermissionReconcile,
+        corePermissionReconcile
+      );
     } finally {
       await invalidateInstancePermissionSnapshots(
         deps,
@@ -329,8 +371,15 @@ export const createSeedIamBaselineHandler =
       managedModuleIds: [...registry.keys()],
       contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
     });
-    const corePermissionReconcile = await syncProtectedSystemAdminPermissions(deps, input.instanceId);
-    await invalidateInstancePermissionSnapshots(deps, input.instanceId, 'instance_module_iam_seeded');
+    const corePermissionReconcile = await syncProtectedSystemAdminPermissions(
+      deps,
+      input.instanceId
+    );
+    await invalidateInstancePermissionSnapshots(
+      deps,
+      input.instanceId,
+      'instance_module_iam_seeded'
+    );
     await deps.repository.appendAuditEvent({
       instanceId: input.instanceId,
       eventType: 'instance_module_iam_seeded',
@@ -338,7 +387,10 @@ export const createSeedIamBaselineHandler =
       requestId: input.requestId,
       details: {
         assignedModules: assignedModuleIds,
-        permissionReconcile: mergeReconcileResults(modulePermissionReconcile, corePermissionReconcile),
+        permissionReconcile: mergeReconcileResults(
+          modulePermissionReconcile,
+          corePermissionReconcile
+        ),
         outcome: 'seeded',
       },
     });

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -1,3 +1,6 @@
+import { resolvesSystemAdminGrant, tenantCorePermissionCatalog } from '@sva/core';
+import type { PermissionCatalogReconcileResult } from '@sva/data-repositories';
+
 import { createGetInstanceDetail } from './service-detail.js';
 import {
   invalidateInstancePermissionSnapshots,
@@ -6,50 +9,6 @@ import {
 } from './service-shared.js';
 import type { InstanceRegistryService, InstanceRegistryServiceDeps } from './service-types.js';
 
-// Keep this direct system_admin bundle aligned with the seeded tenant baseline until the seed accessor
-// is exposed as a stable cross-package runtime API.
-const SYSTEM_ADMIN_DIRECT_PERMISSION_KEYS = [
-  'iam.user.read',
-  'iam.user.write',
-  'iam.role.read',
-  'iam.role.write',
-  'iam.org.read',
-  'iam.org.write',
-  'iam.legalText.read',
-  'iam.legalText.write',
-  'iam.governance.read',
-  'iam.governance.write',
-  'iam.governance.export',
-  'iam.dsr.read',
-  'iam.dsr.write',
-  'iam.dsr.export',
-  'iam.deletionRules.read',
-  'iam.deletionRules.write',
-  'iam.monitoring.read',
-  'iam.monitoring.write',
-  'experimental.read',
-  'app.read',
-  'cockpit.read',
-  'content.read',
-  'content.create',
-  'content.updateMetadata',
-  'content.updatePayload',
-  'content.changeStatus',
-  'content.publish',
-  'content.archive',
-  'content.restore',
-  'content.readHistory',
-  'content.manageRevisions',
-  'content.delete',
-  'integration.manage',
-  'feature.toggle',
-  'media.read',
-  'media.create',
-  'media.update',
-  'media.reference.manage',
-  'media.delete',
-  'media.deliver.protected',
-] as const;
 const SYSTEM_ADMIN_ROLE_KEY = 'system_admin';
 const SYSTEM_ADMIN_DISPLAY_NAME = 'System Administrator';
 const SYSTEM_ADMIN_ROLE_LEVEL = 100;
@@ -67,30 +26,43 @@ const withRequiredCompanionModules = (moduleIds: readonly string[]): string[] =>
   return Array.from(new Set(normalizedModuleIds)).sort((left, right) => left.localeCompare(right, 'de'));
 };
 
-type ProtectedSystemRolePermissionSyncRepository = InstanceRegistryServiceDeps['repository'] & {
-  syncProtectedSystemRolePermissions(input: {
-    instanceId: string;
-    role: {
-      roleKey: string;
-      displayName: string;
-      roleLevel: number;
-      permissionKeys: readonly string[];
-    };
-  }): Promise<void>;
-};
-
 const syncProtectedSystemAdminPermissions = async (deps: InstanceRegistryServiceDeps, instanceId: string) => {
-  const repository = deps.repository as ProtectedSystemRolePermissionSyncRepository;
-  await repository.syncProtectedSystemRolePermissions({
+  return deps.repository.syncProtectedSystemRolePermissions({
     instanceId,
     role: {
       roleKey: SYSTEM_ADMIN_ROLE_KEY,
       displayName: SYSTEM_ADMIN_DISPLAY_NAME,
       roleLevel: SYSTEM_ADMIN_ROLE_LEVEL,
-      permissionKeys: [...SYSTEM_ADMIN_DIRECT_PERMISSION_KEYS],
+      permissions: tenantCorePermissionCatalog.filter(resolvesSystemAdminGrant).map((permission) => ({
+        key: permission.key,
+        description: permission.description,
+        resourceType: permission.resourceType,
+      })),
     },
   });
 };
+
+const normalizeReconcileResult = (
+  result: PermissionCatalogReconcileResult | void
+): PermissionCatalogReconcileResult =>
+  result ?? {
+    permissionsInserted: 0,
+    permissionsUpdated: 0,
+    permissionsUnchanged: 0,
+    grantsInserted: 0,
+    grantsUnchanged: 0,
+  };
+
+const mergeReconcileResults = (
+  ...results: readonly (PermissionCatalogReconcileResult | void)[]
+): PermissionCatalogReconcileResult =>
+  results.map(normalizeReconcileResult).reduce((total, result) => ({
+    permissionsInserted: total.permissionsInserted + result.permissionsInserted,
+    permissionsUpdated: total.permissionsUpdated + result.permissionsUpdated,
+    permissionsUnchanged: total.permissionsUnchanged + result.permissionsUnchanged,
+    grantsInserted: total.grantsInserted + result.grantsInserted,
+    grantsUnchanged: total.grantsUnchanged + result.grantsUnchanged,
+  }));
 
 const createModuleAssignRollbackError = (
   instanceId: string,
@@ -157,6 +129,7 @@ export const createAssignModuleHandler =
     }
 
     let assignedModuleIds: readonly string[];
+    let permissionReconcile: PermissionCatalogReconcileResult | void;
     const newlyAssignedModuleIds = [input.moduleId];
     try {
       const assignedAfterPrimaryInsert = await deps.repository.listAssignedModules(input.instanceId);
@@ -172,7 +145,7 @@ export const createAssignModuleHandler =
       }
 
       assignedModuleIds = withRequiredCompanionModules(await deps.repository.listAssignedModules(input.instanceId));
-      await deps.repository.syncAssignedModuleIam({
+      permissionReconcile = await deps.repository.syncAssignedModuleIam({
         instanceId: input.instanceId,
         managedModuleIds: [...registry.keys()],
         contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
@@ -196,6 +169,7 @@ export const createAssignModuleHandler =
       details: {
         moduleId: input.moduleId,
         assignedModules: assignedModuleIds,
+        permissionReconcile: normalizeReconcileResult(permissionReconcile),
         outcome: 'assigned',
       },
     });
@@ -235,9 +209,10 @@ export const createBootstrapAdminStructureHandler =
     }
 
     let assignedModuleIds: readonly string[];
+    let modulePermissionReconcile: PermissionCatalogReconcileResult | void;
     try {
       assignedModuleIds = await deps.repository.listAssignedModules(input.instanceId);
-      await deps.repository.syncAssignedModuleIam({
+      modulePermissionReconcile = await deps.repository.syncAssignedModuleIam({
         instanceId: input.instanceId,
         managedModuleIds: [...registry.keys()],
         contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
@@ -260,8 +235,9 @@ export const createBootstrapAdminStructureHandler =
 
     let bootstrapCompleted = false;
     try {
-      await syncProtectedSystemAdminPermissions(deps, input.instanceId);
+      const corePermissionReconcile = await syncProtectedSystemAdminPermissions(deps, input.instanceId);
       bootstrapCompleted = true;
+      modulePermissionReconcile = mergeReconcileResults(modulePermissionReconcile, corePermissionReconcile);
     } finally {
       await invalidateInstancePermissionSnapshots(
         deps,
@@ -279,6 +255,7 @@ export const createBootstrapAdminStructureHandler =
         assignedModules: assignedModuleIds,
         selectedModuleIds: requestedModuleIds,
         bootstrapMode: 'system_admin_only',
+        permissionReconcile: normalizeReconcileResult(modulePermissionReconcile),
         outcome: 'bootstrapped',
       },
     });
@@ -310,7 +287,7 @@ export const createRevokeModuleHandler =
     }
 
     const assignedModuleIds = await deps.repository.listAssignedModules(input.instanceId);
-    await deps.repository.syncAssignedModuleIam({
+    const permissionReconcile = await deps.repository.syncAssignedModuleIam({
       instanceId: input.instanceId,
       managedModuleIds: [...registry.keys()],
       contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
@@ -324,6 +301,7 @@ export const createRevokeModuleHandler =
       details: {
         moduleId: input.moduleId,
         assignedModules: assignedModuleIds,
+        permissionReconcile: normalizeReconcileResult(permissionReconcile),
         outcome: 'revoked',
       },
     });
@@ -346,12 +324,12 @@ export const createSeedIamBaselineHandler =
 
     const registry = requireModuleIamRegistry(deps);
     const assignedModuleIds = await deps.repository.listAssignedModules(input.instanceId);
-    await deps.repository.syncAssignedModuleIam({
+    const modulePermissionReconcile = await deps.repository.syncAssignedModuleIam({
       instanceId: input.instanceId,
       managedModuleIds: [...registry.keys()],
       contracts: resolveAssignedModuleContracts(deps, assignedModuleIds),
     });
-    await syncProtectedSystemAdminPermissions(deps, input.instanceId);
+    const corePermissionReconcile = await syncProtectedSystemAdminPermissions(deps, input.instanceId);
     await invalidateInstancePermissionSnapshots(deps, input.instanceId, 'instance_module_iam_seeded');
     await deps.repository.appendAuditEvent({
       instanceId: input.instanceId,
@@ -360,6 +338,7 @@ export const createSeedIamBaselineHandler =
       requestId: input.requestId,
       details: {
         assignedModules: assignedModuleIds,
+        permissionReconcile: mergeReconcileResults(modulePermissionReconcile, corePermissionReconcile),
         outcome: 'seeded',
       },
     });

--- a/packages/instance-registry/src/service-shared.ts
+++ b/packages/instance-registry/src/service-shared.ts
@@ -1,7 +1,10 @@
 import { composePermissionCatalog } from '@sva/core';
 import { createSdkLogger } from '@sva/server-runtime';
 
-import type { InstanceModuleIamRegistryEntry, InstanceRegistryServiceDeps } from './service-types.js';
+import type {
+  InstanceModuleIamRegistryEntry,
+  InstanceRegistryServiceDeps,
+} from './service-types.js';
 
 type LegacyWasteManagementSettingsInput = {
   readonly provider: 'postgresql';
@@ -130,20 +133,33 @@ export const resolveAssignedModuleContracts = (
         throw new Error(`unknown_system_admin_permission_exclusion:${moduleId}:${permissionId}`);
       }
     }
-    const existingSystemRoles = (contract.systemRoles ?? contract.tenantBootstrapRoles ?? []).filter(
+    const existingSystemRoles = (
+      contract.systemRoles ??
+      contract.tenantBootstrapRoles ??
+      []
+    ).filter(
       (role: { readonly roleName: string; readonly permissionIds: readonly string[] }) =>
         role.roleName !== 'system_admin'
     );
     return {
       ...contract,
-      permissions: composePermissionCatalog([], [
-        { moduleId: contract.moduleId, permissionIds: contract.permissionIds },
-      ]).map(({ key, description, resourceType }) => ({ key, description, resourceType })),
+      permissions: composePermissionCatalog(
+        [],
+        [
+          {
+            moduleId: contract.moduleId,
+            permissionIds: contract.permissionIds,
+            systemAdminPermissionExclusions: contract.systemAdminPermissionExclusions,
+          },
+        ]
+      ).map(({ key, description, resourceType }) => ({ key, description, resourceType })),
       systemRoles: [
         ...existingSystemRoles,
         {
           roleName: 'system_admin',
-          permissionIds: contract.permissionIds.filter((permissionId: string) => !exclusions.has(permissionId)),
+          permissionIds: contract.permissionIds.filter(
+            (permissionId: string) => !exclusions.has(permissionId)
+          ),
         },
       ],
     };

--- a/packages/instance-registry/src/service-shared.ts
+++ b/packages/instance-registry/src/service-shared.ts
@@ -1,6 +1,7 @@
+import { composePermissionCatalog } from '@sva/core';
 import { createSdkLogger } from '@sva/server-runtime';
 
-import type { InstanceRegistryServiceDeps } from './service-types.js';
+import type { InstanceModuleIamRegistryEntry, InstanceRegistryServiceDeps } from './service-types.js';
 
 type LegacyWasteManagementSettingsInput = {
   readonly provider: 'postgresql';
@@ -119,11 +120,33 @@ export const resolveAssignedModuleContracts = (
   const registry = requireModuleIamRegistry(deps);
 
   return assignedModuleIds.map((moduleId) => {
-    const contract = registry.get(moduleId);
+    const contract: InstanceModuleIamRegistryEntry | undefined = registry.get(moduleId);
     if (!contract) {
       throw new Error(`unknown_module_contract:${moduleId}`);
     }
-    return contract;
+    const exclusions = new Set(contract.systemAdminPermissionExclusions ?? []);
+    for (const permissionId of exclusions) {
+      if (!contract.permissionIds.includes(permissionId)) {
+        throw new Error(`unknown_system_admin_permission_exclusion:${moduleId}:${permissionId}`);
+      }
+    }
+    const existingSystemRoles = (contract.systemRoles ?? contract.tenantBootstrapRoles ?? []).filter(
+      (role: { readonly roleName: string; readonly permissionIds: readonly string[] }) =>
+        role.roleName !== 'system_admin'
+    );
+    return {
+      ...contract,
+      permissions: composePermissionCatalog([], [
+        { moduleId: contract.moduleId, permissionIds: contract.permissionIds },
+      ]).map(({ key, description, resourceType }) => ({ key, description, resourceType })),
+      systemRoles: [
+        ...existingSystemRoles,
+        {
+          roleName: 'system_admin',
+          permissionIds: contract.permissionIds.filter((permissionId: string) => !exclusions.has(permissionId)),
+        },
+      ],
+    };
   });
 };
 

--- a/packages/instance-registry/src/service-types.ts
+++ b/packages/instance-registry/src/service-types.ts
@@ -52,6 +52,7 @@ export type InstanceModuleIamRegistryEntry = {
     readonly roleName: string;
     readonly permissionIds: readonly string[];
   }[];
+  readonly systemAdminPermissionExclusions?: readonly string[];
 };
 
 type KeycloakProvisioningContext = {

--- a/packages/instance-registry/src/service.test.ts
+++ b/packages/instance-registry/src/service.test.ts
@@ -1090,13 +1090,14 @@ describe('instance registry service facade', () => {
       role: expect.objectContaining({
         roleKey: 'system_admin',
         roleLevel: 100,
-        permissionKeys: expect.arrayContaining([
-          'iam.user.read',
-          'iam.user.write',
-          'iam.role.read',
-          'iam.role.write',
-          'app.read',
-          'cockpit.read',
+        permissions: expect.arrayContaining([
+          expect.objectContaining({ key: 'iam.user.read' }),
+          expect.objectContaining({ key: 'iam.user.write' }),
+          expect.objectContaining({ key: 'iam.role.read' }),
+          expect.objectContaining({ key: 'iam.role.write' }),
+          expect.objectContaining({ key: 'app.read' }),
+          expect.objectContaining({ key: 'cockpit.read' }),
+          expect.objectContaining({ key: 'iam.accounts.delete' }),
         ]),
       }),
     });
@@ -1327,7 +1328,11 @@ describe('instance registry service facade', () => {
       instanceId: 'demo',
       role: expect.objectContaining({
         roleKey: 'system_admin',
-        permissionKeys: expect.arrayContaining(['iam.user.read', 'content.read', 'app.read']),
+        permissions: expect.arrayContaining([
+          expect.objectContaining({ key: 'iam.user.read' }),
+          expect.objectContaining({ key: 'content.read' }),
+          expect.objectContaining({ key: 'app.read' }),
+        ]),
       }),
     });
     expect(deps.invalidatePermissionSnapshots).toHaveBeenNthCalledWith(1, {
@@ -1361,7 +1366,7 @@ describe('instance registry service facade', () => {
             {
               moduleId: 'media',
               permissionIds: ['media.read', 'media.create'],
-              systemRoles: [{ roleName: 'system_admin', permissionIds: ['media.read', 'media.create'] }],
+              systemAdminPermissionExclusions: ['media.create'],
             },
           ],
         ]),
@@ -1388,7 +1393,12 @@ describe('instance registry service facade', () => {
       expect.objectContaining({
         instanceId: 'demo',
         managedModuleIds: ['media'],
-        contracts: [expect.objectContaining({ moduleId: 'media' })],
+        contracts: [
+          expect.objectContaining({
+            moduleId: 'media',
+            systemRoles: [{ roleName: 'system_admin', permissionIds: ['media.read'] }],
+          }),
+        ],
       })
     );
   });

--- a/packages/studio-module-iam/README.md
+++ b/packages/studio-module-iam/README.md
@@ -21,6 +21,7 @@ Exportierte Werte und Funktionen:
 - `studioPluginModuleIamContracts`
 - `studioHostModuleIamContracts`
 - `studioModuleIamContracts`
+- `studioPermissionCatalog` als validierte Gesamtsicht aus Core- und Modul-Permissions
 - `studioModuleIamRegistry`
 - `getStudioModuleIamContract(moduleId)`
 

--- a/packages/studio-module-iam/package.json
+++ b/packages/studio-module-iam/package.json
@@ -12,6 +12,9 @@
       "default": "./dist/index.js"
     }
   },
+  "dependencies": {
+    "@sva/core": "workspace:*"
+  },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.9",
     "vitest": "^4.1.9"

--- a/packages/studio-module-iam/src/index.test.ts
+++ b/packages/studio-module-iam/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   studioHostModuleIamContracts,
   studioModuleIamContracts,
   studioModuleIamRegistry,
+  studioPermissionCatalog,
   studioPluginModuleIamContracts,
 } from './index.js';
 
@@ -58,6 +59,18 @@ describe('@sva/studio-module-iam', () => {
         'waste-management.settings.manage',
       ],
     });
+  });
+
+  it('publishes one validated view of core and module permissions', () => {
+    expect(studioPermissionCatalog.find((permission) => permission.key === 'iam.accounts.delete')).toMatchObject({
+      availability: { kind: 'tenant' },
+    });
+    expect(studioPermissionCatalog.find((permission) => permission.key === 'media.delete')).toMatchObject({
+      availability: { kind: 'module', moduleId: 'media' },
+    });
+    expect(new Set(studioPermissionCatalog.map((permission) => permission.key)).size).toBe(
+      studioPermissionCatalog.length
+    );
   });
 
   it('exposes normalized standard-content contracts for plugin modules', () => {

--- a/packages/studio-module-iam/src/index.ts
+++ b/packages/studio-module-iam/src/index.ts
@@ -24,10 +24,17 @@ export type StudioModuleIamContract = Readonly<{
   systemAdminPermissionExclusions?: readonly string[];
 }>;
 
-const createStandardContentBootstrapRoles = (pluginId: string): readonly StudioModuleIamBootstrapRole[] => [
+const createStandardContentBootstrapRoles = (
+  pluginId: string
+): readonly StudioModuleIamBootstrapRole[] => [
   {
     roleName: 'system_admin',
-    permissionIds: [`${pluginId}.read`, `${pluginId}.create`, `${pluginId}.update`, `${pluginId}.delete`],
+    permissionIds: [
+      `${pluginId}.read`,
+      `${pluginId}.create`,
+      `${pluginId}.update`,
+      `${pluginId}.delete`,
+    ],
   },
 ];
 
@@ -35,7 +42,10 @@ const createSystemAdminSystemRoles = (
   roles: readonly StudioModuleIamBootstrapRole[]
 ): readonly StudioModuleIamSystemRole[] => roles.filter((role) => role.roleName === 'system_admin');
 
-const createStandardContentContract = (pluginId: string, descriptionKey: string): StudioModuleIamContract => {
+const createStandardContentContract = (
+  pluginId: string,
+  descriptionKey: string
+): StudioModuleIamContract => {
   const tenantBootstrapRoles = createStandardContentBootstrapRoles(pluginId);
 
   return {
@@ -43,23 +53,37 @@ const createStandardContentContract = (pluginId: string, descriptionKey: string)
     namespace: pluginId,
     ownerPluginId: pluginId,
     descriptionKey,
-    permissionIds: [`${pluginId}.read`, `${pluginId}.create`, `${pluginId}.update`, `${pluginId}.delete`],
+    permissionIds: [
+      `${pluginId}.read`,
+      `${pluginId}.create`,
+      `${pluginId}.update`,
+      `${pluginId}.delete`,
+    ],
     tenantBootstrapRoles,
     rootSystemRoles: [],
     systemRoles: createSystemAdminSystemRoles(tenantBootstrapRoles),
   };
 };
 
-const categoriesModuleIamContract = createStandardContentContract('categories', 'plugins.categories.description');
+const categoriesModuleIamContract = createStandardContentContract(
+  'categories',
+  'plugins.categories.description'
+);
 const newsModuleIamContract = createStandardContentContract('news', 'plugins.news.description');
-const eventsModuleIamContract = createStandardContentContract('events', 'plugins.events.description');
+const eventsModuleIamContract = createStandardContentContract(
+  'events',
+  'plugins.events.description'
+);
 const poiModuleIamContract = createStandardContentContract('poi', 'plugins.poi.description');
 const genericItemsModuleIamContract = createStandardContentContract(
   'generic-items',
   'plugins.generic-items.description'
 );
 const faqModuleIamContract = createStandardContentContract('faq', 'plugins.faq.description');
-const cockpitCardsModuleIamContract = createStandardContentContract('cockpit-cards', 'plugins.cockpit-cards.description');
+const cockpitCardsModuleIamContract = createStandardContentContract(
+  'cockpit-cards',
+  'plugins.cockpit-cards.description'
+);
 const surveysTenantBootstrapRoles: readonly StudioModuleIamBootstrapRole[] = [
   {
     roleName: 'system_admin',
@@ -171,7 +195,9 @@ export const studioPluginModuleIamContracts = [
   wasteManagementModuleIamContract,
 ] as const satisfies readonly StudioModuleIamContract[];
 
-export const studioHostModuleIamContracts = [mediaModuleIamContract] as const satisfies readonly StudioModuleIamContract[];
+export const studioHostModuleIamContracts = [
+  mediaModuleIamContract,
+] as const satisfies readonly StudioModuleIamContract[];
 
 export const studioModuleIamContracts = [
   ...studioPluginModuleIamContracts,
@@ -184,6 +210,7 @@ export const studioPermissionCatalog = composePermissionCatalog(
   studioModuleIamContracts.map((contract) => ({
     moduleId: contract.moduleId,
     permissionIds: contract.permissionIds,
+    systemAdminPermissionExclusions: contract.systemAdminPermissionExclusions,
   }))
 );
 

--- a/packages/studio-module-iam/src/index.ts
+++ b/packages/studio-module-iam/src/index.ts
@@ -1,3 +1,5 @@
+import { composePermissionCatalog, corePermissionCatalog } from '@sva/core';
+
 export const studioModuleIamVersion = '0.0.1';
 
 export type StudioModuleIamBootstrapRole = Readonly<{
@@ -19,6 +21,7 @@ export type StudioModuleIamContract = Readonly<{
   tenantBootstrapRoles: readonly StudioModuleIamBootstrapRole[];
   rootSystemRoles: readonly StudioModuleIamSystemRole[];
   systemRoles?: readonly StudioModuleIamBootstrapRole[];
+  systemAdminPermissionExclusions?: readonly string[];
 }>;
 
 const createStandardContentBootstrapRoles = (pluginId: string): readonly StudioModuleIamBootstrapRole[] => [
@@ -174,6 +177,15 @@ export const studioModuleIamContracts = [
   ...studioPluginModuleIamContracts,
   ...studioHostModuleIamContracts,
 ] as const satisfies readonly StudioModuleIamContract[];
+
+/** Vollständige, validierte Katalogsicht für Diagnose, Review und Tests. */
+export const studioPermissionCatalog = composePermissionCatalog(
+  corePermissionCatalog,
+  studioModuleIamContracts.map((contract) => ({
+    moduleId: contract.moduleId,
+    permissionIds: contract.permissionIds,
+  }))
+);
 
 export const studioModuleIamRegistry = new Map(
   studioModuleIamContracts.map((contract) => [contract.moduleId, contract] as const)

--- a/packages/studio-module-iam/tsconfig.lib.json
+++ b/packages/studio-module-iam/tsconfig.lib.json
@@ -6,7 +6,10 @@
     "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "@sva/core": ["packages/core/dist/index.d.ts"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
 
   packages/data:
     dependencies:
+      '@sva/core':
+        specifier: workspace:*
+        version: link:../core
       '@sva/data-client':
         specifier: workspace:*
         version: link:../data-client
@@ -542,6 +545,9 @@ importers:
       '@sva/server-runtime':
         specifier: workspace:*
         version: file:packages/server-runtime(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
+      '@sva/studio-module-iam':
+        specifier: workspace:*
+        version: link:../studio-module-iam
       pg:
         specifier: ^8.22.0
         version: 8.22.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1258,6 +1258,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6(bufferutil@4.1.0))(jsdom@29.1.1)(msw@2.15.0(@types/node@25.9.1)(typescript@6.0.3))(vite@8.2.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/studio-module-iam:
+    dependencies:
+      '@sva/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.9

--- a/tooling/testing/tests/bootstrap-entrypoint.test.ts
+++ b/tooling/testing/tests/bootstrap-entrypoint.test.ts
@@ -36,7 +36,7 @@ while (($#)); do
 done
 cp "$sql_file" "$OUTPUT_SQL_PATH"
 `,
-      'utf8',
+      'utf8'
     );
     chmodSync(fakePsqlPath, 0o755);
 
@@ -77,11 +77,22 @@ describe('bootstrap-entrypoint', () => {
     const sql = renderBootstrapSql();
 
     expect(sql).toContain(
-      'INSERT INTO iam.instances (id, display_name, status, parent_domain, primary_hostname, auth_realm, auth_client_id, tenant_admin_client_id)',
+      'INSERT INTO iam.instances (id, display_name, status, parent_domain, primary_hostname, auth_realm, auth_client_id, tenant_admin_client_id)'
     );
     expect(sql).toContain("'sva-studio-admin'");
     expect(sql).toContain(
-      "tenant_admin_client_id = COALESCE(NULLIF(iam.instances.tenant_admin_client_id, ''), EXCLUDED.tenant_admin_client_id)",
+      "tenant_admin_client_id = COALESCE(NULLIF(iam.instances.tenant_admin_client_id, ''), EXCLUDED.tenant_admin_client_id)"
     );
+  });
+
+  it('reconciles canonical tenant permissions and system_admin grants additively', () => {
+    const sql = renderBootstrapSql();
+
+    expect(sql).toContain("'iam.accounts.delete'");
+    expect(sql).toContain("'instance_permission_catalog_reconciled'");
+    expect(sql).toContain('FROM iam.instance_modules instance_module');
+    expect(sql).toContain('ON CONFLICT (instance_id, role_id, permission_id) DO NOTHING');
+    expect(sql).not.toContain('DELETE FROM iam.permissions');
+    expect(sql).not.toContain('DELETE FROM iam.role_permissions');
   });
 });


### PR DESCRIPTION
## Was geändert wurde

- Ein kanonischer, validierter Permission-Katalog bündelt Core- und Modul-Permissions einschließlich Availability, Lifecycle und system_admin-Defaults.
- Tenant-Baseline, Modul-Lifecycle und Release-Bootstrap reconciliieren Definitionen und verwaltete Grants additiv.
- iam.accounts.delete wird für bestehende und zukünftige Tenants materialisiert und standardmäßig an system_admin vergeben.
- OpenSpec, ADR, Arc42 und Betriebsdokumentation beschreiben Erweiterung, Ausnahmen und Non-Deletion-Vertrag.

## Warum

Neue Permissions waren bislang über Seeds, Runtime-Baselines und Migrationen verteilt. Dadurch konnten bestehende oder später angelegte Tenants unterschiedliche effektive Rechte erhalten. Der Katalog wird zur fachlichen Quelle; automatische Reconciles übertragen Änderungen nachvollziehbar in die Tenant-Datenbanken.

## Wichtige Sicherheits- und Lifecycle-Eigenschaften

- Root-Permissions werden nie tenant-lokal an system_admin vergeben.
- Explizite Opt-outs verhindern den automatischen Grant, nicht die Materialisierung der Definition.
- Katalogentfernung löscht weder Definitionen noch Grants aktiver Module.
- Nur die echte Moduldeaktivierung entfernt eindeutig als module_sync markierte Grants.
- Die scoped Runtime- oder CLI-Grenze besitzt die Transaktion und bewahrt den RLS-Tenant-Kontext.

## Validierung

- gezielte Unit-Tests für core, studio-module-iam, data-repositories, instance-registry, data und Bootstrap-Entrypoint
- Type-Targets der betroffenen Packages
- pnpm check:server-runtime
- gezielte Lint-Targets
- pnpm check:file-placement
- pnpm exec openspec validate add-canonical-permission-catalog --strict

## Rollout

Die OpenSpec-Aufgaben für Staging-Live-Reconcile, Live-Verifikation und Production-Promotion bleiben bewusst offen.
