### PR TITLE
Öffentlichen Abfallkalender und PDF-Ausgabe verfeinern

### DIFF
--- a/apps/public-waste-calendar-web/package.json
+++ b/apps/public-waste-calendar-web/package.json
@@ -21,6 +21,7 @@
     "sharp": "^0.35.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "4.3.3",
     "@testing-library/react": "^16.2.0",

--- a/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-app.test.tsx
@@ -11,7 +11,10 @@ import {
   publicWasteSelectionSummaryFixture,
 } from './public-waste-test-fixtures.js';
 
-type CompletePublicWasteAppTestProps = Extract<ComponentProps<typeof PublicWasteApp>, { selectionState: 'complete' }>;
+type CompletePublicWasteAppTestProps = Extract<
+  ComponentProps<typeof PublicWasteApp>,
+  { selectionState: 'complete' }
+>;
 
 const renderCompletePublicWasteApp = (overrides: Partial<CompletePublicWasteAppTestProps> = {}) => {
   render(
@@ -56,48 +59,63 @@ describe('PublicWasteApp', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders address left, fractions right, and a horizontal action block', () => {
+  it('renders a flat location context and explicit disclosure actions', () => {
     renderCompletePublicWasteApp();
 
     expectPublicWasteSelectionHeader();
-    expect(screen.getByRole('button', { name: 'Adresse ändern' })).toBeTruthy();
+    const changeAddressAction = screen.getByRole('button', { name: 'Adresse ändern' });
+    expect(changeAddressAction.parentElement?.classList.contains('selection-summary-row')).toBe(
+      true
+    );
+    expect(changeAddressAction.classList.contains('selection-summary-action')).toBe(true);
     expect(screen.getByRole('group', { name: 'Abfallfraktionen' })).toBeTruthy();
-    expect(screen.getByRole('checkbox', { name: 'Bioabfall' })).toBeTruthy();
+    const bioFraction = screen.getByRole('checkbox', { name: 'Bioabfall' });
+    expect(bioFraction.parentElement?.getAttribute('style')).toBeNull();
+    expect(bioFraction.getAttribute('style')).toContain('accent-color');
+    expect(bioFraction.parentElement?.querySelector('.selection-fraction-swatch')).toBeNull();
+    const fractionInfoAction = screen.getByRole('button', {
+      name: 'Informationen zu Abfallfraktionen',
+    });
+    expect(fractionInfoAction.getAttribute('popovertarget')).toBe('public-waste-fraction-info');
+    const fractionInfoPopover = document.getElementById('public-waste-fraction-info');
+    expect(fractionInfoPopover?.getAttribute('popover')).toBe('auto');
+    expect(fractionInfoPopover?.textContent).toContain(
+      'Diese Auswahl steuert Liste, Kalenderexport, PDF/Druckversion und E-Mail-Erinnerung gemeinsam.'
+    );
     expect(screen.getByRole('checkbox', { name: 'Papier' })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'PDF-Download' })).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'E-Mail-Abo' })).toBeTruthy();
+    const calendarAction = screen.getByRole('button', { name: 'Kalender exportieren' });
+    expect(calendarAction.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByRole('button', { name: 'PDF / Druckversion' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'E-Mail-Erinnerung' })).toBeTruthy();
+    expect(screen.queryByRole('tab', { name: 'Kalender exportieren' })).toBeNull();
   });
 
   it('uses a single open action panel at a time', () => {
     renderCompletePublicWasteApp();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Kalenderexport' }));
-    expect(screen.getByText('Kalender exportieren')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Kalender exportieren' }));
+    expect(screen.getByRole('link', { name: 'Kalender exportieren' })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'PDF-Download' }));
-    expect(screen.queryByText('Kalender exportieren')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'PDF / Druckversion' }));
+    expect(screen.queryByRole('link', { name: 'Kalender exportieren' })).toBeNull();
     expect(screen.getByRole('button', { name: 'PDF herunterladen' })).toBeTruthy();
   });
 
-  it('supports keyboard navigation across the action tabs and links the active panel accessibly', () => {
+  it('links an expanded action to its accessible region', () => {
     renderCompletePublicWasteApp();
 
-    const calendarTab = screen.getByRole('tab', { name: 'Kalenderexport' });
-    fireEvent.keyDown(calendarTab, { key: 'ArrowRight' });
+    const pdfAction = screen.getByRole('button', { name: 'PDF / Druckversion' });
+    fireEvent.click(pdfAction);
 
-    const pdfTab = screen.getByRole('tab', { name: 'PDF-Download' });
-    expect(pdfTab.getAttribute('aria-selected')).toBe('true');
-    expect(document.activeElement).toBe(pdfTab);
-
+    expect(pdfAction.getAttribute('aria-expanded')).toBe('true');
     const panel = screen
-      .getAllByRole('tabpanel')
-      .find((element) => element.getAttribute('id') === pdfTab.getAttribute('aria-controls'));
+      .getAllByRole('region')
+      .find((element) => element.getAttribute('id') === pdfAction.getAttribute('aria-controls'));
     expect(panel).toBeTruthy();
     if (!panel) {
       throw new Error('Expected the PDF action panel to exist');
     }
-    expect(panel.getAttribute('aria-labelledby')).toBe(pdfTab.getAttribute('id'));
+    expect(panel.getAttribute('aria-labelledby')).toBe(pdfAction.getAttribute('id'));
   });
 
   it('updates the visible calendar entries from the right-side fraction list', () => {
@@ -128,18 +146,22 @@ describe('PublicWasteApp', () => {
       },
     });
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Kalenderexport' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Kalender exportieren' }));
 
     const exportLink = screen.getByRole('link', { name: 'Kalender exportieren' });
     expect(exportLink.getAttribute('href')).toContain('fractionId=bio');
     expect(exportLink.getAttribute('href')).toContain('fractionId=paper');
     expect(exportLink.getAttribute('href')).toContain('reminderItem=bio%7Cbio%3Acalendar%3Afirst');
-    expect(exportLink.getAttribute('href')).toContain('reminderItem=paper%7Cpaper%3Acalendar%3Afirst');
+    expect(exportLink.getAttribute('href')).toContain(
+      'reminderItem=paper%7Cpaper%3Acalendar%3Afirst'
+    );
     expect(screen.queryByRole('checkbox', { name: 'Mit Erinnerungen exportieren' })).toBeNull();
   });
 
   it('downloads a pdf for the active fractions and selected year from the action panel', async () => {
-    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:public-waste-pdf');
+    const createObjectUrlSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:public-waste-pdf');
     const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
     fetchMock.mockResolvedValue(
       new Response(new Blob(['pdf'], { type: 'application/pdf' }), {
@@ -152,7 +174,7 @@ describe('PublicWasteApp', () => {
 
     renderCompletePublicWasteApp();
 
-    fireEvent.click(screen.getByRole('tab', { name: 'PDF-Download' }));
+    fireEvent.click(screen.getByRole('button', { name: 'PDF / Druckversion' }));
     fireEvent.change(screen.getByLabelText('PDF-Jahr'), {
       target: { value: '2026' },
     });
@@ -216,8 +238,12 @@ describe('PublicWasteApp', () => {
       },
     });
 
-    fireEvent.click(screen.getByRole('tab', { name: 'E-Mail-Abo' }));
-    const emailPanel = screen.getAllByRole('tabpanel')[0] as HTMLElement;
+    fireEvent.click(screen.getByRole('button', { name: 'E-Mail-Erinnerung' }));
+    const emailPanel = screen
+      .getAllByRole('region')
+      .find(
+        (element) => element.getAttribute('id') === 'public-waste-action-panel-email'
+      ) as HTMLElement;
     fireEvent.change(within(emailPanel).getByLabelText('E-Mail-Adresse'), {
       target: { value: 'person@example.invalid' },
     });
@@ -227,7 +253,9 @@ describe('PublicWasteApp', () => {
       })
     );
 
-    fireEvent.click(within(emailPanel).getByRole('button', { name: 'E-Mail-Abo anfordern' }));
+    fireEvent.click(
+      within(emailPanel).getByRole('button', { name: 'E-Mail-Erinnerung anfordern' })
+    );
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -252,6 +280,9 @@ describe('PublicWasteApp', () => {
 
     expect(screen.getByText('Bestätigungslink versendet')).toBeTruthy();
     expect(screen.getByText('Bitte prüfen Sie Ihr E-Mail-Postfach.')).toBeTruthy();
+    expect(within(emailPanel).getByRole('status').textContent).toContain(
+      'Bestätigungslink versendet'
+    );
     expect(within(emailPanel).queryByLabelText('Zeitfenster für Bioabfall')).toBeNull();
   });
 
@@ -294,10 +325,12 @@ describe('PublicWasteApp', () => {
       },
     });
 
-    fireEvent.click(screen.getByRole('tab', { name: 'E-Mail-Abo' }));
+    fireEvent.click(screen.getByRole('button', { name: 'E-Mail-Erinnerung' }));
     const emailPanel = screen
-      .getAllByRole('tabpanel')
-      .find((element) => element.getAttribute('id') === 'public-waste-action-panel-email') as HTMLElement;
+      .getAllByRole('region')
+      .find(
+        (element) => element.getAttribute('id') === 'public-waste-action-panel-email'
+      ) as HTMLElement;
     fireEvent.change(within(emailPanel).getByLabelText('E-Mail-Adresse'), {
       target: { value: 'person@example.invalid' },
     });
@@ -306,7 +339,9 @@ describe('PublicWasteApp', () => {
         name: 'Ich stimme der Verarbeitung meiner Daten zu. Datenschutzerklärung',
       })
     );
-    fireEvent.click(within(emailPanel).getByRole('button', { name: 'E-Mail-Abo anfordern' }));
+    fireEvent.click(
+      within(emailPanel).getByRole('button', { name: 'E-Mail-Erinnerung anfordern' })
+    );
 
     await screen.findByText('Bestätigungslink versendet');
 
@@ -314,10 +349,12 @@ describe('PublicWasteApp', () => {
 
     expect(screen.queryByText('Bestätigungslink versendet')).toBeNull();
     const refreshedEmailPanel = screen
-      .getAllByRole('tabpanel')
+      .getAllByRole('region')
       .find((element) => element.getAttribute('id') === 'public-waste-action-panel-email');
     expect(refreshedEmailPanel).toBeTruthy();
-    expect(within(refreshedEmailPanel as HTMLElement).getByLabelText('E-Mail-Adresse')).toBeTruthy();
+    expect(
+      within(refreshedEmailPanel as HTMLElement).getByLabelText('E-Mail-Adresse')
+    ).toBeTruthy();
   });
 
   it('uses noopener noreferrer for the privacy policy link', () => {
@@ -343,8 +380,10 @@ describe('PublicWasteApp', () => {
       },
     });
 
-    fireEvent.click(screen.getByRole('tab', { name: 'E-Mail-Abo' }));
-    expect(screen.getByRole('link', { name: 'Datenschutzerklärung' }).getAttribute('rel')).toBe('noopener noreferrer');
+    fireEvent.click(screen.getByRole('button', { name: 'E-Mail-Erinnerung' }));
+    expect(screen.getByRole('link', { name: 'Datenschutzerklärung' }).getAttribute('rel')).toBe(
+      'noopener noreferrer'
+    );
   });
 
   it('opens a pickup detail dialog and keeps the global actions outside the dialog', () => {
@@ -365,6 +404,6 @@ describe('PublicWasteApp', () => {
     const dialog = screen.getByRole('dialog');
     expect(dialog).toBeTruthy();
     expect(within(dialog).getByText('Biotour Nord')).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Kalender exportieren' })).toBeTruthy();
   });
 });

--- a/apps/public-waste-calendar-web/src/components/public-waste-app.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-app.tsx
@@ -20,7 +20,10 @@ import {
 import { PublicWasteCalendarPanels } from './public-waste-calendar-panels.js';
 import { PublicWasteEventDialog } from './public-waste-event-dialog.js';
 import { PublicWasteSelectionHeader } from './public-waste-selection-header.js';
-import { PublicWasteSelectionForm, type PublicWasteSelectionPathItem } from './public-waste-selection-form.js';
+import {
+  PublicWasteSelectionForm,
+  type PublicWasteSelectionPathItem,
+} from './public-waste-selection-form.js';
 import { usePublicWastePdfDownload } from './use-public-waste-pdf-download.js';
 
 type IncompletePublicWasteAppProps = {
@@ -48,12 +51,13 @@ type PublicWasteAppProps = IncompletePublicWasteAppProps | CompletePublicWasteAp
 type ActionPanel = 'calendar' | 'pdf' | 'email';
 type ReminderSelectionState = Record<string, string>;
 const EMPTY_REMINDER_FRACTIONS: readonly PublicWasteReminderFractionOption[] = [];
-const ACTION_PANELS: readonly ActionPanel[] = ['calendar', 'pdf', 'email'];
 
 const splitSelectionSummary = (
   selectionSummary: string
 ): readonly [cityLine: string, streetLine: string, houseNumberLine?: string] => {
-  const [cityPart = '', remainderPart = ''] = selectionSummary.split(',').map((part) => part.trim());
+  const [cityPart = '', remainderPart = ''] = selectionSummary
+    .split(',')
+    .map((part) => part.trim());
   const remainder = remainderPart.trim();
 
   if (remainder.length === 0) {
@@ -61,7 +65,9 @@ const splitSelectionSummary = (
   }
 
   if (remainder.endsWith('Alle Hausnummern')) {
-    const streetLine = remainder.slice(0, Math.max(0, remainder.length - 'Alle Hausnummern'.length)).trim();
+    const streetLine = remainder
+      .slice(0, Math.max(0, remainder.length - 'Alle Hausnummern'.length))
+      .trim();
     return [cityPart, streetLine, 'Alle Hausnummern'];
   }
 
@@ -89,13 +95,18 @@ const buildReminderSlotSelection = (
     }
 
     const previousSlotId = previous[fraction.id];
-    next[fraction.id] = fraction.slots.some((slot) => slot.id === previousSlotId) ? previousSlotId : fraction.slots[0]!.id;
+    next[fraction.id] = fraction.slots.some((slot) => slot.id === previousSlotId)
+      ? previousSlotId
+      : fraction.slots[0]!.id;
   }
 
   return next;
 };
 
-const areReminderSelectionsEqual = (left: ReminderSelectionState, right: ReminderSelectionState): boolean => {
+const areReminderSelectionsEqual = (
+  left: ReminderSelectionState,
+  right: ReminderSelectionState
+): boolean => {
   const leftEntries = Object.entries(left);
   const rightEntries = Object.entries(right);
 
@@ -112,7 +123,9 @@ const resolveReminderContext = (
   reminderFractions: readonly PublicWasteReminderFractionOption[]
 ) => {
   const reminderFractionMap = new Map(reminderFractions.map((fraction) => [fraction.id, fraction]));
-  const fractionLabelMap = new Map(fractionOptions.map((fraction) => [fraction.id, fraction.label]));
+  const fractionLabelMap = new Map(
+    fractionOptions.map((fraction) => [fraction.id, fraction.label])
+  );
   const supportedFractions = activeFractionIds
     .map((fractionId) => reminderFractionMap.get(fractionId))
     .filter((fraction): fraction is PublicWasteReminderFractionOption => fraction !== undefined);
@@ -123,7 +136,10 @@ const resolveReminderContext = (
   return {
     supportedFractions,
     unsupportedLabels,
-    isFullySupported: activeFractionIds.length > 0 && unsupportedLabels.length === 0 && supportedFractions.length > 0,
+    isFullySupported:
+      activeFractionIds.length > 0 &&
+      unsupportedLabels.length === 0 &&
+      supportedFractions.length > 0,
   };
 };
 
@@ -151,8 +167,9 @@ const hasCompleteReminderItems = (
   items: readonly PublicWasteReminderSelectionItem[]
 ): boolean => context.isFullySupported && items.length === context.supportedFractions.length;
 
-const getActionTabId = (panel: ActionPanel): string => `public-waste-action-tab-${panel}`;
+const getActionTriggerId = (panel: ActionPanel): string => `public-waste-action-trigger-${panel}`;
 const getActionPanelId = (panel: ActionPanel): string => `public-waste-action-panel-${panel}`;
+const REMINDER_ERROR_ID = 'public-waste-reminder-error';
 
 export function PublicWasteApp(props: Readonly<PublicWasteAppProps>) {
   if (props.selectionState === 'incomplete') {
@@ -176,11 +193,14 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
   const [email, setEmail] = React.useState('');
   const [consentAccepted, setConsentAccepted] = React.useState(false);
   const [reminderError, setReminderError] = React.useState<string | null>(null);
-  const [reminderSuccess, setReminderSuccess] = React.useState<null | { readonly headline: string; readonly message: string }>(
-    null
-  );
+  const [reminderSuccess, setReminderSuccess] = React.useState<null | {
+    readonly headline: string;
+    readonly message: string;
+  }>(null);
   const [reminderSubmitting, setReminderSubmitting] = React.useState(false);
-  const [calendarReminderSlots, setCalendarReminderSlots] = React.useState<ReminderSelectionState>({});
+  const [calendarReminderSlots, setCalendarReminderSlots] = React.useState<ReminderSelectionState>(
+    {}
+  );
   const [emailReminderSlots, setEmailReminderSlots] = React.useState<ReminderSelectionState>({});
   const {
     selectedFractions,
@@ -201,32 +221,47 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
   const selectedFractionKey = selectedFractions.join('|');
   const previousSelectedFractionKeyRef = React.useRef(selectedFractionKey);
   const emailReminderFractions = props.reminderSignup?.fractions ?? EMPTY_REMINDER_FRACTIONS;
-  const calendarReminderFractions = props.calendarReminderOptions?.fractions ?? EMPTY_REMINDER_FRACTIONS;
+  const calendarReminderFractions =
+    props.calendarReminderOptions?.fractions ?? EMPTY_REMINDER_FRACTIONS;
   const emailReminderContext = React.useMemo(
-    () => resolveReminderContext(selectedFractions, props.calendarModel.fractionOptions, emailReminderFractions),
+    () =>
+      resolveReminderContext(
+        selectedFractions,
+        props.calendarModel.fractionOptions,
+        emailReminderFractions
+      ),
     [emailReminderFractions, props.calendarModel.fractionOptions, selectedFractions]
   );
   const calendarReminderContext = React.useMemo(
-    () => resolveReminderContext(selectedFractions, props.calendarModel.fractionOptions, calendarReminderFractions),
+    () =>
+      resolveReminderContext(
+        selectedFractions,
+        props.calendarModel.fractionOptions,
+        calendarReminderFractions
+      ),
     [calendarReminderFractions, props.calendarModel.fractionOptions, selectedFractions]
   );
 
   React.useEffect(() => {
-    setCalendarReminderSlots((current) =>
-      {
-        const next = buildReminderSlotSelection(selectedFractions, calendarReminderContext.supportedFractions, current);
-        return areReminderSelectionsEqual(current, next) ? current : next;
-      }
-    );
+    setCalendarReminderSlots((current) => {
+      const next = buildReminderSlotSelection(
+        selectedFractions,
+        calendarReminderContext.supportedFractions,
+        current
+      );
+      return areReminderSelectionsEqual(current, next) ? current : next;
+    });
   }, [calendarReminderContext.supportedFractions, selectedFractions]);
 
   React.useEffect(() => {
-    setEmailReminderSlots((current) =>
-      {
-        const next = buildReminderSlotSelection(selectedFractions, emailReminderContext.supportedFractions, current);
-        return areReminderSelectionsEqual(current, next) ? current : next;
-      }
-    );
+    setEmailReminderSlots((current) => {
+      const next = buildReminderSlotSelection(
+        selectedFractions,
+        emailReminderContext.supportedFractions,
+        current
+      );
+      return areReminderSelectionsEqual(current, next) ? current : next;
+    });
   }, [emailReminderContext.supportedFractions, selectedFractions]);
 
   React.useEffect(() => {
@@ -252,27 +287,6 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
     setReminderError(null);
   };
 
-  const handleActionTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, panel: ActionPanel) => {
-    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
-      return;
-    }
-
-    event.preventDefault();
-    const currentIndex = ACTION_PANELS.indexOf(panel);
-    const nextIndex =
-      event.key === 'ArrowRight'
-        ? (currentIndex + 1) % ACTION_PANELS.length
-        : (currentIndex - 1 + ACTION_PANELS.length) % ACTION_PANELS.length;
-    const nextPanel = ACTION_PANELS[nextIndex];
-
-    if (!nextPanel) {
-      return;
-    }
-
-    setActiveActionPanel(nextPanel);
-    document.getElementById(getActionTabId(nextPanel))?.focus();
-  };
-
   const calendarReminderItems = React.useMemo(
     () => buildReminderItems(calendarReminderContext.supportedFractions, calendarReminderSlots),
     [calendarReminderContext.supportedFractions, calendarReminderSlots]
@@ -281,8 +295,14 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
     () => buildReminderItems(emailReminderContext.supportedFractions, emailReminderSlots),
     [emailReminderContext.supportedFractions, emailReminderSlots]
   );
-  const canUseCalendarReminderExport = hasCompleteReminderItems(calendarReminderContext, calendarReminderItems);
-  const canSubmitEmailReminderSelection = hasCompleteReminderItems(emailReminderContext, emailReminderItems);
+  const canUseCalendarReminderExport = hasCompleteReminderItems(
+    calendarReminderContext,
+    calendarReminderItems
+  );
+  const canSubmitEmailReminderSelection = hasCompleteReminderItems(
+    emailReminderContext,
+    emailReminderItems
+  );
   const calendarExportUrl = buildPublicWasteIcalUrl({
     selection: props.selection,
     calendarName: props.selectionSummary,
@@ -301,7 +321,9 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
       return;
     }
     if (!canSubmitEmailReminderSelection || !consentAccepted || email.trim().length === 0) {
-      setReminderError('Bitte wählen Sie gültige Fraktionen, eine E-Mail-Adresse und die Datenschutz-Einwilligung aus.');
+      setReminderError(
+        'Bitte wählen Sie gültige Fraktionen, eine E-Mail-Adresse und die Datenschutz-Einwilligung aus.'
+      );
       return;
     }
 
@@ -320,7 +342,9 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
         message: response.message,
       });
     } catch (error) {
-      setReminderError(error instanceof Error ? error.message : 'Die Erinnerung konnte nicht angefordert werden.');
+      setReminderError(
+        error instanceof Error ? error.message : 'Die Erinnerung konnte nicht angefordert werden.'
+      );
     } finally {
       setReminderSubmitting(false);
     }
@@ -344,48 +368,43 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
       />
 
       <section className="action-hub" aria-label="Kalenderaktionen">
-        <div className="action-hub-toolbar" role="tablist" aria-label="Export- und Abo-Aktionen">
+        <div
+          className="action-hub-toolbar"
+          role="group"
+          aria-label="Export- und Erinnerungsaktionen"
+        >
           <button
             type="button"
-            id={getActionTabId('calendar')}
-            role="tab"
+            id={getActionTriggerId('calendar')}
             aria-controls={getActionPanelId('calendar')}
-            aria-selected={activeActionPanel === 'calendar'}
-            tabIndex={activeActionPanel === null || activeActionPanel === 'calendar' ? 0 : -1}
+            aria-expanded={activeActionPanel === 'calendar'}
             className={`action-hub-trigger${activeActionPanel === 'calendar' ? ' is-active' : ''}`}
             onClick={() => toggleActionPanel('calendar')}
-            onKeyDown={(event) => handleActionTabKeyDown(event, 'calendar')}
           >
             <IconCalendarPlus size={20} stroke={1.8} aria-hidden="true" />
-            <span>Kalenderexport</span>
+            <span>Kalender exportieren</span>
           </button>
           <button
             type="button"
-            id={getActionTabId('pdf')}
-            role="tab"
+            id={getActionTriggerId('pdf')}
             aria-controls={getActionPanelId('pdf')}
-            aria-selected={activeActionPanel === 'pdf'}
-            tabIndex={activeActionPanel === 'pdf' ? 0 : -1}
+            aria-expanded={activeActionPanel === 'pdf'}
             className={`action-hub-trigger${activeActionPanel === 'pdf' ? ' is-active' : ''}`}
             onClick={() => toggleActionPanel('pdf')}
-            onKeyDown={(event) => handleActionTabKeyDown(event, 'pdf')}
           >
             <IconFileTypePdf size={20} stroke={1.8} aria-hidden="true" />
-            <span>PDF-Download</span>
+            <span>PDF / Druckversion</span>
           </button>
           <button
             type="button"
-            id={getActionTabId('email')}
-            role="tab"
+            id={getActionTriggerId('email')}
             aria-controls={getActionPanelId('email')}
-            aria-selected={activeActionPanel === 'email'}
-            tabIndex={activeActionPanel === 'email' ? 0 : -1}
+            aria-expanded={activeActionPanel === 'email'}
             className={`action-hub-trigger${activeActionPanel === 'email' ? ' is-active' : ''}`}
             onClick={() => toggleActionPanel('email')}
-            onKeyDown={(event) => handleActionTabKeyDown(event, 'email')}
           >
             <IconMail size={20} stroke={1.8} aria-hidden="true" />
-            <span>E-Mail-Abo</span>
+            <span>E-Mail-Erinnerung</span>
           </button>
         </div>
 
@@ -393,8 +412,8 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
           <div
             id={getActionPanelId(activeActionPanel)}
             className="action-panel"
-            role="tabpanel"
-            aria-labelledby={getActionTabId(activeActionPanel)}
+            role="region"
+            aria-labelledby={getActionTriggerId(activeActionPanel)}
           >
             <p className="action-panel-intro">{actionPanelDescription}</p>
 
@@ -402,16 +421,20 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
               <div className="action-panel-body">
                 {canUseCalendarReminderExport ? (
                   <p className="action-panel-copy">
-                    Der Export übernimmt automatisch die Standard-Erinnerungen der aktiven Fraktionen.
+                    Der Export übernimmt automatisch die Standard-Erinnerungen der aktiven
+                    Fraktionen.
                   </p>
                 ) : (
                   <p className="action-panel-copy">
                     Der Export enthält die aktiven Abholtermine ohne zusätzliche Erinnerungen.
                   </p>
                 )}
-                {!calendarReminderContext.isFullySupported && calendarReminderContext.supportedFractions.length > 0 ? (
+                {!calendarReminderContext.isFullySupported &&
+                calendarReminderContext.supportedFractions.length > 0 ? (
                   <p className="action-warning">
-                    Für die aktuelle Fraktionsauswahl sind nicht für alle Fraktionen Kalender-Erinnerungen verfügbar. Der Export wird deshalb ohne Erinnerungen erstellt.
+                    Für die aktuelle Fraktionsauswahl sind nicht für alle Fraktionen
+                    Kalender-Erinnerungen verfügbar. Der Export wird deshalb ohne Erinnerungen
+                    erstellt.
                   </p>
                 ) : null}
                 <a
@@ -433,7 +456,11 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
               <div className="action-panel-body">
                 <label className="action-field">
                   <span>Jahr</span>
-                  <select aria-label="PDF-Jahr" value={pdfYear} onChange={(event) => setPdfYear(Number.parseInt(event.target.value, 10))}>
+                  <select
+                    aria-label="PDF-Jahr"
+                    value={pdfYear}
+                    onChange={(event) => setPdfYear(Number.parseInt(event.target.value, 10))}
+                  >
                     {yearOptions.map((year) => (
                       <option key={year} value={year}>
                         {year}
@@ -441,7 +468,11 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
                     ))}
                   </select>
                 </label>
-                {pdfError ? <p className="action-warning">{pdfError}</p> : null}
+                {pdfError ? (
+                  <p className="action-warning" role="alert">
+                    {pdfError}
+                  </p>
+                ) : null}
                 <button
                   type="button"
                   className="action-cta-button"
@@ -458,7 +489,11 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
             {activeActionPanel === 'email' ? (
               <div className="action-panel-body">
                 {reminderSuccess ? (
-                  <div className="reminder-feedback reminder-feedback-success">
+                  <div
+                    className="reminder-feedback reminder-feedback-success"
+                    role="status"
+                    aria-live="polite"
+                  >
                     <strong>{reminderSuccess.headline}</strong>
                     <p className="body-copy">{reminderSuccess.message}</p>
                   </div>
@@ -467,12 +502,15 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
                     {emailReminderContext.isFullySupported ? (
                       <>
                         <p className="action-panel-copy">
-                          Das Abo verwendet automatisch die Standard-Erinnerungen der aktiven Fraktionen.
+                          Das Abo verwendet automatisch die Standard-Erinnerungen der aktiven
+                          Fraktionen.
                         </p>
                         <label className="action-field">
                           <span>E-Mail-Adresse</span>
                           <input
                             aria-label="E-Mail-Adresse"
+                            aria-describedby={reminderError ? REMINDER_ERROR_ID : undefined}
+                            aria-invalid={reminderError ? 'true' : undefined}
                             type="email"
                             value={email}
                             onChange={(event) => setEmail(event.target.value)}
@@ -481,12 +519,21 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
                         <label className="reminder-consent">
                           <input
                             type="checkbox"
+                            aria-describedby={reminderError ? REMINDER_ERROR_ID : undefined}
+                            aria-invalid={reminderError ? 'true' : undefined}
                             checked={consentAccepted}
                             onChange={(event) => setConsentAccepted(event.target.checked)}
                           />
-                          <span>{props.reminderSignup?.consentLabel ?? 'Ich stimme der Verarbeitung meiner Daten zu.'}</span>
+                          <span>
+                            {props.reminderSignup?.consentLabel ??
+                              'Ich stimme der Verarbeitung meiner Daten zu.'}
+                          </span>
                           {props.reminderSignup?.privacyPolicyUrl ? (
-                            <a href={props.reminderSignup.privacyPolicyUrl} target="_blank" rel="noopener noreferrer">
+                            <a
+                              href={props.reminderSignup.privacyPolicyUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
                               Datenschutzerklärung
                             </a>
                           ) : null}
@@ -494,10 +541,16 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
                       </>
                     ) : (
                       <p className="action-warning">
-                        Für die aktuelle Fraktionsauswahl sind nicht für alle Fraktionen E-Mail-Erinnerungen verfügbar. Passen Sie die Fraktionsliste rechts an, um das Abo zu aktivieren.
+                        Für die aktuelle Fraktionsauswahl sind nicht für alle Fraktionen
+                        E-Mail-Erinnerungen verfügbar. Passen Sie die Fraktionsauswahl an, um das
+                        Abo zu aktivieren.
                       </p>
                     )}
-                    {reminderError ? <p className="action-warning">{reminderError}</p> : null}
+                    {reminderError ? (
+                      <p id={REMINDER_ERROR_ID} className="action-warning" role="alert">
+                        {reminderError}
+                      </p>
+                    ) : null}
                     <button
                       type="button"
                       className="action-cta-button"
@@ -506,7 +559,7 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
                         void submitReminderSignup();
                       }}
                     >
-                      {reminderSubmitting ? 'Wird angefordert…' : 'E-Mail-Abo anfordern'}
+                      {reminderSubmitting ? 'Wird angefordert…' : 'E-Mail-Erinnerung anfordern'}
                     </button>
                   </>
                 )}
@@ -516,10 +569,7 @@ function CompletePublicWasteApp(props: Readonly<CompletePublicWasteAppProps>) {
         ) : null}
       </section>
 
-      <PublicWasteCalendarPanels
-        model={filteredModel}
-        onActivateEntry={setSelectedEntry}
-      />
+      <PublicWasteCalendarPanels model={filteredModel} onActivateEntry={setSelectedEntry} />
       <PublicWasteEventDialog entry={selectedEntry} onClose={() => setSelectedEntry(null)} />
     </section>
   );

--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.test.tsx
@@ -94,11 +94,18 @@ describe('PublicWasteCalendarPanels', () => {
     );
 
     const listTab = screen.getByRole('tab', { name: 'Liste' });
+    listTab.focus();
     fireEvent.keyDown(listTab, { key: 'ArrowRight' });
-    expect(screen.getByRole('tab', { name: 'Monat' }).getAttribute('aria-selected')).toBe('true');
+    const monthTab = screen.getByRole('tab', { name: 'Monat' });
+    expect(monthTab.getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(monthTab);
 
-    fireEvent.keyDown(screen.getByRole('tab', { name: 'Monat' }), { key: 'ArrowLeft' });
+    fireEvent.keyDown(monthTab, { key: 'ArrowLeft' });
     expect(screen.getByRole('tab', { name: 'Liste' }).getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(listTab);
+
+    fireEvent.keyDown(listTab, { key: 'End' });
+    expect(document.activeElement).toBe(screen.getByRole('tab', { name: 'Jahr' }));
   });
 
   it('renders upcoming entries before a separate past section in the list view', () => {

--- a/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-calendar-panels.tsx
@@ -261,6 +261,7 @@ export function PublicWasteCalendarPanels(props: Readonly<{
   onActivateEntry: (entry: PublicWasteCalendarEntry) => void;
 }>) {
   const tabs: ReadonlyArray<'list' | 'month' | 'year'> = ['list', 'month', 'year'];
+  const tabButtonRefs = React.useRef(new Map<'list' | 'month' | 'year', HTMLButtonElement>());
   const today = React.useRef(new Date()).current;
   const lowerBoundMonth = React.useRef(startOfYear(addYears(today, -1))).current;
   const maxMonth = React.useRef(startOfMonth(addYears(today, 1))).current;
@@ -310,18 +311,32 @@ export function PublicWasteCalendarPanels(props: Readonly<{
     setVisibleYear((current) => Math.min(maxYear, Math.max(minYear, current)));
   }, [maxYear, minYear]);
 
-  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, tab: 'list' | 'month' | 'year') => {
-    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+  const handleTabKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    tab: 'list' | 'month' | 'year'
+  ) => {
+    if (
+      event.key !== 'ArrowLeft' &&
+      event.key !== 'ArrowRight' &&
+      event.key !== 'Home' &&
+      event.key !== 'End'
+    ) {
       return;
     }
 
     event.preventDefault();
     const currentIndex = tabs.indexOf(tab);
     const nextIndex =
-      event.key === 'ArrowRight'
-        ? (currentIndex + 1) % tabs.length
-        : (currentIndex - 1 + tabs.length) % tabs.length;
-    setActiveTab(tabs[nextIndex]);
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? tabs.length - 1
+          : event.key === 'ArrowRight'
+            ? (currentIndex + 1) % tabs.length
+            : (currentIndex - 1 + tabs.length) % tabs.length;
+    const nextTab = tabs[nextIndex];
+    setActiveTab(nextTab);
+    tabButtonRefs.current.get(nextTab)?.focus();
   };
 
   return (
@@ -331,6 +346,9 @@ export function PublicWasteCalendarPanels(props: Readonly<{
           type="button"
           role="tab"
           id="public-waste-tab-list"
+          ref={(element) => {
+            if (element) tabButtonRefs.current.set('list', element);
+          }}
           aria-controls="public-waste-panel-list"
           aria-selected={activeTab === 'list'}
           tabIndex={activeTab === 'list' ? 0 : -1}
@@ -344,6 +362,9 @@ export function PublicWasteCalendarPanels(props: Readonly<{
           type="button"
           role="tab"
           id="public-waste-tab-month"
+          ref={(element) => {
+            if (element) tabButtonRefs.current.set('month', element);
+          }}
           aria-controls="public-waste-panel-month"
           aria-selected={activeTab === 'month'}
           tabIndex={activeTab === 'month' ? 0 : -1}
@@ -357,6 +378,9 @@ export function PublicWasteCalendarPanels(props: Readonly<{
           type="button"
           role="tab"
           id="public-waste-tab-year"
+          ref={(element) => {
+            if (element) tabButtonRefs.current.set('year', element);
+          }}
           aria-controls="public-waste-panel-year"
           aria-selected={activeTab === 'year'}
           tabIndex={activeTab === 'year' ? 0 : -1}

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { PublicWasteSelectionForm } from './public-waste-selection-form.js';
 
 describe('PublicWasteSelectionForm', () => {
-  it('renders the city step as typeahead and shows suggestions only after typing', () => {
+  it('shows all city options initially and filters them after typing', () => {
     const onSelectOption = vi.fn();
 
     render(
@@ -21,15 +21,19 @@ describe('PublicWasteSelectionForm', () => {
       />
     );
 
-    expect(screen.getByRole('textbox', { name: 'Ort suchen' })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Ahrensdorf' })).toBeNull();
+    expect(screen.getByRole('combobox', { name: 'Ort suchen' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Ahrensdorf' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Buchholz' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Bad Wilsnack' })).toBeTruthy();
+    expect(screen.getByText('3 Einträge')).toBeTruthy();
+    expect(screen.getByRole('status').textContent).toBe('3 Einträge');
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Ort suchen' }), {
+    fireEvent.change(screen.getByRole('combobox', { name: 'Ort suchen' }), {
       target: { value: 'bu' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Buchholz' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Buchholz' }));
 
-    expect(screen.queryByRole('button', { name: 'Ahrensdorf' })).toBeNull();
+    expect(screen.queryByRole('option', { name: 'Ahrensdorf' })).toBeNull();
     expect(onSelectOption).toHaveBeenCalledWith('2');
   });
 
@@ -54,13 +58,13 @@ describe('PublicWasteSelectionForm', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Straße suchen' }), {
+    fireEvent.change(screen.getByRole('combobox', { name: 'Straße suchen' }), {
       target: { value: 'hafen' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Am alten Hafen' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Am alten Hafen' }));
 
     expect(onSelectOption).toHaveBeenCalledWith('2');
-    expect(screen.queryByRole('button', { name: 'Berliner Straße' })).toBeNull();
+    expect(screen.queryByRole('option', { name: 'Berliner Straße' })).toBeNull();
   });
 
   it('uses the same typeahead behavior for short follow-up selections', () => {
@@ -79,15 +83,96 @@ describe('PublicWasteSelectionForm', () => {
       />
     );
 
-    expect(screen.getByRole('textbox', { name: 'Hausnummer suchen' })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: '12' })).toBeNull();
+    expect(screen.getByRole('combobox', { name: 'Hausnummer suchen' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: '12' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: '14a' })).toBeTruthy();
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Hausnummer suchen' }), {
+    fireEvent.change(screen.getByRole('combobox', { name: 'Hausnummer suchen' }), {
       target: { value: '12' },
     });
-    fireEvent.click(screen.getByRole('button', { name: '12' }));
+    fireEvent.click(screen.getByRole('option', { name: '12' }));
 
     expect(onSelectOption).toHaveBeenCalledWith('1');
+  });
+
+  it('does not truncate the initial option list', () => {
+    render(
+      <PublicWasteSelectionForm
+        nextStepLabel="Straße"
+        options={Array.from({ length: 12 }, (_, index) => ({
+          id: String(index + 1),
+          label: `Straße ${String(index + 1).padStart(2, '0')}`,
+        }))}
+        selectionPath={[]}
+        onEditStep={() => undefined}
+        onSelectOption={() => undefined}
+      />
+    );
+
+    expect(screen.getAllByRole('option', { name: /^Straße \d{2}$/u })).toHaveLength(12);
+    expect(screen.getByRole('option', { name: 'Straße 12' })).toBeTruthy();
+    expect(screen.getByText('12 Einträge')).toBeTruthy();
+  });
+
+  it('supports listbox navigation without adding every option to the tab order', () => {
+    const onSelectOption = vi.fn();
+
+    render(
+      <PublicWasteSelectionForm
+        nextStepLabel="Ort"
+        options={[
+          { id: '1', label: 'Ahrensdorf' },
+          { id: '2', label: 'Buchholz' },
+        ]}
+        selectionPath={[]}
+        onEditStep={() => undefined}
+        onSelectOption={onSelectOption}
+      />
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Ort suchen' });
+    const options = screen.getAllByRole('option');
+    expect(combobox.getAttribute('aria-controls')).toBe(
+      screen.getByRole('listbox', { name: 'Ort-Auswahl' }).id
+    );
+    expect(options.every((option) => option.tabIndex === -1)).toBe(true);
+
+    fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    expect(combobox.getAttribute('aria-activedescendant')).toBe(options[0]?.id);
+    expect(options[0]?.getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+    fireEvent.keyDown(combobox, { key: 'Enter' });
+    expect(onSelectOption).toHaveBeenCalledWith('2');
+  });
+
+  it('shows a scroll hint while additional options remain below the viewport', () => {
+    render(
+      <PublicWasteSelectionForm
+        nextStepLabel="Straße"
+        options={Array.from({ length: 12 }, (_, index) => ({
+          id: String(index + 1),
+          label: `Straße ${String(index + 1).padStart(2, '0')}`,
+        }))}
+        selectionPath={[]}
+        onEditStep={() => undefined}
+        onSelectOption={() => undefined}
+      />
+    );
+
+    const results = screen.getByLabelText('Straße-Auswahl');
+    Object.defineProperties(results, {
+      clientHeight: { configurable: true, value: 300 },
+      scrollHeight: { configurable: true, value: 600 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    });
+
+    fireEvent.scroll(results);
+    expect(screen.getByText('Weitere Einträge')).toBeTruthy();
+
+    results.scrollTop = 300;
+    fireEvent.scroll(results);
+    expect(screen.queryByText('Weitere Einträge')).toBeNull();
   });
 
   it('shows the resolved path and allows jumping back to an earlier step', () => {

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
@@ -140,6 +140,8 @@ describe('PublicWasteSelectionForm', () => {
     fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     expect(combobox.getAttribute('aria-activedescendant')).toBe(options[0]?.id);
     expect(options[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(options[0]?.classList.contains('selection-result--active')).toBe(true);
+    expect(options[1]?.classList.contains('selection-result--active')).toBe(false);
 
     fireEvent.keyDown(combobox, { key: 'ArrowDown' });
     fireEvent.keyDown(combobox, { key: 'Enter' });

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
@@ -146,6 +146,50 @@ describe('PublicWasteSelectionForm', () => {
     expect(onSelectOption).toHaveBeenCalledWith('2');
   });
 
+  it('clears an unsuccessful search with Escape', () => {
+    render(
+      <PublicWasteSelectionForm
+        nextStepLabel="Ort"
+        options={[
+          { id: '1', label: 'Ahrensdorf' },
+          { id: '2', label: 'Buchholz' },
+        ]}
+        selectionPath={[]}
+        onEditStep={() => undefined}
+        onSelectOption={() => undefined}
+      />
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Ort suchen' });
+    fireEvent.change(combobox, { target: { value: 'unbekannt' } });
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+
+    fireEvent.keyDown(combobox, { key: 'Escape' });
+
+    expect((combobox as HTMLInputElement).value).toBe('');
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('activates an option when the pointer enters it', () => {
+    render(
+      <PublicWasteSelectionForm
+        nextStepLabel="Ort"
+        options={[
+          { id: '1', label: 'Ahrensdorf' },
+          { id: '2', label: 'Buchholz' },
+        ]}
+        selectionPath={[]}
+        onEditStep={() => undefined}
+        onSelectOption={() => undefined}
+      />
+    );
+
+    const option = screen.getByRole('option', { name: 'Buchholz' });
+    fireEvent.mouseEnter(option);
+
+    expect(option.getAttribute('aria-selected')).toBe('true');
+  });
+
   it('shows a scroll hint while additional options remain below the viewport', () => {
     render(
       <PublicWasteSelectionForm

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-form.test.tsx
@@ -163,6 +163,9 @@ describe('PublicWasteSelectionForm', () => {
     const combobox = screen.getByRole('combobox', { name: 'Ort suchen' });
     fireEvent.change(combobox, { target: { value: 'unbekannt' } });
     expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(
+      screen.getByText('Keine Treffer für diese Suche.').parentElement?.getAttribute('role')
+    ).not.toBe('listbox');
 
     fireEvent.keyDown(combobox, { key: 'Escape' });
 

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-form.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-form.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { IconChevronDown, IconChevronRight, IconSearch } from '@tabler/icons-react';
+import { IconSearch } from '@tabler/icons-react';
 
 import type { PublicWasteSelectableEntry } from '../lib/public-waste-contract.js';
+import { PublicWasteSelectionResults } from './public-waste-selection-results.js';
 
 export type PublicWasteSelectionPathItem = {
   readonly step: string;
@@ -21,6 +22,75 @@ const sortOptions = (
   options: readonly PublicWasteSelectableEntry[]
 ): readonly PublicWasteSelectableEntry[] =>
   [...options].sort((left, right) => left.label.localeCompare(right.label, 'de'));
+
+const useSelectionNavigation = (
+  input: Readonly<{
+    activeOptionIndex: number;
+    comboboxId: string;
+    filteredOptions: readonly PublicWasteSelectableEntry[];
+    onSelectOption: (optionId: string) => void;
+    searchQuery: string;
+    setActiveOptionIndex: React.Dispatch<React.SetStateAction<number>>;
+    setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+  }>
+) => {
+  const activateOption = (index: number) => {
+    const option = input.filteredOptions[index];
+    if (!option) {
+      return;
+    }
+
+    input.setActiveOptionIndex(index);
+    document
+      .getElementById(`${input.comboboxId}-option-${option.id}`)
+      ?.scrollIntoView?.({ block: 'nearest' });
+  };
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape' && (input.searchQuery.length > 0 || input.activeOptionIndex >= 0)) {
+      event.preventDefault();
+      input.setSearchQuery('');
+      input.setActiveOptionIndex(-1);
+      return;
+    }
+
+    if (input.filteredOptions.length === 0) {
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      activateOption(Math.min(input.activeOptionIndex + 1, input.filteredOptions.length - 1));
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      activateOption(
+        input.activeOptionIndex <= 0
+          ? input.filteredOptions.length - 1
+          : input.activeOptionIndex - 1
+      );
+      return;
+    }
+
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      activateOption(event.key === 'Home' ? 0 : input.filteredOptions.length - 1);
+      return;
+    }
+
+    if (event.key === 'Enter' && input.activeOptionIndex >= 0) {
+      event.preventDefault();
+      const activeOption = input.filteredOptions[input.activeOptionIndex];
+      if (activeOption) {
+        input.onSelectOption(activeOption.id);
+      }
+    }
+  };
+
+  return { activateOption, handleSearchKeyDown };
+};
 
 export function PublicWasteSelectionForm(
   props: Readonly<{
@@ -54,62 +124,15 @@ export function PublicWasteSelectionForm(
     setActiveOptionIndex(-1);
   }, [props.nextStepLabel, props.options]);
 
-  const activateOption = (index: number) => {
-    const option = filteredOptions[index];
-    if (!option) {
-      return;
-    }
-
-    setActiveOptionIndex(index);
-    document
-      .getElementById(`${comboboxId}-option-${option.id}`)
-      ?.scrollIntoView?.({ block: 'nearest' });
-  };
-
-  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (filteredOptions.length === 0) {
-      return;
-    }
-
-    if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      activateOption(Math.min(activeOptionIndex + 1, filteredOptions.length - 1));
-      return;
-    }
-
-    if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      activateOption(activeOptionIndex <= 0 ? filteredOptions.length - 1 : activeOptionIndex - 1);
-      return;
-    }
-
-    if (event.key === 'Home') {
-      event.preventDefault();
-      activateOption(0);
-      return;
-    }
-
-    if (event.key === 'End') {
-      event.preventDefault();
-      activateOption(filteredOptions.length - 1);
-      return;
-    }
-
-    if (event.key === 'Enter' && activeOptionIndex >= 0) {
-      event.preventDefault();
-      const activeOption = filteredOptions[activeOptionIndex];
-      if (activeOption) {
-        props.onSelectOption(activeOption.id);
-      }
-      return;
-    }
-
-    if (event.key === 'Escape' && (searchQuery.length > 0 || activeOptionIndex >= 0)) {
-      event.preventDefault();
-      setSearchQuery('');
-      setActiveOptionIndex(-1);
-    }
-  };
+  const { activateOption, handleSearchKeyDown } = useSelectionNavigation({
+    activeOptionIndex,
+    comboboxId,
+    filteredOptions,
+    onSelectOption: props.onSelectOption,
+    searchQuery,
+    setActiveOptionIndex,
+    setSearchQuery,
+  });
 
   const updateScrollHint = React.useCallback(() => {
     const results = resultsRef.current;
@@ -205,48 +228,19 @@ export function PublicWasteSelectionForm(
             </p>
           </div>
         </div>
-        <div className="selection-results-shell">
-          <div
-            id={resultsId}
-            ref={resultsRef}
-            className="selection-results"
-            role="listbox"
-            aria-label={`${props.nextStepLabel}-Auswahl`}
-            onScroll={updateScrollHint}
-          >
-            {filteredOptions.map((option, index) => (
-              <button
-                key={option.id}
-                id={`${comboboxId}-option-${option.id}`}
-                type="button"
-                className="selection-result"
-                role="option"
-                aria-label={option.label}
-                aria-selected={activeOptionIndex === index}
-                tabIndex={-1}
-                onClick={() => props.onSelectOption(option.id)}
-                onMouseMove={() => setActiveOptionIndex(index)}
-              >
-                <span className="selection-result-label">{option.label}</span>
-                <span className="selection-result-action">
-                  <span>Übernehmen</span>
-                  <IconChevronRight size={18} stroke={1.75} aria-hidden="true" />
-                </span>
-              </button>
-            ))}
-            {filteredOptions.length === 0 && searchQuery.trim().length > 0 ? (
-              <div className="selection-empty-state" role="status">
-                Keine Treffer für diese Suche.
-              </div>
-            ) : null}
-          </div>
-          {canScrollDown ? (
-            <div className="selection-scroll-hint" aria-hidden="true">
-              <span>Weitere Einträge</span>
-              <IconChevronDown size={18} stroke={2} />
-            </div>
-          ) : null}
-        </div>
+        <PublicWasteSelectionResults
+          activeOptionIndex={activeOptionIndex}
+          canScrollDown={canScrollDown}
+          comboboxId={comboboxId}
+          filteredOptions={filteredOptions}
+          nextStepLabel={props.nextStepLabel}
+          onActivateOption={activateOption}
+          onScroll={updateScrollHint}
+          onSelectOption={props.onSelectOption}
+          resultsId={resultsId}
+          resultsRef={resultsRef}
+          searchQuery={searchQuery}
+        />
       </div>
     </section>
   );

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-form.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-form.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconChevronRight, IconSearch } from '@tabler/icons-react';
+import { IconChevronDown, IconChevronRight, IconSearch } from '@tabler/icons-react';
 
 import type { PublicWasteSelectableEntry } from '../lib/public-waste-contract.js';
 
@@ -7,8 +7,6 @@ export type PublicWasteSelectionPathItem = {
   readonly step: string;
   readonly label: string;
 };
-
-const MAX_VISIBLE_SUGGESTIONS = 8;
 
 const normalizeSearchValue = (value: string): string =>
   value
@@ -19,34 +17,118 @@ const normalizeSearchValue = (value: string): string =>
     .replaceAll('ü', 'ue')
     .replaceAll('ß', 'ss');
 
-const sortOptions = (options: readonly PublicWasteSelectableEntry[]): readonly PublicWasteSelectableEntry[] =>
+const sortOptions = (
+  options: readonly PublicWasteSelectableEntry[]
+): readonly PublicWasteSelectableEntry[] =>
   [...options].sort((left, right) => left.label.localeCompare(right.label, 'de'));
 
-export function PublicWasteSelectionForm(props: Readonly<{
-  nextStepLabel: string;
-  options: readonly PublicWasteSelectableEntry[];
-  selectionPath: readonly PublicWasteSelectionPathItem[];
-  onEditStep: (stepIndex: number) => void;
-  onSelectOption: (optionId: string) => void;
-}>) {
+export function PublicWasteSelectionForm(
+  props: Readonly<{
+    nextStepLabel: string;
+    options: readonly PublicWasteSelectableEntry[];
+    selectionPath: readonly PublicWasteSelectionPathItem[];
+    onEditStep: (stepIndex: number) => void;
+    onSelectOption: (optionId: string) => void;
+  }>
+) {
   const [searchQuery, setSearchQuery] = React.useState('');
+  const [canScrollDown, setCanScrollDown] = React.useState(false);
+  const [activeOptionIndex, setActiveOptionIndex] = React.useState(-1);
+  const resultsRef = React.useRef<HTMLDivElement>(null);
+  const comboboxId = React.useId();
+  const resultsId = `${comboboxId}-results`;
+  const statusId = `${comboboxId}-status`;
   const sortedOptions = React.useMemo(() => sortOptions(props.options), [props.options]);
-  const shouldUseSearch = true;
   const filteredOptions = React.useMemo(() => {
     const normalizedQuery = normalizeSearchValue(searchQuery);
     if (!normalizedQuery) {
-      return [];
+      return sortedOptions;
     }
-    return sortedOptions.filter((option) => normalizeSearchValue(option.label).includes(normalizedQuery));
+    return sortedOptions.filter((option) =>
+      normalizeSearchValue(option.label).includes(normalizedQuery)
+    );
   }, [searchQuery, sortedOptions]);
-  const visibleOptions = React.useMemo(
-    () => filteredOptions.slice(0, MAX_VISIBLE_SUGGESTIONS),
-    [filteredOptions]
-  );
 
   React.useEffect(() => {
     setSearchQuery('');
+    setActiveOptionIndex(-1);
   }, [props.nextStepLabel, props.options]);
+
+  const activateOption = (index: number) => {
+    const option = filteredOptions[index];
+    if (!option) {
+      return;
+    }
+
+    setActiveOptionIndex(index);
+    document
+      .getElementById(`${comboboxId}-option-${option.id}`)
+      ?.scrollIntoView?.({ block: 'nearest' });
+  };
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (filteredOptions.length === 0) {
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      activateOption(Math.min(activeOptionIndex + 1, filteredOptions.length - 1));
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      activateOption(activeOptionIndex <= 0 ? filteredOptions.length - 1 : activeOptionIndex - 1);
+      return;
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      activateOption(0);
+      return;
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      activateOption(filteredOptions.length - 1);
+      return;
+    }
+
+    if (event.key === 'Enter' && activeOptionIndex >= 0) {
+      event.preventDefault();
+      const activeOption = filteredOptions[activeOptionIndex];
+      if (activeOption) {
+        props.onSelectOption(activeOption.id);
+      }
+      return;
+    }
+
+    if (event.key === 'Escape' && (searchQuery.length > 0 || activeOptionIndex >= 0)) {
+      event.preventDefault();
+      setSearchQuery('');
+      setActiveOptionIndex(-1);
+    }
+  };
+
+  const updateScrollHint = React.useCallback(() => {
+    const results = resultsRef.current;
+    setCanScrollDown(
+      results !== null && results.scrollHeight - results.scrollTop - results.clientHeight > 1
+    );
+  }, []);
+
+  React.useLayoutEffect(() => {
+    updateScrollHint();
+    const results = resultsRef.current;
+    if (!results || typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(updateScrollHint);
+    observer.observe(results);
+    return () => observer.disconnect();
+  }, [filteredOptions, updateScrollHint]);
 
   return (
     <section className="selection-panel" aria-label="Standortauswahl">
@@ -88,41 +170,80 @@ export function PublicWasteSelectionForm(props: Readonly<{
                 id={`selection-search-${props.nextStepLabel}`}
                 className="selection-search-input"
                 type="text"
-                aria-label={`${props.nextStepLabel} suchen`}
+                role="combobox"
                 aria-autocomplete="list"
+                aria-controls={resultsId}
+                aria-describedby={statusId}
+                aria-expanded="true"
+                aria-haspopup="listbox"
+                aria-activedescendant={
+                  activeOptionIndex >= 0 && filteredOptions[activeOptionIndex]
+                    ? `${comboboxId}-option-${filteredOptions[activeOptionIndex].id}`
+                    : undefined
+                }
                 autoComplete="off"
                 placeholder={`${props.nextStepLabel} suchen`}
                 value={searchQuery}
                 autoFocus
-                onChange={(event) => setSearchQuery(event.target.value)}
+                onChange={(event) => {
+                  setSearchQuery(event.target.value);
+                  setActiveOptionIndex(-1);
+                }}
+                onKeyDown={handleSearchKeyDown}
               />
             </div>
-            <p className="selection-search-meta">
+            <p
+              id={statusId}
+              className="selection-search-meta"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
               {searchQuery.trim().length === 0
-                ? 'Geben Sie die ersten Zeichen ein, um Vorschläge zu erhalten.'
+                ? `${filteredOptions.length} ${filteredOptions.length === 1 ? 'Eintrag' : 'Einträge'}`
                 : `${filteredOptions.length} Treffer`}
             </p>
           </div>
         </div>
-        <div className="selection-results" aria-label={`${props.nextStepLabel}-Auswahl`}>
-          {visibleOptions.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              className="selection-result"
-              aria-label={option.label}
-              onClick={() => props.onSelectOption(option.id)}
-            >
-              <span className="selection-result-label">{option.label}</span>
-              <span className="selection-result-action">
-                <span>Übernehmen</span>
-                <IconChevronRight size={18} stroke={1.75} aria-hidden="true" />
-              </span>
-            </button>
-          ))}
-          {shouldUseSearch && filteredOptions.length === 0 && searchQuery.trim().length > 0 ? (
-            <div className="selection-empty-state" role="status">
-              Keine Treffer für diese Suche.
+        <div className="selection-results-shell">
+          <div
+            id={resultsId}
+            ref={resultsRef}
+            className="selection-results"
+            role="listbox"
+            aria-label={`${props.nextStepLabel}-Auswahl`}
+            onScroll={updateScrollHint}
+          >
+            {filteredOptions.map((option, index) => (
+              <button
+                key={option.id}
+                id={`${comboboxId}-option-${option.id}`}
+                type="button"
+                className="selection-result"
+                role="option"
+                aria-label={option.label}
+                aria-selected={activeOptionIndex === index}
+                tabIndex={-1}
+                onClick={() => props.onSelectOption(option.id)}
+                onMouseMove={() => setActiveOptionIndex(index)}
+              >
+                <span className="selection-result-label">{option.label}</span>
+                <span className="selection-result-action">
+                  <span>Übernehmen</span>
+                  <IconChevronRight size={18} stroke={1.75} aria-hidden="true" />
+                </span>
+              </button>
+            ))}
+            {filteredOptions.length === 0 && searchQuery.trim().length > 0 ? (
+              <div className="selection-empty-state" role="status">
+                Keine Treffer für diese Suche.
+              </div>
+            ) : null}
+          </div>
+          {canScrollDown ? (
+            <div className="selection-scroll-hint" aria-hidden="true">
+              <span>Weitere Einträge</span>
+              <IconChevronDown size={18} stroke={2} />
             </div>
           ) : null}
         </div>

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-header.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-header.tsx
@@ -1,4 +1,4 @@
-import { IconPencil } from '@tabler/icons-react';
+import { IconInfoCircle, IconPencil } from '@tabler/icons-react';
 
 import type { PublicWasteFractionOption } from '../lib/public-waste-contract.js';
 
@@ -10,21 +10,6 @@ type PublicWasteSelectionHeaderProps = {
   readonly activeFractionIds: readonly string[];
   readonly onChangeLocation: () => void;
   readonly onToggleFraction: (fractionId: string) => void;
-};
-
-const parseHexColorChannel = (value: string, startIndex: number): number => Number.parseInt(value.slice(startIndex, startIndex + 2), 16);
-
-const deriveReadableTextColor = (backgroundColor?: string): string | undefined => {
-  if (!backgroundColor || !/^#[0-9a-f]{6}$/i.test(backgroundColor)) {
-    return undefined;
-  }
-
-  const red = parseHexColorChannel(backgroundColor, 1);
-  const green = parseHexColorChannel(backgroundColor, 3);
-  const blue = parseHexColorChannel(backgroundColor, 5);
-  const luminance = (red * 0.299 + green * 0.587 + blue * 0.114) / 255;
-
-  return luminance > 0.62 ? 'rgb(24 24 24)' : 'rgb(255 255 255)';
 };
 
 export const PublicWasteSelectionHeader = ({
@@ -40,15 +25,14 @@ export const PublicWasteSelectionHeader = ({
     <div className="selection-header-main">
       <div className="selection-section-heading">
         <h2 className="section-title">Adresse</h2>
-        <p className="selection-step-copy">Der gewählte Standort bleibt erhalten, während Sie Ansichten und Aktionen über die aktiven Fraktionen steuern.</p>
       </div>
-      <div className="selection-summary-block">
-        <p className="selection-summary-line">{cityLine}</p>
-        <p className="selection-summary-line">{streetLine}</p>
-        {houseNumberLine ? <p className="selection-summary-line">{houseNumberLine}</p> : null}
-      </div>
-      <div className="selection-summary-action-row">
-        <button type="button" className="selection-summary-link" onClick={onChangeLocation}>
+      <div className="selection-summary-row">
+        <div className="selection-summary-block">
+          <p className="selection-summary-line">{cityLine}</p>
+          <p className="selection-summary-line">{streetLine}</p>
+          {houseNumberLine ? <p className="selection-summary-line">{houseNumberLine}</p> : null}
+        </div>
+        <button type="button" className="selection-summary-action" onClick={onChangeLocation}>
           <IconPencil size={18} stroke={1.75} aria-hidden="true" />
           <span>Adresse ändern</span>
         </button>
@@ -56,36 +40,38 @@ export const PublicWasteSelectionHeader = ({
     </div>
     <div className="selection-header-fractions">
       <div className="selection-section-heading">
-        <h2 className="section-title">Abfallfraktionen</h2>
-        <p className="selection-step-copy">Diese Auswahl steuert Liste, Kalenderexport, PDF-Download und E-Mail-Abo gemeinsam.</p>
+        <div className="selection-section-title-row">
+          <h2 className="section-title">Abfallfraktionen</h2>
+          <button
+            type="button"
+            className="selection-info-trigger"
+            aria-label="Informationen zu Abfallfraktionen"
+            popoverTarget="public-waste-fraction-info"
+          >
+            <IconInfoCircle size={19} stroke={2.4} aria-hidden="true" />
+          </button>
+        </div>
+        <div id="public-waste-fraction-info" className="selection-info-popover" popover="auto">
+          <p>
+            Diese Auswahl steuert Liste, Kalenderexport, PDF/Druckversion und E-Mail-Erinnerung
+            gemeinsam.
+          </p>
+        </div>
       </div>
       <div className="selection-fraction-list" role="group" aria-label="Abfallfraktionen">
         {fractionOptions.map((fraction) => {
           const checked = activeFractionIds.includes(fraction.id);
-          const textColor = deriveReadableTextColor(fraction.color);
           return (
             <label
               key={fraction.id}
               className={`selection-fraction-item${checked ? ' is-active' : ''}`}
-              style={
-                fraction.color
-                  ? {
-                      ...(checked ? { backgroundColor: fraction.color, borderColor: fraction.color } : { borderColor: fraction.color }),
-                      ...(textColor && checked ? { color: textColor } : {}),
-                    }
-                  : undefined
-              }
             >
               <input
                 type="checkbox"
                 checked={checked}
                 onChange={() => onToggleFraction(fraction.id)}
                 aria-label={fraction.label}
-              />
-              <span
-                className="selection-fraction-swatch"
-                aria-hidden="true"
-                style={fraction.color ? { backgroundColor: fraction.color } : undefined}
+                style={fraction.color ? { accentColor: fraction.color } : undefined}
               />
               <span className="selection-fraction-copy">{fraction.label}</span>
             </label>

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-results.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-results.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+
+import type { PublicWasteSelectableEntry } from '../lib/public-waste-contract.js';
+
+export const PublicWasteSelectionResults = (
+  props: Readonly<{
+    activeOptionIndex: number;
+    canScrollDown: boolean;
+    comboboxId: string;
+    filteredOptions: readonly PublicWasteSelectableEntry[];
+    nextStepLabel: string;
+    onActivateOption: (index: number) => void;
+    onScroll: () => void;
+    onSelectOption: (optionId: string) => void;
+    resultsId: string;
+    resultsRef: React.RefObject<HTMLDivElement | null>;
+    searchQuery: string;
+  }>
+) => (
+  <div className="selection-results-shell">
+    <div
+      id={props.resultsId}
+      ref={props.resultsRef}
+      className="selection-results"
+      role="listbox"
+      aria-label={`${props.nextStepLabel}-Auswahl`}
+      onScroll={props.onScroll}
+    >
+      {props.filteredOptions.map((option, index) => (
+        <button
+          key={option.id}
+          id={`${props.comboboxId}-option-${option.id}`}
+          type="button"
+          className="selection-result"
+          role="option"
+          aria-label={option.label}
+          aria-selected={props.activeOptionIndex === index}
+          tabIndex={-1}
+          onClick={() => props.onSelectOption(option.id)}
+          onMouseEnter={() => props.onActivateOption(index)}
+        >
+          <span className="selection-result-label">{option.label}</span>
+          <span className="selection-result-action">
+            <span>Übernehmen</span>
+            <IconChevronRight size={18} stroke={1.75} aria-hidden="true" />
+          </span>
+        </button>
+      ))}
+      {props.filteredOptions.length === 0 && props.searchQuery.trim().length > 0 ? (
+        <div className="selection-empty-state" role="status">
+          Keine Treffer für diese Suche.
+        </div>
+      ) : null}
+    </div>
+    {props.canScrollDown ? (
+      <div className="selection-scroll-hint" aria-hidden="true">
+        <span>Weitere Einträge</span>
+        <IconChevronDown size={18} stroke={2} />
+      </div>
+    ) : null}
+  </div>
+);

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-results.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-results.tsx
@@ -47,12 +47,12 @@ export const PublicWasteSelectionResults = (
           </span>
         </button>
       ))}
-      {props.filteredOptions.length === 0 && props.searchQuery.trim().length > 0 ? (
-        <div className="selection-empty-state" role="status">
-          Keine Treffer für diese Suche.
-        </div>
-      ) : null}
     </div>
+    {props.filteredOptions.length === 0 && props.searchQuery.trim().length > 0 ? (
+      <div className="selection-empty-state" role="status">
+        Keine Treffer für diese Suche.
+      </div>
+    ) : null}
     {props.canScrollDown ? (
       <div className="selection-scroll-hint" aria-hidden="true">
         <span>Weitere Einträge</span>

--- a/apps/public-waste-calendar-web/src/components/public-waste-selection-results.tsx
+++ b/apps/public-waste-calendar-web/src/components/public-waste-selection-results.tsx
@@ -32,7 +32,9 @@ export const PublicWasteSelectionResults = (
           key={option.id}
           id={`${props.comboboxId}-option-${option.id}`}
           type="button"
-          className="selection-result"
+          className={`selection-result${
+            props.activeOptionIndex === index ? ' selection-result--active' : ''
+          }`}
           role="option"
           aria-label={option.label}
           aria-selected={props.activeOptionIndex === index}

--- a/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.test.ts
@@ -106,6 +106,7 @@ describe('public waste calendar occurrences', () => {
         tourName: 'Papiertour',
         tourDescription: 'Blaue Tonne fuer Papier und Kartonagen.',
         note: 'Straßenfest',
+        isShifted: true,
       },
       {
         id: 'tour-paper:2026-05-28:paper',
@@ -136,6 +137,7 @@ describe('public waste calendar occurrences', () => {
         tourName: 'Biotour',
         tourDescription: 'Regelabfuhr fuer die Innenstadt.',
         note: 'Verschoben wegen Feiertag',
+        isShifted: true,
       },
       {
         id: 'tour-bio:2026-06-05:bio',
@@ -212,6 +214,7 @@ describe('public waste calendar occurrences', () => {
         fractionColor: '#444444',
         tourName: 'Restmüll',
         note: 'Verschoben nach Neujahr',
+        isShifted: true,
       },
     ]);
   });
@@ -303,6 +306,7 @@ describe('public waste calendar occurrences', () => {
         fractionColor: '#444444',
         tourName: 'Restmüll',
         note: null,
+        isShifted: true,
       },
       {
         id: 'tour-rest:2026-01-08:rest',

--- a/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-calendar-occurrences.ts
@@ -330,6 +330,7 @@ export const calculatePublicWasteCalendarEntries = (
           ...(linkedTour.tour.description?.trim()
             ? { tourDescription: linkedTour.tour.description.trim() }
             : {}),
+          ...(shiftedDate !== occurrence.date ? { isShifted: true } : {}),
           note,
         });
       }

--- a/apps/public-waste-calendar-web/src/lib/public-waste-contract.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-contract.ts
@@ -44,6 +44,7 @@ export type PublicWasteCalendarEntry = {
   readonly fractionColor?: string;
   readonly tourName?: string;
   readonly tourDescription?: string;
+  readonly isShifted?: boolean;
   readonly note: string | null;
 };
 

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
@@ -140,7 +140,10 @@ describe('public waste endpoints', () => {
             date: '2026-05-19',
             fractionId: 'bio',
             fractionLabel: 'Bioabfall',
+            fractionDescription: 'Küchen- und Gartenabfälle ohne Kunststoffbeutel.',
             fractionShortLabel: 'BIO',
+            tourName: 'Tour Nord',
+            tourDescription: 'Behälter am Straßenrand bereitstellen.',
             note: 'Bitte Tonne ab 6 Uhr bereitstellen.',
           },
         ]),
@@ -161,6 +164,11 @@ describe('public waste endpoints', () => {
     expect(response.headers.get('content-disposition')).toContain('abfallkalender-2026-musterstadt-hauptstra-e-1.pdf');
     const pdfText = Buffer.from(await response.arrayBuffer()).toString('latin1');
     expect(pdfText).toContain('Abfallkalender 2026');
+    expect(pdfText).toContain('Küchen- und Gartenabfälle ohne Kunststoffbeutel.');
+    expect(pdfText).toContain('Tour: Tour Nord');
+    expect(pdfText).toContain('Behälter am Straßenrand bereitstellen.');
+    expect(pdfText).toContain('19.05. Tour: Tour Nord');
+    expect(pdfText).toContain('Bitte Tonne ab 6 Uhr bereitstellen.');
     expect(pdfText).toContain('/Subtype /Image');
     expect(loadBrandingImage).toHaveBeenCalledWith({
       assetUrl: 'https://cdn.example/logo.svg',
@@ -191,6 +199,7 @@ describe('public waste endpoints', () => {
             fractionId: 'bio',
             fractionLabel: 'Bioabfall',
             fractionShortLabel: 'BIO',
+            isShifted: true,
             note: null,
           },
           {
@@ -212,13 +221,14 @@ describe('public waste endpoints', () => {
 
     expect(buildDocumentSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        notes: [],
+        legendHints: [],
         pickups: [
           {
             date: '2026-05-19',
             fractions: [
               expect.objectContaining({
                 id: 'bio',
+                isShifted: true,
               }),
               expect.objectContaining({
                 id: 'paper',

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.test.ts
@@ -161,7 +161,9 @@ describe('public waste endpoints', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('application/pdf');
-    expect(response.headers.get('content-disposition')).toContain('abfallkalender-2026-musterstadt-hauptstra-e-1.pdf');
+    expect(response.headers.get('content-disposition')).toContain(
+      'abfallkalender-2026-musterstadt-hauptstra-e-1.pdf'
+    );
     const pdfText = Buffer.from(await response.arrayBuffer()).toString('latin1');
     expect(pdfText).toContain('Abfallkalender 2026');
     expect(pdfText).toContain('Küchen- und Gartenabfälle ohne Kunststoffbeutel.');
@@ -169,6 +171,7 @@ describe('public waste endpoints', () => {
     expect(pdfText).toContain('Behälter am Straßenrand bereitstellen.');
     expect(pdfText).toContain('19.05. Tour: Tour Nord');
     expect(pdfText).toContain('Bitte Tonne ab 6 Uhr bereitstellen.');
+    expect(pdfText).toContain('Abfallberatung 03395 / 1234');
     expect(pdfText).toContain('/Subtype /Image');
     expect(loadBrandingImage).toHaveBeenCalledWith({
       assetUrl: 'https://cdn.example/logo.svg',

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
@@ -3,12 +3,14 @@ import {
   renderWasteCalendarPdf,
   type WasteManagementEmailReminderConfig,
   type WasteCalendarPdfBrandingImage,
+  type WasteOutputLegendHint,
   type WasteOutputPickupEntry,
 } from '@sva/core';
 import { PublicWasteReminderSignupError } from '../server/public-waste-email-reminders.server.js';
 
 import { loadNextPublicWasteSelection, loadResolvedPublicWasteCalendar } from './public-waste-api.js';
 import type {
+  PublicWasteCalendarEntry,
   PublicWasteReminderSignupRequest,
   PublicWasteReminderSignupResponse,
 } from './public-waste-contract.js';
@@ -106,27 +108,63 @@ const normalizePdfLocationLabel = (selectionSummary: string): string => {
   return [city, remainder].filter(Boolean).join(', ');
 };
 
-const collectPdfNotes = (notes: readonly (string | null)[]): readonly string[] =>
-  Array.from(new Set(notes.map((note) => note?.trim()).filter((note): note is string => Boolean(note)))).slice(0, 4);
+const formatPdfLegendDate = (value: string): string =>
+  `${value.slice(8, 10)}.${value.slice(5, 7)}.`;
+
+const buildPdfLegendHints = (
+  entries: readonly PublicWasteCalendarEntry[]
+): readonly WasteOutputLegendHint[] => {
+  const tourHints = new Map<string, WasteOutputLegendHint>();
+  const pickupHints = new Map<string, WasteOutputLegendHint>();
+
+  for (const entry of entries) {
+    const tourName = entry.tourName?.trim();
+    const tourDescription = entry.tourDescription?.trim();
+    if (tourName && tourDescription) {
+      const id = `tour:${tourName}:${tourDescription}`;
+      tourHints.set(id, { id, label: `Tour: ${tourName}`, description: tourDescription });
+    }
+
+    const note = entry.note?.trim();
+    if (note) {
+      const contextLabel = tourName ? `Tour: ${tourName}` : entry.fractionLabel;
+      const id = `pickup:${entry.date}:${contextLabel}:${note}`;
+      pickupHints.set(id, {
+        id,
+        label: `${formatPdfLegendDate(entry.date)} ${contextLabel}`,
+        description: note,
+      });
+    }
+  }
+
+  return [...tourHints.values(), ...pickupHints.values()];
+};
 
 const buildPdfPickups = (
   entries: readonly {
     readonly date: string;
     readonly fractionId: string;
     readonly fractionLabel: string;
+    readonly fractionDescription?: string;
     readonly fractionShortLabel?: string;
     readonly fractionColor?: string;
+    readonly isShifted?: boolean;
   }[]
 ): readonly WasteOutputPickupEntry[] => {
   const byDate = new Map<string, Map<string, WasteOutputPickupEntry['fractions'][number]>>();
 
   for (const entry of entries) {
     const fractions = byDate.get(entry.date) ?? new Map<string, WasteOutputPickupEntry['fractions'][number]>();
+    const existingFraction = fractions.get(entry.fractionId);
     fractions.set(entry.fractionId, {
       id: entry.fractionId,
       label: entry.fractionLabel,
+      ...(existingFraction?.description || entry.fractionDescription?.trim()
+        ? { description: existingFraction?.description ?? entry.fractionDescription?.trim() }
+        : {}),
       shortLabel: entry.fractionShortLabel,
       color: entry.fractionColor ?? '#808080',
+      ...(existingFraction?.isShifted || entry.isShifted ? { isShifted: true } : {}),
     });
     byDate.set(entry.date, fractions);
   }
@@ -352,8 +390,7 @@ export const handlePublicWastePdfRequest = async (input: {
         year,
         locationLabel,
         pickups: buildPdfPickups(filteredEntries),
-        notes: [],
-        footerLine: staticConfig.contactBlock?.replace(/\s*\n\s*/g, ' · '),
+        legendHints: buildPdfLegendHints(filteredEntries),
         ...(brandingImage ? { brandingImage } : {}),
         brandingPlaceholderLabel: staticConfig.brandingAssetUrl ? 'Branding-Grafik' : 'Kommunales Waste-Management',
       })

--- a/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-endpoints.server.ts
@@ -8,7 +8,10 @@ import {
 } from '@sva/core';
 import { PublicWasteReminderSignupError } from '../server/public-waste-email-reminders.server.js';
 
-import { loadNextPublicWasteSelection, loadResolvedPublicWasteCalendar } from './public-waste-api.js';
+import {
+  loadNextPublicWasteSelection,
+  loadResolvedPublicWasteCalendar,
+} from './public-waste-api.js';
 import type {
   PublicWasteCalendarEntry,
   PublicWasteReminderSignupRequest,
@@ -28,7 +31,8 @@ import type { PublicWasteRepository } from './public-waste-repository.server.js'
 
 const INVALID_REQUEST_MESSAGE = 'Ungültige Anfrage.';
 const NO_PDF_ENTRIES_MESSAGE = 'Für diese Auswahl konnten keine PDF-Termine ermittelt werden.';
-const REMINDER_SIGNUP_NOT_READY_MESSAGE = 'Der E-Mail-Erinnerungsdienst ist derzeit nicht verfügbar.';
+const REMINDER_SIGNUP_NOT_READY_MESSAGE =
+  'Der E-Mail-Erinnerungsdienst ist derzeit nicht verfügbar.';
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const jsonResponse = (payload: unknown, status = 200): Response =>
@@ -96,7 +100,10 @@ const buildPublicWasteIcalEventDescription = (entry: {
 };
 
 const normalizePdfLocationLabel = (selectionSummary: string): string => {
-  const parts = selectionSummary.split(',').map((part) => part.trim()).filter(Boolean);
+  const parts = selectionSummary
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
   const city = parts[0] ?? '';
   const remainder = parts
     .slice(1)
@@ -154,7 +161,8 @@ const buildPdfPickups = (
   const byDate = new Map<string, Map<string, WasteOutputPickupEntry['fractions'][number]>>();
 
   for (const entry of entries) {
-    const fractions = byDate.get(entry.date) ?? new Map<string, WasteOutputPickupEntry['fractions'][number]>();
+    const fractions =
+      byDate.get(entry.date) ?? new Map<string, WasteOutputPickupEntry['fractions'][number]>();
     const existingFraction = fractions.get(entry.fractionId);
     fractions.set(entry.fractionId, {
       id: entry.fractionId,
@@ -173,12 +181,19 @@ const buildPdfPickups = (
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([date, fractions]) => ({
       date,
-      fractions: Array.from(fractions.values()).sort((left, right) => left.label.localeCompare(right.label, 'de')),
+      fractions: Array.from(fractions.values()).sort((left, right) =>
+        left.label.localeCompare(right.label, 'de')
+      ),
     }));
 };
 
 const toPdfFilename = (year: number, locationLabel: string): string =>
-  `abfallkalender-${year}-${locationLabel.toLowerCase().replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '') || 'standort'}.pdf`;
+  `abfallkalender-${year}-${
+    locationLabel
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gi, '-')
+      .replace(/^-+|-+$/g, '') || 'standort'
+  }.pdf`;
 
 export const handlePublicWasteSelectionRequest = async (input: {
   readonly repository: Pick<PublicWasteRepository, 'listSelectionOptions'>;
@@ -200,27 +215,31 @@ export const handlePublicWasteSelectionRequest = async (input: {
 };
 
 export const handlePublicWasteCalendarRequest = async (input: {
-  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderOptions'>;
+  readonly repository: Pick<
+    PublicWasteRepository,
+    'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderOptions'
+  >;
   readonly request: Request;
   readonly reminderConfig?: WasteManagementEmailReminderConfig;
 }): Promise<Response> => {
   try {
     const url = new URL(input.request.url);
     const selection = readPublicWasteResolvedSelection(url);
-    const [payload, selectionSummary, emailReminderFractions, calendarReminderFractions] = await Promise.all([
-      loadResolvedPublicWasteCalendar({
-        repository: input.repository,
-        input: {
-          selection,
-          referenceDate: readPublicWasteReferenceDate(url),
-        },
-      }),
-      input.repository.loadSelectionSummary({ selection }),
-      input.reminderConfig?.enabled && input.reminderConfig.publicSignupEnabled
-        ? input.repository.loadReminderOptions({ selection, channel: 'email' })
-        : Promise.resolve([]),
-      input.repository.loadReminderOptions({ selection, channel: 'calendar' }),
-    ]);
+    const [payload, selectionSummary, emailReminderFractions, calendarReminderFractions] =
+      await Promise.all([
+        loadResolvedPublicWasteCalendar({
+          repository: input.repository,
+          input: {
+            selection,
+            referenceDate: readPublicWasteReferenceDate(url),
+          },
+        }),
+        input.repository.loadSelectionSummary({ selection }),
+        input.reminderConfig?.enabled && input.reminderConfig.publicSignupEnabled
+          ? input.repository.loadReminderOptions({ selection, channel: 'email' })
+          : Promise.resolve([]),
+        input.repository.loadReminderOptions({ selection, channel: 'calendar' }),
+      ]);
     const baseIcalUrl = `/api/public-waste/ical?${new URLSearchParams({
       ...(selection.regionId ? { regionId: selection.regionId } : {}),
       cityId: selection.cityId,
@@ -239,7 +258,9 @@ export const handlePublicWasteCalendarRequest = async (input: {
             },
           }
         : {}),
-      ...(input.reminderConfig?.enabled && input.reminderConfig.publicSignupEnabled && emailReminderFractions.length > 0
+      ...(input.reminderConfig?.enabled &&
+      input.reminderConfig.publicSignupEnabled &&
+      emailReminderFractions.length > 0
         ? {
             reminderSignup: {
               enabled: true,
@@ -256,7 +277,9 @@ export const handlePublicWasteCalendarRequest = async (input: {
   }
 };
 
-const isPublicWasteReminderSignupRequest = (value: unknown): value is PublicWasteReminderSignupRequest => {
+const isPublicWasteReminderSignupRequest = (
+  value: unknown
+): value is PublicWasteReminderSignupRequest => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return false;
   }
@@ -265,10 +288,18 @@ const isPublicWasteReminderSignupRequest = (value: unknown): value is PublicWast
   if (typeof record.email !== 'string' || !EMAIL_PATTERN.test(record.email.trim())) {
     return false;
   }
-  if (record.consentAccepted !== true || !Array.isArray(record.items) || record.items.length === 0) {
+  if (
+    record.consentAccepted !== true ||
+    !Array.isArray(record.items) ||
+    record.items.length === 0
+  ) {
     return false;
   }
-  if (!record.selection || typeof record.selection !== 'object' || Array.isArray(record.selection)) {
+  if (
+    !record.selection ||
+    typeof record.selection !== 'object' ||
+    Array.isArray(record.selection)
+  ) {
     return false;
   }
 
@@ -278,7 +309,12 @@ const isPublicWasteReminderSignupRequest = (value: unknown): value is PublicWast
     }
 
     const next = item as Record<string, unknown>;
-    return typeof next.fractionId === 'string' && next.fractionId.length > 0 && typeof next.slotId === 'string' && next.slotId.length > 0;
+    return (
+      typeof next.fractionId === 'string' &&
+      next.fractionId.length > 0 &&
+      typeof next.slotId === 'string' &&
+      next.slotId.length > 0
+    );
   });
 };
 
@@ -389,10 +425,13 @@ export const handlePublicWastePdfRequest = async (input: {
       buildWasteCalendarPdfDocument({
         year,
         locationLabel,
+        ...(staticConfig.contactBlock ? { contactBlock: staticConfig.contactBlock } : {}),
         pickups: buildPdfPickups(filteredEntries),
         legendHints: buildPdfLegendHints(filteredEntries),
         ...(brandingImage ? { brandingImage } : {}),
-        brandingPlaceholderLabel: staticConfig.brandingAssetUrl ? 'Branding-Grafik' : 'Kommunales Waste-Management',
+        brandingPlaceholderLabel: staticConfig.brandingAssetUrl
+          ? 'Branding-Grafik'
+          : 'Kommunales Waste-Management',
       })
     );
     const pdfBody = new Blob([Uint8Array.from(pdf)], { type: 'application/pdf' });
@@ -410,7 +449,10 @@ export const handlePublicWastePdfRequest = async (input: {
 };
 
 export const handlePublicWasteIcalRequest = async (input: {
-  readonly repository: Pick<PublicWasteRepository, 'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderOptions'>;
+  readonly repository: Pick<
+    PublicWasteRepository,
+    'loadCalendarEntries' | 'loadSelectionSummary' | 'loadReminderOptions'
+  >;
   readonly request: Request;
 }): Promise<Response> => {
   try {

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.test.ts
@@ -347,6 +347,7 @@ describe('public waste repository', () => {
         fractionLabel: 'Restmuell',
         fractionShortLabel: 'RM',
         tourDescription: 'Importierte Sammeltermine.',
+        isShifted: true,
         note: 'Dienstag 14:00-16:30 Uhr, Parkplatz am Rathaus',
       })
     );
@@ -609,6 +610,7 @@ describe('public waste repository', () => {
       expect.objectContaining({
         id: 'assignment-1:fraction-1',
         date: '2026-01-02',
+        isShifted: true,
         note: 'Sondertermin',
       })
     );

--- a/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
+++ b/apps/public-waste-calendar-web/src/lib/public-waste-repository.server.ts
@@ -754,6 +754,7 @@ export const createPublicWasteRepository = (input: {
           ...(row.fraction_color ? { fractionColor: row.fraction_color } : {}),
           ...(row.tour_name.trim() ? { tourName: row.tour_name.trim() } : {}),
           ...(row.tour_description?.trim() ? { tourDescription: row.tour_description.trim() } : {}),
+          ...(shiftedDate !== pickupDate ? { isShifted: true } : {}),
           note,
         });
       }

--- a/apps/public-waste-calendar-web/src/routes/index.test.tsx
+++ b/apps/public-waste-calendar-web/src/routes/index.test.tsx
@@ -89,7 +89,8 @@ describe('PublicWasteIndexPage', () => {
 
   it('loads selection and calendar data from the public api, stores the cookie, and restores it on the next render', async () => {
     fetchMock.mockImplementation(async (input) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
 
       if (
         url.includes('/api/public-waste/selection') &&
@@ -132,35 +133,35 @@ describe('PublicWasteIndexPage', () => {
     const { unmount } = render(<PublicWasteIndexPage />);
     await act(async () => {});
 
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Ort suchen' }), {
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Ort suchen' }), {
       target: { value: 'Rat' },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Rathenow' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Rathenow' })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Rathenow' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Rathenow' }));
     await act(async () => {});
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Straße suchen' }), {
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Straße suchen' }), {
       target: { value: 'Hafen' },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Am alten Hafen' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Am alten Hafen' })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Am alten Hafen' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Am alten Hafen' }));
     await act(async () => {});
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Hausnummer suchen' }), {
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Hausnummer suchen' }), {
       target: { value: '12' },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: '12' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: '12' })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: '12' }));
+    fireEvent.click(screen.getByRole('option', { name: '12' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Kalender exportieren' })).toBeTruthy();
     });
 
     expect(document.cookie).toContain(
@@ -180,7 +181,7 @@ describe('PublicWasteIndexPage', () => {
     expect(screen.getByText('Rathenow')).toBeTruthy();
     expect(screen.getByText('Am alten Hafen')).toBeTruthy();
     expect(screen.getByText('12')).toBeTruthy();
-    expect(screen.getByRole('tab', { name: 'Kalenderexport' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Kalender exportieren' })).toBeTruthy();
   });
 
   it('clears stale stored selections and falls back to the next valid selection step', async () => {
@@ -188,9 +189,13 @@ describe('PublicWasteIndexPage', () => {
       'sva_public_waste_location=~%3A22222222-2222-4222-8222-222222222222%3A33333333-3333-4333-8333-333333333333%3A44444444-4444-4444-8444-444444444444; Path=/';
 
     fetchMock.mockImplementation(async (input) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
 
-      if (url.includes('/api/public-waste/selection') && url.includes('cityId=22222222-2222-4222-8222-222222222222')) {
+      if (
+        url.includes('/api/public-waste/selection') &&
+        url.includes('cityId=22222222-2222-4222-8222-222222222222')
+      ) {
         return new Response(
           JSON.stringify({
             status: 'incomplete',
@@ -216,11 +221,11 @@ describe('PublicWasteIndexPage', () => {
     render(<PublicWasteIndexPage />);
     await act(async () => {});
 
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Straße suchen' }), {
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Straße suchen' }), {
       target: { value: 'Ber' },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Berliner Straße' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Berliner Straße' })).toBeTruthy();
     });
 
     expect(document.cookie).toBe('');
@@ -229,7 +234,8 @@ describe('PublicWasteIndexPage', () => {
     );
     expect(
       fetchMock.mock.calls.some(([input]) => {
-        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
         return url.includes('/api/public-waste/calendar');
       })
     ).toBe(false);
@@ -237,7 +243,8 @@ describe('PublicWasteIndexPage', () => {
 
   it('renders the public reminder signup when the calendar response provides it', async () => {
     fetchMock.mockImplementation(async (input) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
 
       if (
         url.includes('/api/public-waste/selection') &&
@@ -280,34 +287,34 @@ describe('PublicWasteIndexPage', () => {
     render(<PublicWasteIndexPage />);
     await act(async () => {});
 
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Ort suchen' }), {
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Ort suchen' }), {
       target: { value: 'Rat' },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Rathenow' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Rathenow' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Rathenow' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Rathenow' }));
     await act(async () => {});
 
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Straße suchen' }), {
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Straße suchen' }), {
       target: { value: 'Hafen' },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Am alten Hafen' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Am alten Hafen' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Am alten Hafen' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Am alten Hafen' }));
     await act(async () => {});
 
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Hausnummer suchen' }), {
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Hausnummer suchen' }), {
       target: { value: '12' },
     });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: '12' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: '12' })).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole('button', { name: '12' }));
+    fireEvent.click(screen.getByRole('option', { name: '12' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: 'E-Mail-Abo' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'E-Mail-Erinnerung' })).toBeTruthy();
     });
   });
 });

--- a/apps/public-waste-calendar-web/src/routes/index.tsx
+++ b/apps/public-waste-calendar-web/src/routes/index.tsx
@@ -311,9 +311,13 @@ export function PublicWasteIndexPage() {
     <PublicWasteRootDocument>
       <main className="panel">
         {pageState.status === 'loading' ? (
-          <p className="body-copy">Abfallkalender wird geladen.</p>
+          <p className="body-copy" role="status" aria-live="polite">
+            Abfallkalender wird geladen.
+          </p>
         ) : pageState.status === 'error' ? (
-          <p className="body-copy">{pageState.message}</p>
+          <p className="body-copy" role="alert">
+            {pageState.message}
+          </p>
         ) : pageState.status === 'incomplete' ? (
           <PublicWasteApp
             selectionState="incomplete"

--- a/apps/public-waste-calendar-web/src/styles.css
+++ b/apps/public-waste-calendar-web/src/styles.css
@@ -1,7 +1,11 @@
 :root {
   color-scheme: light;
-  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  font-family: 'IBM Plex Sans', 'Segoe UI', sans-serif;
   color: rgb(28 28 28);
+  --public-waste-line: rgb(224 226 223);
+  --public-waste-action: rgb(54 54 54);
+  --public-waste-action-surface: rgb(244 244 244);
+  --public-waste-action-surface-active: rgb(232 232 232);
 }
 
 * {
@@ -24,7 +28,7 @@ body {
 
 .panel {
   width: 100%;
-  max-width: 52rem;
+  max-width: 56rem;
   margin: 0 auto;
   padding: clamp(0.75rem, 2vw, 1.5rem);
   border: 0;
@@ -40,8 +44,8 @@ body {
 }
 
 .section-title {
-  margin: 0 0 0.75rem;
-  font-size: 1.4rem;
+  margin: 0;
+  font-size: 1.2rem;
 }
 
 .selection-panel,
@@ -80,81 +84,123 @@ body {
 
 .selection-header {
   display: grid;
-  gap: 1.25rem;
-  grid-template-columns: minmax(0, 1.15fr) minmax(15rem, 0.85fr);
-  align-items: start;
-  margin-bottom: 0.5rem;
-  padding: 1.15rem;
-  border: 1px solid rgb(220 220 220);
-  border-radius: 1.25rem;
-  background:
-    linear-gradient(180deg, rgb(255 255 255) 0%, rgb(248 248 248) 100%);
-  box-shadow: 0 22px 55px -42px rgb(30 30 30 / 0.65);
+  gap: 1.1rem;
+  margin-bottom: 0.25rem;
+  padding: 0;
+  border: 0;
 }
 
 .selection-header-main {
   display: grid;
-  gap: 0.9rem;
+  gap: 0.45rem;
   min-width: 0;
 }
 
 .selection-header-fractions,
 .selection-section-heading {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.35rem;
+}
+
+.selection-section-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.selection-info-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  border-radius: 0.35rem;
+  background: transparent;
+  color: rgb(82 82 82);
+  cursor: pointer;
+}
+
+.selection-info-trigger:hover {
+  background: rgb(238 238 238);
+}
+
+.selection-info-trigger:focus-visible {
+  outline: 2px solid rgb(64 64 64);
+  outline-offset: 2px;
+}
+
+.selection-info-popover {
+  max-width: min(24rem, calc(100vw - 2rem));
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border: 0;
+  border-radius: 0.35rem;
+  background: rgb(255 255 255);
+  color: rgb(54 54 54);
+  box-shadow: 0 0.75rem 2rem rgb(0 0 0 / 0.16);
+  line-height: 1.5;
+}
+
+.selection-info-popover p {
+  margin: 0;
+}
+
+.selection-summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.9rem;
 }
 
 .selection-summary-block {
-  display: grid;
-  gap: 0.2rem;
-  padding: 0.95rem 1rem;
-  border-radius: 1rem;
-  background: rgb(255 255 255 / 0.72);
-  border: 1px solid rgb(230 230 230);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 
 .selection-summary-line {
   margin: 0;
-  font-size: 1.08rem;
+  font-size: 1rem;
   line-height: 1.35;
 }
 
-.selection-summary-action-row {
-  display: flex;
-  align-items: center;
+.selection-summary-line:not(:last-child)::after {
+  content: '·';
+  margin-left: 0.25rem;
+  color: rgb(150 153 150);
 }
 
-.selection-summary-link {
+.selection-summary-action {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
-  min-height: 2.75rem;
-  padding: 0.65rem 0.9rem;
-  border: 1px solid rgb(196 196 196);
-  border-radius: 999px;
-  background: rgb(255 255 255);
-  color: rgb(54 54 54);
+  min-height: 2.5rem;
+  padding: 0.5rem 0.7rem;
+  border: 0;
+  border-radius: 0.35rem;
+  background: var(--public-waste-action-surface);
+  color: var(--public-waste-action);
   font: inherit;
-  text-decoration: none;
   cursor: pointer;
 }
 
 .selection-fraction-list {
-  display: grid;
-  gap: 0.65rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.15rem;
 }
 
 .selection-fraction-item {
-  position: relative;
-  display: grid;
-  grid-template-columns: auto auto 1fr;
+  display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  min-height: 3rem;
-  padding: 0.8rem 0.95rem;
-  border: 1px solid rgb(220 220 220);
-  border-radius: 1rem;
-  background: rgb(250 250 250);
+  gap: 0.5rem;
+  min-height: 2.5rem;
+  padding: 0.25rem 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   cursor: pointer;
 }
 
@@ -164,38 +210,27 @@ body {
   margin: 0;
 }
 
-.selection-fraction-swatch {
-  width: 0.95rem;
-  height: 0.95rem;
-  border-radius: 999px;
-  background: rgb(42 42 42);
-  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.08);
-}
-
 .selection-fraction-copy {
   font-size: 0.97rem;
   line-height: 1.25;
 }
 
 .selection-fraction-item.is-active {
-  border-color: rgb(170 170 170);
-  box-shadow: 0 10px 22px -18px rgb(0 0 0 / 0.45);
+  font-weight: 600;
 }
 
 .action-hub {
   display: grid;
-  gap: 0.9rem;
-  padding: 1rem;
-  border: 1px solid rgb(220 220 220);
-  border-radius: 1.25rem;
-  background:
-    linear-gradient(180deg, rgb(252 252 252) 0%, rgb(246 246 246) 100%);
+  gap: 0.75rem;
+  padding: 0;
+  border: 0;
 }
 
 .action-hub-toolbar {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 20px 0;
 }
 
 .action-hub-trigger,
@@ -205,11 +240,11 @@ body {
   align-items: center;
   justify-content: center;
   gap: 0.6rem;
-  min-height: 3rem;
-  padding: 0.8rem 1rem;
-  border: 1px solid rgb(150 150 150);
-  border-radius: 1rem;
-  background: rgb(255 255 255);
+  min-height: 2.75rem;
+  padding: 0.65rem 0.85rem;
+  border: 0;
+  border-radius: 0.35rem;
+  background: var(--public-waste-action-surface);
   color: inherit;
   font: inherit;
   text-decoration: none;
@@ -217,24 +252,23 @@ body {
 }
 
 .action-hub-trigger {
-  flex-direction: column;
-  gap: 0.35rem;
-  min-height: 5.25rem;
-  text-align: center;
+  color: var(--public-waste-action);
+  text-align: left;
 }
 
 .action-hub-trigger.is-active {
-  border-color: rgb(32 32 32);
-  background: rgb(242 242 242);
+  background: var(--public-waste-action-surface-active);
+  font-weight: 600;
 }
 
 .action-panel {
   display: grid;
   gap: 0.9rem;
-  padding: 1rem;
-  border: 1px solid rgb(224 224 224);
-  border-radius: 1.1rem;
-  background: rgb(255 255 255);
+  padding: 1rem 1rem 1rem 1.15rem;
+  border: 0;
+  border-left: 3px solid rgb(116 139 125);
+  border-radius: 0;
+  background: rgb(248 249 248);
 }
 
 .action-panel-body,
@@ -256,7 +290,7 @@ body {
   min-height: 2.9rem;
   padding: 0.7rem 0.85rem;
   border: 1px solid rgb(188 188 188);
-  border-radius: 0.85rem;
+  border-radius: 0.35rem;
   font: inherit;
   background: rgb(255 255 255);
 }
@@ -272,8 +306,9 @@ body {
 .action-warning {
   margin: 0;
   padding: 0.85rem 1rem;
-  border: 1px solid rgb(237 211 170);
-  border-radius: 0.95rem;
+  border: 0;
+  border-left: 3px solid rgb(194 145 64);
+  border-radius: 0;
   background: rgb(255 249 238);
   color: rgb(101 64 0);
   line-height: 1.5;
@@ -299,12 +334,9 @@ body {
 .selection-step-card {
   display: grid;
   gap: 0.9rem;
-  padding: 1rem;
-  border: 1px solid rgb(220 220 220);
-  border-radius: 1rem;
-  background:
-    linear-gradient(180deg, rgb(255 255 255) 0%, rgb(250 250 250) 100%);
-  box-shadow: 0 18px 45px -36px rgb(30 30 30 / 0.55);
+  padding: 1rem 0;
+  border-top: 1px solid var(--public-waste-line);
+  border-bottom: 1px solid var(--public-waste-line);
 }
 
 .selection-step-card-header {
@@ -341,7 +373,7 @@ body {
   min-height: 2.9rem;
   padding: 0 0.95rem;
   border: 1px solid rgb(122 122 122);
-  border-radius: 0.95rem;
+  border-radius: 0.35rem;
   background: rgb(255 255 255);
   color: rgb(92 92 92);
   transition:
@@ -360,7 +392,7 @@ body {
 }
 
 .selection-search-input::placeholder {
-  color: rgb(120 120 120);
+  color: rgb(112 112 112);
 }
 
 .selection-search-meta {
@@ -369,12 +401,52 @@ body {
   font-size: 0.88rem;
 }
 
+.selection-results-shell {
+  position: relative;
+  min-height: 0;
+}
+
 .selection-results {
   display: grid;
-  gap: 0.55rem;
+  gap: 0;
   max-height: min(24rem, 52vh);
-  padding-right: 0.2rem;
-  overflow: auto;
+  padding-right: 0.35rem;
+  overflow-y: auto;
+  scrollbar-color: rgb(150 150 150) rgb(242 242 242);
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+}
+
+.selection-results::-webkit-scrollbar {
+  width: 0.7rem;
+}
+
+.selection-results::-webkit-scrollbar-track {
+  background: rgb(242 242 242);
+}
+
+.selection-results::-webkit-scrollbar-thumb {
+  border: 2px solid rgb(242 242 242);
+  border-radius: 0.35rem;
+  background: rgb(150 150 150);
+}
+
+.selection-scroll-hint {
+  position: absolute;
+  right: 0.7rem;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 4rem;
+  padding-top: 1.5rem;
+  background: linear-gradient(180deg, rgb(255 255 255 / 0), rgb(255 255 255) 58%);
+  color: rgb(74 74 74);
+  font-size: 0.88rem;
+  font-weight: 600;
+  pointer-events: none;
 }
 
 .selection-path-chip,
@@ -385,8 +457,8 @@ body {
   gap: 0.8rem;
   width: 100%;
   min-height: 2.75rem;
-  border: 1px solid rgb(122 122 122);
-  background: rgb(255 255 255);
+  border: 0;
+  background: transparent;
   color: inherit;
   font: inherit;
   text-decoration: none;
@@ -397,10 +469,9 @@ body {
   justify-content: flex-start;
   width: auto;
   min-height: 0;
-  padding: 0.6rem 0.8rem;
-  border-color: rgb(208 208 208);
-  border-radius: 999px;
-  background: rgb(246 246 246);
+  padding: 0.35rem 0;
+  border-bottom: 1px solid rgb(170 173 170);
+  border-radius: 0;
 }
 
 .selection-path-chip-step {
@@ -422,9 +493,9 @@ body {
 
 .selection-result {
   justify-content: space-between;
-  padding: 0.8rem 0.95rem 0.8rem 1rem;
-  border-color: rgb(214 214 214);
-  border-radius: 1rem;
+  padding: 0.85rem 0.25rem;
+  border-bottom: 1px solid var(--public-waste-line);
+  border-radius: 0;
   text-align: left;
 }
 
@@ -444,9 +515,10 @@ body {
 }
 
 .selection-empty-state {
-  padding: 1rem;
-  border: 1px dashed rgb(196 196 196);
-  border-radius: 1rem;
+  padding: 0.9rem 1rem;
+  border: 0;
+  border-left: 3px solid rgb(172 175 172);
+  border-radius: 0;
   color: rgb(96 96 96);
   background: rgb(252 252 252);
   font-size: 0.95rem;
@@ -455,14 +527,14 @@ body {
 .selection-path-chip:hover,
 .selection-result:hover,
 .selection-trigger:hover,
-.selection-summary-link:hover {
-  background: rgb(247 247 247);
+.selection-summary-action:hover {
+  background: rgb(238 238 238);
 }
 
 .selection-path-chip:focus-visible,
 .selection-result:focus-visible,
 .selection-trigger:focus-visible,
-.selection-summary-link:focus-visible,
+.selection-summary-action:focus-visible,
 .action-hub-trigger:focus-visible,
 .action-cta-button:focus-visible,
 .action-cta-link:focus-visible,
@@ -561,7 +633,7 @@ body {
 
 @media (max-width: 640px) {
   .selection-step-card {
-    padding: 0.9rem;
+    padding: 0.9rem 0;
   }
 
   .selection-result {
@@ -625,7 +697,8 @@ body {
 }
 
 .calendar-nav-button {
-  border-radius: 999px;
+  border: 0;
+  border-radius: 0.35rem;
   background: rgb(247 247 247);
 }
 
@@ -649,7 +722,7 @@ body {
 
 .month-calendar-weekday,
 .year-calendar-weekday {
-  color: rgb(122 122 122);
+  color: rgb(102 102 102);
   font-size: 0.85rem;
   text-align: center;
 }
@@ -666,7 +739,8 @@ body {
 }
 
 .month-calendar-cell.is-outside-month {
-  opacity: 0.35;
+  background: rgb(244 244 244);
+  color: rgb(102 102 102);
 }
 
 .month-calendar-cell.has-entries,
@@ -817,7 +891,7 @@ body {
 }
 
 .filter-chip.is-active .filter-indicator::after {
-  content: "";
+  content: '';
   position: absolute;
   left: 0.3rem;
   top: 0.14rem;
@@ -829,12 +903,13 @@ body {
 }
 
 @media (max-width: 720px) {
-  .selection-header {
-    grid-template-columns: 1fr;
+  .action-hub-toolbar {
+    align-items: stretch;
   }
 
-  .action-hub-toolbar {
-    grid-template-columns: 1fr;
+  .action-hub-trigger {
+    flex: 1 1 12rem;
+    justify-content: flex-start;
   }
 
   .calendar-view-header {
@@ -881,7 +956,7 @@ body {
 }
 
 .pickup-weekday {
-  color: rgb(158 158 158);
+  color: rgb(102 102 102);
   font-size: 1rem;
   line-height: 1.2;
 }

--- a/apps/public-waste-calendar-web/src/styles.css
+++ b/apps/public-waste-calendar-web/src/styles.css
@@ -526,6 +526,7 @@ body {
 
 .selection-path-chip:hover,
 .selection-result:hover,
+.selection-result--active,
 .selection-trigger:hover,
 .selection-summary-action:hover {
   background: rgb(238 238 238);

--- a/apps/public-waste-calendar-web/tests/public-waste-calendar.e2e.ts
+++ b/apps/public-waste-calendar-web/tests/public-waste-calendar.e2e.ts
@@ -1,4 +1,24 @@
-import { expect, test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+
+const expectNoAccessibilityViolations = async (page: Page) => {
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa'])
+    .analyze();
+
+  expect(
+    results.violations,
+    JSON.stringify(
+      results.violations.map((violation) => ({
+        id: violation.id,
+        impact: violation.impact,
+        nodes: violation.nodes.map((node) => node.target),
+      })),
+      null,
+      2
+    )
+  ).toEqual([]);
+};
 
 test('resolves a location, restores it from cookie, and exposes accessible export and detail actions', async ({
   page,
@@ -85,30 +105,122 @@ test('resolves a location, restores it from cookie, and exposes accessible expor
 
   await page.goto('/');
 
-  await page.getByRole('textbox', { name: 'Ort suchen' }).fill('Rat');
-  await page.getByRole('button', { name: 'Rathenow' }).click();
-  await page.getByRole('textbox', { name: 'Straße suchen' }).fill('Hafen');
-  await page.getByRole('button', { name: 'Am alten Hafen' }).click();
-  await page.getByRole('textbox', { name: 'Hausnummer suchen' }).fill('12');
-  await page.getByRole('button', { name: '12' }).click();
+  await expect(page.getByRole('combobox', { name: 'Ort suchen' })).toBeVisible();
+  await expectNoAccessibilityViolations(page);
+
+  const cityCombobox = page.getByRole('combobox', { name: 'Ort suchen' });
+  await cityCombobox.fill('Rat');
+  await cityCombobox.press('ArrowDown');
+  await expect(cityCombobox).toHaveAttribute('aria-activedescendant', /option-/u);
+  await cityCombobox.press('Enter');
+  await page.getByRole('combobox', { name: 'Straße suchen' }).fill('Hafen');
+  await page.getByRole('option', { name: 'Am alten Hafen' }).click();
+  await page.getByRole('combobox', { name: 'Hausnummer suchen' }).fill('12');
+  await page.getByRole('option', { name: '12' }).click();
 
   await expect(page.getByText('Rathenow')).toBeVisible();
   await expect(page.getByText('Am alten Hafen')).toBeVisible();
   await expect(page.getByText('12')).toBeVisible();
+  await expectNoAccessibilityViolations(page);
 
-  await page.getByRole('tab', { name: 'Kalenderexport' }).click();
+  const listTab = page.getByRole('tab', { name: 'Liste' });
+  await listTab.focus();
+  await listTab.press('ArrowRight');
+  const monthTab = page.getByRole('tab', { name: 'Monat' });
+  await expect(monthTab).toBeFocused();
+  await expect(monthTab).toHaveAttribute('aria-selected', 'true');
+  await monthTab.press('Home');
+  await expect(listTab).toBeFocused();
+
+  const calendarExportAction = page.getByRole('button', { name: 'Kalender exportieren' });
+  await expect(calendarExportAction).toHaveAttribute('aria-expanded', 'false');
+  await calendarExportAction.click();
+  await expect(calendarExportAction).toHaveAttribute('aria-expanded', 'true');
+  await expect(calendarExportAction).toHaveCSS('background-color', 'rgb(232, 232, 232)');
+  await expect(calendarExportAction).toHaveCSS('box-shadow', 'none');
   await expect(page.getByRole('link', { name: 'Kalender exportieren' })).toBeVisible();
 
-  await page.getByRole('button', { name: 'Termin Bioabfall am 2026-05-19' }).click();
+  const pickupButton = page.getByRole('button', { name: 'Termin Bioabfall am 2026-05-19' });
+  await pickupButton.click();
 
   await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Schließen' })).toBeFocused();
   await expect(page.getByText('Bitte Tonne ab 6 Uhr bereitstellen.')).toBeVisible();
+  await expectNoAccessibilityViolations(page);
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('dialog')).toBeHidden();
+  await expect(pickupButton).toBeFocused();
 
   await page.reload();
 
   await expect(page.getByText('Rathenow')).toBeVisible();
   await expect(page.getByText('Am alten Hafen')).toBeVisible();
   await expect(page.getByText('12')).toBeVisible();
-  await page.getByRole('tab', { name: 'Kalenderexport' }).click();
+  await page.getByRole('button', { name: 'Kalender exportieren' }).click();
   await expect(page.getByRole('link', { name: 'Kalender exportieren' })).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.setContent(`
+    <main style="max-width: 40rem; margin: 0 auto; padding: 1rem; font-family: sans-serif">
+      <h1>Kommunale Service-Seite</h1>
+      <p>Ihre Abfuhrtermine:</p>
+      <iframe
+        title="Abfallkalender"
+        src="http://127.0.0.1:3002/"
+        style="display: block; width: 100%; height: 700px; border: 0"
+      ></iframe>
+    </main>
+  `);
+
+  const embeddedCalendar = page.frameLocator('iframe[title="Abfallkalender"]');
+  await expect(embeddedCalendar.getByText('Rathenow')).toBeVisible();
+  await expect(embeddedCalendar.getByRole('button', { name: 'Adresse ändern' })).toBeVisible();
+  await expect(
+    embeddedCalendar.getByRole('button', { name: 'Kalender exportieren' })
+  ).toBeVisible();
+  await embeddedCalendar.getByRole('button', { name: 'Informationen zu Abfallfraktionen' }).click();
+  await expect(
+    embeddedCalendar.getByText(
+      'Diese Auswahl steuert Liste, Kalenderexport, PDF/Druckversion und E-Mail-Erinnerung gemeinsam.'
+    )
+  ).toBeVisible();
+
+  await expect
+    .poll(() =>
+      embeddedCalendar
+        .locator('html')
+        .evaluate((element) => element.scrollWidth <= element.clientWidth)
+    )
+    .toBe(true);
+  await expect
+    .poll(() =>
+      embeddedCalendar
+        .locator('body')
+        .evaluate((element) => getComputedStyle(element).backgroundColor)
+    )
+    .toBe('rgba(0, 0, 0, 0)');
+  await expect
+    .poll(() =>
+      embeddedCalendar.locator('.selection-header').evaluate((element) => ({
+        borderBottomWidth: getComputedStyle(element).borderBottomWidth,
+        borderRadius: getComputedStyle(element).borderRadius,
+        borderTopWidth: getComputedStyle(element).borderTopWidth,
+      }))
+    )
+    .toEqual({ borderBottomWidth: '0px', borderRadius: '0px', borderTopWidth: '0px' });
+  await expect
+    .poll(() =>
+      embeddedCalendar.locator('.action-hub-toolbar').evaluate((element) => ({
+        paddingBottom: getComputedStyle(element).paddingBottom,
+        paddingTop: getComputedStyle(element).paddingTop,
+      }))
+    )
+    .toEqual({ paddingBottom: '20px', paddingTop: '20px' });
+  await expect
+    .poll(() =>
+      embeddedCalendar
+        .locator('.action-hub')
+        .evaluate((element) => getComputedStyle(element).borderBottomWidth)
+    )
+    .toBe('0px');
 });

--- a/docs/changelog/entries/pr-943.json
+++ b/docs/changelog/entries/pr-943.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 943,
+  "body": "Öffentlicher Abfallkalender und PDF-Ausgabe übersichtlicher\n\n- Standort, Fraktionsfilter und Exportaktionen sind in eingebetteten Ansichten klarer gegliedert und die Standortsuche zeigt verfügbare Optionen früher an.\n- Ausweichtermine werden im PDF mit einem roten Asterisk gekennzeichnet und direkt am Anfang der Legende erklärt.\n- Die kompakte vertikale PDF-Legende zeigt vorhandene Fraktions-, Tour- und Terminhinweise einzeilig im Format Label - Hinweis."
+}

--- a/openspec/changes/add-vertical-pdf-legend-hints/proposal.md
+++ b/openspec/changes/add-vertical-pdf-legend-hints/proposal.md
@@ -1,0 +1,19 @@
+# Change: Strukturierte Hinweise in der vertikalen PDF-Legende anzeigen
+
+## Why
+
+Die waagerechte PDF-Legende bietet keinen verlässlichen Platz für vorhandene Hinweise zu Abfallfraktionen, Touren und einzelnen Terminen. Gleichzeitig wiederholt die bisherige Fußzeile bereits im Kopfbereich sichtbare Angaben und belegt den benötigten Raum.
+
+## What Changes
+
+- Die PDF-Legende wird unterhalb des unverändert großen Kalenderrasters vertikal mit höchstens acht einzeiligen Einträgen dargestellt.
+- Fraktions-, Tour- und terminbezogene Hinweise werden mit ihrer fachlichen Herkunft in einer deterministischen Reihenfolge dargestellt.
+- Texte, die den verbleibenden horizontalen Platz überschreiten, werden mit `...` gekürzt.
+- Der PDF-Kopfbereich wird kompakter; die redundante Fußzeile entfällt.
+- Der rote Asterisk bleibt außerhalb der Fraktionsbox und wird in einer eigenen vertikalen Legendenzeile als Ausweichtermin erklärt.
+
+## Impact
+
+- Betroffene Specs: `public-waste-calendar`
+- Betroffener Code: öffentlicher PDF-Endpunkt sowie PDF-Dokumentmodell und Rendering
+- Betroffene arc42-Abschnitte: keine; bestehende Verantwortungsgrenzen bleiben erhalten

--- a/openspec/changes/add-vertical-pdf-legend-hints/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/add-vertical-pdf-legend-hints/specs/public-waste-calendar/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: PDF-Legende zeigt kontextbezogene Hinweise vertikal
+
+Das System SHALL die Legende des PDF-Abfallkalenders direkt unterhalb des Kalenderrasters als vertikale Liste mit höchstens acht einzeiligen Einträgen darstellen.
+
+#### Scenario: Sichtbare Fraktion besitzt eine Beschreibung
+
+- **WHEN** eine im PDF sichtbare Fraktion eine Beschreibung besitzt
+- **THEN** zeigt ihre Legendenzeile Farbbox, Kürzel und den Text `<Bezeichnung> - <Beschreibung>` ohne feste Beschreibungsspalte
+- **AND** die Beschreibung verwendet den verbleibenden Platz bis zum rechten Seitenrand
+
+#### Scenario: Sichtbare Tour oder einzelner Termin besitzt einen Hinweis
+
+- **WHEN** eine Tour mindestens einen sichtbaren PDF-Termin erzeugt oder ein sichtbarer Termin einen eigenen Hinweis besitzt
+- **THEN** zeigt die Legende den jeweiligen Tour- beziehungsweise Terminbezug und den Hinweis getrennt durch ` - ` ohne feste Beschreibungsspalte
+- **AND** Hinweise nicht sichtbarer Touren oder Termine werden ausgelassen
+
+#### Scenario: Legendentext überschreitet die verfügbare Breite
+
+- **WHEN** ein Legendentext nicht vollständig in seine einzelne Zeile passt
+- **THEN** kürzt das System ihn anhand seiner gerenderten Breite
+- **AND** der sichtbare Text endet mit `...`
+- **AND** es entsteht kein Zeilenumbruch
+
+### Requirement: PDF reserviert Raum für höchstens acht Legendenzeilen
+
+Das System SHALL durch einen kompakteren Kopfbereich und den Wegfall der redundanten Fußzeile Raum für acht Legendenzeilen schaffen, ohne das Kalenderraster zu verkleinern.
+
+#### Scenario: PDF enthält die maximale Legendenmenge
+
+- **WHEN** acht Legendenzeilen dargestellt werden
+- **THEN** überlappt keine Legendenzeile das Kalenderraster oder den Seitenrand
+- **AND** der Kopfbereich zeigt weiterhin Titel, Abholort und Branding lesbar
+- **AND** die redundante Fußzeile `Abfallkalender <Jahr> · <Abholort>` wird nicht dargestellt
+
+#### Scenario: PDF enthält Ausweichtermine
+
+- **WHEN** mindestens ein sichtbarer Termin als Ausweichtermin gekennzeichnet ist
+- **THEN** belegt `* = Ausweichtermin` die erste Zeile innerhalb der höchstens acht Legendenzeilen
+- **AND** der Asterisk wird rot und fett dargestellt

--- a/openspec/changes/add-vertical-pdf-legend-hints/tasks.md
+++ b/openspec/changes/add-vertical-pdf-legend-hints/tasks.md
@@ -1,0 +1,11 @@
+## 1. PDF-Datenmodell und Rendering
+
+- [x] 1.1 Strukturierte Legendenzeilen aus sichtbaren Fraktionen, Touren und Terminen bilden
+- [x] 1.2 Kompakten Header, entfernte Fußzeile und vertikale Acht-Zeilen-Legende umsetzen
+- [x] 1.3 Breitenbasierte Ein-Zeilen-Kürzung mit `...` implementieren
+
+## 2. Qualitätssicherung und Dokumentation
+
+- [x] 2.1 API-, Dokumentmodell- und Renderer-Tests anpassen
+- [x] 2.2 Relevante Unit-, Typ-, Lint- und Server-Runtime-Prüfungen ausführen
+- [x] 2.3 PDF rendern und Header, Grundlinien, Asterisk sowie Kürzung visuell prüfen

--- a/openspec/changes/mark-shifted-pdf-pickups/proposal.md
+++ b/openspec/changes/mark-shifted-pdf-pickups/proposal.md
@@ -1,0 +1,19 @@
+# Change: Ausweichtermine im PDF-Abfallkalender kennzeichnen
+
+## Why
+
+Verschobene Abholungstermine sind im PDF derzeit nicht von regulären Terminen zu unterscheiden. Dadurch fehlt Leserinnen und Lesern ein wichtiger Hinweis auf abweichende Abholtage.
+
+## What Changes
+
+- Abholungen, deren wirksames Datum vom regulären Ursprungsdatum abweicht, werden im PDF unmittelbar rechts neben der farbigen Fraktionsbox mit einem roten, fetten Asterisk gekennzeichnet.
+- Die Kennzeichnung gilt für manuelle Tour- und globale Datumsverschiebungen sowie für automatisch angewendete Feiertagsregeln.
+- Die PDF-Legende erhält eine eigene Zeile `* = Ausweichtermin`.
+- Der Asterisk liegt außerhalb der farbigen Box; nachfolgende Fraktionsboxen halten ausreichend Abstand zum Marker.
+- Reguläre Termine bleiben unverändert.
+
+## Impact
+
+- Betroffene Specs: `public-waste-calendar`
+- Betroffener Code: Terminberechnung und öffentlicher Kalendervertrag unter `apps/public-waste-calendar-web`, PDF-Dokumentmodell und Rendering unter `packages/core`
+- Betroffene arc42-Abschnitte: keine; die bestehende Systemstruktur und ihre Verantwortungsgrenzen bleiben unverändert

--- a/openspec/changes/mark-shifted-pdf-pickups/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/mark-shifted-pdf-pickups/specs/public-waste-calendar/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: PDF kennzeichnet Ausweichtermine eindeutig
+
+Das System SHALL jeden PDF-Abholungstermin, dessen wirksames Datum vom regulären Ursprungsdatum abweicht, sichtbar als Ausweichtermin kennzeichnen.
+
+#### Scenario: Manuell verschobener Termin erhält einen Asterisk
+
+- **WHEN** eine Tour- oder globale Datumsverschiebung einen regulären Abholungstermin auf ein anderes Datum verlegt
+- **THEN** zeigt das PDF unmittelbar rechts neben der farbigen Fraktionsbox einen roten, fetten Asterisk
+- **AND** der Asterisk liegt außerhalb der farbigen Box
+- **AND** nachfolgende Fraktionsboxen überlappen den Asterisk nicht
+- **AND** erklärt eine eigene Legendenzeile den Asterisk mit `* = Ausweichtermin`
+
+#### Scenario: Feiertagsregel erzeugt einen Ausweichtermin
+
+- **WHEN** eine Feiertagsregel das wirksame Datum eines regulären Abholungstermins verändert
+- **THEN** kennzeichnet das PDF den betroffenen Abholungseintrag ebenfalls mit einem roten, fetten Asterisk
+
+#### Scenario: Regulärer Termin bleibt unmarkiert
+
+- **WHEN** das wirksame Datum eines Abholungstermins seinem regulären Ursprungsdatum entspricht
+- **THEN** zeigt das PDF an diesem Abholungseintrag keinen Asterisk

--- a/openspec/changes/mark-shifted-pdf-pickups/tasks.md
+++ b/openspec/changes/mark-shifted-pdf-pickups/tasks.md
@@ -1,0 +1,14 @@
+## 1. Umsetzung
+
+- [x] 1.1 Abweichung zwischen regulärem und wirksamem Datum explizit im Kalendervertrag abbilden
+- [x] 1.2 Verschiebungskennzeichen verlustfrei in das PDF-Dokumentmodell übertragen
+- [x] 1.3 Roten, fetten Asterisk unmittelbar rechts außerhalb der Fraktionsbox rendern und Folgeeinträge kollisionsfrei positionieren
+- [x] 1.4 Eigene Legendenzeile `* = Ausweichtermin` rendern
+
+## 2. Verifikation
+
+- [x] 2.1 Unit-Tests für manuelle und feiertagsbedingte Verschiebungen ergänzen
+- [x] 2.2 PDF-Rendering für markierte und reguläre Termine gezielt testen
+- [x] 2.3 Kontroll-PDF rendern und visuell prüfen
+- [x] 2.4 Betroffene Core- und Public-Waste-Tests sowie Type-Gates ausführen
+- [x] 2.5 OpenSpec-Änderung strikt validieren und Checkliste abschließen

--- a/openspec/changes/refine-public-waste-embedded-layout/proposal.md
+++ b/openspec/changes/refine-public-waste-embedded-layout/proposal.md
@@ -1,0 +1,20 @@
+# Change: Eingebettetes Layout des öffentlichen Abfallkalenders verfeinern
+
+## Why
+
+Die öffentliche Abfallkalender-App verwendet derzeit mehrere verschachtelte Karten, Rahmen, Radien und Schatten. Dadurch wirkt sie in einer fremden Webseite wie eine eigenständige Anwendung im iFrame statt wie ein integrierter Inhaltsbereich. Außerdem sind globale Aktionen visuell und semantisch als Tabs modelliert, obwohl sie jeweils eine Aktion mit aufklappbaren Optionen auslösen.
+
+## What Changes
+
+- Adresse, direkt zugeordnete Änderungsaktion und Fraktionsfilter werden in einen flachen Standortkontext überführt.
+- Kalenderexport, PDF/Druckversion und E-Mail-Erinnerung werden als eigenständige Disclosure-Aktionen statt als Tabs dargestellt und ausgezeichnet.
+- Rahmen, Radien, Verläufe und Schatten werden auf funktional notwendige Elemente reduziert; Inhaltsbereiche werden vorrangig durch Abstand und dezente Trennlinien gegliedert.
+- Die Standortsuche zeigt vor der Texteingabe alle verfügbaren Optionen und filtert diese Liste während der Eingabe.
+- Die Ansichten Liste, Monat und Jahr bleiben als echte Tabs erhalten.
+- Betroffene Komponenten- und Routentests werden auf die korrigierte Semantik angepasst.
+
+## Impact
+
+- Affected specs: `public-waste-calendar`
+- Affected code: `apps/public-waste-calendar-web/src/components`, `apps/public-waste-calendar-web/src/styles.css`
+- Affected arc42 sections: keine; die Änderung bleibt innerhalb der bestehenden Public-Waste-Capability und verändert weder Laufzeit- noch Integrationsarchitektur

--- a/openspec/changes/refine-public-waste-embedded-layout/specs/public-waste-calendar/spec.md
+++ b/openspec/changes/refine-public-waste-embedded-layout/specs/public-waste-calendar/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Öffentliche App zeigt verfügbare Standortoptionen unmittelbar
+
+Das System SHALL in jedem noch offenen Schritt der Standortauswahl alle verfügbaren Optionen bereits vor einer Texteingabe anzeigen und die sichtbare Liste bei einer Eingabe nach dem Suchtext filtern.
+
+#### Scenario: Auswahloptionen sind ohne Suchtext vollständig sichtbar
+
+- **WHEN** ein Standortauswahlschritt mehrere verfügbare Optionen enthält
+- **THEN** zeigt die App alle Optionen unmittelbar in einer scrollbar begrenzten Liste
+- **AND** verlangt sie keine vorherige Texteingabe
+- **AND** kennzeichnet sie sichtbar, wenn unterhalb des aktuellen Ausschnitts weitere Optionen vorhanden sind
+- **AND** filtert sie die Liste nach einer Eingabe auf passende Optionen
+
+## MODIFIED Requirements
+
+### Requirement: Öffentliche App erlaubt Fraktionsfilter auf geladenen Kalenderdaten
+
+Das System SHALL Benutzerinnen und Benutzern erlauben, die sichtbaren Abfallarten nach dem Laden des Kalenders in einem eigenständigen Kontextbereich der vollständigen Standortansicht zu filtern.
+
+#### Scenario: Standortaktion und Fraktionsfilter bilden einen flachen Kontextbereich
+
+- **WHEN** der Standort vollständig aufgelöst ist
+- **THEN** zeigt die App die Änderungsaktion unmittelbar bei der dargestellten Adresse
+- **AND** zeigt die auswählbaren Abfallfraktionen darunter als kompakte, umbrechende Auswahl statt als verschachtelte Karten
+- **AND** stellt sie die Auswirkung der Fraktionsauswahl über ein Info-Popover unmittelbar an der Überschrift bereit
+- **AND** Änderungen an den Fraktionen wirken auf Kalenderdarstellungen und globale Aktionen aus demselben geladenen Kalenderzustand
+- **AND** die Standortauswahl muss nicht erneut durchlaufen werden
+
+### Requirement: Öffentliche App liefert PDF- und iCal-Aktionen konsistent zum Standort
+
+Das System SHALL globale PDF-, iCal- und Erinnerungsaktionen aus demselben finalen Standortkontext und aus derselben aktiven Fraktionsauswahl ableiten wie die Kalenderansicht.
+
+#### Scenario: Werkzeuge erscheinen als eigenständige Disclosure-Aktionen
+
+- **WHEN** der Standort vollständig aufgelöst ist
+- **THEN** zeigt die App unter Adresse und Fraktionsauswahl die Aktionen `Kalender exportieren`, `PDF / Druckversion` und `E-Mail-Erinnerung` als kompakte Aktionsleiste
+- **AND** die Aktionen verwenden Button- und Disclosure-Semantik statt Tab-Semantik
+- **AND** genau ein zugehöriger Optionsbereich ist gleichzeitig geöffnet
+- **AND** ein erneuter Klick auf die aktive Aktion schließt deren Optionsbereich wieder
+
+#### Scenario: PDF-Aktion erzeugt das Dokument ad hoc in der öffentlichen Runtime
+
+- **WHEN** Benutzerinnen oder Benutzer den Optionsbereich `PDF / Druckversion` öffnen
+- **THEN** können sie dort das Jahr wählen und den Download für die aktuell aktiven Fraktionen auslösen
+- **AND** die öffentliche Runtime erzeugt das PDF serverseitig ad hoc
+- **AND** es wird kein persistentes PDF-Artefakt gespeichert
+
+#### Scenario: iCal-Feed nutzt verfügbare Standard-Reminder ohne zusätzliche Abfrage
+
+- **WHEN** Benutzerinnen oder Benutzer den Optionsbereich `Kalender exportieren` öffnen
+- **THEN** können sie den Export für die aktuell aktiven Fraktionen direkt auslösen, ohne zuvor Reminder-Slots auswählen zu müssen
+- **AND** die App übernimmt verfügbare kalenderfähige Standard-Reminder automatisch
+- **AND** der serverseitig erzeugte iCal-Feed bleibt konsistent zu den in der App sichtbaren Kalenderdaten
+
+#### Scenario: Gemischte Fraktionsauswahl ohne gemeinsame Reminder-Fähigkeit bleibt fail-closed
+
+- **WHEN** die aktuell aktiven Fraktionen nicht für alle gewählten Fraktionen gültige kalender- oder e-mailfähige Reminder-Slots besitzen
+- **THEN** zeigt die App eine klare Hinweisnachricht im jeweiligen Optionsbereich
+- **AND** sie erzeugt keinen impliziten Reminder-Fallback
+- **AND** Nutzerinnen und Nutzer können die Fraktionsauswahl anpassen, um wieder gültige Reminder-Optionen zu erhalten
+
+### Requirement: Öffentliche App ist für eingebettete Nutzung barrierearm und schlicht
+
+Das System SHALL die öffentliche Abfallkalender-App als reduzierte, iFrame-taugliche und barrierearme Oberfläche bereitstellen.
+
+#### Scenario: Öffentliche App fügt sich als neutraler Inhaltsbereich ein
+
+- **WHEN** die öffentliche App eigenständig oder in einem iFrame dargestellt wird
+- **THEN** bleibt ihr äußerer Hintergrund transparent und ohne eigenen Kartenrahmen
+- **AND** gliedert sie Inhaltsbereiche vorrangig mit Abstand und dezenten Trennlinien
+- **AND** beschränkt sie Radien, Rahmen, Flächen und Schatten auf funktional notwendige Bedienelemente
+- **AND** verwendet sie für allgemeine Bedienelemente ausschließlich neutrale Oberflächen und reserviert konfigurierte Farben für fachliche Abfallfraktionen
+- **AND** hängt sie nicht von der Studio-Plugin-Oberfläche als UI-Basis ab
+
+#### Scenario: Auswahlfluss und Kalender erfüllen Accessibility-Mindestanforderungen
+
+- **WHEN** Benutzerinnen oder Benutzer die öffentliche App mit Tastatur oder Screenreader bedienen
+- **THEN** sind Auswahlfluss, Fraktionsfilter, Kalendernavigation, globale Aktionen und Modal grundsätzlich zugänglich
+- **AND** die Capability zielt mindestens auf WCAG 2.1 AA
+
+#### Scenario: Standortauswahl ist ohne Maus effizient bedienbar
+
+- **WHEN** Benutzerinnen oder Benutzer eine Standortoption mit der Tastatur auswählen
+- **THEN** exponiert das Suchfeld seine Ergebnisliste als Combobox mit zugehöriger Listbox
+- **AND** lassen sich Optionen mit Pfeiltasten, Pos1, Ende und Eingabetaste ansteuern und übernehmen
+- **AND** bleiben die einzelnen Optionen außerhalb der regulären Tab-Reihenfolge
+- **AND** werden Trefferzahl, Ladezustände sowie Erfolgs- und Fehlermeldungen für assistive Technologien angekündigt
+
+#### Scenario: Kalenderansichten führen den Tastaturfokus mit
+
+- **WHEN** Benutzerinnen oder Benutzer in der Ansichtsleiste Pfeiltasten, Pos1 oder Ende verwenden
+- **THEN** wechseln Auswahl und Tastaturfokus gemeinsam auf die entsprechende Ansicht
+- **AND** bleibt immer genau ein Tab in der regulären Tab-Reihenfolge
+
+#### Scenario: Automatisierte Accessibility-Prüfung bleibt grün
+
+- **WHEN** die Browser-End-to-End-Tests Auswahlfluss, Kalender und Termindialog rendern
+- **THEN** meldet Axe für WCAG 2.0 A/AA, WCAG 2.1 AA und WCAG 2.2 AA keine automatisch erkennbaren Verstöße

--- a/openspec/changes/refine-public-waste-embedded-layout/tasks.md
+++ b/openspec/changes/refine-public-waste-embedded-layout/tasks.md
@@ -1,0 +1,16 @@
+## 1. Spezifikation und Oberfläche
+
+- [x] 1.1 Freigegebenes Content-first-Design als Delta-Spezifikation dokumentieren
+- [x] 1.2 Standortkontext und Fraktionsfilter flach und iFrame-tauglich gestalten
+- [x] 1.3 Globale Werkzeuge als Disclosure-Aktionen statt als Tabs modellieren
+- [x] 1.4 Auswahlfluss und Optionspanels visuell auf notwendige Flächen und Trennlinien reduzieren
+- [x] 1.5 Verfügbare Standortoptionen bereits vor einer Texteingabe vollständig anzeigen
+- [x] 1.6 Auswahl, Kalendernavigation und Rückmeldungen mit vollständiger Tastatur- und Screenreader-Semantik versehen
+
+## 2. Verifikation
+
+- [x] 2.1 Betroffene Vitest-Komponenten- und Routentests anpassen und grün ausführen
+- [x] 2.2 TypeScript- und Lint-Gates für `public-waste-calendar-web` grün ausführen
+- [x] 2.3 Desktop-, Mobil- und iFrame-Darstellung im Browser prüfen
+- [x] 2.4 OpenSpec-Änderung strikt validieren und Checkliste abschließen
+- [x] 2.5 Automatisierte WCAG-AA-, Fokus- und Tastaturprüfungen im Browser ergänzen

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -289,6 +289,7 @@ export {
 export type {
   WasteCalendarPdfBrandingImage,
   WasteCalendarPdfDocument,
+  WasteOutputLegendHint,
   WasteOutputPickupEntry,
   WasteOutputFraction,
 } from './waste-management-output.types.js';

--- a/packages/core/src/waste-management-output.calendar.ts
+++ b/packages/core/src/waste-management-output.calendar.ts
@@ -1,0 +1,67 @@
+export const MONTH_NAMES = [
+  'Januar',
+  'Februar',
+  'März',
+  'April',
+  'Mai',
+  'Juni',
+  'Juli',
+  'August',
+  'September',
+  'Oktober',
+  'November',
+  'Dezember',
+] as const;
+
+export const WEEKDAY_SHORT_NAMES = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'] as const;
+
+export const normalizeWeekday = (utcDay: number): number => (utcDay === 0 ? 6 : utcDay - 1);
+
+export const formatIsoDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+export const getIsoWeekNumber = (date: Date): number => {
+  const target = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = target.getUTCDay() || 7;
+  target.setUTCDate(target.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(target.getUTCFullYear(), 0, 1));
+  return Math.ceil(((target.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+};
+
+const computeEasterSunday = (year: number): Date => {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return new Date(Date.UTC(year, month - 1, day));
+};
+
+const addUtcDays = (value: Date, days: number): Date => {
+  const copy = new Date(value.getTime());
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+};
+
+export const buildHolidayMap = (year: number): ReadonlyMap<string, string> => {
+  const easterSunday = computeEasterSunday(year);
+  return new Map<string, string>([
+    [`${year}-01-01`, 'Neujahr'],
+    [formatIsoDate(addUtcDays(easterSunday, -2)), 'Karfreitag'],
+    [formatIsoDate(addUtcDays(easterSunday, 1)), 'Ostermontag'],
+    [`${year}-05-01`, 'Maifeiertag'],
+    [formatIsoDate(addUtcDays(easterSunday, 39)), 'Christi Himmelfahrt'],
+    [formatIsoDate(addUtcDays(easterSunday, 50)), 'Pfingstmontag'],
+    [`${year}-10-03`, 'Tag der Deutschen Einheit'],
+    [`${year}-12-25`, '1. Weihnachtstag'],
+    [`${year}-12-26`, '2. Weihnachtstag'],
+  ]);
+};

--- a/packages/core/src/waste-management-output.document.ts
+++ b/packages/core/src/waste-management-output.document.ts
@@ -212,9 +212,13 @@ export const buildWasteCalendarPdfDocument = (input: {
     pickup.fractions.some((fraction) => fraction.isShifted === true)
   );
   const contentRowLimit = MAX_LEGEND_ROWS - (hasShiftedPickups ? 1 : 0);
+  const reservedHintRows = hintLegend.length > 0 ? 1 : 0;
+  const visibleFractions = fractionLegend.slice(0, contentRowLimit - reservedHintRows);
+  const visibleHints = hintLegend.slice(0, contentRowLimit - visibleFractions.length);
   const legend: WasteCalendarPdfLegendRow[] = [
     ...(hasShiftedPickups ? ([{ kind: 'shift', label: '= Ausweichtermin' }] as const) : []),
-    ...[...fractionLegend, ...hintLegend].slice(0, contentRowLimit),
+    ...visibleFractions,
+    ...visibleHints,
   ];
   const buildPage = (months: readonly number[]) => ({
     title: `Abfallkalender ${input.year}`,

--- a/packages/core/src/waste-management-output.document.ts
+++ b/packages/core/src/waste-management-output.document.ts
@@ -1,17 +1,33 @@
-import type { WasteCalendarPdfDocument, WasteOutputPickupEntry } from './waste-management-output.types.js';
+import type {
+  WasteCalendarPdfDocument,
+  WasteOutputLegendHint,
+  WasteOutputPickupEntry,
+} from './waste-management-output.types.js';
 
 type RgbColor = readonly [red: number, green: number, blue: number];
 
 type WasteCalendarPdfEntry = Readonly<{
   code: string;
   fillColor: RgbColor;
+  isShifted: boolean;
 }>;
 
 type WasteCalendarPdfLegendEntry = Readonly<{
+  kind: 'fraction';
   code: string;
   label: string;
+  description?: string;
   fillColor: RgbColor;
 }>;
+
+type WasteCalendarPdfLegendRow =
+  | WasteCalendarPdfLegendEntry
+  | Readonly<{ kind: 'hint'; label: string; description: string }>
+  | Readonly<{ kind: 'shift'; label: string }>;
+
+const MAX_LEGEND_ROWS = 8;
+
+const normalizeLegendText = (value: string): string => value.trim().replace(/\s+/gu, ' ');
 
 type WasteCalendarPdfDay = Readonly<{
   isoDate: string;
@@ -159,17 +175,27 @@ const buildEntriesByDate = (pickups: readonly WasteOutputPickupEntry[]) => {
     const dayEntries = entriesByDate.get(pickup.date) ?? [];
     for (const fraction of pickup.fractions) {
       const existingLegend = legendFractions.get(fraction.id);
-      const legendEntry =
-        existingLegend ??
-        {
+      const legendEntry = existingLegend
+        ? {
+            ...existingLegend,
+            ...(!existingLegend.description && fraction.description?.trim()
+              ? { description: normalizeLegendText(fraction.description) }
+              : {}),
+          }
+        : {
+          kind: 'fraction' as const,
           code: buildFractionCode(fraction.label, fraction.shortLabel, usedCodes),
           label: fraction.label,
+          ...(fraction.description?.trim()
+            ? { description: normalizeLegendText(fraction.description) }
+            : {}),
           fillColor: parseHexColor(fraction.color),
         };
       legendFractions.set(fraction.id, legendEntry);
       dayEntries.push({
         code: legendEntry.code,
         fillColor: legendEntry.fillColor,
+        isShifted: fraction.isShifted === true,
       });
     }
     dayEntries.sort((left, right) => left.code.localeCompare(right.code, 'de'));
@@ -214,21 +240,36 @@ export const buildWasteCalendarPdfDocument = (input: {
   readonly year: number;
   readonly locationLabel: string;
   readonly pickups: readonly WasteOutputPickupEntry[];
-  readonly notes?: readonly string[];
-  readonly footerLine?: string;
+  readonly legendHints?: readonly WasteOutputLegendHint[];
   readonly brandingPlaceholderLabel?: string;
   readonly brandingImage?: WasteCalendarPdfDocument['pages'][number]['brandingImage'];
 }): WasteCalendarPdfDocument => {
   const { entriesByDate, legendFractions } = buildEntriesByDate(input.pickups);
   const holidayMap = buildHolidayMap(input.year);
-  const legend = Array.from(legendFractions.values()).sort((left, right) => left.label.localeCompare(right.label, 'de'));
-  const notes =
-    input.notes !== undefined
-      ? [...input.notes]
-      : [`Stand ${new Date().toISOString().slice(0, 10)}`, 'Alle wirksamen Fraktionen und Verschiebungen sind enthalten.'];
-  const footerLine =
-    input.footerLine ??
-    `Abfallkalender ${input.year} · ${input.locationLabel}`;
+  const fractionLegend = Array.from(legendFractions.values()).sort((left, right) =>
+    left.label.localeCompare(right.label, 'de')
+  );
+  const seenHintIds = new Set<string>();
+  const hintLegend = (input.legendHints ?? []).flatMap((hint) => {
+    const id = hint.id.trim();
+    const label = normalizeLegendText(hint.label);
+    const description = normalizeLegendText(hint.description);
+    if (!id || !label || !description || seenHintIds.has(id)) {
+      return [];
+    }
+    seenHintIds.add(id);
+    return [{ kind: 'hint' as const, label, description }];
+  });
+  const hasShiftedPickups = input.pickups.some((pickup) =>
+    pickup.fractions.some((fraction) => fraction.isShifted === true)
+  );
+  const contentRowLimit = MAX_LEGEND_ROWS - (hasShiftedPickups ? 1 : 0);
+  const legend: WasteCalendarPdfLegendRow[] = [
+    ...(hasShiftedPickups
+      ? ([{ kind: 'shift', label: '= Ausweichtermin' }] as const)
+      : []),
+    ...[...fractionLegend, ...hintLegend].slice(0, contentRowLimit),
+  ];
   const buildPage = (months: readonly number[]) => ({
     title: `Abfallkalender ${input.year}`,
     locationLabel: input.locationLabel,
@@ -236,8 +277,6 @@ export const buildWasteCalendarPdfDocument = (input: {
     ...(input.brandingImage ? { brandingImage: input.brandingImage } : {}),
     months: months.map((month) => buildMonth(input.year, month, holidayMap, entriesByDate)),
     legend,
-    notes,
-    footerLine,
   });
 
   return {

--- a/packages/core/src/waste-management-output.document.ts
+++ b/packages/core/src/waste-management-output.document.ts
@@ -3,6 +3,14 @@ import type {
   WasteOutputLegendHint,
   WasteOutputPickupEntry,
 } from './waste-management-output.types.js';
+import {
+  buildHolidayMap,
+  formatIsoDate,
+  getIsoWeekNumber,
+  MONTH_NAMES,
+  normalizeWeekday,
+  WEEKDAY_SHORT_NAMES,
+} from './waste-management-output.calendar.js';
 
 type RgbColor = readonly [red: number, green: number, blue: number];
 
@@ -44,27 +52,6 @@ type WasteCalendarPdfMonth = Readonly<{
   days: readonly WasteCalendarPdfDay[];
 }>;
 
-const MONTH_NAMES = [
-  'Januar',
-  'Februar',
-  'März',
-  'April',
-  'Mai',
-  'Juni',
-  'Juli',
-  'August',
-  'September',
-  'Oktober',
-  'November',
-  'Dezember',
-] as const;
-
-const WEEKDAY_SHORT_NAMES = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'] as const;
-
-const normalizeWeekday = (utcDay: number): number => (utcDay === 0 ? 6 : utcDay - 1);
-
-const formatIsoDate = (date: Date): string => date.toISOString().slice(0, 10);
-
 const parseHexColor = (value: string): RgbColor => {
   const normalized = value.trim();
   const hex = normalized.startsWith('#') ? normalized.slice(1) : normalized;
@@ -79,53 +66,6 @@ const parseHexColor = (value: string): RgbColor => {
   ];
 };
 
-const getIsoWeekNumber = (date: Date): number => {
-  const target = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-  const day = target.getUTCDay() || 7;
-  target.setUTCDate(target.getUTCDate() + 4 - day);
-  const yearStart = new Date(Date.UTC(target.getUTCFullYear(), 0, 1));
-  return Math.ceil(((target.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-};
-
-const computeEasterSunday = (year: number): Date => {
-  const a = year % 19;
-  const b = Math.floor(year / 100);
-  const c = year % 100;
-  const d = Math.floor(b / 4);
-  const e = b % 4;
-  const f = Math.floor((b + 8) / 25);
-  const g = Math.floor((b - f + 1) / 3);
-  const h = (19 * a + b - d - g + 15) % 30;
-  const i = Math.floor(c / 4);
-  const k = c % 4;
-  const l = (32 + 2 * e + 2 * i - h - k) % 7;
-  const m = Math.floor((a + 11 * h + 22 * l) / 451);
-  const month = Math.floor((h + l - 7 * m + 114) / 31);
-  const day = ((h + l - 7 * m + 114) % 31) + 1;
-  return new Date(Date.UTC(year, month - 1, day));
-};
-
-const addUtcDays = (value: Date, days: number): Date => {
-  const copy = new Date(value.getTime());
-  copy.setUTCDate(copy.getUTCDate() + days);
-  return copy;
-};
-
-const buildHolidayMap = (year: number): ReadonlyMap<string, string> => {
-  const easterSunday = computeEasterSunday(year);
-  return new Map<string, string>([
-    [`${year}-01-01`, 'Neujahr'],
-    [formatIsoDate(addUtcDays(easterSunday, -2)), 'Karfreitag'],
-    [formatIsoDate(addUtcDays(easterSunday, 1)), 'Ostermontag'],
-    [`${year}-05-01`, 'Maifeiertag'],
-    [formatIsoDate(addUtcDays(easterSunday, 39)), 'Christi Himmelfahrt'],
-    [formatIsoDate(addUtcDays(easterSunday, 50)), 'Pfingstmontag'],
-    [`${year}-10-03`, 'Tag der Deutschen Einheit'],
-    [`${year}-12-25`, '1. Weihnachtstag'],
-    [`${year}-12-26`, '2. Weihnachtstag'],
-  ]);
-};
-
 const normalizeFractionCode = (value: string): string =>
   value
     .replace(/[^A-Za-z0-9]+/g, '')
@@ -133,7 +73,11 @@ const normalizeFractionCode = (value: string): string =>
     .toUpperCase()
     .slice(0, 4);
 
-const buildFractionCode = (label: string, shortLabel: string | undefined, usedCodes: Set<string>): string => {
+const buildFractionCode = (
+  label: string,
+  shortLabel: string | undefined,
+  usedCodes: Set<string>
+): string => {
   const preferredCode = shortLabel ? normalizeFractionCode(shortLabel) : '';
   if (preferredCode && !usedCodes.has(preferredCode)) {
     usedCodes.add(preferredCode);
@@ -145,7 +89,10 @@ const buildFractionCode = (label: string, shortLabel: string | undefined, usedCo
     .trim()
     .split(/\s+/)
     .filter(Boolean);
-  const initials = normalized.map((part) => part[0] ?? '').join('').toUpperCase();
+  const initials = normalized
+    .map((part) => part[0] ?? '')
+    .join('')
+    .toUpperCase();
   const compact = normalized.join('').toUpperCase();
   const base = (initials.length >= 2 ? initials : compact.slice(0, 3) || 'FR').slice(0, 4);
 
@@ -183,14 +130,14 @@ const buildEntriesByDate = (pickups: readonly WasteOutputPickupEntry[]) => {
               : {}),
           }
         : {
-          kind: 'fraction' as const,
-          code: buildFractionCode(fraction.label, fraction.shortLabel, usedCodes),
-          label: fraction.label,
-          ...(fraction.description?.trim()
-            ? { description: normalizeLegendText(fraction.description) }
-            : {}),
-          fillColor: parseHexColor(fraction.color),
-        };
+            kind: 'fraction' as const,
+            code: buildFractionCode(fraction.label, fraction.shortLabel, usedCodes),
+            label: fraction.label,
+            ...(fraction.description?.trim()
+              ? { description: normalizeLegendText(fraction.description) }
+              : {}),
+            fillColor: parseHexColor(fraction.color),
+          };
       legendFractions.set(fraction.id, legendEntry);
       dayEntries.push({
         code: legendEntry.code,
@@ -265,9 +212,7 @@ export const buildWasteCalendarPdfDocument = (input: {
   );
   const contentRowLimit = MAX_LEGEND_ROWS - (hasShiftedPickups ? 1 : 0);
   const legend: WasteCalendarPdfLegendRow[] = [
-    ...(hasShiftedPickups
-      ? ([{ kind: 'shift', label: '= Ausweichtermin' }] as const)
-      : []),
+    ...(hasShiftedPickups ? ([{ kind: 'shift', label: '= Ausweichtermin' }] as const) : []),
     ...[...fractionLegend, ...hintLegend].slice(0, contentRowLimit),
   ];
   const buildPage = (months: readonly number[]) => ({

--- a/packages/core/src/waste-management-output.document.ts
+++ b/packages/core/src/waste-management-output.document.ts
@@ -186,6 +186,7 @@ const buildMonth = (
 export const buildWasteCalendarPdfDocument = (input: {
   readonly year: number;
   readonly locationLabel: string;
+  readonly contactBlock?: string;
   readonly pickups: readonly WasteOutputPickupEntry[];
   readonly legendHints?: readonly WasteOutputLegendHint[];
   readonly brandingPlaceholderLabel?: string;
@@ -218,6 +219,9 @@ export const buildWasteCalendarPdfDocument = (input: {
   const buildPage = (months: readonly number[]) => ({
     title: `Abfallkalender ${input.year}`,
     locationLabel: input.locationLabel,
+    ...(input.contactBlock?.trim()
+      ? { contactBlock: normalizeLegendText(input.contactBlock) }
+      : {}),
     brandingPlaceholderLabel: input.brandingPlaceholderLabel ?? 'Kommunales Waste-Management',
     ...(input.brandingImage ? { brandingImage: input.brandingImage } : {}),
     months: months.map((month) => buildMonth(input.year, month, holidayMap, entriesByDate)),

--- a/packages/core/src/waste-management-output.encoding.ts
+++ b/packages/core/src/waste-management-output.encoding.ts
@@ -1,0 +1,42 @@
+const WIN_ANSI_CODE_POINTS = new Map<number, number>([
+  [0x20ac, 0x80],
+  [0x201a, 0x82],
+  [0x0192, 0x83],
+  [0x201e, 0x84],
+  [0x2026, 0x85],
+  [0x2020, 0x86],
+  [0x2021, 0x87],
+  [0x02c6, 0x88],
+  [0x2030, 0x89],
+  [0x0160, 0x8a],
+  [0x2039, 0x8b],
+  [0x0152, 0x8c],
+  [0x017d, 0x8e],
+  [0x2018, 0x91],
+  [0x2019, 0x92],
+  [0x201c, 0x93],
+  [0x201d, 0x94],
+  [0x2022, 0x95],
+  [0x2013, 0x96],
+  [0x2014, 0x97],
+  [0x02dc, 0x98],
+  [0x2122, 0x99],
+  [0x0161, 0x9a],
+  [0x203a, 0x9b],
+  [0x0153, 0x9c],
+  [0x017e, 0x9e],
+  [0x0178, 0x9f],
+]);
+
+const encodeWinAnsi = (value: string): string =>
+  Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint <= 0xff) {
+      return character;
+    }
+    const winAnsiCode = WIN_ANSI_CODE_POINTS.get(codePoint);
+    return winAnsiCode === undefined ? '?' : String.fromCharCode(winAnsiCode);
+  }).join('');
+
+export const escapePdfText = (value: string): string =>
+  encodeWinAnsi(value).replaceAll('\\', '\\\\').replaceAll('(', '\\(').replaceAll(')', '\\)');

--- a/packages/core/src/waste-management-output.render.helpers.ts
+++ b/packages/core/src/waste-management-output.render.helpers.ts
@@ -6,11 +6,133 @@ export type { RgbColor };
 
 export const BRANDING_BOX = {
   x: 640,
-  top: 22,
+  top: 14,
   width: 163,
-  height: 48,
-  padding: 6,
+  height: 40,
+  padding: 5,
 } as const;
+
+const HELVETICA_WIDTHS: Readonly<Record<string, number>> = {
+  ' ': 278,
+  '!': 278,
+  '"': 355,
+  '#': 556,
+  '$': 556,
+  '%': 889,
+  '&': 667,
+  "'": 191,
+  '(': 333,
+  ')': 333,
+  '*': 389,
+  '+': 584,
+  ',': 278,
+  '-': 333,
+  '.': 278,
+  '/': 278,
+  ':': 278,
+  ';': 278,
+  '<': 584,
+  '=': 584,
+  '>': 584,
+  '?': 556,
+  '@': 1015,
+  A: 667,
+  B: 667,
+  C: 722,
+  D: 722,
+  E: 667,
+  F: 611,
+  G: 778,
+  H: 722,
+  I: 278,
+  J: 500,
+  K: 667,
+  L: 556,
+  M: 833,
+  N: 722,
+  O: 778,
+  P: 667,
+  Q: 778,
+  R: 722,
+  S: 667,
+  T: 611,
+  U: 722,
+  V: 667,
+  W: 944,
+  X: 667,
+  Y: 667,
+  Z: 611,
+  a: 556,
+  b: 556,
+  c: 500,
+  d: 556,
+  e: 556,
+  f: 278,
+  g: 556,
+  h: 556,
+  i: 222,
+  j: 222,
+  k: 500,
+  l: 222,
+  m: 833,
+  n: 556,
+  o: 556,
+  p: 556,
+  q: 556,
+  r: 333,
+  s: 500,
+  t: 278,
+  u: 556,
+  v: 500,
+  w: 722,
+  x: 500,
+  y: 500,
+  z: 500,
+  Ä: 667,
+  Ö: 778,
+  Ü: 722,
+  ä: 556,
+  ö: 556,
+  ü: 556,
+  ß: 556,
+};
+
+const getHelveticaCharacterWidth = (character: string): number => {
+  const knownWidth = HELVETICA_WIDTHS[character];
+  if (knownWidth !== undefined) {
+    return knownWidth;
+  }
+  return 556;
+};
+
+export const getHelveticaTextWidth = (text: string, fontSize: number): number =>
+  Array.from(text).reduce((width, character) => width + getHelveticaCharacterWidth(character), 0) *
+  (fontSize / 1000);
+
+export const truncateHelveticaText = (
+  text: string,
+  fontSize: number,
+  maxWidth: number
+): string => {
+  if (getHelveticaTextWidth(text, fontSize) <= maxWidth) {
+    return text;
+  }
+
+  const suffix = '...';
+  const suffixWidth = getHelveticaTextWidth(suffix, fontSize);
+  let visibleText = '';
+  let visibleWidth = 0;
+  for (const character of Array.from(text)) {
+    const characterWidth = getHelveticaTextWidth(character, fontSize);
+    if (visibleWidth + characterWidth + suffixWidth > maxWidth) {
+      break;
+    }
+    visibleText += character;
+    visibleWidth += characterWidth;
+  }
+
+  return `${visibleText.trimEnd()}${suffix}`;
+};
 
 export const splitLegendLabel = (label: string): readonly string[] => {
   if (label.length <= 24) {

--- a/packages/core/src/waste-management-output.render.ts
+++ b/packages/core/src/waste-management-output.render.ts
@@ -111,6 +111,16 @@ const renderHeader = (
 ): void => {
   drawText({ commands, x: 38, top: 16, fontSize: 20, text: page.title, fontName: 'F2' });
   drawText({ commands, x: 38, top: 44, fontSize: 10.5, text: page.locationLabel, fontName: 'F1' });
+  if (page.contactBlock) {
+    drawText({
+      commands,
+      x: 38,
+      top: 60,
+      fontSize: 7.5,
+      text: truncateHelveticaText(page.contactBlock, 7.5, 570),
+      fontName: 'F1',
+    });
+  }
   if (page.brandingImage && imageObjectName) {
     commands.push(buildBrandingImageCommand(page, imageObjectName, PAGE_HEIGHT) ?? '');
     return;

--- a/packages/core/src/waste-management-output.render.ts
+++ b/packages/core/src/waste-management-output.render.ts
@@ -1,4 +1,5 @@
 import type { WasteCalendarPdfDocument } from './waste-management-output.types.js';
+import { escapePdfText } from './waste-management-output.encoding.js';
 import { PdfBuilder } from './waste-management-output.pdf-builder.js';
 import {
   abbreviateHolidayLabel,
@@ -45,7 +46,15 @@ type RectangleDrawInput = Readonly<{
   x: number;
 }>;
 
-const drawText = ({ commands, x, top, fontSize, text, fontName, color = [0.15, 0.15, 0.15] }: TextDrawInput): void => {
+const drawText = ({
+  commands,
+  x,
+  top,
+  fontSize,
+  text,
+  fontName,
+  color = [0.15, 0.15, 0.15],
+}: TextDrawInput): void => {
   const baselineY = PAGE_HEIGHT - top - fontSize;
   commands.push(
     `BT /${fontName} ${fontSize.toFixed(2)} Tf ${color[0].toFixed(3)} ${color[1].toFixed(3)} ${color[2].toFixed(
@@ -106,8 +115,27 @@ const renderHeader = (
     commands.push(buildBrandingImageCommand(page, imageObjectName, PAGE_HEIGHT) ?? '');
     return;
   }
-  drawFilledRectangle({ commands, x: BRANDING_BOX.x, top: BRANDING_BOX.top, width: BRANDING_BOX.width, height: BRANDING_BOX.height }, [0.93, 0.95, 0.98]);
-  drawStrokedRectangle({ commands, x: BRANDING_BOX.x, top: BRANDING_BOX.top, width: BRANDING_BOX.width, height: BRANDING_BOX.height }, [0.55, 0.62, 0.7], 1);
+  drawFilledRectangle(
+    {
+      commands,
+      x: BRANDING_BOX.x,
+      top: BRANDING_BOX.top,
+      width: BRANDING_BOX.width,
+      height: BRANDING_BOX.height,
+    },
+    [0.93, 0.95, 0.98]
+  );
+  drawStrokedRectangle(
+    {
+      commands,
+      x: BRANDING_BOX.x,
+      top: BRANDING_BOX.top,
+      width: BRANDING_BOX.width,
+      height: BRANDING_BOX.height,
+    },
+    [0.55, 0.62, 0.7],
+    1
+  );
   drawCenteredText({
     commands,
     x: BRANDING_BOX.x,
@@ -120,7 +148,10 @@ const renderHeader = (
   });
 };
 
-const renderMonthGrid = (commands: string[], page: WasteCalendarPdfDocument['pages'][number]): void => {
+const renderMonthGrid = (
+  commands: string[],
+  page: WasteCalendarPdfDocument['pages'][number]
+): void => {
   const monthTop = 78;
   const monthLeft = 34;
   const monthWidth = 116;
@@ -130,8 +161,15 @@ const renderMonthGrid = (commands: string[], page: WasteCalendarPdfDocument['pag
 
   for (const [index, month] of page.months.entries()) {
     const x = monthLeft + index * (monthWidth + monthGap);
-    drawFilledRectangle({ commands, x, top: monthTop, width: monthWidth, height: headerHeight }, [0.16, 0.47, 0.74]);
-    drawStrokedRectangle({ commands, x, top: monthTop, width: monthWidth, height: headerHeight }, [0.15, 0.15, 0.15], 0.8);
+    drawFilledRectangle(
+      { commands, x, top: monthTop, width: monthWidth, height: headerHeight },
+      [0.16, 0.47, 0.74]
+    );
+    drawStrokedRectangle(
+      { commands, x, top: monthTop, width: monthWidth, height: headerHeight },
+      [0.15, 0.15, 0.15],
+      0.8
+    );
     drawCenteredText({
       commands,
       x,
@@ -145,72 +183,145 @@ const renderMonthGrid = (commands: string[], page: WasteCalendarPdfDocument['pag
     });
 
     for (let rowIndex = 0; rowIndex < 31; rowIndex += 1) {
-      const rowTop = monthTop + headerHeight + rowIndex * rowHeight;
-      const day = month.days[rowIndex] ?? null;
-      const hasWeekend = day !== null && (day.weekdayShort === 'Sa' || day.weekdayShort === 'So');
-      drawFilledRectangle({ commands, x, top: rowTop, width: monthWidth, height: rowHeight }, hasWeekend ? [0.94, 0.96, 0.99] : [1, 1, 1]);
-      drawStrokedRectangle({ commands, x, top: rowTop, width: monthWidth, height: rowHeight }, [0.2, 0.2, 0.2], 0.45);
-
-      if (day === null) {
-        continue;
-      }
-
-      const centeredTextTop = (fontSize: number): number => rowTop + (rowHeight - fontSize) / 2 - 0.2;
-      const dayTextTop = centeredTextTop(8.5);
-      drawText({ commands, x: x + 4, top: dayTextTop, fontSize: 8.5, text: pad2(day.dayOfMonth), fontName: 'F1' });
-      drawText({ commands, x: x + 24, top: dayTextTop, fontSize: 8.5, text: day.weekdayShort, fontName: 'F1' });
-
-      if (day.weekNumber !== null) {
-        drawText({
-          commands,
-          x: x - 12,
-          top: centeredTextTop(8),
-          fontSize: 8,
-          text: String(day.weekNumber),
-          fontName: 'F1',
-        });
-      }
-      if (day.holidayLabel !== null) {
-        drawText({
-          commands,
-          x: x + 42,
-          top: centeredTextTop(6.8),
-          fontSize: 6.8,
-          text: abbreviateHolidayLabel(day.holidayLabel),
-          fontName: 'F1',
-        });
-      }
-
-      let labelX = x + 42;
-      for (const entry of day.entries) {
-        const labelWidth = getEntryLabelWidth(entry.code);
-        drawFilledRectangle({ commands, x: labelX, top: rowTop + 1.2, width: labelWidth, height: rowHeight - 2.5 }, entry.fillColor);
-        drawText({
-          commands,
-          x: labelX + 2.8,
-          top: centeredTextTop(7.5),
-          fontSize: 7.5,
-          text: entry.code,
-          fontName: 'F1',
-        });
-        if (entry.isShifted) {
-          drawText({
-            commands,
-            x: labelX + labelWidth + 2,
-            top: centeredTextTop(8),
-            fontSize: 8,
-            text: '*',
-            fontName: 'F2',
-            color: SHIFT_MARKER_COLOR,
-          });
-        }
-        labelX += labelWidth + 2 + (entry.isShifted ? SHIFT_MARKER_ADVANCE : 0);
-      }
+      renderMonthDay({
+        commands,
+        day: month.days[rowIndex] ?? null,
+        rowHeight,
+        rowTop: monthTop + headerHeight + rowIndex * rowHeight,
+        width: monthWidth,
+        x,
+      });
     }
   }
 };
 
-const renderLegend = (commands: string[], page: WasteCalendarPdfDocument['pages'][number]): void => {
+const renderMonthDay = (
+  input: Readonly<{
+    commands: string[];
+    day: WasteCalendarPdfDocument['pages'][number]['months'][number]['days'][number] | null;
+    rowHeight: number;
+    rowTop: number;
+    width: number;
+    x: number;
+  }>
+): void => {
+  const { commands, day, rowHeight, rowTop, width, x } = input;
+  const hasWeekend = day !== null && (day.weekdayShort === 'Sa' || day.weekdayShort === 'So');
+  drawFilledRectangle(
+    { commands, x, top: rowTop, width, height: rowHeight },
+    hasWeekend ? [0.94, 0.96, 0.99] : [1, 1, 1]
+  );
+  drawStrokedRectangle(
+    { commands, x, top: rowTop, width, height: rowHeight },
+    [0.2, 0.2, 0.2],
+    0.45
+  );
+
+  if (day === null) {
+    return;
+  }
+
+  const centeredTextTop = (fontSize: number): number => rowTop + (rowHeight - fontSize) / 2 - 0.2;
+  renderDayMetadata({ commands, centeredTextTop, day, x });
+  renderDayEntries({ commands, centeredTextTop, day, rowHeight, rowTop, x });
+};
+
+type CalendarDay = WasteCalendarPdfDocument['pages'][number]['months'][number]['days'][number];
+
+const renderDayMetadata = (
+  input: Readonly<{
+    centeredTextTop: (fontSize: number) => number;
+    commands: string[];
+    day: CalendarDay;
+    x: number;
+  }>
+): void => {
+  const { centeredTextTop, commands, day, x } = input;
+  const dayTextTop = centeredTextTop(8.5);
+  drawText({
+    commands,
+    x: x + 4,
+    top: dayTextTop,
+    fontSize: 8.5,
+    text: pad2(day.dayOfMonth),
+    fontName: 'F1',
+  });
+  drawText({
+    commands,
+    x: x + 24,
+    top: dayTextTop,
+    fontSize: 8.5,
+    text: day.weekdayShort,
+    fontName: 'F1',
+  });
+
+  if (day.weekNumber !== null) {
+    drawText({
+      commands,
+      x: x - 12,
+      top: centeredTextTop(8),
+      fontSize: 8,
+      text: String(day.weekNumber),
+      fontName: 'F1',
+    });
+  }
+  if (day.holidayLabel !== null) {
+    drawText({
+      commands,
+      x: x + 42,
+      top: centeredTextTop(6.8),
+      fontSize: 6.8,
+      text: abbreviateHolidayLabel(day.holidayLabel),
+      fontName: 'F1',
+    });
+  }
+};
+
+const renderDayEntries = (
+  input: Readonly<{
+    centeredTextTop: (fontSize: number) => number;
+    commands: string[];
+    day: CalendarDay;
+    rowHeight: number;
+    rowTop: number;
+    x: number;
+  }>
+): void => {
+  const { centeredTextTop, commands, day, rowHeight, rowTop, x } = input;
+  let labelX = x + 42;
+  for (const entry of day.entries) {
+    const labelWidth = getEntryLabelWidth(entry.code);
+    drawFilledRectangle(
+      { commands, x: labelX, top: rowTop + 1.2, width: labelWidth, height: rowHeight - 2.5 },
+      entry.fillColor
+    );
+    drawText({
+      commands,
+      x: labelX + 2.8,
+      top: centeredTextTop(7.5),
+      fontSize: 7.5,
+      text: entry.code,
+      fontName: 'F1',
+    });
+    if (entry.isShifted) {
+      drawText({
+        commands,
+        x: labelX + labelWidth + 2,
+        top: centeredTextTop(8),
+        fontSize: 8,
+        text: '*',
+        fontName: 'F2',
+        color: SHIFT_MARKER_COLOR,
+      });
+    }
+    labelX += labelWidth + 2 + (entry.isShifted ? SHIFT_MARKER_ADVANCE : 0);
+  }
+};
+
+const renderLegend = (
+  commands: string[],
+  page: WasteCalendarPdfDocument['pages'][number]
+): void => {
   const baseX = 38;
   const baseY = 476;
   const boxWidth = 22;
@@ -222,14 +333,39 @@ const renderLegend = (commands: string[], page: WasteCalendarPdfDocument['pages'
   for (const [index, entry] of page.legend.entries()) {
     const rowTop = baseY + index * rowHeight;
     if (entry.kind === 'shift') {
-      drawText({ commands, x: baseX, top: rowTop + 1, fontSize: 9, text: '*', fontName: 'F2', color: SHIFT_MARKER_COLOR });
-      drawText({ commands, x: baseX + 12, top: rowTop + 1.5, fontSize, text: entry.label, fontName: 'F1' });
+      drawText({
+        commands,
+        x: baseX,
+        top: rowTop + 1,
+        fontSize: 9,
+        text: '*',
+        fontName: 'F2',
+        color: SHIFT_MARKER_COLOR,
+      });
+      drawText({
+        commands,
+        x: baseX + 12,
+        top: rowTop + 1.5,
+        fontSize,
+        text: entry.label,
+        fontName: 'F1',
+      });
       continue;
     }
 
     if (entry.kind === 'fraction') {
-      drawFilledRectangle({ commands, x: baseX, top: rowTop + 0.8, width: boxWidth, height: 10.4 }, entry.fillColor);
-      drawText({ commands, x: baseX + 4, top: rowTop + 1.9, fontSize: 7.2, text: entry.code, fontName: 'F1' });
+      drawFilledRectangle(
+        { commands, x: baseX, top: rowTop + 0.8, width: boxWidth, height: 10.4 },
+        entry.fillColor
+      );
+      drawText({
+        commands,
+        x: baseX + 4,
+        top: rowTop + 1.9,
+        fontSize: 7.2,
+        text: entry.code,
+        fontName: 'F1',
+      });
       drawText({
         commands,
         x: labelX,
@@ -265,14 +401,15 @@ const renderPageCommands = (
   imageObjectName?: string
 ): string => {
   const commands: string[] = [];
-  drawFilledRectangle({ commands, x: 0, top: 0, width: PAGE_WIDTH, height: PAGE_HEIGHT }, [1, 1, 1]);
+  drawFilledRectangle(
+    { commands, x: 0, top: 0, width: PAGE_WIDTH, height: PAGE_HEIGHT },
+    [1, 1, 1]
+  );
   renderHeader(commands, page, imageObjectName);
   renderMonthGrid(commands, page);
   renderLegend(commands, page);
   return commands.join('\n');
 };
-const escapePdfText = (value: string): string =>
-  value.replaceAll('\\', '\\\\').replaceAll('(', '\\(').replaceAll(')', '\\)');
 export const renderWasteCalendarPdf = (document: WasteCalendarPdfDocument): Buffer => {
   const pdf = new PdfBuilder();
   const regularFontId = pdf.addObject(
@@ -287,7 +424,9 @@ export const renderWasteCalendarPdf = (document: WasteCalendarPdfDocument): Buff
     addStreamObject: (streamContent, dictionary) => pdf.addStreamObject(streamContent, dictionary),
   });
   const pageIds = document.pages.map((page) => {
-    const streamId = pdf.addStreamObject(renderPageCommands(page, brandingImageResource?.objectName));
+    const streamId = pdf.addStreamObject(
+      renderPageCommands(page, brandingImageResource?.objectName)
+    );
     const xObjectSection = brandingImageResource
       ? ` /XObject << /${brandingImageResource.objectName} ${brandingImageResource.id} 0 R >>`
       : '';

--- a/packages/core/src/waste-management-output.render.ts
+++ b/packages/core/src/waste-management-output.render.ts
@@ -6,11 +6,14 @@ import {
   buildBrandingImageCommand,
   createBrandingImageResource,
   getEntryLabelWidth,
+  truncateHelveticaText,
   pad2,
   type RgbColor,
 } from './waste-management-output.render.helpers.js';
 const PAGE_WIDTH = 841.89;
 const PAGE_HEIGHT = 595.28;
+const SHIFT_MARKER_COLOR: RgbColor = [0.78, 0.05, 0.05];
+const SHIFT_MARKER_ADVANCE = 7;
 
 type TextDrawInput = Readonly<{
   color?: RgbColor;
@@ -97,8 +100,8 @@ const renderHeader = (
   page: WasteCalendarPdfDocument['pages'][number],
   imageObjectName?: string
 ): void => {
-  drawText({ commands, x: 38, top: 28, fontSize: 24, text: page.title, fontName: 'F2' });
-  drawText({ commands, x: 38, top: 64, fontSize: 12, text: page.locationLabel, fontName: 'F1' });
+  drawText({ commands, x: 38, top: 16, fontSize: 20, text: page.title, fontName: 'F2' });
+  drawText({ commands, x: 38, top: 44, fontSize: 10.5, text: page.locationLabel, fontName: 'F1' });
   if (page.brandingImage && imageObjectName) {
     commands.push(buildBrandingImageCommand(page, imageObjectName, PAGE_HEIGHT) ?? '');
     return;
@@ -118,7 +121,7 @@ const renderHeader = (
 };
 
 const renderMonthGrid = (commands: string[], page: WasteCalendarPdfDocument['pages'][number]): void => {
-  const monthTop = 100;
+  const monthTop = 78;
   const monthLeft = 34;
   const monthWidth = 116;
   const monthGap = 18;
@@ -190,37 +193,71 @@ const renderMonthGrid = (commands: string[], page: WasteCalendarPdfDocument['pag
           text: entry.code,
           fontName: 'F1',
         });
-        labelX += labelWidth + 2;
+        if (entry.isShifted) {
+          drawText({
+            commands,
+            x: labelX + labelWidth + 2,
+            top: centeredTextTop(8),
+            fontSize: 8,
+            text: '*',
+            fontName: 'F2',
+            color: SHIFT_MARKER_COLOR,
+          });
+        }
+        labelX += labelWidth + 2 + (entry.isShifted ? SHIFT_MARKER_ADVANCE : 0);
       }
     }
   }
 };
 
-const renderNotes = (commands: string[], page: WasteCalendarPdfDocument['pages'][number]): void => {
-  for (const [index, note] of page.notes.slice(0, 4).entries()) {
-    drawText({ commands, x: 38, top: 512 + index * 16, fontSize: 10.2, text: note, fontName: 'F1' });
-  }
-};
-
 const renderLegend = (commands: string[], page: WasteCalendarPdfDocument['pages'][number]): void => {
   const baseX = 38;
-  const baseY = 500;
+  const baseY = 476;
   const boxWidth = 22;
-  const gap = 12;
-  const availableWidth = PAGE_WIDTH - baseX * 2;
-  const slotWidth =
-    page.legend.length > 0 ? (availableWidth - gap * (page.legend.length - 1)) / page.legend.length : availableWidth;
+  const rowHeight = 12;
+  const labelX = baseX + boxWidth + 8;
+  const rightEdge = PAGE_WIDTH - baseX;
+  const fontSize = 8;
 
   for (const [index, entry] of page.legend.entries()) {
-    const x = baseX + index * (slotWidth + gap);
-    drawFilledRectangle({ commands, x, top: baseY, width: boxWidth, height: 14 }, entry.fillColor);
-    drawText({ commands, x: x + 4, top: baseY + 2.2, fontSize: 7.8, text: entry.code, fontName: 'F1' });
-    drawText({ commands, x: x + boxWidth + 8, top: baseY + 8.7, fontSize: 8, text: entry.label, fontName: 'F1' });
-  }
-};
+    const rowTop = baseY + index * rowHeight;
+    if (entry.kind === 'shift') {
+      drawText({ commands, x: baseX, top: rowTop + 1, fontSize: 9, text: '*', fontName: 'F2', color: SHIFT_MARKER_COLOR });
+      drawText({ commands, x: baseX + 12, top: rowTop + 1.5, fontSize, text: entry.label, fontName: 'F1' });
+      continue;
+    }
 
-const renderFooter = (commands: string[], page: WasteCalendarPdfDocument['pages'][number]): void => {
-  drawText({ commands, x: 38, top: 568, fontSize: 9.6, text: page.footerLine, fontName: 'F1' });
+    if (entry.kind === 'fraction') {
+      drawFilledRectangle({ commands, x: baseX, top: rowTop + 0.8, width: boxWidth, height: 10.4 }, entry.fillColor);
+      drawText({ commands, x: baseX + 4, top: rowTop + 1.9, fontSize: 7.2, text: entry.code, fontName: 'F1' });
+      drawText({
+        commands,
+        x: labelX,
+        top: rowTop + 1.5,
+        fontSize,
+        text: truncateHelveticaText(
+          entry.description ? `${entry.label} - ${entry.description}` : entry.label,
+          fontSize,
+          rightEdge - labelX
+        ),
+        fontName: 'F1',
+      });
+      continue;
+    }
+
+    drawText({
+      commands,
+      x: baseX,
+      top: rowTop + 1.5,
+      fontSize,
+      text: truncateHelveticaText(
+        `${entry.label} - ${entry.description}`,
+        fontSize,
+        rightEdge - baseX
+      ),
+      fontName: 'F1',
+    });
+  }
 };
 
 const renderPageCommands = (
@@ -231,17 +268,19 @@ const renderPageCommands = (
   drawFilledRectangle({ commands, x: 0, top: 0, width: PAGE_WIDTH, height: PAGE_HEIGHT }, [1, 1, 1]);
   renderHeader(commands, page, imageObjectName);
   renderMonthGrid(commands, page);
-  renderNotes(commands, page);
   renderLegend(commands, page);
-  renderFooter(commands, page);
   return commands.join('\n');
 };
 const escapePdfText = (value: string): string =>
   value.replaceAll('\\', '\\\\').replaceAll('(', '\\(').replaceAll(')', '\\)');
 export const renderWasteCalendarPdf = (document: WasteCalendarPdfDocument): Buffer => {
   const pdf = new PdfBuilder();
-  const regularFontId = pdf.addObject('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
-  const boldFontId = pdf.addObject('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>');
+  const regularFontId = pdf.addObject(
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>'
+  );
+  const boldFontId = pdf.addObject(
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>'
+  );
   const pagesId = pdf.reserveObject();
   const brandingImageResource = createBrandingImageResource({
     document,

--- a/packages/core/src/waste-management-output.test.ts
+++ b/packages/core/src/waste-management-output.test.ts
@@ -10,12 +10,17 @@ describe('waste-management output pdf', () => {
       pickups: [
         {
           date: '2026-01-14',
-          fractions: [{ id: 'hm', label: 'Hausmuell', shortLabel: 'HM', color: '#666666' }],
+          fractions: [{ id: 'hm', label: 'Hausmuell', shortLabel: 'HM', color: '#666666', isShifted: true }],
         },
         {
           date: '2026-01-15',
           fractions: [
-            { id: 'bio', label: 'Bioabfall', color: '#00AA00' },
+            {
+              id: 'bio',
+              label: 'Bioabfall',
+              description: 'Bitte ohne Kunststoffbeutel bereitstellen.',
+              color: '#00AA00',
+            },
             { id: 'papier', label: 'Papier und Pappe', color: '#3366FF' },
           ],
         },
@@ -23,6 +28,9 @@ describe('waste-management output pdf', () => {
           date: '2026-10-03',
           fractions: [{ id: 'lvp', label: 'Leichtverpackungen', color: '#FFDD00' }],
         },
+      ],
+      legendHints: [
+        { id: 'tour:nord', label: 'Tour: Nord', description: 'Bereitstellung am Fahrbahnrand.' },
       ],
     });
 
@@ -34,14 +42,21 @@ describe('waste-management output pdf', () => {
     const january = document.pages[0]?.months[0];
     const october = document.pages[1]?.months[3];
     expect(january?.days.find((day) => day.dayOfMonth === 14)?.entries.map((entry) => entry.code)).toEqual(['HM']);
+    expect(january?.days.find((day) => day.dayOfMonth === 14)?.entries[0]?.isShifted).toBe(true);
     expect(january?.days.find((day) => day.dayOfMonth === 15)?.entries).toHaveLength(2);
     expect(october?.days.find((day) => day.dayOfMonth === 3)?.holidayLabel).toBe('Tag der Deutschen Einheit');
     expect(document.pages[0]?.legend.map((entry) => entry.label)).toEqual([
+      '= Ausweichtermin',
       'Bioabfall',
       'Hausmuell',
       'Leichtverpackungen',
       'Papier und Pappe',
+      'Tour: Nord',
     ]);
+    expect(document.pages[0]?.legend[1]).toMatchObject({
+      kind: 'fraction',
+      description: 'Bitte ohne Kunststoffbeutel bereitstellen.',
+    });
     expect(document.pages[0]?.months[2]?.label).toBe('März');
   });
 
@@ -71,6 +86,20 @@ describe('waste-management output pdf', () => {
     expect(pdfText).toContain('HM');
   });
 
+  it('declares the Windows ANSI encoding used for German umlauts', () => {
+    const pdfText = renderWasteCalendarPdf(
+      buildWasteCalendarPdfDocument({
+        year: 2026,
+        locationLabel: 'Bärensprung',
+        pickups: [],
+      })
+    ).toString('latin1');
+
+    expect(pdfText).toContain('/BaseFont /Helvetica /Encoding /WinAnsiEncoding');
+    expect(pdfText).toContain('/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding');
+    expect(pdfText).toContain('(Bärensprung) Tj');
+  });
+
   it('vertically centers day content inside calendar table cells', () => {
     const pdfText = renderWasteCalendarPdf(
       buildWasteCalendarPdfDocument({
@@ -85,11 +114,11 @@ describe('waste-management output pdf', () => {
       })
     ).toString('latin1');
 
-    expect(pdfText).toContain('1 0 0 1 38.00 465.23 Tm (01) Tj ET');
-    expect(pdfText).toContain('1 0 0 1 58.00 465.23 Tm (Do) Tj ET');
+    expect(pdfText).toContain('1 0 0 1 38.00 487.23 Tm (01) Tj ET');
+    expect(pdfText).toContain('1 0 0 1 58.00 487.23 Tm (Do) Tj ET');
   });
 
-  it('uses a more compact header and leaves the footer content below the table', () => {
+  it('uses a compact header and omits the redundant footer', () => {
     const pdfText = renderWasteCalendarPdf(
       buildWasteCalendarPdfDocument({
         year: 2026,
@@ -100,19 +129,21 @@ describe('waste-management output pdf', () => {
             fractions: [{ id: 'hm', label: 'Hausmuell', shortLabel: 'HM', color: '#666666' }],
           },
         ],
-        notes: ['Stand 2026-06-14'],
-        footerLine: 'Abfallberatung · Beispielkontakt',
+        legendHints: [
+          { id: 'tour:nord', label: 'Tour: Nord', description: 'Hinweis zur\nBereitstellung.' },
+        ],
       })
     ).toString('latin1');
 
-    expect(pdfText).toContain('/F2 24.00 Tf');
-    expect(pdfText).toContain('/F1 12.00 Tf');
-    expect(pdfText).toMatch(/1 0 0 1 38\.00 543\.28 Tm \(Abfallkalender 2026\) Tj ET/);
-    expect(pdfText).toMatch(/1 0 0 1 38\.00 73\.08 Tm \(Stand 2026-06-14\) Tj ET/);
-    expect(pdfText).toMatch(/1 0 0 1 38\.00 17\.68 Tm \(Abfallberatung · Beispielkontakt\) Tj ET/);
+    expect(pdfText).toContain('/F2 20.00 Tf');
+    expect(pdfText).toContain('/F1 10.50 Tf');
+    expect(pdfText).toMatch(/1 0 0 1 38\.00 559\.28 Tm \(Abfallkalender 2026\) Tj ET/);
+    expect(pdfText).toContain('(Tour: Nord - Hinweis zur Bereitstellung.) Tj ET');
+    expect(pdfText).not.toContain('Abfallkalender 2026 · Rathenow');
+    expect(pdfText).not.toContain('Abfallberatung · Beispielkontakt');
   });
 
-  it('does not render default notes when an explicit empty notes array is provided', () => {
+  it('does not render legacy default notes or a footer', () => {
     const pdfText = renderWasteCalendarPdf(
       buildWasteCalendarPdfDocument({
         year: 2026,
@@ -123,12 +154,12 @@ describe('waste-management output pdf', () => {
             fractions: [{ id: 'hm', label: 'Hausmuell', shortLabel: 'HM', color: '#666666' }],
           },
         ],
-        notes: [],
       })
     ).toString('latin1');
 
     expect(pdfText).not.toContain('Stand ');
     expect(pdfText).not.toContain('Alle wirksamen Fraktionen und Verschiebungen sind enthalten.');
+    expect(pdfText).not.toContain('Abfallkalender 2026 · Rathenow');
   });
 
   it('embeds a branding image when one is provided', () => {
@@ -158,11 +189,11 @@ describe('waste-management output pdf', () => {
     expect(pdfText).toContain('/Subtype /Image');
     expect(pdfText).toContain('/XObject << /Im1');
     expect(pdfText).toContain('/Im1 Do');
-    expect(pdfText).not.toContain('640.00 525.28 163.00 48.00 re f');
-    expect(pdfText).not.toContain('640.00 525.28 163.00 48.00 re S');
+    expect(pdfText).not.toContain('640.00 541.28 163.00 40.00 re f');
+    expect(pdfText).not.toContain('640.00 541.28 163.00 40.00 re S');
   });
 
-  it('renders legend labels in one horizontal row beneath the calendar', () => {
+  it('renders at most eight legend entries as vertical rows beneath the calendar', () => {
     const pdfText = renderWasteCalendarPdf(
       buildWasteCalendarPdfDocument({
         year: 2026,
@@ -193,7 +224,115 @@ describe('waste-management output pdf', () => {
     expect(positions.every((value) => value !== null)).toBe(true);
     expect(new Set(positions).size).toBe(7);
     const yPositions = positions.map((value) => value?.split(':')[1]);
-    expect(new Set(yPositions).size).toBe(1);
-    expect(pdfText).toContain('1 0 0 1 42.00 85.28 Tm (F1) Tj ET');
+    expect(new Set(yPositions).size).toBe(7);
+    expect(pdfText).toContain('1 0 0 1 42.00 110.18 Tm (F1) Tj ET');
+    expect(pdfText).toContain('1 0 0 1 68.00 109.78 Tm (Fraktion 1) Tj ET');
+  });
+
+  it('reserves the first legend row for the shift explanation', () => {
+    const document = buildWasteCalendarPdfDocument({
+      year: 2026,
+      locationLabel: 'Bärensprung',
+      pickups: [
+        {
+          date: '2026-01-14',
+          fractions: Array.from({ length: 9 }, (_, index) => ({
+            id: `fraction-${index + 1}`,
+            label: `Fraktion ${index + 1}`,
+            color: '#666666',
+            ...(index === 0 ? { isShifted: true } : {}),
+          })),
+        },
+      ],
+    });
+
+    expect(document.pages[0]?.legend).toHaveLength(8);
+    expect(document.pages[0]?.legend.at(0)).toEqual({
+      kind: 'shift',
+      label: '= Ausweichtermin',
+    });
+  });
+
+  it('renders legend descriptions inline after their labels', () => {
+    const pdfText = renderWasteCalendarPdf(
+      buildWasteCalendarPdfDocument({
+        year: 2026,
+        locationLabel: 'Bärensprung',
+        pickups: [
+          {
+            date: '2026-01-14',
+            fractions: [
+              {
+                id: 'bio',
+                label: 'Biogut',
+                description: 'Bitte melden Sie die Abholung min. 2 Tage vor dem Termin an!',
+                shortLabel: 'BIO',
+                color: '#55AA33',
+              },
+            ],
+          },
+        ],
+        legendHints: [
+          {
+            id: 'tour-bio',
+            label: 'Tour: Bio.11.B.3',
+            description: 'Behälter am Straßenrand bereitstellen.',
+          },
+        ],
+      })
+    ).toString('latin1');
+
+    expect(pdfText).toContain(
+      '1 0 0 1 68.00 109.78 Tm (Biogut - Bitte melden Sie die Abholung min. 2 Tage vor dem Termin an!) Tj ET'
+    );
+    expect(pdfText).toContain(
+      '1 0 0 1 38.00 97.78 Tm (Tour: Bio.11.B.3 - Behälter am Straßenrand bereitstellen.) Tj ET'
+    );
+    expect(pdfText).not.toContain('1 0 0 1 238.00');
+  });
+
+  it('truncates long single-line legend descriptions with three dots', () => {
+    const longDescription = 'Dieser sehr lange Hinweis soll ausschließlich in einer einzigen Legendenzeile stehen und darf den rechten Seitenrand auf keinen Fall überschreiten, auch wenn noch viele weitere Wörter folgen. Deshalb enthält dieser Test bewusst zusätzlichen Text, der garantiert nicht mehr vollständig auf die Seite passt.';
+    const pdfText = renderWasteCalendarPdf(
+      buildWasteCalendarPdfDocument({
+        year: 2026,
+        locationLabel: 'Bärensprung',
+        pickups: [
+          {
+            date: '2026-01-14',
+            fractions: [
+              { id: 'bio', label: 'Biogut', description: longDescription, shortLabel: 'BIO', color: '#55AA33' },
+            ],
+          },
+        ],
+      })
+    ).toString('latin1');
+
+    expect(pdfText).not.toContain(`(${longDescription}) Tj ET`);
+    expect(pdfText).toMatch(/\(Biogut - Dieser sehr lange Hinweis[^)]*\.\.\.\) Tj ET/);
+  });
+
+  it('renders shifted pickup markers outside their colored boxes and explains them below the legend', () => {
+    const pdfText = renderWasteCalendarPdf(
+      buildWasteCalendarPdfDocument({
+        year: 2026,
+        locationLabel: 'Bärensprung',
+        pickups: [
+          {
+            date: '2026-01-14',
+            fractions: [
+              { id: 'hm', label: 'Hausmüll', shortLabel: 'HM', color: '#666666', isShifted: true },
+              { id: 'ppk', label: 'Papier', shortLabel: 'PPK', color: '#58BCE5' },
+            ],
+          },
+        ],
+      })
+    ).toString('latin1');
+
+    expect(pdfText).toContain('76.00 330.58 18.00 9.50 re f');
+    expect(pdfText).toContain('/F2 8.00 Tf 0.780 0.050 0.050 rg 1 0 0 1 96.00 331.48 Tm (*) Tj ET');
+    expect(pdfText).toContain('103.00 330.58 22.00 9.50 re f');
+    expect(pdfText).toContain('/F2 9.00 Tf 0.780 0.050 0.050 rg 1 0 0 1 38.00 109.28 Tm (*) Tj ET');
+    expect(pdfText).toContain('1 0 0 1 50.00 109.78 Tm (= Ausweichtermin) Tj ET');
   });
 });

--- a/packages/core/src/waste-management-output.test.ts
+++ b/packages/core/src/waste-management-output.test.ts
@@ -159,6 +159,7 @@ describe('waste-management output pdf', () => {
       buildWasteCalendarPdfDocument({
         year: 2026,
         locationLabel: 'Rathenow, Berliner Str. 12',
+        contactBlock: 'Abfallberatung\n03395 / 1234',
         pickups: [
           {
             date: '2026-01-14',
@@ -175,6 +176,7 @@ describe('waste-management output pdf', () => {
     expect(pdfText).toContain('/F1 10.50 Tf');
     expect(pdfText).toMatch(/1 0 0 1 38\.00 559\.28 Tm \(Abfallkalender 2026\) Tj ET/);
     expect(pdfText).toContain('(Tour: Nord - Hinweis zur Bereitstellung.) Tj ET');
+    expect(pdfText).toContain('1 0 0 1 38.00 527.78 Tm (Abfallberatung 03395 / 1234) Tj ET');
     expect(pdfText).not.toContain('Abfallkalender 2026 · Rathenow');
     expect(pdfText).not.toContain('Abfallberatung · Beispielkontakt');
   });

--- a/packages/core/src/waste-management-output.test.ts
+++ b/packages/core/src/waste-management-output.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildWasteCalendarPdfDocument, renderWasteCalendarPdf } from './waste-management-output.js';
+import {
+  buildWasteCalendarPdfDocument,
+  renderWasteCalendarPdf,
+} from './waste-management-output.js';
 
 describe('waste-management output pdf', () => {
   it('builds a two-page yearly document with mapped pickup entries', () => {
@@ -10,7 +13,9 @@ describe('waste-management output pdf', () => {
       pickups: [
         {
           date: '2026-01-14',
-          fractions: [{ id: 'hm', label: 'Hausmuell', shortLabel: 'HM', color: '#666666', isShifted: true }],
+          fractions: [
+            { id: 'hm', label: 'Hausmuell', shortLabel: 'HM', color: '#666666', isShifted: true },
+          ],
         },
         {
           date: '2026-01-15',
@@ -41,10 +46,14 @@ describe('waste-management output pdf', () => {
 
     const january = document.pages[0]?.months[0];
     const october = document.pages[1]?.months[3];
-    expect(january?.days.find((day) => day.dayOfMonth === 14)?.entries.map((entry) => entry.code)).toEqual(['HM']);
+    expect(
+      january?.days.find((day) => day.dayOfMonth === 14)?.entries.map((entry) => entry.code)
+    ).toEqual(['HM']);
     expect(january?.days.find((day) => day.dayOfMonth === 14)?.entries[0]?.isShifted).toBe(true);
     expect(january?.days.find((day) => day.dayOfMonth === 15)?.entries).toHaveLength(2);
-    expect(october?.days.find((day) => day.dayOfMonth === 3)?.holidayLabel).toBe('Tag der Deutschen Einheit');
+    expect(october?.days.find((day) => day.dayOfMonth === 3)?.holidayLabel).toBe(
+      'Tag der Deutschen Einheit'
+    );
     expect(document.pages[0]?.legend.map((entry) => entry.label)).toEqual([
       '= Ausweichtermin',
       'Bioabfall',
@@ -98,6 +107,33 @@ describe('waste-management output pdf', () => {
     expect(pdfText).toContain('/BaseFont /Helvetica /Encoding /WinAnsiEncoding');
     expect(pdfText).toContain('/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding');
     expect(pdfText).toContain('(Bärensprung) Tj');
+  });
+
+  it('encodes Windows ANSI punctuation in imported legend descriptions', () => {
+    const pdfText = renderWasteCalendarPdf(
+      buildWasteCalendarPdfDocument({
+        year: 2026,
+        locationLabel: 'Bärensprung',
+        pickups: [
+          {
+            date: '2026-01-14',
+            fractions: [
+              {
+                id: 'bio',
+                label: 'Biogut',
+                description: '09:00–11:00 Uhr „bereitstellen“…',
+                color: '#55AA33',
+              },
+            ],
+          },
+        ],
+      })
+    ).toString('latin1');
+    const winAnsiDescription = `09:00${String.fromCharCode(0x96)}11:00 Uhr ${String.fromCharCode(
+      0x84
+    )}bereitstellen${String.fromCharCode(0x93)}${String.fromCharCode(0x85)}`;
+
+    expect(pdfText).toContain(`Biogut - ${winAnsiDescription}`);
   });
 
   it('vertically centers day content inside calendar table cells', () => {
@@ -176,12 +212,7 @@ describe('waste-management output pdf', () => {
         brandingImage: {
           width: 2,
           height: 2,
-          rgbData: new Uint8Array([
-            255, 0, 0,
-            0, 255, 0,
-            0, 0, 255,
-            255, 255, 0,
-          ]),
+          rgbData: new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 0]),
         },
       })
     ).toString('latin1');
@@ -216,11 +247,15 @@ describe('waste-management output pdf', () => {
     ).toString('latin1');
 
     const extractLegendPosition = (label: string): string | null => {
-      const match = pdfText.match(new RegExp(`1 0 0 1 ([0-9.]+) ([0-9.]+) Tm \\(${label}\\) Tj ET`));
+      const match = pdfText.match(
+        new RegExp(`1 0 0 1 ([0-9.]+) ([0-9.]+) Tm \\(${label}\\) Tj ET`)
+      );
       return match ? `${match[1]}:${match[2]}` : null;
     };
 
-    const positions = Array.from({ length: 7 }, (_, index) => extractLegendPosition(`Fraktion ${index + 1}`));
+    const positions = Array.from({ length: 7 }, (_, index) =>
+      extractLegendPosition(`Fraktion ${index + 1}`)
+    );
     expect(positions.every((value) => value !== null)).toBe(true);
     expect(new Set(positions).size).toBe(7);
     const yPositions = positions.map((value) => value?.split(':')[1]);
@@ -292,7 +327,8 @@ describe('waste-management output pdf', () => {
   });
 
   it('truncates long single-line legend descriptions with three dots', () => {
-    const longDescription = 'Dieser sehr lange Hinweis soll ausschließlich in einer einzigen Legendenzeile stehen und darf den rechten Seitenrand auf keinen Fall überschreiten, auch wenn noch viele weitere Wörter folgen. Deshalb enthält dieser Test bewusst zusätzlichen Text, der garantiert nicht mehr vollständig auf die Seite passt.';
+    const longDescription =
+      'Dieser sehr lange Hinweis soll ausschließlich in einer einzigen Legendenzeile stehen und darf den rechten Seitenrand auf keinen Fall überschreiten, auch wenn noch viele weitere Wörter folgen. Deshalb enthält dieser Test bewusst zusätzlichen Text, der garantiert nicht mehr vollständig auf die Seite passt.';
     const pdfText = renderWasteCalendarPdf(
       buildWasteCalendarPdfDocument({
         year: 2026,
@@ -301,7 +337,13 @@ describe('waste-management output pdf', () => {
           {
             date: '2026-01-14',
             fractions: [
-              { id: 'bio', label: 'Biogut', description: longDescription, shortLabel: 'BIO', color: '#55AA33' },
+              {
+                id: 'bio',
+                label: 'Biogut',
+                description: longDescription,
+                shortLabel: 'BIO',
+                color: '#55AA33',
+              },
             ],
           },
         ],

--- a/packages/core/src/waste-management-output.test.ts
+++ b/packages/core/src/waste-management-output.test.ts
@@ -290,6 +290,33 @@ describe('waste-management output pdf', () => {
     });
   });
 
+  it('reserves a legend row for contextual hints when fractions fill the row limit', () => {
+    const document = buildWasteCalendarPdfDocument({
+      year: 2026,
+      locationLabel: 'Bärensprung',
+      pickups: [
+        {
+          date: '2026-01-14',
+          fractions: Array.from({ length: 8 }, (_, index) => ({
+            id: `fraction-${index + 1}`,
+            label: `Fraktion ${index + 1}`,
+            color: '#666666',
+          })),
+        },
+      ],
+      legendHints: [
+        { id: 'tour:nord', label: 'Tour: Nord', description: 'Am Fahrbahnrand bereitstellen.' },
+        { id: 'pickup:14', label: '14.01.', description: 'Zufahrt freihalten.' },
+      ],
+    });
+
+    expect(document.pages[0]?.legend).toHaveLength(8);
+    expect(document.pages[0]?.legend.at(-1)).toMatchObject({
+      kind: 'hint',
+      label: 'Tour: Nord',
+    });
+  });
+
   it('renders legend descriptions inline after their labels', () => {
     const pdfText = renderWasteCalendarPdf(
       buildWasteCalendarPdfDocument({

--- a/packages/core/src/waste-management-output.types.ts
+++ b/packages/core/src/waste-management-output.types.ts
@@ -72,6 +72,7 @@ type WasteCalendarPdfLegendEntry =
 type WasteCalendarPdfPage = Readonly<{
   title: string;
   locationLabel: string;
+  contactBlock?: string;
   brandingPlaceholderLabel: string;
   brandingImage?: WasteCalendarPdfBrandingImage;
   months: readonly WasteCalendarPdfMonth[];

--- a/packages/core/src/waste-management-output.types.ts
+++ b/packages/core/src/waste-management-output.types.ts
@@ -1,13 +1,21 @@
 export type WasteOutputFraction = Readonly<{
   id: string;
   label: string;
+  description?: string;
   shortLabel?: string;
   color: string;
+  isShifted?: boolean;
 }>;
 
 export type WasteOutputPickupEntry = Readonly<{
   date: string;
   fractions: readonly WasteOutputFraction[];
+}>;
+
+export type WasteOutputLegendHint = Readonly<{
+  id: string;
+  label: string;
+  description: string;
 }>;
 
 export type WasteCalendarPdfBrandingImage = Readonly<{
@@ -19,6 +27,7 @@ export type WasteCalendarPdfBrandingImage = Readonly<{
 type WasteCalendarPdfEntry = Readonly<{
   code: string;
   fillColor: readonly [red: number, green: number, blue: number];
+  isShifted: boolean;
 }>;
 
 type WasteCalendarPdfDay = Readonly<{
@@ -36,11 +45,29 @@ type WasteCalendarPdfMonth = Readonly<{
   days: readonly WasteCalendarPdfDay[];
 }>;
 
-type WasteCalendarPdfLegendEntry = Readonly<{
+type WasteCalendarPdfFractionLegendEntry = Readonly<{
+  kind: 'fraction';
   code: string;
   label: string;
+  description?: string;
   fillColor: readonly [red: number, green: number, blue: number];
 }>;
+
+type WasteCalendarPdfHintLegendEntry = Readonly<{
+  kind: 'hint';
+  label: string;
+  description: string;
+}>;
+
+type WasteCalendarPdfShiftLegendEntry = Readonly<{
+  kind: 'shift';
+  label: string;
+}>;
+
+type WasteCalendarPdfLegendEntry =
+  | WasteCalendarPdfFractionLegendEntry
+  | WasteCalendarPdfHintLegendEntry
+  | WasteCalendarPdfShiftLegendEntry;
 
 type WasteCalendarPdfPage = Readonly<{
   title: string;
@@ -49,8 +76,6 @@ type WasteCalendarPdfPage = Readonly<{
   brandingImage?: WasteCalendarPdfBrandingImage;
   months: readonly WasteCalendarPdfMonth[];
   legend: readonly WasteCalendarPdfLegendEntry[];
-  notes: readonly string[];
-  footerLine: string;
 }>;
 
 export type WasteCalendarPdfDocument = Readonly<{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
         specifier: ^0.35.2
         version: 0.35.2
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.62.1)
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1


### PR DESCRIPTION
## Zusammenfassung

- vereinfacht das eingebettete Layout des öffentlichen Abfallkalenders und trennt Standort, Fraktionsfilter und Exportaktionen klarer
- modelliert Kalenderexport, PDF/Druck und E-Mail-Erinnerung als zugängliche Disclosure-Aktionen; Listen-, Monats- und Jahresansicht bleiben Tabs
- zeigt bei der Standortsuche bereits vor der Eingabe verfügbare Optionen und filtert sie anschließend
- kennzeichnet verschobene Abholtermine im PDF mit einem roten, fetten Asterisk außerhalb der Fraktionsbox
- baut die PDF-Legende vertikal mit höchstens acht Zeilen auf, stellt den Ausweichtermin-Hinweis zuerst dar und ergänzt vorhandene Fraktions-, Tour- und Terminhinweise im Format `Label - Hinweis`
- verdichtet den PDF-Kopf, entfernt die redundante Fußzeile und kürzt überlange Legendentexte einzeilig mit `...`

## Hintergrund

Das bisherige eingebettete Layout wirkte durch verschachtelte Karten und als Tabs modellierte Aktionen wie eine eigenständige Anwendung im iFrame. In der PDF-Ausgabe waren Ausweichtermine nicht erkennbar; außerdem bot die waagerechte Legende keinen verlässlichen Platz für vorhandene Hinweise und zeigte bei Umlauten beziehungsweise Legendeninhalten Layoutprobleme.

## Auswirkungen

Nutzerinnen und Nutzer erhalten eine flachere, besser integrierbare Kalenderansicht und eine kompakte, verständlichere PDF-Ausgabe. Es werden ausschließlich bereits vorhandene Hinweise zu Fraktionen, Touren und einzelnen Terminen verwendet; für Abholorte wird kein neues Hinweisfeld eingeführt.

## Validierung

- `pnpm nx run public-waste-calendar-web:test` (24 Dateien, 113 Tests)
- `pnpm nx run public-waste-calendar-web:test:types`
- `pnpm nx run public-waste-calendar-web:lint`
- `pnpm nx run public-waste-calendar-web:build`
- `pnpm nx run public-waste-calendar-web:test:e2e` (1 Playwright-Test)
- `pnpm nx run core:test:unit --testFiles=src/waste-management-output.test.ts` (12 Tests)
- `pnpm nx run core:check:runtime`
- strikte OpenSpec-Validierung aller drei Änderungen
- `pnpm check:file-placement`
- visuelle Prüfung des gerenderten Bärensprung-PDFs

Der erste lokale Build- und E2E-Aufruf scheiterte beim Start an `public_waste_config_invalid` aus einer lokalen, nicht versionierten Konfiguration. Beide Gates liefen anschließend mit der validierten lokalen Mandantenkonfiguration erfolgreich durch.
