### PR TITLE
Verify Studio and Waste staging evidence

### DIFF
--- a/docs/changelog/entries/pr-936.json
+++ b/docs/changelog/entries/pr-936.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 936,
+  "body": "Staging-Parität umfasst Studio- und Waste-Backups\n\n- Der Production-Backup-Drill wertet getrennte Studio- und Waste-Nachweise gemeinsam aus.\n- Alle vorhandenen Backup-Nachweise müssen erfolgreich sein und exakt zum Ziel-Digest gehören."
+}

--- a/scripts/ci/verify-staging-promote-evidence.test.ts
+++ b/scripts/ci/verify-staging-promote-evidence.test.ts
@@ -9,10 +9,11 @@ import {
   isSuccessfulStagingBackupWorkflowRun,
   listArtifacts,
   matchesSuccessfulStagingBackupEvidence,
+  matchesSuccessfulStagingBackupEvidenceSet,
   matchesSuccessfulStagingEvidence,
   requiresStagingParity,
   selectEvidenceJsonFile,
-  selectStagingBackupEvidenceJsonFile,
+  selectStagingBackupEvidenceJsonFiles,
 } from './verify-staging-promote-evidence.ts';
 
 const productionBackupWorkflow = readFileSync(
@@ -138,6 +139,29 @@ describe('staging parity evidence', () => {
     ).toBe(false);
   });
 
+  it('accepts distinct Studio and Waste evidence only when both match the target digest', () => {
+    const studio = {
+      database: 'studio',
+      deployImageDigest: 'sha256:expected',
+      environment: 'staging',
+      status: 'succeeded',
+    };
+    const waste = { ...studio, database: 'waste' };
+
+    expect(matchesSuccessfulStagingBackupEvidenceSet([studio, waste], 'sha256:expected')).toBe(
+      true
+    );
+    expect(
+      matchesSuccessfulStagingBackupEvidenceSet(
+        [studio, { ...waste, deployImageDigest: 'sha256:other' }],
+        'sha256:expected'
+      )
+    ).toBe(false);
+    expect(matchesSuccessfulStagingBackupEvidenceSet([studio, studio], 'sha256:expected')).toBe(
+      false
+    );
+  });
+
   it('reads paginated artifact responses before filtering parity evidence', () => {
     const firstPage = Array.from({ length: 100 }, (_, index) => ({ id: index + 1 }));
     const artifacts = listArtifacts((page) =>
@@ -166,18 +190,26 @@ describe('staging parity evidence', () => {
     expect(selectEvidenceJsonFile('README.md\n')).toBeUndefined();
   });
 
-  it('selects the unique agent result when a staging drill artifact contains verification evidence', () => {
+  it('selects one or two agent results when a staging drill artifact contains verification evidence', () => {
     const archiveEntries = [
       'promote-backup-agent-gha-30512741172-1.json',
       'promote-backup-verification-30512741172-1.json',
     ].join('\n');
 
-    expect(selectStagingBackupEvidenceJsonFile(archiveEntries)).toBe(
-      'promote-backup-agent-gha-30512741172-1.json'
-    );
+    expect(selectStagingBackupEvidenceJsonFiles(archiveEntries)).toEqual([
+      'promote-backup-agent-gha-30512741172-1.json',
+    ]);
     expect(
-      selectStagingBackupEvidenceJsonFile(
-        `${archiveEntries}\npromote-backup-agent-gha-duplicate.json\n`
+      selectStagingBackupEvidenceJsonFiles(
+        `${archiveEntries}\npromote-backup-agent-gha-30512741172-1-waste.json\n`
+      )
+    ).toEqual([
+      'promote-backup-agent-gha-30512741172-1.json',
+      'promote-backup-agent-gha-30512741172-1-waste.json',
+    ]);
+    expect(
+      selectStagingBackupEvidenceJsonFiles(
+        `${archiveEntries}\npromote-backup-agent-gha-30512741172-1-waste.json\npromote-backup-agent-gha-duplicate.json\n`
       )
     ).toBeUndefined();
   });

--- a/scripts/ci/verify-staging-promote-evidence.ts
+++ b/scripts/ci/verify-staging-promote-evidence.ts
@@ -10,6 +10,7 @@ import { matchesExpectedLiveImage } from './promote-live-digest.ts';
 type Artifact = { expired?: boolean; id?: number; name?: string; workflow_run?: { id?: number } };
 type ArtifactPage = { artifacts?: Artifact[]; total_count?: number };
 type StagingEvidence = {
+  database?: string;
   deployImageDigest?: string;
   digest?: string;
   environment?: string;
@@ -35,6 +36,17 @@ export const matchesSuccessfulStagingBackupEvidence = (
   evidence.environment === 'staging' &&
   evidence.status === 'succeeded' &&
   evidence.deployImageDigest === targetDigest;
+
+export const matchesSuccessfulStagingBackupEvidenceSet = (
+  evidence: StagingEvidence[],
+  targetDigest: string
+) => {
+  if (evidence.length < 1 || evidence.length > 2) return false;
+  const databases = evidence.map((entry) => entry.database);
+  if (databases.some((database) => database !== 'studio' && database !== 'waste')) return false;
+  if (new Set(databases).size !== databases.length) return false;
+  return evidence.every((entry) => matchesSuccessfulStagingBackupEvidence(entry, targetDigest));
+};
 
 export const listArtifacts = (readPage: (page: number) => ArtifactPage): Artifact[] => {
   const artifacts: Artifact[] = [];
@@ -65,11 +77,11 @@ export const selectEvidenceJsonFile = (archiveEntries: string) => {
   return files.length === 1 ? files[0] : undefined;
 };
 
-export const selectStagingBackupEvidenceJsonFile = (archiveEntries: string) => {
+export const selectStagingBackupEvidenceJsonFiles = (archiveEntries: string) => {
   const files = archiveEntries
     .split('\n')
     .filter((entry) => /(^|\/)promote-backup-agent-[^/]+\.json$/u.test(entry));
-  return files.length === 1 ? files[0] : undefined;
+  return files.length >= 1 && files.length <= 2 ? files : undefined;
 };
 const required = (value: string | undefined, name: string) => {
   const trimmed = value?.trim();
@@ -124,20 +136,24 @@ const main = () => {
         })
       );
       const archiveEntries = execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf8' });
-      const evidenceFile =
-        evidenceKind === 'promote'
-          ? selectEvidenceJsonFile(archiveEntries)
-          : selectStagingBackupEvidenceJsonFile(archiveEntries);
-      if (!evidenceFile) continue;
-      const evidence = JSON.parse(
-        execFileSync('unzip', ['-p', zipPath, evidenceFile], { encoding: 'utf8' })
-      ) as StagingEvidence;
-      if (
-        evidenceKind === 'promote'
-          ? matchesSuccessfulStagingEvidence(evidence, targetDigest)
-          : matchesSuccessfulStagingBackupEvidence(evidence, targetDigest)
-      )
-        return;
+      if (evidenceKind === 'promote') {
+        const evidenceFile = selectEvidenceJsonFile(archiveEntries);
+        if (!evidenceFile) continue;
+        const evidence = JSON.parse(
+          execFileSync('unzip', ['-p', zipPath, evidenceFile], { encoding: 'utf8' })
+        ) as StagingEvidence;
+        if (matchesSuccessfulStagingEvidence(evidence, targetDigest)) return;
+        continue;
+      }
+      const evidenceFiles = selectStagingBackupEvidenceJsonFiles(archiveEntries);
+      if (!evidenceFiles) continue;
+      const evidence = evidenceFiles.map(
+        (evidenceFile) =>
+          JSON.parse(
+            execFileSync('unzip', ['-p', zipPath, evidenceFile], { encoding: 'utf8' })
+          ) as StagingEvidence
+      );
+      if (matchesSuccessfulStagingBackupEvidenceSet(evidence, targetDigest)) return;
     }
     throw new Error(`Kein erfolgreicher Staging-Paritätsnachweis für ${targetDigest} gefunden.`);
   } finally {


### PR DESCRIPTION
## Änderung

- akzeptiert Staging-Backup-Artefakte mit getrennten Studio- und Waste-Nachweisen
- bindet bei mehreren Nachweisen jeden Eintrag an denselben Ziel-Digest
- lehnt doppelte Datenbanktypen und mehr als zwei Agent-Nachweise fail-closed ab

## Ursache und Wirkung

Der erfolgreiche Staging-Drill liefert seit aktivierten Waste-Backups zwei Agent-Ergebnisdateien. Der Production-Paritätsprüfer erwartete weiterhin exakt eine Datei und fand daher trotz grüner Studio- und Waste-Nachweise keine gültige Parität.

## Prüfung

- `pnpm nx run tooling-testing:test:unit --testFiles=scripts/ci/verify-staging-promote-evidence.test.ts --skipNxCache`
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
