### PR TITLE
Fix production backup parity inputs

### DIFF
--- a/.github/workflows/production-backup-drill.yml
+++ b/.github/workflows/production-backup-drill.yml
@@ -65,6 +65,7 @@ jobs:
       - name: require successful staging backup parity
         env:
           DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}
+          DEPLOY_IMAGE_REF: ${{ steps.image_contract.outputs.deploy_image_ref }}
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm exec tsx scripts/ci/verify-staging-promote-evidence.ts backup-drill
 

--- a/docs/changelog/entries/pr-934.json
+++ b/docs/changelog/entries/pr-934.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 934,
+  "body": "Production-Backups prüfen Staging wieder vollständig\n\n- Der Production-Backup-Drill bindet den Staging-Nachweis an Digest und unveränderliche Image-Referenz.\n- Der Workflow-Vertrag ist durch einen gezielten Regressionstest abgesichert."
+}

--- a/scripts/ci/verify-staging-promote-evidence.test.ts
+++ b/scripts/ci/verify-staging-promote-evidence.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -12,7 +15,25 @@ import {
   selectStagingBackupEvidenceJsonFile,
 } from './verify-staging-promote-evidence.ts';
 
+const productionBackupWorkflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/production-backup-drill.yml'),
+  'utf8'
+);
+
 describe('staging parity evidence', () => {
+  it('binds the production backup drill to the immutable image reference and digest', () => {
+    const parityStep = productionBackupWorkflow.match(
+      /- name: require successful staging backup parity[\s\S]*?run: pnpm exec tsx scripts\/ci\/verify-staging-promote-evidence\.ts backup-drill/u
+    )?.[0];
+
+    expect(parityStep).toContain(
+      'DEPLOY_IMAGE_DIGEST: ${{ steps.image_contract.outputs.deploy_summary_digest }}'
+    );
+    expect(parityStep).toContain(
+      'DEPLOY_IMAGE_REF: ${{ steps.image_contract.outputs.deploy_image_ref }}'
+    );
+  });
+
   it('requires staging evidence only when production would change the live digest', () => {
     const target = `ghcr.io/example/app@sha256:${'a'.repeat(64)}`;
     expect(requiresStagingParity(target, target)).toBe(false);

--- a/tooling/testing/vitest.config.ts
+++ b/tooling/testing/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       '../../scripts/ci/pr-review-intake.test.ts',
       '../../scripts/ci/promote-deploy-gates.test.ts',
       '../../scripts/ci/promote-image-contract.test.ts',
+      '../../scripts/ci/verify-staging-promote-evidence.test.ts',
       '../../scripts/ci/backup-agent-contract.test.ts',
       '../../scripts/ci/restore-agent-contract.test.ts',
       '../../scripts/ci/submit-backup-agent-request.test.ts',


### PR DESCRIPTION
## Änderung

- übergibt dem Production-Backup-Paritätsprüfer neben dem Digest auch die unveränderliche Image-Referenz
- nimmt die vorhandenen Paritätstests in den Tooling-Testlauf auf
- schützt die Workflow-Verkabelung mit einem Regressionstest

## Ursache und Wirkung

Der Production-Backup-Drill brach vor jeder Backup-Anfrage fail-closed ab, weil `verify-staging-promote-evidence.ts` zwingend `DEPLOY_IMAGE_REF` benötigt, der Workflow aber nur `DEPLOY_IMAGE_DIGEST` setzte.

## Prüfung

- `pnpm nx run tooling-testing:test:unit --testFiles=scripts/ci/verify-staging-promote-evidence.test.ts --skipNxCache`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
