### PR TITLE
fix(content): show projected featured projects

### DIFF
--- a/apps/sva-studio-react/src/lib/iam-content-list-visibility.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-visibility.server.test.ts
@@ -135,6 +135,25 @@ describe('iam content list visibility', () => {
     });
   });
 
+  it('uses projects.read for projected project rows instead of the generic content.read fallback', () => {
+    const [rule] = buildProjectionReadVisibilityRules(
+      ['projects.project'],
+      [
+        createPermission({
+          action: 'projects.read',
+          resourceType: 'projects',
+        }),
+      ]
+    );
+
+    expect(rule).toEqual({
+      contentType: 'projects.project',
+      allowGlobal: true,
+      allowOrganizationIds: [],
+      allowOwn: false,
+    });
+  });
+
   it('evaluates row visibility with own fallback', () => {
     const [rule] = buildProjectionReadVisibilityRules(
       ['generic'],

--- a/apps/sva-studio-react/src/lib/iam-content-list-visibility.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-visibility.ts
@@ -24,6 +24,7 @@ const buildReadAction = (contentType: string): string =>
   contentType === 'news.article' ||
   contentType === 'events.event-record' ||
   contentType === 'poi.point-of-interest' ||
+  contentType === 'projects.project' ||
   contentType === 'surveys.survey'
     ? `${contentType.split('.')[0] ?? 'content'}.read`
     : 'content.read';

--- a/docs/changelog/entries/pr-920.json
+++ b/docs/changelog/entries/pr-920.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 920,
+  "body": "Featured Projects wieder in der Inhaltsliste sichtbar\n\n- Featured Projects werden mit der vorhandenen Projekte-Leseberechtigung nicht mehr aus der gemeinsamen Inhaltsliste herausgefiltert.\n- Das gilt auch für GenericItems, die außerhalb des Studios über die Mainserver-API erstellt wurden."
+}


### PR DESCRIPTION
## Problem

`projects.project` was authorized with `projects.read`, but row visibility still fell back to `content.read`. As a result, valid `FeaturedProject` GenericItems were filtered out of the shared content list.

## Fix

- map `projects.project` to `projects.read` in projection row visibility
- add a focused regression test for the permission mapping

## Verification

- `pnpm nx run sva-studio-react:test:unit:server --testFiles=src/lib/iam-content-list-visibility.server.test.ts` (7/7 green)

The broader wrapper also started an unrelated `public-waste-calendar-web` build which cannot run locally without tenant environment configuration; the directly relevant server target is green.