### PR TITLE
fix(dev): lokale Waste-Runtime-Secrets vereinheitlichen

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -22,14 +22,17 @@ services:
       - ./dev/redis-tls/redis.pem:/etc/redis/certs/redis.pem:ro
       - ./dev/redis-tls/redis-key.pem:/etc/redis/certs/redis-key.pem:ro
       - ./dev/redis-tls/ca.pem:/etc/redis/certs/ca.pem:ro
-    command: >-
-      redis-server --port 6379 --tls-port 6380
-      --tls-cert-file /etc/redis/certs/redis.pem
-      --tls-key-file /etc/redis/certs/redis-key.pem
-      --tls-ca-cert-file /etc/redis/certs/ca.pem
-      --tls-replication yes --appendonly yes
-      --maxmemory 256mb --maxmemory-policy allkeys-lru
-      --requirepass "$${REDIS_PASSWORD}"
+    command:
+      - sh
+      - -ec
+      - |
+        exec redis-server --port 6379 --tls-port 6380 \
+          --tls-cert-file /etc/redis/certs/redis.pem \
+          --tls-key-file /etc/redis/certs/redis-key.pem \
+          --tls-ca-cert-file /etc/redis/certs/ca.pem \
+          --tls-replication yes --appendonly yes \
+          --maxmemory 256mb --maxmemory-policy allkeys-lru \
+          --requirepass "$${REDIS_PASSWORD}"
     healthcheck:
       test: ['CMD-SHELL', 'REDISCLI_AUTH=$${REDIS_PASSWORD} redis-cli ping']
       interval: 5s
@@ -46,3 +49,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-sva}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-sva_local_dev_password}
     restart: unless-stopped
+
+secrets:
+  waste_database_provisioner_password: !override
+    environment: WASTE_DATABASE_PROVISIONER_PASSWORD

--- a/config/runtime/local-keycloak.vars.example
+++ b/config/runtime/local-keycloak.vars.example
@@ -1,0 +1,10 @@
+# Lokale, nicht produktive Entwicklungswerte für das Profil `local-keycloak`.
+#
+# Diese Musterdatei enthält keine echten Zugangsdaten. Den gewünschten Wert in
+# `config/runtime/local-keycloak.vars` oder vorzugsweise in
+# `config/runtime/local-keycloak.local.vars` übernehmen. Beide Zieldateien sind
+# git-ignoriert und dürfen nicht committed werden.
+
+# Passwort der lokalen PostgreSQL-Rolle, die tenantbezogene Waste-Datenbanken
+# und deren eingeschränkte Runtime-Rollen provisioniert.
+WASTE_DATABASE_PROVISIONER_PASSWORD=__SET_LOCAL_DEVELOPMENT_PASSWORD__

--- a/docs/changelog/entries/pr-925.json
+++ b/docs/changelog/entries/pr-925.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 925,
+  "body": "Lokale Waste-Entwicklungsumgebung vereinheitlicht\n\n- Das Provisioner-Passwort kann über die lokale Runtime-Variablendatei als Compose-Secret gesetzt werden.\n- Redis wertet sein lokales Passwort zuverlässig im Container aus.\n- Eine secret-freie Musterdatei dokumentiert die notwendige lokale Variable."
+}


### PR DESCRIPTION
## Zusammenfassung

- reicht das lokale Waste-Provisioner-Passwort über eine explizite Compose-Secret-Umgebungsvariable durch
- lässt Redis das Passwort erst im Container-Shell-Kontext expandieren
- ergänzt eine sichere, secret-freie Mustervariablendatei für die lokale Entwicklung

## Abgrenzung

Die Änderungen betreffen ausschließlich `compose.override.yaml` und die lokale Mustervariablendatei. Es werden keine Zugangsdaten eingecheckt.

## Tests

- `docker compose --env-file config/runtime/local-keycloak.vars.example config`
- `pnpm check:file-placement`
- `git diff --check`