### PR TITLE
Featured Projects im History-Change ergänzen

### DIFF
--- a/docs/changelog/entries/pr-944.json
+++ b/docs/changelog/entries/pr-944.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 944,
+  "body": "Inhaltshistorie für Projekte vollständig dokumentiert\n\n- Die Spezifikation führt Projekte nun ausdrücklich als historienpflichtige Inhalte.\n- Projekte verwenden dieselbe externe Inhaltsreferenz und Mutationszuordnung wie die übrigen Mainserver-Inhalte.\n- Eine parallele Historienidentität oder ein zweites Mutationsjournal ist ausgeschlossen."
+}

--- a/openspec/changes/standardize-plugin-content-history/design.md
+++ b/openspec/changes/standardize-plugin-content-history/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-Die lokale IAM-Content-Persistenz schreibt bereits unveränderliche Historieneinträge mit Actor, Aktion, Änderungsfeldern, Statusübergang, Zusammenfassung und Snapshot. FAQ, Cockpit Cards, News und Surveys besitzen bereits unterschiedlich ausgeprägte Historienansichten; Events, POI und Generic Items enthalten derzeit Platzhalter. News, Events und POI werden im Mainserver gespeichert, dessen vollständige externe Änderungshistorie nicht Teil des Studio-Vertrags ist. Waste Management besitzt eine eigene fachliche und technische Historie.
+Die lokale IAM-Content-Persistenz schreibt bereits unveränderliche Historieneinträge mit Actor, Aktion, Änderungsfeldern, Statusübergang, Zusammenfassung und Snapshot. FAQ, Cockpit Cards, News und Surveys besitzen bereits unterschiedlich ausgeprägte Historienansichten; Events, POI und Generic Items enthalten derzeit Platzhalter. Featured Projects werden bewusst vorher ohne Historien-Tab ausgeliefert. Ihr Change führt bereits die allgemeine External-Content-Referenz, stabile `externalId`, bestehende Idempotenz und Reconciliation für Mainserver-Inhalte ein. News, Events und POI werden ebenfalls im Mainserver gespeichert, dessen vollständige externe Änderungshistorie nicht Teil des Studio-Vertrags ist. Waste Management besitzt eine eigene fachliche und technische Historie.
 
 Der Change betrifft mehrere Plugins, Host-Runtime, IAM, Plugin-SDK und UI und benötigt deshalb einen gemeinsamen Architekturvertrag statt weiterer pluginlokaler Sonderlösungen.
 
@@ -32,6 +32,12 @@ Alternativen:
 
 - Pluginlokale Clients und Tabellen fortführen: verworfen, weil sie Rechte-, Fehler- und UX-Drift begünstigen.
 - Eine zweite generische History-Datenbank einführen: verworfen, weil `iam.content_history` und der host-owned Auditpfad bereits die passende Grundlage bilden.
+
+### Decision: Bestehende External-Content-Identität wird wiederverwendet
+
+Der Change `add-featured-projects-plugin` ist die technische Vorleistung für externe Content-Identität und Provider-Reconciliation. Dieser History-Change verwendet dieselbe Zuordnung von `iam.contents` zu Mainserver-Entitäten, dieselbe stabile Operations-/`externalId` und denselben Idempotenz- und Reconciliation-Vertrag. Er führt weder eine zweite externe Referenztabelle noch ein paralleles plugin- oder historylokales Mutation-Journal ein.
+
+Die External-Content-Referenz identifiziert den lokalen History-Subject. Der History-Change ergänzt ausschließlich die korrelierbare Erfolgsfinalisierung, History-Read-Verträge und Darstellung. Lifecycle-, Autoren- und fachliche Reconciliation-Regeln bleiben bei Content-Core und jeweiligem Fachadapter.
 
 ### Decision: Mainserver-Historie bedeutet Studio-Mutationshistorie
 
@@ -65,6 +71,7 @@ Die History ist schreibgeschützt. Speichern-Aktionen des Editors erscheinen nic
 - `plugin-news`, `plugin-events` und `plugin-poi`: Studio-Mutationen gegen den Mainserver korrelierbar erfassen; Herkunft und begrenzte Abdeckung anzeigen.
 - `plugin-generic-items`, `plugin-faq` und `plugin-cockpit-cards`: auf den gemeinsamen IAM-History-Client und dieselben Zustände vereinheitlichen.
 - `plugin-surveys`: bestehende History-Anbindung gegen den gemeinsamen Vertrag prüfen und vereinheitlichen.
+- `plugin-projects`: die bereits vorhandene External-Content-Referenz konsumieren, History-Capability und `content.readHistory` registrieren und den nachgelagerten Tab `Historie` ergänzen; keine neue Identitäts- oder Mutationspersistenz.
 - `plugin-waste-management`: fachliche und technische History gegen Rechte-, Scope-, Herkunfts- und UX-Invarianten prüfen; keine erzwungene Umstellung auf `iam.content_history`, wenn der fachliche Vertrag dies nicht trägt.
 - `plugin-categories`, `plugin-sdk` und weitere Beiträge ohne eigene redaktionelle Mutation: explizit als nicht historienpflichtig klassifizieren.
 
@@ -86,10 +93,10 @@ Die Implementierung muss vor Änderungen die tatsächlichen aktiven Contribution
 
 ## Migration Plan
 
-1. Aktive Plugin-Contributions und ihre Mutations-/History-Pfade inventarisieren.
-2. Gemeinsamen Contract, Client, Normalisierung und Registry-Validierung ergänzen.
+1. Aktive Plugin-Contributions und ihre Mutations-/History-Pfade einschließlich Featured Projects inventarisieren und die Vorleistung aus `add-featured-projects-plugin` verifizieren.
+2. Gemeinsamen Contract, Client, Normalisierung und Registry-Validierung auf der vorhandenen External-Content-Referenz ergänzen.
 3. Lokale IAM-Plugins auf den gemeinsamen Pfad migrieren.
-4. Mainserver-Plugins an die Studio-Mutationshistorie anbinden.
+4. Mainserver-Plugins einschließlich Featured Projects an die Studio-Mutationshistorie anbinden.
 5. Waste und nicht historienpflichtige Plugins explizit klassifizieren.
 6. Plugin-Scaffolding, Dokumentation und blockierende Contract-Tests aktualisieren.
 7. Bestehende Daten bleiben unverändert; neue Mainserver-Historie beginnt mit den nach Deployment über das Studio ausgeführten Mutationen.

--- a/openspec/changes/standardize-plugin-content-history/design.md
+++ b/openspec/changes/standardize-plugin-content-history/design.md
@@ -37,7 +37,7 @@ Alternativen:
 
 Der Change `add-featured-projects-plugin` ist die technische Vorleistung für externe Content-Identität und Provider-Reconciliation. Dieser History-Change verwendet dieselbe Zuordnung von `iam.contents` zu Mainserver-Entitäten, dieselbe stabile Operations-/`externalId` und denselben Idempotenz- und Reconciliation-Vertrag. Er führt weder eine zweite externe Referenztabelle noch ein paralleles plugin- oder historylokales Mutation-Journal ein.
 
-Die External-Content-Referenz identifiziert den lokalen History-Subject. Der History-Change ergänzt ausschließlich die korrelierbare Erfolgsfinalisierung, History-Read-Verträge und Darstellung. Lifecycle-, Autoren- und fachliche Reconciliation-Regeln bleiben bei Content-Core und jeweiligem Fachadapter.
+Die External-Content-Referenz ordnet den lokalen Historiengegenstand eindeutig zu. Der History-Change ergänzt ausschließlich die korrelierbare Erfolgsfinalisierung, History-Read-Verträge und Darstellung. Lifecycle-, Autoren- und fachliche Reconciliation-Regeln bleiben bei Content-Core und jeweiligem Fachadapter.
 
 ### Decision: Mainserver-Historie bedeutet Studio-Mutationshistorie
 

--- a/openspec/changes/standardize-plugin-content-history/proposal.md
+++ b/openspec/changes/standardize-plugin-content-history/proposal.md
@@ -7,16 +7,17 @@ Das Studio besitzt bereits eine hostseitige Inhaltshistorie und die Berechtigung
 ## What Changes
 
 - Alle vorhandenen Plugins mit redaktionell veränderbaren Datensätzen werden inventarisiert und an einen gemeinsamen hostseitigen Historienvertrag angebunden.
-- Die Content-Plugins für News, Events, POI, Generic Items, FAQ, Cockpit Cards und Surveys erhalten eine funktionsfähige, einheitliche Historienansicht; bestehende Platzhalter werden entfernt.
+- Die Content-Plugins für Featured Projects, News, Events, POI, Generic Items, FAQ, Cockpit Cards und Surveys erhalten eine funktionsfähige, einheitliche Historienansicht; bestehende Platzhalter werden entfernt und Featured Projects erhalten erstmals den bewusst nachgelagerten Historien-Tab.
 - Bei Mainserver-basierten Inhalten erfasst die Historie ausschließlich Mutationen, die über das Studio ausgelöst wurden. Änderungen außerhalb des Studios werden weder synthetisch ergänzt noch als vollständig erfasst dargestellt.
 - Die Waste-Management-Historie bleibt fachlich eigenständig, erfüllt aber dieselben verbindlichen Anforderungen an Autorisierung, Mandantenisolation, Herkunft, Zustände und barrierefreie Darstellung.
 - Plugins ohne eigene veränderbare redaktionelle Datensätze, insbesondere reine Infrastruktur-, SDK- oder Auswahlbeiträge, werden explizit als nicht historienpflichtig klassifiziert statt mit einer leeren Schein-Historie versehen.
 - Der Plugin-Vertrag und blockierende Validierungen verankern die Historienfähigkeit für zukünftige Plugins. Eine Ausnahme ist nur als deklarative, begründete und hostvalidierte Klassifikation zulässig.
+- Die durch `add-featured-projects-plugin` eingeführte allgemeine External-Content-Referenz, stabile `externalId`, bestehende Idempotenz und Reconciliation werden als verbindliche Vorleistung wiederverwendet und nicht durch eine zweite History-Identität oder ein paralleles Journal ersetzt.
 - Snapshot-Vergleich, Feld-Diff und Wiederherstellung früherer Versionen bleiben außerhalb dieses Changes.
 
 ## Impact
 
 - Affected specs: `content-management`, `iam-auditing`, `iam-access-control`, `plugin-platform`, `architecture-documentation`
 - Affected code: `packages/plugin-*`, `packages/plugin-sdk`, Host-Registry und deren Validierungen, `packages/auth-runtime`, gemeinsame Content-History-Clients und Studio-UI-Primitiven
-- Affected data: bestehende `iam.content_history`; gegebenenfalls hostseitige Referenzabbildung für Mainserver-Inhalte, jedoch keine Historienübernahme aus dem Mainserver
+- Affected data: bestehende `iam.content_history` und die aus `add-featured-projects-plugin` übernommene External-Content-Referenz; keine zweite Referenzabbildung und keine Historienübernahme aus dem Mainserver
 - Affected arc42 sections: `05-building-block-view`, `06-runtime-view`, `08-cross-cutting-concepts`

--- a/openspec/changes/standardize-plugin-content-history/specs/content-management/spec.md
+++ b/openspec/changes/standardize-plugin-content-history/specs/content-management/spec.md
@@ -39,6 +39,13 @@ Das System MUST für Mainserver-basierte Inhalte eine Studio-Mutationshistorie f
 - **DANN** erzeugt das Studio keinen synthetischen Historieneintrag
 - **UND** die Historienansicht behauptet keine vollständige Erfassung externer Änderungen
 
+#### Scenario: Featured Project erhält die nachgelagerte Historie
+
+- **GIVEN** ein Featured Project besitzt bereits die allgemeine External-Content-Referenz aus `add-featured-projects-plugin`
+- **WHEN** der History-Change das Projekte-Plugin anbindet
+- **THEN** verwendet der Host dieselbe lokale Content-ID und externe Referenz als History-Subject
+- **AND** ergänzt das Plugin den gemeinsamen Historien-Tab ohne zweite Identitäts- oder Mutation-Persistenz
+
 ### Requirement: Plugin-Historien verwenden ein gemeinsames Darstellungsmodell
 
 Das System SHALL Plugin-Historien mit einem gemeinsamen, lokalisierten und barrierefreien Darstellungsmodell ausgeben. Die Historienansicht MUST schreibgeschützt sein und MUST Herkunft sowie Abdeckungsgrenze erkennbar machen, wenn die führende Datenquelle außerhalb des Studios liegt.

--- a/openspec/changes/standardize-plugin-content-history/specs/content-management/spec.md
+++ b/openspec/changes/standardize-plugin-content-history/specs/content-management/spec.md
@@ -43,7 +43,7 @@ Das System MUST für Mainserver-basierte Inhalte eine Studio-Mutationshistorie f
 
 - **WENN** ein Featured Project bereits die allgemeine External-Content-Referenz aus `add-featured-projects-plugin` besitzt
 - **UND** der History-Change das Projekte-Plugin anbindet
-- **DANN** verwendet der Host dieselbe lokale Content-ID und externe Referenz als History-Subject
+- **DANN** verwendet der Host dieselbe lokale Content-ID und externe Referenz für die Historie
 - **UND** ergänzt das Plugin den gemeinsamen Historien-Tab ohne zweite Identitäts- oder Mutation-Persistenz
 
 ### Requirement: Plugin-Historien verwenden ein gemeinsames Darstellungsmodell

--- a/openspec/changes/standardize-plugin-content-history/specs/content-management/spec.md
+++ b/openspec/changes/standardize-plugin-content-history/specs/content-management/spec.md
@@ -41,10 +41,10 @@ Das System MUST für Mainserver-basierte Inhalte eine Studio-Mutationshistorie f
 
 #### Scenario: Featured Project erhält die nachgelagerte Historie
 
-- **GIVEN** ein Featured Project besitzt bereits die allgemeine External-Content-Referenz aus `add-featured-projects-plugin`
-- **WHEN** der History-Change das Projekte-Plugin anbindet
-- **THEN** verwendet der Host dieselbe lokale Content-ID und externe Referenz als History-Subject
-- **AND** ergänzt das Plugin den gemeinsamen Historien-Tab ohne zweite Identitäts- oder Mutation-Persistenz
+- **WENN** ein Featured Project bereits die allgemeine External-Content-Referenz aus `add-featured-projects-plugin` besitzt
+- **UND** der History-Change das Projekte-Plugin anbindet
+- **DANN** verwendet der Host dieselbe lokale Content-ID und externe Referenz als History-Subject
+- **UND** ergänzt das Plugin den gemeinsamen Historien-Tab ohne zweite Identitäts- oder Mutation-Persistenz
 
 ### Requirement: Plugin-Historien verwenden ein gemeinsames Darstellungsmodell
 

--- a/openspec/changes/standardize-plugin-content-history/specs/iam-auditing/spec.md
+++ b/openspec/changes/standardize-plugin-content-history/specs/iam-auditing/spec.md
@@ -20,6 +20,8 @@ Das System SHALL Historieneinträge für Plugin-Content-Mutationen ausschließli
 
 Das System MUST erfolgreiche sichtbare History-Einträge für Mainserver-Inhalte von abgelehnten und fehlgeschlagenen Versuchen trennen. Jeder Eintrag MUST als Studio-seitig identifizierbar sein und darf keine externe Vollständigkeit suggerieren.
 
+Für Mainserver-Inhalte MUST der Host die bereits etablierte External-Content-Referenz und stabile Operationskorrelation wiederverwenden. Eine History-Implementierung darf weder eine zweite externe Identität noch ein paralleles Mutation-Journal anlegen.
+
 #### Scenario: Provider-Erfolg wird historisiert
 
 - **WENN** der Mainserver den fachlichen Erfolg einer über das Studio ausgelösten Mutation bestätigt

--- a/openspec/changes/standardize-plugin-content-history/tasks.md
+++ b/openspec/changes/standardize-plugin-content-history/tasks.md
@@ -5,7 +5,7 @@
 - [x] 1.3 Den gemeinsamen History-Read-Client und normalisierte Fehlerverträge im passenden Host-/SDK-Boundary bereitstellen.
 - [x] 1.4 Die Plugin-Registry um eine fail-closed History-Capability-Validierung mit stabilen Diagnosecodes erweitern.
 - [x] 1.5 Contract-Tests für gültige Contributions, fehlendes History-Binding und zulässige Nicht-History-Klassifikationen ergänzen.
-- [x] 1.6 Die von `add-featured-projects-plugin` bereitgestellte External-Content-Referenz, stabile `externalId`, Idempotenz und Reconciliation als verbindliche Identitätsgrundlage prüfen und jede zweite Referenz- oder Journal-Persistenz ausschließen.
+- [x] 1.6 Die von `add-featured-projects-plugin` bereitgestellte External-Content-Referenz, stabile `externalId`, Idempotenz und Reconciliation als verbindliche Identitätsgrundlage prüfen und jede zusätzliche Referenz- oder Journal-Persistenz ausschließen.
 
 ## 2. Host-Runtime und Autorisierung
 

--- a/openspec/changes/standardize-plugin-content-history/tasks.md
+++ b/openspec/changes/standardize-plugin-content-history/tasks.md
@@ -5,12 +5,13 @@
 - [x] 1.3 Den gemeinsamen History-Read-Client und normalisierte Fehlerverträge im passenden Host-/SDK-Boundary bereitstellen.
 - [x] 1.4 Die Plugin-Registry um eine fail-closed History-Capability-Validierung mit stabilen Diagnosecodes erweitern.
 - [x] 1.5 Contract-Tests für gültige Contributions, fehlendes History-Binding und zulässige Nicht-History-Klassifikationen ergänzen.
+- [x] 1.6 Die von `add-featured-projects-plugin` bereitgestellte External-Content-Referenz, stabile `externalId`, Idempotenz und Reconciliation als verbindliche Identitätsgrundlage prüfen und jede zweite Referenz- oder Journal-Persistenz ausschließen.
 
 ## 2. Host-Runtime und Autorisierung
 
 - [x] 2.1 History-Lesezugriffe einheitlich über `content.readHistory`, Instance-Scope und Ownership-Scope autorisieren.
 - [x] 2.2 Lokale IAM-History-Einträge über den gemeinsamen Contract ausgeben, ohne `snapshot_json` offenzulegen.
-- [x] 2.3 Für Mainserver-Mutationen korrelierbare, idempotent finalisierbare Studio-History-Einträge erzeugen.
+- [x] 2.3 Für Mainserver-Mutationen auf Basis der vorhandenen External-Content-Referenz und Operationskorrelation idempotent finalisierbare Studio-History-Einträge erzeugen.
 - [x] 2.4 Erfolg, Providerfehler, Autorisierungsablehnung und Wiederholung so testen, dass nur erfolgreiche fachliche Änderungen in der sichtbaren Historie erscheinen.
 - [x] 2.5 Actor-Fallback, PII-Redaktion, Tenant-Isolation und gelöschte Accounts in Integrations- und Negativtests abdecken.
 
@@ -22,6 +23,7 @@
 - [x] 3.4 `plugin-surveys` gegen den gemeinsamen Vertrag migrieren und bestehende History-Tests angleichen.
 - [x] 3.5 `plugin-waste-management` gegen die gemeinsamen Rechte-, Scope-, Herkunfts-, Fehler- und Accessibility-Invarianten härten.
 - [x] 3.6 `plugin-categories`, `plugin-sdk` und alle weiteren nicht historienpflichtigen Contributions explizit klassifizieren und diese Entscheidung testen.
+- [x] 3.7 `plugin-projects` als historienpflichtig registrieren, `content.readHistory` und den gemeinsamen Client anbinden sowie den Tab `Historie` mit Herkunfts- und Abdeckungshinweis ergänzen.
 
 ## 4. Gemeinsame UI und Qualität
 


### PR DESCRIPTION
## Was wurde geändert?

- Featured Projects als historienpflichtiges Mainserver-Plugin im bestehenden OpenSpec-Change ergänzt.
- Die vorhandene External-Content-Referenz und Operationskorrelation ausdrücklich als gemeinsame Identitätsgrundlage festgeschrieben.
- Eine zweite History-Identität oder ein paralleles Mutation-Journal ausgeschlossen.
- Die bereits umgesetzten Projects- und History-Aufgaben im vollständigen Taskstand dokumentiert.

## Warum?

Die Projects-Implementierung und die standardisierte Inhaltshistorie sind bereits über die PRs #906 und #918 integriert. Der aktive OpenSpec-Change beschrieb diese Verbindung bislang jedoch nicht vollständig.

## Auswirkung

Keine Runtime-Änderung. Der Change gleicht Proposal, Design, Delta-Spezifikationen und Taskliste mit der bereits implementierten Architektur ab.

## Validierung

- `pnpm exec openspec validate standardize-plugin-content-history --strict`
- `pnpm check:file-placement`
- `git diff --check`
