### PR TITLE
fix(projects): use FeaturedProject generic type

### DIFF
--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -2388,6 +2388,50 @@ describe('content list projection', () => {
     );
   });
 
+  it('includes featured projects in the generic-item projection', async () => {
+    state.listSvaMainserverGenericItems.mockResolvedValue({
+      data: [
+        {
+          id: 'featured-project-1',
+          title: 'Featured Project',
+          contentType: 'generic-items.generic-item',
+          genericType: 'FeaturedProject',
+          teaser: null,
+          keywords: [],
+          payload: {},
+          categories: [],
+          contacts: [],
+          webUrls: [],
+          addresses: [],
+          contentBlocks: [],
+          openingHours: [],
+          mediaContents: [],
+          locations: [],
+          dates: [],
+          accessibilityInformations: [],
+          priceInformations: [],
+          visible: true,
+          author: null,
+          createdAt: '2026-08-04T10:00:00.000Z',
+          updatedAt: '2026-08-04T11:00:00.000Z',
+        },
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false },
+    });
+
+    await refreshProjectedContents(ctx, {
+      visibleTypes: ['generic-items.generic-item'],
+      force: true,
+    });
+
+    expect(projectionRows).toEqual([
+      expect.objectContaining({
+        content_type: 'generic-items.generic-item',
+        source_entity_id: 'featured-project-1',
+      }),
+    ]);
+  });
+
   it('upserts only the latest loaded page during progressive batch refreshes', async () => {
     state.listSvaMainserverEvents
       .mockResolvedValueOnce({

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -1640,7 +1640,7 @@ const mainserverProjectionPageLoaders: Record<
               (item) =>
                 item.genericType !== 'FAQ' &&
                 item.genericType !== 'COCKPIT_CARD' &&
-                item.genericType !== 'PROJECT'
+                item.genericType !== 'FeaturedProject'
             ),
           },
           pagingResult: result,

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -1639,8 +1639,7 @@ const mainserverProjectionPageLoaders: Record<
             data: result.data.filter(
               (item) =>
                 item.genericType !== 'FAQ' &&
-                item.genericType !== 'COCKPIT_CARD' &&
-                item.genericType !== 'FeaturedProject'
+                item.genericType !== 'COCKPIT_CARD'
             ),
           },
           pagingResult: result,

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -78,7 +78,7 @@ Abhängigkeiten des aktuellen Systems.
 - dedizierte Integrationsschicht für OAuth2, GraphQL-Transport, Fehlerabbildung und Fachadapter
 - trennt client-sichere Typen von serverseitigen Delegations- und Diagnostikfunktionen
 - exportiert die kanonischen serverseitigen Host-Verträge für Mainserver-News, -Events, -POI und die Schnittstellenverwaltung; `apps/sva-studio-react` hält dafür nur dünne Request- und TanStack-Adapter
-- kapselt Featured Projects als Mainserver-`GenericItem` mit `genericType: "PROJECT"`; der lokale `iam.contents`-Core bleibt für Lifecycle und Autorenschaft führend und wird über `iam.external_content_references` eindeutig an die externe Entität gebunden
+- kapselt Featured Projects als Mainserver-`GenericItem` mit `genericType: "FeaturedProject"`; der lokale `iam.contents`-Core bleibt für Lifecycle und Autorenschaft führend und wird über `iam.external_content_references` eindeutig an die externe Entität gebunden
 - kapselt zusätzlich den getypten Schreibpfad für Mainserver-Static-Content wie `wasteTypes` über `createOrUpdateStaticContent`, ohne Browser- oder Plugin-Code direkt an GraphQL zu koppeln
 - liest seine instanzbezogene Endpunktkonfiguration nicht mehr aus einer Mainserver-Spezialtabelle, sondern aus der zentralen External-Interface-Registry
 - hält `src/server/service.ts` bewusst als schlanke Fassade; Credentials, Token, GraphQL-Transport, Sichtbarkeits-Pagination, Mapper und ressourcenspezifische Operationen liegen in getrennten internen Modulen unter `src/server/service-internals/`

--- a/docs/changelog/entries/pr-916.json
+++ b/docs/changelog/entries/pr-916.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 916,
-  "body": "Featured Projects wieder zuverlässig verfügbar\n\n- Das Studio erkennt und speichert Featured Projects jetzt mit dem korrekten Inhaltstyp.\n- Vorhandene Featured Projects erscheinen dadurch wieder in den Projektlisten und lassen sich zuverlässig bearbeiten."
+  "body": "Featured Projects wieder zuverlässig verfügbar\n\n- Das Studio erkennt und speichert Featured Projects jetzt mit der korrekten technischen Typkennung.\n- Vorhandene Featured Projects erscheinen dadurch wieder in den Projektlisten und lassen sich zuverlässig bearbeiten."
 }

--- a/docs/changelog/entries/pr-916.json
+++ b/docs/changelog/entries/pr-916.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 916,
+  "body": "Featured Projects wieder zuverlässig verfügbar\n\n- Das Studio erkennt und speichert Featured Projects jetzt mit dem korrekten Inhaltstyp.\n- Vorhandene Featured Projects erscheinen dadurch wieder in den Projektlisten und lassen sich zuverlässig bearbeiten."
+}

--- a/docs/guides/featured-projects.md
+++ b/docs/guides/featured-projects.md
@@ -1,6 +1,6 @@
 # Featured Projects verwalten
 
-Featured Projects sind hervorgehobene Projektinhalte im Studio. Sie werden fachlich als `projects.project` geführt und im SVA-Mainserver als `GenericItem` mit `genericType: "PROJECT"` gespeichert.
+Featured Projects sind hervorgehobene Projektinhalte im Studio. Sie werden fachlich als `projects.project` geführt und im SVA-Mainserver als `GenericItem` mit `genericType: "FeaturedProject"` gespeichert.
 
 ## Berechtigungen und Einstieg
 

--- a/openspec/changes/update-featured-project-generic-type/proposal.md
+++ b/openspec/changes/update-featured-project-generic-type/proposal.md
@@ -1,0 +1,17 @@
+# Change: GenericType für Featured Projects korrigieren
+
+## Why
+
+Die vorhandenen Featured-Project-Datensätze sind im Mainserver mit `genericType: "FeaturedProject"` gekennzeichnet. Das Studio verwendet derzeit abweichend `PROJECT` und kann diese Datensätze deshalb weder zuverlässig lesen noch korrekt fortschreiben.
+
+## What Changes
+
+- **BREAKING**: Projekte-Routen lesen und schreiben ausschließlich GenericItems mit `genericType: "FeaturedProject"`.
+- Der bisherige Diskriminator `PROJECT` wird ohne Übergangs- oder Fallback-Verhalten entfernt.
+- Inhaltsprojektion, Tests und Dokumentation werden auf den korrigierten Diskriminator abgestimmt.
+
+## Impact
+
+- Affected specs: `content-management`, `sva-mainserver-integration`
+- Affected code: `packages/plugin-projects`, `packages/sva-mainserver`, `apps/sva-studio-react`
+- Affected arc42 sections: `docs/architecture/05-building-block-view.md`

--- a/openspec/changes/update-featured-project-generic-type/proposal.md
+++ b/openspec/changes/update-featured-project-generic-type/proposal.md
@@ -8,7 +8,7 @@ Die vorhandenen Featured-Project-Datensätze sind im Mainserver mit `genericType
 
 - **BREAKING**: Projekte-Routen lesen und schreiben ausschließlich GenericItems mit `genericType: "FeaturedProject"`.
 - Der bisherige Diskriminator `PROJECT` wird ohne Übergangs- oder Fallback-Verhalten entfernt.
-- Inhaltsprojektion, Tests und Dokumentation werden auf den korrigierten Diskriminator abgestimmt.
+- Fachliche und generische Inhaltsprojektion, Tests und Dokumentation werden auf den korrigierten Diskriminator und den technischen GenericItems-Vollzugriff abgestimmt.
 
 ## Impact
 

--- a/openspec/changes/update-featured-project-generic-type/specs/content-management/spec.md
+++ b/openspec/changes/update-featured-project-generic-type/specs/content-management/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Featured Projects sind eigenständige GenericItem-Fachinhalte
+
+Das System MUST Featured Projects als eigenständigen Content-Type `projects.project` bereitstellen und als GenericItem mit `genericType` gleich `FeaturedProject` speichern. Die gemeinsame Inhaltsübersicht MUST diese Datensätze ausschließlich als `projects.project` darstellen. Der frühere Diskriminator `PROJECT` MUST nicht als Featured Project behandelt werden.
+
+#### Scenario: Featured Project wird angelegt
+
+- **WHEN** ein Benutzer mit `projects.create` ein Featured Project anlegt
+- **THEN** zeigt das System ausschließlich die fachlich erlaubten Felder
+- **AND** speichert den Datensatz mit `genericType` gleich `FeaturedProject`
+- **AND** projiziert ihn als `projects.project`
+
+#### Scenario: Featured Project erscheint nicht doppelt
+
+- **GIVEN** ein GenericItem mit `genericType` gleich `FeaturedProject`
+- **WHEN** die Inhaltsprojektion aktualisiert wird
+- **THEN** erscheint es als `projects.project`
+- **AND** nicht zusätzlich als `generic-items.generic-item`
+
+#### Scenario: Alter Diskriminator wird nicht übernommen
+
+- **GIVEN** ein GenericItem mit `genericType` gleich `PROJECT`
+- **WHEN** die Inhaltsprojektion aktualisiert wird
+- **THEN** behandelt das System es nicht als Featured Project

--- a/openspec/changes/update-featured-project-generic-type/specs/content-management/spec.md
+++ b/openspec/changes/update-featured-project-generic-type/specs/content-management/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Featured Projects sind eigenständige GenericItem-Fachinhalte
 
-Das System MUST Featured Projects als eigenständigen Content-Type `projects.project` bereitstellen und als GenericItem mit `genericType` gleich `FeaturedProject` speichern. Die gemeinsame Inhaltsübersicht MUST diese Datensätze ausschließlich als `projects.project` darstellen. Der frühere Diskriminator `PROJECT` MUST nicht als Featured Project behandelt werden.
+Das System MUST Featured Projects als eigenständigen Content-Type `projects.project` bereitstellen und als GenericItem mit `genericType` gleich `FeaturedProject` speichern. Die fachliche Projektansicht MUST diese Datensätze als `projects.project` darstellen. Der generische Zugriff MUST denselben Mainserver-Datensatz zusätzlich als `generic-items.generic-item` bereitstellen, wenn die handelnde Person über `generic-items.*` verfügt. Der frühere Diskriminator `PROJECT` MUST nicht als Featured Project behandelt werden.
 
 #### Scenario: Featured Project wird angelegt
 
@@ -11,15 +11,17 @@ Das System MUST Featured Projects als eigenständigen Content-Type `projects.pro
 - **AND** speichert den Datensatz mit `genericType` gleich `FeaturedProject`
 - **AND** projiziert ihn als `projects.project`
 
-#### Scenario: Featured Project erscheint nicht doppelt
+#### Scenario: Featured Project besitzt zwei autorisierte Repräsentationen
 
 - **GIVEN** ein GenericItem mit `genericType` gleich `FeaturedProject`
+- **AND** ein Benutzer besitzt `projects.read` und `generic-items.read`
 - **WHEN** die Inhaltsprojektion aktualisiert wird
-- **THEN** erscheint es als `projects.project`
-- **AND** nicht zusätzlich als `generic-items.generic-item`
+- **THEN** erscheint der Datensatz als `projects.project`
+- **AND** zusätzlich als `generic-items.generic-item`
 
 #### Scenario: Alter Diskriminator wird nicht übernommen
 
 - **GIVEN** ein GenericItem mit `genericType` gleich `PROJECT`
 - **WHEN** die Inhaltsprojektion aktualisiert wird
 - **THEN** behandelt das System es nicht als Featured Project
+- **AND** darf es weiterhin als generischen Inhalt darstellen

--- a/openspec/changes/update-featured-project-generic-type/specs/sva-mainserver-integration/spec.md
+++ b/openspec/changes/update-featured-project-generic-type/specs/sva-mainserver-integration/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Mainserver-Zugriffe grenzen Featured Projects als eigenen GenericItem-Typ ab
+
+Das System MUST Projekte-Routen auf GenericItems mit `genericType` gleich `FeaturedProject` begrenzen und diese Datensätze als `projects.project` projizieren. Listen MUST vollständig nach dem technischen Diskriminator und dem internen Löschstatus filtern, bevor lokale Pagination angewendet wird. Der frühere Diskriminator `PROJECT` MUST ohne Übergangs- oder Fallback-Verhalten als Fremdtyp gelten.
+
+#### Scenario: Projekte-Liste wird aus gemischten GenericItems erzeugt
+
+- **GIVEN** die Upstream-Seiten enthalten Projekte, gelöschte Projekte und andere GenericItem-Typen
+- **WHEN** der Host die Projekte-Liste erzeugt
+- **THEN** liest er alle Upstream-Seiten bis zum nachgewiesenen Ende
+- **AND** gibt ausschließlich aktive Datensätze mit `genericType` gleich `FeaturedProject` zurück
+- **AND** wendet erst danach die lokale Pagination an
+
+#### Scenario: Fremdtyp wird über Projekte-Endpunkt adressiert
+
+- **WHEN** eine ID eines anderen GenericItem-Typs einschließlich `PROJECT` über einen Projekte-Detail- oder Mutationspfad adressiert wird
+- **THEN** antwortet der Host wie bei einer unbekannten Projekt-ID
+- **AND** führt keine Mutation aus

--- a/openspec/changes/update-featured-project-generic-type/tasks.md
+++ b/openspec/changes/update-featured-project-generic-type/tasks.md
@@ -1,0 +1,7 @@
+## 1. Umsetzung
+
+- [x] 1.1 Projekte-Konstanten und Mainserver-Routen auf `FeaturedProject` umstellen
+- [x] 1.2 Inhaltsprojektion auf `FeaturedProject` umstellen
+- [x] 1.3 Unit-Tests und Test-Fixtures aktualisieren
+- [x] 1.4 OpenSpec-, Architektur- und Nutzerdokumentation aktualisieren
+- [x] 1.5 Relevante Unit-, Type- und Server-Runtime-Gates ausführen

--- a/openspec/specs/content-management/spec.md
+++ b/openspec/specs/content-management/spec.md
@@ -1160,21 +1160,27 @@ Das System SHALL für Inhaltslisten, Inhaltsdetails und Inhaltsmutationen diesel
 
 ### Requirement: Featured Projects sind eigenständige GenericItem-Fachinhalte
 
-Das System MUST Featured Projects als eigenständigen Content-Type `projects.project` bereitstellen und als GenericItem mit `genericType` gleich `PROJECT` speichern. Die gemeinsame Inhaltsübersicht MUST diese Datensätze ausschließlich als `projects.project` darstellen.
+Das System MUST Featured Projects als eigenständigen Content-Type `projects.project` bereitstellen und als GenericItem mit `genericType` gleich `FeaturedProject` speichern. Die gemeinsame Inhaltsübersicht MUST diese Datensätze ausschließlich als `projects.project` darstellen. Der frühere Diskriminator `PROJECT` MUST nicht als Featured Project behandelt werden.
 
 #### Scenario: Featured Project wird angelegt
 
 - **WHEN** ein Benutzer mit `projects.create` ein Featured Project anlegt
 - **THEN** zeigt das System ausschließlich die fachlich erlaubten Felder
-- **AND** speichert den Datensatz mit `genericType` gleich `PROJECT`
+- **AND** speichert den Datensatz mit `genericType` gleich `FeaturedProject`
 - **AND** projiziert ihn als `projects.project`
 
 #### Scenario: Featured Project erscheint nicht doppelt
 
-- **GIVEN** ein GenericItem mit `genericType` gleich `PROJECT`
+- **GIVEN** ein GenericItem mit `genericType` gleich `FeaturedProject`
 - **WHEN** die Inhaltsprojektion aktualisiert wird
 - **THEN** erscheint es als `projects.project`
 - **AND** nicht zusätzlich als `generic-items.generic-item`
+
+#### Scenario: Alter Diskriminator wird nicht übernommen
+
+- **GIVEN** ein GenericItem mit `genericType` gleich `PROJECT`
+- **WHEN** die Inhaltsprojektion aktualisiert wird
+- **THEN** behandelt das System es nicht als Featured Project
 
 ### Requirement: Featured Projects besitzen einen eigenständigen API-Vertrag
 

--- a/openspec/specs/content-management/spec.md
+++ b/openspec/specs/content-management/spec.md
@@ -1160,7 +1160,7 @@ Das System SHALL für Inhaltslisten, Inhaltsdetails und Inhaltsmutationen diesel
 
 ### Requirement: Featured Projects sind eigenständige GenericItem-Fachinhalte
 
-Das System MUST Featured Projects als eigenständigen Content-Type `projects.project` bereitstellen und als GenericItem mit `genericType` gleich `FeaturedProject` speichern. Die gemeinsame Inhaltsübersicht MUST diese Datensätze ausschließlich als `projects.project` darstellen. Der frühere Diskriminator `PROJECT` MUST nicht als Featured Project behandelt werden.
+Das System MUST Featured Projects als eigenständigen Content-Type `projects.project` bereitstellen und als GenericItem mit `genericType` gleich `FeaturedProject` speichern. Die fachliche Projektansicht MUST diese Datensätze als `projects.project` darstellen. Der generische Zugriff MUST denselben Mainserver-Datensatz zusätzlich als `generic-items.generic-item` bereitstellen, wenn die handelnde Person über `generic-items.*` verfügt. Der frühere Diskriminator `PROJECT` MUST nicht als Featured Project behandelt werden.
 
 #### Scenario: Featured Project wird angelegt
 
@@ -1169,18 +1169,20 @@ Das System MUST Featured Projects als eigenständigen Content-Type `projects.pro
 - **AND** speichert den Datensatz mit `genericType` gleich `FeaturedProject`
 - **AND** projiziert ihn als `projects.project`
 
-#### Scenario: Featured Project erscheint nicht doppelt
+#### Scenario: Featured Project besitzt zwei autorisierte Repräsentationen
 
 - **GIVEN** ein GenericItem mit `genericType` gleich `FeaturedProject`
+- **AND** ein Benutzer besitzt `projects.read` und `generic-items.read`
 - **WHEN** die Inhaltsprojektion aktualisiert wird
-- **THEN** erscheint es als `projects.project`
-- **AND** nicht zusätzlich als `generic-items.generic-item`
+- **THEN** erscheint der Datensatz als `projects.project`
+- **AND** zusätzlich als `generic-items.generic-item`
 
 #### Scenario: Alter Diskriminator wird nicht übernommen
 
 - **GIVEN** ein GenericItem mit `genericType` gleich `PROJECT`
 - **WHEN** die Inhaltsprojektion aktualisiert wird
 - **THEN** behandelt das System es nicht als Featured Project
+- **AND** darf es weiterhin als generischen Inhalt darstellen
 
 ### Requirement: Featured Projects besitzen einen eigenständigen API-Vertrag
 
@@ -1313,4 +1315,3 @@ Das System MUST `Deleted` im Studio-Vertrag systemverwaltet führen. Eine autori
 - **WHEN** eine ID eines anderen GenericItem-Typs an den Projekte-Löschpfad übermittelt wird
 - **THEN** behandelt das System die ID wie eine unbekannte Projekt-ID
 - **AND** führt keine Mutation aus
-

--- a/openspec/specs/sva-mainserver-integration/spec.md
+++ b/openspec/specs/sva-mainserver-integration/spec.md
@@ -1208,19 +1208,19 @@ Das System MUST einen lokalen Content-Core-Datensatz über eine allgemeine Exter
 
 ### Requirement: Mainserver-Zugriffe grenzen Featured Projects als eigenen GenericItem-Typ ab
 
-Das System MUST Projekte-Routen auf GenericItems mit `genericType` gleich `PROJECT` begrenzen und diese Datensätze als `projects.project` projizieren. Listen MUST vollständig nach dem technischen Diskriminator und dem internen Löschstatus filtern, bevor lokale Pagination angewendet wird.
+Das System MUST Projekte-Routen auf GenericItems mit `genericType` gleich `FeaturedProject` begrenzen und diese Datensätze als `projects.project` projizieren. Listen MUST vollständig nach dem technischen Diskriminator und dem internen Löschstatus filtern, bevor lokale Pagination angewendet wird. Der frühere Diskriminator `PROJECT` MUST ohne Übergangs- oder Fallback-Verhalten als Fremdtyp gelten.
 
 #### Scenario: Projekte-Liste wird aus gemischten GenericItems erzeugt
 
 - **GIVEN** die Upstream-Seiten enthalten Projekte, gelöschte Projekte und andere GenericItem-Typen
 - **WHEN** der Host die Projekte-Liste erzeugt
 - **THEN** liest er alle Upstream-Seiten bis zum nachgewiesenen Ende
-- **AND** gibt ausschließlich aktive Datensätze mit `genericType` gleich `PROJECT` zurück
+- **AND** gibt ausschließlich aktive Datensätze mit `genericType` gleich `FeaturedProject` zurück
 - **AND** wendet erst danach die lokale Pagination an
 
 #### Scenario: Fremdtyp wird über Projekte-Endpunkt adressiert
 
-- **WHEN** eine ID eines anderen GenericItem-Typs über einen Projekte-Detail- oder Mutationspfad adressiert wird
+- **WHEN** eine ID eines anderen GenericItem-Typs einschließlich `PROJECT` über einen Projekte-Detail- oder Mutationspfad adressiert wird
 - **THEN** antwortet der Host wie bei einer unbekannten Projekt-ID
 - **AND** führt keine Mutation aus
 

--- a/packages/plugin-projects/src/projects.constants.ts
+++ b/packages/plugin-projects/src/projects.constants.ts
@@ -1,2 +1,2 @@
 export const PROJECTS_CONTENT_TYPE = 'projects.project' as const;
-export const PROJECTS_GENERIC_TYPE = 'PROJECT' as const;
+export const PROJECTS_GENERIC_TYPE = 'FeaturedProject' as const;

--- a/packages/sva-mainserver/src/server/projects-contract.test.ts
+++ b/packages/sva-mainserver/src/server/projects-contract.test.ts
@@ -31,7 +31,7 @@ const existing: SvaMainserverGenericItem = {
   title: 'Alt',
   contentType: 'generic-items.generic-item',
   status: 'published',
-  genericType: 'PROJECT',
+  genericType: 'FeaturedProject',
   teaser: 'Alt',
   visible: false,
   author: 'Alt',
@@ -98,7 +98,7 @@ describe('projects contract', () => {
     ).toEqual(
       expect.objectContaining({
         title: 'Projekt',
-        genericType: 'PROJECT',
+        genericType: 'FeaturedProject',
         teaser: 'Kurz',
         visible: true,
         externalId: 'operation-1',

--- a/packages/sva-mainserver/src/server/projects-contract.ts
+++ b/packages/sva-mainserver/src/server/projects-contract.ts
@@ -18,7 +18,7 @@ import type {
 import { errorJson, isRecord } from './content-route-core.js';
 
 export const PROJECTS_CONTENT_TYPE = 'projects.project' as const;
-export const PROJECTS_GENERIC_TYPE = 'PROJECT' as const;
+export const PROJECTS_GENERIC_TYPE = 'FeaturedProject' as const;
 
 const requiredText = z.string().trim().min(1);
 const imageSchema = z.object({

--- a/packages/sva-mainserver/src/server/projects-listing.ts
+++ b/packages/sva-mainserver/src/server/projects-listing.ts
@@ -35,7 +35,7 @@ export const listAllActiveProjectItems = async (
   }
 
   const data = upstreamItems.filter(
-    (item) => item.genericType === 'PROJECT' && !isDeleted(item)
+    (item) => item.genericType === 'FeaturedProject' && !isDeleted(item)
   );
   return {
     data,

--- a/packages/sva-mainserver/src/server/projects-route.test.ts
+++ b/packages/sva-mainserver/src/server/projects-route.test.ts
@@ -115,7 +115,7 @@ const genericItem = {
   title: 'Projekt',
   contentType: 'generic-items.generic-item' as const,
   status: 'published' as const,
-  genericType: 'PROJECT',
+  genericType: 'FeaturedProject',
   teaser: 'Kurz',
   visible: true,
   author: 'Gemeinde',
@@ -185,7 +185,7 @@ describe('projects route', () => {
     state.loadCore.mockResolvedValue(core);
     state.listGenericItems
       .mockResolvedValueOnce({
-        data: [{ ...genericItem, genericType: 'INFO' }],
+        data: [{ ...genericItem, genericType: 'PROJECT' }],
         pagination: { page: 1, pageSize: 100, hasNextPage: true },
       })
       .mockResolvedValueOnce({
@@ -262,7 +262,7 @@ describe('projects route', () => {
     expect(state.createGenericItem).toHaveBeenCalledWith(
       expect.objectContaining({
         genericItem: expect.objectContaining({
-          genericType: 'PROJECT',
+          genericType: 'FeaturedProject',
           externalId: 'operation-1',
           visible: true,
         }),
@@ -431,14 +431,14 @@ describe('projects route', () => {
     prepareDefaults();
     state.loadCore.mockResolvedValue(core);
     state.loadReferenceByContentId.mockResolvedValue(reference);
-    state.getGenericItem.mockResolvedValueOnce({ ...genericItem, genericType: 'INFO' });
+    state.getGenericItem.mockResolvedValueOnce({ ...genericItem, genericType: 'PROJECT' });
 
     const wrongType = await dispatchSvaMainserverProjectsRequest(
       request(`/api/v1/mainserver/projects/${contentId}`)
     );
     expect(wrongType?.status).toBe(404);
 
-    state.getGenericItem.mockResolvedValueOnce({ ...genericItem, teaser: '' });
+    state.getGenericItem.mockResolvedValueOnce({ ...genericItem, title: '' });
     const invalidProjection = await dispatchSvaMainserverProjectsRequest(
       request(`/api/v1/mainserver/projects/${contentId}`)
     );

--- a/packages/sva-mainserver/src/server/projects-route.ts
+++ b/packages/sva-mainserver/src/server/projects-route.ts
@@ -36,6 +36,7 @@ import { parseMainserverListQuery } from './list-pagination.js';
 import { toMainserverErrorResponse } from './mainserver-error-response.js';
 import {
   PROJECTS_CONTENT_TYPE,
+  PROJECTS_GENERIC_TYPE,
   mapGenericItemToProject,
   mergeProjectIntoGenericItem,
   parseProjectInput,
@@ -180,7 +181,7 @@ const loadProjectContext = async (
     ...(activeOrganizationId ? { activeOrganizationId } : {}),
     genericItemId: reference.sourceEntityId,
   });
-  if (item.genericType !== 'FeaturedProject') return undefined;
+  if (item.genericType !== PROJECTS_GENERIC_TYPE) return undefined;
   const payload =
     item.payload && typeof item.payload === 'object' && !Array.isArray(item.payload)
       ? (item.payload as Record<string, unknown>)
@@ -463,7 +464,7 @@ const updateProject = async (
           ...actor,
           genericItemId: context.reference.sourceEntityId!,
         });
-        if (!freshCore || freshItem.genericType !== 'FeaturedProject') {
+        if (!freshCore || freshItem.genericType !== PROJECTS_GENERIC_TYPE) {
           return errorJson(404, 'not_found', 'Projekt wurde nicht gefunden.');
         }
         const publishedAt = publishedAtFor(project, freshCore.publishedAt);
@@ -551,7 +552,7 @@ const deleteProject = async (
           ...actor,
           genericItemId: context.reference.sourceEntityId!,
         });
-        if (!freshCore || freshItem.genericType !== 'FeaturedProject') {
+        if (!freshCore || freshItem.genericType !== PROJECTS_GENERIC_TYPE) {
           return errorJson(404, 'not_found', 'Projekt wurde nicht gefunden.');
         }
         const freshProject = mapAndValidate(freshItem, freshCore);

--- a/packages/sva-mainserver/src/server/projects-route.ts
+++ b/packages/sva-mainserver/src/server/projects-route.ts
@@ -180,7 +180,7 @@ const loadProjectContext = async (
     ...(activeOrganizationId ? { activeOrganizationId } : {}),
     genericItemId: reference.sourceEntityId,
   });
-  if (item.genericType !== 'PROJECT') return undefined;
+  if (item.genericType !== 'FeaturedProject') return undefined;
   const payload =
     item.payload && typeof item.payload === 'object' && !Array.isArray(item.payload)
       ? (item.payload as Record<string, unknown>)
@@ -463,7 +463,7 @@ const updateProject = async (
           ...actor,
           genericItemId: context.reference.sourceEntityId!,
         });
-        if (!freshCore || freshItem.genericType !== 'PROJECT') {
+        if (!freshCore || freshItem.genericType !== 'FeaturedProject') {
           return errorJson(404, 'not_found', 'Projekt wurde nicht gefunden.');
         }
         const publishedAt = publishedAtFor(project, freshCore.publishedAt);
@@ -551,7 +551,7 @@ const deleteProject = async (
           ...actor,
           genericItemId: context.reference.sourceEntityId!,
         });
-        if (!freshCore || freshItem.genericType !== 'PROJECT') {
+        if (!freshCore || freshItem.genericType !== 'FeaturedProject') {
           return errorJson(404, 'not_found', 'Projekt wurde nicht gefunden.');
         }
         const freshProject = mapAndValidate(freshItem, freshCore);


### PR DESCRIPTION
## Zusammenfassung

- verwendet für Featured Projects durchgängig den Mainserver-GenericType `FeaturedProject`
- entfernt die bisherige Behandlung von `PROJECT` ohne Übergangs-Fallback
- aktualisiert Projektion, Tests, OpenSpec sowie Architektur- und Nutzerdokumentation

## Ursache

Das Projects Plugin schrieb und filterte bisher auf `PROJECT`, während die vorhandenen Mainserver-Datensätze bereits mit `FeaturedProject` gekennzeichnet sind. Dadurch konnten die Datensätze nicht zuverlässig gelesen oder fortgeschrieben werden.

## Validierung

- `openspec validate update-featured-project-generic-type --strict`
- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/projects-contract.test.ts --testFiles=src/server/projects-route.test.ts`
- `pnpm nx run sva-studio-react:test:unit:server --testFiles=src/lib/iam-content-list-projection.server.test.ts`
- `pnpm nx run plugin-projects:test:unit`
- `pnpm nx run sva-mainserver:test:types`
- `pnpm nx run plugin-projects:test:types`
- `pnpm exec tsc --noEmit -p apps/sva-studio-react/tsconfig.json`
- `pnpm nx run sva-mainserver:check:runtime`
- `pnpm check:file-placement`