### PR TITLE
Fix Waste backup request signatures

### DIFF
--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -162,11 +162,11 @@ export const readBackupAgentRevision = (env = process.env) => env.BACKUP_AGENT_I
 export const canonicalRequest = (request) =>
   JSON.stringify({
     action: request.action,
-    ...(request.database ? { database: request.database } : {}),
-    ...(request.tenantInstanceId ? { tenantInstanceId: request.tenantInstanceId } : {}),
     deployImageDigest: request.deployImageDigest,
     environment: request.environment,
     expiresAt: request.expiresAt,
+    ...(request.database ? { database: request.database } : {}),
+    ...(request.tenantInstanceId ? { tenantInstanceId: request.tenantInstanceId } : {}),
     ...(request.version === 1
       ? { maintenanceWindowReference: request.maintenanceWindowReference ?? null }
       : {}),

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { canonicalBackupRequest } from '../../scripts/ci/backup-agent-contract.ts';
+
 import {
   archiveSchemaCompatible,
   backupDumpArgs,
@@ -207,6 +209,15 @@ describe('backup agent runtime contract', () => {
     expect(validRequest({ ...request, database: 'other' }, now)).toBe(false);
     expect(canonicalRequest(request)).not.toContain('database');
     expect(canonicalRequest({ ...request, database: 'waste' })).toContain('"database":"waste"');
+    const versionTwoWasteRequest = {
+      ...request,
+      version: 2 as const,
+      database: 'waste' as const,
+      tenantInstanceId: 'bb-prignitz',
+    };
+    expect(canonicalRequest(versionTwoWasteRequest)).toBe(
+      canonicalBackupRequest(versionTwoWasteRequest)
+    );
     expect(
       validRequest({ ...request, database: 'waste', tenantInstanceId: 'bb-prignitz' }, now)
     ).toBe(true);

--- a/docs/changelog/entries/pr-933.json
+++ b/docs/changelog/entries/pr-933.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 933,
+  "body": "Waste-Datenbank-Backups werden wieder korrekt autorisiert\n\n- Workflow und Backup-Agent verwenden dieselbe kanonische Darstellung für signierte Waste-Aufträge.\n- Ein gemeinsamer Vertragstest verhindert, dass optionale Waste-Felder künftig unbemerkt zu HTTP-401-Fehlern führen."
+}


### PR DESCRIPTION
## Änderung

- richtet die kanonische HMAC-Darstellung des Backup-Agenten am Workflow-Vertrag aus
- schützt Waste-Aufträge mit einem Cross-Contract-Regressionstest gegen erneutes Auseinanderlaufen

## Ursache und Wirkung

Der Workflow setzte das optionale `database`-Feld nach den gemeinsamen Pflichtfeldern ein, der Agent davor. Da JSON-Feldreihenfolge Teil der signierten Darstellung war, wurden nur Waste-Aufträge mit HTTP 401 abgewiesen; Studio-Aufträge blieben unauffällig.

## Prüfung

- `pnpm nx run tooling-testing:test:unit --testFiles=deploy/backup-agent/agent.test.ts --testFiles=scripts/ci/backup-agent-contract.test.ts`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
