### PR TITLE
Fix empty permission reconcile aggregation

### DIFF
--- a/docs/changelog/entries/pr-899.json
+++ b/docs/changelog/entries/pr-899.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 899,
+  "body": "Stabilerer Abgleich von Berechtigungskatalogen\n\n- Leere Ergebnisse beim Abgleich von Berechtigungen werden zuverlässig als vollständige Null-Zusammenfassung behandelt.\n- Der Abgleich kann dadurch auch ohne gemeldete Änderungen sicher abgeschlossen und nachvollziehbar protokolliert werden."
+}

--- a/packages/instance-registry/src/service-module-mutations.test.ts
+++ b/packages/instance-registry/src/service-module-mutations.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { mergeReconcileResults } from './service-module-mutations.js';
+
+describe('mergeReconcileResults', () => {
+  it('returns an empty summary when no reconcile results exist', () => {
+    expect(mergeReconcileResults()).toEqual({
+      permissionsInserted: 0,
+      permissionsUpdated: 0,
+      permissionsUnchanged: 0,
+      grantsInserted: 0,
+      grantsUnchanged: 0,
+    });
+  });
+});

--- a/packages/instance-registry/src/service-module-mutations.ts
+++ b/packages/instance-registry/src/service-module-mutations.ts
@@ -63,16 +63,19 @@ const normalizeReconcileResult = (
     grantsUnchanged: 0,
   };
 
-const mergeReconcileResults = (
+export const mergeReconcileResults = (
   ...results: readonly (PermissionCatalogReconcileResult | void)[]
 ): PermissionCatalogReconcileResult =>
-  results.map(normalizeReconcileResult).reduce((total, result) => ({
-    permissionsInserted: total.permissionsInserted + result.permissionsInserted,
-    permissionsUpdated: total.permissionsUpdated + result.permissionsUpdated,
-    permissionsUnchanged: total.permissionsUnchanged + result.permissionsUnchanged,
-    grantsInserted: total.grantsInserted + result.grantsInserted,
-    grantsUnchanged: total.grantsUnchanged + result.grantsUnchanged,
-  }));
+  results.map(normalizeReconcileResult).reduce(
+    (total, result) => ({
+      permissionsInserted: total.permissionsInserted + result.permissionsInserted,
+      permissionsUpdated: total.permissionsUpdated + result.permissionsUpdated,
+      permissionsUnchanged: total.permissionsUnchanged + result.permissionsUnchanged,
+      grantsInserted: total.grantsInserted + result.grantsInserted,
+      grantsUnchanged: total.grantsUnchanged + result.grantsUnchanged,
+    }),
+    normalizeReconcileResult(undefined)
+  );
 
 const createModuleAssignRollbackError = (
   instanceId: string,


### PR DESCRIPTION
## Änderung

- ergänzt ein neutrales Initialergebnis für die Aggregation von Permission-Reconcile-Zählern
- deckt den leeren Aggregationsfall mit einem fokussierten Unit-Test ab

## Ursache

PR #897 führte einen `reduce()`-Aufruf ohne Initialwert ein. Ein leerer Aufruf konnte dadurch zur Laufzeit werfen und setzte das SonarCloud Reliability Rating auf neuem Code auf C (`typescript:S6959`).

## Auswirkung

Leere Reconcile-Ergebnisse liefern deterministisch eine vollständige Null-Summary. Das SonarCloud-Issue kann durch den nächsten Scan regulär geschlossen werden.

## Validierung

- `pnpm nx run instance-registry:test:unit --testFiles=src/service-module-mutations.test.ts`
- `pnpm nx run instance-registry:test:types`
- `pnpm nx run instance-registry:lint`
- `pnpm check:server-runtime`
- `pnpm complexity-gate --base origin/main`
- Prettier-Check für die beiden Patch-Dateien
