### PR TITLE
fix(studio): bind dark variants to theme mode

### DIFF
--- a/apps/sva-studio-react/src/components/styles-foundation.test.ts
+++ b/apps/sva-studio-react/src/components/styles-foundation.test.ts
@@ -21,6 +21,10 @@ function resolveStylesPath(): string {
 const stylesSource = readFileSync(resolveStylesPath(), 'utf8');
 
 describe('styles foundation tokens', () => {
+  it('binds Tailwind dark variants to the Studio theme class', () => {
+    expect(stylesSource).toContain('@custom-variant dark (&:where(.dark, .dark *));');
+  });
+
   it('maps the default shell action tokens to a KERN-blue palette', () => {
     expect(stylesSource).toContain('--primary: 0 90 158;');
     expect(stylesSource).toContain('--ring: 0 90 158;');

--- a/apps/sva-studio-react/src/styles.css
+++ b/apps/sva-studio-react/src/styles.css
@@ -1,6 +1,7 @@
 @import "@kern-ux/native/dist/fonts/fira-sans.css";
 @import "tailwindcss";
 @source "../../../packages";
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
   --color-border: rgb(var(--border));

--- a/docs/changelog/entries/pr-914.json
+++ b/docs/changelog/entries/pr-914.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 914,
+  "body": "Korrigierte Darstellung im Nacht-Modus\n\n- Farbflächen und Verläufe folgen nun zuverlässig dem im Studio ausgewählten Darstellungsmodus.\n- Die Darstellung ist damit unabhängig von einer abweichenden Betriebssystemeinstellung."
+}

--- a/docs/development/ui-shell-theming.md
+++ b/docs/development/ui-shell-theming.md
@@ -15,6 +15,7 @@ Die Layout-Shell von `apps/sva-studio-react` verwendet semantische Design-Tokens
 - Shell-nahe Komponenten verwenden bevorzugt semantische Klassen wie `bg-background`, `text-foreground`, `bg-card`, `bg-sidebar`, `border-border` und `text-muted-foreground`.
 - Direkte Farbcodes oder projektspezifische Tailwind-Farben wie `slate-*` oder `emerald-*` sollen in neuen Shell-Komponenten nicht mehr verwendet werden.
 - Theme-Auswahl erfolgt zentral über `ThemeProvider` und `src/lib/theme.ts`.
+- Tailwind-Varianten mit `dark:` werden in `src/styles.css` explizit an die vom `ThemeProvider` gesetzte `.dark`-Klasse gebunden. Sie dürfen nicht vom Betriebssystem-Media-Query abweichen.
 - `instanceId` bestimmt optional die Theme-Variante; unbekannte Werte fallen auf `sva-default` zurück.
 - Light-/Dark-Mode bleibt ein separater Modus und darf nicht über Theme-Namen kodiert werden.
 - Ohne gespeicherte Studio-Auswahl fällt der Light-/Dark-Mode auf den Studio-Default `light` zurück, nicht auf Browser- oder Betriebssystem-Präferenzen.


### PR DESCRIPTION
## Änderung

- bindet Tailwind-`dark:`-Varianten explizit an die vom Studio gesetzte `.dark`-Klasse
- ergänzt einen Regressionstest für die Theme-Grundlage
- dokumentiert die Kopplung zwischen `ThemeProvider` und Tailwind

## Ursache

Tailwind v4 erzeugte `dark:` standardmäßig anhand von `prefers-color-scheme`. Das Studio steuert den Modus dagegen über die `.dark`-Klasse und `data-theme-mode`. Dadurch konnten Betriebssystempräferenz und ausgewählter Studio-Modus auseinanderlaufen; unter anderem blieb der Hero-Gradient im falschen Farbschema.

## Auswirkung

Alle vorhandenen `dark:`-Utilities folgen nun zuverlässig dem im Studio ausgewählten Light-/Dark-Modus.

## Validierung

- `pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/styles-foundation.test.ts`
- fokussierter Studio-Produktionsbuild mit `pnpm exec vite build`
- erzeugtes CSS enthält `:where(.dark,.dark *)` statt eines Dark-Mode-Media-Queries

Der breite Nx-Build wurde vor dem Studio-Target durch die umgebungsabhängige, nicht betroffene Dependency `public-waste-calendar-web:build` mit `public_waste_config_invalid` gestoppt.