### PR TITLE
fix(deps): repair merged lockfile snapshots

### DIFF
--- a/docs/changelog/entries/pr-910.json
+++ b/docs/changelog/entries/pr-910.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 910,
+  "body": "Stabilere Abhängigkeitsinstallation\n\n- Die nach mehreren Abhängigkeitsaktualisierungen inkonsistente Sperrdatei wurde repariert.\n- Builds können die festgeschriebenen Abhängigkeiten dadurch wieder zuverlässig und reproduzierbar installieren."
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1121,7 +1121,7 @@ importers:
         version: 29.1.1
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6(bufferutil@4.1.0))(jsdom@29.1.1)(msw@2.15.0(@types/node@25.9.1)(typescript@6.0.3))(vite@8.2.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6(bufferutil@4.1.0))(jsdom@29.1.1)(msw@2.15.0(@types/node@25.9.1)(typescript@7.0.2))(vite@8.2.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/plugin-sdk:
     dependencies:
@@ -13792,7 +13792,7 @@ snapshots:
       file-type: 22.0.1
       graphile-worker: 0.16.6(typescript@7.0.2)
       ioredis: 5.11.1
-      jose: 6.2.3
+      jose: 6.2.7
       openid-client: 6.8.4
       pg: 8.22.0
       postcss: 8.5.18


### PR DESCRIPTION
## Zusammenfassung

- repariert den nach dem Merge von #843 inkonsistenten `jose`-Snapshot
- gleicht die bereits veraltete Vitest/MSW-TypeScript-Peer-Auflösung ab
- stellt `pnpm install --frozen-lockfile` auf `main` wieder her

## Ursache

Der Dependabot-Diff aktualisierte den direkten `jose`-Import, ließ aber einen zweiten Workspace-Snapshot auf `jose@6.2.3`, während dessen Package-Eintrag entfernt wurde.

## Validierung

- `pnpm install --lockfile-only --fix-lockfile`
- `pnpm install --frozen-lockfile`
- `git diff --check`