### PR TITLE
Content-Detailnavigation vereinheitlichen

### DIFF
--- a/apps/sva-studio-react/src/i18n/resources/de/content.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/content.resources.ts
@@ -75,6 +75,7 @@ export const contentDEResources = {
     headerAccess: 'Bearbeitbarkeit',
     headerContext: 'Kontext',
     headerActions: 'Aktionen',
+    notAvailable: 'Nicht verfügbar',
     notPublished: 'Nicht gesetzt',
   },
   editor: {

--- a/apps/sva-studio-react/src/i18n/resources/en/content.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/content.resources.ts
@@ -74,6 +74,7 @@ export const contentENResources = {
     headerAccess: 'Access',
     headerContext: 'Context',
     headerActions: 'Actions',
+    notAvailable: 'Not available',
     notPublished: 'Not set',
   },
   editor: {

--- a/apps/sva-studio-react/src/lib/breadcrumbs.test.ts
+++ b/apps/sva-studio-react/src/lib/breadcrumbs.test.ts
@@ -72,6 +72,28 @@ describe('resolveBreadcrumbItems', () => {
     ]);
   });
 
+  it.each([
+    ['generic-items', 'Generischen Inhalt anlegen', 'Generischen Inhalt bearbeiten'],
+    ['faq', 'FAQ anlegen', 'FAQ bearbeiten'],
+    ['cockpit-cards', 'Cockpit Card anlegen', 'Cockpit Card bearbeiten'],
+    ['surveys', 'Umfrage anlegen', 'Umfrage bearbeiten'],
+  ])(
+    'returns content breadcrumbs for %s create and edit pages',
+    (basePath, createTitle, editTitle) => {
+      expect(resolveBreadcrumbItems(`/admin/${basePath}/new`)).toEqual([
+        { href: '/', label: 'Übersicht' },
+        { href: '/admin/content', label: 'Inhalte' },
+        { label: createTitle },
+      ]);
+
+      expect(resolveBreadcrumbItems(`/admin/${basePath}/content-1`)).toEqual([
+        { href: '/', label: 'Übersicht' },
+        { href: '/admin/content', label: 'Inhalte' },
+        { label: editTitle },
+      ]);
+    }
+  );
+
   it('falls back to overview for unknown paths', () => {
     expect(resolveBreadcrumbItems('/unbekannt')).toEqual([{ label: 'Übersicht' }]);
   });

--- a/apps/sva-studio-react/src/lib/breadcrumbs.ts
+++ b/apps/sva-studio-react/src/lib/breadcrumbs.ts
@@ -131,6 +131,70 @@ const breadcrumbRoutes: ReadonlyArray<
     ],
   },
   {
+    pattern: /^\/admin\/generic-items\/new$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('genericItems.editor.createTitle') },
+    ],
+  },
+  {
+    pattern: /^\/admin\/generic-items\/[^/]+$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('genericItems.editor.editTitle') },
+    ],
+  },
+  {
+    pattern: /^\/admin\/faq\/new$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('faq.editor.createTitle') },
+    ],
+  },
+  {
+    pattern: /^\/admin\/faq\/[^/]+$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('faq.editor.editTitle') },
+    ],
+  },
+  {
+    pattern: /^\/admin\/cockpit-cards\/new$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('cockpit-cards.editor.createTitle') },
+    ],
+  },
+  {
+    pattern: /^\/admin\/cockpit-cards\/[^/]+$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('cockpit-cards.editor.editTitle') },
+    ],
+  },
+  {
+    pattern: /^\/admin\/surveys\/new$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('surveys.pages.createTitle') },
+    ],
+  },
+  {
+    pattern: /^\/admin\/surveys\/[^/]+$/,
+    build: () => [
+      overviewBreadcrumb(),
+      { href: '/admin/content', label: t('content.page.title') },
+      { label: t('surveys.pages.editTitle') },
+    ],
+  },
+  {
     pattern: /^\/interfaces$/,
     build: () => [overviewBreadcrumb(), { label: t('interfaces.page.title') }],
   },
@@ -274,7 +338,9 @@ const breadcrumbRoutes: ReadonlyArray<
 
 export const resolveBreadcrumbItems = (pathname: string): ReadonlyArray<BreadcrumbItem> => {
   const normalizedPathname = normalizePathname(pathname);
-  const routeMatch = breadcrumbRoutes.find((candidate) => candidate.pattern.test(normalizedPathname));
+  const routeMatch = breadcrumbRoutes.find((candidate) =>
+    candidate.pattern.test(normalizedPathname)
+  );
 
   if (!routeMatch) {
     return [{ label: t('shell.sidebar.overview') }];

--- a/apps/sva-studio-react/src/routes/content/-content-list-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/content/-content-list-page.test.tsx
@@ -316,7 +316,7 @@ describe('ContentListPage', () => {
             id: 'content-2',
             contentType: 'poi.point-of-interest',
             createdAt: '2026-03-20T10:00:00.000Z',
-            updatedAt: '2026-03-21T11:00:00.000Z',
+            updatedAt: '',
             title: 'Archiv',
             author: 'Redaktion',
             payload: { blocks: ['A'] },
@@ -359,8 +359,11 @@ describe('ContentListPage', () => {
     expect(screen.getAllByRole('button', { name: 'Löschen' }).length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText('content-1')).toHaveLength(2);
     expect(screen.getAllByText('content-2')).toHaveLength(2);
+    expect(screen.getAllByRole('columnheader', { name: 'Änderungsdatum' })).toHaveLength(1);
     expect(screen.getAllByText('20.03.2026, 11:00')).toHaveLength(4);
     expect(screen.getAllByText('21.03.2026, 11:00')).toHaveLength(2);
+    expect(screen.getAllByText('21.03.2026, 12:00')).toHaveLength(2);
+    expect(screen.getAllByText('Nicht verfügbar')).toHaveLength(2);
     const statusButton = screen.getAllByRole('button', {
       name: 'Status von Startseite ändern',
     })[0] as HTMLElement;

--- a/apps/sva-studio-react/src/routes/content/-content-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/content/-content-list-page.tsx
@@ -726,6 +726,14 @@ export const ContentListPage = () => {
         sortValue: (item) => item.createdAt,
       },
       {
+        id: 'updatedAt',
+        header: t('content.table.headerUpdated'),
+        cell: (item) =>
+          item.updatedAt ? formatDateTime(item.updatedAt) : t('content.table.notAvailable'),
+        sortable: true,
+        sortValue: (item) => item.updatedAt ?? '',
+      },
+      {
         id: 'publishedAt',
         header: t('content.table.headerPublished'),
         cell: (item) =>

--- a/docs/changelog/entries/pr-903.json
+++ b/docs/changelog/entries/pr-903.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 903,
+  "body": "Content-Navigation und Inhaltsübersicht vereinheitlicht\n\n- Breadcrumbs, Tab-Symbole und Abstände sind über die Standard-Content-Editoren hinweg konsistent.\n- Die Inhaltsübersicht zeigt zusätzlich das Änderungsdatum und kennzeichnet fehlende Werte verständlich."
+}

--- a/packages/plugin-cockpit-cards/src/cockpit-cards.pages.tsx
+++ b/packages/plugin-cockpit-cards/src/cockpit-cards.pages.tsx
@@ -15,6 +15,7 @@ import {
   Input,
   Select,
   StudioDataTable,
+  StudioDetailTabIcon,
   StudioDetailPageTemplate,
   StudioEmptyState,
   StudioErrorState,
@@ -26,6 +27,7 @@ import {
   TabsList,
   TabsTrigger,
   Textarea,
+  type StudioDetailTabIconName,
 } from '@sva/studio-ui-react';
 import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import * as React from 'react';
@@ -57,6 +59,13 @@ const defaults: CockpitCardFormValues = {
   visible: true,
 };
 type Tab = 'basis' | 'content' | 'settings' | 'history';
+
+const tabIconNames = {
+  basis: 'basis',
+  content: 'content',
+  settings: 'settings',
+  history: 'history',
+} as const satisfies Record<Tab, StudioDetailTabIconName>;
 
 const panel = (title: string, children: React.ReactNode) => (
   <section className="space-y-4 rounded-2xl border border-border/60 p-5">
@@ -269,7 +278,9 @@ function Editor({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; content
     } catch (cause) {
       const reason = cause instanceof Error ? cause.message : '';
       setMutationError(
-        reason ? pt('messages.saveErrorWithReason').replace('{{reason}}', reason) : pt('messages.saveError')
+        reason
+          ? pt('messages.saveErrorWithReason').replace('{{reason}}', reason)
+          : pt('messages.saveError')
       );
     }
   });
@@ -307,16 +318,25 @@ function Editor({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; content
         </Button>
       }
     >
-      {mutationError ? <p role="alert" className="text-sm text-destructive">{mutationError}</p> : null}
-      <Tabs value={tab} onValueChange={(value) => setTab(value as Tab)}>
-        <TabsList aria-label={pt('tabs.ariaLabel')}>
+      {mutationError ? (
+        <p role="alert" className="text-sm text-destructive">
+          {mutationError}
+        </p>
+      ) : null}
+      <Tabs value={tab} onValueChange={(value) => setTab(value as Tab)} className="space-y-0">
+        <TabsList aria-label={pt('tabs.ariaLabel')} className="ml-[10px] gap-10">
           {tabs.map((item) => (
-            <TabsTrigger key={item} value={item}>
-              {pt(`tabs.${item}.label`)}
+            <TabsTrigger
+              key={item}
+              value={item}
+              className="gap-2 rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none"
+            >
+              <StudioDetailTabIcon name={tabIconNames[item]} />
+              <span>{pt(`tabs.${item}.label`)}</span>
             </TabsTrigger>
           ))}
         </TabsList>
-        <TabsContent value="basis" forceMount className="data-[state=inactive]:hidden">
+        <TabsContent value="basis" forceMount className="mt-0 data-[state=inactive]:hidden">
           {panel(
             pt('tabs.basis.title'),
             <div className="space-y-4">
@@ -350,10 +370,10 @@ function Editor({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; content
             </div>
           )}
         </TabsContent>
-        <TabsContent value="content" forceMount className="data-[state=inactive]:hidden">
+        <TabsContent value="content" forceMount className="mt-0 data-[state=inactive]:hidden">
           {panel(pt('tabs.content.title'), <ContentFields form={form} pt={pt} />)}
         </TabsContent>
-        <TabsContent value="settings" forceMount className="data-[state=inactive]:hidden">
+        <TabsContent value="settings" forceMount className="mt-0 data-[state=inactive]:hidden">
           {panel(
             pt('tabs.settings.title'),
             <div className="space-y-4">
@@ -387,7 +407,7 @@ function Editor({ mode, contentId }: Readonly<{ mode: 'create' | 'edit'; content
           )}
         </TabsContent>
         {mode === 'edit' && contentId ? (
-          <TabsContent value="history">
+          <TabsContent value="history" className="mt-0">
             {panel(pt('tabs.history.title'), <CockpitCardsHistory contentId={contentId} />)}
           </TabsContent>
         ) : null}

--- a/packages/plugin-cockpit-cards/tests/cockpit-cards.pages.test.tsx
+++ b/packages/plugin-cockpit-cards/tests/cockpit-cards.pages.test.tsx
@@ -91,8 +91,13 @@ describe('cockpit cards pages', () => {
   it('places text and image controls together and loads category and media options', async () => {
     const { CockpitCardsCreatePage } = await import('../src/cockpit-cards.pages.js');
     render(<CockpitCardsCreatePage />);
+    const tablist = screen.getByRole('tablist', { name: 'tabs.ariaLabel' });
+    const basisTab = screen.getByRole('tab', { name: 'tabs.basis.label' });
     const contentPanel = screen.getByLabelText('fields.text').closest('[role="tabpanel"]');
     const addImage = screen.getByRole('button', { name: 'actions.addImage' });
+    expect(tablist.className).toContain('ml-[10px]');
+    expect(basisTab.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+    expect(contentPanel?.className).toContain('mt-0');
     expect(contentPanel?.contains(addImage)).toBe(true);
     expect(await screen.findByRole('option', { name: 'Startseite' })).toBeTruthy();
     expect(await screen.findByRole('option', { name: 'bild.jpg' })).toBeTruthy();
@@ -138,11 +143,16 @@ describe('cockpit cards pages', () => {
     fireEvent.change(screen.getByLabelText('fields.text'), { target: { value: 'Geändert' } });
     fireEvent.click(screen.getByLabelText('fields.visible'));
     fireEvent.click(screen.getAllByRole('button', { name: 'actions.save' })[1]!);
-    await waitFor(() => expect(state.update).toHaveBeenCalledWith('card-1', expect.objectContaining({
-      contentBlocks: [{ body: 'Geändert' }],
-      payload: { languageCode: 'de', sortWeight: 2, legacy: 'keep' },
-      visible: true,
-    })));
+    await waitFor(() =>
+      expect(state.update).toHaveBeenCalledWith(
+        'card-1',
+        expect.objectContaining({
+          contentBlocks: [{ body: 'Geändert' }],
+          payload: { languageCode: 'de', sortWeight: 2, legacy: 'keep' },
+          visible: true,
+        })
+      )
+    );
     fireEvent.click(screen.getByRole('button', { name: 'actions.delete' }));
     await waitFor(() => expect(state.delete).toHaveBeenCalledWith('card-1'));
     expect(state.navigate).toHaveBeenCalledWith({ to: '/admin/content' });
@@ -153,9 +163,8 @@ describe('cockpit cards pages', () => {
     state.get.mockRejectedValue(new Error('load failed'));
     state.listCategories.mockRejectedValue(new Error('categories failed'));
     state.listAssets.mockRejectedValue(new Error('media failed'));
-    const { CockpitCardsCreatePage, CockpitCardsEditPage } = await import(
-      '../src/cockpit-cards.pages.js'
-    );
+    const { CockpitCardsCreatePage, CockpitCardsEditPage } =
+      await import('../src/cockpit-cards.pages.js');
     const edit = render(<CockpitCardsEditPage />);
     await screen.findByText('messages.loadError');
     edit.unmount();
@@ -202,7 +211,14 @@ describe('cockpit cards pages', () => {
 
   it('renders history entries and history errors', async () => {
     state.history.mockResolvedValue([
-      { id: 'h1', createdAt: '2026-08-01', action: 'update', actor: 'Ada', summary: '', changedFields: ['title'] },
+      {
+        id: 'h1',
+        createdAt: '2026-08-01',
+        action: 'update',
+        actor: 'Ada',
+        summary: '',
+        changedFields: ['title'],
+      },
     ]);
     const { CockpitCardsHistory } = await import('../src/cockpit-cards.pages.js');
     const view = render(<CockpitCardsHistory contentId="card-1" />);
@@ -219,14 +235,20 @@ describe('cockpit cards pages', () => {
   it('renders list loading, data, empty and error states with normalized pagination', async () => {
     const { CockpitCardsListPage } = await import('../src/cockpit-cards.pages.js');
     state.search = { page: -1, pageSize: 42 };
-    state.list.mockResolvedValue({ data: [record], pagination: { page: 1, pageSize: 25, hasNextPage: false } });
+    state.list.mockResolvedValue({
+      data: [record],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
     const data = render(<CockpitCardsListPage />);
     expect((await screen.findAllByText('Bestehende Karte')).length).toBeGreaterThan(0);
     expect(state.list).toHaveBeenCalledWith({ page: 1, pageSize: 25 });
     expect(screen.getAllByText('de').length).toBeGreaterThan(0);
     data.unmount();
 
-    state.list.mockResolvedValue({ data: [], pagination: { page: 1, pageSize: 50, hasNextPage: false } });
+    state.list.mockResolvedValue({
+      data: [],
+      pagination: { page: 1, pageSize: 50, hasNextPage: false },
+    });
     state.search = { page: 2, pageSize: 50 };
     const empty = render(<CockpitCardsListPage />);
     expect(await screen.findByText('list.empty')).toBeTruthy();

--- a/packages/plugin-faq/src/faq.editor-tabs.tsx
+++ b/packages/plugin-faq/src/faq.editor-tabs.tsx
@@ -2,12 +2,14 @@ import {
   Checkbox,
   Input,
   Select,
+  StudioDetailTabIcon,
   StudioField,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
   Textarea,
+  type StudioDetailTabIconName,
 } from '@sva/studio-ui-react';
 import { Controller, type UseFormReturn } from 'react-hook-form';
 
@@ -16,6 +18,13 @@ import type { FaqFormValues } from './faq.types.js';
 
 export type FaqTab = 'basis' | 'content' | 'settings' | 'history';
 
+const tabIconNames = {
+  basis: 'basis',
+  content: 'content',
+  settings: 'settings',
+  history: 'history',
+} as const satisfies Record<FaqTab, StudioDetailTabIconName>;
+
 const renderPanel = (title: string, content: React.ReactNode) => (
   <div className="space-y-4 rounded-2xl border border-border/60 bg-[rgb(var(--waste-panel-surface))] p-5">
     <h2 className="text-base font-semibold text-foreground">{title}</h2>
@@ -23,7 +32,10 @@ const renderPanel = (title: string, content: React.ReactNode) => (
   </div>
 );
 
-const FaqBasisTab = ({ form, pt }: Readonly<{ form: UseFormReturn<FaqFormValues>; pt: (key: string) => string }>) => (
+const FaqBasisTab = ({
+  form,
+  pt,
+}: Readonly<{ form: UseFormReturn<FaqFormValues>; pt: (key: string) => string }>) => (
   <div className="space-y-4">
     <StudioField id="faq-question" label={pt('fields.question')}>
       <Input id="faq-question" {...form.register('question')} />
@@ -34,27 +46,43 @@ const FaqBasisTab = ({ form, pt }: Readonly<{ form: UseFormReturn<FaqFormValues>
   </div>
 );
 
-const FaqContentTab = ({ form, pt }: Readonly<{ form: UseFormReturn<FaqFormValues>; pt: (key: string) => string }>) => (
+const FaqContentTab = ({
+  form,
+  pt,
+}: Readonly<{ form: UseFormReturn<FaqFormValues>; pt: (key: string) => string }>) => (
   <StudioField id="faq-answer" label={pt('fields.answer')}>
     <Textarea id="faq-answer" className="min-h-32" {...form.register('answer')} />
   </StudioField>
 );
 
-const FaqSettingsTab = ({ form, pt }: Readonly<{ form: UseFormReturn<FaqFormValues>; pt: (key: string) => string }>) => (
+const FaqSettingsTab = ({
+  form,
+  pt,
+}: Readonly<{ form: UseFormReturn<FaqFormValues>; pt: (key: string) => string }>) => (
   <div className="space-y-4">
     <StudioField id="faq-publication-date" label={pt('fields.publicationDate')}>
       <Input id="faq-publication-date" {...form.register('publicationDate')} />
     </StudioField>
     <StudioField id="faq-sort-weight" label={pt('fields.sortWeight')}>
-      <Input id="faq-sort-weight" type="number" {...form.register('sortWeight', { valueAsNumber: true })} />
-      {form.formState.errors.sortWeight ? <span className="text-destructive">{pt('validation.sortWeight')}</span> : null}
+      <Input
+        id="faq-sort-weight"
+        type="number"
+        {...form.register('sortWeight', { valueAsNumber: true })}
+      />
+      {form.formState.errors.sortWeight ? (
+        <span className="text-destructive">{pt('validation.sortWeight')}</span>
+      ) : null}
     </StudioField>
     <StudioField id="faq-visible" label={pt('fields.visible')}>
       <Controller
         name="visible"
         control={form.control}
         render={({ field }) => (
-          <Checkbox id="faq-visible" checked={field.value} onChange={(event) => field.onChange(event.currentTarget.checked)} />
+          <Checkbox
+            id="faq-visible"
+            checked={field.value}
+            onChange={(event) => field.onChange(event.currentTarget.checked)}
+          />
         )}
       />
     </StudioField>
@@ -76,19 +104,39 @@ export const FaqEditorTabs = ({
   onTabChange: (tab: FaqTab) => void;
   pt: (key: string, variables?: Readonly<Record<string, string | number>>) => string;
 }>) => {
-  const tabs: readonly FaqTab[] = mode === 'edit' ? ['basis', 'content', 'settings', 'history'] : ['basis', 'content', 'settings'];
+  const tabs: readonly FaqTab[] =
+    mode === 'edit'
+      ? ['basis', 'content', 'settings', 'history']
+      : ['basis', 'content', 'settings'];
   const selectTab = (value: string) => onTabChange(value as FaqTab);
 
   return (
     <Tabs value={activeTab} onValueChange={selectTab} className="space-y-0">
       <label className="block md:hidden">
         <span className="sr-only">{pt('tabs.mobileLabel')}</span>
-        <Select aria-label={pt('tabs.mobileLabel')} value={activeTab} onChange={(event) => selectTab(event.target.value)}>
-          {tabs.map((tab) => <option key={tab} value={tab}>{pt(`tabs.${tab}.label`)}</option>)}
+        <Select
+          aria-label={pt('tabs.mobileLabel')}
+          value={activeTab}
+          onChange={(event) => selectTab(event.target.value)}
+        >
+          {tabs.map((tab) => (
+            <option key={tab} value={tab}>
+              {pt(`tabs.${tab}.label`)}
+            </option>
+          ))}
         </Select>
       </label>
       <TabsList aria-label={pt('tabs.ariaLabel')} className="ml-[10px] hidden gap-10 md:flex">
-        {tabs.map((tab) => <TabsTrigger key={tab} value={tab} className="rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none">{pt(`tabs.${tab}.label`)}</TabsTrigger>)}
+        {tabs.map((tab) => (
+          <TabsTrigger
+            key={tab}
+            value={tab}
+            className="gap-2 rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none"
+          >
+            <StudioDetailTabIcon name={tabIconNames[tab]} />
+            <span>{pt(`tabs.${tab}.label`)}</span>
+          </TabsTrigger>
+        ))}
       </TabsList>
       <TabsContent value="basis" forceMount className="mt-0 data-[state=inactive]:hidden">
         {renderPanel(pt('tabs.basis.title'), <FaqBasisTab form={form} pt={pt} />)}
@@ -101,7 +149,10 @@ export const FaqEditorTabs = ({
       </TabsContent>
       {mode === 'edit' && contentId ? (
         <TabsContent value="history" className="mt-0">
-          {renderPanel(pt('tabs.history.title'), <FaqDetailHistoryTab contentId={contentId} pt={pt} />)}
+          {renderPanel(
+            pt('tabs.history.title'),
+            <FaqDetailHistoryTab contentId={contentId} pt={pt} />
+          )}
         </TabsContent>
       ) : null}
     </Tabs>

--- a/packages/plugin-faq/tests/faq.pages.test.tsx
+++ b/packages/plugin-faq/tests/faq.pages.test.tsx
@@ -59,6 +59,9 @@ describe('faq editor pages', () => {
 
     render(<FaqCreatePage />);
 
+    const basisTab = screen.getByRole('tab', { name: 'tabs.basis.label' });
+    expect(basisTab.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+
     fireEvent.change(screen.getByLabelText('fields.question'), { target: { value: 'Neue Frage' } });
     fireEvent.change(screen.getByLabelText('fields.answer'), { target: { value: 'Eine Antwort' } });
     fireEvent.change(screen.getByLabelText('fields.languageCode'), { target: { value: 'en-us' } });

--- a/packages/plugin-generic-items/src/generic-items.detail-page.tabs.tsx
+++ b/packages/plugin-generic-items/src/generic-items.detail-page.tabs.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@sva/studio-ui-react';
+import {
+  StudioDetailTabIcon,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  type StudioDetailTabIconName,
+} from '@sva/studio-ui-react';
 
 import { GenericItemsDetailBasisTab } from './generic-items.detail-basis-tab.js';
 import { GenericItemsDetailContentTab } from './generic-items.detail-content-tab.js';
 import { GenericItemsDetailHistoryTab } from './generic-items.detail-history-tab.js';
 import { GenericItemsDetailSettingsTab } from './generic-items.detail-settings-tab.js';
-import { genericItemsDetailTabIds, type GenericItemsDetailTabId } from './generic-items.detail-tabs.js';
+import {
+  genericItemsDetailTabIds,
+  type GenericItemsDetailTabId,
+} from './generic-items.detail-tabs.js';
 import type { GenericItemCategoryOption } from './generic-items.api-types.js';
+
+const tabIconNames = {
+  basis: 'basis',
+  content: 'content',
+  settings: 'settings',
+  history: 'history',
+} as const satisfies Record<GenericItemsDetailTabId, StudioDetailTabIconName>;
 
 const renderTabPanel = (title: string, description: string, panel: React.JSX.Element) => (
   <div className="space-y-4 rounded-2xl border border-border/60 bg-[rgb(var(--waste-panel-surface))] p-5">
@@ -37,16 +54,25 @@ export const GenericItemsDetailTabs = ({
   onTabChange: (tabId: GenericItemsDetailTabId) => void;
   pt: (key: string) => string;
 }>) => (
-  <Tabs value={activeTab} onValueChange={(value: string) => onTabChange(value as GenericItemsDetailTabId)}>
-    <TabsList aria-label={pt('tabs.ariaLabel')}>
+  <Tabs
+    value={activeTab}
+    onValueChange={(value: string) => onTabChange(value as GenericItemsDetailTabId)}
+    className="space-y-0"
+  >
+    <TabsList aria-label={pt('tabs.ariaLabel')} className="ml-[10px] gap-10">
       {genericItemsDetailTabIds.map((tabId) => (
-        <TabsTrigger key={tabId} value={tabId}>
-          {pt(`tabs.${tabId}.label`)}
+        <TabsTrigger
+          key={tabId}
+          value={tabId}
+          className="gap-2 rounded-none border-x-0 border-t-0 border-b-[3px] px-0 pr-5 shadow-none"
+        >
+          <StudioDetailTabIcon name={tabIconNames[tabId]} />
+          <span>{pt(`tabs.${tabId}.label`)}</span>
         </TabsTrigger>
       ))}
     </TabsList>
 
-    <TabsContent value="basis">
+    <TabsContent value="basis" className="mt-0">
       {renderTabPanel(
         pt('tabs.basis.title'),
         pt('tabs.basis.description'),
@@ -58,21 +84,21 @@ export const GenericItemsDetailTabs = ({
         />
       )}
     </TabsContent>
-    <TabsContent value="content">
+    <TabsContent value="content" className="mt-0">
       {renderTabPanel(
         pt('tabs.content.title'),
         pt('tabs.content.description'),
         <GenericItemsDetailContentTab labels={labels} onOpenMediaPicker={onOpenMediaPicker} />
       )}
     </TabsContent>
-    <TabsContent value="settings">
+    <TabsContent value="settings" className="mt-0">
       {renderTabPanel(
         pt('tabs.settings.title'),
         pt('tabs.settings.description'),
         <GenericItemsDetailSettingsTab labels={labels} />
       )}
     </TabsContent>
-    <TabsContent value="history">
+    <TabsContent value="history" className="mt-0">
       {renderTabPanel(
         pt('tabs.history.title'),
         pt('tabs.history.description'),

--- a/packages/plugin-generic-items/tests/generic-items.detail-page.test.tsx
+++ b/packages/plugin-generic-items/tests/generic-items.detail-page.test.tsx
@@ -303,6 +303,12 @@ describe('GenericItemsDetailPage', () => {
   it('creates a generic item', async () => {
     render(<GenericItemsDetailPage mode="create" />);
 
+    const tablist = screen.getByRole('tablist', { name: 'Detailbereiche' });
+    const basisTab = screen.getByRole('tab', { name: 'Basis' });
+    expect(tablist.className).toContain('ml-[10px]');
+    expect(basisTab.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+    expect(screen.getByRole('tabpanel', { name: 'Basis' }).className).toContain('mt-0');
+
     expect(screen.getByRole('link', { name: 'Zurück' }).getAttribute('href')).toBe(
       '/admin/content?type=generic-items.generic-item'
     );

--- a/packages/plugin-poi/src/poi.detail-page.tsx
+++ b/packages/plugin-poi/src/poi.detail-page.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Button,
   Select,
+  StudioDetailTabIcon,
   StudioDetailPageTemplate,
   StudioFormSummary,
   StudioLoadingState,
@@ -668,7 +669,10 @@ export function PoiDetailPage({
                         : 'border-transparent text-muted-foreground'
                     }`}
                   >
-                    <PoiTabTriggerLabel label={tab.label} />
+                    <span className="inline-flex items-center gap-2">
+                      <StudioDetailTabIcon name={tab.id} />
+                      <PoiTabTriggerLabel label={tab.label} />
+                    </span>
                   </TabsTrigger>
                 );
               })}

--- a/packages/plugin-poi/tests/poi.detail-page.test.tsx
+++ b/packages/plugin-poi/tests/poi.detail-page.test.tsx
@@ -287,6 +287,9 @@ describe('PoiDetailPage', () => {
     expect(screen.getByRole('tab', { name: 'Inhalt' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Einstellungen' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Historie' })).toBeTruthy();
+    expect(
+      screen.getByRole('tab', { name: 'Basis' }).querySelector('svg')?.getAttribute('aria-hidden')
+    ).toBe('true');
   });
 
   it('shows the content section cards inside the content tab', async () => {

--- a/packages/plugin-surveys/src/surveys.editor-tabs.tsx
+++ b/packages/plugin-surveys/src/surveys.editor-tabs.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { usePluginTranslation } from '@sva/plugin-sdk';
+import { type StudioDetailTabDefinition } from '@sva/studio-ui-react';
+
+import { SurveyDetailBasisTab, type SurveyTargetAreaOption } from './surveys.detail-basis-tab.js';
+import { SurveyDetailContentTab } from './surveys.detail-content-tab.js';
+import { SurveyDetailHistoryTab } from './surveys.detail-history-tab.js';
+import { SurveyDetailModerationTab } from './surveys.detail-moderation-tab.js';
+import { SurveyDetailResultsTab } from './surveys.detail-results-tab.js';
+import {
+  mapSurveyModerationGroups,
+  mapSurveyResultsTabData,
+  type SurveyEditorMode,
+  type SurveyEditorTabId,
+} from './surveys.editor.shared.js';
+import type { SurveyContentItem } from './surveys.types.js';
+
+const deriveSurveyTargetAreaOptions = (
+  item: SurveyContentItem | null
+): SurveyTargetAreaOption[] => {
+  if (!item) {
+    return [];
+  }
+  return [...new Set(item.targetAreaIds)].map((targetAreaId) => ({
+    id: targetAreaId,
+    label: targetAreaId,
+  }));
+};
+
+export const createSurveyEditorTabs = (
+  pt: ReturnType<typeof usePluginTranslation>,
+  mode: SurveyEditorMode,
+  loadedItem: SurveyContentItem | null,
+  contentId?: string
+): readonly StudioDetailTabDefinition<SurveyEditorTabId>[] => {
+  const moderationGroups = loadedItem ? mapSurveyModerationGroups(loadedItem) : [];
+  const resultData = loadedItem ? mapSurveyResultsTabData(loadedItem, pt) : null;
+  const availableTargetAreas = deriveSurveyTargetAreaOptions(loadedItem);
+  return [
+    {
+      id: 'basis',
+      label: pt('tabs.basis.label'),
+      icon: 'basis',
+      title: pt('tabs.basis.title'),
+      description: pt('tabs.basis.description'),
+      panel: (
+        <SurveyDetailBasisTab
+          mode={mode}
+          loadedItem={loadedItem}
+          availableTargetAreas={availableTargetAreas}
+          pt={pt}
+        />
+      ),
+    },
+    {
+      id: 'content',
+      label: pt('tabs.content.label'),
+      icon: 'content',
+      title: pt('tabs.content.title'),
+      description: pt('tabs.content.description'),
+      panel: <SurveyDetailContentTab pt={pt} />,
+    },
+    {
+      id: 'moderation',
+      label: pt('tabs.moderation.label'),
+      icon: 'moderation',
+      title: pt('tabs.moderation.title'),
+      description: pt('tabs.moderation.description'),
+      panel: <SurveyDetailModerationTab mode={mode} groups={moderationGroups} pt={pt} />,
+    },
+    {
+      id: 'results',
+      label: pt('tabs.results.label'),
+      icon: 'results',
+      title: pt('tabs.results.title'),
+      description: pt('tabs.results.description'),
+      panel: <SurveyDetailResultsTab mode={mode} resultData={resultData} pt={pt} />,
+    },
+    {
+      id: 'history',
+      label: pt('tabs.history.label'),
+      icon: 'history',
+      title: pt('tabs.history.title'),
+      description: pt('tabs.history.description'),
+      panel: <SurveyDetailHistoryTab contentId={contentId} pt={pt} />,
+    },
+  ];
+};

--- a/packages/plugin-surveys/src/surveys.editor.shared.tsx
+++ b/packages/plugin-surveys/src/surveys.editor.shared.tsx
@@ -1,21 +1,11 @@
-import React from 'react';
 import {
   fromDatetimeLocalValue,
   toDatetimeLocalValue,
   usePluginTranslation,
 } from '@sva/plugin-sdk';
-import { type StudioDetailTabDefinition } from '@sva/studio-ui-react';
-
-import { SurveyDetailBasisTab } from './surveys.detail-basis-tab.js';
-import type { SurveyTargetAreaOption } from './surveys.detail-basis-tab.js';
-import { SurveyDetailContentTab } from './surveys.detail-content-tab.js';
 import { type SurveyDetailFormValues } from './surveys.detail-form.js';
-import { SurveyDetailHistoryTab } from './surveys.detail-history-tab.js';
-import {
-  SurveyDetailModerationTab,
-  type SurveyModerationQuestionGroup,
-} from './surveys.detail-moderation-tab.js';
-import { SurveyDetailResultsTab, type SurveyResultsTabData } from './surveys.detail-results-tab.js';
+import { type SurveyModerationQuestionGroup } from './surveys.detail-moderation-tab.js';
+import { type SurveyResultsTabData } from './surveys.detail-results-tab.js';
 import type { SurveyMutationInput } from './surveys.mutation.types.js';
 import type { SurveyContentItem, SurveyLocalizedText } from './surveys.types.js';
 export type SurveyEditorMode = 'create' | 'edit';
@@ -42,17 +32,6 @@ const surveyStatusLabelKey = {
   ACTIVE: 'fields.statusOptions.active',
   ARCHIVED: 'fields.statusOptions.archived',
 } as const satisfies Record<SurveyContentItem['status'], string>;
-const deriveSurveyTargetAreaOptions = (
-  item: SurveyContentItem | null
-): SurveyTargetAreaOption[] => {
-  if (!item) {
-    return [];
-  }
-  return [...new Set(item.targetAreaIds)].map((targetAreaId) => ({
-    id: targetAreaId,
-    label: targetAreaId,
-  }));
-};
 export const mapSurveyModerationGroups = (
   item: SurveyContentItem
 ): SurveyModerationQuestionGroup[] =>
@@ -234,62 +213,3 @@ export const toSurveyMutationInput = (
 };
 export const getSurveyEditorErrorMessage = (error: unknown, fallback: string): string =>
   error instanceof Error && error.message.trim().length > 0 ? error.message : fallback;
-export const createSurveyEditorTabs = (
-  pt: ReturnType<typeof usePluginTranslation>,
-  mode: SurveyEditorMode,
-  loadedItem: SurveyContentItem | null,
-  contentId?: string
-): readonly StudioDetailTabDefinition<SurveyEditorTabId>[] => {
-  const moderationGroups = loadedItem ? mapSurveyModerationGroups(loadedItem) : [];
-  const resultData = loadedItem ? mapSurveyResultsTabData(loadedItem, pt) : null;
-  const availableTargetAreas = deriveSurveyTargetAreaOptions(loadedItem);
-  return [
-    {
-      id: 'basis',
-      label: pt('tabs.basis.label'),
-      icon: 'basis',
-      title: pt('tabs.basis.title'),
-      description: pt('tabs.basis.description'),
-      panel: (
-        <SurveyDetailBasisTab
-          mode={mode}
-          loadedItem={loadedItem}
-          availableTargetAreas={availableTargetAreas}
-          pt={pt}
-        />
-      ),
-    },
-    {
-      id: 'content',
-      label: pt('tabs.content.label'),
-      icon: 'content',
-      title: pt('tabs.content.title'),
-      description: pt('tabs.content.description'),
-      panel: <SurveyDetailContentTab pt={pt} />,
-    },
-    {
-      id: 'moderation',
-      label: pt('tabs.moderation.label'),
-      icon: 'moderation',
-      title: pt('tabs.moderation.title'),
-      description: pt('tabs.moderation.description'),
-      panel: <SurveyDetailModerationTab mode={mode} groups={moderationGroups} pt={pt} />,
-    },
-    {
-      id: 'results',
-      label: pt('tabs.results.label'),
-      icon: 'results',
-      title: pt('tabs.results.title'),
-      description: pt('tabs.results.description'),
-      panel: <SurveyDetailResultsTab mode={mode} resultData={resultData} pt={pt} />,
-    },
-    {
-      id: 'history',
-      label: pt('tabs.history.label'),
-      icon: 'history',
-      title: pt('tabs.history.title'),
-      description: pt('tabs.history.description'),
-      panel: <SurveyDetailHistoryTab contentId={contentId} pt={pt} />,
-    },
-  ];
-};

--- a/packages/plugin-surveys/src/surveys.editor.shared.tsx
+++ b/packages/plugin-surveys/src/surveys.editor.shared.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { fromDatetimeLocalValue, toDatetimeLocalValue, usePluginTranslation } from '@sva/plugin-sdk';
+import {
+  fromDatetimeLocalValue,
+  toDatetimeLocalValue,
+  usePluginTranslation,
+} from '@sva/plugin-sdk';
 import { type StudioDetailTabDefinition } from '@sva/studio-ui-react';
 
 import { SurveyDetailBasisTab } from './surveys.detail-basis-tab.js';
@@ -26,7 +30,11 @@ const resolveLocalizedText = (value: SurveyLocalizedText | undefined): string =>
       return candidate;
     }
   }
-  return Object.values(value).find((candidate) => candidate.trim().length > 0)?.trim() ?? '';
+  return (
+    Object.values(value)
+      .find((candidate) => candidate.trim().length > 0)
+      ?.trim() ?? ''
+  );
 };
 const normalizeDateInput = (value?: string): string => (value ? toDatetimeLocalValue(value) : '');
 const surveyStatusLabelKey = {
@@ -34,7 +42,9 @@ const surveyStatusLabelKey = {
   ACTIVE: 'fields.statusOptions.active',
   ARCHIVED: 'fields.statusOptions.archived',
 } as const satisfies Record<SurveyContentItem['status'], string>;
-const deriveSurveyTargetAreaOptions = (item: SurveyContentItem | null): SurveyTargetAreaOption[] => {
+const deriveSurveyTargetAreaOptions = (
+  item: SurveyContentItem | null
+): SurveyTargetAreaOption[] => {
   if (!item) {
     return [];
   }
@@ -43,11 +53,17 @@ const deriveSurveyTargetAreaOptions = (item: SurveyContentItem | null): SurveyTa
     label: targetAreaId,
   }));
 };
-export const mapSurveyModerationGroups = (item: SurveyContentItem): SurveyModerationQuestionGroup[] =>
+export const mapSurveyModerationGroups = (
+  item: SurveyContentItem
+): SurveyModerationQuestionGroup[] =>
   (item.results?.questions ?? [])
     .map((questionResult) => {
-      const matchingQuestion = item.questions.find((question) => question.id === questionResult.questionId);
-      const optionFreeTextResponses = questionResult.optionResults.flatMap((optionResult) => optionResult.freeTextResponses);
+      const matchingQuestion = item.questions.find(
+        (question) => question.id === questionResult.questionId
+      );
+      const optionFreeTextResponses = questionResult.optionResults.flatMap(
+        (optionResult) => optionResult.freeTextResponses
+      );
 
       return {
         questionId: questionResult.questionId,
@@ -69,7 +85,9 @@ export const mapSurveyResultsTabData = (
     submissionCount: item.results.submissionCount,
     questionCount: item.questionCount,
     questions: item.results.questions.map((questionResult) => {
-      const matchingQuestion = item.questions.find((question) => question.id === questionResult.questionId);
+      const matchingQuestion = item.questions.find(
+        (question) => question.id === questionResult.questionId
+      );
       return {
         questionId: questionResult.questionId,
         questionTitle: resolveLocalizedText(matchingQuestion?.title),
@@ -135,7 +153,9 @@ const buildRemovedOptionMutations = (
   question: SurveyDetailFormValues['content']['questions'][number]
 ) => {
   const loadedQuestion = findLoadedQuestion(loadedItem, question.id);
-  const currentOptionIds = new Set(question.options.flatMap((option) => (option.id ? [option.id] : [])));
+  const currentOptionIds = new Set(
+    question.options.flatMap((option) => (option.id ? [option.id] : []))
+  );
   return (
     loadedQuestion?.options
       .filter((option) => currentOptionIds.has(option.id) === false)
@@ -155,18 +175,23 @@ const buildQuestionMutation = (
   type: question.type,
   required: question.required,
   position: question.position ?? questionIndex,
-  options: [...question.options.map((option, optionIndex) => ({
-    ...(option.id ? { id: option.id } : {}),
-    title: option.title.trim(),
-    position: option.position ?? optionIndex,
-    enablesFreeText: option.enablesFreeText,
-  })), ...buildRemovedOptionMutations(loadedItem, question)],
+  options: [
+    ...question.options.map((option, optionIndex) => ({
+      ...(option.id ? { id: option.id } : {}),
+      title: option.title.trim(),
+      position: option.position ?? optionIndex,
+      enablesFreeText: option.enablesFreeText,
+    })),
+    ...buildRemovedOptionMutations(loadedItem, question),
+  ],
 });
 const buildRemovedQuestionMutations = (
   loadedItem: SurveyContentItem | null | undefined,
   questions: SurveyDetailFormValues['content']['questions']
 ) => {
-  const currentQuestionIds = new Set(questions.flatMap((question) => (question.id ? [question.id] : [])));
+  const currentQuestionIds = new Set(
+    questions.flatMap((question) => (question.id ? [question.id] : []))
+  );
   return (
     loadedItem?.questions
       .filter((question) => currentQuestionIds.has(question.id) === false)
@@ -222,6 +247,7 @@ export const createSurveyEditorTabs = (
     {
       id: 'basis',
       label: pt('tabs.basis.label'),
+      icon: 'basis',
       title: pt('tabs.basis.title'),
       description: pt('tabs.basis.description'),
       panel: (
@@ -233,10 +259,18 @@ export const createSurveyEditorTabs = (
         />
       ),
     },
-    { id: 'content', label: pt('tabs.content.label'), title: pt('tabs.content.title'), description: pt('tabs.content.description'), panel: <SurveyDetailContentTab pt={pt} /> },
+    {
+      id: 'content',
+      label: pt('tabs.content.label'),
+      icon: 'content',
+      title: pt('tabs.content.title'),
+      description: pt('tabs.content.description'),
+      panel: <SurveyDetailContentTab pt={pt} />,
+    },
     {
       id: 'moderation',
       label: pt('tabs.moderation.label'),
+      icon: 'moderation',
       title: pt('tabs.moderation.title'),
       description: pt('tabs.moderation.description'),
       panel: <SurveyDetailModerationTab mode={mode} groups={moderationGroups} pt={pt} />,
@@ -244,6 +278,7 @@ export const createSurveyEditorTabs = (
     {
       id: 'results',
       label: pt('tabs.results.label'),
+      icon: 'results',
       title: pt('tabs.results.title'),
       description: pt('tabs.results.description'),
       panel: <SurveyDetailResultsTab mode={mode} resultData={resultData} pt={pt} />,
@@ -251,6 +286,7 @@ export const createSurveyEditorTabs = (
     {
       id: 'history',
       label: pt('tabs.history.label'),
+      icon: 'history',
       title: pt('tabs.history.title'),
       description: pt('tabs.history.description'),
       panel: <SurveyDetailHistoryTab contentId={contentId} pt={pt} />,

--- a/packages/plugin-surveys/src/surveys.editor.tsx
+++ b/packages/plugin-surveys/src/surveys.editor.tsx
@@ -15,11 +15,8 @@ import {
 } from './surveys.detail-form.js';
 import { SurveyEditorActions, SurveyEditorPrimaryAction } from './surveys.editor.actions.js';
 import { useSurveyEditorController } from './surveys.editor-logic.js';
-import {
-  createSurveyEditorTabs,
-  type SurveyEditorMode,
-  type SurveyEditorTabId,
-} from './surveys.editor.shared.js';
+import { type SurveyEditorMode, type SurveyEditorTabId } from './surveys.editor.shared.js';
+import { createSurveyEditorTabs } from './surveys.editor-tabs.js';
 
 const formId = 'survey-detail-form';
 

--- a/packages/plugin-surveys/src/surveys.question-option-actions.tsx
+++ b/packages/plugin-surveys/src/surveys.question-option-actions.tsx
@@ -19,7 +19,9 @@ export function SurveyQuestionOptionActions({
 }>) {
   return (
     <div className="flex flex-col gap-3 border-b border-border/60 pb-4 sm:flex-row sm:items-center sm:justify-between">
-      <h5 className="text-sm font-semibold text-foreground">{pt('labels.optionSection', { index: optionIndex + 1 })}</h5>
+      <h5 className="text-sm font-semibold text-foreground">
+        {pt('labels.answerSection', { index: optionIndex + 1 })}
+      </h5>
       <div className="flex flex-wrap gap-2">
         <Button
           type="button"

--- a/packages/plugin-surveys/tests/surveys.editor.shared.test.ts
+++ b/packages/plugin-surveys/tests/surveys.editor.shared.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  createSurveyEditorTabs,
   getSurveyEditorErrorMessage,
   mapSurveyItemToFormValues,
   mapSurveyModerationGroups,
   mapSurveyResultsTabData,
   toSurveyMutationInput,
 } from '../src/surveys.editor.shared.js';
+import { createSurveyEditorTabs } from '../src/surveys.editor-tabs.js';
 import { reorderEntries } from '../src/surveys.question-editor.shared.js';
 import type { SurveyContentItem } from '../src/surveys.types.js';
 
@@ -86,7 +86,9 @@ const surveyItem: SurveyContentItem = {
 
 describe('survey editor shared mappings', () => {
   it('maps loaded survey results into the results tab contract', () => {
-    const result = mapSurveyResultsTabData(surveyItem, (key) => (key === 'fields.statusOptions.active' ? 'Aktiv' : key));
+    const result = mapSurveyResultsTabData(surveyItem, (key) =>
+      key === 'fields.statusOptions.active' ? 'Aktiv' : key
+    );
 
     expect(result).toEqual({
       statusLabel: 'Aktiv',
@@ -472,7 +474,9 @@ describe('survey editor shared mappings', () => {
   });
 
   it('prefers non-empty error messages from thrown errors', () => {
-    expect(getSurveyEditorErrorMessage(new Error('Echte Fehlermeldung'), 'Fallback')).toBe('Echte Fehlermeldung');
+    expect(getSurveyEditorErrorMessage(new Error('Echte Fehlermeldung'), 'Fallback')).toBe(
+      'Echte Fehlermeldung'
+    );
   });
 
   it('emits delete markers when loaded survey questions are removed entirely', () => {
@@ -491,14 +495,15 @@ describe('survey editor shared mappings', () => {
   });
 
   it('creates editor tabs with empty result data and empty target areas before the first save', () => {
-    const tabs = createSurveyEditorTabs(
-      (key) => key,
-      'create',
-      null,
-      undefined
-    );
+    const tabs = createSurveyEditorTabs((key) => key, 'create', null, undefined);
 
-    expect(tabs.map((tab) => tab.id)).toEqual(['basis', 'content', 'moderation', 'results', 'history']);
+    expect(tabs.map((tab) => tab.id)).toEqual([
+      'basis',
+      'content',
+      'moderation',
+      'results',
+      'history',
+    ]);
   });
 
   it('trims optional mutation fields, converts date values, and removes empty descriptions', () => {

--- a/packages/plugin-surveys/tests/surveys.pages.test.tsx
+++ b/packages/plugin-surveys/tests/surveys.pages.test.tsx
@@ -10,14 +10,18 @@ const createSurveyMock = vi.fn();
 const updateSurveyMock = vi.fn();
 const useParamsMock = vi.fn(() => ({ contentId: 'survey-123' }));
 
-const surveyTranslate = (key: string, variables?: Readonly<Record<string, string | number>>): string => {
+const surveyTranslate = (
+  key: string,
+  variables?: Readonly<Record<string, string | number>>
+): string => {
   const template = messages[`surveys.${key}` as keyof typeof messages] ?? key;
   if (!variables) {
     return template;
   }
 
   return Object.entries(variables).reduce(
-    (value, [variableName, variableValue]) => value.replace(`{{${variableName}}}`, String(variableValue)),
+    (value, [variableName, variableValue]) =>
+      value.replace(`{{${variableName}}}`, String(variableValue)),
     template
   );
 };
@@ -48,8 +52,10 @@ vi.mock('@sva/plugin-sdk', async () => {
 const messages = {
   'surveys.pages.createTitle': 'Umfrage anlegen',
   'surveys.pages.editTitle': 'Umfrage bearbeiten',
-  'surveys.pages.createDescription': 'Neue Umfragen folgen dem gleichen Editor-Rahmen wie bestehende Inhalte.',
-  'surveys.pages.editDescription': 'Bestehende Umfragen nutzen denselben Editor-Rahmen wie neue Umfragen.',
+  'surveys.pages.createDescription':
+    'Neue Umfragen folgen dem gleichen Editor-Rahmen wie bestehende Inhalte.',
+  'surveys.pages.editDescription':
+    'Bestehende Umfragen nutzen denselben Editor-Rahmen wie neue Umfragen.',
   'surveys.tabs.ariaLabel': 'Umfrage-Bereiche',
   'surveys.tabs.basis.label': 'Basis',
   'surveys.tabs.basis.title': 'Basis',
@@ -67,7 +73,8 @@ const messages = {
   'surveys.tabs.history.title': 'Historie',
   'surveys.tabs.history.description': 'Änderungsverlauf der Umfrage.',
   'surveys.cards.basis.title': 'Basis-Rahmen',
-  'surveys.cards.basis.description': 'Status, Laufzeit, Zielgebiet und Metadaten folgen in den nächsten Schritten.',
+  'surveys.cards.basis.description':
+    'Status, Laufzeit, Zielgebiet und Metadaten folgen in den nächsten Schritten.',
   'surveys.cards.basis.identity.title': 'Identität',
   'surveys.cards.basis.identity.description': 'Titel und Status der Umfrage.',
   'surveys.cards.basis.schedule.title': 'Laufzeit',
@@ -77,24 +84,32 @@ const messages = {
   'surveys.cards.basis.metadata.title': 'Metadaten',
   'surveys.cards.basis.metadata.description': 'Zeitliche Metadaten der Umfrage.',
   'surveys.cards.content.title': 'Inhalts-Rahmen',
-  'surveys.cards.content.description': 'Beschreibung, Hinweise und Frageneditor folgen in den nächsten Schritten.',
+  'surveys.cards.content.description':
+    'Beschreibung, Hinweise und Frageneditor folgen in den nächsten Schritten.',
   'surveys.cards.moderation.title': 'Moderations-Rahmen',
-  'surveys.cards.moderation.description': 'Freitext-Freigaben werden nach dem ersten Speichern verfügbar.',
+  'surveys.cards.moderation.description':
+    'Freitext-Freigaben werden nach dem ersten Speichern verfügbar.',
   'surveys.cards.results.title': 'Ergebnis-Rahmen',
-  'surveys.cards.results.description': 'Ergebnisse und Exporte werden nach dem ersten Speichern verfügbar.',
+  'surveys.cards.results.description':
+    'Ergebnisse und Exporte werden nach dem ersten Speichern verfügbar.',
   'surveys.cards.results.summary.title': 'Übersicht',
   'surveys.cards.results.summary.description': 'Kompakter Überblick über die laufende Umfrage.',
   'surveys.cards.history.title': 'Historien-Rahmen',
-  'surveys.cards.history.description': 'Historieneinträge werden nach dem ersten Speichern verfügbar.',
-  'surveys.messages.createPendingHint': 'Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.',
-  'surveys.messages.sectionPlaceholder': 'Die fachlichen Felder dieses Bereichs folgen in den nächsten Umsetzungsabschnitten.',
-  'surveys.messages.historyPlaceholder': 'Die Historie erscheint hier, sobald die Umfrage bereits angelegt wurde.',
+  'surveys.cards.history.description':
+    'Historieneinträge werden nach dem ersten Speichern verfügbar.',
+  'surveys.messages.createPendingHint':
+    'Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.',
+  'surveys.messages.sectionPlaceholder':
+    'Die fachlichen Felder dieses Bereichs folgen in den nächsten Umsetzungsabschnitten.',
+  'surveys.messages.historyPlaceholder':
+    'Die Historie erscheint hier, sobald die Umfrage bereits angelegt wurde.',
   'surveys.messages.editorLoading': 'Umfrage wird geladen.',
   'surveys.history.createHint': 'Die Historie wird nach dem ersten Speichern verfügbar.',
   'surveys.history.loading': 'Historie wird geladen.',
   'surveys.messages.unlimitedScheduleHint': 'Ohne Enddatum bleibt die Umfrage unbefristet.',
   'surveys.messages.targetAreasEmpty': 'Es stehen derzeit keine Zielgebiete zur Auswahl.',
-  'surveys.messages.metadataCreateHint': 'Metadaten erscheinen nach dem ersten Speichern der Umfrage.',
+  'surveys.messages.metadataCreateHint':
+    'Metadaten erscheinen nach dem ersten Speichern der Umfrage.',
   'surveys.fields.title': 'Titel',
   'surveys.fields.status': 'Status',
   'surveys.fields.startAt': 'Start',
@@ -208,6 +223,21 @@ describe('survey editor pages', () => {
     expect(scoped.getByRole('tab', { name: 'Moderation' })).toBeTruthy();
     expect(scoped.getByRole('tab', { name: 'Ergebnisse' })).toBeTruthy();
     expect(scoped.getByRole('tab', { name: 'Historie' })).toBeTruthy();
+    expect(
+      scoped.getByRole('tab', { name: 'Basis' }).querySelector('svg')?.getAttribute('aria-hidden')
+    ).toBe('true');
+    expect(
+      scoped
+        .getByRole('tab', { name: 'Moderation' })
+        .querySelector('svg')
+        ?.getAttribute('aria-hidden')
+    ).toBe('true');
+    expect(
+      scoped
+        .getByRole('tab', { name: 'Ergebnisse' })
+        .querySelector('svg')
+        ?.getAttribute('aria-hidden')
+    ).toBe('true');
     expect(scoped.getAllByRole('tablist')).toHaveLength(1);
     expect(scoped.getByRole('heading', { name: 'Identität' })).toBeTruthy();
   });
@@ -222,13 +252,17 @@ describe('survey editor pages', () => {
       scoped.getByText('Freitext-Freigaben werden nach dem ersten Speichern verfügbar.')
     ).toBeTruthy();
     expect(
-      scoped.getByText('Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.')
+      scoped.getByText(
+        'Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.'
+      )
     ).toBeTruthy();
 
     fireEvent.change(tabSelect, { target: { value: 'results' } });
     expect(scoped.getByText('Kompakter Überblick über die laufende Umfrage.')).toBeTruthy();
     expect(
-      scoped.getAllByText('Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.').length
+      scoped.getAllByText(
+        'Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.'
+      ).length
     ).toBeGreaterThan(0);
 
     fireEvent.change(tabSelect, { target: { value: 'history' } });
@@ -262,7 +296,9 @@ describe('survey editor pages', () => {
       expect(scoped.getByRole('tab', { name: 'Basis' })).toBeTruthy();
       expect(scoped.getByRole('tab', { name: 'Historie' })).toBeTruthy();
       expect(
-        scoped.queryByText('Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.')
+        scoped.queryByText(
+          'Dieser Bereich ist bereits sichtbar, wird aber erst nach dem ersten Speichern mit Daten gefüllt.'
+        )
       ).toBeNull();
     })();
   });
@@ -286,5 +322,4 @@ describe('survey editor pages', () => {
     expect(scoped.getByText('Umfrage wird geladen.')).toBeTruthy();
     expect(getSurveyMock).toHaveBeenCalledWith('survey-legacy-123');
   });
-
 });

--- a/packages/studio-ui-react/src/index.ts
+++ b/packages/studio-ui-react/src/index.ts
@@ -111,6 +111,7 @@ export {
   type StudioResourceHeaderProps,
   type StudioSectionProps,
 } from './studio-surfaces.js';
+export { StudioDetailTabIcon, type StudioDetailTabIconName } from './studio-detail-tab-icon.js';
 export {
   StudioDetailTabs,
   type StudioDetailTab,

--- a/packages/studio-ui-react/src/studio-detail-tab-icon.tsx
+++ b/packages/studio-ui-react/src/studio-detail-tab-icon.tsx
@@ -1,0 +1,31 @@
+import {
+  ChartColumn,
+  FileText,
+  History,
+  Images,
+  ShieldCheck,
+  SlidersHorizontal,
+} from 'lucide-react';
+
+import { cn } from './utils.js';
+
+export type StudioDetailTabIconName =
+  'basis' | 'content' | 'settings' | 'moderation' | 'results' | 'history';
+
+const studioDetailTabIcons = {
+  basis: FileText,
+  content: Images,
+  settings: SlidersHorizontal,
+  moderation: ShieldCheck,
+  results: ChartColumn,
+  history: History,
+} as const satisfies Record<StudioDetailTabIconName, typeof FileText>;
+
+export function StudioDetailTabIcon({
+  name,
+  className,
+}: Readonly<{ name: StudioDetailTabIconName; className?: string }>) {
+  const Icon = studioDetailTabIcons[name];
+
+  return <Icon aria-hidden="true" className={cn('h-4 w-4 shrink-0', className)} />;
+}

--- a/packages/studio-ui-react/src/studio-detail-tabs.test.tsx
+++ b/packages/studio-ui-react/src/studio-detail-tabs.test.tsx
@@ -31,6 +31,19 @@ describe('StudioDetailTabs', () => {
     expect(screen.getByText('Inhalte Panel')).toBeTruthy();
   });
 
+  it('renders a decorative icon without changing the accessible tab label', () => {
+    render(
+      <StudioDetailTabs
+        ariaLabel="Detailbereiche"
+        tabs={[{ id: 'base', label: 'Basis', icon: 'basis', panel: <p>Basis Panel</p> }]}
+      />
+    );
+
+    const tab = screen.getByRole('tab', { name: 'Basis' });
+    expect(tab.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+    expect(screen.getByRole('option').getAttribute('label')).toBe('Basis');
+  });
+
   it('supports keyboard-only tab switching and moves focus to the selected trigger', () => {
     render(
       <StudioDetailTabs
@@ -153,7 +166,9 @@ describe('StudioDetailTabs', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), { target: { value: 'history' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), {
+      target: { value: 'history' },
+    });
 
     expect(screen.getByText('Basis Panel')).toBeTruthy();
     expect(screen.getByText('Historie Panel')).toBeTruthy();
@@ -170,7 +185,9 @@ describe('StudioDetailTabs', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), { target: { value: 'history' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), {
+      target: { value: 'history' },
+    });
 
     expect(screen.queryByText('Basis Panel')).toBeNull();
     expect(screen.getByText('Historie Panel')).toBeTruthy();
@@ -220,8 +237,12 @@ describe('StudioDetailTabs', () => {
     expect(screen.getByRole('tablist').className).toContain('ml-[10px]');
     expect(screen.getByRole('tablist').className).toContain('gap-10');
     expect(screen.getByRole('heading', { name: 'Freigabe' }).className).toContain('text-base');
-    expect(screen.getByText('Steuert den Veröffentlichungsstatus.').className).toContain('leading-relaxed');
-    expect(screen.getByRole('tabpanel').firstElementChild?.className).toContain('bg-[rgb(var(--waste-panel-surface))]');
+    expect(screen.getByText('Steuert den Veröffentlichungsstatus.').className).toContain(
+      'leading-relaxed'
+    );
+    expect(screen.getByRole('tabpanel').firstElementChild?.className).toContain(
+      'bg-[rgb(var(--waste-panel-surface))]'
+    );
   });
 
   it('announces blocked tab switches through an accessible status surface', () => {
@@ -236,7 +257,9 @@ describe('StudioDetailTabs', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), { target: { value: 'content' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), {
+      target: { value: 'content' },
+    });
 
     const status = screen.getByRole('status');
     expect(status.getAttribute('aria-live')).toBe('polite');
@@ -259,7 +282,9 @@ describe('StudioDetailTabs', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), { target: { value: 'history' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), {
+      target: { value: 'history' },
+    });
 
     expect(onValueChange).toHaveBeenCalledWith('history');
     expect(screen.getByRole('tab', { name: 'Basis' }).getAttribute('data-state')).toBe('active');
@@ -295,7 +320,9 @@ describe('StudioDetailTabs', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), { target: { value: 'history' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), {
+      target: { value: 'history' },
+    });
 
     expect(onValueChange).toHaveBeenCalledTimes(1);
     expect(onValueChange).toHaveBeenCalledWith('history');
@@ -315,7 +342,9 @@ describe('StudioDetailTabs', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), { target: { value: 'history' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), {
+      target: { value: 'history' },
+    });
 
     expect(onValueChange).not.toHaveBeenCalled();
     expect(screen.getByRole('tab', { name: 'Basis' }).getAttribute('data-state')).toBe('active');
@@ -356,9 +385,13 @@ describe('StudioDetailTabs', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), { target: { value: 'history' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Detailbereiche' }), {
+      target: { value: 'history' },
+    });
 
-    expect(screen.getByRole('status').textContent).toContain('Save changes before leaving this tab.');
+    expect(screen.getByRole('status').textContent).toContain(
+      'Save changes before leaving this tab.'
+    );
     expect(screen.getByRole('tab', { name: 'Basis' }).getAttribute('data-state')).toBe('active');
     expect(screen.queryByText('Historie Panel')).toBeNull();
   });

--- a/packages/studio-ui-react/src/studio-detail-tabs.tsx
+++ b/packages/studio-ui-react/src/studio-detail-tabs.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { StudioDetailTabIcon, type StudioDetailTabIconName } from './studio-detail-tab-icon.js';
 import { Tabs } from './tabs.js';
 import { cn } from './utils.js';
 import {
@@ -12,6 +13,7 @@ import {
 export type StudioDetailTabDefinition<TTabId extends string> = Readonly<{
   id: TTabId;
   label: string;
+  icon?: StudioDetailTabIconName;
   title?: React.ReactNode;
   description?: string;
   isVisible?: boolean;
@@ -38,8 +40,7 @@ type StudioDetailTabLegacy<TTabId extends string> = Readonly<{
 }>;
 
 export type StudioDetailTab<TTabId extends string = string> =
-  | StudioDetailTabDefinition<TTabId>
-  | StudioDetailTabLegacy<TTabId>;
+  StudioDetailTabDefinition<TTabId> | StudioDetailTabLegacy<TTabId>;
 
 export type StudioDetailTabsProps<TTabId extends string = string> = Readonly<{
   ariaLabel: string;
@@ -48,7 +49,9 @@ export type StudioDetailTabsProps<TTabId extends string = string> = Readonly<{
   defaultValue?: TTabId;
   value?: TTabId;
   onValueChange?: (value: TTabId) => void;
-  onBeforeTabChange?: (context: Readonly<{ currentValue: TTabId; nextValue: TTabId }>) => boolean | string | void;
+  onBeforeTabChange?: (
+    context: Readonly<{ currentValue: TTabId; nextValue: TTabId }>
+  ) => boolean | string | void;
   blockedTabChangeMessage?: string;
   keepMounted?: boolean;
   status?: React.ReactNode;
@@ -56,7 +59,9 @@ export type StudioDetailTabsProps<TTabId extends string = string> = Readonly<{
   className?: string;
 }>;
 
-function isLegacyTab<TTabId extends string>(tab: StudioDetailTab<TTabId>): tab is StudioDetailTabLegacy<TTabId> {
+function isLegacyTab<TTabId extends string>(
+  tab: StudioDetailTab<TTabId>
+): tab is StudioDetailTabLegacy<TTabId> {
   return 'content' in tab;
 }
 
@@ -96,14 +101,14 @@ function getMobileOptionLabel<TTabId extends string>(tab: StudioDetailTab<TTabId
 
 function renderTabLabel<TTabId extends string>(tab: StudioDetailTab<TTabId>) {
   const changeLabel = getChangeLabel(tab);
+  const icon = !isLegacyTab(tab) ? tab.icon : undefined;
 
   return (
     <span className="inline-flex flex-wrap items-center gap-2">
+      {icon ? <StudioDetailTabIcon name={icon} /> : null}
       <span>{tab.label}</span>
       {tabHasChanges(tab) && changeLabel ? (
-        <span className="text-xs font-medium text-foreground">
-          {changeLabel}
-        </span>
+        <span className="text-xs font-medium text-foreground">{changeLabel}</span>
       ) : null}
     </span>
   );
@@ -125,9 +130,13 @@ export function StudioDetailTabs<TTabId extends string = string>({
 }: StudioDetailTabsProps<TTabId>) {
   const visibleTabs = React.useMemo(() => tabs.filter(isTabVisible), [tabs]);
   const firstTabId = visibleTabs[0]?.id;
-  const [internalValue, setInternalValue] = React.useState<TTabId | undefined>(defaultValue ?? firstTabId);
+  const [internalValue, setInternalValue] = React.useState<TTabId | undefined>(
+    defaultValue ?? firstTabId
+  );
   const requestedValue = value ?? internalValue ?? defaultValue ?? firstTabId;
-  const currentValue = visibleTabs.some((tab) => tab.id === requestedValue) ? requestedValue : firstTabId;
+  const currentValue = visibleTabs.some((tab) => tab.id === requestedValue)
+    ? requestedValue
+    : firstTabId;
   const [statusMessage, setStatusMessage] = React.useState<string>();
   const [visitedTabs, setVisitedTabs] = React.useState<ReadonlySet<TTabId>>(
     () => new Set(currentValue ? [currentValue] : [])
@@ -167,7 +176,9 @@ export function StudioDetailTabs<TTabId extends string = string>({
       });
 
       if (switchGuardResult === false || typeof switchGuardResult === 'string') {
-        setStatusMessage(typeof switchGuardResult === 'string' ? switchGuardResult : blockedTabChangeMessage);
+        setStatusMessage(
+          typeof switchGuardResult === 'string' ? switchGuardResult : blockedTabChangeMessage
+        );
         return;
       }
 
@@ -181,7 +192,11 @@ export function StudioDetailTabs<TTabId extends string = string>({
   );
 
   return (
-    <Tabs value={currentValue} onValueChange={handleValueChange} className={cn('space-y-0', className)}>
+    <Tabs
+      value={currentValue}
+      onValueChange={handleValueChange}
+      className={cn('space-y-0', className)}
+    >
       <StudioDetailTabsMobileSelect
         mobileSelectLabel={mobileSelectLabel}
         currentValue={currentValue}
@@ -195,7 +210,11 @@ export function StudioDetailTabs<TTabId extends string = string>({
         renderTabLabel={renderTabLabel}
         onChange={handleValueChange}
       />
-      <StudioDetailTabsStatus status={status} statusMessage={statusMessage} statusAriaLive={statusAriaLive} />
+      <StudioDetailTabsStatus
+        status={status}
+        statusMessage={statusMessage}
+        statusAriaLive={statusAriaLive}
+      />
 
       {visibleTabs.map((tab) => {
         const title = getTabTitle(tab);

--- a/scripts/ci/check-i18n-keys.test.ts
+++ b/scripts/ci/check-i18n-keys.test.ts
@@ -9,6 +9,9 @@ import {
 describe('check-i18n-keys', () => {
   it('scans app and plugin ui source roots', () => {
     expect(SOURCE_ROOTS).toContain('apps/sva-studio-react/src');
+    expect(SOURCE_ROOTS).toContain('packages/plugin-generic-items/src');
+    expect(SOURCE_ROOTS).toContain('packages/plugin-cockpit-cards/src');
+    expect(SOURCE_ROOTS).toContain('packages/plugin-surveys/src');
     expect(SOURCE_ROOTS).toContain('packages/plugin-waste-management/src');
   });
 
@@ -17,7 +20,10 @@ describe('check-i18n-keys', () => {
 
     expect(keys.has('news.navigation.title')).toBe(true);
     expect(keys.has('events.navigation.title')).toBe(true);
+    expect(keys.has('genericItems.editor.createTitle')).toBe(true);
+    expect(keys.has('cockpit-cards.editor.createTitle')).toBe(true);
     expect(keys.has('poi.navigation.title')).toBe(true);
+    expect(keys.has('surveys.pages.createTitle')).toBe(true);
     expect(keys.has('wasteManagement.page.title')).toBe(true);
   });
 

--- a/scripts/ci/check-i18n-keys.ts
+++ b/scripts/ci/check-i18n-keys.ts
@@ -3,10 +3,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { DEFAULT_LOCALE, i18nResources } from '../../apps/sva-studio-react/src/i18n/resources';
+import { pluginCockpitCardsTranslations } from '../../packages/plugin-cockpit-cards/src/plugin.translations';
 import { pluginEventsTranslations } from '../../packages/plugin-events/src/plugin.translations';
 import { pluginFaqTranslations } from '../../packages/plugin-faq/src/plugin.translations';
+import { pluginGenericItemsTranslations } from '../../packages/plugin-generic-items/src/plugin.translations';
 import { pluginNewsTranslations } from '../../packages/plugin-news/src/plugin.translations';
 import { pluginPoiTranslations } from '../../packages/plugin-poi/src/plugin.translations';
+import { pluginSurveysTranslations } from '../../packages/plugin-surveys/src/plugin.translations';
 import { wasteManagementPluginTranslations } from '../../packages/plugin-waste-management/src/plugin.translations';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -19,7 +22,10 @@ export const SOURCE_ROOTS = [
   'packages/plugin-news/src',
   'packages/plugin-events/src',
   'packages/plugin-faq/src',
+  'packages/plugin-generic-items/src',
+  'packages/plugin-cockpit-cards/src',
   'packages/plugin-poi/src',
+  'packages/plugin-surveys/src',
   'packages/plugin-waste-management/src',
 ] as const;
 
@@ -28,7 +34,10 @@ const SOURCE_ROOT_CONFIGS = [
   { relativeRoot: 'packages/plugin-news/src', namespace: 'news' },
   { relativeRoot: 'packages/plugin-events/src', namespace: 'events' },
   { relativeRoot: 'packages/plugin-faq/src', namespace: 'faq' },
+  { relativeRoot: 'packages/plugin-generic-items/src', namespace: 'genericItems' },
+  { relativeRoot: 'packages/plugin-cockpit-cards/src', namespace: 'cockpit-cards' },
   { relativeRoot: 'packages/plugin-poi/src', namespace: 'poi' },
+  { relativeRoot: 'packages/plugin-surveys/src', namespace: 'surveys' },
   { relativeRoot: 'packages/plugin-waste-management/src', namespace: 'wasteManagement' },
 ] as const;
 
@@ -36,7 +45,10 @@ const pluginTranslationResources = [
   pluginNewsTranslations,
   pluginEventsTranslations,
   pluginFaqTranslations,
+  pluginGenericItemsTranslations,
+  pluginCockpitCardsTranslations,
   pluginPoiTranslations,
+  pluginSurveysTranslations,
   wasteManagementPluginTranslations,
 ] as const;
 
@@ -70,7 +82,10 @@ const flattenTranslationKeys = (input: TranslationNode, prefix = ''): string[] =
 
 const isTestSourceFile = (fileName: string): boolean => /\.(?:test|spec)\.[jt]sx?$/u.test(fileName);
 
-const collectSourceFiles = async (directory: string, namespace: string | null): Promise<SourceFileContext[]> => {
+const collectSourceFiles = async (
+  directory: string,
+  namespace: string | null
+): Promise<SourceFileContext[]> => {
   const entries = await readdir(directory, { withFileTypes: true });
   const files: SourceFileContext[] = [];
 
@@ -145,7 +160,10 @@ const collectUsedTranslationKeys = async (
 
 const ensureLocaleParity = (): string[] => {
   const localeKeys = Object.fromEntries(
-    Object.entries(i18nResources).map(([locale, translations]) => [locale, new Set(flattenTranslationKeys(translations))])
+    Object.entries(i18nResources).map(([locale, translations]) => [
+      locale,
+      new Set(flattenTranslationKeys(translations)),
+    ])
   ) as Record<string, Set<string>>;
 
   const referenceKeys = localeKeys[DEFAULT_LOCALE];
@@ -164,11 +182,15 @@ const ensureLocaleParity = (): string[] => {
     const extraInLocale = [...keys].filter((key) => !referenceKeys.has(key));
 
     if (missingInLocale.length > 0) {
-      problems.push(`Locale '${locale}' fehlen ${missingInLocale.length} Keys: ${missingInLocale.join(', ')}`);
+      problems.push(
+        `Locale '${locale}' fehlen ${missingInLocale.length} Keys: ${missingInLocale.join(', ')}`
+      );
     }
 
     if (extraInLocale.length > 0) {
-      problems.push(`Locale '${locale}' hat ${extraInLocale.length} unbekannte Keys: ${extraInLocale.join(', ')}`);
+      problems.push(
+        `Locale '${locale}' hat ${extraInLocale.length} unbekannte Keys: ${extraInLocale.join(', ')}`
+      );
     }
   }
 
@@ -191,7 +213,9 @@ const run = async (): Promise<void> => {
   const parityProblems = ensureLocaleParity();
 
   const fileGroups = await Promise.all(
-    SOURCE_ROOT_CONFIGS.map(({ relativeRoot, namespace }) => collectSourceFiles(resolveSourceRoot(relativeRoot), namespace))
+    SOURCE_ROOT_CONFIGS.map(({ relativeRoot, namespace }) =>
+      collectSourceFiles(resolveSourceRoot(relativeRoot), namespace)
+    )
   );
   const files = fileGroups.flat();
   const usedByFile = await collectUsedTranslationKeys(files);
@@ -228,7 +252,9 @@ const run = async (): Promise<void> => {
   }
 
   const usedKeyCount = [...usedByFile.values()].reduce((acc, current) => acc + current.size, 0);
-  console.info(`i18n-Key-Check erfolgreich (${usedKeyCount} verwendete Keys, ${availableKeys.size} definierte Keys).`);
+  console.info(
+    `i18n-Key-Check erfolgreich (${usedKeyCount} verwendete Keys, ${availableKeys.size} definierte Keys).`
+  );
 };
 
 void run().catch((error: unknown) => {


### PR DESCRIPTION
## Was wurde geändert?

- Vereinheitlicht Breadcrumbs für Anlegen- und Bearbeiten-Seiten von generischen Inhalten, FAQ, Cockpit Cards und Umfragen.
- Ergänzt konsistente, dekorative Tab-Icons für GenericItems, FAQ, Cockpit Cards, POI und Umfragen.
- Richtet Tabs und Tabpanels bei GenericItems und Cockpit Cards wie in den etablierten News-/Events-Editoren aus.
- Zeigt das Änderungsdatum als sortierbare Spalte in der Inhaltsübersicht und einen lokalisierten Fallback für fehlende Werte.

## Warum?

Mehrere Standard-Content-Editoren wichen strukturell voneinander ab: Breadcrumbs fehlten, Tab-Symbole waren uneinheitlich und Panels hatten abweichende Abstände. Zusätzlich fehlte das Änderungsdatum in der gemeinsamen Inhaltsübersicht.

## Auswirkungen

Die Navigation und Detailbereiche der Content-Editoren sind konsistenter. Die fachliche Formular-, Persistenz- und Mounting-Logik bleibt unverändert.

## Validierung

- Unit-Suiten: `studio-ui-react`, `plugin-generic-items`, `plugin-faq`, `plugin-cockpit-cards`, `plugin-poi`, `plugin-surveys`
- `sva-studio-react:test:unit:hooks` für Breadcrumbs
- `sva-studio-react:test:unit:routes` für die Inhaltsliste
- Type-Gates für alle betroffenen sieben Projekte
- Lint für alle betroffenen sieben Projekte (keine Fehler; bestehende Warnungen)
- `pnpm check:file-placement`
- `git diff --check`