### PR TITLE
Kontolöschregeln präzisieren und Baseline anheben

### DIFF
--- a/apps/sva-studio-react/src/i18n/resources/de/account/privacy.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/account/privacy.resources.ts
@@ -105,9 +105,9 @@ export const privacyAccountDEResources = {
     summary: {
       lastLoginAt: 'Zuletzt eingeloggt',
       lifecycleState: 'Kontostatus',
-      deactivateAfterDays: 'Deaktivierung nach Tagen',
-      pseudonymizeAfterDays: 'Pseudonymisierung nach Tagen',
-      deleteAfterDays: 'Löschung nach Tagen',
+      deactivateAfterDays: 'Deaktivierung nach Tagen seit dem letzten erfolgreichen Login',
+      pseudonymizeAfterDays: 'Pseudonymisierung nach Tagen seit dem letzten erfolgreichen Login',
+      deleteAfterDays: 'Tombstone-Soft-Delete nach Tagen seit dem letzten erfolgreichen Login',
       tenantDefaultStrategy: 'Tenant-Standard für Inhalte',
       effectiveStrategy: 'Wirksame Inhaltsregel',
     },

--- a/apps/sva-studio-react/src/i18n/resources/de/account/rules.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/account/rules.resources.ts
@@ -5,22 +5,24 @@ export const rulesAccountDEResources = {
     'Prüfen Sie tenantweite Löschregeln und die Behandlung Ihrer eigenen Inhalte in einer separaten Ansicht.',
   summary: {
     deactivateAfterDays: 'Deaktivierung nach',
-    deactivateAfterDaysHint: 'Zeit bis zur Deaktivierung in Tagen.',
+    deactivateAfterDaysHint: 'Tage seit dem letzten erfolgreichen Login bis zur Deaktivierung.',
     pseudonymizeAfterDays: 'Pseudonymisierung nach',
-    pseudonymizeAfterDaysHint: 'Zeit bis zur Pseudonymisierung in Tagen.',
-    deleteAfterDays: 'Löschung nach',
-    deleteAfterDaysHint: 'Zeit bis zur endgültigen Löschung in Tagen.',
+    pseudonymizeAfterDaysHint:
+      'Tage seit dem letzten erfolgreichen Login bis zur Pseudonymisierung.',
+    deleteAfterDays: 'Tombstone-Soft-Delete nach',
+    deleteAfterDaysHint:
+      'Tage seit dem letzten erfolgreichen Login bis zum finalen Tombstone-Soft-Delete.',
     defaultContentStrategy: 'Standardregel für Inhalte',
   },
   sections: {
     global: {
       title: 'Tenantweite Regeln',
       deactivateAfterDays:
-        'Nach der konfigurierten Frist wird das Konto zunächst deaktiviert und für direkte Logins gesperrt.',
+        'Nach der konfigurierten Anzahl von Tagen seit dem letzten erfolgreichen Login wird das Konto deaktiviert und für direkte Logins gesperrt.',
       pseudonymizeAfterDays:
-        'Nach der zweiten Frist werden personenbezogene Daten pseudonymisiert, soweit keine Aufbewahrungspflicht greift.',
+        'Nach der konfigurierten Anzahl von Tagen seit dem letzten erfolgreichen Login werden personenbezogene Daten pseudonymisiert, soweit keine Aufbewahrungspflicht greift.',
       deleteAfterDays:
-        'Nach Ablauf der letzten Frist wird das Konto endgültig entfernt, sofern keine rechtliche Sperre besteht.',
+        'Nach der konfigurierten Anzahl von Tagen seit dem letzten erfolgreichen Login erhält das Konto den finalen Tombstone-Soft-Delete-Zustand; es wird dabei nicht physisch entfernt.',
       defaultContentStrategy:
         'Die Standardregel für Inhalte legt fest, ob eigene Inhalte erhalten bleiben oder mit dem Besitzer-Lebenszyklus mitlaufen.',
     },

--- a/apps/sva-studio-react/src/i18n/resources/de/admin/iam.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/admin/iam.resources.ts
@@ -244,9 +244,9 @@ export const iamAdminDEResources = {
     subtitle:
       'Verwalten Sie die tenantweiten Fristen für Deaktivierung, Pseudonymisierung und Soft-Delete sowie die Standardregel für Inhalte.',
     fields: {
-      deactivateAfterDays: 'Deaktivierung nach Tagen',
-      pseudonymizeAfterDays: 'Pseudonymisierung nach Tagen',
-      deleteAfterDays: 'Löschung nach Tagen',
+      deactivateAfterDays: 'Deaktivierung nach Tagen seit dem letzten erfolgreichen Login',
+      pseudonymizeAfterDays: 'Pseudonymisierung nach Tagen seit dem letzten erfolgreichen Login',
+      deleteAfterDays: 'Tombstone-Soft-Delete nach Tagen seit dem letzten erfolgreichen Login',
       defaultContentStrategy: 'Standardregel für Inhalte',
       allowContentPreferenceOverride:
         'Nutzer dürfen die Standardregel für eigene Inhalte überschreiben',

--- a/apps/sva-studio-react/src/i18n/resources/en/account/privacy.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/account/privacy.resources.ts
@@ -104,9 +104,9 @@ export const privacyAccountENResources = {
     summary: {
       lastLoginAt: 'Last login',
       lifecycleState: 'Account state',
-      deactivateAfterDays: 'Deactivation after days',
-      pseudonymizeAfterDays: 'Pseudonymization after days',
-      deleteAfterDays: 'Deletion after days',
+      deactivateAfterDays: 'Deactivation after days since the last successful login',
+      pseudonymizeAfterDays: 'Pseudonymization after days since the last successful login',
+      deleteAfterDays: 'Tombstone soft delete after days since the last successful login',
       tenantDefaultStrategy: 'Tenant default for content',
       effectiveStrategy: 'Effective content rule',
     },

--- a/apps/sva-studio-react/src/i18n/resources/en/account/rules.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/account/rules.resources.ts
@@ -5,22 +5,23 @@ export const rulesAccountENResources = {
     'Review tenant-wide deletion rules and the handling of your own content in a dedicated view.',
   summary: {
     deactivateAfterDays: 'Deactivate after',
-    deactivateAfterDaysHint: 'Time until account deactivation in days.',
+    deactivateAfterDaysHint: 'Days since the last successful login until account deactivation.',
     pseudonymizeAfterDays: 'Pseudonymize after',
-    pseudonymizeAfterDaysHint: 'Time until pseudonymization in days.',
-    deleteAfterDays: 'Delete after',
-    deleteAfterDaysHint: 'Time until final deletion in days.',
+    pseudonymizeAfterDaysHint: 'Days since the last successful login until pseudonymization.',
+    deleteAfterDays: 'Tombstone soft delete after',
+    deleteAfterDaysHint:
+      'Days since the last successful login until the final tombstone soft delete.',
     defaultContentStrategy: 'Default content rule',
   },
   sections: {
     global: {
       title: 'Tenant-wide rules',
       deactivateAfterDays:
-        'After the configured period the account is deactivated first and blocked for direct sign-ins.',
+        'After the configured number of days since the last successful login, the account is deactivated and blocked for direct sign-ins.',
       pseudonymizeAfterDays:
-        'After the second period personal data is pseudonymized unless retention duties still apply.',
+        'After the configured number of days since the last successful login, personal data is pseudonymized unless retention duties still apply.',
       deleteAfterDays:
-        'After the final period the account is permanently removed unless a legal hold is active.',
+        'After the configured number of days since the last successful login, the account enters the final tombstone soft-delete state; it is not physically removed.',
       defaultContentStrategy:
         'The default content rule defines whether personal content is kept or follows the owner lifecycle.',
     },

--- a/apps/sva-studio-react/src/i18n/resources/en/admin/iam.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/admin/iam.resources.ts
@@ -235,9 +235,9 @@ export const iamAdminENResources = {
     subtitle:
       'Manage the tenant-wide deadlines for deactivation, pseudonymization, and soft delete as well as the default content rule.',
     fields: {
-      deactivateAfterDays: 'Deactivation after days',
-      pseudonymizeAfterDays: 'Pseudonymization after days',
-      deleteAfterDays: 'Deletion after days',
+      deactivateAfterDays: 'Deactivation after days since the last successful login',
+      pseudonymizeAfterDays: 'Pseudonymization after days since the last successful login',
+      deleteAfterDays: 'Tombstone soft delete after days since the last successful login',
       defaultContentStrategy: 'Default content rule',
       allowContentPreferenceOverride: 'Users may override the default rule for their own content',
       allowContentPreferenceOverrideHint:

--- a/apps/sva-studio-react/src/routes/account/-account-rules-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/account/-account-rules-page.test.tsx
@@ -25,9 +25,9 @@ describe('AccountRulesPage', () => {
         instanceId: 'de-test',
         allowContentPreferenceOverride: true,
         defaultContentStrategy: 'retain',
-        deactivateAfterDays: 90,
-        pseudonymizeAfterDays: 180,
-        deleteAfterDays: 365,
+        deactivateAfterDays: 365,
+        pseudonymizeAfterDays: 730,
+        deleteAfterDays: 1_095,
         canEdit: false,
       },
       contentPreference: { isOverridden: false, effectiveStrategy: 'retain' },
@@ -47,7 +47,21 @@ describe('AccountRulesPage', () => {
 
     expect(screen.getByText('Deaktivierung nach')).toBeTruthy();
     expect(screen.getByText('Pseudonymisierung nach')).toBeTruthy();
-    expect(screen.getByText('Löschung nach')).toBeTruthy();
+    expect(screen.getByText('Tombstone-Soft-Delete nach')).toBeTruthy();
+    expect(screen.getByText('365')).toBeTruthy();
+    expect(screen.getByText('730')).toBeTruthy();
+    expect(screen.getByText('1095')).toBeTruthy();
+    expect(
+      screen.getByText('Tage seit dem letzten erfolgreichen Login bis zur Deaktivierung.')
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Tage seit dem letzten erfolgreichen Login bis zur Pseudonymisierung.')
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Tage seit dem letzten erfolgreichen Login bis zum finalen Tombstone-Soft-Delete.'
+      )
+    ).toBeTruthy();
     expect(screen.getByLabelText('Regel für eigene Inhalte')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Inhaltsregel speichern' })).toBeTruthy();
   });
@@ -61,9 +75,9 @@ describe('AccountRulesPage', () => {
         instanceId: 'de-test',
         allowContentPreferenceOverride: false,
         defaultContentStrategy: 'retain',
-        deactivateAfterDays: 90,
-        pseudonymizeAfterDays: 180,
-        deleteAfterDays: 365,
+        deactivateAfterDays: 365,
+        pseudonymizeAfterDays: 730,
+        deleteAfterDays: 1_095,
         canEdit: false,
       },
       contentPreference: { isOverridden: false, effectiveStrategy: 'retain' },
@@ -85,9 +99,9 @@ describe('AccountRulesPage', () => {
         instanceId: 'de-test',
         allowContentPreferenceOverride: true,
         defaultContentStrategy: 'retain',
-        deactivateAfterDays: 90,
-        pseudonymizeAfterDays: 180,
-        deleteAfterDays: 365,
+        deactivateAfterDays: 365,
+        pseudonymizeAfterDays: 730,
+        deleteAfterDays: 1_095,
         canEdit: false,
       },
       contentPreference: {

--- a/apps/sva-studio-react/src/routes/admin/-iam-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/-iam-page.test.tsx
@@ -703,15 +703,26 @@ describe('IamViewerPage', () => {
       expect(screen.getByRole('heading', { name: 'Tenant-Löschregeln' })).toBeTruthy();
     });
 
-    fireEvent.change(screen.getByLabelText('Deaktivierung nach Tagen'), {
-      target: { value: '120' },
-    });
-    fireEvent.change(screen.getByLabelText('Pseudonymisierung nach Tagen'), {
-      target: { value: '240' },
-    });
-    fireEvent.change(screen.getByLabelText('Löschung nach Tagen'), {
-      target: { value: '480' },
-    });
+    fireEvent.change(
+      screen.getByLabelText('Deaktivierung nach Tagen seit dem letzten erfolgreichen Login'),
+      {
+        target: { value: '120' },
+      }
+    );
+    fireEvent.change(
+      screen.getByLabelText('Pseudonymisierung nach Tagen seit dem letzten erfolgreichen Login'),
+      {
+        target: { value: '240' },
+      }
+    );
+    fireEvent.change(
+      screen.getByLabelText(
+        'Tombstone-Soft-Delete nach Tagen seit dem letzten erfolgreichen Login'
+      ),
+      {
+        target: { value: '480' },
+      }
+    );
     fireEvent.change(screen.getByLabelText('Standardregel für Inhalte'), {
       target: { value: 'with_owner_lifecycle' },
     });

--- a/docs/changelog/entries/pr-932.json
+++ b/docs/changelog/entries/pr-932.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 932,
+  "body": "Kontolöschfristen verlängert und verständlicher erklärt\n\n- Ohne eigene Tenant-Konfiguration werden Konten nach 365 Tagen deaktiviert, nach 730 Tagen pseudonymisiert und nach 1.095 Tagen als finaler Tombstone-Soft-Delete markiert.\n- Alle drei Fristen beziehen sich eindeutig auf denselben letzten erfolgreichen Login und werden nicht nacheinander addiert.\n- Individuell gespeicherte Tenant-Regeln bleiben unverändert."
+}

--- a/docs/guides/iam-account-deletion-rules-runbook.md
+++ b/docs/guides/iam-account-deletion-rules-runbook.md
@@ -11,6 +11,8 @@ Dieses Runbook beschreibt den operativen Lauf für tenantbezogene Konten-Löschr
 - Inaktivität wird nur aus erfolgreichen Login-Events abgeleitet:
   - Quelle: `iam.activity_logs`
   - Kriterium: `event_type = 'login'` und `result = 'success'`
+- Die drei Fristen sind absolute Schwellwerte seit demselben letzten erfolgreichen Login und keine aufeinander aufbauenden Zusatzfristen.
+- Ohne explizite Tenant-Konfiguration gelten `365 / 730 / 1.095` Tage für Deaktivierung, Pseudonymisierung und finalen Tombstone-Soft-Delete.
 - Accounts ohne erfolgreiches Login-Event werden von diesem V1-Mechanismus nicht verarbeitet.
 - Ein einzelner Lauf bewegt einen Account höchstens um eine Stufe weiter.
 - Inhalte werden nur mitbehandelt, wenn die effektive Inhaltsstrategie `with_owner_lifecycle` ist.

--- a/docs/superpowers/specs/2026-05-20-datenloeschkonzept-design.md
+++ b/docs/superpowers/specs/2026-05-20-datenloeschkonzept-design.md
@@ -108,11 +108,11 @@ Die drei Fristen sind absolute Schwellwerte relativ zum selben Referenzzeitpunkt
 
 Beispiel für Defaults:
 
-- Deaktivierung nach 90 Tagen
-- Pseudonymisierung nach 180 Tagen
-- Löschung nach 365 Tagen
+- Deaktivierung nach 365 Tagen
+- Pseudonymisierung nach 730 Tagen
+- finaler Tombstone-Soft-Delete nach 1.095 Tagen
 
-Ein Tenant kann diese Werte anpassen. Die Default-Annahme für den ersten Entwurf ist `90 / 180 / 365`.
+Ein Tenant kann diese Werte anpassen. Die Baseline-Defaults sind `365 / 730 / 1.095`.
 
 ### Account-Zustände
 

--- a/openspec/changes/update-account-deletion-rule-baseline/design.md
+++ b/openspec/changes/update-account-deletion-rule-baseline/design.md
@@ -1,0 +1,36 @@
+## Context
+
+Löschregelfristen sind absolute Schwellwerte relativ zum letzten erfolgreichen Login eines Tenant-Accounts. Unkonfigurierte Tenants verwenden eine zentrale Baseline; explizit konfigurierte Tenants speichern eigene Werte in `iam.instance_deletion_rules`.
+
+## Goals / Non-Goals
+
+- Goals:
+  - zentrale Baseline auf `365 / 730 / 1.095` Tage anheben
+  - den gemeinsamen Referenzzeitpunkt in Admin- und Self-Service-Texten unmissverständlich benennen
+  - explizite Tenant-Konfigurationen unverändert lassen
+- Non-Goals:
+  - keine Migration oder Überschreibung explizit gespeicherter Tenant-Regeln
+  - keine Änderung der Lifecycle-Zustände oder der Verarbeitungshäufigkeit
+  - keine physische Löschung durch den automatischen Lifecycle
+
+## Decisions
+
+- Decision: Die vorhandene zentrale Baseline-Konstante wird geändert. Dadurch gilt die neue Baseline auch für bereits bestehende Tenants ohne explizite Konfiguration.
+- Decision: Alle drei Schwellen werden als absolute Tage seit dem letzten erfolgreichen Login formuliert; sie sind keine aufeinander aufbauenden Zusatzfristen.
+- Decision: Der bestehende Seed für den Muster-Tenant bleibt eine explizite Tenant-Konfiguration und wird nicht automatisch überschrieben.
+- Alternatives considered:
+  - Defaults nur im Provisioning neuer Tenants speichern: verworfen, weil die zentrale Baseline einfacher ist und die Wirkung auf unkonfigurierte Bestands-Tenants akzeptiert wurde.
+  - Bestehende explizite Werte migrieren: verworfen, weil bewusst gesetzte Tenant-Konfigurationen erhalten bleiben müssen.
+
+## Risks / Trade-offs
+
+- Unkonfigurierte Bestands-Tenants wechseln ebenfalls auf die neue Baseline. Das ist Teil der freigegebenen zentralen Änderung.
+- Tests mit alten Beispielwerten dürfen nur dort geändert werden, wo sie die Baseline abbilden; frei konfigurierte Testwerte bleiben unverändert.
+
+## Migration Plan
+
+Es ist keine Datenmigration erforderlich. Die Runtime verwendet die neue Baseline nur, wenn keine explizite Regelzeile vorliegt. Ein Rollback besteht aus dem Zurücksetzen der Baseline-Konstante und der zugehörigen Texte und Spezifikationen.
+
+## Open Questions
+
+- Keine.

--- a/openspec/changes/update-account-deletion-rule-baseline/proposal.md
+++ b/openspec/changes/update-account-deletion-rule-baseline/proposal.md
@@ -1,0 +1,18 @@
+# Change: Baseline der Kontolöschregeln aktualisieren
+
+## Why
+
+Die bisherige Baseline `90 / 180 / 365` ist für den vorgesehenen Konten-Lebenszyklus zu kurz. Außerdem beschreibt die Oberfläche die Fristen derzeit nicht überall eindeutig als absolute Schwellwerte seit dem letzten erfolgreichen Login.
+
+## What Changes
+
+- Die zentrale Baseline für Deaktivierung, Pseudonymisierung und finalen Tombstone-Soft-Delete wird auf `365 / 730 / 1.095` Tage geändert.
+- Bereits explizit gespeicherte Tenant-Regeln bleiben unverändert; die neue Baseline wirkt für alle Tenants ohne explizite Konfiguration.
+- Admin- und Self-Service-Oberflächen formulieren jede Frist eindeutig als absoluten Zeitraum seit dem letzten erfolgreichen Login.
+- Die Texte stellen weiterhin klar, dass `deleted` im automatischen Lifecycle einen finalen Tombstone-Soft-Delete und keine physische Löschung bezeichnet.
+
+## Impact
+
+- Affected specs: `iam-data-subject-rights`, `account-ui`
+- Affected code: `packages/iam-governance`, Account- und IAM-Admin-UI, zugehörige Tests und Dokumentation
+- Affected arc42 sections: keine; Datenmodell und Systemgrenzen bleiben unverändert

--- a/openspec/changes/update-account-deletion-rule-baseline/specs/account-ui/spec.md
+++ b/openspec/changes/update-account-deletion-rule-baseline/specs/account-ui/spec.md
@@ -1,0 +1,108 @@
+## MODIFIED Requirements
+
+### Requirement: Tenant-Löschregeln im IAM-Admin-Cockpit
+
+Das System MUST unter `/admin/iam?tab=deletion-rules` einen tenantgebundenen Admin-Tab für Löschregeln bereitstellen. Der Tab zeigt und bearbeitet ausschließlich die Regeln der aktiven `instanceId` und ist nicht für Root- oder Plattform-Administration ohne Tenant-Scope vorgesehen.
+
+#### Scenario: Tenant-Admin bearbeitet Löschregeln der aktiven Instanz
+
+- **WENN** ein berechtigter Tenant-Admin `/admin/iam?tab=deletion-rules` öffnet
+- **DANN** zeigt die UI die aktuellen Werte für `deactivateAfterDays`, `pseudonymizeAfterDays`, `deleteAfterDays`, die tenantweite Default-Inhaltsstrategie und den Tenant-Schalter `Nutzer dürfen die Standardregel für eigene Inhalte überschreiben`
+- **UND** zeigt die UI die Baseline-Defaults/Fallbacks `365 / 730 / 1.095` getrennt von tenant-spezifischen Werten an
+- **UND** zeigt die UI bei unkonfigurierten Tenants die Baseline-Defaults `365 / 730 / 1.095`, die geerbte Default-Inhaltsstrategie `beibehalten` und den Override-Schalter standardmäßig deaktiviert als wirksamen Zustand
+- **UND** können die Werte in einer validierten Bearbeitungsmaske geändert werden
+- **UND** ist die auswählbare Strategiemenge auf `beibehalten` und `mit Eigentümer-Lifecycle mitbehandeln` begrenzt
+- **UND** wird klar angezeigt, dass sich die Regeln nur auf Tenant-Accounts der aktiven `instanceId` beziehen
+
+#### Scenario: Speichern erzeugt oder aktualisiert explizite Tenant-Konfiguration
+
+- **WENN** ein berechtigter Tenant-Admin im Tab `deletion-rules` Werte speichert
+- **DANN** erzeugt das System für zuvor unkonfigurierte Tenants eine explizite Tenant-Konfiguration
+- **UND** aktualisiert das System für bereits konfigurierte Tenants die bestehende Tenant-Konfiguration
+- **UND** zeigt die UI nach dem Speichern die gespeicherten tenant-spezifischen Werte statt nur geerbter Baseline-Defaults
+- **UND** bleibt die Speicheraktion ausschließlich mit `iam.deletionRules.manage` verfügbar
+
+#### Scenario: Entfernen einer expliziten Tenant-Konfiguration kehrt zum geerbten Zustand zurück
+
+- **WENN** ein berechtigter Tenant-Admin eine bestehende explizite Tenant-Konfiguration entfernt
+- **DANN** zeigt die UI wieder die wirksamen Baseline-Defaults `365 / 730 / 1.095` und die geerbte Strategie `beibehalten`
+- **UND** behandelt die UI dies als gültigen Zustandswechsel statt als leeren oder fehlerhaften Zustand
+
+#### Scenario: UI erklärt die fachlichen Lebenszykluszustände
+
+- **WENN** der Tab `deletion-rules` dargestellt wird
+- **DANN** beschreibt die UI die Zustände `active`, `deactivated`, `pseudonymized` und `deleted`
+- **UND** erläutert, dass `deleted` einen finalen Tombstone-Soft-Delete und keine physische Löschung bedeutet
+- **UND** erläutert, dass `deactivated` nicht automatisch durch Login aufgehoben wird und eine separate Reaktivierung verlangt
+- **UND** macht kenntlich, dass ohne Reaktivierung spätere automatische Lifecycle-Stufen weiterlaufen können
+- **UND** weist darauf hin, dass V1 Inaktivität ausschließlich aus dem letzten erfolgreichen `login`-Event der aktiven `instanceId` ableitet
+
+#### Scenario: Root- oder plattformweite Administration erhält keinen Tenant-Regeltab
+
+- **WENN** ein Benutzer ohne aktiven Tenant-Scope oder nur mit Root-/Plattformrechten `/admin/iam?tab=deletion-rules` aufruft
+- **DANN** zeigt die UI keinen bearbeitbaren Tenant-Regelzustand
+- **UND** erhält der Benutzer einen verweigerten oder nicht verfügbaren Zustand ohne Leckage tenantbezogener Konfigurationsdaten
+
+#### Scenario: Ladezustand zeigt wirksame Regelermittlung an
+
+- **WENN** die UI die wirksamen Regeln, Baseline-Defaults oder tenant-spezifischen Werte für `deletion-rules` lädt
+- **DANN** zeigt sie einen expliziten Ladezustand
+- **UND** vermeidet sie währenddessen irreführende Leer- oder Default-Formulare als vermeintlich bereits geladene Daten
+
+#### Scenario: Fehlerzustand für Laden oder Speichern ist handlungsleitend
+
+- **WENN** das Laden oder Speichern der Löschregeln fehlschlägt
+- **DANN** zeigt die UI einen expliziten Fehlerzustand mit verständlicher, handlungsleitender Meldung
+- **UND** bleibt erkennbar, ob der Fehler beim Laden oder beim Speichern entstanden ist
+- **UND** werden keine unbestätigten Eingaben als erfolgreich übernommen dargestellt
+
+#### Scenario: Unkonfigurierter Tenant erzeugt keinen leeren Admin-Zustand
+
+- **WENN** für einen Tenant noch keine explizite Löschregel-Konfiguration gespeichert ist
+- **DANN** zeigt die UI die Baseline-Defaults `365 / 730 / 1.095`, die geerbte Strategie `beibehalten` und den Override-Default `deaktiviert` als wirksamen Zustand
+- **UND** verwendet sie keinen leeren oder mehrdeutigen Empty-State anstelle dieser wirksamen Standardwerte
+
+### Requirement: Self-Service zeigt Löschregeln und Inhaltspräferenz transparent an
+
+Das System MUST in den Account-/Privacy-Oberflächen die tenantweiten Löschregeln transparent darstellen und dem Benutzer einen per-Account-Override für die Behandlung eigener Inhalte im Scope `iam.contents` anbieten.
+
+#### Scenario: Benutzer sieht tenantweite Fristen und eigene Inhaltspräferenz
+
+- **WENN** ein authentifizierter Benutzer `/account/privacy` oder die zugehörige Datenschutzfläche seines Accounts öffnet
+- **DANN** sieht er die tenantweiten Fristen für Deaktivierung, Pseudonymisierung und finalen Tombstone-Soft-Delete
+- **UND** sieht er bei nicht konfigurierten Tenants die Baseline-Defaults/Fallbacks `365 / 730 / 1.095` als wirksame Standardwerte
+- **UND** sieht er bei nicht konfigurierten Tenants `beibehalten` als geerbte wirksame Default-Inhaltsstrategie
+- **UND** wird erklärt, dass jede der drei Fristen ein absoluter Schwellwert seit dem letzten erfolgreichen `login`-Event innerhalb der aktiven `instanceId` ist und nicht auf der vorherigen Lifecycle-Stufe aufbaut
+- **UND** wird erklärt, dass Accounts ohne erfolgreiches Login-Event in V1 nicht automatisch in den Inaktivitäts-Lifecycle fallen
+- **UND** sieht der Benutzer den aktuell wirksamen Strategiewert für eigene Inhalte im Scope `iam.contents`
+- **UND** werden die zulässigen Strategiewerte `beibehalten` und `mit Eigentümer-Lifecycle mitbehandeln` verständlich benannt
+- **UND** werden die Strategiewirkungen verständlich erklärt: unverändert lassen oder die jeweils erreichte Account-Stufe auf Inhalte spiegeln
+
+#### Scenario: Root- oder Plattform-Accounts ohne Tenant-Scope sehen keine Konten-Löschregeln-Box
+
+- **WENN** ein Root- oder Plattform-Account ohne aktive `instanceId` `/account/privacy` öffnet
+- **DANN** zeigt die UI keine Konten-Löschregeln-Box
+- **UND** leakt sie keinen tenantbezogenen Regelzustand in diese Oberfläche
+
+#### Scenario: Benutzer überschreibt die tenantweite Default-Inhaltsstrategie für eigene Inhalte
+
+- **WENN** ein Benutzer seine Inhaltspräferenz in der Privacy-Oberfläche ändert und der Tenant Self-Service-Overrides erlaubt
+- **DANN** kann er die tenantweite Default-Inhaltsstrategie für seine eigenen Inhalte gezielt überschreiben
+- **UND** ist der Override auf den Scope `iam.contents` begrenzt
+- **UND** ist der schreibbare Zielaccount serverseitig aus dem Session-/Authentifizierungskontext des Benutzers gebunden
+- **UND** kann die Self-Service-Oberfläche keinen Override für andere Benutzerkonten schreiben
+- **UND** ist im Auswahlfeld direkt die wirksame Regel vorausgewählt
+- **UND** zeigt die UI nach dem Speichern den wirksamen Zustand verständlich und ohne Rohdateninterpretation an
+
+#### Scenario: Tenant deaktiviert Self-Service-Overrides
+
+- **WENN** für den Tenant `allowContentPreferenceOverride = false` gilt
+- **DANN** zeigt die UI in der Konten-Löschregeln-Box keinen Überschreibungs- und Speicherbereich
+- **UND** bleibt nur die tenantweit wirksame Regel sichtbar
+
+#### Scenario: Self-Service bleibt auch ohne verfügbare Override-Daten verständlich
+
+- **WENN** für einen Benutzer noch kein individueller Override gespeichert ist
+- **DANN** zeigt die UI die tenantweite Default-Inhaltsstrategie als wirksamen Zustand
+- **UND** erklärt, dass nur eigene Inhalte im Scope `iam.contents` betroffen sind
+- **UND** bleibt die Oberfläche tastaturbedienbar, screenreader-tauglich und mit klaren Leer-, Lade- und Fehlerzuständen ausgestattet

--- a/openspec/changes/update-account-deletion-rule-baseline/specs/iam-data-subject-rights/spec.md
+++ b/openspec/changes/update-account-deletion-rule-baseline/specs/iam-data-subject-rights/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Inhaltsbehandlung ist tenantweit steuerbar und pro Account überschreibbar
+
+Das System SHALL für den Lösch-Lebenszyklus eine tenantweite Default-Inhaltsstrategie und einen tenantseitig freischaltbaren per-Account-Override für eigene Inhalte unterstützen. In V1 ist `iam.contents` die einzige unterstützte Inhaltsdomäne. Die normative V1-Strategiemenge lautet `beibehalten` und `mit Eigentümer-Lifecycle mitbehandeln`.
+
+#### Scenario: Strategiebedeutungen sind zustandsbezogen, nicht physisch und labelstabil
+
+- **WHEN** das System die Inhaltsstrategie eines Accounts im Scope `iam.contents` auswertet
+- **THEN** bedeutet `beibehalten`, dass Inhalte über alle Account-Zustandswechsel unverändert bleiben
+- **AND** bedeutet `mit Eigentümer-Lifecycle mitbehandeln`, dass Inhalte die jeweils erreichte Owner-Stufe spiegeln
+- **AND** führt ein Owner-Übergang nach `deactivated` mindestens zu einem referenzwahrenden Content-Lifecycle-Zustand `deactivated`
+- **AND** kann die fachliche Auswirkung dieses Zustands in V1 je nach konsumierender Oberfläche als deaktiviert oder ausgeblendet interpretiert werden, ohne dass `iam.contents` physisch gelöscht wird
+- **AND** führt ein Owner-Übergang nach `pseudonymized` zu einem referenzwahrenden pseudonymisierten Content-Zustand, in dem owner-/author-facing Ownership- und Display-Name-Felder durch ein stabiles pseudonymisiertes Label ersetzt werden
+- **AND** führt ein Owner-Übergang nach `deleted` zu einem referenzwahrenden Deleted-Tombstone-Zustand, in dem owner-/author-facing Ownership- und Display-Name-Felder durch ein Deleted-Label ersetzt werden
+- **AND** sind das pseudonymisierte Label und das Deleted-Label pro Locale über alle betroffenen Entitäten stabil und nicht pro Account oder Inhalt individuell abgeleitet
+- **AND** werden `iam.contents`-Zeilen in V1 nicht physisch gelöscht
+
+#### Scenario: Tenantweite Default-Strategie wirkt ohne individuellen Override
+
+- **WHEN** ein Tenant Löschregeln mit einer Default-Inhaltsstrategie konfiguriert
+- **THEN** gilt diese Strategie für eigene Inhalte eines Accounts, solange kein individueller Override gesetzt ist
+- **AND** stammt die Strategie aus der normativen V1-Menge `beibehalten`, `mit Eigentümer-Lifecycle mitbehandeln`
+- **AND** ist die Wirkung auf `iam.contents` begrenzt
+
+#### Scenario: Individueller Override ersetzt nur die Inhaltsstrategie des eigenen Accounts
+
+- **WHEN** ein Benutzer eine abweichende Inhaltspräferenz für die Behandlung seiner eigenen Inhalte speichert
+- **THEN** überschreibt diese Präferenz nur die tenantweite Default-Inhaltsstrategie für diesen Account
+- **AND** verändert sie keine Fristenwerte des Tenants
+- **AND** bleibt auch der Override auf die normative V1-Menge `beibehalten`, `mit Eigentümer-Lifecycle mitbehandeln` begrenzt
+- **AND** erweitert sie den Scope nicht auf andere Inhaltsdomänen als `iam.contents`
+- **AND** ist der Override nur verfügbar, wenn der Tenant `allowContentPreferenceOverride = true` gesetzt hat
+
+#### Scenario: Unkonfigurierter Tenant verwendet geerbte Regeln bis zur expliziten Speicherung
+
+- **WHEN** für einen Tenant noch keine explizite Löschregel-Konfiguration gespeichert ist
+- **THEN** gelten die Baseline-Defaults `365 / 730 / 1.095`, die geerbte Default-Inhaltsstrategie `beibehalten` und der geerbte Override-Default `false` als wirksamer Tenant-Zustand
+- **AND** sind Deaktivierung, Pseudonymisierung und finaler Tombstone-Soft-Delete jeweils absolute Schwellwerte seit dem letzten erfolgreichen Login und keine inkrementellen Zusatzfristen
+- **AND** bleibt dieser geerbte Zustand wirksam, bis ein Tenant-Admin eine explizite Konfiguration speichert
+
+#### Scenario: Expliziter Self-Service-Override kann auf Tenant-Default zurückgesetzt werden
+
+- **WHEN** ein Benutzer denselben Strategiewert wie den aktuellen Tenant-Standard speichert
+- **THEN** gilt wieder die tenantweite Default-Inhaltsstrategie für diesen Account
+- **AND** bleibt dafür kein eigener expliziter Override mehr erforderlich

--- a/openspec/changes/update-account-deletion-rule-baseline/tasks.md
+++ b/openspec/changes/update-account-deletion-rule-baseline/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spezifikation und Kernlogik
+
+- [x] 1.1 Zentrale Baseline auf `365 / 730 / 1.095` Tage ändern
+- [x] 1.2 Unit-Tests für Fallbacks und explizit gespeicherte Tenant-Regeln anpassen
+
+## 2. Benutzeroberfläche und Dokumentation
+
+- [x] 2.1 Deutsche und englische Admin- und Self-Service-Texte auf absolute Fristen seit dem letzten erfolgreichen Login präzisieren
+- [x] 2.2 UI-Tests für die präzisierten Texte und neuen Baseline-Werte anpassen
+- [x] 2.3 Löschkonzept und operatives Runbook aktualisieren
+
+## 3. Verifikation
+
+- [x] 3.1 Betroffene Unit-Tests ausführen
+- [x] 3.2 Betroffene Type-Tests ausführen
+- [x] 3.3 Server-Runtime-Gate ausführen
+- [x] 3.4 OpenSpec strikt validieren

--- a/packages/iam-governance/src/deletion-rules-read-models.test.ts
+++ b/packages/iam-governance/src/deletion-rules-read-models.test.ts
@@ -45,9 +45,9 @@ describe('deletion-rules/read-models', () => {
 
     expect(overview).toEqual({
       instanceId: 'de-test',
-      deactivateAfterDays: 90,
-      pseudonymizeAfterDays: 180,
-      deleteAfterDays: 365,
+      deactivateAfterDays: 365,
+      pseudonymizeAfterDays: 730,
+      deleteAfterDays: 1_095,
       defaultContentStrategy: 'retain',
       allowContentPreferenceOverride: false,
       canEdit: false,

--- a/packages/iam-governance/src/deletion-rules.types.ts
+++ b/packages/iam-governance/src/deletion-rules.types.ts
@@ -2,9 +2,9 @@ import type { IamInstanceId, IamUuid } from '@sva/iam-core';
 import type { IamDeletionContentStrategy, IamDeletionLifecycleState } from '@sva/core';
 
 export const deletionRulesBaselineDefaults = {
-  deactivateAfterDays: 90,
-  pseudonymizeAfterDays: 180,
-  deleteAfterDays: 365,
+  deactivateAfterDays: 365,
+  pseudonymizeAfterDays: 730,
+  deleteAfterDays: 1_095,
   defaultContentStrategy: 'retain',
   allowContentPreferenceOverride: false,
 } as const satisfies Readonly<{
@@ -54,8 +54,10 @@ export const resolveTenantDeletionThresholds = (input: {
   pseudonymize_after_days: number | null;
   delete_after_days: number | null;
 }) => ({
-  deactivateAfterDays: input.deactivate_after_days ?? deletionRulesBaselineDefaults.deactivateAfterDays,
-  pseudonymizeAfterDays: input.pseudonymize_after_days ?? deletionRulesBaselineDefaults.pseudonymizeAfterDays,
+  deactivateAfterDays:
+    input.deactivate_after_days ?? deletionRulesBaselineDefaults.deactivateAfterDays,
+  pseudonymizeAfterDays:
+    input.pseudonymize_after_days ?? deletionRulesBaselineDefaults.pseudonymizeAfterDays,
   deleteAfterDays: input.delete_after_days ?? deletionRulesBaselineDefaults.deleteAfterDays,
 });
 


### PR DESCRIPTION
## Was ändert sich?

- hebt die zentrale Baseline für Deaktivierung, Pseudonymisierung und finalen Tombstone-Soft-Delete auf 365 / 730 / 1.095 Tage an
- formuliert alle drei Fristen eindeutig als absolute Schwellwerte seit dem letzten erfolgreichen Login
- lässt explizit gespeicherte Tenant-Regeln unverändert
- aktualisiert deutsche und englische UI-Texte, Tests, Runbook und OpenSpec

## Warum?

Die bisherigen Werte waren für den vorgesehenen Konten-Lebenszyklus zu kurz. Gleichzeitig war nicht überall eindeutig erkennbar, dass alle drei Schwellen vom selben letzten erfolgreichen Login ausgehen und nicht aufeinander aufbauen.

## Auswirkung

Tenants ohne explizite Löschregel-Konfiguration verwenden künftig 365 / 730 / 1.095. Explizite Tenant-Konfigurationen bleiben unverändert. Der automatische Zustand `deleted` bleibt ein finaler Tombstone-Soft-Delete und keine physische Löschung.

## Verifikation

- iam-governance Unit-Tests: 138/138 grün
- fokussierte React-Routentests: 29/29 grün
- React-Typecheck und iam-governance-Typecheck grün
- i18n-Key-Check grün
- Server-Runtime-Guard grün
- OpenSpec strict und File-Placement grün
- breiter affected Lauf zeigte nur PR-fremde Parallelitäts-Timeouts; alle timeoutenden Dateien wurden isoliert grün reproduziert