### PR TITLE
Tenant-Namen in der Seitenleiste anzeigen

### DIFF
--- a/apps/sva-studio-react/src/components/Sidebar.test.tsx
+++ b/apps/sva-studio-react/src/components/Sidebar.test.tsx
@@ -234,6 +234,22 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+it('zeigt den Tenant-Namen unter dem App-Titel und nutzt die Tenant-ID als Fallback', () => {
+  const { rerender } = renderSidebar({
+    user: createSidebarUser({
+      instanceId: 'tenant-a',
+      instanceDisplayName: 'Stadt Musterhausen',
+    }),
+  });
+
+  expect(screen.getByText('Stadt Musterhausen')).toBeTruthy();
+
+  setupSidebarSession({ user: createSidebarUser({ instanceId: 'tenant-a' }) });
+  rerender(<Sidebar />);
+
+  expect(screen.getByText('tenant-a')).toBeTruthy();
+});
+
 describe('Sidebar', () => {
   it('rendert im Loading-Zustand keine interaktiven Links', () => {
     useAuthMock.mockReturnValue(unauthenticatedAuthState);

--- a/apps/sva-studio-react/src/components/Sidebar.tsx
+++ b/apps/sva-studio-react/src/components/Sidebar.tsx
@@ -99,6 +99,7 @@ type SidebarPanelProps = Readonly<{
   sections: readonly SidebarSection[];
   footerItems: readonly SidebarLeafItem[];
   isCollapsed: boolean;
+  tenantName?: string;
   allowCollapse: boolean;
   onToggleCollapsed?: () => void;
   onNavigate?: () => void;
@@ -551,6 +552,7 @@ const SidebarPanel = ({
   sections,
   footerItems,
   isCollapsed,
+  tenantName,
   allowCollapse,
   onToggleCollapsed,
   onNavigate,
@@ -632,7 +634,14 @@ const SidebarPanel = ({
           className={`relative flex min-h-12 items-center ${isCollapsed ? 'justify-center' : 'justify-between'}`}
         >
           {showAppTitle ? (
-            <p className="text-3xl font-semibold text-foreground">{t('shell.appName')}</p>
+            <div className="min-w-0">
+              <p className="text-3xl font-semibold text-foreground">{t('shell.appName')}</p>
+              {tenantName ? (
+                <p className="truncate text-xs font-medium text-muted-foreground" title={tenantName}>
+                  {tenantName}
+                </p>
+              ) : null}
+            </div>
           ) : null}
           {allowCollapse ? (
             <Button
@@ -747,6 +756,7 @@ export default function Sidebar({
   onMobileOpenChange,
 }: SidebarProps) {
   const { user, isAuthenticated, isDevAuthAvailable: devAuthAvailable } = useAuth();
+  const tenantName = user?.instanceDisplayName?.trim() || user?.instanceId?.trim() || undefined;
   const contentAccessApi = useContentAccess();
   const canAccessWorkspace = isAuthenticated && isIamUiEnabled();
   const canAccessContent =
@@ -1142,6 +1152,7 @@ export default function Sidebar({
           sections={sections}
           footerItems={footerItems}
           isCollapsed={isCollapsed}
+          tenantName={tenantName}
           allowCollapse
           onToggleCollapsed={() => setIsCollapsed((current) => !current)}
         />
@@ -1164,6 +1175,7 @@ export default function Sidebar({
               sections={sections}
               footerItems={footerItems}
               isCollapsed={false}
+              tenantName={tenantName}
               allowCollapse={false}
               showMobileHeader
               onCloseMobileNavigation={() => onMobileOpenChange?.(false)}

--- a/apps/sva-studio-react/src/providers/auth-provider.tsx
+++ b/apps/sva-studio-react/src/providers/auth-provider.tsx
@@ -48,6 +48,7 @@ import {
 type SessionUser = {
   id: string;
   instanceId?: string;
+  instanceDisplayName?: string;
   assignedModules?: string[];
   groups?: readonly IamUserGroupAssignment[];
   keycloakRoles?: string[];

--- a/docs/changelog/entries/pr-902.json
+++ b/docs/changelog/entries/pr-902.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 902,
+  "body": "Tenant-Kontext direkt in der Seitenleiste sichtbar\n\n- Der lesbare Tenant-Name wird unter dem Titel „SVA Studio“ angezeigt.\n- Falls kein Anzeigename verfügbar ist, bleibt der Tenant über seine technische ID erkennbar."
+}

--- a/packages/auth-runtime/src/auth-route-handlers.test.ts
+++ b/packages/auth-runtime/src/auth-route-handlers.test.ts
@@ -213,8 +213,12 @@ describe('meHandler', () => {
       cacheStatus: 'hit',
       snapshotVersion: 'snap-1',
     });
-    mocks.withRegistryRepository.mockImplementation(async (handler: (repository: { listAssignedModules: (instanceId: string) => Promise<string[]> }) => Promise<unknown>) =>
+    mocks.withRegistryRepository.mockImplementation(async (handler: (repository: {
+      getInstanceById: (instanceId: string) => Promise<{ displayName: string }>;
+      listAssignedModules: (instanceId: string) => Promise<string[]>;
+    }) => Promise<unknown>) =>
       handler({
+        getInstanceById: async () => ({ displayName: 'Tenant Test' }),
         listAssignedModules: async () => ['news'],
       })
     );
@@ -264,12 +268,14 @@ describe('meHandler', () => {
         id: string;
         assignedModules: string[];
         groups: IamUserGroupAssignment[];
+        instanceDisplayName?: string;
         permissionActions: string[];
       };
     };
 
     expect(payload.user.id).toBe('kc-user-1');
     expect(payload.user.assignedModules).toEqual(['news']);
+    expect(payload.user.instanceDisplayName).toBe('Tenant Test');
     expect(payload.user.groups).toEqual([
       {
         groupId: 'group-1',

--- a/packages/auth-runtime/src/auth-route-handlers.ts
+++ b/packages/auth-runtime/src/auth-route-handlers.ts
@@ -467,6 +467,7 @@ type CallbackDependencies = {
 };
 
 type AuthMeResolution = {
+  readonly instanceDisplayName?: string;
   readonly permissionActions: string[];
   readonly permissionStatus: 'ok' | 'degraded';
   readonly assignedModules: string[];
@@ -867,6 +868,28 @@ const loadAssignedModulesForAuthMe = async (user: { instanceId?: string }): Prom
   }
 };
 
+const loadInstanceDisplayNameForAuthMe = async (user: { instanceId?: string }): Promise<string | undefined> => {
+  if (!user.instanceId) {
+    return undefined;
+  }
+  const instanceId = user.instanceId;
+
+  try {
+    const instance = await withRegistryRepository((repository) => repository.getInstanceById(instanceId));
+    const displayName = instance?.displayName.trim();
+    return displayName || undefined;
+  } catch (error) {
+    logger.error('Auth me instance display name lookup failed', {
+      endpoint: '/auth/me',
+      operation: 'get_current_user',
+      error_type: error instanceof Error ? error.name : typeof error,
+      reason_code: 'instance_display_name_lookup_failed',
+      ...buildLogContext({ kind: 'instance', instanceId }),
+    });
+    return undefined;
+  }
+};
+
 type AuthMeGroupRow = {
   readonly group_id: string;
   readonly group_key: string;
@@ -939,12 +962,14 @@ ORDER BY g.display_name ASC, g.group_key ASC
 const resolveAuthMeState = async (user: { id: string; instanceId?: string }): Promise<AuthMeResolution> => {
   const permissionState = await loadAuthMePermissionState(user);
   const assignedModules = await loadAssignedModulesForAuthMe(user);
+  const instanceDisplayName = await loadInstanceDisplayNameForAuthMe(user);
   const groups = await loadGroupsForAuthMe(user);
 
   return {
     ...permissionState,
     assignedModules,
     groups,
+    instanceDisplayName,
   };
 };
 
@@ -963,6 +988,7 @@ const createAuthMeResponse = (
         ...user,
         assignedModules: resolution.assignedModules,
         groups: resolution.groups,
+        ...(resolution.instanceDisplayName ? { instanceDisplayName: resolution.instanceDisplayName } : {}),
         permissionActions: resolution.permissionActions,
         permissionStatus,
       },


### PR DESCRIPTION
## Was ändert sich?

- Zeigt den lesbaren Tenant-Namen unter „SVA Studio“ in der Seitenleiste.
- Nutzt die Tenant-ID als Fallback.
- Liefert den Anzeigenamen ohne zusätzlichen Browser-Request über `/auth/me`.
- Blendet die Zusatzzeile bei eingeklappter Seitenleiste aus.

## Warum?

Nutzer erkennen damit jederzeit, in welchem Tenant-Kontext sie arbeiten.

## Validierung

- `pnpm nx run auth-runtime:test:unit --testFiles=src/auth-route-handlers.test.ts`
- `pnpm nx run sva-studio-react:test:unit --testFiles=src/components/Sidebar.test.tsx`
- `pnpm nx run auth-runtime:test:types`
- `pnpm nx run sva-studio-react:test:types`
- `pnpm check:server-runtime`