### PR TITLE
Fix GenericItem writes against the live Mainserver schema

### DIFF
--- a/docs/changelog/entries/pr-923.json
+++ b/docs/changelog/entries/pr-923.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 923,
+  "body": "Kacheln wieder über den Mainserver speicherbar\n\n- GenericItem-Mutationen senden kein vom Mainserver-Schema nicht unterstütztes Teaser-Argument mehr.\n- Kachel-Inhalte in Content-Blöcken bleiben beim Anlegen und Bearbeiten unverändert erhalten."
+}

--- a/packages/sva-mainserver/src/generated/generic-items.ts
+++ b/packages/sva-mainserver/src/generated/generic-items.ts
@@ -362,7 +362,6 @@ export const svaMainserverCreateGenericItemDocument = /* GraphQL */ `
     $author: String
     $keywords: String
     $title: String!
-    $teaser: String
     $genericType: String
     $externalId: String
     $publicationDate: String
@@ -388,7 +387,6 @@ export const svaMainserverCreateGenericItemDocument = /* GraphQL */ `
       author: $author
       keywords: $keywords
       title: $title
-      teaser: $teaser
       genericType: $genericType
       externalId: $externalId
       publicationDate: $publicationDate

--- a/packages/sva-mainserver/src/server/service-internals/generic-item-operations.ts
+++ b/packages/sva-mainserver/src/server/service-internals/generic-item-operations.ts
@@ -37,7 +37,6 @@ const buildGenericItemMutationVariables = (input: {
   ...includeTruthyField('id', input.genericItemId),
   ...includeDefinedField('forceCreate', input.forceCreate),
   title: input.genericItem.title,
-  ...includeDefinedField('teaser', input.genericItem.teaser),
   ...includeTruthyField('author', input.genericItem.author),
   ...includeTruthyField('keywords', input.genericItem.keywords),
   genericType: input.genericItem.genericType,

--- a/packages/sva-mainserver/src/server/service.test.ts
+++ b/packages/sva-mainserver/src/server/service.test.ts
@@ -2179,14 +2179,14 @@ describe('createSvaMainserverService', () => {
       id: 'generic-1',
       forceCreate: false,
       genericType: 'faq',
-      teaser: '',
       payload: { answer: '43' },
     });
-    expect(requestBodies[2]?.variables).toMatchObject({ teaser: 'Kurztext' });
+    expect(requestBodies[2]?.variables).not.toHaveProperty('teaser');
+    expect(requestBodies[3]?.variables).not.toHaveProperty('teaser');
     expect(requestBodies[3]?.variables).not.toHaveProperty('visible');
     const genericItemMutation = String(fetchImpl.mock.calls[3]?.[1]?.body);
-    expect(genericItemMutation).toContain('$teaser: String');
-    expect(genericItemMutation).toContain('teaser: $teaser');
+    expect(genericItemMutation).not.toContain('$teaser: String');
+    expect(genericItemMutation).not.toContain('teaser: $teaser');
     expect(genericItemMutation).not.toContain('$visible: Boolean');
     expect(genericItemMutation).not.toContain('visible: $visible');
     expect(requestBodies[4]?.variables).toEqual({ id: 'generic-1', recordType: 'GenericItem' });


### PR DESCRIPTION
## Ursache

Der gemeinsame GenericItem-Client deklarierte und sendete `teaser` als Argument von `createGenericItem`. Das produktive SVA-Mainserver-Schema stellt `teaser` nur im Query-Typ bereit, nicht als Mutation-Argument. Dadurch scheiterte jede GenericItem-Mutation bereits bei der GraphQL-Validierung, auch Kacheln, die selbst keinen Teaser senden.

## Änderung

- entfernt das nicht unterstützte `teaser`-Argument aus dem GraphQL-Schreibdokument
- entfernt `teaser` aus den Mutation-Variablen
- ergänzt einen Regressionstest für beide Vertragsgrenzen
- ergänzt den Changelog-Eintrag

Kacheltexte bleiben unverändert in `contentBlocks[0].body`.

## Verifikation

- `pnpm nx run sva-mainserver:test:unit --testFiles=src/server/service.test.ts` (66/66)
- `pnpm nx run sva-mainserver:test:types`
- `pnpm nx run sva-mainserver:check:runtime`
- `pnpm check:file-placement`