### PR TITLE
fix: decouple backup tooling from image revision

### DIFF
--- a/.github/workflows/production-backup-drill.yml
+++ b/.github/workflows/production-backup-drill.yml
@@ -25,12 +25,12 @@ jobs:
     environment: prod
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: checkout current backup tooling source
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: bind executor source to image revision
+      - name: verify image revision belongs to main
         env:
           CHANGE_HEAD: ${{ inputs.change_head }}
         run: |
@@ -38,7 +38,6 @@ jobs:
           git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
           head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
           git merge-base --is-ancestor "${head}" origin/main
-          git checkout --detach "${head}"
 
       - name: setup pnpm workspace
         uses: ./.github/actions/setup-pnpm-workspace

--- a/.github/workflows/staging-backup-drill.yml
+++ b/.github/workflows/staging-backup-drill.yml
@@ -24,12 +24,12 @@ jobs:
     environment: staging
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: checkout current backup tooling source
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: bind executor source to image revision
+      - name: verify image revision belongs to main
         env:
           CHANGE_HEAD: ${{ inputs.change_head }}
         run: |
@@ -37,7 +37,6 @@ jobs:
           git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
           head="$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"
           git merge-base --is-ancestor "${head}" origin/main
-          git checkout --detach "${head}"
 
       - name: setup pnpm workspace
         uses: ./.github/actions/setup-pnpm-workspace

--- a/docs/changelog/entries/pr-937.json
+++ b/docs/changelog/entries/pr-937.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 937,
+  "body": "Backup-Drills verwenden aktuelle Operator-Logik\n\n- Staging- und Production-Backup-Drills prüfen weiterhin die exakte Image-Revision, führen Reparaturen am Operator-Tooling aber aus dem aktuellen Workflow-Stand aus.\n- Ein Readiness-Bericht dokumentiert die noch offenen Sicherheitsgates des bb-prignitz-Waste-Cutovers."
+}

--- a/docs/reports/bb-prignitz-waste-cutover-readiness-2026-08-09.md
+++ b/docs/reports/bb-prignitz-waste-cutover-readiness-2026-08-09.md
@@ -1,0 +1,75 @@
+# Readiness des Waste-Cutovers für `bb-prignitz` vom 9. August 2026
+
+## Ergebnis
+
+Der produktive Offline-Cutover ist derzeit **No-Go**. Produktion läuft unverändert; Studio-App, Public-Waste-App, Worker und Datenbanken wurden durch diesen Audit nicht gestoppt oder mutiert.
+
+Die Datenmigration selbst ist klein und technisch erprobt. Blockierend sind der fehlende vollständig getestete Wartungs- und Transferpfad sowie ein Fehler in der Quellbindung der Backup-Workflows.
+
+## Bestätigter Zustand
+
+| Bereich | Nachweis | Bewertung |
+| --- | --- | --- |
+| Supabase-Quelle | PostgreSQL 17.6, 13 `waste_*`-Tabellen, 7.494 Zeilen | bereit |
+| Quellclient | `pg_dump` und `pg_restore` 17.10 | bereit |
+| Quellsitzungen | keine aktive Fremdsitzung bei der Read-only-Prüfung | bereit, vor finalem Dump erneut prüfen |
+| Quellarchiv | frisches Custom-Archiv mit 414.502 Byte; `pg_restore --list` erfolgreich | bereit |
+| Zielregistrierung | `bb-prignitz`, Status `ready`, Generation 2, Datenbank `sva_w_bb_prignitz_4fc528d5be47_db` | bereit |
+| Zielschema | 19 Waste-Tabellen, 0 Zeilen | bereit, vor Import erneut prüfen |
+| Zielspeicher | rund 326 GB frei | bereit |
+| Staging-Backup | Studio- und Waste-Backup einschließlich Objektprüfung erfolgreich, Run `31307071023` | bereit |
+| Production-Backup | noch kein erfolgreicher vollständiger Run | blockiert |
+| Studio-Runtime | App, Provisionierer, PostgreSQL und Redis laufen | unverändert |
+| Public-Waste-Runtime | `web-waste-calendar` läuft mit einer Replik | unverändert |
+
+## Ursachen der fehlgeschlagenen Production-Backup-Drills
+
+1. Backup-Auftraggeber und Agent verwendeten zunächst unterschiedliche HMAC-Kanonisierung.
+2. Der Production-Workflow übergab dem Paritätsprüfer keine vollständige Image-Referenz.
+3. Der Paritätsprüfer akzeptierte nur eine Agent-Evidenzdatei, obwohl ein vollständiger Lauf getrennte Studio- und Waste-Evidenz erzeugt.
+4. Staging- und Production-Backup-Workflow wechselten den gesamten Arbeitsbaum auf den historischen Commit des unveränderlichen Anwendungsimages. Dadurch wurden später gemergte Operator-Fixes nicht ausgeführt.
+
+Die Punkte 1 bis 3 sind auf `main` korrigiert. Punkt 4 wird als gemeinsamer Workflow-Fix vorbereitet: Operator-Logik stammt aus dem aktuellen geprüften Workflow-Commit; die unveränderliche Image-Revision wird weiterhin über Image-Contract, Commit-Existenz und Main-Ancestry validiert.
+
+## Blockierende Lücken des eigentlichen Cutovers
+
+### Public-Waste-Stopp und -Restart
+
+Für den Studio-Stack existiert im kontrollierten Restore-Workflow ein getestetes Muster, das App und Provisionierer auf null Replikate setzt und PostgreSQL weiterlaufen lässt. Für `web-waste-calendar` existiert nur der Release-/Rollback-Pfad über ein Image-Tag. Ein geschützter, reversibler Stop-/Restart-Vertrag mit Zustandsprüfung ist nicht implementiert.
+
+Damit ist OpenSpec-Aufgabe 3.3 noch nicht erfüllt und wurde wieder geöffnet.
+
+### Ausführbarer Zielzugang
+
+Das Einmalskript verlangt einen libpq-Service mit der tenantgebundenen Migrationsrolle. Deren Passwort wird bei der Provisionierung zufällig erzeugt, für Schemaaufbau verwendet und anschließend nicht gespeichert. In der verschlüsselten Interface-Konfiguration werden nur Studio- und Public-Runtime-Verbindungen persistiert.
+
+Der zentrale Backup-Agent besitzt zwar PostgreSQL-18-Tools, Netzwerkzugriff und die eingeschränkte Waste-Provisioniererrolle, bietet aber keinen signierten Einmalimport. Lokal ist nur der Supabase-Quellzugang vorhanden; die Ziel-Datenbank ist nicht direkt exponiert. Der dokumentierte `TARGET_PGSERVICE` kann daher derzeit nicht regelkonform hergestellt werden.
+
+### Atomare Orchestrierung und Rückfall
+
+Es gibt keinen ausführbaren Ablauf, der gemeinsam und fail-closed:
+
+1. Studio- und Public-Waste-Schreiber stoppt,
+2. Job- und Session-Drain bestätigt,
+3. den finalen Dump unverändert sichert,
+4. den Data-only-Import mit einer geschützten Zielrolle ausführt,
+5. Tabellen-, Rechte- und Fach-Smokes prüft,
+6. beide Runtimes nur bei Erfolg wieder startet und
+7. bei Fehlern die Runtimes gestoppt hält beziehungsweise kontrolliert auf die unveränderte Quelle zurückführt.
+
+## Go-Gates vor dem nächsten Cutover-Versuch
+
+- [ ] Backup-Workflows verwenden aktuelle Operator-Logik bei weiterhin exakter Image-Bindung.
+- [ ] Ein vollständiger Production-Backup-Drill bestätigt Studio- und Waste-Objekte.
+- [ ] Geschützter Public-Waste-Stop und -Restart sind implementiert und in einer nichtproduktiven Probe verifiziert.
+- [ ] Der Import läuft über einen geschützten, nicht offengelegten Zielzugang; kein Passwort erscheint in Argumenten, Logs oder Evidenz.
+- [ ] Der Importpfad wurde mit einem realistischen Quellartefakt gegen eine isolierte Ziel-Datenbank ausgeführt.
+- [ ] Job- und Session-Drain für Studio, Quelle und Ziel sind Teil desselben fail-closed Ablaufs.
+- [ ] Studio-Read/Write-, Public-Read/Reminder- und Backup-/Restore-Smokes sind ausführbar festgelegt.
+- [ ] Der Rückfall vor der ersten freigegebenen Zielschreiboperation ist praktisch ausführbar.
+
+## Nächste technische Entscheidung
+
+Empfohlen wird ein einmaliger, signierter Import über den vorhandenen zentralen Backup-Agenten. Der Agent besitzt bereits die richtigen PostgreSQL-Tools, internen Netzwerkzugriff, S3-Anbindung, OIDC-Workflowbindung und die geschützte Waste-Provisioniererrolle. Der Import soll ein vorab hochgeladenes, prüfsummengebundenes Data-only-Artefakt verwenden und im Ziel auf die tenantbezogene Owner-Rolle wechseln. Eine neue dauerhafte Runtime oder das Offenlegen eines Migrator-Passworts ist dafür nicht erforderlich.
+
+Vor dieser Erweiterung muss geklärt und getestet werden, wie das lokal erzeugte Quellartefakt ohne neue langlebige Credentials in den geschützten S3-Pfad gelangt. Bis dahin bleibt der Cutover No-Go.

--- a/openspec/changes/migrate-waste-from-supabase-to-postgresql/tasks.md
+++ b/openspec/changes/migrate-waste-from-supabase-to-postgresql/tasks.md
@@ -15,7 +15,7 @@
 
 - [x] 3.1 `sva_waste` sowie `sva_waste_owner`, `sva_waste_migrator`, `sva_waste_app` und `sva_waste_public_app` mit minimalen Rechten reproduzierbar für die kanonischen Umgebungen provisionieren.
 - [x] 3.2 Backup- und Restore-Abläufe um die Waste-Fachdatenbank erweitern und mit einem Restore-Drill nachweisen.
-- [x] 3.3 Kontrollierten Stopp von Studio-App, Public-Waste-App und Waste-Worker sowie Job- und Datenbanksitzungs-Drain für das Sonntagsfenster festlegen und testen; keinen neuen Anwendungs-Wartungsmodus einführen.
+- [ ] 3.3 Kontrollierten Stopp von Studio-App, Public-Waste-App und Waste-Worker sowie Job- und Datenbanksitzungs-Drain für das Sonntagsfenster festlegen und testen; keinen neuen Anwendungs-Wartungsmodus einführen. Der Readiness-Audit vom 9. August 2026 hat für die Public-Waste-App keinen getesteten Stop-/Restart-Vertrag gefunden.
 - [x] 3.4 Maschinenlesbare Vorher-/Nachher-Verifikation für Schemaobjekte, Migrationen und Zeilenzahlen bereitstellen.
 
 ## 4. Einmaliger Cutover

--- a/scripts/ci/verify-staging-promote-evidence.test.ts
+++ b/scripts/ci/verify-staging-promote-evidence.test.ts
@@ -20,8 +20,24 @@ const productionBackupWorkflow = readFileSync(
   resolve(import.meta.dirname, '../../.github/workflows/production-backup-drill.yml'),
   'utf8'
 );
+const stagingBackupWorkflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/staging-backup-drill.yml'),
+  'utf8'
+);
 
 describe('staging parity evidence', () => {
+  it.each([
+    ['staging', stagingBackupWorkflow],
+    ['production', productionBackupWorkflow],
+  ])('uses current %s backup tooling while validating the immutable image revision', (_, workflow) => {
+    expect(workflow).toContain('checkout current backup tooling source');
+    expect(workflow).toContain('git merge-base --is-ancestor');
+    expect(workflow).not.toContain('git checkout --detach');
+    expect(workflow).toContain(
+      '--expected-revision "$(git rev-parse --verify "${CHANGE_HEAD}^{commit}")"'
+    );
+  });
+
   it('binds the production backup drill to the immutable image reference and digest', () => {
     const parityStep = productionBackupWorkflow.match(
       /- name: require successful staging backup parity[\s\S]*?run: pnpm exec tsx scripts\/ci\/verify-staging-promote-evidence\.ts backup-drill/u


### PR DESCRIPTION
## Was sich ändert

- Staging- und Production-Backup-Drills führen aktuelle, geprüfte Operator-Logik aus.
- Die unveränderliche Anwendungsrevision bleibt über Image-Contract und Main-Ancestry gebunden.
- Ein Contract-Test verhindert den Rückfall auf einen historischen Tooling-Checkout.
- Der bb-prignitz-Readiness-Bericht dokumentiert die verbleibenden Cutover-No-Gos.
- Die fälschlich abgeschlossene OpenSpec-Aufgabe für den Public-Waste-Stop ist wieder geöffnet.

## Ursache

Die Workflows wechselten nach dem Checkout vollständig auf den historischen Commit des laufenden Images. Dadurch wurden gemergte Reparaturen am Backup-Verifier im Production-Run nicht ausgeführt.

## Verifikation

- 14 gezielte Vitest-Tests
- reale Staging-Evidenz aus Run 31307071023 gegen den exakten Production-Digest
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- `pnpm check:file-placement`
- `openspec validate migrate-waste-from-supabase-to-postgresql --strict`
- `git diff --check`

## Betriebswirkung

Dieser PR startet keinen Cutover und mutiert Production nicht. Der Readiness-Bericht bewertet den eigentlichen Cutover bis zur Stop-/Transfer-Orchestrierung weiterhin als No-Go.