### PR TITLE
Leere Berechtigungs-Scopes als unbeschränkt behandeln

### DIFF
--- a/docs/changelog/entries/pr-940.json
+++ b/docs/changelog/entries/pr-940.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 940,
+  "body": "Abfallkalender wieder im Studio-Menü sichtbar\n\n- Global erteilte Modulberechtigungen werden auch mit einem technisch leeren Geltungsbereich korrekt erkannt.\n- Zugewiesene Fachmodule wie der Abfallkalender erscheinen dadurch wieder in der Navigation.\n- Tatsächlich eingeschränkte Berechtigungen bleiben weiterhin geschützt."
+}

--- a/packages/iam-core/src/ui-access.test.ts
+++ b/packages/iam-core/src/ui-access.test.ts
@@ -183,6 +183,49 @@ describe('evaluateUiAccess', () => {
     ).toEqual({ status: 'allowed', reason: 'allowed_by_permission' });
   });
 
+  it('treats an empty structured scope as unscoped', () => {
+    const snapshot = readyTenantSnapshot(
+      [
+        {
+          action: 'waste-management.read',
+          resourceType: 'waste-management',
+          accessScope: 'all',
+          scope: {},
+        },
+      ],
+      ['waste-management']
+    );
+
+    expect(
+      evaluateUiAccess({
+        isAuthenticated: true,
+        requirement: tenantRequirement(['waste-management.read'], {
+          moduleId: 'waste-management',
+        }),
+        snapshot,
+      })
+    ).toEqual({ status: 'allowed', reason: 'allowed_by_permission' });
+  });
+
+  it('keeps a non-empty structured scope resource-scoped', () => {
+    const snapshot = readyTenantSnapshot([
+      {
+        action: 'news.read',
+        resourceType: 'content',
+        accessScope: 'all',
+        scope: { contentType: 'news.article' },
+      },
+    ]);
+
+    expect(
+      evaluateUiAccess({
+        isAuthenticated: true,
+        requirement: tenantRequirement(['news.read'], { moduleId: 'news' }),
+        snapshot,
+      })
+    ).toEqual({ status: 'denied', reason: 'resource_capability_missing' });
+  });
+
   it('accepts existing camel-case segments in fully-qualified IAM actions', () => {
     const snapshot = readyTenantSnapshot([
       { action: 'iam.legalText.read', resourceType: 'legalText', accessScope: 'all' },

--- a/packages/iam-core/src/ui-access.ts
+++ b/packages/iam-core/src/ui-access.ts
@@ -122,7 +122,7 @@ const hasScopedConstraints = (permission: EffectivePermission): boolean =>
   permission.organizationId !== undefined ||
   permission.resourceId !== undefined ||
   permission.geoScope !== undefined ||
-  permission.scope !== undefined;
+  (permission.scope !== undefined && Object.keys(permission.scope).length > 0);
 
 const deny = (reason: UiAccessDecisionReason): UiAccessDecision => ({
   status: 'denied',


### PR DESCRIPTION
## Änderung

- Leere strukturierte Berechtigungs-Scopes (`scope: {}`) gelten in der UI-Zugriffsentscheidung als unbeschränkt.
- Nichtleere Scopes bleiben weiterhin ressourcenbeschränkt und benötigen eine passende Capability.
- Regressionstests decken beide Fälle ab.

## Ursache und Auswirkung

Die Datenbank materialisiert den strukturierten Scope standardmäßig als leeres JSON-Objekt. Die UI wertete bereits die Existenz dieses Objekts als Ressourcenbeschränkung. Dadurch wurde `waste-management.read` trotz `accessScope: all` und zugewiesenem Modul mit `resource_capability_missing` abgelehnt; der Menüpunkt „Abfallkalender“ wurde ausgeblendet.

## Validierung

- `pnpm nx run iam-core:test:unit` (64 Tests)
- `pnpm nx run iam-core:test:types`
- `pnpm nx run iam-core:lint`
- `git diff --check`