### PR TITLE
Fix Waste backup and add protected bb-prignitz cutover

### DIFF
--- a/.github/workflows/waste-bb-prignitz-cutover.yml
+++ b/.github/workflows/waste-bb-prignitz-cutover.yml
@@ -42,9 +42,16 @@ jobs:
         run: |
           set -euo pipefail
           base_url="${PUBLIC_WASTE_BASE_URL%/}"
+          [[ -n "${base_url}" ]] || { echo 'PUBLIC_WASTE_BASE_URL fehlt.' >&2; exit 1; }
+          consecutive_failures=0
           for attempt in {1..30}; do
             if ! curl --fail --silent --show-error --max-time 5 "${base_url}/health/live" >/dev/null; then
-              exit 0
+              ((consecutive_failures += 1))
+              if (( consecutive_failures >= 3 )); then
+                exit 0
+              fi
+            else
+              consecutive_failures=0
             fi
             sleep 5
           done

--- a/.github/workflows/waste-bb-prignitz-cutover.yml
+++ b/.github/workflows/waste-bb-prignitz-cutover.yml
@@ -103,8 +103,8 @@ jobs:
           set -euo pipefail
           base_url="${PUBLIC_WASTE_BASE_URL%/}"
           for attempt in {1..30}; do
-            if curl --fail --silent --show-error "${base_url}/health/live" >/dev/null &&
-               curl --fail --silent --show-error "${base_url}/api/public-waste/selection" | jq -e '.options | length > 0' >/dev/null; then
+            if curl --fail --silent --show-error --max-time 10 "${base_url}/health/live" >/dev/null &&
+               curl --fail --silent --show-error --max-time 15 "${base_url}/api/public-waste/selection" | jq -e '.options | length > 0' >/dev/null; then
               exit 0
             fi
             sleep 10

--- a/.github/workflows/waste-bb-prignitz-cutover.yml
+++ b/.github/workflows/waste-bb-prignitz-cutover.yml
@@ -1,0 +1,118 @@
+name: Waste bb-prignitz Cutover
+run-name: Waste bb-prignitz cutover ${{ inputs.maintenance_window }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      maintenance_window:
+        description: 'Nicht sensible Freigabereferenz für den Produktionsstopp'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: waste-bb-prignitz-cutover
+  cancel-in-progress: false
+
+jobs:
+  stop-public-waste:
+    name: Stop public Waste
+    environment: web-waste-calendar
+    runs-on: ubuntu-latest
+    env:
+      PUBLIC_WASTE_BASE_URL: ${{ vars.PUBLIC_WASTE_BASE_URL }}
+      PUBLIC_WASTE_MAINTENANCE_MODE: stop
+      PUBLIC_WASTE_STACK_NAME: ${{ vars.PUBLIC_WASTE_STACK_NAME || 'web-waste-calendar' }}
+      QUANTUM_API_KEY: ${{ secrets.QUANTUM_API_KEY }}
+      QUANTUM_ENDPOINT_ID: ${{ vars.QUANTUM_ENDPOINT_ID }}
+      QUANTUM_HOST: ${{ vars.QUANTUM_HOST }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-pnpm-workspace
+      - name: validate maintenance reference
+        env:
+          MAINTENANCE_WINDOW: ${{ inputs.maintenance_window }}
+        run: '[[ "${MAINTENANCE_WINDOW}" =~ ^[A-Za-z0-9][A-Za-z0-9._:/#\ -]{2,159}$ ]]'
+      - name: stop public Waste stack
+        run: pnpm exec tsx scripts/ops/public-waste/portainer-maintenance.ts
+      - name: verify public runtime is stopped
+        run: |
+          set -euo pipefail
+          base_url="${PUBLIC_WASTE_BASE_URL%/}"
+          for attempt in {1..30}; do
+            if ! curl --fail --silent --show-error --max-time 5 "${base_url}/health/live" >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo 'Public Waste blieb trotz Wartungsstopp erreichbar.' >&2
+          exit 1
+
+  import-waste-data:
+    name: Import audited Waste data
+    needs: stop-public-waste
+    environment: prod
+    runs-on: ubuntu-latest
+    env:
+      MAINTENANCE_WINDOW_REFERENCE: ${{ inputs.maintenance_window }}
+      RESTORE_AGENT_SIGNING_KEY: ${{ secrets.RESTORE_AGENT_SIGNING_KEY }}
+      RESTORE_SOURCE_OBJECT_KEY: prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql
+      RESTORE_SOURCE_SHA256: df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc
+      S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+      S3_ENDPOINT: https://fileserver.smart-village.app
+      S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+      WASTE_TENANT_INSTANCE_ID: bb-prignitz
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-pnpm-workspace
+      - name: submit tenant-bound one-time import
+        id: import_agent
+        run: pnpm exec tsx scripts/ci/submit-restore-agent-request.ts prod waste-import
+      - name: upload redacted import evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: waste-bb-prignitz-import-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.import_agent.outputs.restore_evidence_path }}
+          if-no-files-found: warn
+          retention-days: 90
+
+  start-public-waste:
+    name: Start public Waste on tenant PostgreSQL
+    needs: import-waste-data
+    environment: web-waste-calendar
+    runs-on: ubuntu-latest
+    env:
+      PUBLIC_WASTE_BASE_URL: ${{ vars.PUBLIC_WASTE_BASE_URL }}
+      PUBLIC_WASTE_MAINTENANCE_MODE: start
+      PUBLIC_WASTE_POSTGRESQL_DATABASE_URL: ${{ secrets.PUBLIC_WASTE_POSTGRESQL_DATABASE_URL }}
+      PUBLIC_WASTE_STACK_NAME: ${{ vars.PUBLIC_WASTE_STACK_NAME || 'web-waste-calendar' }}
+      QUANTUM_API_KEY: ${{ secrets.QUANTUM_API_KEY }}
+      QUANTUM_ENDPOINT_ID: ${{ vars.QUANTUM_ENDPOINT_ID }}
+      QUANTUM_HOST: ${{ vars.QUANTUM_HOST }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-pnpm-workspace
+      - name: start public Waste stack on PostgreSQL
+        run: pnpm exec tsx scripts/ops/public-waste/portainer-maintenance.ts
+      - name: verify public data path
+        run: |
+          set -euo pipefail
+          base_url="${PUBLIC_WASTE_BASE_URL%/}"
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error "${base_url}/health/live" >/dev/null &&
+               curl --fail --silent --show-error "${base_url}/api/public-waste/selection" | jq -e '.options | length > 0' >/dev/null; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo 'Public Waste lieferte nach dem Cutover keine Auswahlwerte.' >&2
+          exit 1
+      - name: stop public Waste again after failed smoke
+        if: failure()
+        env:
+          PUBLIC_WASTE_MAINTENANCE_MODE: stop
+        run: pnpm exec tsx scripts/ops/public-waste/portainer-maintenance.ts

--- a/apps/sva-studio-react/src/lib/waste-tenant-database-provisioner.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-tenant-database-provisioner.server.test.ts
@@ -155,6 +155,11 @@ describe('waste tenant database provisioner', () => {
     expect(statements.some(({ text }) => text.includes('REVOKE ALL ON DATABASE'))).toBe(true);
     expect(
       statements.some(({ text }) =>
+        text.includes('GRANT CONNECT ON DATABASE') && text.includes('TO CURRENT_USER')
+      )
+    ).toBe(true);
+    expect(
+      statements.some(({ text }) =>
         text.includes('public.waste_email_reminder_subscriptions')
       )
     ).toBe(true);

--- a/apps/sva-studio-react/src/lib/waste-tenant-database-provisioner.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-tenant-database-provisioner.server.ts
@@ -131,6 +131,9 @@ const ensureDatabase = async (
   await client.query(
     `GRANT CONNECT ON DATABASE ${quoteIdentifier(names.database)} TO ${quoteIdentifier(names.migratorRole)}, ${quoteIdentifier(names.appRole)}, ${quoteIdentifier(names.publicAppRole)};`
   );
+  await client.query(
+    `GRANT CONNECT ON DATABASE ${quoteIdentifier(names.database)} TO CURRENT_USER;`
+  );
 };
 
 const migrateAndGrant = async (pool: ProvisioningPool, names: WasteTenantDatabaseNames) => {

--- a/deploy/backup-agent-stack.yaml
+++ b/deploy/backup-agent-stack.yaml
@@ -3,7 +3,7 @@ services:
     image: ${IMAGE_REF}
     environment:
       BACKUP_AGENT_ALLOWED_WORKFLOWS: promote.yml,staging-backup-drill.yml,production-backup-drill.yml
-      RESTORE_AGENT_ALLOWED_WORKFLOWS: database-restore.yml,waste-database-restore-drill.yml
+      RESTORE_AGENT_ALLOWED_WORKFLOWS: database-restore.yml,waste-database-restore-drill.yml,waste-bb-prignitz-cutover.yml
       BACKUP_AGENT_GITHUB_REPOSITORY: smart-village-solutions/sva-studio
       BACKUP_AGENT_IMAGE_REF: ${IMAGE_REF}
       BACKUP_AGENT_OIDC_AUDIENCE: studio-backup-agent

--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -24,6 +24,8 @@ const oidcIssuer = 'https://token.actions.githubusercontent.com';
 const jwksUrl = `${oidcIssuer}/.well-known/jwks`;
 const maxBodyBytes = 16_384;
 const maxRequestLifetimeMs = 10 * 60_000;
+const bbPrignitzWasteImportSha256 =
+  'df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc';
 const acceptanceCommandTimeoutMs = 10_000;
 export const minioAwsCompatibilityEnv = {
   AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required',
@@ -93,21 +95,18 @@ export const validTenantInstanceId = (value) =>
 
 export const deriveWasteDatabaseName = (instanceId) => {
   if (!validTenantInstanceId(instanceId)) throw new Error('waste_inventory_target_invalid');
-  const normalized = instanceId
-    .normalize('NFKD')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, '_')
-    .replace(/^_+|_+$/gu, '') || 'tenant';
+  const normalized =
+    instanceId
+      .normalize('NFKD')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gu, '_')
+      .replace(/^_+|_+$/gu, '') || 'tenant';
   const safeSlug = /^[a-z]/u.test(normalized) ? normalized : `t_${normalized}`;
   const hash = createHash('sha256').update(instanceId).digest('hex').slice(0, 12);
   return `sva_w_${safeSlug.slice(0, 25)}_${hash}_db`;
 };
 
-export const deriveWasteInventoryTarget = (
-  environment,
-  inventory,
-  operation = 'backup'
-) => {
+export const deriveWasteInventoryTarget = (environment, inventory, operation = 'backup') => {
   const target = targets[environment];
   if (
     !target ||
@@ -152,12 +151,14 @@ export const resolveCapabilityEnvironment = (requestUrl, host) => {
   if (url.pathname !== capabilityPath) return undefined;
   const hostEnvironment = Object.entries(targets).find(([, target]) => target.host === host)?.[0];
   const requestedEnvironment = url.searchParams.get('environment');
-  if (requestedEnvironment && requestedEnvironment !== 'staging' && requestedEnvironment !== 'prod') return undefined;
+  if (requestedEnvironment && requestedEnvironment !== 'staging' && requestedEnvironment !== 'prod')
+    return undefined;
   if (requestedEnvironment && requestedEnvironment !== hostEnvironment) return undefined;
   return requestedEnvironment ?? hostEnvironment;
 };
 
-export const readBackupAgentRevision = (env = process.env) => env.BACKUP_AGENT_IMAGE_REF?.trim() || undefined;
+export const readBackupAgentRevision = (env = process.env) =>
+  env.BACKUP_AGENT_IMAGE_REF?.trim() || undefined;
 
 export const canonicalRequest = (request) =>
   JSON.stringify({
@@ -205,13 +206,19 @@ export const validRequest = (request, now = Date.now()) => {
   if ((request.version !== 1 && request.version !== 2) || request.action !== 'backup-and-verify')
     return false;
   if (request.environment !== 'staging' && request.environment !== 'prod') return false;
-  if (request.database !== undefined && request.database !== 'studio' && request.database !== 'waste')
+  if (
+    request.database !== undefined &&
+    request.database !== 'studio' &&
+    request.database !== 'waste'
+  )
     return false;
   if (
-    (request.database === 'waste' && request.tenantInstanceId !== undefined &&
+    (request.database === 'waste' &&
+      request.tenantInstanceId !== undefined &&
       !validTenantInstanceId(request.tenantInstanceId)) ||
     (request.database !== 'waste' && request.tenantInstanceId !== undefined)
-  ) return false;
+  )
+    return false;
   if (
     typeof request.requestId !== 'string' ||
     !/^[a-zA-Z0-9][a-zA-Z0-9._-]{7,127}$/u.test(request.requestId)
@@ -249,11 +256,23 @@ export const validRestoreRequest = (request, now = Date.now()) => {
     'version',
   ]);
   if (Object.keys(request).some((key) => !allowedKeys.has(key))) return false;
-  if (request.version !== 1 || request.action !== 'restore-and-verify-v1') return false;
-  if (request.environment !== 'staging' && request.environment !== 'prod') return false;
-  if (request.database !== undefined && request.database !== 'studio' && request.database !== 'waste')
+  if (
+    request.version !== 1 ||
+    (request.action !== 'restore-and-verify-v1' && request.action !== 'import-waste-data-v1')
+  )
     return false;
-  if (request.database === 'waste' ? !validTenantInstanceId(request.tenantInstanceId) : request.tenantInstanceId !== undefined)
+  if (request.environment !== 'staging' && request.environment !== 'prod') return false;
+  if (
+    request.database !== undefined &&
+    request.database !== 'studio' &&
+    request.database !== 'waste'
+  )
+    return false;
+  if (
+    request.database === 'waste'
+      ? !validTenantInstanceId(request.tenantInstanceId)
+      : request.tenantInstanceId !== undefined
+  )
     return false;
   if (
     typeof request.requestId !== 'string' ||
@@ -267,13 +286,26 @@ export const validRestoreRequest = (request, now = Date.now()) => {
     return false;
   if (typeof request.sourceSha256 !== 'string' || !/^[a-f0-9]{64}$/u.test(request.sourceSha256))
     return false;
-  const prefix = request.database === 'waste'
-    ? `${targets[request.environment].prefix}/waste/${request.tenantInstanceId}/`
-    : `${resolveDatabaseTarget(request.environment, request.database).prefix}/`;
+  const isWasteImport = request.action === 'import-waste-data-v1';
+  if (
+    isWasteImport &&
+    (request.environment !== 'prod' ||
+      request.database !== 'waste' ||
+      request.tenantInstanceId !== 'bb-prignitz' ||
+      request.sourceSha256 !== bbPrignitzWasteImportSha256)
+  )
+    return false;
+  const prefix =
+    request.database === 'waste'
+      ? `${targets[request.environment].prefix}/waste/${request.tenantInstanceId}/${isWasteImport ? 'import/' : ''}`
+      : `${resolveDatabaseTarget(request.environment, request.database).prefix}/`;
+  const sourcePattern = isWasteImport
+    ? /^[A-Za-z0-9][A-Za-z0-9._/-]{7,511}\.sql$/u
+    : /^[A-Za-z0-9][A-Za-z0-9._/-]{7,511}\.dump$/u;
   if (
     typeof request.sourceObjectKey !== 'string' ||
     !request.sourceObjectKey.startsWith(prefix) ||
-    !/^[A-Za-z0-9][A-Za-z0-9._/-]{7,511}\.dump$/u.test(request.sourceObjectKey) ||
+    !sourcePattern.test(request.sourceObjectKey) ||
     request.sourceObjectKey.includes('..')
   )
     return false;
@@ -320,7 +352,7 @@ export const validateOidcClaims = (
     throw new Error('oidc_repository_invalid');
   if (claims.environment !== environment) throw new Error('oidc_environment_invalid');
   const workflowVariable =
-    action === 'restore-and-verify-v1'
+    action === 'restore-and-verify-v1' || action === 'import-waste-data-v1'
       ? 'RESTORE_AGENT_ALLOWED_WORKFLOWS'
       : 'BACKUP_AGENT_ALLOWED_WORKFLOWS';
   const allowedWorkflows = required(process.env[workflowVariable], workflowVariable)
@@ -422,7 +454,8 @@ export const parseWasteInventory = (value) => {
       !postgresIdentifierPattern.test(row.databaseName) ||
       row.databaseName !== deriveWasteDatabaseName(row.instanceId) ||
       !['ready', 'disabled'].includes(row.status)
-    ) throw new Error('waste_inventory_invalid');
+    )
+      throw new Error('waste_inventory_invalid');
     return {
       instanceId: row.instanceId,
       databaseName: row.databaseName,
@@ -435,9 +468,7 @@ export const discoverWasteInventory = async (environment, tenantInstanceId) => {
   const target = targets[environment];
   if (!target || (tenantInstanceId !== undefined && !validTenantInstanceId(tenantInstanceId)))
     throw new Error('waste_inventory_request_invalid');
-  const tenantFilter = tenantInstanceId
-    ? `AND instance_id = ${sqlLiteral(tenantInstanceId)}`
-    : '';
+  const tenantFilter = tenantInstanceId ? `AND instance_id = ${sqlLiteral(tenantInstanceId)}` : '';
   const sql = `
 SELECT COALESCE(json_agg(json_build_object(
   'instanceId', instance_id,
@@ -451,15 +482,21 @@ WHERE status IN ('ready', 'disabled')
   const output = await runCapture(
     'psql',
     [
-      '--host', target.postgresHost,
-      '--port', '5432',
-      '--username', target.postgresUser,
-      '--dbname', target.postgresDatabase,
+      '--host',
+      target.postgresHost,
+      '--port',
+      '5432',
+      '--username',
+      target.postgresUser,
+      '--dbname',
+      target.postgresDatabase,
       '--no-psqlrc',
       '--tuples-only',
       '--no-align',
-      '--set', 'ON_ERROR_STOP=1',
-      '--command', sql,
+      '--set',
+      'ON_ERROR_STOP=1',
+      '--command',
+      sql,
     ],
     {
       env: {
@@ -557,6 +594,9 @@ export const safeErrorCode = (error) => {
       'waste_inventory_tenant_not_found',
       'waste_inventory_target_invalid',
       'waste_restore_target_invalid',
+      'waste_import_target_not_empty',
+      'waste_import_inventory_mismatch',
+      'waste_import_backfill_mismatch',
     ].includes(message)
   )
     return message;
@@ -609,10 +649,12 @@ const executeBackupTargetForIntegration = async (request, target) => {
     requestId: request.requestId,
     environment: request.environment,
     database: target.database,
-    ...(target.tenantInstanceId ? {
-      tenantInstanceId: target.tenantInstanceId,
-      databaseName: target.sourceDatabase,
-    } : {}),
+    ...(target.tenantInstanceId
+      ? {
+          tenantInstanceId: target.tenantInstanceId,
+          databaseName: target.sourceDatabase,
+        }
+      : {}),
     deployImageDigest: request.deployImageDigest,
     agentImage: required(process.env.BACKUP_AGENT_IMAGE_REF, 'BACKUP_AGENT_IMAGE_REF'),
     tools: JSON.parse(
@@ -622,11 +664,7 @@ const executeBackupTargetForIntegration = async (request, target) => {
   try {
     await mkdir(workdir, { recursive: true, mode: 0o700 });
     const pgEnv = { ...process.env, PGPASSWORD: await readSecret(target.postgresPasswordFile) };
-    await runCommand(
-      'pg_dump',
-      backupDumpArgs(target, dump),
-      { env: pgEnv }
-    );
+    await runCommand('pg_dump', backupDumpArgs(target, dump), { env: pgEnv });
     complete('pg_dump');
     const env = await s3Env(target);
     const endpoint = required(process.env.BACKUP_S3_ENDPOINT, 'BACKUP_S3_ENDPOINT');
@@ -717,10 +755,12 @@ export const executeBackupForIntegration = async (request) => {
     const inventory = await discoverWasteInventory(request.environment, request.tenantInstanceId);
     const backups = [];
     for (const item of inventory) {
-      backups.push(await executeBackupTargetForIntegration(
-        request,
-        deriveWasteInventoryTarget(request.environment, item)
-      ));
+      backups.push(
+        await executeBackupTargetForIntegration(
+          request,
+          deriveWasteInventoryTarget(request.environment, item)
+        )
+      );
     }
     const succeeded = backups.every((backup) => backup.status === 'succeeded');
     const manifest = {
@@ -796,13 +836,13 @@ const assertRuntimePrincipalTarget = (target) => {
   const studioTarget = Object.keys(targets)
     .map((environment) => resolveDatabaseTarget(environment, 'studio'))
     .some(
-    (candidate) =>
-      candidate.postgresDatabase === target.postgresDatabase &&
-      candidate.postgresHost === target.postgresHost &&
-      candidate.runtimeRole === target.runtimeRole &&
-      candidate.runtimeUser === target.runtimeUser &&
-      candidate.schemaOwner === target.schemaOwner
-  );
+      (candidate) =>
+        candidate.postgresDatabase === target.postgresDatabase &&
+        candidate.postgresHost === target.postgresHost &&
+        candidate.runtimeRole === target.runtimeRole &&
+        candidate.runtimeUser === target.runtimeUser &&
+        candidate.schemaOwner === target.schemaOwner
+    );
   const dynamicWasteTarget =
     target.database === 'waste' &&
     validTenantInstanceId(target.tenantInstanceId) &&
@@ -994,25 +1034,26 @@ SELECT json_build_object(
 };
 
 export const validateRuntimePrincipalProbe = (probe) => {
-  const requiredChecks = probe && 'publicRuntimeSchemaUsage' in probe
-    ? [
-        'databaseConnect',
-        'runtimeUserSchemaUsage',
-        'runtimeUserTablesReady',
-        'publicRuntimeSchemaUsage',
-        'publicRuntimeTablesReadable',
-        'publicRuntimeReminderWrites',
-      ]
-    : [
-    'databaseConnect',
-    'roleMembership',
-    'runtimeUserSchemaUsage',
-    'runtimeRoleSchemaUsage',
-    'runtimeUserTablesReady',
-    'runtimeRoleTablesReady',
-    'runtimeUserSequencesReady',
-    'runtimeRoleSequencesReady',
-      ];
+  const requiredChecks =
+    probe && 'publicRuntimeSchemaUsage' in probe
+      ? [
+          'databaseConnect',
+          'runtimeUserSchemaUsage',
+          'runtimeUserTablesReady',
+          'publicRuntimeSchemaUsage',
+          'publicRuntimeTablesReadable',
+          'publicRuntimeReminderWrites',
+        ]
+      : [
+          'databaseConnect',
+          'roleMembership',
+          'runtimeUserSchemaUsage',
+          'runtimeRoleSchemaUsage',
+          'runtimeUserTablesReady',
+          'runtimeRoleTablesReady',
+          'runtimeUserSequencesReady',
+          'runtimeRoleSequencesReady',
+        ];
   if (!probe || typeof probe !== 'object' || requiredChecks.some((check) => probe[check] !== true))
     throw new Error('runtime_principal_probe_failed');
   return Object.fromEntries(requiredChecks.map((check) => [check, true]));
@@ -1091,8 +1132,67 @@ export const validateDatabasePostchecks = ({
 };
 
 export const validateWasteDatabasePostchecks = ({ requiredTables, regionsTable, toursTable }) => {
-  if (!/^\d+$/u.test(requiredTables) || Number(requiredTables) < 3 || regionsTable !== 't' || toursTable !== 't')
+  if (
+    !/^\d+$/u.test(requiredTables) ||
+    Number(requiredTables) < 3 ||
+    regionsTable !== 't' ||
+    toursTable !== 't'
+  )
     throw new Error('database_postcheck_failed');
+};
+
+const bbPrignitzWasteImportInventory = Object.freeze({
+  waste_tours: 65,
+  waste_cities: 596,
+  waste_regions: 14,
+  waste_streets: 1438,
+  waste_fractions: 7,
+  waste_holiday_rules: 120,
+  waste_house_numbers: 1438,
+  waste_tour_date_shifts: 0,
+  waste_global_date_shifts: 0,
+  waste_location_tour_links: 2938,
+  waste_collection_locations: 718,
+  waste_custom_recurrence_presets: 0,
+  waste_location_tour_pickup_dates: 160,
+});
+
+export const validateWasteImportInventory = (inventory) => {
+  if (
+    !inventory ||
+    typeof inventory !== 'object' ||
+    Array.isArray(inventory) ||
+    Object.keys(inventory).length !== Object.keys(bbPrignitzWasteImportInventory).length ||
+    Object.entries(bbPrignitzWasteImportInventory).some(
+      ([table, expected]) => inventory[table] !== expected
+    )
+  )
+    throw new Error('waste_import_inventory_mismatch');
+  return Object.values(bbPrignitzWasteImportInventory).reduce((total, count) => total + count, 0);
+};
+
+export const wasteImportBackfillSql = (schemaOwner) => {
+  if (!postgresIdentifierPattern.test(schemaOwner))
+    throw new Error('runtime_principal_target_invalid');
+  return `SET ROLE ${sqlIdentifier(schemaOwner)};
+INSERT INTO public.waste_tour_assignments (id, tour_id, pickup_date, note, created_at, updated_at)
+SELECT legacy_pickup.id, legacy_pickup.tour_id, legacy_pickup.pickup_date, legacy_pickup.note, legacy_pickup.created_at, legacy_pickup.updated_at
+FROM public.waste_location_tour_pickup_dates AS legacy_pickup
+ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.waste_tour_assignment_locations (assignment_id, collection_location_id)
+SELECT assignment.id, legacy_pickup.location_id
+FROM public.waste_location_tour_pickup_dates AS legacy_pickup
+INNER JOIN public.waste_tour_assignments AS assignment
+  ON assignment.id = legacy_pickup.id
+  AND assignment.tour_id = legacy_pickup.tour_id
+  AND assignment.pickup_date = legacy_pickup.pickup_date
+ON CONFLICT (assignment_id, collection_location_id) DO NOTHING;`;
+};
+
+export const wasteRuntimeConnectLockSql = (target, locked) => {
+  assertRuntimePrincipalTarget(target);
+  if (target.database !== 'waste') throw new Error('runtime_principal_target_invalid');
+  return `${locked ? 'REVOKE' : 'GRANT'} CONNECT ON DATABASE ${sqlIdentifier(target.postgresDatabase)} ${locked ? 'FROM' : 'TO'} ${sqlIdentifier(target.runtimeUser)}, ${sqlIdentifier(target.publicRuntimeUser)};`;
 };
 
 export const archiveSchemaCompatible = (listing) =>
@@ -1163,7 +1263,11 @@ const verifyArchiveSchema = async (archive, database = 'studio') => {
   const listing = await runCapture('pg_restore', ['--list', archive], {
     maxOutputBytes: 10 * 1024 * 1024,
   });
-  if (database === 'waste' ? !wasteArchiveSchemaCompatible(listing) : !archiveSchemaCompatible(listing))
+  if (
+    database === 'waste'
+      ? !wasteArchiveSchemaCompatible(listing)
+      : !archiveSchemaCompatible(listing)
+  )
     throw new Error('archive_schema_incompatible');
 };
 
@@ -1185,18 +1289,27 @@ export const ensureWasteRestoreDatabase = async (environment, target, pgEnv) => 
   const owner = sqlIdentifier(target.schemaOwner);
   const login = sqlIdentifier(target.restoreUser);
   const centralArgs = [
-    '--host', centralTarget.postgresHost,
-    '--port', '5432',
-    '--username', target.restoreUser,
-    '--dbname', centralTarget.postgresDatabase,
+    '--host',
+    centralTarget.postgresHost,
+    '--port',
+    '5432',
+    '--username',
+    target.restoreUser,
+    '--dbname',
+    centralTarget.postgresDatabase,
     '--no-psqlrc',
     '--tuples-only',
     '--no-align',
-    '--set', 'ON_ERROR_STOP=1',
+    '--set',
+    'ON_ERROR_STOP=1',
   ];
   const exists = await runCapture(
     'psql',
-    [...centralArgs, '--command', `SELECT 1 FROM pg_database WHERE datname = ${sqlLiteral(target.postgresDatabase)}`],
+    [
+      ...centralArgs,
+      '--command',
+      `SELECT 1 FROM pg_database WHERE datname = ${sqlLiteral(target.postgresDatabase)}`,
+    ],
     { env: pgEnv }
   );
   if (exists !== '1') {
@@ -1221,21 +1334,256 @@ END
 $restore_database_guard$;
 REVOKE ALL ON DATABASE ${database} FROM PUBLIC;
 GRANT CONNECT, TEMPORARY ON DATABASE ${database} TO ${owner}, ${login};`;
-  await runCapture(
-    'psql',
-    [...centralArgs, '--command', sql],
-    { env: pgEnv }
+  await runCapture('psql', [...centralArgs, '--command', sql], { env: pgEnv });
+};
+
+const writeWasteImportSql = async (source, target, schemaOwner) => {
+  if (!postgresIdentifierPattern.test(schemaOwner))
+    throw new Error('runtime_principal_target_invalid');
+  const input = createReadStream(source);
+  const output = createWriteStream(target, { mode: 0o600 });
+  try {
+    if (!output.write(`SET ROLE ${sqlIdentifier(schemaOwner)};\n`)) await once(output, 'drain');
+    for await (const chunk of input) {
+      if (!output.write(chunk)) await once(output, 'drain');
+    }
+    output.end();
+    await finished(output);
+  } catch (error) {
+    output.destroy();
+    throw error;
+  }
+};
+
+const wasteImportInventorySql = `SELECT json_build_object(
+${Object.keys(bbPrignitzWasteImportInventory)
+  .map((table) => `  ${sqlLiteral(table)}, (SELECT count(*) FROM public.${sqlIdentifier(table)})`)
+  .join(',\n')}
+)::text;`;
+
+const readWasteImportInventory = async (target, pgEnv) => {
+  const output = await runSqlAsSchemaOwner(target, pgEnv, wasteImportInventorySql);
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    throw new Error('waste_import_inventory_mismatch', { cause: error });
+  }
+};
+
+export const executeWasteImportForIntegration = async (request) => {
+  const target = deriveWasteInventoryTarget(
+    request.environment,
+    (await discoverWasteInventory(request.environment, request.tenantInstanceId))[0],
+    'backup'
   );
+  const keys = restoreControlKeysFor(request.requestId);
+  const workdir = join(tmpdir(), `waste-import-${request.requestId}-${randomUUID()}`);
+  const sourceSql = join(workdir, 'source.sql');
+  const importSql = join(workdir, 'import.sql');
+  const safetyDump = join(workdir, 'safety.dump');
+  const timestamp = new Date().toISOString().replaceAll(/[:.]/gu, '-');
+  const safetyObjectKey = `${target.prefix}/safety-before-import/${timestamp}/${request.requestId}.dump`;
+  const steps = [];
+  const complete = (step, details = {}) => steps.push({ step, status: 'succeeded', ...details });
+  const evidence = {
+    version: 1,
+    action: request.action,
+    requestId: request.requestId,
+    environment: request.environment,
+    database: 'waste',
+    tenantInstanceId: target.tenantInstanceId,
+    databaseName: target.postgresDatabase,
+    sourceObjectKey: request.sourceObjectKey,
+    sourceSha256: request.sourceSha256,
+    maintenanceWindowReference: request.maintenanceWindowReference,
+    agentImage: required(process.env.BACKUP_AGENT_IMAGE_REF, 'BACKUP_AGENT_IMAGE_REF'),
+  };
+  let mutationStarted = false;
+  let connectLocked = false;
+  try {
+    await mkdir(workdir, { recursive: true, mode: 0o700 });
+    const endpoint = required(process.env.BACKUP_S3_ENDPOINT, 'BACKUP_S3_ENDPOINT');
+    const storageEnv = await s3Env(target);
+    await runCommand(
+      'aws',
+      [
+        '--endpoint-url',
+        endpoint,
+        's3',
+        'cp',
+        `s3://${target.bucket}/${request.sourceObjectKey}`,
+        sourceSql,
+        '--only-show-errors',
+      ],
+      { env: storageEnv, timeoutMs: 5 * 60_000 }
+    );
+    if ((await sha256(sourceSql)) !== bbPrignitzWasteImportSha256)
+      throw new Error('checksum_mismatch');
+    complete('source-object-and-checksum-verify');
+
+    const pgEnv = {
+      ...process.env,
+      PGCONNECT_TIMEOUT: '10',
+      PGPASSWORD: await readSecret(target.restorePasswordFile),
+    };
+    await runSql(target, pgEnv, wasteRuntimeConnectLockSql(target, true));
+    connectLocked = true;
+    complete('runtime-connect-lock');
+    await waitForSessionDrain(target, pgEnv);
+    complete('app-session-drain');
+    const existingRows = Number(
+      await runSqlAsSchemaOwner(
+        target,
+        pgEnv,
+        `SELECT COALESCE(sum((xpath('/row/count/text()', query_to_xml(format('SELECT count(*) AS count FROM %I.%I', table_schema, table_name), false, true, '')))[1]::text::bigint), 0) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE' AND table_name LIKE 'waste\\_%' ESCAPE '\\'`
+      )
+    );
+    if (existingRows !== 0) throw new Error('waste_import_target_not_empty');
+    complete('empty-target-verify');
+
+    await runCommand(
+      'pg_dump',
+      [
+        '--format=custom',
+        '--no-owner',
+        '--no-privileges',
+        '--role',
+        target.schemaOwner,
+        '--host',
+        target.postgresHost,
+        '--port',
+        '5432',
+        '--username',
+        target.restoreUser,
+        '--file',
+        safetyDump,
+        target.postgresDatabase,
+      ],
+      { env: pgEnv, timeoutMs: 10 * 60_000 }
+    );
+    await runCommand('pg_restore', ['--list', safetyDump], { timeoutMs: 60_000 });
+    const safetySha256 = await sha256(safetyDump);
+    await runCommand(
+      'aws',
+      [
+        '--endpoint-url',
+        endpoint,
+        's3',
+        'cp',
+        safetyDump,
+        `s3://${target.bucket}/${safetyObjectKey}`,
+        '--only-show-errors',
+      ],
+      { env: storageEnv, timeoutMs: 5 * 60_000 }
+    );
+    const safetyDownloaded = join(workdir, 'safety.download');
+    await runCommand(
+      'aws',
+      [
+        '--endpoint-url',
+        endpoint,
+        's3',
+        'cp',
+        `s3://${target.bucket}/${safetyObjectKey}`,
+        safetyDownloaded,
+        '--only-show-errors',
+      ],
+      { env: storageEnv, timeoutMs: 5 * 60_000 }
+    );
+    if ((await sha256(safetyDownloaded)) !== safetySha256) throw new Error('checksum_mismatch');
+    await uploadJson(target, keys.safetyBackup, {
+      ...evidence,
+      objectKey: safetyObjectKey,
+      sha256: safetySha256,
+      status: 'verified',
+      completedAt: new Date().toISOString(),
+    });
+    complete('safety-backup', { objectKey: safetyObjectKey, sha256: safetySha256 });
+
+    await writeWasteImportSql(sourceSql, importSql, target.schemaOwner);
+    mutationStarted = true;
+    await runCommand(
+      'psql',
+      [
+        ...postgresArgs(target),
+        '--no-psqlrc',
+        '--set',
+        'ON_ERROR_STOP=1',
+        '--single-transaction',
+        '--file',
+        importSql,
+      ],
+      { env: pgEnv, timeoutMs: 20 * 60_000 }
+    );
+    complete('waste-data-import');
+    const importedRows = validateWasteImportInventory(
+      await readWasteImportInventory(target, pgEnv)
+    );
+    complete('source-inventory-verify', { importedRows });
+
+    await runSql(target, pgEnv, wasteImportBackfillSql(target.schemaOwner));
+    const backfill = JSON.parse(
+      await runSqlAsSchemaOwner(
+        target,
+        pgEnv,
+        `SELECT json_build_object('assignments', (SELECT count(*) FROM public.waste_tour_assignments), 'assignmentLocations', (SELECT count(*) FROM public.waste_tour_assignment_locations))::text`
+      )
+    );
+    if (backfill.assignments !== 160 || backfill.assignmentLocations !== 160)
+      throw new Error('waste_import_backfill_mismatch');
+    complete('legacy-pickup-backfill', backfill);
+
+    const principalProbe = await reconcileAndProbeRuntimePrincipal(target, pgEnv);
+    connectLocked = false;
+    complete('runtime-principal-reconciliation', { principal: target.runtimeUser });
+    complete('runtime-principal-probe', { principal: target.runtimeUser, ...principalProbe });
+    await uploadJson(target, keys.result, {
+      ...evidence,
+      status: 'waste-data-imported',
+      mutationStarted,
+      safetyObjectKey,
+      steps,
+      completedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    if (connectLocked && !mutationStarted) {
+      try {
+        const pgEnv = {
+          ...process.env,
+          PGCONNECT_TIMEOUT: '10',
+          PGPASSWORD: await readSecret(target.restorePasswordFile),
+        };
+        await runSql(target, pgEnv, wasteRuntimeConnectLockSql(target, false));
+        connectLocked = false;
+      } catch {
+        // The failed result remains authoritative; operators must reconcile access before retrying.
+      }
+    }
+    await uploadJson(target, keys.result, {
+      ...evidence,
+      status: 'failed',
+      mutationStarted,
+      runtimeConnectLocked: connectLocked,
+      errorCode: safeErrorCode(error),
+      steps,
+      completedAt: new Date().toISOString(),
+    });
+  } finally {
+    terminalRequests.add(request.requestId);
+    active = false;
+    await rm(workdir, { recursive: true, force: true });
+  }
 };
 
 export const executeRestoreForIntegration = async (request) => {
-  const target = request.database === 'waste'
-    ? deriveWasteInventoryTarget(
-        request.environment,
-        (await discoverWasteInventory(request.environment, request.tenantInstanceId))[0],
-        'restore'
-      )
-    : resolveDatabaseTarget(request.environment, 'studio', 'restore');
+  const target =
+    request.database === 'waste'
+      ? deriveWasteInventoryTarget(
+          request.environment,
+          (await discoverWasteInventory(request.environment, request.tenantInstanceId))[0],
+          'restore'
+        )
+      : resolveDatabaseTarget(request.environment, 'studio', 'restore');
   const keys = restoreControlKeysFor(request.requestId);
   const workdir = join(tmpdir(), `restore-agent-${request.requestId}-${randomUUID()}`);
   const sourceDump = join(workdir, 'source.dump');
@@ -1252,11 +1600,13 @@ export const executeRestoreForIntegration = async (request) => {
     requestId: request.requestId,
     environment: request.environment,
     database: target.database,
-    ...(target.tenantInstanceId ? {
-      tenantInstanceId: target.tenantInstanceId,
-      sourceDatabaseName: target.sourceDatabase,
-      restoreDatabaseName: target.postgresDatabase,
-    } : {}),
+    ...(target.tenantInstanceId
+      ? {
+          tenantInstanceId: target.tenantInstanceId,
+          sourceDatabaseName: target.sourceDatabase,
+          restoreDatabaseName: target.postgresDatabase,
+        }
+      : {}),
     sourceObjectKey: request.sourceObjectKey,
     sourceSha256: request.sourceSha256,
     maintenanceWindowReference: request.maintenanceWindowReference,
@@ -1283,7 +1633,8 @@ export const executeRestoreForIntegration = async (request) => {
     if ((await sha256(sourceDump)) !== request.sourceSha256) throw new Error('checksum_mismatch');
     complete('source-object-and-checksum-verify');
     await verifyArchiveSchema(sourceDump, target.database);
-    const sourceGooseVersion = target.database === 'studio' ? await readArchiveGooseVersion(sourceDump) : null;
+    const sourceGooseVersion =
+      target.database === 'studio' ? await readArchiveGooseVersion(sourceDump) : null;
     if (target.database === 'studio' && !Number.isSafeInteger(sourceGooseVersion))
       throw new Error('archive_schema_incompatible');
     complete('archive-and-schema-preflight', {
@@ -1502,13 +1853,19 @@ export const createBackupAgentServer = () =>
   createServer(async (incoming, response) => {
     if (incoming.method === 'GET' && incoming.url === '/health/live')
       return respond(response, 200, { status: 'ok' });
-    if (incoming.method === 'GET' && new URL(incoming.url ?? '', 'http://backup-agent.internal').pathname === capabilityPath) {
+    if (
+      incoming.method === 'GET' &&
+      new URL(incoming.url ?? '', 'http://backup-agent.internal').pathname === capabilityPath
+    ) {
       try {
         const environment = resolveCapabilityEnvironment(incoming.url, incoming.headers.host);
-        if (environment !== 'staging' && environment !== 'prod') return respond(response, 400, { error: 'invalid_request' });
-        if (!validRequestHost(environment, incoming.headers.host)) return respond(response, 400, { error: 'invalid_request' });
+        if (environment !== 'staging' && environment !== 'prod')
+          return respond(response, 400, { error: 'invalid_request' });
+        if (!validRequestHost(environment, incoming.headers.host))
+          return respond(response, 400, { error: 'invalid_request' });
         const auth = incoming.headers.authorization;
-        if (typeof auth !== 'string' || !auth.startsWith('Bearer ')) return respond(response, 401, { error: 'unauthorized' });
+        if (typeof auth !== 'string' || !auth.startsWith('Bearer '))
+          return respond(response, 401, { error: 'unauthorized' });
         await verifyOidc(auth.slice('Bearer '.length), environment, 'backup-and-verify');
         const agentRevision = readBackupAgentRevision();
         if (!agentRevision) return respond(response, 503, { error: 'agent_misconfigured' });
@@ -1516,7 +1873,17 @@ export const createBackupAgentServer = () =>
           protocolVersions: [2],
           agentRevision,
           databaseTargets: ['studio', 'waste'],
-          resultFields: ['bytes', 'database', 'deployImageDigest', 'environment', 'objectKey', 'requestId', 'sha256', 'status', 'steps'],
+          resultFields: [
+            'bytes',
+            'database',
+            'deployImageDigest',
+            'environment',
+            'objectKey',
+            'requestId',
+            'sha256',
+            'status',
+            'steps',
+          ],
           wasteInventory: true,
         });
       } catch {
@@ -1569,6 +1936,8 @@ export const createBackupAgentServer = () =>
         throw error;
       }
       if (isBackup) void executeBackupForIntegration(request);
+      else if (request.action === 'import-waste-data-v1')
+        void executeWasteImportForIntegration(request);
       else void executeRestoreForIntegration(request);
       return respond(response, 202, { requestId: request.requestId });
     } catch {

--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -26,6 +26,8 @@ const maxBodyBytes = 16_384;
 const maxRequestLifetimeMs = 10 * 60_000;
 const bbPrignitzWasteImportSha256 =
   'df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc';
+const bbPrignitzWasteImportObjectKey =
+  'prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql';
 const acceptanceCommandTimeoutMs = 10_000;
 export const minioAwsCompatibilityEnv = {
   AWS_REQUEST_CHECKSUM_CALCULATION: 'when_required',
@@ -292,6 +294,7 @@ export const validRestoreRequest = (request, now = Date.now()) => {
     (request.environment !== 'prod' ||
       request.database !== 'waste' ||
       request.tenantInstanceId !== 'bb-prignitz' ||
+      request.sourceObjectKey !== bbPrignitzWasteImportObjectKey ||
       request.sourceSha256 !== bbPrignitzWasteImportSha256)
   )
     return false;
@@ -1370,12 +1373,7 @@ const readWasteImportInventory = async (target, pgEnv) => {
   }
 };
 
-export const executeWasteImportForIntegration = async (request) => {
-  const target = deriveWasteInventoryTarget(
-    request.environment,
-    (await discoverWasteInventory(request.environment, request.tenantInstanceId))[0],
-    'backup'
-  );
+const executeResolvedWasteImportForIntegration = async (request, target) => {
   const keys = restoreControlKeysFor(request.requestId);
   const workdir = join(tmpdir(), `waste-import-${request.requestId}-${randomUUID()}`);
   const sourceSql = join(workdir, 'source.sql');
@@ -1572,6 +1570,45 @@ export const executeWasteImportForIntegration = async (request) => {
     terminalRequests.add(request.requestId);
     active = false;
     await rm(workdir, { recursive: true, force: true });
+  }
+};
+
+export const executeWasteImportForIntegration = async (request) => {
+  try {
+    const target = deriveWasteInventoryTarget(
+      request.environment,
+      (await discoverWasteInventory(request.environment, request.tenantInstanceId))[0],
+      'backup'
+    );
+    await executeResolvedWasteImportForIntegration(request, target);
+  } catch (error) {
+    try {
+      await uploadJson(
+        targets[request.environment],
+        restoreControlKeysFor(request.requestId).result,
+        {
+          version: 1,
+          action: request.action,
+          requestId: request.requestId,
+          environment: request.environment,
+          database: 'waste',
+          tenantInstanceId: request.tenantInstanceId,
+          sourceObjectKey: request.sourceObjectKey,
+          sourceSha256: request.sourceSha256,
+          maintenanceWindowReference: request.maintenanceWindowReference,
+          status: 'failed',
+          mutationStarted: false,
+          errorCode: safeErrorCode(error),
+          steps: [],
+          completedAt: new Date().toISOString(),
+        }
+      );
+    } catch {
+      // The slot must still be released if even failure evidence cannot be persisted.
+    } finally {
+      terminalRequests.add(request.requestId);
+      active = false;
+    }
   }
 };
 

--- a/deploy/backup-agent/agent.mjs
+++ b/deploy/backup-agent/agent.mjs
@@ -1195,7 +1195,8 @@ ON CONFLICT (assignment_id, collection_location_id) DO NOTHING;`;
 export const wasteRuntimeConnectLockSql = (target, locked) => {
   assertRuntimePrincipalTarget(target);
   if (target.database !== 'waste') throw new Error('runtime_principal_target_invalid');
-  return `${locked ? 'REVOKE' : 'GRANT'} CONNECT ON DATABASE ${sqlIdentifier(target.postgresDatabase)} ${locked ? 'FROM' : 'TO'} ${sqlIdentifier(target.runtimeUser)}, ${sqlIdentifier(target.publicRuntimeUser)};`;
+  return `SET ROLE ${sqlIdentifier(target.schemaOwner)};
+${locked ? 'REVOKE' : 'GRANT'} CONNECT ON DATABASE ${sqlIdentifier(target.postgresDatabase)} ${locked ? 'FROM' : 'TO'} ${sqlIdentifier(target.runtimeUser)}, ${sqlIdentifier(target.publicRuntimeUser)};`;
 };
 
 export const archiveSchemaCompatible = (listing) =>
@@ -1574,41 +1575,44 @@ const executeResolvedWasteImportForIntegration = async (request, target) => {
 };
 
 export const executeWasteImportForIntegration = async (request) => {
+  let targetResolved = false;
   try {
     const target = deriveWasteInventoryTarget(
       request.environment,
       (await discoverWasteInventory(request.environment, request.tenantInstanceId))[0],
       'backup'
     );
+    targetResolved = true;
     await executeResolvedWasteImportForIntegration(request, target);
   } catch (error) {
-    try {
-      await uploadJson(
-        targets[request.environment],
-        restoreControlKeysFor(request.requestId).result,
-        {
-          version: 1,
-          action: request.action,
-          requestId: request.requestId,
-          environment: request.environment,
-          database: 'waste',
-          tenantInstanceId: request.tenantInstanceId,
-          sourceObjectKey: request.sourceObjectKey,
-          sourceSha256: request.sourceSha256,
-          maintenanceWindowReference: request.maintenanceWindowReference,
-          status: 'failed',
-          mutationStarted: false,
-          errorCode: safeErrorCode(error),
-          steps: [],
-          completedAt: new Date().toISOString(),
-        }
-      );
-    } catch {
-      // The slot must still be released if even failure evidence cannot be persisted.
-    } finally {
-      terminalRequests.add(request.requestId);
-      active = false;
+    if (!targetResolved) {
+      try {
+        await uploadJson(
+          targets[request.environment],
+          restoreControlKeysFor(request.requestId).result,
+          {
+            version: 1,
+            action: request.action,
+            requestId: request.requestId,
+            environment: request.environment,
+            database: 'waste',
+            tenantInstanceId: request.tenantInstanceId,
+            sourceObjectKey: request.sourceObjectKey,
+            sourceSha256: request.sourceSha256,
+            maintenanceWindowReference: request.maintenanceWindowReference,
+            status: 'failed',
+            mutationStarted: false,
+            errorCode: safeErrorCode(error),
+            steps: [],
+            completedAt: new Date().toISOString(),
+          }
+        );
+      } catch {
+        // The slot must still be released if even setup-failure evidence cannot be persisted.
+      }
     }
+    terminalRequests.add(request.requestId);
+    active = false;
   }
 };
 

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -576,6 +576,9 @@ describe('backup agent runtime contract', () => {
       'backup'
     );
     expect(wasteRuntimeConnectLockSql(target, true)).toContain(
+      'SET ROLE "sva_w_bb_prignitz_4fc528d5be47_owner";'
+    );
+    expect(wasteRuntimeConnectLockSql(target, true)).toContain(
       'REVOKE CONNECT ON DATABASE "sva_w_bb_prignitz_4fc528d5be47_db"'
     );
     expect(wasteRuntimeConnectLockSql(target, false)).toContain(

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -36,6 +36,9 @@ import {
   validTenantInstanceId,
   waitForSessionDrain,
   wasteArchiveSchemaCompatible,
+  validateWasteImportInventory,
+  wasteImportBackfillSql,
+  wasteRuntimeConnectLockSql,
   wasteRestoreSchemaResetSql,
   wasteRuntimePrincipalProbeSql,
 } from './agent.mjs';
@@ -51,15 +54,31 @@ const request = {
 
 describe('backup agent runtime contract', () => {
   it('resolves capability requests with or without an explicit environment query', () => {
-    expect(resolveCapabilityEnvironment('/_ops/backup/v1/capabilities', targets.staging.host)).toBe('staging');
-    expect(resolveCapabilityEnvironment('/_ops/backup/v1/capabilities?environment=prod', targets.prod.host)).toBe('prod');
-    expect(resolveCapabilityEnvironment('/_ops/backup/v1/capabilities?environment=prod', targets.staging.host)).toBeUndefined();
-    expect(resolveCapabilityEnvironment('/_ops/backup/v1/requests', targets.staging.host)).toBeUndefined();
+    expect(resolveCapabilityEnvironment('/_ops/backup/v1/capabilities', targets.staging.host)).toBe(
+      'staging'
+    );
+    expect(
+      resolveCapabilityEnvironment(
+        '/_ops/backup/v1/capabilities?environment=prod',
+        targets.prod.host
+      )
+    ).toBe('prod');
+    expect(
+      resolveCapabilityEnvironment(
+        '/_ops/backup/v1/capabilities?environment=prod',
+        targets.staging.host
+      )
+    ).toBeUndefined();
+    expect(
+      resolveCapabilityEnvironment('/_ops/backup/v1/requests', targets.staging.host)
+    ).toBeUndefined();
   });
 
   it('reports a missing agent revision as runtime misconfiguration instead of auth state', () => {
     expect(readBackupAgentRevision({})).toBeUndefined();
-    expect(readBackupAgentRevision({ BACKUP_AGENT_IMAGE_REF: '  image@sha256:abc  ' })).toBe('image@sha256:abc');
+    expect(readBackupAgentRevision({ BACKUP_AGENT_IMAGE_REF: '  image@sha256:abc  ' })).toBe(
+      'image@sha256:abc'
+    );
   });
 
   it('binds GitHub identity to repository, environment and allowlisted main workflow', () => {
@@ -114,6 +133,21 @@ describe('backup agent runtime contract', () => {
         },
         'staging',
         1_000
+      )
+    ).not.toThrow();
+    process.env.RESTORE_AGENT_ALLOWED_WORKFLOWS =
+      'database-restore.yml,waste-bb-prignitz-cutover.yml';
+    expect(() =>
+      validateOidcClaims(
+        {
+          ...claims,
+          environment: 'prod',
+          workflow_ref:
+            'smart-village-solutions/sva-studio/.github/workflows/waste-bb-prignitz-cutover.yml@refs/heads/main',
+        },
+        'prod',
+        1_000,
+        'import-waste-data-v1'
       )
     ).not.toThrow();
   });
@@ -221,13 +255,15 @@ describe('backup agent runtime contract', () => {
     expect(
       validRequest({ ...request, database: 'waste', tenantInstanceId: 'bb-prignitz' }, now)
     ).toBe(true);
-    expect(
-      validRequest({ ...request, tenantInstanceId: 'bb-prignitz' }, now)
-    ).toBe(false);
+    expect(validRequest({ ...request, tenantInstanceId: 'bb-prignitz' }, now)).toBe(false);
   });
 
   it('derives dynamic Waste targets only from validated central inventory', () => {
-    const inventory = { instanceId: 'bb-prignitz', databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db', status: 'ready' };
+    const inventory = {
+      instanceId: 'bb-prignitz',
+      databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db',
+      status: 'ready',
+    };
     const backup = deriveWasteInventoryTarget('prod', inventory);
     const restore = deriveWasteInventoryTarget('prod', inventory, 'restore');
     expect(backup).toMatchObject({
@@ -242,21 +278,39 @@ describe('backup agent runtime contract', () => {
     expect(validTenantInstanceId('bb-prignitz')).toBe(true);
     expect(validTenantInstanceId('../bb-prignitz')).toBe(false);
     expect(deriveWasteDatabaseName('bb-prignitz')).toBe(inventory.databaseName);
-    expect(() => deriveWasteInventoryTarget('prod', { ...inventory, databaseName: 'foreign' })).toThrow(
-      'waste_inventory_target_invalid'
-    );
+    expect(() =>
+      deriveWasteInventoryTarget('prod', { ...inventory, databaseName: 'foreign' })
+    ).toThrow('waste_inventory_target_invalid');
   });
 
   it('rejects malformed or non-retained Waste inventory rows', () => {
-    expect(parseWasteInventory(JSON.stringify([
-      { instanceId: 'bb-prignitz', databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db', status: 'disabled' },
-    ]))).toHaveLength(1);
-    expect(() => parseWasteInventory(JSON.stringify([
-      { instanceId: 'bb-prignitz', databaseName: 'postgres', status: 'ready' },
-    ]))).toThrow('waste_inventory_invalid');
-    expect(() => parseWasteInventory(JSON.stringify([
-      { instanceId: 'bb-prignitz', databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db', status: 'failed' },
-    ]))).toThrow('waste_inventory_invalid');
+    expect(
+      parseWasteInventory(
+        JSON.stringify([
+          {
+            instanceId: 'bb-prignitz',
+            databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db',
+            status: 'disabled',
+          },
+        ])
+      )
+    ).toHaveLength(1);
+    expect(() =>
+      parseWasteInventory(
+        JSON.stringify([{ instanceId: 'bb-prignitz', databaseName: 'postgres', status: 'ready' }])
+      )
+    ).toThrow('waste_inventory_invalid');
+    expect(() =>
+      parseWasteInventory(
+        JSON.stringify([
+          {
+            instanceId: 'bb-prignitz',
+            databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db',
+            status: 'failed',
+          },
+        ])
+      )
+    ).toThrow('waste_inventory_invalid');
   });
 
   it('accepts only the dedicated host of the requested environment', () => {
@@ -298,11 +352,14 @@ describe('backup agent runtime contract', () => {
   });
 
   it('dumps Waste through the NOLOGIN owner role without changing Studio dump arguments', () => {
-    const wasteArgs = backupDumpArgs(deriveWasteInventoryTarget('prod', {
-      instanceId: 'bb-prignitz',
-      databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db',
-      status: 'ready',
-    }), '/tmp/waste.dump');
+    const wasteArgs = backupDumpArgs(
+      deriveWasteInventoryTarget('prod', {
+        instanceId: 'bb-prignitz',
+        databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db',
+        status: 'ready',
+      }),
+      '/tmp/waste.dump'
+    );
     const studioArgs = backupDumpArgs(resolveDatabaseTarget('prod', 'studio'), '/tmp/studio.dump');
     expect(wasteArgs).toContain('sva_w_bb_prignitz_4fc528d5be47_db');
     expect(wasteArgs).toContain('sva_waste_provisioner');
@@ -439,6 +496,82 @@ describe('backup agent runtime contract', () => {
       safetyBackup: `control/restores/safety-backups/${restore.requestId}.json`,
       result: `control/restores/results/${restore.requestId}.json`,
     });
+  });
+
+  it('accepts the one-time production import only for the fixed bb-prignitz source', () => {
+    const importRequest = {
+      version: 1,
+      action: 'import-waste-data-v1',
+      requestId: 'import-12345678',
+      environment: 'prod',
+      expiresAt: '2026-07-30T10:05:00.000Z',
+      maintenanceWindowReference: '2026-08-09 bb-prignitz',
+      sourceObjectKey: 'prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql',
+      sourceSha256: 'df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc',
+      database: 'waste',
+      tenantInstanceId: 'bb-prignitz',
+    };
+    const now = Date.parse('2026-07-30T10:00:00.000Z');
+
+    expect(validRestoreRequest(importRequest, now)).toBe(true);
+    expect(validRestoreRequest({ ...importRequest, environment: 'staging' }, now)).toBe(false);
+    expect(validRestoreRequest({ ...importRequest, tenantInstanceId: 'bb-guben' }, now)).toBe(
+      false
+    );
+    expect(
+      validRestoreRequest(
+        { ...importRequest, sourceObjectKey: 'prod/waste/bb-prignitz/backup.dump' },
+        now
+      )
+    ).toBe(false);
+  });
+
+  it('binds the one-time import to the audited source inventory and legacy backfill', () => {
+    expect(
+      validateWasteImportInventory({
+        waste_tours: 65,
+        waste_cities: 596,
+        waste_regions: 14,
+        waste_streets: 1438,
+        waste_fractions: 7,
+        waste_holiday_rules: 120,
+        waste_house_numbers: 1438,
+        waste_tour_date_shifts: 0,
+        waste_global_date_shifts: 0,
+        waste_location_tour_links: 2938,
+        waste_collection_locations: 718,
+        waste_custom_recurrence_presets: 0,
+        waste_location_tour_pickup_dates: 160,
+      })
+    ).toBe(7494);
+    expect(() => validateWasteImportInventory({ waste_tours: 65 })).toThrow(
+      'waste_import_inventory_mismatch'
+    );
+    expect(wasteImportBackfillSql('sva_w_bb_prignitz_4fc528d5be47_owner')).toContain(
+      'INSERT INTO public.waste_tour_assignments'
+    );
+    expect(() => wasteImportBackfillSql('attacker-role')).toThrow(
+      'runtime_principal_target_invalid'
+    );
+  });
+
+  it('locks both Waste runtime principals out before the import session drain', () => {
+    const target = deriveWasteInventoryTarget(
+      'prod',
+      {
+        instanceId: 'bb-prignitz',
+        databaseName: 'sva_w_bb_prignitz_4fc528d5be47_db',
+        interfaceId: 'waste-management:bb-prignitz',
+        status: 'ready',
+      },
+      'backup'
+    );
+    expect(wasteRuntimeConnectLockSql(target, true)).toContain(
+      'REVOKE CONNECT ON DATABASE "sva_w_bb_prignitz_4fc528d5be47_db"'
+    );
+    expect(wasteRuntimeConnectLockSql(target, false)).toContain(
+      'GRANT CONNECT ON DATABASE "sva_w_bb_prignitz_4fc528d5be47_db"'
+    );
   });
 
   it('uses checksum settings compatible with the deployed MinIO endpoint', () => {

--- a/deploy/backup-agent/agent.test.ts
+++ b/deploy/backup-agent/agent.test.ts
@@ -524,6 +524,15 @@ describe('backup agent runtime contract', () => {
         now
       )
     ).toBe(false);
+    expect(
+      validRestoreRequest(
+        {
+          ...importRequest,
+          sourceObjectKey: 'prod/waste/bb-prignitz/import/other/waste-data-pg16.sql',
+        },
+        now
+      )
+    ).toBe(false);
   });
 
   it('binds the one-time import to the audited source inventory and legacy backfill', () => {

--- a/docs/changelog/entries/pr-938.json
+++ b/docs/changelog/entries/pr-938.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 938,
+  "body": "Geschützter Waste-Cutover für bb-prignitz\n\n- Tenantgenaue Waste-Sicherungen erhalten den fehlenden Provisionierer-Zugriff.\n- Der geprüfte Supabase-Bestand kann einmalig und ausschließlich nach bb-prignitz importiert werden.\n- Public Waste wird während des Imports kontrolliert gestoppt und erst nach Daten-, Rechte- und Smoke-Prüfungen mit der neuen PostgreSQL-Datenbank gestartet."
+}

--- a/docs/guides/waste-postgresql-cutover.md
+++ b/docs/guides/waste-postgresql-cutover.md
@@ -29,7 +29,32 @@ Ein verlustfreier Rückwechsel ist nur möglich, solange nach dem finalen Dump k
 5. Den freien Speicher auf dem PostgreSQL-Host in Bytes ermitteln. Der Migrationslauf verlangt mindestens das Dreifache der finalen Dump-Größe für Dump, Restore und Sicherheitsreserve.
 6. Einen regulären Waste-Backup-Auftrag ausführen. Das Ergebnis muss ein Manifest unter `<umgebung>/waste/inventory/` und einen Eintrag für `bb-prignitz` unter `<umgebung>/waste/bb-prignitz/` enthalten.
 
+Für den produktiven Einmallauf müssen zusätzlich der Studio-Build mit dem
+Provisionierer-Fix und das dazugehörige Backup-Agent-Image über die regulären,
+geschützten Rollout-Workflows ausgerollt sein. Anschließend wird die
+Provisionierung von `bb-prignitz` erneut ausgeführt. Dadurch erhält die bereits
+vorhandene Tenant-Datenbank den fehlenden `CONNECT`-Grant für den
+Provisionierer; zugleich werden die Runtime-Passwörter kontrolliert rotiert.
+Die dabei erzeugte Public-Verbindungs-URL wird ausschließlich als Environment-
+Secret `PUBLIC_WASTE_POSTGRESQL_DATABASE_URL` im geschützten GitHub Environment
+`web-waste-calendar` hinterlegt.
+
+Der geprüfte PG16-Datenexport wird einmalig unter
+`prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql` in den
+Produktions-Backup-Bucket geladen. Dateipfad und SHA-256
+`df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc`
+sind Teil des Agent-Vertrags. Andere Tenants, Umgebungen, Pfade oder Inhalte
+werden abgewiesen.
+
 ## Offline-Fenster
+
+Der produktive Ablauf wird ausschließlich über den manuell freigegebenen
+GitHub-Actions-Workflow **Waste bb-prignitz Cutover** gestartet. Dessen drei
+geschützte Jobs verwenden die Environments `web-waste-calendar`, `prod` und
+erneut `web-waste-calendar`. Der Workflow stoppt zunächst nur die öffentliche
+Waste-Runtime. Schlägt danach Import oder Verifikation fehl, bleibt sie
+gestoppt; ein automatischer Start auf einem ungeprüften Ziel findet nicht
+statt.
 
 Am vereinbarten Sonntag werden über den bestehenden Betriebsweg Studio-App, öffentliche Waste-App und relevante Worker gestoppt. Ein eigener Wartungsmodus ist nicht vorgesehen. Vor dem Dump müssen folgende Prüfungen leer sein:
 
@@ -78,14 +103,28 @@ scripts/ops/migrate-waste-postgresql.sh
 
 `SOURCE_PG_BIN` muss auf einen Client zeigen, dessen Hauptversion mindestens der Supabase-Quellversion entspricht. Die lokale PostgreSQL-Serverinstanz muss dafür nicht gewechselt werden. Der Import überträgt ausschließlich Daten aus `public.waste_*` in das durch die versionierten Waste-Migrationen vorbereitete Schema; Owner und Supabase-ACLs werden nicht übernommen.
 
+Der produktive Workflow wiederholt den mutierenden Teil nicht lokal. Der
+signierte Backup-Agent lädt ausschließlich das fest verdrahtete, per SHA-256
+gebundene Daten-SQL, wartet auf abgeflossene App-Sitzungen, verlangt ein leeres
+Ziel und erstellt vor der ersten Mutation ein tenantgenaues Sicherheitsbackup.
+Der Import läuft in einer einzelnen Transaktion unter der Owner-Rolle. Danach
+werden die bekannten Legacy-Abholtermine idempotent in Tour-Zuordnungen
+überführt.
+
 ## Verifikation und Evidenz
 
-Der Lauf vergleicht Tabelleninventar und Zeilenzahlen. Zusätzlich sind fachliche Stichproben für Regionen, Orte, Touren, Termine, Einstellungen und Reminder-Daten durchzuführen. Anschließend:
+Der Lauf vergleicht Tabelleninventar und Zeilenzahlen. Für den gebundenen
+Produktionsbestand müssen genau 13 Quelltabellen mit insgesamt 7.494 Zeilen
+vorliegen; aus 160 Legacy-Abholterminen müssen 160 Tour-Zuordnungen und 160
+Ortsverknüpfungen entstehen. Zusätzlich sind fachliche Stichproben für
+Regionen, Orte, Touren, Termine, Einstellungen und Reminder-Daten
+durchzuführen. Anschließend:
 
 1. den Waste-Reconcile-/Migrationsjob für `bb-prignitz` erneut ausführen,
 2. Status `ready` und erfolgreiche Studio-/Public-Rechteproben prüfen,
 3. Studio-Smoke für lesenden und schreibenden Waste-Zugriff ausführen,
-4. Public-Waste-Smoke mit der tenantbezogenen Public-Rolle ausführen,
+4. Public-Waste-Smoke mit der tenantbezogenen Public-Rolle ausführen; der
+   Cutover-Workflow verlangt dafür mindestens eine nicht leere Ortsauswahl,
 5. einen Registry-basierten Backup-Lauf und den Workflow **Waste Database Restore Drill** mit `tenant_instance_id: bb-prignitz` erfolgreich abschließen.
 
 Das geschützte Evidenzverzeichnis enthält mindestens:

--- a/scripts/ci/restore-agent-contract.test.ts
+++ b/scripts/ci/restore-agent-contract.test.ts
@@ -108,5 +108,14 @@ describe('restore agent contract', () => {
         now
       )
     ).toBe(false);
+    expect(
+      isValidRestoreRequest(
+        {
+          ...importRequest,
+          sourceObjectKey: 'prod/waste/bb-prignitz/import/other/waste-data-pg16.sql',
+        },
+        now
+      )
+    ).toBe(false);
   });
 });

--- a/scripts/ci/restore-agent-contract.test.ts
+++ b/scripts/ci/restore-agent-contract.test.ts
@@ -77,7 +77,36 @@ describe('restore agent contract', () => {
     expect(
       isValidRestoreRequest({ ...wasteRequest, sourceObjectKey: request.sourceObjectKey }, now)
     ).toBe(false);
-    expect(signRestoreRequest(wasteRequest, 'secret')).not.toBe(signRestoreRequest(request, 'secret'));
-    expect(isValidRestoreRequest({ ...wasteRequest, tenantInstanceId: 'bb-guben' }, now)).toBe(false);
+    expect(signRestoreRequest(wasteRequest, 'secret')).not.toBe(
+      signRestoreRequest(request, 'secret')
+    );
+    expect(isValidRestoreRequest({ ...wasteRequest, tenantInstanceId: 'bb-guben' }, now)).toBe(
+      false
+    );
+  });
+
+  it('binds the one-time Waste import to production bb-prignitz SQL', () => {
+    const now = new Date('2026-08-01T10:00:00.000Z');
+    const importRequest: RestoreRequest = {
+      ...request,
+      action: 'import-waste-data-v1',
+      environment: 'prod',
+      database: 'waste',
+      tenantInstanceId: 'bb-prignitz',
+      sourceObjectKey: 'prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql',
+      sourceSha256: 'df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc',
+    };
+
+    expect(isValidRestoreRequest(importRequest, now)).toBe(true);
+    expect(isValidRestoreRequest({ ...importRequest, environment: 'staging' }, now)).toBe(false);
+    expect(isValidRestoreRequest({ ...importRequest, tenantInstanceId: 'bb-guben' }, now)).toBe(
+      false
+    );
+    expect(
+      isValidRestoreRequest(
+        { ...importRequest, sourceObjectKey: 'prod/waste/bb-prignitz/source.dump' },
+        now
+      )
+    ).toBe(false);
   });
 });

--- a/scripts/ci/restore-agent-contract.ts
+++ b/scripts/ci/restore-agent-contract.ts
@@ -98,48 +98,48 @@ const hasValidExpiry = (expiresAt: unknown, now: Date) => {
   );
 };
 
+type RestoreRequestEnvelope = Partial<RestoreRequest> &
+  Readonly<{
+    action: RestoreRequest['action'];
+    environment: BackupEnvironment;
+  }>;
+
+const hasValidEnvelope = (request: Partial<RestoreRequest>): request is RestoreRequestEnvelope =>
+  request.version === 1 &&
+  (request.action === 'restore-and-verify-v1' || request.action === 'import-waste-data-v1') &&
+  (request.environment === 'staging' || request.environment === 'prod') &&
+  (request.database === undefined || request.database === 'studio' || request.database === 'waste');
+
+const hasValidTenantBinding = (request: RestoreRequestEnvelope): boolean =>
+  request.database === 'waste'
+    ? typeof request.tenantInstanceId === 'string' &&
+      /^[a-z0-9][a-z0-9-]{1,62}$/u.test(request.tenantInstanceId)
+    : request.tenantInstanceId === undefined;
+
+const hasValidImportBinding = (request: RestoreRequestEnvelope): boolean =>
+  request.action !== 'import-waste-data-v1' ||
+  (request.environment === 'prod' &&
+    request.database === 'waste' &&
+    request.tenantInstanceId === 'bb-prignitz' &&
+    request.sourceSha256 === bbPrignitzWasteImportSha256);
+
+const hasValidRequestMetadata = (request: RestoreRequestEnvelope): boolean =>
+  typeof request.requestId === 'string' &&
+  requestIdPattern.test(request.requestId) &&
+  typeof request.maintenanceWindowReference === 'string' &&
+  maintenanceWindowPattern.test(request.maintenanceWindowReference);
+
 export const isValidRestoreRequest = (
   value: unknown,
   now = new Date()
 ): value is RestoreRequest => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const request = value as Partial<RestoreRequest>;
-  if (!hasOnlyRestoreRequestKeys(request)) return false;
-  if (
-    request.version !== 1 ||
-    (request.action !== 'restore-and-verify-v1' && request.action !== 'import-waste-data-v1')
-  )
-    return false;
-  if (request.environment !== 'staging' && request.environment !== 'prod') return false;
-  if (
-    request.database !== undefined &&
-    request.database !== 'studio' &&
-    request.database !== 'waste'
-  )
-    return false;
-  if (
-    request.database === 'waste'
-      ? typeof request.tenantInstanceId !== 'string' ||
-        !/^[a-z0-9][a-z0-9-]{1,62}$/u.test(request.tenantInstanceId)
-      : request.tenantInstanceId !== undefined
-  )
-    return false;
-  if (
-    request.action === 'import-waste-data-v1' &&
-    (request.environment !== 'prod' ||
-      request.database !== 'waste' ||
-      request.tenantInstanceId !== 'bb-prignitz' ||
-      request.sourceSha256 !== bbPrignitzWasteImportSha256)
-  )
-    return false;
-  if (typeof request.requestId !== 'string' || !requestIdPattern.test(request.requestId))
-    return false;
-  if (
-    typeof request.maintenanceWindowReference !== 'string' ||
-    !maintenanceWindowPattern.test(request.maintenanceWindowReference)
-  )
-    return false;
+  if (!hasOnlyRestoreRequestKeys(request) || !hasValidEnvelope(request)) return false;
   return (
+    hasValidTenantBinding(request) &&
+    hasValidImportBinding(request) &&
+    hasValidRequestMetadata(request) &&
     hasValidSourceObject(
       request.environment,
       request.action,
@@ -147,7 +147,8 @@ export const isValidRestoreRequest = (
       request.tenantInstanceId,
       request.sourceObjectKey,
       request.sourceSha256
-    ) && hasValidExpiry(request.expiresAt, now)
+    ) &&
+    hasValidExpiry(request.expiresAt, now)
   );
 };
 

--- a/scripts/ci/restore-agent-contract.ts
+++ b/scripts/ci/restore-agent-contract.ts
@@ -1,10 +1,14 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
-import { backupEnvironmentConfig, type BackupDatabase, type BackupEnvironment } from './backup-agent-contract.ts';
+import {
+  backupEnvironmentConfig,
+  type BackupDatabase,
+  type BackupEnvironment,
+} from './backup-agent-contract.ts';
 
 export type RestoreRequest = Readonly<{
   version: 1;
-  action: 'restore-and-verify-v1';
+  action: 'restore-and-verify-v1' | 'import-waste-data-v1';
   requestId: string;
   environment: BackupEnvironment;
   expiresAt: string;
@@ -18,6 +22,8 @@ export type RestoreRequest = Readonly<{
 const requestIdPattern = /^[a-zA-Z0-9][a-zA-Z0-9._-]{7,127}$/u;
 const maintenanceWindowPattern = /^[A-Za-z0-9][A-Za-z0-9._:/# -]{2,159}$/u;
 const sha256Pattern = /^[a-f0-9]{64}$/u;
+const bbPrignitzWasteImportSha256 =
+  'df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc';
 const restoreRequestKeys = new Set([
   'action',
   'database',
@@ -61,17 +67,22 @@ const hasOnlyRestoreRequestKeys = (request: object) =>
 
 const hasValidSourceObject = (
   environment: BackupEnvironment,
+  action: RestoreRequest['action'],
   database: BackupDatabase | undefined,
   tenantInstanceId: string | undefined,
   sourceObjectKey: unknown,
   sourceSha256: unknown
 ) => {
-  const databasePrefix = database === 'waste' ? `/waste/${tenantInstanceId}/` : '/';
+  const isWasteImport = action === 'import-waste-data-v1';
+  const databasePrefix =
+    database === 'waste' ? `/waste/${tenantInstanceId}/${isWasteImport ? 'import/' : ''}` : '/';
   const prefix = `${restoreEnvironmentConfig(environment).objectPrefix}${databasePrefix}`;
   return (
     typeof sourceObjectKey === 'string' &&
     sourceObjectKey.startsWith(prefix) &&
-    /^[A-Za-z0-9][A-Za-z0-9._/-]{7,511}\.dump$/u.test(sourceObjectKey) &&
+    (isWasteImport
+      ? /^[A-Za-z0-9][A-Za-z0-9._/-]{7,511}\.sql$/u.test(sourceObjectKey)
+      : /^[A-Za-z0-9][A-Za-z0-9._/-]{7,511}\.dump$/u.test(sourceObjectKey)) &&
     !sourceObjectKey.includes('..') &&
     typeof sourceSha256 === 'string' &&
     sha256Pattern.test(sourceSha256)
@@ -94,14 +105,33 @@ export const isValidRestoreRequest = (
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const request = value as Partial<RestoreRequest>;
   if (!hasOnlyRestoreRequestKeys(request)) return false;
-  if (request.version !== 1 || request.action !== 'restore-and-verify-v1') return false;
+  if (
+    request.version !== 1 ||
+    (request.action !== 'restore-and-verify-v1' && request.action !== 'import-waste-data-v1')
+  )
+    return false;
   if (request.environment !== 'staging' && request.environment !== 'prod') return false;
-  if (request.database !== undefined && request.database !== 'studio' && request.database !== 'waste') return false;
+  if (
+    request.database !== undefined &&
+    request.database !== 'studio' &&
+    request.database !== 'waste'
+  )
+    return false;
   if (
     request.database === 'waste'
-      ? typeof request.tenantInstanceId !== 'string' || !/^[a-z0-9][a-z0-9-]{1,62}$/u.test(request.tenantInstanceId)
+      ? typeof request.tenantInstanceId !== 'string' ||
+        !/^[a-z0-9][a-z0-9-]{1,62}$/u.test(request.tenantInstanceId)
       : request.tenantInstanceId !== undefined
-  ) return false;
+  )
+    return false;
+  if (
+    request.action === 'import-waste-data-v1' &&
+    (request.environment !== 'prod' ||
+      request.database !== 'waste' ||
+      request.tenantInstanceId !== 'bb-prignitz' ||
+      request.sourceSha256 !== bbPrignitzWasteImportSha256)
+  )
+    return false;
   if (typeof request.requestId !== 'string' || !requestIdPattern.test(request.requestId))
     return false;
   if (
@@ -110,8 +140,14 @@ export const isValidRestoreRequest = (
   )
     return false;
   return (
-    hasValidSourceObject(request.environment, request.database, request.tenantInstanceId, request.sourceObjectKey, request.sourceSha256) &&
-    hasValidExpiry(request.expiresAt, now)
+    hasValidSourceObject(
+      request.environment,
+      request.action,
+      request.database,
+      request.tenantInstanceId,
+      request.sourceObjectKey,
+      request.sourceSha256
+    ) && hasValidExpiry(request.expiresAt, now)
   );
 };
 

--- a/scripts/ci/restore-agent-contract.ts
+++ b/scripts/ci/restore-agent-contract.ts
@@ -24,6 +24,8 @@ const maintenanceWindowPattern = /^[A-Za-z0-9][A-Za-z0-9._:/# -]{2,159}$/u;
 const sha256Pattern = /^[a-f0-9]{64}$/u;
 const bbPrignitzWasteImportSha256 =
   'df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc';
+const bbPrignitzWasteImportObjectKey =
+  'prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql';
 const restoreRequestKeys = new Set([
   'action',
   'database',
@@ -121,6 +123,7 @@ const hasValidImportBinding = (request: RestoreRequestEnvelope): boolean =>
   (request.environment === 'prod' &&
     request.database === 'waste' &&
     request.tenantInstanceId === 'bb-prignitz' &&
+    request.sourceObjectKey === bbPrignitzWasteImportObjectKey &&
     request.sourceSha256 === bbPrignitzWasteImportSha256);
 
 const hasValidRequestMetadata = (request: RestoreRequestEnvelope): boolean =>

--- a/scripts/ci/submit-restore-agent-request.test.ts
+++ b/scripts/ci/submit-restore-agent-request.test.ts
@@ -4,9 +4,26 @@ import {
   buildRestoreAgentRequest,
   hasRuntimePrincipalRestoreEvidence,
   hasWasteImportEvidence,
+  parseRestoreMode,
 } from './submit-restore-agent-request.ts';
 
 describe('submit restore agent request', () => {
+  it('rejects unknown restore modes instead of falling back to Studio', () => {
+    expect(parseRestoreMode(undefined)).toEqual({
+      database: 'studio',
+      action: 'restore-and-verify-v1',
+    });
+    expect(parseRestoreMode('waste')).toEqual({
+      database: 'waste',
+      action: 'restore-and-verify-v1',
+    });
+    expect(parseRestoreMode('waste-import')).toEqual({
+      database: 'waste',
+      action: 'import-waste-data-v1',
+    });
+    expect(() => parseRestoreMode('waste-improt')).toThrow('akzeptiert nur die Modi');
+  });
+
   it('builds the complete short-lived workflow request', () => {
     expect(
       buildRestoreAgentRequest({

--- a/scripts/ci/submit-restore-agent-request.test.ts
+++ b/scripts/ci/submit-restore-agent-request.test.ts
@@ -74,6 +74,7 @@ describe('submit restore agent request', () => {
     ).toMatchObject({ action: 'import-waste-data-v1', database: 'waste' });
 
     const steps = [
+      'source-object-and-checksum-verify',
       'runtime-connect-lock',
       'app-session-drain',
       'empty-target-verify',

--- a/scripts/ci/submit-restore-agent-request.test.ts
+++ b/scripts/ci/submit-restore-agent-request.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildRestoreAgentRequest,
   hasRuntimePrincipalRestoreEvidence,
+  hasWasteImportEvidence,
 } from './submit-restore-agent-request.ts';
 
 describe('submit restore agent request', () => {
@@ -43,15 +44,47 @@ describe('submit restore agent request', () => {
   });
 
   it('includes the tenant identity in Waste restore requests', () => {
-    expect(buildRestoreAgentRequest({
-      environment: 'staging',
-      maintenanceWindowReference: 'DRILL-42',
-      now: new Date('2026-08-01T10:00:00.000Z'),
-      requestId: 'restore-gha-456-1',
-      sourceObjectKey: 'staging/waste/bb-prignitz/run/source.dump',
-      sourceSha256: 'c'.repeat(64),
-      database: 'waste',
-      tenantInstanceId: 'bb-prignitz',
-    })).toMatchObject({ database: 'waste', tenantInstanceId: 'bb-prignitz' });
+    expect(
+      buildRestoreAgentRequest({
+        environment: 'staging',
+        maintenanceWindowReference: 'DRILL-42',
+        now: new Date('2026-08-01T10:00:00.000Z'),
+        requestId: 'restore-gha-456-1',
+        sourceObjectKey: 'staging/waste/bb-prignitz/run/source.dump',
+        sourceSha256: 'c'.repeat(64),
+        database: 'waste',
+        tenantInstanceId: 'bb-prignitz',
+      })
+    ).toMatchObject({ database: 'waste', tenantInstanceId: 'bb-prignitz' });
+  });
+
+  it('builds and verifies the fixed one-time Waste import evidence', () => {
+    expect(
+      buildRestoreAgentRequest({
+        action: 'import-waste-data-v1',
+        environment: 'prod',
+        maintenanceWindowReference: 'CUTOVER-42',
+        now: new Date('2026-08-01T10:00:00.000Z'),
+        requestId: 'waste-import-gha-456-1',
+        sourceObjectKey: 'prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql',
+        sourceSha256: 'df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc',
+        database: 'waste',
+        tenantInstanceId: 'bb-prignitz',
+      })
+    ).toMatchObject({ action: 'import-waste-data-v1', database: 'waste' });
+
+    const steps = [
+      'runtime-connect-lock',
+      'app-session-drain',
+      'empty-target-verify',
+      'safety-backup',
+      'waste-data-import',
+      'source-inventory-verify',
+      'legacy-pickup-backfill',
+      'runtime-principal-reconciliation',
+      'runtime-principal-probe',
+    ].map((step) => ({ step, status: 'succeeded' }));
+    expect(hasWasteImportEvidence({ steps })).toBe(true);
+    expect(hasWasteImportEvidence({ steps: steps.slice(1) })).toBe(false);
   });
 });

--- a/scripts/ci/submit-restore-agent-request.ts
+++ b/scripts/ci/submit-restore-agent-request.ts
@@ -141,7 +141,11 @@ const waitForRestoreResult = async (
           : hasRuntimePrincipalRestoreEvidence(result))
       ) {
         const errorCode = typeof result.errorCode === 'string' ? result.errorCode : 'unknown';
-        throw new Error(`Der Restore-Agent meldet keinen erfolgreichen DB-Restore (${errorCode}).`);
+        const operation =
+          request.action === 'import-waste-data-v1' ? 'Waste-Datenimport' : 'DB-Restore';
+        throw new Error(
+          `Der Restore-Agent meldet keinen erfolgreichen ${operation} (${errorCode}).`
+        );
       }
       return result;
     } catch (error) {

--- a/scripts/ci/submit-restore-agent-request.ts
+++ b/scripts/ci/submit-restore-agent-request.ts
@@ -95,6 +95,7 @@ export const hasRuntimePrincipalRestoreEvidence = (result: Record<string, unknow
 
 export const hasWasteImportEvidence = (result: Record<string, unknown>): boolean =>
   [
+    'source-object-and-checksum-verify',
     'runtime-connect-lock',
     'app-session-drain',
     'empty-target-verify',

--- a/scripts/ci/submit-restore-agent-request.ts
+++ b/scripts/ci/submit-restore-agent-request.ts
@@ -24,6 +24,15 @@ const parseEnvironment = (value: string | undefined): BackupEnvironment => {
   throw new Error('Der Restore-Agent akzeptiert nur staging oder prod.');
 };
 
+export const parseRestoreMode = (
+  value: string | undefined
+): Readonly<{ database: BackupDatabase; action: RestoreRequest['action'] }> => {
+  if (value === undefined) return { database: 'studio', action: 'restore-and-verify-v1' };
+  if (value === 'waste') return { database: 'waste', action: 'restore-and-verify-v1' };
+  if (value === 'waste-import') return { database: 'waste', action: 'import-waste-data-v1' };
+  throw new Error('Der Restore-Agent akzeptiert nur die Modi studio, waste oder waste-import.');
+};
+
 export const buildRestoreAgentRequest = (input: {
   action?: RestoreRequest['action'];
   environment: BackupEnvironment;
@@ -166,10 +175,7 @@ const waitForRestoreResult = async (
 
 const main = async () => {
   const target = parseEnvironment(process.argv[2]);
-  const mode = process.argv[3];
-  const database: BackupDatabase = mode === 'waste' || mode === 'waste-import' ? 'waste' : 'studio';
-  const action: RestoreRequest['action'] =
-    mode === 'waste-import' ? 'import-waste-data-v1' : 'restore-and-verify-v1';
+  const { database, action } = parseRestoreMode(process.argv[3]);
   const request = buildRestoreAgentRequest({
     action,
     environment: target,

--- a/scripts/ci/submit-restore-agent-request.ts
+++ b/scripts/ci/submit-restore-agent-request.ts
@@ -25,6 +25,7 @@ const parseEnvironment = (value: string | undefined): BackupEnvironment => {
 };
 
 export const buildRestoreAgentRequest = (input: {
+  action?: RestoreRequest['action'];
   environment: BackupEnvironment;
   maintenanceWindowReference: string;
   now: Date;
@@ -35,7 +36,7 @@ export const buildRestoreAgentRequest = (input: {
   tenantInstanceId?: string;
 }): RestoreRequest => ({
   version: 1,
-  action: 'restore-and-verify-v1',
+  action: input.action ?? 'restore-and-verify-v1',
   requestId: input.requestId,
   environment: input.environment,
   expiresAt: new Date(input.now.getTime() + 10 * 60_000).toISOString(),
@@ -92,6 +93,17 @@ export const hasRuntimePrincipalRestoreEvidence = (result: Record<string, unknow
   hasSucceededStep(result, 'runtime-principal-reconciliation') &&
   hasSucceededStep(result, 'runtime-principal-probe');
 
+export const hasWasteImportEvidence = (result: Record<string, unknown>): boolean =>
+  [
+    'runtime-connect-lock',
+    'app-session-drain',
+    'empty-target-verify',
+    'safety-backup',
+    'waste-data-import',
+    'source-inventory-verify',
+    'legacy-pickup-backfill',
+  ].every((step) => hasSucceededStep(result, step)) && hasRuntimePrincipalRestoreEvidence(result);
+
 const waitForRestoreResult = async (
   target: BackupEnvironment,
   request: RestoreRequest,
@@ -118,10 +130,15 @@ const waitForRestoreResult = async (
       )
         throw new Error('Das Restore-Ergebnis stimmt nicht mit dem Auftrag überein.');
       if (
-        result.status !== 'database-restored' ||
+        result.status !==
+          (request.action === 'import-waste-data-v1'
+            ? 'waste-data-imported'
+            : 'database-restored') ||
         result.mutationStarted !== true ||
         typeof result.safetyObjectKey !== 'string' ||
-        !hasRuntimePrincipalRestoreEvidence(result)
+        !(request.action === 'import-waste-data-v1'
+          ? hasWasteImportEvidence(result)
+          : hasRuntimePrincipalRestoreEvidence(result))
       ) {
         const errorCode = typeof result.errorCode === 'string' ? result.errorCode : 'unknown';
         throw new Error(`Der Restore-Agent meldet keinen erfolgreichen DB-Restore (${errorCode}).`);
@@ -144,23 +161,32 @@ const waitForRestoreResult = async (
 
 const main = async () => {
   const target = parseEnvironment(process.argv[2]);
-  const database: BackupDatabase = process.argv[3] === 'waste' ? 'waste' : 'studio';
+  const mode = process.argv[3];
+  const database: BackupDatabase = mode === 'waste' || mode === 'waste-import' ? 'waste' : 'studio';
+  const action: RestoreRequest['action'] =
+    mode === 'waste-import' ? 'import-waste-data-v1' : 'restore-and-verify-v1';
   const request = buildRestoreAgentRequest({
+    action,
     environment: target,
     maintenanceWindowReference: required(
       process.env.MAINTENANCE_WINDOW_REFERENCE,
       'MAINTENANCE_WINDOW_REFERENCE'
     ),
     now: new Date(),
-    requestId: `restore-gha-${required(process.env.GITHUB_RUN_ID, 'GITHUB_RUN_ID')}-${required(
+    requestId: `${action === 'import-waste-data-v1' ? 'waste-import' : 'restore'}-gha-${required(process.env.GITHUB_RUN_ID, 'GITHUB_RUN_ID')}-${required(
       process.env.GITHUB_RUN_ATTEMPT,
       'GITHUB_RUN_ATTEMPT'
-    )}${database === 'waste' ? '-waste' : ''}`,
+    )}${database === 'waste' && action === 'restore-and-verify-v1' ? '-waste' : ''}`,
     sourceObjectKey: required(process.env.RESTORE_SOURCE_OBJECT_KEY, 'RESTORE_SOURCE_OBJECT_KEY'),
     sourceSha256: required(process.env.RESTORE_SOURCE_SHA256, 'RESTORE_SOURCE_SHA256'),
     database,
     ...(database === 'waste'
-      ? { tenantInstanceId: required(process.env.WASTE_TENANT_INSTANCE_ID, 'WASTE_TENANT_INSTANCE_ID') }
+      ? {
+          tenantInstanceId: required(
+            process.env.WASTE_TENANT_INSTANCE_ID,
+            'WASTE_TENANT_INSTANCE_ID'
+          ),
+        }
       : {}),
   });
   if (!isValidRestoreRequest(request))

--- a/scripts/ci/waste-bb-prignitz-cutover-workflow-contract.test.ts
+++ b/scripts/ci/waste-bb-prignitz-cutover-workflow-contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/waste-bb-prignitz-cutover.yml'),
+  'utf8'
+);
+
+describe('bb-prignitz Waste cutover workflow', () => {
+  it('stops before the fixed import and starts only after successful verification', () => {
+    expect(workflow.indexOf('stop-public-waste:')).toBeLessThan(
+      workflow.indexOf('import-waste-data:')
+    );
+    expect(workflow).toContain('needs: stop-public-waste');
+    expect(workflow).toContain('needs: import-waste-data');
+    expect(workflow).toContain('submit-restore-agent-request.ts prod waste-import');
+    expect(workflow).toContain("jq -e '.options | length > 0'");
+  });
+
+  it('binds the immutable source, tenant and protected environments without exposing credentials', () => {
+    expect(workflow).toContain('prod/waste/bb-prignitz/import/2026-08-09/waste-data-pg16.sql');
+    expect(workflow).toContain('df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc');
+    expect(workflow).toContain('WASTE_TENANT_INSTANCE_ID: bb-prignitz');
+    expect(workflow).toContain('environment: prod');
+    expect(workflow).toContain('environment: web-waste-calendar');
+    expect(workflow).not.toContain('postgres://');
+    expect(workflow).not.toContain('quantum-cli stacks deploy');
+  });
+});

--- a/scripts/ci/waste-bb-prignitz-cutover-workflow-contract.test.ts
+++ b/scripts/ci/waste-bb-prignitz-cutover-workflow-contract.test.ts
@@ -15,6 +15,8 @@ describe('bb-prignitz Waste cutover workflow', () => {
     expect(workflow).toContain('needs: stop-public-waste');
     expect(workflow).toContain('needs: import-waste-data');
     expect(workflow).toContain('submit-restore-agent-request.ts prod waste-import');
+    expect(workflow).toContain('PUBLIC_WASTE_BASE_URL fehlt.');
+    expect(workflow).toContain('consecutive_failures >= 3');
     expect(workflow).toContain("jq -e '.options | length > 0'");
   });
 

--- a/scripts/ops/public-waste/portainer-maintenance.ts
+++ b/scripts/ops/public-waste/portainer-maintenance.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { setPublicWasteStackMaintenance } from './portainer-release.ts';
+
+const main = async () => {
+  const mode = process.env.PUBLIC_WASTE_MAINTENANCE_MODE;
+  if (mode !== 'start' && mode !== 'stop')
+    throw new Error('PUBLIC_WASTE_MAINTENANCE_MODE muss start oder stop sein.');
+  const result = await setPublicWasteStackMaintenance({
+    mode,
+    ...(mode === 'start' ? { databaseUrl: process.env.PUBLIC_WASTE_POSTGRESQL_DATABASE_URL } : {}),
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+};
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/public-waste/portainer-release.test.ts
+++ b/scripts/ops/public-waste/portainer-release.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   parseWasteWebReleaseTag,
   releasePublicWasteStack,
+  setPublicWasteStackMaintenance,
+  updatePublicWasteDatabaseUrl,
+  updatePublicWasteReplicas,
   updateStackEnv,
 } from './portainer-release.ts';
 
@@ -20,13 +23,38 @@ describe('public waste portainer release', () => {
       updateStackEnv(
         [
           { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.2' },
-          { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+          {
+            name: 'PUBLIC_WASTE_PUBLIC_HOST',
+            value: 'bb-prignitz.abfallkalender.smart-village.app',
+          },
         ],
         'v1.2.3'
       )
     ).toEqual([
       { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.3' },
       { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+    ]);
+  });
+
+  it('renders the stopped and PostgreSQL-backed running stack without touching other settings', () => {
+    const stack =
+      'services:\n  app:\n    image: example\n    deploy:\n      replicas: 1\n      restart_policy:\n        condition: any\n';
+    expect(updatePublicWasteReplicas(stack, 0)).toContain('      replicas: 0');
+    expect(updatePublicWasteReplicas(updatePublicWasteReplicas(stack, 0), 1)).toContain(
+      '      replicas: 1'
+    );
+    expect(() => updatePublicWasteReplicas('services: {}\n', 0)).toThrow('eindeutigen');
+    expect(
+      updatePublicWasteDatabaseUrl(
+        [
+          { name: 'PUBLIC_WASTE_DATABASE_URL', value: 'postgres://supabase' },
+          { name: 'PUBLIC_WASTE_INSTANCE_ID', value: 'bb-prignitz' },
+        ],
+        'postgres://tenant-db'
+      )
+    ).toEqual([
+      { name: 'PUBLIC_WASTE_DATABASE_URL', value: 'postgres://tenant-db' },
+      { name: 'PUBLIC_WASTE_INSTANCE_ID', value: 'bb-prignitz' },
     ]);
   });
 
@@ -52,7 +80,10 @@ describe('public waste portainer release', () => {
             EndpointId: 7,
             Env: [
               { name: 'PUBLIC_WASTE_IMAGE_TAG', value: 'v1.2.2' },
-              { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
+              {
+                name: 'PUBLIC_WASTE_PUBLIC_HOST',
+                value: 'bb-prignitz.abfallkalender.smart-village.app',
+              },
             ],
           })
         )
@@ -60,7 +91,8 @@ describe('public waste portainer release', () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            StackFileContent: "version: '3.8'\nservices:\n  app:\n    image: ghcr.io/example/public-waste:v1.2.2\n",
+            StackFileContent:
+              "version: '3.8'\nservices:\n  app:\n    image: ghcr.io/example/public-waste:v1.2.2\n",
           })
         )
       )
@@ -106,7 +138,54 @@ describe('public waste portainer release', () => {
         { name: 'PUBLIC_WASTE_PUBLIC_HOST', value: 'bb-prignitz.abfallkalender.smart-village.app' },
       ],
       Prune: false,
-      StackFileContent: "version: '3.8'\nservices:\n  app:\n    image: ghcr.io/example/public-waste:v1.2.2\n",
+      StackFileContent:
+        "version: '3.8'\nservices:\n  app:\n    image: ghcr.io/example/public-waste:v1.2.2\n",
     });
+  });
+
+  it('starts the remote stack with the tenant PostgreSQL URL and one replica', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ Id: 42, Name: 'web-waste-calendar', EndpointId: 7 }]))
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            Env: [
+              { name: 'PUBLIC_WASTE_DATABASE_URL', value: 'postgres://supabase' },
+              { name: 'PUBLIC_WASTE_INSTANCE_ID', value: 'bb-prignitz' },
+            ],
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            StackFileContent: 'services:\n  app:\n    deploy:\n      replicas: 0\n',
+          })
+        )
+      )
+      .mockResolvedValueOnce(new Response('{}'));
+
+    await expect(
+      setPublicWasteStackMaintenance(
+        { mode: 'start', databaseUrl: 'postgres://tenant-db' },
+        {
+          PUBLIC_WASTE_STACK_NAME: 'web-waste-calendar',
+          QUANTUM_API_KEY: 'secret',
+          QUANTUM_ENDPOINT_ID: '7',
+          QUANTUM_HOST: 'https://portainer.example.invalid',
+        },
+        { commandExists: vi.fn().mockReturnValue(false), fetch, runCapture: vi.fn() }
+      )
+    ).resolves.toMatchObject({ mode: 'start', stackId: 42 });
+
+    const payload = JSON.parse(String(fetch.mock.calls[3]?.[1]?.body));
+    expect(payload.StackFileContent).toContain('      replicas: 1');
+    expect(payload.Env).toEqual([
+      { name: 'PUBLIC_WASTE_DATABASE_URL', value: 'postgres://tenant-db' },
+      { name: 'PUBLIC_WASTE_INSTANCE_ID', value: 'bb-prignitz' },
+    ]);
   });
 });

--- a/scripts/ops/public-waste/portainer-release.ts
+++ b/scripts/ops/public-waste/portainer-release.ts
@@ -2,7 +2,10 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { commandExists, runCapture } from '../runtime/process.ts';
-import { resolveQuantumOperatorEnv, resolveRemoteDockerEndpointId } from '../runtime/remote-portainer.ts';
+import {
+  resolveQuantumOperatorEnv,
+  resolveRemoteDockerEndpointId,
+} from '../runtime/remote-portainer.ts';
 
 type StackEnvEntry = {
   readonly name: string;
@@ -26,7 +29,11 @@ type PortainerStackRecord = {
 type ReleaseDeps = {
   readonly commandExists: (commandName: string) => boolean;
   readonly fetch: typeof fetch;
-  readonly runCapture: (commandName: string, args: readonly string[], env?: NodeJS.ProcessEnv) => string;
+  readonly runCapture: (
+    commandName: string,
+    args: readonly string[],
+    env?: NodeJS.ProcessEnv
+  ) => string;
 };
 
 type ReleaseResult = {
@@ -39,8 +46,14 @@ type ReleaseResult = {
   readonly version: string;
 };
 
+type MaintenanceResult = {
+  readonly endpointId: number;
+  readonly mode: 'start' | 'stop';
+  readonly stackId: number;
+  readonly stackName: string;
+};
+
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
-const currentScriptPath = fileURLToPath(import.meta.url);
 
 const defaultDeps: ReleaseDeps = {
   commandExists: (commandName) => commandExists(rootDir, commandName),
@@ -128,7 +141,10 @@ export const parseWasteWebReleaseTag = (ref: string) => {
   } as const;
 };
 
-export const updateStackEnv = (env: readonly StackEnvEntry[], imageTag: string): StackEnvEntry[] => {
+export const updateStackEnv = (
+  env: readonly StackEnvEntry[],
+  imageTag: string
+): StackEnvEntry[] => {
   const nextEnv = [...env];
   const imageTagIndex = nextEnv.findIndex((entry) => entry.name === 'PUBLIC_WASTE_IMAGE_TAG');
 
@@ -147,19 +163,109 @@ export const updateStackEnv = (env: readonly StackEnvEntry[], imageTag: string):
   return nextEnv;
 };
 
+export const updatePublicWasteDatabaseUrl = (
+  env: readonly StackEnvEntry[],
+  databaseUrl: string
+): StackEnvEntry[] => {
+  const nextEnv = [...env];
+  const index = nextEnv.findIndex((entry) => entry.name === 'PUBLIC_WASTE_DATABASE_URL');
+  const entry = { name: 'PUBLIC_WASTE_DATABASE_URL', value: databaseUrl };
+  if (index === -1) nextEnv.push(entry);
+  else nextEnv[index] = entry;
+  return nextEnv;
+};
+
+export const updatePublicWasteReplicas = (stackFileContent: string, replicas: 0 | 1): string => {
+  const matches = [...stackFileContent.matchAll(/^(\s{6}replicas:)\s+\d+\s*$/gmu)];
+  if (matches.length !== 1)
+    throw new Error('Der Public-Waste-Stack besitzt keinen eindeutigen app-replicas-Eintrag.');
+  return stackFileContent.replace(/^(\s{6}replicas:)\s+\d+\s*$/gmu, `$1 ${String(replicas)}`);
+};
+
+export const setPublicWasteStackMaintenance = async (
+  input: Readonly<{ mode: 'start' | 'stop'; databaseUrl?: string }>,
+  env: NodeJS.ProcessEnv = process.env,
+  deps: ReleaseDeps = defaultDeps
+): Promise<MaintenanceResult> => {
+  const databaseUrl = input.databaseUrl?.trim();
+  if (input.mode === 'start' && !databaseUrl)
+    throw new Error('PUBLIC_WASTE_POSTGRESQL_DATABASE_URL fehlt.');
+  const operatorEnv = resolveQuantumOperatorEnv(env);
+  const host = trimTrailingSlash(
+    operatorEnv.QUANTUM_HOST?.trim() || 'https://console.planetary-quantum.com'
+  );
+  const apiKey = requireEnvValue(operatorEnv.QUANTUM_API_KEY, 'QUANTUM_API_KEY');
+  const stackName = requireEnvValue(
+    env.PUBLIC_WASTE_STACK_NAME ?? operatorEnv.PUBLIC_WASTE_STACK_NAME,
+    'PUBLIC_WASTE_STACK_NAME'
+  );
+  const endpointId = resolveRemoteDockerEndpointId(
+    deps,
+    operatorEnv,
+    env.PORTAINER_ENDPOINT_NAME?.trim() || 'sva'
+  );
+  const stacks = (await (
+    await portainerRequest({ deps, host, apiKey, path: '/api/stacks' })
+  ).json()) as PortainerStackRecord[];
+  const stack = stacks.find(
+    (candidate) =>
+      candidate.Name === stackName &&
+      (candidate.EndpointId === undefined || candidate.EndpointId === endpointId)
+  );
+  if (!stack?.Id) throw new Error(`Portainer-Stack ${stackName} wurde nicht gefunden.`);
+  const details = (await (
+    await portainerRequest({ deps, host, apiKey, path: `/api/stacks/${String(stack.Id)}` })
+  ).json()) as PortainerStackRecord;
+  const stackFileContent = parseStackFileContent(
+    await (
+      await portainerRequest({ deps, host, apiKey, path: `/api/stacks/${String(stack.Id)}/file` })
+    ).text()
+  );
+  const currentEnv = normalizeStackEnv(details.Env ?? stack.Env);
+  const nextEnv =
+    input.mode === 'start'
+      ? updatePublicWasteDatabaseUrl(currentEnv, databaseUrl ?? '')
+      : currentEnv;
+  await portainerRequest({
+    deps,
+    host,
+    apiKey,
+    path: `/api/stacks/${String(stack.Id)}?endpointId=${String(endpointId)}`,
+    init: {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        Env: nextEnv,
+        Prune: false,
+        StackFileContent: updatePublicWasteReplicas(
+          stackFileContent,
+          input.mode === 'stop' ? 0 : 1
+        ),
+      }),
+    },
+  });
+  return { endpointId, mode: input.mode, stackId: stack.Id, stackName };
+};
+
 export const releasePublicWasteStack = async (
   env: NodeJS.ProcessEnv = process.env,
   deps: ReleaseDeps = defaultDeps
 ): Promise<ReleaseResult> => {
   const release = parseWasteWebReleaseTag(requireEnvValue(env.GITHUB_REF, 'GITHUB_REF'));
   const operatorEnv = resolveQuantumOperatorEnv(env);
-  const host = trimTrailingSlash(operatorEnv.QUANTUM_HOST?.trim() || 'https://console.planetary-quantum.com');
+  const host = trimTrailingSlash(
+    operatorEnv.QUANTUM_HOST?.trim() || 'https://console.planetary-quantum.com'
+  );
   const apiKey = requireEnvValue(operatorEnv.QUANTUM_API_KEY, 'QUANTUM_API_KEY');
   const stackName = requireEnvValue(
     env.PUBLIC_WASTE_STACK_NAME ?? operatorEnv.PUBLIC_WASTE_STACK_NAME,
     'PUBLIC_WASTE_STACK_NAME'
   );
-  const endpointId = resolveRemoteDockerEndpointId(deps, operatorEnv, env.PORTAINER_ENDPOINT_NAME?.trim() || 'sva');
+  const endpointId = resolveRemoteDockerEndpointId(
+    deps,
+    operatorEnv,
+    env.PORTAINER_ENDPOINT_NAME?.trim() || 'sva'
+  );
 
   const stacksResponse = await portainerRequest({
     deps,
@@ -169,7 +275,9 @@ export const releasePublicWasteStack = async (
   });
   const stacks = (await stacksResponse.json()) as PortainerStackRecord[];
   const stack = stacks.find(
-    (candidate) => candidate.Name === stackName && (candidate.EndpointId === undefined || candidate.EndpointId === endpointId)
+    (candidate) =>
+      candidate.Name === stackName &&
+      (candidate.EndpointId === undefined || candidate.EndpointId === endpointId)
   );
 
   if (!stack?.Id) {
@@ -193,7 +301,8 @@ export const releasePublicWasteStack = async (
   const stackFileContent = parseStackFileContent(await stackFileResponse.text());
 
   const currentEnv = normalizeStackEnv(stackDetails.Env ?? stack.Env);
-  const previousImageTag = currentEnv.find((entry) => entry.name === 'PUBLIC_WASTE_IMAGE_TAG')?.value ?? null;
+  const previousImageTag =
+    currentEnv.find((entry) => entry.name === 'PUBLIC_WASTE_IMAGE_TAG')?.value ?? null;
   const nextEnv = updateStackEnv(currentEnv, release.imageTag);
 
   await portainerRequest({
@@ -235,4 +344,4 @@ if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.m
     });
 }
 
-export type { ReleaseDeps, ReleaseResult, StackEnvEntry };
+export type { MaintenanceResult, ReleaseDeps, ReleaseResult, StackEnvEntry };


### PR DESCRIPTION
## Zusammenfassung

- gewährt dem Waste-Provisionierer den für tenantgenaue Dumps erforderlichen Datenbankzugriff
- ergänzt einen signierten, ausschließlich an prod/bb-prignitz und den geprüften PG16-Export gebundenen Einmalimport
- stoppt und startet Public Waste über einen geschützten dreistufigen Cutover-Workflow mit Daten-, Backfill-, Rechte- und Smoke-Verifikation
- dokumentiert den operativen Ablauf und den unveränderlichen Quellnachweis

## Nachweise

- 16 Provisionierer-Unit-Tests
- 68 Agent-/Contract-/Workflow-/Maintenance-Tests
- sva-studio-react Type-Gate
- Server-Runtime-Gate (19 Projekte)
- Backup-Agent Container-Integrationstest
- File-Placement-Gate
- Importobjekt im Produktions-Bucket: 2.273.666 Bytes, SHA-256 df75392bee510be71444eec28914f704c0917a5a59ac46e6380ef050c3ffd5dc

## Rollout

Nach Merge: regulärer Build/Studio-Rollout, geschützter Backup-Agent-Rollout, Reconcile von bb-prignitz, Hinterlegung der rotierten Public-DB-URL und erst danach der manuell freigegebene Cutover-Workflow.