### PR TITLE
fix(content): align Mainserver read visibility

### DIFF
--- a/apps/sva-studio-react/src/lib/iam-content-list-visibility.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-visibility.server.test.ts
@@ -26,6 +26,32 @@ const findRule = (
 };
 
 describe('iam content list visibility', () => {
+  it.each([
+    ['news.article', 'news.read', 'news'],
+    ['events.event-record', 'events.read', 'events'],
+    ['poi.point-of-interest', 'poi.read', 'poi'],
+    ['generic-items.generic-item', 'generic-items.read', 'generic-items'],
+    ['faq.faq', 'faq.read', 'faq'],
+    ['cockpit-cards.cockpit-card', 'cockpit-cards.read', 'cockpit-cards'],
+    ['projects.project', 'projects.read', 'projects'],
+    ['surveys.survey', 'surveys.read', 'surveys'],
+  ] as const)(
+    'uses the namespace read permission for Mainserver type %s',
+    (contentType, action, resourceType) => {
+      const [rule] = buildProjectionReadVisibilityRules(
+        [contentType],
+        [createPermission({ action, resourceType })]
+      );
+
+      expect(rule).toEqual({
+        contentType,
+        allowGlobal: true,
+        allowOrganizationIds: [],
+        allowOwn: false,
+      });
+    }
+  );
+
   it('derives organization-scoped allow rules for projected rows', () => {
     const rules = buildProjectionReadVisibilityRules(
       ['generic', 'news.article'],

--- a/apps/sva-studio-react/src/lib/iam-content-list-visibility.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-visibility.ts
@@ -1,5 +1,7 @@
 import type { EffectivePermission } from '@sva/iam-core';
 
+import { isMainserverContentType } from './iam-content-list-api.shared.js';
+
 type ProjectionRowReadView = {
   readonly contentType: string;
   readonly organizationId?: string;
@@ -21,11 +23,7 @@ const ORGANIZATION_OPTIONAL_CONTENT_TYPES = new Set([
 ]);
 
 const buildReadAction = (contentType: string): string =>
-  contentType === 'news.article' ||
-  contentType === 'events.event-record' ||
-  contentType === 'poi.point-of-interest' ||
-  contentType === 'projects.project' ||
-  contentType === 'surveys.survey'
+  isMainserverContentType(contentType)
     ? `${contentType.split('.')[0] ?? 'content'}.read`
     : 'content.read';
 

--- a/docs/changelog/entries/pr-921.json
+++ b/docs/changelog/entries/pr-921.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 921,
+  "body": "Mainserver-Inhalte zuverlässig in Inhaltslisten sichtbar\n\n- Generische Inhalte, FAQ und Kacheln werden mit ihrer jeweiligen Leseberechtigung nicht mehr aus gemeinsamen Inhaltslisten herausgefiltert.\n- Die Berechtigungsprüfung verwendet nun für alle Mainserver-Inhaltstypen dieselbe zentrale Typdefinition."
+}


### PR DESCRIPTION
## Problem

Projection authorization derives `<namespace>.read` for every registered Mainserver content type. Row visibility used a separate allowlist, so Generic Items, FAQ and Cockpit Cards could fall back to `content.read` and be filtered despite valid namespace permissions.

## Fix

- reuse the shared Mainserver content-type registry in row visibility
- remove the divergent local type allowlist
- cover all eight registered Mainserver types with a table-driven regression test

## Verification

- `pnpm nx run sva-studio-react:test:unit:server --testFiles=src/lib/iam-content-list-visibility.server.test.ts` (15/15 green)