### PR TITLE
feat: Kachel-Editor-Vertrag vervollständigen

### DIFF
--- a/apps/sva-studio-react/e2e/cockpit-cards.spec.ts
+++ b/apps/sva-studio-react/e2e/cockpit-cards.spec.ts
@@ -1,0 +1,212 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+import {
+  gotoHomeAsAuthenticatedUser,
+  mockSharedShellRequests,
+  navigateClientSide,
+} from './news-plugin.fixtures';
+
+const cockpitCardsUser = {
+  user: {
+    id: 'kc-editor-1',
+    name: 'Editor One',
+    email: 'editor@example.com',
+    instanceId: 'de-musterhausen',
+    assignedModules: ['cockpit-cards'],
+    roles: ['editor'],
+    permissionActions: [
+      'cockpit-cards.read',
+      'cockpit-cards.create',
+      'cockpit-cards.update',
+      'cockpit-cards.delete',
+    ],
+  },
+};
+
+const cockpitCardsPermissions = {
+  instanceId: 'de-musterhausen',
+  permissions: ['read', 'create', 'update', 'delete'].map((action) => ({
+    action: `cockpit-cards.${action}`,
+    resourceType: 'cockpit-cards',
+  })),
+  subject: { actorUserId: 'kc-editor-1', effectiveUserId: 'kc-editor-1', isImpersonating: false },
+  evaluatedAt: '2026-08-09T12:00:00.000Z',
+};
+
+test('creates, updates and deletes a Kachel while preserving its server identity', async ({
+  page,
+}) => {
+  await mockSharedShellRequests(page);
+  let card: Record<string, unknown> | undefined;
+  let createdBody: Record<string, unknown> | undefined;
+  let updatedBody: Record<string, unknown> | undefined;
+  let deleted = false;
+
+  await page.route('**/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(cockpitCardsUser),
+    })
+  );
+  await page.route('**/iam/me/permissions?**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(cockpitCardsPermissions),
+    })
+  );
+  await page.route('**/api/v1/mainserver/categories', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [{ id: 'category-1', name: 'Service' }] }),
+    })
+  );
+  await page.route('**/api/v1/iam/media**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [] }),
+    })
+  );
+  await page.route('**/api/v1/iam/contents**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [],
+        pagination: { page: 1, pageSize: 25, total: 0, hasNextPage: false },
+      }),
+    })
+  );
+  await page.route('**/api/v1/mainserver/cockpit-cards**', async (route) => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const isDetail = pathname.endsWith('/card-1');
+
+    if (request.method() === 'POST') {
+      createdBody = request.postDataJSON() as Record<string, unknown>;
+      card = {
+        ...createdBody,
+        id: 'card-1',
+        externalId: 'mainserver-card-4711',
+        payload: { ...(createdBody.payload as object), importedBy: 'fixture' },
+        createdAt: '2026-08-09T12:00:00.000Z',
+        updatedAt: '2026-08-09T12:00:00.000Z',
+      };
+      return route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: card }),
+      });
+    }
+    if (isDetail && request.method() === 'GET') {
+      return route.fulfill({
+        status: card && !deleted ? 200 : 404,
+        contentType: 'application/json',
+        headers: card && !deleted ? { 'X-SVA-Context-Binding': 'v1.loaded-context' } : undefined,
+        body: JSON.stringify(card && !deleted ? { data: card } : { error: 'not_found' }),
+      });
+    }
+    if (isDetail && request.method() === 'PATCH') {
+      updatedBody = request.postDataJSON() as Record<string, unknown>;
+      card = {
+        ...card,
+        ...updatedBody,
+        updatedAt: '2026-08-09T12:30:00.000Z',
+      };
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: card }),
+      });
+    }
+    if (isDetail && request.method() === 'DELETE') {
+      deleted = true;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { id: 'card-1' } }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: card && !deleted ? [card] : [],
+        pagination: { page: 1, pageSize: 25, total: card && !deleted ? 1 : 0, hasNextPage: false },
+      }),
+    });
+  });
+
+  await gotoHomeAsAuthenticatedUser(page);
+  await navigateClientSide(page, '/admin/cockpit-cards/new');
+  await expect(page.getByRole('heading', { name: 'Kachel anlegen' })).toBeVisible();
+  const accessibility = await new AxeBuilder({ page }).include('#main-content').analyze();
+  expect(
+    accessibility.violations.filter((entry) => ['serious', 'critical'].includes(entry.impact ?? ''))
+  ).toEqual([]);
+  await page.locator('#cockpit-card-heading').fill('Bürgerbüro');
+  await page.locator('#cockpit-card-category').selectOption('Service');
+  await page.getByRole('tab', { name: 'Inhalt' }).click();
+  await page.getByRole('button', { name: 'Bild-URL hinzufügen' }).click();
+  await page.getByRole('button', { name: 'Bild-URL hinzufügen' }).click();
+  await page.getByLabel('Bild-URL').nth(0).fill('https://example.test/buergerbuero-aussen.jpg');
+  await page.getByLabel('Alternativtext').nth(0).fill('Eingang des Bürgerbüros');
+  await page.getByLabel('Bild-URL').nth(1).fill('https://example.test/buergerbuero-innen.jpg');
+  await page.getByLabel('Alternativtext').nth(1).fill('Wartebereich des Bürgerbüros');
+  await page.getByRole('tab', { name: 'Einstellungen' }).click();
+  await page.locator('#cockpit-card-link').fill('https://example.test/buergerbuero');
+  await page.locator('#cockpit-card-link-text').fill('Zum Bürgerbüro');
+  await page.locator('#cockpit-card-open-new-tab').check();
+  await page.getByRole('button', { name: 'Kachel anlegen' }).last().click();
+
+  await expect.poll(() => createdBody).toBeDefined();
+  expect(createdBody).not.toHaveProperty('externalId');
+  expect(createdBody).toMatchObject({
+    title: 'Bürgerbüro',
+    genericType: 'COCKPIT_CARD',
+    contentBlocks: [],
+    mediaContents: [
+      {
+        sourceUrl: {
+          url: 'https://example.test/buergerbuero-aussen.jpg',
+          description: 'Eingang des Bürgerbüros',
+        },
+        contentType: 'image',
+      },
+      {
+        sourceUrl: {
+          url: 'https://example.test/buergerbuero-innen.jpg',
+          description: 'Wartebereich des Bürgerbüros',
+        },
+        contentType: 'image',
+      },
+    ],
+    webUrls: [{ url: 'https://example.test/buergerbuero', description: 'Zum Bürgerbüro' }],
+    payload: { languageCode: 'de', sortWeight: 0, openInNewTab: true },
+  });
+
+  await expect(page).toHaveURL(/\/admin\/cockpit-cards\/card-1$/);
+  await expect(page.locator('#cockpit-card-heading')).toHaveValue('Bürgerbüro');
+  await page.locator('#cockpit-card-heading').fill('Bürgerbüro aktualisiert');
+  await page.getByRole('button', { name: 'Kachel speichern' }).last().click();
+
+  await expect.poll(() => updatedBody).toBeDefined();
+  expect(updatedBody).toMatchObject({
+    title: 'Bürgerbüro aktualisiert',
+    externalId: 'mainserver-card-4711',
+    payload: {
+      languageCode: 'de',
+      sortWeight: 0,
+      openInNewTab: true,
+      importedBy: 'fixture',
+    },
+  });
+
+  await page.getByRole('button', { name: 'Kachel löschen' }).click();
+  await page.getByRole('alertdialog').getByRole('button', { name: 'Kachel löschen' }).click();
+  await expect.poll(() => deleted).toBe(true);
+});

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -105,9 +105,9 @@ Abhängigkeiten des aktuellen Systems.
 11b. Plugin Cockpit Cards (`packages/plugin-cockpit-cards`)
 
 - eigenständiges Standard-Content-Plugin mit `cockpit-cards.cockpit-card` und festem GenericItem-Discriminator `COCKPIT_CARD`
-- begrenzt die Bearbeitung auf Überschrift, Klartext, Sprache, genau eine bestehende Kategorie, Bilder, einen HTTPS-Link und Publikationsmetadaten
+- begrenzt die Bearbeitung auf die erforderliche Überschrift und genau eine bestehende Kategorie sowie optional Klartext, Sprache, Bilder, einen HTTPS-Link mit Linktext und Öffnungsverhalten und Publikationsmetadaten
 - nutzt die hostgeführte Fassade `/api/v1/mainserver/cockpit-cards`, die eigenen `cockpit-cards.*`-Rechte sowie vorhandene Kategorien- und Medienbausteine
-- heißt in der deutschen Redaktion „Kacheln“ und nutzt gemeinsame Detail-Tabs, semantische Kartenflächen, History-Darstellung, Löschbestätigung und URL-gesteuerte Pagination
+- heißt in der deutschen Redaktion „Kacheln“ und nutzt gemeinsame Detail-Tabs, semantische Kartenflächen, History-Darstellung, Löschbestätigung und URL-gesteuerte Pagination; die Kachel-Variante der Medienauswahl zeigt ausschließlich den Alternativtext, erhält aber den gemeinsamen Berechtigungs-, Referenz- und Delivery-Vertrag
   11c. Plugin Surveys (`packages/plugin-surveys`)
 
 - produktives Fachplugin für Mainserver-gestützte Umfragen mit pluginnahem Modell `surveys.survey`

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -98,7 +98,7 @@ Fehlerpfad:
 2. Das Plugin lädt die bestehende Kategorienliste und öffentliche Bildmedien hostgeführt; Text und Bilder werden gemeinsam im Tab `Inhalt` bearbeitet.
 3. Die Fassade autorisiert mit `cockpit-cards.*`, validiert Überschrift, genau eine Kategorie, optionale Bilder und höchstens einen HTTPS-Link und erzwingt `genericType: "COCKPIT_CARD"`. Linktext und Öffnen-in-neuem-Tab werden nur gemeinsam mit dem Link gespeichert.
 4. Der Leseweg sammelt alle GenericItem-Upstream-Seiten, filtert und sortiert die Cockpit Cards und paginiert anschließend lokal.
-5. Beim Update bleiben die serverseitige `externalId`, unbekannte Payload-Schlüssel und nicht durch die Kachel-Oberfläche bearbeitete Web-URL-Metadaten erhalten; beim Create wird keine clientseitige `externalId` akzeptiert.
+5. Beim Update bleiben die serverseitige `externalId`, unbekannte Payload-Schlüssel und schema-kompatible Medienmetadaten erhalten; Response-only- und unbekannte Rohfelder werden nicht in GraphQL-Inputs übernommen. Beim Create wird keine clientseitige `externalId` akzeptiert.
 6. Die Inhaltsprojektion führt den Datensatz als `cockpit-cards.cockpit-card`; in der gemeinsamen Inhaltsübersicht erscheint kein generischer Ersatz. Der getrennte technische GenericItem-Vollzugriff bleibt davon unberührt.
 
 ### Waste-Management: Settings, CRUD, PDF-Stamminhalte und technische Tools

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -96,9 +96,10 @@ Fehlerpfad:
 
 1. Ein Benutzer öffnet eine Cockpit Card aus der gemeinsamen Inhaltsübersicht oder legt eine neue an.
 2. Das Plugin lädt die bestehende Kategorienliste und öffentliche Bildmedien hostgeführt; Text und Bilder werden gemeinsam im Tab `Inhalt` bearbeitet.
-3. Die Fassade autorisiert mit `cockpit-cards.*`, validiert genau eine Kategorie, mindestens ein Bild und höchstens einen HTTPS-Link und erzwingt `genericType: "COCKPIT_CARD"`.
+3. Die Fassade autorisiert mit `cockpit-cards.*`, validiert Überschrift, genau eine Kategorie, optionale Bilder und höchstens einen HTTPS-Link und erzwingt `genericType: "COCKPIT_CARD"`. Linktext und Öffnen-in-neuem-Tab werden nur gemeinsam mit dem Link gespeichert.
 4. Der Leseweg sammelt alle GenericItem-Upstream-Seiten, filtert und sortiert die Cockpit Cards und paginiert anschließend lokal.
-5. Die Inhaltsprojektion führt den Datensatz als `cockpit-cards.cockpit-card`; bei vorhandenen `generic-items.read`-Rechten darf derselbe Datensatz zusätzlich als `generic-items.generic-item` erscheinen.
+5. Beim Update bleiben die serverseitige `externalId`, unbekannte Payload-Schlüssel und nicht durch die Kachel-Oberfläche bearbeitete Web-URL-Metadaten erhalten; beim Create wird keine clientseitige `externalId` akzeptiert.
+6. Die Inhaltsprojektion führt den Datensatz als `cockpit-cards.cockpit-card`; in der gemeinsamen Inhaltsübersicht erscheint kein generischer Ersatz. Der getrennte technische GenericItem-Vollzugriff bleibt davon unberührt.
 
 ### Waste-Management: Settings, CRUD, PDF-Stamminhalte und technische Tools
 

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -594,9 +594,11 @@ Referenzen:
 ### Ergänzung 2026-08: Cockpit Cards als gefilterter GenericItem-Fachtyp
 
 - Cockpit-Cards-Fassaden verwenden ausschließlich die Actions `cockpit-cards.read`, `cockpit-cards.create`, `cockpit-cards.update` und `cockpit-cards.delete`.
-- Der Server erzwingt `genericType: "COCKPIT_CARD"`, genau eine Kategorie, mindestens ein Bild und höchstens einen HTTPS-Link; fremde Typ-IDs werden als nicht gefunden behandelt.
+- Der Server erzwingt `genericType: "COCKPIT_CARD"`, eine Überschrift, genau eine Kategorie, optionale Bilder und höchstens einen HTTPS-Link; fremde Typ-IDs werden als nicht gefunden behandelt.
 - Beobachtbarkeitsdaten des vollständigen Paging-Lesewegs enthalten nur technische Zähler und Laufzeiten, keine Überschriften, Texte, Kategorien oder URLs.
-- Sprachcode und Sortiergewicht sind kontrollierte `payload`-Schlüssel; unbekannte historische Schlüssel bleiben bei Updates erhalten. Die Antwort ist Klartext und wird vor dem Write gegen HTML geprüft.
+- Sprachcode, Sortiergewicht und Öffnungsverhalten sind kontrollierte `payload`-Schlüssel; unbekannte historische Schlüssel und die serverseitige `externalId` bleiben bei Updates erhalten. Kacheltext ist Klartext und wird vor dem Write gegen HTML geprüft.
+- Linktext liegt als Beschreibung der einen Web-URL vor. Ohne Link werden weder Linktext noch Öffnen-in-neuem-Tab gespeichert.
+- Die gemeinsame Medienauswahl zeigt für Kacheln nur den Alternativtext, behält jedoch die zentralen Read-only-Zustände sowie persistente Delivery-URLs und Media-References bei.
 
 ### Ergänzung 2026-08: GenericItems als technischer Vollzugriff
 

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -358,6 +358,8 @@ Referenzen:
 - FAQ-Sprachfilter müssen URL-stabil sein und vor Sortierung, Gesamtzahl und Pagination auf der vollständigen FAQ-Menge wirken.
 - Löschaktionen benötigen einen zugänglichen Bestätigungsdialog, eine Pending-Sperre und sichtbare Fehler; eine erfolgreiche Aktion darf genau eine Mutation auslösen.
 - Die deutschen sichtbaren Texte des Cockpit-Card-Plugins verwenden durchgängig „Kachel“ beziehungsweise „Kacheln“.
+- Kacheln lassen sich mit Überschrift und Kategorie ohne Sprache, Text oder Bild anlegen; Linktext und Öffnungsverhalten sind nur bei vorhandenem HTTPS-Link aktiv.
+- Updates erhalten die serverseitige `externalId`, unbekannte Payload-Schlüssel und nicht sichtbare Web-URL-Metadaten; Browser-CRUD-Tests sichern Create, Read, Update und Delete gemeinsam ab.
 - Schlanke und Legacy-GenericItem-Projektionen müssen bekannte wie unbekannte `genericType`-Werte vollständig und mit identischer Typmenge abbilden.
 - Tests müssen die getrennte Autorisierung fachlicher und generischer Pfade sowie die mögliche Mehrfachdarstellung bei kombinierten Rechten absichern.
 - Reguläre Live-Rollen sollen keine `generic-items.*`-Actions erhalten, weil der technische Vollzugriff fachliche Validierungen bewusst umgehen kann.

--- a/docs/architecture/10-quality-requirements.md
+++ b/docs/architecture/10-quality-requirements.md
@@ -359,7 +359,7 @@ Referenzen:
 - Löschaktionen benötigen einen zugänglichen Bestätigungsdialog, eine Pending-Sperre und sichtbare Fehler; eine erfolgreiche Aktion darf genau eine Mutation auslösen.
 - Die deutschen sichtbaren Texte des Cockpit-Card-Plugins verwenden durchgängig „Kachel“ beziehungsweise „Kacheln“.
 - Kacheln lassen sich mit Überschrift und Kategorie ohne Sprache, Text oder Bild anlegen; Linktext und Öffnungsverhalten sind nur bei vorhandenem HTTPS-Link aktiv.
-- Updates erhalten die serverseitige `externalId`, unbekannte Payload-Schlüssel und nicht sichtbare Web-URL-Metadaten; Browser-CRUD-Tests sichern Create, Read, Update und Delete gemeinsam ab.
+- Updates erhalten die serverseitige `externalId`, unbekannte Payload-Schlüssel und schema-kompatible Medienmetadaten; Response-only- und unbekannte Rohfelder gelangen nicht in GraphQL-Inputs. Browser-CRUD-Tests sichern Create, Read, Update und Delete gemeinsam ab.
 - Schlanke und Legacy-GenericItem-Projektionen müssen bekannte wie unbekannte `genericType`-Werte vollständig und mit identischer Typmenge abbilden.
 - Tests müssen die getrennte Autorisierung fachlicher und generischer Pfade sowie die mögliche Mehrfachdarstellung bei kombinierten Rechten absichern.
 - Reguläre Live-Rollen sollen keine `generic-items.*`-Actions erhalten, weil der technische Vollzugriff fachliche Validierungen bewusst umgehen kann.

--- a/docs/changelog/entries/pr-945.json
+++ b/docs/changelog/entries/pr-945.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 945,
+  "body": "Kachel-Editor mit vollständigem Link- und Medienvertrag\n\n- Kacheln können mit Überschrift und Kategorie angelegt werden; Sprache, Text und Bilder bleiben optional.\n- Linktext und Öffnen-in-neuem-Tab stehen unter Einstellungen zur Verfügung.\n- Beim Bearbeiten bleiben Mainserver-Identität, unbekannte Payload-Daten und nicht sichtbare Medienmetadaten erhalten."
+}

--- a/docs/changelog/entries/pr-945.json
+++ b/docs/changelog/entries/pr-945.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 945,
-  "body": "Kachel-Editor mit vollständigem Link- und Medienvertrag\n\n- Kacheln können mit Überschrift und Kategorie angelegt werden; Sprache, Text und Bilder bleiben optional.\n- Linktext und Öffnen-in-neuem-Tab stehen unter Einstellungen zur Verfügung.\n- Beim Bearbeiten bleiben Mainserver-Identität, unbekannte Payload-Daten und nicht sichtbare Medienmetadaten erhalten."
+  "body": "Kachel-Editor mit vollständigem Link- und Medienvertrag\n\n- Kacheln können mit Überschrift und Kategorie angelegt werden; Sprache, Text und Bilder bleiben optional.\n- Linktext und Öffnen-in-neuem-Tab stehen unter Einstellungen zur Verfügung.\n- Beim Bearbeiten bleiben Mainserver-Identität, unbekannte Payload-Daten und schema-kompatible Medienmetadaten erhalten."
 }

--- a/docs/development/studio-form-migrationsinventur.md
+++ b/docs/development/studio-form-migrationsinventur.md
@@ -43,7 +43,7 @@ Grundlage: Reale Codeinspektion der im Plan `docs/superpowers/plans/2026-05-21-s
 ### Fortschreibung 2026-08: FAQ, Kacheln und GenericItems
 
 - `plugin-faq`: RHF/Zod bleibt fachlich erhalten; Detail-Tabs, Fehlerzusammenfassung, URL-Sprachfilter, Pagination und Löschdialog sind auf den Studio-Standard migriert.
-- `plugin-cockpit-cards`: Der deutsche Redaktionsbegriff ist „Kachel“; Detail-Tabs, Formularstatus, History-Fläche, Pagination und Löschdialog verwenden den gemeinsamen Studio-Pfad.
+- `plugin-cockpit-cards`: Der deutsche Redaktionsbegriff ist „Kachel“; Detail-Tabs, Formularstatus, History-Fläche, Pagination und Löschdialog verwenden den gemeinsamen Studio-Pfad. Überschrift und Kategorie sind die einzigen Pflichtfelder. Linktext und Öffnungsverhalten liegen unter `Einstellungen`; Medienvorschau und Medienauswahl bearbeiten für Kacheln ausschließlich den Alternativtext.
 - `plugin-generic-items`: Die lokale Tab- und Detailkartenhülle wurde auf `StudioDetailTabs` und `StudioDetailCard` reduziert; die Löschbestätigung verwendet keinen Browserdialog mehr.
 - Referenzentscheidung: News liefert den Seiten- und Tabzustand, POIs die Karten- und Listenstruktur, Events die URL-Normalisierung. Pluginlokale Doppelimplementierungen dieser Referenzen werden nicht als neue Shared-Basis übernommen.
 

--- a/openspec/changes/add-cockpit-cards-plugin/design.md
+++ b/openspec/changes/add-cockpit-cards-plugin/design.md
@@ -1,6 +1,6 @@
 ## Kontext
 
-Cockpit Cards sind fachlich abgegrenzte GenericItems. Sie ähneln FAQ in Navigation, Lifecycle und Publikationsmetadaten, erweitern das reduzierte Modell aber um eine bestehende Kategorie, ein oder mehrere Bilder und einen Link.
+Kacheln sind fachlich abgegrenzte GenericItems. Sie ähneln FAQ in Navigation, Lifecycle und Publikationsmetadaten, erweitern das reduzierte Modell aber um eine bestehende Kategorie, optionale Bilder und einen Link.
 
 ## Ziele und Nicht-Ziele
 
@@ -15,19 +15,21 @@ Cockpit Cards sind fachlich abgegrenzte GenericItems. Sie ähneln FAQ in Navigat
 
 ### Kanonische Abbildung
 
-| Fachfeld                   | GenericItem-Feld        |
-| -------------------------- | ----------------------- |
-| Überschrift                | `title`                 |
-| Text                       | `contentBlocks[0].body` |
-| Sprachcode                 | `payload.languageCode`  |
-| Sortiergewicht             | `payload.sortWeight`    |
-| Kategorie                  | `categories[0]`         |
-| Bilder                     | `mediaContents`         |
-| Link                       | `webUrls[0]`            |
-| Sichtbarkeit               | `visible`               |
-| Veröffentlichungszeitpunkt | `publicationDate`       |
+| Fachfeld                   | GenericItem-Feld         |
+| -------------------------- | ------------------------ |
+| Überschrift                | `title`                  |
+| Text                       | `contentBlocks[0].body`  |
+| Sprachcode                 | `payload.languageCode`   |
+| Sortiergewicht             | `payload.sortWeight`     |
+| Kategorie                  | `categories[0]`          |
+| Bilder                     | `mediaContents`          |
+| Link                       | `webUrls[0].url`         |
+| Linktext                   | `webUrls[0].description` |
+| In neuem Tab öffnen        | `payload.openInNewTab`   |
+| Sichtbarkeit               | `visible`                |
+| Veröffentlichungszeitpunkt | `publicationDate`        |
 
-Überschrift, Text, Sprachcode, genau eine Kategorie und mindestens ein Bild sind Pflicht. Der Text bleibt reiner Text. Medien müssen Bilder sein; die vorhandene Medienverwaltung und deren Upload werden wiederverwendet. Der optionale Link muss eine HTTPS-URL sein. Beim Schreiben werden Kategorie und Link auf ihre erlaubte Kardinalität normalisiert. Unbekannte bestehende Payload-Schlüssel bleiben erhalten; kontrolliert werden ausschließlich `languageCode` und `sortWeight`.
+Nur Überschrift und genau eine Kategorie sind Pflicht. Der optionale Text bleibt reiner Text und wird leer ohne Content-Block gespeichert. Medien müssen Bilder mit HTTPS-URL sein; die vorhandene Medienverwaltung, persistente Delivery-URLs und Media-References werden wiederverwendet. Der optionale Link muss eine HTTPS-URL sein. Ohne Link wird `openInNewTab` auf `false` normalisiert. Beim Schreiben werden Kategorie und Link auf ihre erlaubte Kardinalität normalisiert. Unbekannte bestehende Payload-Schlüssel, `externalId` und unterstützte Medienmetadaten bleiben erhalten; kontrolliert werden ausschließlich `languageCode`, `sortWeight` und `openInNewTab`.
 
 ### Typ- und Projektionsabgrenzung
 
@@ -35,7 +37,7 @@ Cockpit Cards sind fachlich abgegrenzte GenericItems. Sie ähneln FAQ in Navigat
 
 ### Editor-Workspace
 
-Die Tab-Reihenfolge lautet `Basis`, `Inhalt`, `Einstellungen`, `Historie`; beim Anlegen fehlt `Historie`. `Basis` enthält Überschrift, Sprachcode und die einzelne Kategorie. `Inhalt` enthält Text und Bilder gemeinsam. `Einstellungen` enthält Link, Sichtbarkeit, Veröffentlichungszeitpunkt und Sortiergewicht. Bilder können aus der Mediathek gewählt oder über den vorhandenen Bild-Upload ergänzt, sortiert und entfernt werden.
+Die Tab-Reihenfolge lautet `Basis`, `Inhalt`, `Einstellungen`, `Historie`; beim Anlegen fehlt `Historie`. `Basis` enthält Überschrift, Sprachcode und die einzelne Kategorie. `Inhalt` enthält Text und Bilder gemeinsam. `Einstellungen` enthält Link, Linktext, Öffnungsverhalten, Sichtbarkeit, Veröffentlichungszeitpunkt und Sortiergewicht. Bilder können aus der Mediathek gewählt oder über den vorhandenen Bild-Upload ergänzt, als Vorschaukarten geprüft, sortiert und entfernt werden. Die Kachel-Variante begrenzt die bearbeitbaren Medienmetadaten im gemeinsamen Auswahldialog auf den Alternativtext, ohne die Media-Reference-, Delivery- oder Berechtigungsverträge zu umgehen.
 
 ### Listen und Pagination
 

--- a/openspec/changes/add-cockpit-cards-plugin/proposal.md
+++ b/openspec/changes/add-cockpit-cards-plugin/proposal.md
@@ -1,16 +1,18 @@
-# Change: Eigenständiges Cockpit-Cards-Plugin ergänzen
+# Change: Eigenständiges Kachel-Plugin ergänzen
 
 ## Warum
 
-Cockpit Cards benötigen im Studio eine schlanke, fachlich eindeutige Redaktionserfahrung. Das offene Generic-Items-Plugin stellt dafür zu viele fachfremde Felder bereit; das FAQ-Plugin ist strukturell passend, kennt jedoch weder Kategorien, Bilder noch einen weiterführenden Link.
+Kacheln benötigen im Studio eine schlanke, fachlich eindeutige Redaktionserfahrung. Das offene Generic-Items-Plugin stellt dafür zu viele fachfremde Felder bereit; das FAQ-Plugin ist strukturell passend, kennt jedoch weder Kategorien, Bilder noch einen weiterführenden Link.
 
 ## Was sich ändert
 
 - Ein neues eigenständiges `@sva/plugin-cockpit-cards` folgt dem Fachplugin-Muster von FAQ und wird über die gemeinsame Inhaltsübersicht erreichbar.
-- Cockpit Cards werden als `GenericItem` mit dem unveränderlichen Diskriminator `genericType: "COCKPIT_CARD"` gespeichert und als `cockpit-cards.cockpit-card` projiziert.
-- Das Fachmodell umfasst Überschrift, Nur-Text-Inhalt, Sprachcode, genau eine bestehende Mainserver-Kategorie, mindestens ein Bild, höchstens einen HTTPS-Link, Sortiergewicht, Sichtbarkeit und Veröffentlichungszeitpunkt.
+- Kacheln werden als `GenericItem` mit dem unveränderlichen Diskriminator `genericType: "COCKPIT_CARD"` gespeichert und als `cockpit-cards.cockpit-card` projiziert.
+- Das Fachmodell umfasst Überschrift, optionalen Nur-Text-Inhalt, optionalen Sprachcode, genau eine bestehende Mainserver-Kategorie, null oder mehr Bilder, höchstens einen HTTPS-Link mit optionalem Linktext und Öffnungsverhalten, Sortiergewicht, Sichtbarkeit und Veröffentlichungszeitpunkt.
 - Der Tab `Inhalt` enthält gemeinsam den Text und die Bilder. Es gibt keinen separaten Medien-Tab.
-- Kategorie, Bilder und Link verwenden die vorhandenen GenericItem-Felder `categories`, `mediaContents` und `webUrls`; Kategorien werden aus dem Kategorien-Plugin geladen und Bilder über die bestehende Medienauswahl beziehungsweise den bestehenden Upload zugeordnet.
+- Der Tab `Einstellungen` enthält Link, Linktext und das Öffnungsverhalten zusammen mit den Publikationsmetadaten.
+- Kategorie, Bilder und Link verwenden die vorhandenen GenericItem-Felder `categories`, `mediaContents` und `webUrls`; Kategorien werden aus dem Kategorien-Plugin geladen und Bilder über die bestehende Medienauswahl beziehungsweise den bestehenden Upload zugeordnet. Die Kachel-Variante des gemeinsamen Medienauswahldialogs bearbeitet ausschließlich den Alternativtext.
+- Bestehende `externalId`, unbekannte Payload-Schlüssel und unterstützte Medienmetadaten bleiben bei Updates erhalten; technische Herkunftsfelder werden nicht im Editor angezeigt.
 - Das Plugin erhält die Actions `cockpit-cards.read`, `cockpit-cards.create`, `cockpit-cards.update` und `cockpit-cards.delete`.
 
 ## Auswirkungen

--- a/openspec/changes/add-cockpit-cards-plugin/specs/content-management/spec.md
+++ b/openspec/changes/add-cockpit-cards-plugin/specs/content-management/spec.md
@@ -20,13 +20,19 @@ Das System MUST Cockpit Cards als eigenständigen Content-Type `cockpit-cards.co
 
 ### Requirement: Cockpit Cards besitzen ein begrenztes Fachmodell
 
-Das System MUST Überschrift, optionalen Nur-Text, optionalen Sprachcode, genau eine bestehende Kategorie, null oder mehr Bilder, höchstens einen HTTPS-Link, Sortiergewicht, Sichtbarkeit und Veröffentlichungszeitpunkt bearbeiten. Ausschließlich Überschrift und Kategorie MUST fachliche Pflichtfelder sein. Andere GenericItem-Bereiche MUST verborgen bleiben.
+Das System MUST Überschrift, optionalen Nur-Text, optionalen Sprachcode, genau eine bestehende Kategorie, null oder mehr Bilder, höchstens einen HTTPS-Link mit optionalem Linktext und Öffnungsverhalten, Sortiergewicht, Sichtbarkeit und Veröffentlichungszeitpunkt bearbeiten. Ausschließlich Überschrift und Kategorie MUST fachliche Pflichtfelder sein. Andere GenericItem-Bereiche und technische Herkunftsfelder MUST verborgen bleiben.
 
 #### Scenario: Cockpit Card mit optionalen Inhalten wird gespeichert
 
 - **WHEN** ein Benutzer Überschrift und Kategorie sowie optional Text, Sprache, gültige Bilder und einen HTTPS-Link speichert
-- **THEN** persistiert das System Überschrift in `title`, Kategorie in `categories`, vorhandenen Text als alleinigen Content-Block, Bilder in `mediaContents` und den Link in `webUrls`
-- **AND** erhält es unbekannte bestehende Payload-Schlüssel
+- **THEN** persistiert das System Überschrift in `title`, Kategorie in `categories`, vorhandenen Text als alleinigen Content-Block, Bilder in `mediaContents`, den Link in `webUrls[0].url`, den Linktext in `webUrls[0].description` und das Öffnungsverhalten in `payload.openInNewTab`
+- **AND** erhält es `externalId`, unbekannte bestehende Payload-Schlüssel und unterstützte Medienmetadaten
+
+#### Scenario: Öffnungsverhalten ohne Link wird normalisiert
+
+- **WHEN** ein Benutzer keinen Link speichert
+- **THEN** speichert das System keine `webUrls`
+- **AND** normalisiert `payload.openInNewTab` auf `false`
 
 #### Scenario: Ungültige Kardinalität wird abgewiesen
 
@@ -48,13 +54,14 @@ Das System MUST Überschrift, optionalen Nur-Text, optionalen Sprachcode, genau 
 
 ### Requirement: Text und Bilder teilen den Inhalts-Tab
 
-Das System MUST für gespeicherte Cockpit Cards die Tabs `Basis`, `Inhalt`, `Einstellungen` und `Historie` anbieten. `Basis` MUST Überschrift, Sprachcode und Kategorie enthalten. `Inhalt` MUST Text und Bilder gemeinsam enthalten. `Einstellungen` MUST Link und Publikationsmetadaten enthalten.
+Das System MUST für gespeicherte Kacheln die Tabs `Basis`, `Inhalt`, `Einstellungen` und `Historie` anbieten. `Basis` MUST Überschrift, Sprachcode und Kategorie enthalten. `Inhalt` MUST Text und Bilder gemeinsam enthalten. `Einstellungen` MUST Link, Linktext, Öffnungsverhalten und Publikationsmetadaten enthalten.
 
 #### Scenario: Inhalt wird gemeinsam bearbeitet
 
 - **WHEN** ein Benutzer den Tab `Inhalt` öffnet
 - **THEN** kann er dort den Text bearbeiten
 - **AND** Bilder auswählen, hochladen, sortieren und entfernen
+- **AND** den Alternativtext in Vorschaukarten und als einziges Medienmetadatum im gemeinsamen Medienauswahldialog bearbeiten
 - **AND** gibt es keinen separaten Medien-Tab
 
 #### Scenario: Neue Cockpit Card besitzt noch keine Historie

--- a/openspec/changes/add-cockpit-cards-plugin/specs/sva-mainserver-integration/spec.md
+++ b/openspec/changes/add-cockpit-cards-plugin/specs/sva-mainserver-integration/spec.md
@@ -21,5 +21,7 @@ Das System MUST Cockpit Cards über den vorhandenen Mainserver-GenericItem-Trans
 #### Scenario: Schreibvertrag wird serverseitig erzwungen
 
 - **WHEN** eine Cockpit Card angelegt oder aktualisiert wird
-- **THEN** erzwingt der Host `genericType` gleich `COCKPIT_CARD`, genau eine Kategorie, mindestens ein Bild und höchstens einen HTTPS-Link
+- **THEN** erzwingt der Host `genericType` gleich `COCKPIT_CARD`, genau eine Kategorie, ausschließlich gültige optionale HTTPS-Bilder und höchstens einen HTTPS-Link
+- **AND** normalisiert er das Öffnungsverhalten ohne Link auf `false`
+- **AND** erhält er bei Updates `externalId`, unbekannte Payload-Schlüssel und unterstützte Medienmetadaten
 - **AND** weist er fachfremde GenericItem-Felder ab

--- a/openspec/changes/add-cockpit-cards-plugin/tasks.md
+++ b/openspec/changes/add-cockpit-cards-plugin/tasks.md
@@ -8,14 +8,17 @@
 ## 2. Fachplugin
 
 - [x] 2.1 `@sva/plugin-cockpit-cards` mit Manifest, Nx-Konfiguration, Übersetzungen und öffentlichem API-Vertrag erstellen.
-- [x] 2.2 Fachmodell, Mapper und Validierung für Überschrift, Nur-Text, Sprache, genau eine bestehende Kategorie, mindestens ein Bild, höchstens einen HTTPS-Link und Publikationsmetadaten implementieren.
+- [x] 2.2 Fachmodell, Mapper und Validierung für Überschrift, optionalen Nur-Text, optionale Sprache, genau eine bestehende Kategorie, optionale Bilder, höchstens einen HTTPS-Link und Publikationsmetadaten implementieren.
 - [x] 2.3 Liste sowie Create-/Edit-Seiten mit den Tabs `Basis`, `Inhalt`, `Einstellungen` und `Historie` umsetzen; Text und Bilder gemeinsam im Tab `Inhalt` platzieren.
 - [x] 2.4 Vorhandene Kategorienauswahl, Medienbibliothek und Bild-Upload wiederverwenden und zugängliche Lade-, Fehler- und Leerzustände bereitstellen.
+- [x] 2.5 Deutsche Fachbezeichnung auf Kachel/Kacheln umstellen sowie Linktext und Öffnungsverhalten unter `Einstellungen` ergänzen.
+- [x] 2.6 `externalId`, unbekannte Payload-Daten und unterstützte Medienmetadaten bei Studio-Updates verlustfrei erhalten.
+- [x] 2.7 Bildbearbeitung als Vorschaukarten darstellen und den gemeinsamen Medienauswahldialog für Kacheln auf den Alternativtext begrenzen, ohne Media-References, persistente Delivery-URLs oder Berechtigungszustände zu umgehen.
 
 ## 3. Qualität und Dokumentation
 
 - [x] 3.1 Unit-, Komponenten- und Host-Tests für Fachvertrag, UI, IAM, Typabgrenzung, Projektion, Paging und CRUD ergänzen.
-- [ ] 3.2 Einen E2E-Test für CRUD mit Kategorie, mehreren Bildern und Link ergänzen.
+- [x] 3.2 Einen E2E-Test für CRUD mit Kategorie, mehreren Bildern und Link ergänzen.
 - [x] 3.3 Nach jedem Block die kleinsten relevanten Nx-Unit- und Type-Gates sowie bei Serveränderungen früh `pnpm check:server-runtime` ausführen.
 - [x] 3.4 Relevante deutsche Fach- und arc42-Dokumentation aktualisieren und `pnpm check:file-placement` ausführen.
 - [x] 3.5 `openspec validate add-cockpit-cards-plugin --strict` ausführen.

--- a/packages/plugin-cockpit-cards/src/cockpit-cards.history-translations.ts
+++ b/packages/plugin-cockpit-cards/src/cockpit-cards.history-translations.ts
@@ -4,9 +4,10 @@ export const cockpitCardsHistoryTranslations = {
     error: 'Historie konnte nicht geladen werden.',
     empty: 'Noch keine Historie verfügbar.',
     createHint: 'Speichere die Kachel, bevor die Historie verfügbar ist.',
-    sourceNotice: 'Diese Historie enthält ausschließlich Änderungen, die über das Studio ausgeführt wurden.',
+    sourceNotice:
+      'Diese Historie enthält ausschließlich Änderungen, die über das Studio ausgeführt wurden.',
     emptySummary: 'Keine weiteren Änderungsdetails.',
-    label: 'Cockpit-Card-Historie',
+    label: 'Kachelhistorie',
     time: 'Zeitpunkt',
     action: 'Aktion',
     actor: 'Bearbeitet von',

--- a/packages/plugin-cockpit-cards/src/cockpit-cards.model.ts
+++ b/packages/plugin-cockpit-cards/src/cockpit-cards.model.ts
@@ -13,15 +13,19 @@ import type {
 
 const htmlTagPattern = /<\/?[a-z][^>]*>/i;
 const languageCodePattern = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
-const imageSchema = z.object({
-  sourceUrl: z.object({
-    url: z.string().url().startsWith('https://'),
-    description: z.string().optional(),
-  }).passthrough(),
-  contentType: z.literal('image'),
-  captionText: z.string().optional(),
-  copyright: z.string().optional(),
-}).passthrough();
+const imageSchema = z
+  .object({
+    sourceUrl: z
+      .object({
+        url: z.string().url().startsWith('https://'),
+        description: z.string().optional(),
+      })
+      .passthrough(),
+    contentType: z.literal('image'),
+    captionText: z.string().optional(),
+    copyright: z.string().optional(),
+  })
+  .passthrough();
 
 export const cockpitCardFormSchema = z.object({
   heading: z.string().trim().min(1),
@@ -29,14 +33,19 @@ export const cockpitCardFormSchema = z.object({
     .string()
     .trim()
     .refine((value) => !htmlTagPattern.test(value), 'html_not_allowed'),
-  languageCode: z.string().trim().refine(
-    (value) => value.length === 0 || languageCodePattern.test(value),
-    'invalid_language_code'
-  ),
+  languageCode: z
+    .string()
+    .trim()
+    .refine(
+      (value) => value.length === 0 || languageCodePattern.test(value),
+      'invalid_language_code'
+    ),
   sortWeight: z.number().int().finite(),
   category: z.string().trim().min(1),
   images: z.array(imageSchema),
   link: z.string().trim().url().startsWith('https://').optional().or(z.literal('')),
+  linkText: z.string().trim(),
+  openInNewTab: z.boolean(),
   visible: z.boolean(),
   publicationDate: z.string().trim().min(1).optional().or(z.literal('')),
 });
@@ -59,14 +68,15 @@ export const readCockpitCardPayload = (value: unknown): CockpitCardPayload => {
   const payload = toPayloadRecord(value);
   const languageCode =
     typeof payload.languageCode === 'string' &&
-    (payload.languageCode.trim().length === 0 || languageCodePattern.test(payload.languageCode.trim()))
+    (payload.languageCode.trim().length === 0 ||
+      languageCodePattern.test(payload.languageCode.trim()))
       ? normalizeLanguageCode(payload.languageCode)
       : DEFAULT_COCKPIT_CARD_LANGUAGE_CODE;
   const sortWeight =
     typeof payload.sortWeight === 'number' && Number.isInteger(payload.sortWeight)
       ? payload.sortWeight
       : 0;
-  return { languageCode, sortWeight };
+  return { languageCode, sortWeight, openInNewTab: payload.openInNewTab === true };
 };
 
 export const mapGenericItemToCockpitCardFormValues = (
@@ -81,6 +91,8 @@ export const mapGenericItemToCockpitCardFormValues = (
     category: item.categories[0]?.name ?? '',
     images: [...item.mediaContents],
     link: item.webUrls[0]?.url ?? '',
+    linkText: item.webUrls[0]?.description ?? '',
+    openInNewTab: payload.openInNewTab,
     visible: item.visible,
     ...(item.publicationDate ? { publicationDate: item.publicationDate } : {}),
   };
@@ -88,22 +100,40 @@ export const mapGenericItemToCockpitCardFormValues = (
 
 export const mapCockpitCardFormValuesToGenericItemInput = (
   values: CockpitCardFormValues,
-  existingPayload?: unknown
+  existing?: Pick<GenericItemCockpitCardRecord, 'externalId' | 'payload' | 'webUrls'>
 ): GenericItemCockpitCardInput => {
   const parsed = cockpitCardFormSchema.parse(values);
+  const existingLink = existing?.webUrls[0];
+  const {
+    url: existingUrl,
+    description: existingDescription,
+    ...existingLinkData
+  } = existingLink ?? { url: undefined, description: undefined };
+  void existingUrl;
+  void existingDescription;
   return {
     title: parsed.heading,
     genericType: COCKPIT_CARD_GENERIC_TYPE,
+    ...(existing?.externalId ? { externalId: existing.externalId } : {}),
     contentBlocks: parsed.text ? [{ body: parsed.text }] : [],
     payload: {
-      ...toPayloadRecord(existingPayload),
+      ...toPayloadRecord(existing?.payload),
       languageCode: normalizeLanguageCode(parsed.languageCode),
       sortWeight: parsed.sortWeight,
+      openInNewTab: parsed.link ? parsed.openInNewTab : false,
     },
     categoryName: parsed.category,
     categories: [{ name: parsed.category }],
     mediaContents: parsed.images,
-    webUrls: parsed.link ? [{ url: parsed.link }] : [],
+    webUrls: parsed.link
+      ? [
+          {
+            ...existingLinkData,
+            url: parsed.link,
+            ...(parsed.linkText ? { description: parsed.linkText } : {}),
+          },
+        ]
+      : [],
     visible: parsed.visible,
     ...(parsed.publicationDate ? { publicationDate: parsed.publicationDate } : {}),
   };

--- a/packages/plugin-cockpit-cards/src/cockpit-cards.model.ts
+++ b/packages/plugin-cockpit-cards/src/cockpit-cards.model.ts
@@ -100,17 +100,9 @@ export const mapGenericItemToCockpitCardFormValues = (
 
 export const mapCockpitCardFormValuesToGenericItemInput = (
   values: CockpitCardFormValues,
-  existing?: Pick<GenericItemCockpitCardRecord, 'externalId' | 'payload' | 'webUrls'>
+  existing?: Pick<GenericItemCockpitCardRecord, 'externalId' | 'payload'>
 ): GenericItemCockpitCardInput => {
   const parsed = cockpitCardFormSchema.parse(values);
-  const existingLink = existing?.webUrls[0];
-  const {
-    url: existingUrl,
-    description: existingDescription,
-    ...existingLinkData
-  } = existingLink ?? { url: undefined, description: undefined };
-  void existingUrl;
-  void existingDescription;
   return {
     title: parsed.heading,
     genericType: COCKPIT_CARD_GENERIC_TYPE,
@@ -128,7 +120,6 @@ export const mapCockpitCardFormValuesToGenericItemInput = (
     webUrls: parsed.link
       ? [
           {
-            ...existingLinkData,
             url: parsed.link,
             ...(parsed.linkText ? { description: parsed.linkText } : {}),
           },

--- a/packages/plugin-cockpit-cards/src/cockpit-cards.pages.tsx
+++ b/packages/plugin-cockpit-cards/src/cockpit-cards.pages.tsx
@@ -96,6 +96,7 @@ const defaults: CockpitCardFormValues = {
   openInNewTab: false,
   visible: true,
 };
+const cockpitCardMetadataFields = ['altText'] as const;
 type Tab = 'basis' | 'content' | 'settings' | 'history';
 const hasPersistablePublicDelivery = (delivery: { readonly deliveryUrl: string }): boolean =>
   (delivery as { readonly isPublicUrl?: unknown }).isPublicUrl === true &&
@@ -364,6 +365,7 @@ function Editor({
     []
   );
   const mediaPicker = useStudioMediaPickerOverlay<StudioMediaPickerAssetDetail>({
+    editableMetadataFields: cockpitCardMetadataFields,
     onAccept: (asset) => {
       if (!asset.persistentUrl || !isPersistableContentMediaUrl(asset.persistentUrl)) return;
       const usage: ContentMediaUsage = {
@@ -835,7 +837,7 @@ function Editor({
         isLoadingReviewAsset={mediaPicker.isLoadingReviewAsset}
         isSavingReviewAsset={mediaPicker.isSavingReviewAsset}
         isMetadataEditable={canUpdateMedia}
-        visibleMetadataFields={['altText']}
+        visibleMetadataFields={cockpitCardMetadataFields}
         feedbackMessage={mediaPicker.errorCode ? pt('messages.mediaError') : null}
         feedbackTone={mediaPicker.errorCode ? 'error' : 'default'}
         isAssetSelectable={(asset) => !mediaUsages.some((usage) => usage.assetId === asset.id)}

--- a/packages/plugin-cockpit-cards/src/cockpit-cards.pages.tsx
+++ b/packages/plugin-cockpit-cards/src/cockpit-cards.pages.tsx
@@ -92,6 +92,8 @@ const defaults: CockpitCardFormValues = {
   category: '',
   images: [],
   link: '',
+  linkText: '',
+  openInNewTab: false,
   visible: true,
 };
 type Tab = 'basis' | 'content' | 'settings' | 'history';
@@ -169,7 +171,7 @@ function ContentFields({
           onOpenUpload={canUploadMedia ? () => onOpenMediaPicker('upload') : undefined}
           onLoadAssetSnapshot={onLoadAssetSnapshot}
           showHeader={false}
-          supportedFields={{ altText: true, caption: true, credit: true, license: false }}
+          supportedFields={{ altText: true, caption: false, credit: false, license: false }}
           labels={{
             title: pt('fields.images'),
             description: pt('media.description'),
@@ -238,6 +240,16 @@ function Editor({
     defaultValues: defaults,
     resolver: zodResolver(cockpitCardFormSchema),
   });
+  const link = form.watch('link');
+  React.useEffect(() => {
+    if (link.trim()) return;
+    if (form.getValues('linkText')) {
+      form.setValue('linkText', '', { shouldDirty: true });
+    }
+    if (form.getValues('openInNewTab')) {
+      form.setValue('openInNewTab', false, { shouldDirty: true });
+    }
+  }, [form, link]);
   const saveFeedback = useStudioSaveFeedback();
   React.useEffect(() => {
     if (form.formState.isDirty) {
@@ -269,7 +281,6 @@ function Editor({
   const [mutationError, setMutationError] = React.useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [deletePending, setDeletePending] = React.useState(false);
-  const [payload, setPayload] = React.useState<unknown>();
   const [loadedItem, setLoadedItem] = React.useState<Awaited<
     ReturnType<typeof getCockpitCard>
   > | null>(null);
@@ -483,7 +494,6 @@ function Editor({
               )
             );
             setRequiresReferenceSync(references.length > 0);
-            setPayload(item.payload);
             setLoadedItem(item);
           }
         },
@@ -504,7 +514,7 @@ function Editor({
       try {
         const input = mapCockpitCardFormValuesToGenericItemInput(
           { ...values, images: [...cockpitCardUsagesToMedia(mediaUsages)] },
-          payload
+          loadedItem ?? undefined
         );
         const saveContent = () =>
           mode === 'create'
@@ -692,6 +702,27 @@ function Editor({
                 {...form.register('link')}
               />
             </StudioField>
+            <StudioField id="cockpit-card-link-text" label={pt('fields.linkText')}>
+              <Input
+                id="cockpit-card-link-text"
+                disabled={!link.trim()}
+                {...form.register('linkText')}
+              />
+            </StudioField>
+            <StudioField id="cockpit-card-open-new-tab" label={pt('fields.openInNewTab')}>
+              <Controller
+                control={form.control}
+                name="openInNewTab"
+                render={({ field }) => (
+                  <Checkbox
+                    id="cockpit-card-open-new-tab"
+                    checked={field.value}
+                    disabled={!link.trim()}
+                    onChange={(event) => field.onChange(event.currentTarget.checked)}
+                  />
+                )}
+              />
+            </StudioField>
           </StudioDetailCard>
           <StudioField id="cockpit-card-publication" label={pt('fields.publicationDate')}>
             <Input id="cockpit-card-publication" {...form.register('publicationDate')} />
@@ -804,6 +835,7 @@ function Editor({
         isLoadingReviewAsset={mediaPicker.isLoadingReviewAsset}
         isSavingReviewAsset={mediaPicker.isSavingReviewAsset}
         isMetadataEditable={canUpdateMedia}
+        visibleMetadataFields={['altText']}
         feedbackMessage={mediaPicker.errorCode ? pt('messages.mediaError') : null}
         feedbackTone={mediaPicker.errorCode ? 'error' : 'default'}
         isAssetSelectable={(asset) => !mediaUsages.some((usage) => usage.assetId === asset.id)}

--- a/packages/plugin-cockpit-cards/src/cockpit-cards.types.ts
+++ b/packages/plugin-cockpit-cards/src/cockpit-cards.types.ts
@@ -1,4 +1,8 @@
-export type CockpitCardPayload = Readonly<{ languageCode: string; sortWeight: number }>;
+export type CockpitCardPayload = Readonly<{
+  languageCode: string;
+  sortWeight: number;
+  openInNewTab: boolean;
+}>;
 
 export type CockpitCardCategory = Readonly<{ name: string }>;
 export type CockpitCardWebUrl = Readonly<{
@@ -22,12 +26,15 @@ export type CockpitCardFormValues = Readonly<{
   category: string;
   images: CockpitCardMedia[];
   link: string;
+  linkText: string;
+  openInNewTab: boolean;
   visible: boolean;
   publicationDate?: string;
 }>;
 
 export type GenericItemCockpitCardRecord = Readonly<{
   id: string;
+  externalId?: string;
   title: string;
   genericType: string;
   contentBlocks: readonly Readonly<{ body?: string }>[];
@@ -45,6 +52,7 @@ export type GenericItemCockpitCardRecord = Readonly<{
 export type GenericItemCockpitCardInput = Readonly<{
   title: string;
   genericType: 'COCKPIT_CARD';
+  externalId?: string;
   contentBlocks: readonly Readonly<{ body: string }>[];
   payload: Readonly<Record<string, unknown>>;
   categories: readonly CockpitCardCategory[];

--- a/packages/plugin-cockpit-cards/src/plugin.translations.ts
+++ b/packages/plugin-cockpit-cards/src/plugin.translations.ts
@@ -47,7 +47,7 @@ export const pluginCockpitCardsTranslations = {
         unavailable: 'Nicht verfügbar',
       },
       tabs: {
-        ariaLabel: 'Cockpit-Card-Bereiche',
+        ariaLabel: 'Kachelbereiche',
         mobileLabel: 'Bereich auswählen',
         basis: {
           label: 'Basis',
@@ -78,6 +78,8 @@ export const pluginCockpitCardsTranslations = {
         images: 'Bilder',
         imageUrl: 'Bild-URL',
         link: 'Link',
+        linkText: 'Linktext',
+        openInNewTab: 'Link in neuem Tab öffnen',
         sortWeight: 'Sortiergewicht',
         visible: 'Sichtbar',
         publicationDate: 'Veröffentlichungszeitpunkt',
@@ -96,7 +98,7 @@ export const pluginCockpitCardsTranslations = {
         cancel: 'Abbrechen',
       },
       pagination: {
-        ariaLabel: 'Cockpit-Cards-Paginierung',
+        ariaLabel: 'Kachelpaginierung',
         pageLabel: 'Seite {{page}}',
         previous: 'Zurück',
         next: 'Weiter',
@@ -198,6 +200,8 @@ export const pluginCockpitCardsTranslations = {
         images: 'Images',
         imageUrl: 'Image URL',
         link: 'Link',
+        linkText: 'Link text',
+        openInNewTab: 'Open link in a new tab',
         sortWeight: 'Sort weight',
         visible: 'Visible',
         publicationDate: 'Publication date',

--- a/packages/plugin-cockpit-cards/tests/cockpit-cards.model.test.ts
+++ b/packages/plugin-cockpit-cards/tests/cockpit-cards.model.test.ts
@@ -27,7 +27,6 @@ describe('cockpit card model', () => {
       mapCockpitCardFormValuesToGenericItemInput(values, {
         externalId: 'source-1',
         payload: { legacy: true },
-        webUrls: [{ url: 'https://example.test/old', description: 'Alt', source: 'import' }],
       })
     ).toEqual(
       expect.objectContaining({
@@ -48,7 +47,6 @@ describe('cockpit card model', () => {
           {
             url: 'https://example.test/details',
             description: 'Mehr erfahren',
-            source: 'import',
           },
         ],
       })

--- a/packages/plugin-cockpit-cards/tests/cockpit-cards.model.test.ts
+++ b/packages/plugin-cockpit-cards/tests/cockpit-cards.model.test.ts
@@ -16,21 +16,41 @@ const values = {
   category: 'Startseite',
   images: [{ sourceUrl: { url: 'https://example.test/image.jpg' }, contentType: 'image' as const }],
   link: 'https://example.test/details',
+  linkText: 'Mehr erfahren',
+  openInNewTab: true,
   visible: true,
 };
 
 describe('cockpit card model', () => {
   it('maps the constrained form to GenericItem fields and preserves payload', () => {
-    expect(mapCockpitCardFormValuesToGenericItemInput(values, { legacy: true })).toEqual(
+    expect(
+      mapCockpitCardFormValuesToGenericItemInput(values, {
+        externalId: 'source-1',
+        payload: { legacy: true },
+        webUrls: [{ url: 'https://example.test/old', description: 'Alt', source: 'import' }],
+      })
+    ).toEqual(
       expect.objectContaining({
         title: 'Willkommen',
         genericType: 'COCKPIT_CARD',
+        externalId: 'source-1',
         contentBlocks: [{ body: 'Mehr erfahren' }],
-        payload: { legacy: true, languageCode: 'de-DE', sortWeight: 2 },
+        payload: {
+          legacy: true,
+          languageCode: 'de-DE',
+          sortWeight: 2,
+          openInNewTab: true,
+        },
         categories: [{ name: 'Startseite' }],
         categoryName: 'Startseite',
         mediaContents: values.images,
-        webUrls: [{ url: 'https://example.test/details' }],
+        webUrls: [
+          {
+            url: 'https://example.test/details',
+            description: 'Mehr erfahren',
+            source: 'import',
+          },
+        ],
       })
     );
   });
@@ -42,10 +62,10 @@ describe('cockpit card model', () => {
         title: 'Willkommen',
         genericType: 'COCKPIT_CARD',
         contentBlocks: [{ body: 'Text' }],
-        payload: { languageCode: 'en', sortWeight: 1 },
+        payload: { languageCode: 'en', sortWeight: 1, openInNewTab: true },
         categories: [{ name: 'Home' }],
         mediaContents: values.images,
-        webUrls: [{ url: 'https://example.test' }],
+        webUrls: [{ url: 'https://example.test', description: 'Details' }],
         visible: true,
         createdAt: '',
         updatedAt: '',
@@ -57,6 +77,8 @@ describe('cockpit card model', () => {
         category: 'Home',
         images: values.images,
         link: 'https://example.test',
+        linkText: 'Details',
+        openInNewTab: true,
       })
     );
   });
@@ -81,23 +103,40 @@ describe('cockpit card model', () => {
         text: '',
         languageCode: '',
         images: [],
+        link: '',
+        linkText: 'Wird entfernt',
+        openInNewTab: true,
       })
     ).toEqual(
       expect.objectContaining({
         contentBlocks: [],
-        payload: { languageCode: '', sortWeight: 2 },
+        payload: { languageCode: '', sortWeight: 2, openInNewTab: false },
         mediaContents: [],
+        webUrls: [],
       })
     );
-    expect(readCockpitCardPayload({ languageCode: '', sortWeight: 2 })).toEqual({ languageCode: '', sortWeight: 2 });
+    expect(readCockpitCardPayload({ languageCode: '', sortWeight: 2 })).toEqual({
+      languageCode: '',
+      sortWeight: 2,
+      openInNewTab: false,
+    });
   });
 
   it('uses safe defaults for malformed payloads and missing optional GenericItem fields', () => {
-    expect(readCockpitCardPayload(null)).toEqual({ languageCode: 'und', sortWeight: 0 });
-    expect(readCockpitCardPayload([])).toEqual({ languageCode: 'und', sortWeight: 0 });
+    expect(readCockpitCardPayload(null)).toEqual({
+      languageCode: 'und',
+      sortWeight: 0,
+      openInNewTab: false,
+    });
+    expect(readCockpitCardPayload([])).toEqual({
+      languageCode: 'und',
+      sortWeight: 0,
+      openInNewTab: false,
+    });
     expect(readCockpitCardPayload({ languageCode: 'invalid!', sortWeight: 1.5 })).toEqual({
       languageCode: 'und',
       sortWeight: 0,
+      openInNewTab: false,
     });
     expect(
       mapGenericItemToCockpitCardFormValues({
@@ -113,7 +152,14 @@ describe('cockpit card model', () => {
         createdAt: '',
         updatedAt: '',
       })
-    ).toMatchObject({ text: '', category: '', link: '', visible: false });
+    ).toMatchObject({
+      text: '',
+      category: '',
+      link: '',
+      linkText: '',
+      openInNewTab: false,
+      visible: false,
+    });
   });
 
   it('identifies and deterministically orders cockpit card records', () => {
@@ -132,10 +178,20 @@ describe('cockpit card model', () => {
     });
     expect(isCockpitCardGenericItem(makeRecord('1', 'A', 'de', 0))).toBe(true);
     expect(isCockpitCardGenericItem({ genericType: 'FAQ' } as never)).toBe(false);
-    expect(compareCockpitCardRecords(makeRecord('1', 'A', 'de', 0), makeRecord('2', 'A', 'en', 0))).toBeLessThan(0);
-    expect(compareCockpitCardRecords(makeRecord('1', 'A', 'de', 1), makeRecord('2', 'A', 'de', 2))).toBeLessThan(0);
-    expect(compareCockpitCardRecords(makeRecord('1', 'A2', 'de', 1), makeRecord('2', 'A10', 'de', 1))).toBeLessThan(0);
-    expect(compareCockpitCardRecords(makeRecord('1', 'A', 'de', 1), makeRecord('2', 'A', 'de', 1))).toBeLessThan(0);
-    expect(compareCockpitCardRecords(makeRecord('1', 'A', '', 1), makeRecord('2', 'B', '', 1))).toBeLessThan(0);
+    expect(
+      compareCockpitCardRecords(makeRecord('1', 'A', 'de', 0), makeRecord('2', 'A', 'en', 0))
+    ).toBeLessThan(0);
+    expect(
+      compareCockpitCardRecords(makeRecord('1', 'A', 'de', 1), makeRecord('2', 'A', 'de', 2))
+    ).toBeLessThan(0);
+    expect(
+      compareCockpitCardRecords(makeRecord('1', 'A2', 'de', 1), makeRecord('2', 'A10', 'de', 1))
+    ).toBeLessThan(0);
+    expect(
+      compareCockpitCardRecords(makeRecord('1', 'A', 'de', 1), makeRecord('2', 'A', 'de', 1))
+    ).toBeLessThan(0);
+    expect(
+      compareCockpitCardRecords(makeRecord('1', 'A', '', 1), makeRecord('2', 'B', '', 1))
+    ).toBeLessThan(0);
   });
 });

--- a/packages/plugin-cockpit-cards/tests/cockpit-cards.pages.test.tsx
+++ b/packages/plugin-cockpit-cards/tests/cockpit-cards.pages.test.tsx
@@ -121,15 +121,16 @@ vi.mock('@tanstack/react-router', () => ({
 
 const record = {
   id: 'card-1',
+  externalId: 'source-card-1',
   title: 'Bestehende Karte',
   genericType: 'CockpitCard' as const,
   contentBlocks: [{ body: 'Bestehender Text' }],
-  payload: { languageCode: 'de', sortWeight: 2, legacy: 'keep' },
+  payload: { languageCode: 'de', sortWeight: 2, openInNewTab: true, legacy: 'keep' },
   categories: [{ name: 'Startseite' }],
   mediaContents: [
     { sourceUrl: { url: 'https://example.test/old.jpg' }, contentType: 'image' as const },
   ],
-  webUrls: [{ url: 'https://example.test/alt' }],
+  webUrls: [{ url: 'https://example.test/alt', description: 'Alte Kachel', source: 'import' }],
   visible: false,
   publicationDate: '2026-08-02T10:00:00.000Z',
   createdAt: '',
@@ -248,8 +249,11 @@ describe('cockpit cards pages', () => {
     fireEvent.click(screen.getByRole('button', { name: 'actions.selectImage' }));
     await screen.findAllByRole('button', { name: 'actions.selectImage' });
     fireEvent.click(screen.getAllByRole('button', { name: 'actions.selectImage' }).at(-1)!);
-    await screen.findByDisplayValue('Titel');
-    fireEvent.change(screen.getByDisplayValue('Titel'), { target: { value: 'Neuer Titel' } });
+    const altText = await screen.findByLabelText('media.altText');
+    expect(screen.queryByLabelText('media.caption')).toBeNull();
+    expect(screen.queryByLabelText('media.credit')).toBeNull();
+    expect(screen.queryByLabelText('media.license')).toBeNull();
+    fireEvent.change(altText, { target: { value: 'Neuer Alternativtext' } });
     fireEvent.click(screen.getByRole('button', { name: 'media.use' }));
 
     await waitFor(() =>
@@ -290,7 +294,7 @@ describe('cockpit cards pages', () => {
     fireEvent.change(screen.getByTestId('media-upload-input'), {
       target: { files: [new File(['image'], 'upload.jpg', { type: 'image/jpeg' })] },
     });
-    await screen.findByDisplayValue('asset.jpg');
+    await screen.findByLabelText('media.altText');
     fireEvent.click(screen.getByRole('button', { name: 'media.use' }));
     await waitFor(() =>
       expect(screen.getByDisplayValue('https://example.test/upload.jpg')).toBeTruthy()
@@ -311,6 +315,10 @@ describe('cockpit cards pages', () => {
     fireEvent.change(screen.getByLabelText('fields.link'), {
       target: { value: 'https://example.test/ziel' },
     });
+    fireEvent.change(screen.getByLabelText('fields.linkText'), {
+      target: { value: 'Mehr erfahren' },
+    });
+    fireEvent.click(screen.getByLabelText('fields.openInNewTab'));
     fireEvent.change(screen.getByLabelText('fields.sortWeight'), { target: { value: '7' } });
     fireEvent.click(screen.getAllByRole('button', { name: 'actions.create' }).at(-1)!);
 
@@ -318,10 +326,10 @@ describe('cockpit cards pages', () => {
     expect(state.create.mock.calls[0]?.[0]).toMatchObject({
       title: 'Neue Karte',
       contentBlocks: [{ body: 'Neuer Text' }],
-      payload: { languageCode: 'en-US', sortWeight: 7 },
+      payload: { languageCode: 'en-US', sortWeight: 7, openInNewTab: true },
       categoryName: 'Startseite',
       categories: [{ name: 'Startseite' }],
-      webUrls: [{ url: 'https://example.test/ziel' }],
+      webUrls: [{ url: 'https://example.test/ziel', description: 'Mehr erfahren' }],
     });
     expect(state.create.mock.calls[0]?.[1]).toBe('user');
     expect(state.navigate).toHaveBeenCalledWith(
@@ -357,7 +365,20 @@ describe('cockpit cards pages', () => {
         'card-1',
         expect.objectContaining({
           contentBlocks: [{ body: 'Geändert' }],
-          payload: { languageCode: 'de', sortWeight: 2, legacy: 'keep' },
+          externalId: 'source-card-1',
+          payload: {
+            languageCode: 'de',
+            sortWeight: 2,
+            openInNewTab: true,
+            legacy: 'keep',
+          },
+          webUrls: [
+            {
+              url: 'https://example.test/alt',
+              description: 'Alte Kachel',
+              source: 'import',
+            },
+          ],
           visible: true,
         }),
         'user'

--- a/packages/plugin-cockpit-cards/tests/cockpit-cards.pages.test.tsx
+++ b/packages/plugin-cockpit-cards/tests/cockpit-cards.pages.test.tsx
@@ -376,7 +376,6 @@ describe('cockpit cards pages', () => {
             {
               url: 'https://example.test/alt',
               description: 'Alte Kachel',
-              source: 'import',
             },
           ],
           visible: true,

--- a/packages/studio-ui-react/src/studio-media-picker-overlay.shared.ts
+++ b/packages/studio-ui-react/src/studio-media-picker-overlay.shared.ts
@@ -1,6 +1,7 @@
 export type StudioMediaPickerMode = 'library' | 'upload' | 'review';
 export type StudioMediaPickerReviewSource = 'library' | 'upload';
-export type StudioMediaPickerUploadPhase = 'idle' | 'initializing' | 'uploading' | 'finalizing' | 'success' | 'error';
+export type StudioMediaPickerUploadPhase =
+  'idle' | 'initializing' | 'uploading' | 'finalizing' | 'success' | 'error';
 export type StudioMediaPickerErrorCode =
   | 'unsupported_upload_type'
   | 'upload_failed'
@@ -15,6 +16,7 @@ export type StudioMediaPickerMetadataDraft = Readonly<{
   copyright: string;
   license: string;
 }>;
+export type StudioMediaPickerMetadataField = keyof StudioMediaPickerMetadataDraft;
 
 export type StudioMediaPickerAssetSummary = Readonly<{
   id: string;
@@ -25,10 +27,11 @@ export type StudioMediaPickerAssetSummary = Readonly<{
   visibility?: string;
 }>;
 
-export type StudioMediaPickerAssetDetail = StudioMediaPickerAssetSummary & Readonly<{
-  metadata: StudioMediaPickerMetadataDraft;
-  persistentUrl?: string | null;
-}>;
+export type StudioMediaPickerAssetDetail = StudioMediaPickerAssetSummary &
+  Readonly<{
+    metadata: StudioMediaPickerMetadataDraft;
+    persistentUrl?: string | null;
+  }>;
 
 export type StudioMediaPickerOverlayLabels = Readonly<{
   title: string;
@@ -80,7 +83,8 @@ export const createMetadataDraft = (
   license: asset.metadata.license || '',
 });
 
-export const normalizeStudioMediaPickerSearchValue = (value: string) => value.trim().toLocaleLowerCase('de-DE');
+export const normalizeStudioMediaPickerSearchValue = (value: string) =>
+  value.trim().toLocaleLowerCase('de-DE');
 
 export const studioMediaPickerPreviewClassName =
   'flex aspect-[4/3] items-center justify-center overflow-hidden rounded-xl border border-border/60 bg-muted/20';

--- a/packages/studio-ui-react/src/studio-media-picker-overlay.test.tsx
+++ b/packages/studio-ui-react/src/studio-media-picker-overlay.test.tsx
@@ -150,6 +150,41 @@ describe('useStudioMediaPickerOverlay', () => {
     expect(result.current.open).toBe(false);
   });
 
+  it('saves only explicitly editable metadata fields', async () => {
+    const asset = createAsset({
+      title: 'hero.jpg',
+      metadata: {
+        title: '',
+        altText: 'Old alt text',
+        description: 'Hidden description',
+        copyright: 'Hidden copyright',
+        license: 'Hidden license',
+      },
+    });
+    const saveAssetMetadata = vi.fn(async (_assetId: string, metadata) =>
+      createAsset({ metadata: { ...asset.metadata, ...metadata } })
+    );
+    const { result } = renderHook(() =>
+      useStudioMediaPickerOverlay({
+        editableMetadataFields: ['altText'],
+        onAccept: vi.fn(),
+        isSupportedUploadFile: () => true,
+        uploadAsset: vi.fn(),
+        loadAsset: vi.fn(async () => asset),
+        saveAssetMetadata,
+      })
+    );
+
+    act(() => result.current.openLibrary());
+    await act(async () => result.current.selectAsset(asset));
+    act(() => result.current.updateMetadataField('altText', 'Updated alt text'));
+    await act(async () => result.current.confirmSelection());
+
+    expect(saveAssetMetadata).toHaveBeenCalledWith(asset.id, {
+      altText: 'Updated alt text',
+    });
+  });
+
   it('preserves the upload preview url until the host asset exposes one itself', async () => {
     const asset = createAsset({ previewUrl: '' });
     const onAccept = vi.fn();

--- a/packages/studio-ui-react/src/studio-media-picker-overlay.test.tsx
+++ b/packages/studio-ui-react/src/studio-media-picker-overlay.test.tsx
@@ -1,12 +1,15 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, render, renderHook, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  StudioMediaPickerOverlay,
   type StudioMediaPickerAssetDetail,
   useStudioMediaPickerOverlay,
 } from './studio-media-picker-overlay.js';
 
-const createAsset = (overrides?: Partial<StudioMediaPickerAssetDetail>): StudioMediaPickerAssetDetail => ({
+const createAsset = (
+  overrides?: Partial<StudioMediaPickerAssetDetail>
+): StudioMediaPickerAssetDetail => ({
   id: 'asset-1',
   title: 'Hero',
   fileName: 'hero.jpg',
@@ -24,6 +27,66 @@ const createAsset = (overrides?: Partial<StudioMediaPickerAssetDetail>): StudioM
 });
 
 describe('useStudioMediaPickerOverlay', () => {
+  it('limits review metadata fields while retaining the read-only state', () => {
+    const asset = createAsset();
+    render(
+      <StudioMediaPickerOverlay
+        assets={[]}
+        isMetadataEditable={false}
+        labels={{
+          title: 'Media',
+          description: 'Select media',
+          modes: { library: 'Library', upload: 'Upload', review: 'Review' },
+          library: { searchLabel: 'Search', empty: 'Empty', select: 'Select' },
+          upload: {
+            regionLabel: 'Upload region',
+            title: 'Upload',
+            description: 'Upload an image',
+            browseAction: 'Browse',
+            supportLabel: 'Images only',
+          },
+          review: { title: 'Review', description: 'Review image' },
+          fields: {
+            title: 'Title',
+            altText: 'Alternative text',
+            description: 'Description field',
+            copyright: 'Copyright',
+            license: 'License',
+          },
+          actions: {
+            cancel: 'Cancel',
+            backToLibrary: 'Back',
+            backToUpload: 'Back to upload',
+            openMediaManagement: 'Open media',
+            useMedia: 'Use image',
+          },
+        }}
+        metadataDraft={asset.metadata}
+        mode="review"
+        onBackFromReview={vi.fn()}
+        onChangeMode={vi.fn()}
+        onClose={vi.fn()}
+        onConfirmSelection={vi.fn()}
+        onMetadataChange={vi.fn()}
+        onSearchValueChange={vi.fn()}
+        onSelectAsset={vi.fn()}
+        onUploadFile={vi.fn()}
+        open
+        reviewAsset={asset}
+        reviewSource="library"
+        searchValue=""
+        uploadPhase="idle"
+        visibleMetadataFields={['altText']}
+      />
+    );
+
+    expect((screen.getByLabelText('Alternative text') as HTMLInputElement).disabled).toBe(true);
+    expect(screen.queryByLabelText('Title')).toBeNull();
+    expect(screen.queryByLabelText('Description field')).toBeNull();
+    expect(screen.queryByLabelText('Copyright')).toBeNull();
+    expect(screen.queryByLabelText('License')).toBeNull();
+  });
+
   it('starts in upload mode, uploads, switches to review, and only accepts after metadata save', async () => {
     const asset = createAsset();
     const onAccept = vi.fn();
@@ -95,7 +158,10 @@ describe('useStudioMediaPickerOverlay', () => {
       useStudioMediaPickerOverlay({
         onAccept,
         isSupportedUploadFile: () => true,
-        uploadAsset: vi.fn(async () => ({ assetId: asset.id, previewUrl: 'https://cdn.example.test/uploaded.jpg' })),
+        uploadAsset: vi.fn(async () => ({
+          assetId: asset.id,
+          previewUrl: 'https://cdn.example.test/uploaded.jpg',
+        })),
         loadAsset: vi.fn(async () => asset),
         saveAssetMetadata: vi.fn(async () => ({ ...asset, previewUrl: '' })),
       })

--- a/packages/studio-ui-react/src/studio-media-picker-overlay.tsx
+++ b/packages/studio-ui-react/src/studio-media-picker-overlay.tsx
@@ -7,6 +7,7 @@ import type {
   StudioMediaPickerAssetDetail,
   StudioMediaPickerAssetSummary,
   StudioMediaPickerMetadataDraft,
+  StudioMediaPickerMetadataField,
   StudioMediaPickerMode,
   StudioMediaPickerOverlayLabels,
   StudioMediaPickerReviewSource,
@@ -17,6 +18,7 @@ export type {
   StudioMediaPickerAssetSummary,
   StudioMediaPickerErrorCode,
   StudioMediaPickerMetadataDraft,
+  StudioMediaPickerMetadataField,
   StudioMediaPickerMode,
   StudioMediaPickerOverlayLabels,
   StudioMediaPickerReviewSource,
@@ -38,13 +40,17 @@ type StudioMediaPickerOverlayProps = Readonly<{
   onUploadFile: (file: File) => void | Promise<void>;
   reviewAsset: StudioMediaPickerAssetDetail | null;
   metadataDraft: StudioMediaPickerMetadataDraft;
-  onMetadataChange: <Key extends keyof StudioMediaPickerMetadataDraft>(key: Key, value: StudioMediaPickerMetadataDraft[Key]) => void;
+  onMetadataChange: <Key extends keyof StudioMediaPickerMetadataDraft>(
+    key: Key,
+    value: StudioMediaPickerMetadataDraft[Key]
+  ) => void;
   onBackFromReview: () => void;
   onConfirmSelection: () => void | Promise<void>;
   onOpenMediaManagement?: (assetId: string) => void | Promise<void>;
   isLoadingReviewAsset?: boolean;
   isSavingReviewAsset?: boolean;
   isMetadataEditable?: boolean;
+  visibleMetadataFields?: readonly StudioMediaPickerMetadataField[];
   isAssetSelectable?: (asset: StudioMediaPickerAssetSummary) => boolean;
   feedbackMessage?: string | null;
   feedbackTone?: 'default' | 'success' | 'error';
@@ -63,10 +69,20 @@ const StudioMediaPickerModeTabs = ({
   disabled: boolean;
 }>) => (
   <div className="flex flex-wrap gap-2 border-b border-border/60 pb-4">
-    <Button type="button" disabled={disabled} variant={mode === 'library' ? 'default' : 'outline'} onClick={() => onChangeMode('library')}>
+    <Button
+      type="button"
+      disabled={disabled}
+      variant={mode === 'library' ? 'default' : 'outline'}
+      onClick={() => onChangeMode('library')}
+    >
       {labels.library}
     </Button>
-    <Button type="button" disabled={disabled} variant={mode === 'upload' ? 'default' : 'outline'} onClick={() => onChangeMode('upload')}>
+    <Button
+      type="button"
+      disabled={disabled}
+      variant={mode === 'upload' ? 'default' : 'outline'}
+      onClick={() => onChangeMode('upload')}
+    >
       {labels.upload}
     </Button>
     {mode === 'review' ? (
@@ -100,6 +116,7 @@ const StudioMediaPickerOverlayBody = ({
   reviewSource,
   searchValue,
   uploadPhase,
+  visibleMetadataFields,
 }: Omit<StudioMediaPickerOverlayProps, 'open' | 'onChangeMode'>) => (
   <div className="max-h-[72vh] overflow-y-auto pr-1">
     {mode === 'library' ? (
@@ -146,6 +163,7 @@ const StudioMediaPickerOverlayBody = ({
         onOpenMediaManagement={onOpenMediaManagement}
         reviewAsset={reviewAsset}
         reviewSource={reviewSource}
+        visibleMetadataFields={visibleMetadataFields}
       />
     ) : null}
   </div>
@@ -176,6 +194,7 @@ export const StudioMediaPickerOverlay = ({
   reviewSource,
   searchValue,
   uploadPhase,
+  visibleMetadataFields,
 }: StudioMediaPickerOverlayProps) => {
   const isBusy = isLoadingReviewAsset || isSavingReviewAsset;
 
@@ -187,7 +206,12 @@ export const StudioMediaPickerOverlay = ({
           <DialogDescription>{labels.description}</DialogDescription>
         </DialogHeader>
 
-        <StudioMediaPickerModeTabs disabled={isBusy} labels={labels.modes} mode={mode} onChangeMode={onChangeMode} />
+        <StudioMediaPickerModeTabs
+          disabled={isBusy}
+          labels={labels.modes}
+          mode={mode}
+          onChangeMode={onChangeMode}
+        />
         <StudioMediaPickerOverlayBody
           assets={assets}
           feedbackMessage={feedbackMessage}
@@ -211,6 +235,7 @@ export const StudioMediaPickerOverlay = ({
           reviewSource={reviewSource}
           searchValue={searchValue}
           uploadPhase={uploadPhase}
+          visibleMetadataFields={visibleMetadataFields}
         />
       </DialogContent>
     </Dialog>

--- a/packages/studio-ui-react/src/studio-media-picker-review-fields.tsx
+++ b/packages/studio-ui-react/src/studio-media-picker-review-fields.tsx
@@ -1,0 +1,58 @@
+import { Input } from './input.js';
+import {
+  type StudioMediaPickerMetadataDraft,
+  type StudioMediaPickerMetadataField,
+  type StudioMediaPickerOverlayLabels,
+} from './studio-media-picker-overlay.shared.js';
+import { Textarea } from './textarea.js';
+
+const metadataFieldDefinitions: readonly Readonly<{
+  key: StudioMediaPickerMetadataField;
+  id: string;
+  multiline?: boolean;
+}>[] = [
+  { key: 'title', id: 'studio-media-review-title' },
+  { key: 'altText', id: 'studio-media-review-alt-text' },
+  { key: 'description', id: 'studio-media-review-description', multiline: true },
+  { key: 'copyright', id: 'studio-media-review-copyright' },
+  { key: 'license', id: 'studio-media-review-license' },
+];
+
+export const defaultStudioMediaPickerMetadataFields = metadataFieldDefinitions.map(
+  ({ key }) => key
+);
+
+export const StudioMediaPickerReviewFields = ({
+  isMetadataEditable,
+  labels,
+  metadataDraft,
+  onMetadataChange,
+  visibleMetadataFields,
+}: Readonly<{
+  isMetadataEditable: boolean;
+  labels: Pick<StudioMediaPickerOverlayLabels, 'fields'>;
+  metadataDraft: StudioMediaPickerMetadataDraft;
+  onMetadataChange: (key: StudioMediaPickerMetadataField, value: string) => void;
+  visibleMetadataFields: readonly StudioMediaPickerMetadataField[];
+}>) => (
+  <div className="space-y-4">
+    {metadataFieldDefinitions
+      .filter(({ key }) => visibleMetadataFields.includes(key))
+      .map(({ id, key, multiline }) => {
+        const Field = multiline ? Textarea : Input;
+        return (
+          <div className="space-y-2" key={key}>
+            <label className="text-sm font-medium text-foreground" htmlFor={id}>
+              {labels.fields[key]}
+            </label>
+            <Field
+              disabled={!isMetadataEditable}
+              id={id}
+              value={metadataDraft[key]}
+              onChange={(event) => onMetadataChange(key, event.target.value)}
+            />
+          </div>
+        );
+      })}
+  </div>
+);

--- a/packages/studio-ui-react/src/studio-media-picker-review-panel.tsx
+++ b/packages/studio-ui-react/src/studio-media-picker-review-panel.tsx
@@ -1,6 +1,4 @@
 import { Button } from './button.js';
-import { Input } from './input.js';
-import { Textarea } from './textarea.js';
 import {
   studioMediaPickerPreviewClassName,
   type StudioMediaPickerAssetDetail,
@@ -9,6 +7,10 @@ import {
   type StudioMediaPickerOverlayLabels,
   type StudioMediaPickerReviewSource,
 } from './studio-media-picker-overlay.shared.js';
+import {
+  defaultStudioMediaPickerMetadataFields,
+  StudioMediaPickerReviewFields,
+} from './studio-media-picker-review-fields.js';
 
 const StudioMediaPreview = ({ alt, url }: Readonly<{ alt: string; url?: string | null }>) =>
   url ? (
@@ -18,53 +20,6 @@ const StudioMediaPreview = ({ alt, url }: Readonly<{ alt: string; url?: string |
   );
 
 type MetadataKey = StudioMediaPickerMetadataField;
-
-const defaultMetadataFields: readonly MetadataKey[] = [
-  'title',
-  'altText',
-  'description',
-  'copyright',
-  'license',
-];
-
-type ReviewFieldProps = Readonly<{
-  id: string;
-  label: string;
-  value: string;
-  multiline?: boolean;
-  disabled?: boolean;
-  onChange: (value: string) => void;
-}>;
-
-const ReviewField = ({
-  disabled = false,
-  id,
-  label,
-  multiline = false,
-  onChange,
-  value,
-}: ReviewFieldProps) => (
-  <div className="space-y-2">
-    <label className="text-sm font-medium text-foreground" htmlFor={id}>
-      {label}
-    </label>
-    {multiline ? (
-      <Textarea
-        disabled={disabled}
-        id={id}
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-      />
-    ) : (
-      <Input
-        disabled={disabled}
-        id={id}
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-      />
-    )}
-  </div>
-);
 
 const feedbackToneClassName = (feedbackTone: 'default' | 'success' | 'error') =>
   feedbackTone === 'error'
@@ -93,72 +48,6 @@ const ReviewAssetPreview = ({
       </p>
       <p className="text-xs text-muted-foreground">{reviewAsset.fileName}</p>
     </div>
-  </div>
-);
-
-const ReviewMetadataFields = ({
-  isMetadataEditable,
-  labels,
-  metadataDraft,
-  onMetadataChange,
-  visibleMetadataFields,
-}: Readonly<{
-  isMetadataEditable: boolean;
-  labels: Pick<StudioMediaPickerOverlayLabels, 'fields'>;
-  metadataDraft: StudioMediaPickerMetadataDraft;
-  onMetadataChange: <Key extends MetadataKey>(
-    key: Key,
-    value: StudioMediaPickerMetadataDraft[Key]
-  ) => void;
-  visibleMetadataFields: readonly MetadataKey[];
-}>) => (
-  <div className="space-y-4">
-    {visibleMetadataFields.includes('title') ? (
-      <ReviewField
-        disabled={!isMetadataEditable}
-        id="studio-media-review-title"
-        label={labels.fields.title}
-        value={metadataDraft.title}
-        onChange={(value) => onMetadataChange('title', value)}
-      />
-    ) : null}
-    {visibleMetadataFields.includes('altText') ? (
-      <ReviewField
-        disabled={!isMetadataEditable}
-        id="studio-media-review-alt-text"
-        label={labels.fields.altText}
-        value={metadataDraft.altText}
-        onChange={(value) => onMetadataChange('altText', value)}
-      />
-    ) : null}
-    {visibleMetadataFields.includes('description') ? (
-      <ReviewField
-        disabled={!isMetadataEditable}
-        id="studio-media-review-description"
-        label={labels.fields.description}
-        multiline
-        value={metadataDraft.description}
-        onChange={(value) => onMetadataChange('description', value)}
-      />
-    ) : null}
-    {visibleMetadataFields.includes('copyright') ? (
-      <ReviewField
-        disabled={!isMetadataEditable}
-        id="studio-media-review-copyright"
-        label={labels.fields.copyright}
-        value={metadataDraft.copyright}
-        onChange={(value) => onMetadataChange('copyright', value)}
-      />
-    ) : null}
-    {visibleMetadataFields.includes('license') ? (
-      <ReviewField
-        disabled={!isMetadataEditable}
-        id="studio-media-review-license"
-        label={labels.fields.license}
-        value={metadataDraft.license}
-        onChange={(value) => onMetadataChange('license', value)}
-      />
-    ) : null}
   </div>
 );
 
@@ -254,7 +143,7 @@ export const StudioMediaPickerReviewPanel = ({
   onOpenMediaManagement,
   reviewAsset,
   reviewSource,
-  visibleMetadataFields = defaultMetadataFields,
+  visibleMetadataFields = defaultStudioMediaPickerMetadataFields,
 }: StudioMediaPickerReviewPanelProps) => {
   return (
     <div className="space-y-5">
@@ -279,7 +168,7 @@ export const StudioMediaPickerReviewPanel = ({
       ) : (
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <ReviewAssetPreview metadataDraft={metadataDraft} reviewAsset={reviewAsset} />
-          <ReviewMetadataFields
+          <StudioMediaPickerReviewFields
             isMetadataEditable={isMetadataEditable}
             labels={labels}
             metadataDraft={metadataDraft}

--- a/packages/studio-ui-react/src/studio-media-picker-review-panel.tsx
+++ b/packages/studio-ui-react/src/studio-media-picker-review-panel.tsx
@@ -5,6 +5,7 @@ import {
   studioMediaPickerPreviewClassName,
   type StudioMediaPickerAssetDetail,
   type StudioMediaPickerMetadataDraft,
+  type StudioMediaPickerMetadataField,
   type StudioMediaPickerOverlayLabels,
   type StudioMediaPickerReviewSource,
 } from './studio-media-picker-overlay.shared.js';
@@ -16,7 +17,15 @@ const StudioMediaPreview = ({ alt, url }: Readonly<{ alt: string; url?: string |
     <div className="px-4 text-center text-sm text-muted-foreground">{alt}</div>
   );
 
-type MetadataKey = keyof StudioMediaPickerMetadataDraft;
+type MetadataKey = StudioMediaPickerMetadataField;
+
+const defaultMetadataFields: readonly MetadataKey[] = [
+  'title',
+  'altText',
+  'description',
+  'copyright',
+  'license',
+];
 
 type ReviewFieldProps = Readonly<{
   id: string;
@@ -27,15 +36,32 @@ type ReviewFieldProps = Readonly<{
   onChange: (value: string) => void;
 }>;
 
-const ReviewField = ({ disabled = false, id, label, multiline = false, onChange, value }: ReviewFieldProps) => (
+const ReviewField = ({
+  disabled = false,
+  id,
+  label,
+  multiline = false,
+  onChange,
+  value,
+}: ReviewFieldProps) => (
   <div className="space-y-2">
     <label className="text-sm font-medium text-foreground" htmlFor={id}>
       {label}
     </label>
     {multiline ? (
-      <Textarea disabled={disabled} id={id} value={value} onChange={(event) => onChange(event.target.value)} />
+      <Textarea
+        disabled={disabled}
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
     ) : (
-      <Input disabled={disabled} id={id} value={value} onChange={(event) => onChange(event.target.value)} />
+      <Input
+        disabled={disabled}
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
     )}
   </div>
 );
@@ -56,10 +82,15 @@ const ReviewAssetPreview = ({
 }>) => (
   <div className="space-y-4">
     <div className={studioMediaPickerPreviewClassName}>
-      <StudioMediaPreview alt={metadataDraft.altText || metadataDraft.title || reviewAsset.title} url={reviewAsset.previewUrl} />
+      <StudioMediaPreview
+        alt={metadataDraft.altText || metadataDraft.title || reviewAsset.title}
+        url={reviewAsset.previewUrl}
+      />
     </div>
     <div className="rounded-xl border border-border/60 bg-muted/10 px-4 py-3">
-      <p className="text-sm font-medium text-foreground">{metadataDraft.title || reviewAsset.title}</p>
+      <p className="text-sm font-medium text-foreground">
+        {metadataDraft.title || reviewAsset.title}
+      </p>
       <p className="text-xs text-muted-foreground">{reviewAsset.fileName}</p>
     </div>
   </div>
@@ -70,49 +101,64 @@ const ReviewMetadataFields = ({
   labels,
   metadataDraft,
   onMetadataChange,
+  visibleMetadataFields,
 }: Readonly<{
   isMetadataEditable: boolean;
   labels: Pick<StudioMediaPickerOverlayLabels, 'fields'>;
   metadataDraft: StudioMediaPickerMetadataDraft;
-  onMetadataChange: <Key extends MetadataKey>(key: Key, value: StudioMediaPickerMetadataDraft[Key]) => void;
+  onMetadataChange: <Key extends MetadataKey>(
+    key: Key,
+    value: StudioMediaPickerMetadataDraft[Key]
+  ) => void;
+  visibleMetadataFields: readonly MetadataKey[];
 }>) => (
   <div className="space-y-4">
-    <ReviewField
-      disabled={!isMetadataEditable}
-      id="studio-media-review-title"
-      label={labels.fields.title}
-      value={metadataDraft.title}
-      onChange={(value) => onMetadataChange('title', value)}
-    />
-    <ReviewField
-      disabled={!isMetadataEditable}
-      id="studio-media-review-alt-text"
-      label={labels.fields.altText}
-      value={metadataDraft.altText}
-      onChange={(value) => onMetadataChange('altText', value)}
-    />
-    <ReviewField
-      disabled={!isMetadataEditable}
-      id="studio-media-review-description"
-      label={labels.fields.description}
-      multiline
-      value={metadataDraft.description}
-      onChange={(value) => onMetadataChange('description', value)}
-    />
-    <ReviewField
-      disabled={!isMetadataEditable}
-      id="studio-media-review-copyright"
-      label={labels.fields.copyright}
-      value={metadataDraft.copyright}
-      onChange={(value) => onMetadataChange('copyright', value)}
-    />
-    <ReviewField
-      disabled={!isMetadataEditable}
-      id="studio-media-review-license"
-      label={labels.fields.license}
-      value={metadataDraft.license}
-      onChange={(value) => onMetadataChange('license', value)}
-    />
+    {visibleMetadataFields.includes('title') ? (
+      <ReviewField
+        disabled={!isMetadataEditable}
+        id="studio-media-review-title"
+        label={labels.fields.title}
+        value={metadataDraft.title}
+        onChange={(value) => onMetadataChange('title', value)}
+      />
+    ) : null}
+    {visibleMetadataFields.includes('altText') ? (
+      <ReviewField
+        disabled={!isMetadataEditable}
+        id="studio-media-review-alt-text"
+        label={labels.fields.altText}
+        value={metadataDraft.altText}
+        onChange={(value) => onMetadataChange('altText', value)}
+      />
+    ) : null}
+    {visibleMetadataFields.includes('description') ? (
+      <ReviewField
+        disabled={!isMetadataEditable}
+        id="studio-media-review-description"
+        label={labels.fields.description}
+        multiline
+        value={metadataDraft.description}
+        onChange={(value) => onMetadataChange('description', value)}
+      />
+    ) : null}
+    {visibleMetadataFields.includes('copyright') ? (
+      <ReviewField
+        disabled={!isMetadataEditable}
+        id="studio-media-review-copyright"
+        label={labels.fields.copyright}
+        value={metadataDraft.copyright}
+        onChange={(value) => onMetadataChange('copyright', value)}
+      />
+    ) : null}
+    {visibleMetadataFields.includes('license') ? (
+      <ReviewField
+        disabled={!isMetadataEditable}
+        id="studio-media-review-license"
+        label={labels.fields.license}
+        value={metadataDraft.license}
+        onChange={(value) => onMetadataChange('license', value)}
+      />
+    ) : null}
   </div>
 );
 
@@ -140,30 +186,35 @@ const ReviewPanelActions = ({
   const isBusy = isLoadingReviewAsset || isSavingReviewAsset;
 
   return (
-  <div className="flex flex-wrap justify-between gap-3 border-t border-border/60 pt-4">
-    <div className="flex flex-wrap gap-3">
-      <Button type="button" disabled={isBusy} variant="outline" onClick={onBackFromReview}>
-        {reviewSource === 'library' ? labels.actions.backToLibrary : labels.actions.backToUpload}
-      </Button>
-      {reviewAsset && onOpenMediaManagement ? (
-        <Button type="button" disabled={isBusy} variant="outline" onClick={() => void onOpenMediaManagement(reviewAsset.id)}>
-          {labels.actions.openMediaManagement}
+    <div className="flex flex-wrap justify-between gap-3 border-t border-border/60 pt-4">
+      <div className="flex flex-wrap gap-3">
+        <Button type="button" disabled={isBusy} variant="outline" onClick={onBackFromReview}>
+          {reviewSource === 'library' ? labels.actions.backToLibrary : labels.actions.backToUpload}
         </Button>
-      ) : null}
+        {reviewAsset && onOpenMediaManagement ? (
+          <Button
+            type="button"
+            disabled={isBusy}
+            variant="outline"
+            onClick={() => void onOpenMediaManagement(reviewAsset.id)}
+          >
+            {labels.actions.openMediaManagement}
+          </Button>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap gap-3">
+        <Button type="button" disabled={isBusy} variant="outline" onClick={onClose}>
+          {labels.actions.cancel}
+        </Button>
+        <Button
+          type="button"
+          disabled={isLoadingReviewAsset || isSavingReviewAsset || !reviewAsset}
+          onClick={() => void onConfirmSelection()}
+        >
+          {labels.actions.useMedia}
+        </Button>
+      </div>
     </div>
-    <div className="flex flex-wrap gap-3">
-      <Button type="button" disabled={isBusy} variant="outline" onClick={onClose}>
-        {labels.actions.cancel}
-      </Button>
-      <Button
-        type="button"
-        disabled={isLoadingReviewAsset || isSavingReviewAsset || !reviewAsset}
-        onClick={() => void onConfirmSelection()}
-      >
-        {labels.actions.useMedia}
-      </Button>
-    </div>
-  </div>
   );
 };
 
@@ -177,11 +228,15 @@ export type StudioMediaPickerReviewPanelProps = Readonly<{
   isLoadingReviewAsset?: boolean;
   isSavingReviewAsset?: boolean;
   isMetadataEditable?: boolean;
-  onMetadataChange: <Key extends MetadataKey>(key: Key, value: StudioMediaPickerMetadataDraft[Key]) => void;
+  onMetadataChange: <Key extends MetadataKey>(
+    key: Key,
+    value: StudioMediaPickerMetadataDraft[Key]
+  ) => void;
   onBackFromReview: () => void;
   onClose: () => void;
   onConfirmSelection: () => void | Promise<void>;
   onOpenMediaManagement?: (assetId: string) => void | Promise<void>;
+  visibleMetadataFields?: readonly StudioMediaPickerMetadataField[];
 }>;
 
 export const StudioMediaPickerReviewPanel = ({
@@ -199,6 +254,7 @@ export const StudioMediaPickerReviewPanel = ({
   onOpenMediaManagement,
   reviewAsset,
   reviewSource,
+  visibleMetadataFields = defaultMetadataFields,
 }: StudioMediaPickerReviewPanelProps) => {
   return (
     <div className="space-y-5">
@@ -208,7 +264,12 @@ export const StudioMediaPickerReviewPanel = ({
       </div>
 
       {feedbackMessage ? (
-        <p aria-live="polite" className={`text-sm font-medium ${feedbackToneClassName(feedbackTone)}`}>{feedbackMessage}</p>
+        <p
+          aria-live="polite"
+          className={`text-sm font-medium ${feedbackToneClassName(feedbackTone)}`}
+        >
+          {feedbackMessage}
+        </p>
       ) : null}
 
       {isLoadingReviewAsset || !reviewAsset ? (
@@ -223,6 +284,7 @@ export const StudioMediaPickerReviewPanel = ({
             labels={labels}
             metadataDraft={metadataDraft}
             onMetadataChange={onMetadataChange}
+            visibleMetadataFields={visibleMetadataFields}
           />
         </div>
       )}

--- a/packages/studio-ui-react/src/use-studio-media-picker-overlay.actions.ts
+++ b/packages/studio-ui-react/src/use-studio-media-picker-overlay.actions.ts
@@ -8,38 +8,17 @@ import {
   type StudioMediaPickerMetadataField,
   type StudioMediaPickerReviewSource,
 } from './studio-media-picker-overlay.shared.js';
+import {
+  useConfirmSelectionAction,
+  withPreviewUrlFallback,
+  type StudioMediaPickerMetadataUpdate,
+} from './use-studio-media-picker-overlay.confirm.js';
 import { useStudioMediaPickerOverlayState } from './use-studio-media-picker-overlay.state.js';
-
-const allMetadataFields: readonly StudioMediaPickerMetadataField[] = [
-  'title',
-  'altText',
-  'description',
-  'copyright',
-  'license',
-];
 
 export type StudioMediaPickerUploadAssetResult = Readonly<{
   assetId: string;
   previewUrl?: string | null;
 }>;
-
-type StudioMediaPickerMetadataUpdate = Readonly<
-  Partial<{ [Key in StudioMediaPickerMetadataField]: string | null }>
->;
-
-const metadataDraftsMatch = (
-  left: StudioMediaPickerMetadataDraft,
-  right: StudioMediaPickerMetadataDraft,
-  fields: readonly StudioMediaPickerMetadataField[]
-) => fields.every((key) => left[key] === right[key]);
-
-const toMetadataUpdate = (
-  draft: StudioMediaPickerMetadataDraft,
-  fields: readonly StudioMediaPickerMetadataField[]
-): StudioMediaPickerMetadataUpdate =>
-  Object.fromEntries(
-    fields.map((key) => [key, draft[key].trim() || null])
-  ) as StudioMediaPickerMetadataUpdate;
 
 export type StudioMediaPickerOverlayOptions<TAssetDetail extends StudioMediaPickerAssetDetail> =
   Readonly<{
@@ -54,23 +33,6 @@ export type StudioMediaPickerOverlayOptions<TAssetDetail extends StudioMediaPick
     canAcceptAsset?: (asset: TAssetDetail) => boolean;
     editableMetadataFields?: readonly StudioMediaPickerMetadataField[];
   }>;
-
-const withPreviewUrlFallback = <TAssetDetail extends StudioMediaPickerAssetDetail>(
-  asset: TAssetDetail,
-  previewUrlFallback?: string | null
-): TAssetDetail => {
-  if (asset.previewUrl && asset.previewUrl.trim().length > 0) {
-    return asset;
-  }
-  if (!previewUrlFallback || previewUrlFallback.trim().length === 0) {
-    return asset;
-  }
-
-  return {
-    ...asset,
-    previewUrl: previewUrlFallback,
-  };
-};
 
 const useReviewAssetLoader = <TAssetDetail extends StudioMediaPickerAssetDetail>(
   state: ReturnType<typeof useStudioMediaPickerOverlayState>,
@@ -156,76 +118,6 @@ const useUploadFileAction = (
     },
     [actions, isSupportedUploadFile, loadReviewAsset, uploadAsset]
   );
-};
-
-const useConfirmSelectionAction = <TAssetDetail extends StudioMediaPickerAssetDetail>(
-  state: ReturnType<typeof useStudioMediaPickerOverlayState>,
-  reviewAsset: TAssetDetail | null,
-  metadataDraft: StudioMediaPickerMetadataDraft,
-  saveAssetMetadata: (
-    assetId: string,
-    metadata: StudioMediaPickerMetadataUpdate
-  ) => Promise<TAssetDetail>,
-  onAccept: (asset: TAssetDetail) => void,
-  canAcceptAsset?: (asset: TAssetDetail) => boolean,
-  editableMetadataFields: readonly StudioMediaPickerMetadataField[] = allMetadataFields
-) => {
-  const { actions } = state;
-
-  return React.useCallback(async () => {
-    if (!reviewAsset) {
-      return;
-    }
-
-    actions.setErrorCode(null);
-
-    if (canAcceptAsset && !canAcceptAsset(reviewAsset)) {
-      actions.setErrorCode('asset_unavailable');
-      return;
-    }
-
-    if (
-      metadataDraftsMatch(metadataDraft, createMetadataDraft(reviewAsset), editableMetadataFields)
-    ) {
-      onAccept(reviewAsset);
-      actions.close();
-      return;
-    }
-
-    actions.setIsSavingReviewAsset(true);
-
-    try {
-      const updatedAsset = withPreviewUrlFallback(
-        await saveAssetMetadata(
-          reviewAsset.id,
-          toMetadataUpdate(metadataDraft, editableMetadataFields)
-        ),
-        reviewAsset.previewUrl
-      );
-      if (canAcceptAsset && !canAcceptAsset(updatedAsset)) {
-        actions.setReviewAsset(updatedAsset);
-        actions.setMetadataDraft(createMetadataDraft(updatedAsset));
-        actions.setErrorCode('asset_unavailable');
-        return;
-      }
-      actions.setReviewAsset(updatedAsset);
-      actions.setMetadataDraft(createMetadataDraft(updatedAsset));
-      onAccept(updatedAsset);
-      actions.close();
-    } catch {
-      actions.setErrorCode('metadata_save_failed');
-    } finally {
-      actions.setIsSavingReviewAsset(false);
-    }
-  }, [
-    actions,
-    canAcceptAsset,
-    editableMetadataFields,
-    metadataDraft,
-    onAccept,
-    reviewAsset,
-    saveAssetMetadata,
-  ]);
 };
 
 export const useStudioMediaPickerOverlayActions = <

--- a/packages/studio-ui-react/src/use-studio-media-picker-overlay.actions.ts
+++ b/packages/studio-ui-react/src/use-studio-media-picker-overlay.actions.ts
@@ -5,35 +5,55 @@ import {
   type StudioMediaPickerAssetDetail,
   type StudioMediaPickerAssetSummary,
   type StudioMediaPickerMetadataDraft,
+  type StudioMediaPickerMetadataField,
   type StudioMediaPickerReviewSource,
 } from './studio-media-picker-overlay.shared.js';
 import { useStudioMediaPickerOverlayState } from './use-studio-media-picker-overlay.state.js';
+
+const allMetadataFields: readonly StudioMediaPickerMetadataField[] = [
+  'title',
+  'altText',
+  'description',
+  'copyright',
+  'license',
+];
 
 export type StudioMediaPickerUploadAssetResult = Readonly<{
   assetId: string;
   previewUrl?: string | null;
 }>;
 
-type StudioMediaPickerMetadataUpdate = Readonly<{
-  [Key in keyof StudioMediaPickerMetadataDraft]: string | null;
-}>;
+type StudioMediaPickerMetadataUpdate = Readonly<
+  Partial<{ [Key in StudioMediaPickerMetadataField]: string | null }>
+>;
 
-const metadataDraftsMatch = (left: StudioMediaPickerMetadataDraft, right: StudioMediaPickerMetadataDraft) =>
-  Object.keys(left).every((key) => left[key as keyof StudioMediaPickerMetadataDraft] === right[key as keyof StudioMediaPickerMetadataDraft]);
+const metadataDraftsMatch = (
+  left: StudioMediaPickerMetadataDraft,
+  right: StudioMediaPickerMetadataDraft,
+  fields: readonly StudioMediaPickerMetadataField[]
+) => fields.every((key) => left[key] === right[key]);
 
-const toMetadataUpdate = (draft: StudioMediaPickerMetadataDraft): StudioMediaPickerMetadataUpdate =>
+const toMetadataUpdate = (
+  draft: StudioMediaPickerMetadataDraft,
+  fields: readonly StudioMediaPickerMetadataField[]
+): StudioMediaPickerMetadataUpdate =>
   Object.fromEntries(
-    Object.entries(draft).map(([key, value]) => [key, value.trim() || null])
+    fields.map((key) => [key, draft[key].trim() || null])
   ) as StudioMediaPickerMetadataUpdate;
 
-export type StudioMediaPickerOverlayOptions<TAssetDetail extends StudioMediaPickerAssetDetail> = Readonly<{
-  onAccept: (asset: TAssetDetail) => void;
-  isSupportedUploadFile: (file: File) => boolean;
-  uploadAsset: (file: File) => Promise<StudioMediaPickerUploadAssetResult>;
-  loadAsset: (assetId: string) => Promise<TAssetDetail>;
-  saveAssetMetadata: (assetId: string, metadata: StudioMediaPickerMetadataUpdate) => Promise<TAssetDetail>;
-  canAcceptAsset?: (asset: TAssetDetail) => boolean;
-}>;
+export type StudioMediaPickerOverlayOptions<TAssetDetail extends StudioMediaPickerAssetDetail> =
+  Readonly<{
+    onAccept: (asset: TAssetDetail) => void;
+    isSupportedUploadFile: (file: File) => boolean;
+    uploadAsset: (file: File) => Promise<StudioMediaPickerUploadAssetResult>;
+    loadAsset: (assetId: string) => Promise<TAssetDetail>;
+    saveAssetMetadata: (
+      assetId: string,
+      metadata: StudioMediaPickerMetadataUpdate
+    ) => Promise<TAssetDetail>;
+    canAcceptAsset?: (asset: TAssetDetail) => boolean;
+    editableMetadataFields?: readonly StudioMediaPickerMetadataField[];
+  }>;
 
 const withPreviewUrlFallback = <TAssetDetail extends StudioMediaPickerAssetDetail>(
   asset: TAssetDetail,
@@ -60,7 +80,11 @@ const useReviewAssetLoader = <TAssetDetail extends StudioMediaPickerAssetDetail>
   const { actions } = state;
 
   return React.useCallback(
-    async (assetId: string, source: StudioMediaPickerReviewSource, previewUrlFallback?: string | null) => {
+    async (
+      assetId: string,
+      source: StudioMediaPickerReviewSource,
+      previewUrlFallback?: string | null
+    ) => {
       const currentRequestId = ++requestId.current;
       actions.setIsLoadingReviewAsset(true);
       actions.setErrorCode(null);
@@ -96,7 +120,11 @@ const useUploadFileAction = (
   state: ReturnType<typeof useStudioMediaPickerOverlayState>,
   isSupportedUploadFile: (file: File) => boolean,
   uploadAsset: (file: File) => Promise<StudioMediaPickerUploadAssetResult>,
-  loadReviewAsset: (assetId: string, source: StudioMediaPickerReviewSource, previewUrlFallback?: string | null) => Promise<boolean>
+  loadReviewAsset: (
+    assetId: string,
+    source: StudioMediaPickerReviewSource,
+    previewUrlFallback?: string | null
+  ) => Promise<boolean>
 ) => {
   const { actions } = state;
 
@@ -115,7 +143,11 @@ const useUploadFileAction = (
         actions.setUploadPhase('uploading');
         const uploaded = await uploadAsset(file);
         actions.setUploadPhase('finalizing');
-        const didLoadReviewAsset = await loadReviewAsset(uploaded.assetId, 'upload', uploaded.previewUrl);
+        const didLoadReviewAsset = await loadReviewAsset(
+          uploaded.assetId,
+          'upload',
+          uploaded.previewUrl
+        );
         actions.setUploadPhase(didLoadReviewAsset ? 'success' : 'error');
       } catch {
         actions.setUploadPhase('error');
@@ -130,9 +162,13 @@ const useConfirmSelectionAction = <TAssetDetail extends StudioMediaPickerAssetDe
   state: ReturnType<typeof useStudioMediaPickerOverlayState>,
   reviewAsset: TAssetDetail | null,
   metadataDraft: StudioMediaPickerMetadataDraft,
-  saveAssetMetadata: (assetId: string, metadata: StudioMediaPickerMetadataUpdate) => Promise<TAssetDetail>,
+  saveAssetMetadata: (
+    assetId: string,
+    metadata: StudioMediaPickerMetadataUpdate
+  ) => Promise<TAssetDetail>,
   onAccept: (asset: TAssetDetail) => void,
-  canAcceptAsset?: (asset: TAssetDetail) => boolean
+  canAcceptAsset?: (asset: TAssetDetail) => boolean,
+  editableMetadataFields: readonly StudioMediaPickerMetadataField[] = allMetadataFields
 ) => {
   const { actions } = state;
 
@@ -148,7 +184,9 @@ const useConfirmSelectionAction = <TAssetDetail extends StudioMediaPickerAssetDe
       return;
     }
 
-    if (metadataDraftsMatch(metadataDraft, createMetadataDraft(reviewAsset))) {
+    if (
+      metadataDraftsMatch(metadataDraft, createMetadataDraft(reviewAsset), editableMetadataFields)
+    ) {
       onAccept(reviewAsset);
       actions.close();
       return;
@@ -158,7 +196,10 @@ const useConfirmSelectionAction = <TAssetDetail extends StudioMediaPickerAssetDe
 
     try {
       const updatedAsset = withPreviewUrlFallback(
-        await saveAssetMetadata(reviewAsset.id, toMetadataUpdate(metadataDraft)),
+        await saveAssetMetadata(
+          reviewAsset.id,
+          toMetadataUpdate(metadataDraft, editableMetadataFields)
+        ),
         reviewAsset.previewUrl
       );
       if (canAcceptAsset && !canAcceptAsset(updatedAsset)) {
@@ -176,14 +217,32 @@ const useConfirmSelectionAction = <TAssetDetail extends StudioMediaPickerAssetDe
     } finally {
       actions.setIsSavingReviewAsset(false);
     }
-  }, [actions, canAcceptAsset, metadataDraft, onAccept, reviewAsset, saveAssetMetadata]);
+  }, [
+    actions,
+    canAcceptAsset,
+    editableMetadataFields,
+    metadataDraft,
+    onAccept,
+    reviewAsset,
+    saveAssetMetadata,
+  ]);
 };
 
-export const useStudioMediaPickerOverlayActions = <TAssetDetail extends StudioMediaPickerAssetDetail>(
+export const useStudioMediaPickerOverlayActions = <
+  TAssetDetail extends StudioMediaPickerAssetDetail,
+>(
   state: ReturnType<typeof useStudioMediaPickerOverlayState>,
   options: StudioMediaPickerOverlayOptions<TAssetDetail>
 ) => {
-  const { canAcceptAsset, isSupportedUploadFile, loadAsset, onAccept, saveAssetMetadata, uploadAsset } = options;
+  const {
+    canAcceptAsset,
+    editableMetadataFields,
+    isSupportedUploadFile,
+    loadAsset,
+    onAccept,
+    saveAssetMetadata,
+    uploadAsset,
+  } = options;
   const { actions } = state;
   const reviewAsset = state.reviewAsset as TAssetDetail | null;
   const loadReviewAsset = useReviewAssetLoader(state, loadAsset);
@@ -195,10 +254,18 @@ export const useStudioMediaPickerOverlayActions = <TAssetDetail extends StudioMe
     [loadReviewAsset]
   );
 
-  const uploadFile = useUploadFileAction(state, isSupportedUploadFile, uploadAsset, loadReviewAsset);
+  const uploadFile = useUploadFileAction(
+    state,
+    isSupportedUploadFile,
+    uploadAsset,
+    loadReviewAsset
+  );
 
   const updateMetadataField = React.useCallback(
-    <Key extends keyof StudioMediaPickerMetadataDraft>(key: Key, value: StudioMediaPickerMetadataDraft[Key]) => {
+    <Key extends keyof StudioMediaPickerMetadataDraft>(
+      key: Key,
+      value: StudioMediaPickerMetadataDraft[Key]
+    ) => {
       actions.setMetadataDraft((current) => ({
         ...current,
         [key]: value,
@@ -219,7 +286,8 @@ export const useStudioMediaPickerOverlayActions = <TAssetDetail extends StudioMe
     state.metadataDraft,
     saveAssetMetadata,
     onAccept,
-    canAcceptAsset
+    canAcceptAsset,
+    editableMetadataFields
   );
 
   return {

--- a/packages/studio-ui-react/src/use-studio-media-picker-overlay.confirm.ts
+++ b/packages/studio-ui-react/src/use-studio-media-picker-overlay.confirm.ts
@@ -1,0 +1,111 @@
+import * as React from 'react';
+
+import {
+  createMetadataDraft,
+  type StudioMediaPickerAssetDetail,
+  type StudioMediaPickerMetadataDraft,
+  type StudioMediaPickerMetadataField,
+} from './studio-media-picker-overlay.shared.js';
+import { useStudioMediaPickerOverlayState } from './use-studio-media-picker-overlay.state.js';
+
+const allMetadataFields: readonly StudioMediaPickerMetadataField[] = [
+  'title',
+  'altText',
+  'description',
+  'copyright',
+  'license',
+];
+
+export const withPreviewUrlFallback = <TAssetDetail extends StudioMediaPickerAssetDetail>(
+  asset: TAssetDetail,
+  previewUrlFallback?: string | null
+): TAssetDetail => {
+  if (asset.previewUrl?.trim() || !previewUrlFallback?.trim()) return asset;
+  return { ...asset, previewUrl: previewUrlFallback };
+};
+
+export type StudioMediaPickerMetadataUpdate = Readonly<
+  Partial<{ [Key in StudioMediaPickerMetadataField]: string | null }>
+>;
+
+const metadataDraftsMatch = (
+  left: StudioMediaPickerMetadataDraft,
+  right: StudioMediaPickerMetadataDraft,
+  fields: readonly StudioMediaPickerMetadataField[]
+) => fields.every((key) => left[key] === right[key]);
+
+const toMetadataUpdate = (
+  draft: StudioMediaPickerMetadataDraft,
+  fields: readonly StudioMediaPickerMetadataField[]
+): StudioMediaPickerMetadataUpdate =>
+  Object.fromEntries(
+    fields.map((key) => [key, draft[key].trim() || null])
+  ) as StudioMediaPickerMetadataUpdate;
+
+export const useConfirmSelectionAction = <
+  TAssetDetail extends StudioMediaPickerAssetDetail,
+>(
+  state: ReturnType<typeof useStudioMediaPickerOverlayState>,
+  reviewAsset: TAssetDetail | null,
+  metadataDraft: StudioMediaPickerMetadataDraft,
+  saveAssetMetadata: (
+    assetId: string,
+    metadata: StudioMediaPickerMetadataUpdate
+  ) => Promise<TAssetDetail>,
+  onAccept: (asset: TAssetDetail) => void,
+  canAcceptAsset?: (asset: TAssetDetail) => boolean,
+  editableMetadataFields: readonly StudioMediaPickerMetadataField[] = allMetadataFields
+) => {
+  const { actions } = state;
+
+  return React.useCallback(async () => {
+    if (!reviewAsset) return;
+
+    actions.setErrorCode(null);
+    if (canAcceptAsset && !canAcceptAsset(reviewAsset)) {
+      actions.setErrorCode('asset_unavailable');
+      return;
+    }
+
+    if (
+      metadataDraftsMatch(metadataDraft, createMetadataDraft(reviewAsset), editableMetadataFields)
+    ) {
+      onAccept(reviewAsset);
+      actions.close();
+      return;
+    }
+
+    actions.setIsSavingReviewAsset(true);
+    try {
+      const updatedAsset = withPreviewUrlFallback(
+        await saveAssetMetadata(
+          reviewAsset.id,
+          toMetadataUpdate(metadataDraft, editableMetadataFields)
+        ),
+        reviewAsset.previewUrl
+      );
+      if (canAcceptAsset && !canAcceptAsset(updatedAsset)) {
+        actions.setReviewAsset(updatedAsset);
+        actions.setMetadataDraft(createMetadataDraft(updatedAsset));
+        actions.setErrorCode('asset_unavailable');
+        return;
+      }
+      actions.setReviewAsset(updatedAsset);
+      actions.setMetadataDraft(createMetadataDraft(updatedAsset));
+      onAccept(updatedAsset);
+      actions.close();
+    } catch {
+      actions.setErrorCode('metadata_save_failed');
+    } finally {
+      actions.setIsSavingReviewAsset(false);
+    }
+  }, [
+    actions,
+    canAcceptAsset,
+    editableMetadataFields,
+    metadataDraft,
+    onAccept,
+    reviewAsset,
+    saveAssetMetadata,
+  ]);
+};

--- a/packages/studio-ui-react/src/use-studio-media-picker-overlay.ts
+++ b/packages/studio-ui-react/src/use-studio-media-picker-overlay.ts
@@ -7,6 +7,7 @@ import { useStudioMediaPickerOverlayState } from './use-studio-media-picker-over
 
 export const useStudioMediaPickerOverlay = <TAssetDetail extends StudioMediaPickerAssetDetail>({
   canAcceptAsset,
+  editableMetadataFields,
   isSupportedUploadFile,
   loadAsset,
   onAccept,
@@ -16,6 +17,7 @@ export const useStudioMediaPickerOverlay = <TAssetDetail extends StudioMediaPick
   const state = useStudioMediaPickerOverlayState();
   const actions = useStudioMediaPickerOverlayActions<TAssetDetail>(state, {
     canAcceptAsset,
+    editableMetadataFields,
     isSupportedUploadFile,
     loadAsset,
     onAccept,

--- a/packages/sva-mainserver/src/server/cockpit-cards-listing.ts
+++ b/packages/sva-mainserver/src/server/cockpit-cards-listing.ts
@@ -41,7 +41,7 @@ export const listCockpitCardItems = async (
     if (page > MAX_UPSTREAM_PAGES)
       throw new SvaMainserverError({
         code: 'invalid_response',
-        message: 'Cockpit-Cards-Auflistung überschreitet das erlaubte Upstream-Seitenlimit.',
+        message: 'Die Kachelauflistung überschreitet das erlaubte Upstream-Seitenlimit.',
         statusCode: 502,
       });
     const result = await listItems({ ...input, page, pageSize: 100 });

--- a/packages/sva-mainserver/src/server/content-route-parsers-poi.ts
+++ b/packages/sva-mainserver/src/server/content-route-parsers-poi.ts
@@ -96,7 +96,14 @@ export const parseOperatingCompany = (value: unknown): SvaMainserverOperatingCom
   };
 };
 
-export const parseMediaContents = (value: unknown): readonly SvaMainserverMediaContentInput[] | Response | undefined => {
+type ParseMediaContentsOptions = {
+  readonly preserveAdditionalFields?: boolean;
+};
+
+export const parseMediaContents = (
+  value: unknown,
+  options?: ParseMediaContentsOptions,
+): readonly SvaMainserverMediaContentInput[] | Response | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -109,12 +116,28 @@ export const parseMediaContents = (value: unknown): readonly SvaMainserverMediaC
     if (!isRecord(media)) {
       return errorJson(400, 'invalid_request', 'MediaContent-Einträge müssen Objekte sein.');
     }
-    const sourceUrl = parseWebUrl(media.sourceUrl);
+    const sourceUrl = parseWebUrl(media.sourceUrl, options);
     if (sourceUrl instanceof Response) {
       return sourceUrl;
     }
+    const {
+      captionText: ignoredCaptionText,
+      copyright: ignoredCopyright,
+      contentType: ignoredContentType,
+      height: ignoredHeight,
+      width: ignoredWidth,
+      sourceUrl: ignoredSourceUrl,
+      ...additionalFields
+    } = media;
+    void ignoredCaptionText;
+    void ignoredCopyright;
+    void ignoredContentType;
+    void ignoredHeight;
+    void ignoredWidth;
+    void ignoredSourceUrl;
 
     mediaContents.push({
+      ...(options?.preserveAdditionalFields ? additionalFields : {}),
       ...(readString(media.captionText) ? { captionText: readString(media.captionText) } : {}),
       ...(readString(media.copyright) ? { copyright: readString(media.copyright) } : {}),
       ...(readString(media.contentType) ? { contentType: readString(media.contentType) } : {}),

--- a/packages/sva-mainserver/src/server/content-route-parsers-poi.ts
+++ b/packages/sva-mainserver/src/server/content-route-parsers-poi.ts
@@ -96,14 +96,7 @@ export const parseOperatingCompany = (value: unknown): SvaMainserverOperatingCom
   };
 };
 
-type ParseMediaContentsOptions = {
-  readonly preserveAdditionalFields?: boolean;
-};
-
-export const parseMediaContents = (
-  value: unknown,
-  options?: ParseMediaContentsOptions,
-): readonly SvaMainserverMediaContentInput[] | Response | undefined => {
+export const parseMediaContents = (value: unknown): readonly SvaMainserverMediaContentInput[] | Response | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -116,28 +109,11 @@ export const parseMediaContents = (
     if (!isRecord(media)) {
       return errorJson(400, 'invalid_request', 'MediaContent-Einträge müssen Objekte sein.');
     }
-    const sourceUrl = parseWebUrl(media.sourceUrl, options);
+    const sourceUrl = parseWebUrl(media.sourceUrl);
     if (sourceUrl instanceof Response) {
       return sourceUrl;
     }
-    const {
-      captionText: ignoredCaptionText,
-      copyright: ignoredCopyright,
-      contentType: ignoredContentType,
-      height: ignoredHeight,
-      width: ignoredWidth,
-      sourceUrl: ignoredSourceUrl,
-      ...additionalFields
-    } = media;
-    void ignoredCaptionText;
-    void ignoredCopyright;
-    void ignoredContentType;
-    void ignoredHeight;
-    void ignoredWidth;
-    void ignoredSourceUrl;
-
     mediaContents.push({
-      ...(options?.preserveAdditionalFields ? additionalFields : {}),
       ...(readString(media.captionText) ? { captionText: readString(media.captionText) } : {}),
       ...(readString(media.copyright) ? { copyright: readString(media.copyright) } : {}),
       ...(readString(media.contentType) ? { contentType: readString(media.contentType) } : {}),

--- a/packages/sva-mainserver/src/server/content-route-parsers.shared.ts
+++ b/packages/sva-mainserver/src/server/content-route-parsers.shared.ts
@@ -49,7 +49,14 @@ const readGeoLocation = (
   return { latitude, longitude };
 };
 
-export const parseWebUrl = (value: unknown): SvaMainserverWebUrlInput | Response | undefined => {
+type ParseWebUrlOptions = {
+  readonly preserveAdditionalFields?: boolean;
+};
+
+export const parseWebUrl = (
+  value: unknown,
+  options?: ParseWebUrlOptions,
+): SvaMainserverWebUrlInput | Response | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -60,13 +67,20 @@ export const parseWebUrl = (value: unknown): SvaMainserverWebUrlInput | Response
   if (!url || !isHttpsUrl(url)) {
     return errorJson(400, 'invalid_request', 'URL-Angaben müssen eine gültige HTTPS-URL enthalten.');
   }
+  const { url: ignoredUrl, description: ignoredDescription, ...additionalFields } = value;
+  void ignoredUrl;
+  void ignoredDescription;
   return {
+    ...(options?.preserveAdditionalFields ? additionalFields : {}),
     url,
     ...(readString(value.description) ? { description: readString(value.description) } : {}),
   };
 };
 
-export const parseWebUrls = (value: unknown): readonly SvaMainserverWebUrlInput[] | Response | undefined => {
+export const parseWebUrls = (
+  value: unknown,
+  options?: ParseWebUrlOptions,
+): readonly SvaMainserverWebUrlInput[] | Response | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -76,7 +90,7 @@ export const parseWebUrls = (value: unknown): readonly SvaMainserverWebUrlInput[
 
   const urls: SvaMainserverWebUrlInput[] = [];
   for (const item of value) {
-    const parsed = parseWebUrl(item);
+    const parsed = parseWebUrl(item, options);
     if (parsed instanceof Response) {
       return parsed;
     }

--- a/packages/sva-mainserver/src/server/content-route-parsers.shared.ts
+++ b/packages/sva-mainserver/src/server/content-route-parsers.shared.ts
@@ -49,14 +49,7 @@ const readGeoLocation = (
   return { latitude, longitude };
 };
 
-type ParseWebUrlOptions = {
-  readonly preserveAdditionalFields?: boolean;
-};
-
-export const parseWebUrl = (
-  value: unknown,
-  options?: ParseWebUrlOptions,
-): SvaMainserverWebUrlInput | Response | undefined => {
+export const parseWebUrl = (value: unknown): SvaMainserverWebUrlInput | Response | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -67,20 +60,13 @@ export const parseWebUrl = (
   if (!url || !isHttpsUrl(url)) {
     return errorJson(400, 'invalid_request', 'URL-Angaben müssen eine gültige HTTPS-URL enthalten.');
   }
-  const { url: ignoredUrl, description: ignoredDescription, ...additionalFields } = value;
-  void ignoredUrl;
-  void ignoredDescription;
   return {
-    ...(options?.preserveAdditionalFields ? additionalFields : {}),
     url,
     ...(readString(value.description) ? { description: readString(value.description) } : {}),
   };
 };
 
-export const parseWebUrls = (
-  value: unknown,
-  options?: ParseWebUrlOptions,
-): readonly SvaMainserverWebUrlInput[] | Response | undefined => {
+export const parseWebUrls = (value: unknown): readonly SvaMainserverWebUrlInput[] | Response | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -90,7 +76,7 @@ export const parseWebUrls = (
 
   const urls: SvaMainserverWebUrlInput[] = [];
   for (const item of value) {
-    const parsed = parseWebUrl(item, options);
+    const parsed = parseWebUrl(item);
     if (parsed instanceof Response) {
       return parsed;
     }

--- a/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.test.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.test.ts
@@ -135,4 +135,47 @@ describe('cockpit card route validation', () => {
       })
     );
   });
+
+  it('preserves additional link and media metadata', async () => {
+    const result = await validateCockpitCardWriteOrResponse(
+      new Request('https://studio.test/api/v1/mainserver/generic-items/card-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...validItem,
+          webUrls: [{ ...validItem.webUrls[0], source: 'legacy-link-source' }],
+          mediaContents: [
+            {
+              ...validItem.mediaContents[0],
+              legacyMediaKey: 'legacy-media-value',
+              sourceUrl: {
+                ...validItem.mediaContents[0]?.sourceUrl,
+                source: 'legacy-media-source',
+              },
+            },
+          ],
+        }),
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        webUrls: [
+          {
+            source: 'legacy-link-source',
+            url: 'https://example.test/details',
+          },
+        ],
+        mediaContents: [
+          expect.objectContaining({
+            legacyMediaKey: 'legacy-media-value',
+            sourceUrl: {
+              source: 'legacy-media-source',
+              url: 'https://example.test/image.jpg',
+            },
+          }),
+        ],
+      })
+    );
+  });
 });

--- a/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.test.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.test.ts
@@ -72,9 +72,14 @@ describe('cockpit card route validation', () => {
     [{ ...validItem, webUrls: [{ url: 'https://one.test' }, { url: 'https://two.test' }] }, 'Link'],
     [{ ...validItem, webUrls: [{ url: 'http://example.test' }] }, 'Link'],
     [{ ...validItem, contentBlocks: [{ body: '<b>Text</b>' }] }, 'HTML'],
-    [{ ...validItem, contacts: [{ email: 'person@example.test' }] }, 'Kontakte'],
-    [{ ...validItem, addresses: [{}] }, 'Kontakte'],
-    [{ ...validItem, locations: [{}] }, 'Kontakte'],
+    [
+      { ...validItem, contacts: [{ email: 'person@example.test' }] },
+      'fachfremden GenericItem-Felder',
+    ],
+    [{ ...validItem, addresses: [{}] }, 'fachfremden GenericItem-Felder'],
+    [{ ...validItem, locations: [{}] }, 'fachfremden GenericItem-Felder'],
+    [{ ...validItem, keywords: 'fachfremd' }, 'fachfremden GenericItem-Felder'],
+    [{ ...validItem, contacts: [] }, 'fachfremden GenericItem-Felder'],
   ])('rejects a contract violation', async (item, message) => {
     const response = validateCockpitCardItemOrResponse(item);
     expect(response?.status).toBe(400);
@@ -136,20 +141,28 @@ describe('cockpit card route validation', () => {
     );
   });
 
-  it('preserves additional link and media metadata', async () => {
+  it('forwards only schema-supported link and media fields', async () => {
     const result = await validateCockpitCardWriteOrResponse(
       new Request('https://studio.test/api/v1/mainserver/generic-items/card-1', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...validItem,
-          webUrls: [{ ...validItem.webUrls[0], source: 'legacy-link-source' }],
+          webUrls: [
+            {
+              ...validItem.webUrls[0],
+              id: 'response-link-id',
+              source: 'legacy-link-source',
+            },
+          ],
           mediaContents: [
             {
               ...validItem.mediaContents[0],
+              id: 'response-media-id',
               legacyMediaKey: 'legacy-media-value',
               sourceUrl: {
                 ...validItem.mediaContents[0]?.sourceUrl,
+                id: 'response-source-id',
                 source: 'legacy-media-source',
               },
             },
@@ -160,20 +173,12 @@ describe('cockpit card route validation', () => {
 
     expect(result).toEqual(
       expect.objectContaining({
-        webUrls: [
-          {
-            source: 'legacy-link-source',
-            url: 'https://example.test/details',
-          },
-        ],
+        webUrls: [{ url: 'https://example.test/details' }],
         mediaContents: [
-          expect.objectContaining({
-            legacyMediaKey: 'legacy-media-value',
-            sourceUrl: {
-              source: 'legacy-media-source',
-              url: 'https://example.test/image.jpg',
-            },
-          }),
+          {
+            contentType: 'image',
+            sourceUrl: { url: 'https://example.test/image.jpg' },
+          },
         ],
       })
     );

--- a/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.test.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.test.ts
@@ -11,7 +11,7 @@ const validItem: SvaMainserverGenericItemInput = {
   title: 'Überschrift',
   genericType: 'COCKPIT_CARD',
   contentBlocks: [{ body: 'Text' }],
-  payload: { languageCode: 'de', sortWeight: 0 },
+  payload: { languageCode: 'de', sortWeight: 0, openInNewTab: true },
   categoryName: 'Startseite',
   categories: [{ name: 'Startseite' }],
   mediaContents: [{ sourceUrl: { url: 'https://example.test/image.jpg' }, contentType: 'image' }],
@@ -40,12 +40,35 @@ describe('cockpit card route validation', () => {
     [{ ...validItem, payload: { languageCode: 'invalid!', sortWeight: 0 } }, 'Sprachcode'],
     [{ ...validItem, payload: { languageCode: 'de', sortWeight: '0' } }, 'Sortiergewicht'],
     [{ ...validItem, payload: { languageCode: 'de', sortWeight: 1.5 } }, 'Sortiergewicht'],
-    [{ ...validItem, payload: { languageCode: 'de', sortWeight: Number.POSITIVE_INFINITY } }, 'Sortiergewicht'],
+    [
+      { ...validItem, payload: { languageCode: 'de', sortWeight: Number.POSITIVE_INFINITY } },
+      'Sortiergewicht',
+    ],
+    [
+      { ...validItem, payload: { languageCode: 'de', sortWeight: 0, openInNewTab: 'yes' } },
+      'Linkoption',
+    ],
     [{ ...validItem, categories: [] }, 'Kategorie'],
     [{ ...validItem, categories: [{ name: ' ' }] }, 'Kategorie'],
     [{ ...validItem, categories: [{ name: 'A' }, { name: 'B' }] }, 'Kategorie'],
-    [{ ...validItem, mediaContents: [{ sourceUrl: { url: 'https://example.test/image.jpg' }, contentType: 'video' }] }, 'Bild'],
-    [{ ...validItem, mediaContents: [{ sourceUrl: { url: 'http://example.test/image.jpg' }, contentType: 'image' }] }, 'Bild'],
+    [
+      {
+        ...validItem,
+        mediaContents: [
+          { sourceUrl: { url: 'https://example.test/image.jpg' }, contentType: 'video' },
+        ],
+      },
+      'Bild',
+    ],
+    [
+      {
+        ...validItem,
+        mediaContents: [
+          { sourceUrl: { url: 'http://example.test/image.jpg' }, contentType: 'image' },
+        ],
+      },
+      'Bild',
+    ],
     [{ ...validItem, webUrls: [{ url: 'https://one.test' }, { url: 'https://two.test' }] }, 'Link'],
     [{ ...validItem, webUrls: [{ url: 'http://example.test' }] }, 'Link'],
     [{ ...validItem, contentBlocks: [{ body: '<b>Text</b>' }] }, 'HTML'],
@@ -78,7 +101,7 @@ describe('cockpit card route validation', () => {
         body: JSON.stringify({
           title: validItem.title,
           genericType: validItem.genericType,
-          payload: { sortWeight: 0 },
+          payload: { sortWeight: 0, openInNewTab: true },
           categoryName: validItem.categoryName,
           categories: validItem.categories,
           visible: true,
@@ -91,7 +114,24 @@ describe('cockpit card route validation', () => {
         contentBlocks: [],
         mediaContents: [],
         webUrls: [],
-        payload: { languageCode: '', sortWeight: 0 },
+        payload: { languageCode: '', sortWeight: 0, openInNewTab: false },
+      })
+    );
+  });
+
+  it('keeps the opening option only when a link is present', async () => {
+    const result = await validateCockpitCardWriteOrResponse(
+      new Request('https://studio.test/api/v1/mainserver/generic-items/card-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validItem),
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        payload: expect.objectContaining({ openInNewTab: true }),
+        webUrls: validItem.webUrls,
       })
     );
   });

--- a/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.ts
@@ -4,6 +4,18 @@ import { parseGenericItemInput } from './generic-items-route-input.js';
 
 const htmlPattern = /<\/?[a-z][^>]*>/i;
 const languagePattern = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
+const unsupportedCockpitCardFields = [
+  'author',
+  'keywords',
+  'publishedAt',
+  'contacts',
+  'addresses',
+  'openingHours',
+  'priceInformations',
+  'locations',
+  'dates',
+  'accessibilityInformations',
+] as const satisfies readonly (keyof SvaMainserverGenericItemInput)[];
 const payloadRecord = (payload: unknown): Record<string, unknown> =>
   payload && typeof payload === 'object' && !Array.isArray(payload)
     ? (payload as Record<string, unknown>)
@@ -62,15 +74,11 @@ export const validateCockpitCardItemOrResponse = (
     item.webUrls?.some((link) => !link.url.startsWith('https://'))
   )
     return errorJson(400, 'invalid_request', 'Kacheln unterstützen höchstens einen HTTPS-Link.');
-  if (
-    (item.contacts?.length ?? 0) ||
-    (item.addresses?.length ?? 0) ||
-    (item.locations?.length ?? 0)
-  )
+  if (unsupportedCockpitCardFields.some((field) => item[field] !== undefined))
     return errorJson(
       400,
       'invalid_request',
-      'Kacheln unterstützen keine Kontakte, Adressen oder Orte.'
+      'Kacheln unterstützen keine fachfremden GenericItem-Felder.'
     );
   return null;
 };
@@ -78,9 +86,7 @@ export const validateCockpitCardItemOrResponse = (
 export const validateCockpitCardWriteOrResponse = async (
   request: Request
 ): Promise<SvaMainserverGenericItemInput | Response> => {
-  const item = await parseGenericItemInput(request, {
-    preserveWebAndMediaAdditionalFields: true,
-  });
+  const item = await parseGenericItemInput(request);
   if (isResponse(item)) return item;
   const validation = validateCockpitCardItemOrResponse(item);
   if (validation) return validation;

--- a/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.ts
@@ -78,7 +78,9 @@ export const validateCockpitCardItemOrResponse = (
 export const validateCockpitCardWriteOrResponse = async (
   request: Request
 ): Promise<SvaMainserverGenericItemInput | Response> => {
-  const item = await parseGenericItemInput(request);
+  const item = await parseGenericItemInput(request, {
+    preserveWebAndMediaAdditionalFields: true,
+  });
   if (isResponse(item)) return item;
   const validation = validateCockpitCardItemOrResponse(item);
   if (validation) return validation;

--- a/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-cockpit-cards.ts
@@ -20,30 +20,33 @@ export const validateCockpitCardItemOrResponse = (
   const firstBlock = contentBlocks[0];
   const text = firstBlock?.body?.trim() ?? '';
   if (contentBlocks.length > 1)
-    return errorJson(400, 'invalid_request', 'Cockpit Cards unterstützen höchstens einen Textblock.');
+    return errorJson(400, 'invalid_request', 'Kacheln unterstützen höchstens einen Textblock.');
   if (firstBlock && (!text || Object.keys(firstBlock).some((key) => key !== 'body')))
     return errorJson(
       400,
       'invalid_request',
-      'Cockpit-Card-Textblöcke dürfen ausschließlich nicht leeren Text enthalten.'
+      'Kachel-Textblöcke dürfen ausschließlich nicht leeren Text enthalten.'
     );
   if (htmlPattern.test(text))
-    return errorJson(400, 'invalid_request', 'HTML im Cockpit-Card-Text ist nicht erlaubt.');
+    return errorJson(400, 'invalid_request', 'HTML im Kacheltext ist nicht erlaubt.');
   const payload = payloadRecord(item.payload);
   if (
     payload.languageCode !== undefined &&
     (typeof payload.languageCode !== 'string' ||
-      (payload.languageCode.trim().length > 0 && !languagePattern.test(payload.languageCode.trim())))
+      (payload.languageCode.trim().length > 0 &&
+        !languagePattern.test(payload.languageCode.trim())))
   )
-    return errorJson(400, 'invalid_request', 'Der Cockpit-Card-Sprachcode ist ungültig.');
+    return errorJson(400, 'invalid_request', 'Der Kachel-Sprachcode ist ungültig.');
   if (
     typeof payload.sortWeight !== 'number' ||
     !Number.isInteger(payload.sortWeight) ||
     !Number.isFinite(payload.sortWeight)
   )
-    return errorJson(400, 'invalid_request', 'Das Cockpit-Card-Sortiergewicht ist ungültig.');
+    return errorJson(400, 'invalid_request', 'Das Kachel-Sortiergewicht ist ungültig.');
+  if (payload.openInNewTab !== undefined && typeof payload.openInNewTab !== 'boolean')
+    return errorJson(400, 'invalid_request', 'Die Kachel-Linkoption ist ungültig.');
   if (item.categories?.length !== 1 || !item.categories[0]?.name?.trim())
-    return errorJson(400, 'invalid_request', 'Genau eine Cockpit-Card-Kategorie ist erforderlich.');
+    return errorJson(400, 'invalid_request', 'Genau eine Kachel-Kategorie ist erforderlich.');
   if (
     item.mediaContents?.some(
       (media) => media.contentType !== 'image' || !media.sourceUrl?.url.startsWith('https://')
@@ -52,17 +55,13 @@ export const validateCockpitCardItemOrResponse = (
     return errorJson(
       400,
       'invalid_request',
-      'Cockpit Cards unterstützen ausschließlich gültige HTTPS-Bilder.'
+      'Kacheln unterstützen ausschließlich gültige HTTPS-Bilder.'
     );
   if (
     (item.webUrls?.length ?? 0) > 1 ||
     item.webUrls?.some((link) => !link.url.startsWith('https://'))
   )
-    return errorJson(
-      400,
-      'invalid_request',
-      'Cockpit Cards unterstützen höchstens einen HTTPS-Link.'
-    );
+    return errorJson(400, 'invalid_request', 'Kacheln unterstützen höchstens einen HTTPS-Link.');
   if (
     (item.contacts?.length ?? 0) ||
     (item.addresses?.length ?? 0) ||
@@ -71,7 +70,7 @@ export const validateCockpitCardItemOrResponse = (
     return errorJson(
       400,
       'invalid_request',
-      'Cockpit Cards unterstützen keine Kontakte, Adressen oder Orte.'
+      'Kacheln unterstützen keine Kontakte, Adressen oder Orte.'
     );
   return null;
 };
@@ -84,14 +83,16 @@ export const validateCockpitCardWriteOrResponse = async (
   const validation = validateCockpitCardItemOrResponse(item);
   if (validation) return validation;
   const payload = payloadRecord(item.payload);
+  const webUrls = item.webUrls ?? [];
   return {
     ...item,
     contentBlocks: item.contentBlocks ?? [],
     mediaContents: item.mediaContents ?? [],
-    webUrls: item.webUrls ?? [],
+    webUrls,
     payload: {
       ...payload,
       languageCode: typeof payload.languageCode === 'string' ? payload.languageCode : '',
+      openInNewTab: webUrls.length > 0 && payload.openInNewTab === true,
     },
   };
 };

--- a/packages/sva-mainserver/src/server/generic-items-route-input.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-input.ts
@@ -33,15 +33,26 @@ import { parseContactList } from './generic-items-route-input.contacts.js';
 import { parseDates } from './generic-items-route-input.dates.js';
 import { parseLocations } from './generic-items-route-input.locations.js';
 
-const parseGenericItemSections = (body: Record<string, unknown>) => ({
+type ParseGenericItemInputOptions = {
+  readonly preserveWebAndMediaAdditionalFields?: boolean;
+};
+
+const parseGenericItemSections = (
+  body: Record<string, unknown>,
+  options?: ParseGenericItemInputOptions,
+) => ({
   categories: parseCategories(body.categories),
   contacts: parseContactList(body.contacts),
-  webUrls: parseWebUrls(body.webUrls),
+  webUrls: parseWebUrls(body.webUrls, {
+    preserveAdditionalFields: options?.preserveWebAndMediaAdditionalFields,
+  }),
   addresses: parseAddressList(body.addresses),
   contentBlocks: parseContentBlocks(body.contentBlocks),
   openingHours: parseOpeningHours(body.openingHours),
   priceInformations: parsePrices(body.priceInformations),
-  mediaContents: parseMediaContents(body.mediaContents),
+  mediaContents: parseMediaContents(body.mediaContents, {
+    preserveAdditionalFields: options?.preserveWebAndMediaAdditionalFields,
+  }),
   locations: parseLocations(body.locations),
   dates: parseDates(body.dates),
   accessibilityInformations: parseAccessibilityInformations(body.accessibilityInformations),
@@ -57,7 +68,10 @@ const hasSectionParseError = (
 const findSectionParseError = (sections: ParsedGenericItemSections) =>
   Object.values(sections).find((parsed): parsed is Response => parsed instanceof Response);
 
-export const parseGenericItemInput = async (request: Request): Promise<SvaMainserverGenericItemInput | Response> => {
+export const parseGenericItemInput = async (
+  request: Request,
+  options?: ParseGenericItemInputOptions,
+): Promise<SvaMainserverGenericItemInput | Response> => {
   const body = await parseJsonObjectBody(request, 'Generic-Item-Daten müssen als Objekt gesendet werden.');
   if (isResponse(body)) {
     return body;
@@ -73,7 +87,7 @@ export const parseGenericItemInput = async (request: Request): Promise<SvaMainse
     return errorJson(400, 'invalid_request', 'Der Generic-Type ist erforderlich.');
   }
 
-  const sections = parseGenericItemSections(body);
+  const sections = parseGenericItemSections(body, options);
   if (hasSectionParseError(sections)) {
     return findSectionParseError(sections) ?? errorJson(400, 'invalid_request', 'Ungültige Generic-Item-Daten.');
   }

--- a/packages/sva-mainserver/src/server/generic-items-route-input.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route-input.ts
@@ -33,26 +33,15 @@ import { parseContactList } from './generic-items-route-input.contacts.js';
 import { parseDates } from './generic-items-route-input.dates.js';
 import { parseLocations } from './generic-items-route-input.locations.js';
 
-type ParseGenericItemInputOptions = {
-  readonly preserveWebAndMediaAdditionalFields?: boolean;
-};
-
-const parseGenericItemSections = (
-  body: Record<string, unknown>,
-  options?: ParseGenericItemInputOptions,
-) => ({
+const parseGenericItemSections = (body: Record<string, unknown>) => ({
   categories: parseCategories(body.categories),
   contacts: parseContactList(body.contacts),
-  webUrls: parseWebUrls(body.webUrls, {
-    preserveAdditionalFields: options?.preserveWebAndMediaAdditionalFields,
-  }),
+  webUrls: parseWebUrls(body.webUrls),
   addresses: parseAddressList(body.addresses),
   contentBlocks: parseContentBlocks(body.contentBlocks),
   openingHours: parseOpeningHours(body.openingHours),
   priceInformations: parsePrices(body.priceInformations),
-  mediaContents: parseMediaContents(body.mediaContents, {
-    preserveAdditionalFields: options?.preserveWebAndMediaAdditionalFields,
-  }),
+  mediaContents: parseMediaContents(body.mediaContents),
   locations: parseLocations(body.locations),
   dates: parseDates(body.dates),
   accessibilityInformations: parseAccessibilityInformations(body.accessibilityInformations),
@@ -68,10 +57,7 @@ const hasSectionParseError = (
 const findSectionParseError = (sections: ParsedGenericItemSections) =>
   Object.values(sections).find((parsed): parsed is Response => parsed instanceof Response);
 
-export const parseGenericItemInput = async (
-  request: Request,
-  options?: ParseGenericItemInputOptions,
-): Promise<SvaMainserverGenericItemInput | Response> => {
+export const parseGenericItemInput = async (request: Request): Promise<SvaMainserverGenericItemInput | Response> => {
   const body = await parseJsonObjectBody(request, 'Generic-Item-Daten müssen als Objekt gesendet werden.');
   if (isResponse(body)) {
     return body;
@@ -87,7 +73,7 @@ export const parseGenericItemInput = async (
     return errorJson(400, 'invalid_request', 'Der Generic-Type ist erforderlich.');
   }
 
-  const sections = parseGenericItemSections(body, options);
+  const sections = parseGenericItemSections(body);
   if (hasSectionParseError(sections)) {
     return findSectionParseError(sections) ?? errorJson(400, 'invalid_request', 'Ungültige Generic-Item-Daten.');
   }

--- a/packages/sva-mainserver/src/server/generic-items-route.test.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route.test.ts
@@ -337,7 +337,7 @@ describe('dispatchSvaMainserverGenericItemsRequest', () => {
       })
     );
     expect(state.loggerInfo).toHaveBeenCalledWith(
-      'Cockpit Cards list upstream pagination completed',
+      'Kachel list upstream pagination completed',
       expect.objectContaining({ matching_item_count: 1 })
     );
   });
@@ -347,8 +347,9 @@ describe('dispatchSvaMainserverGenericItemsRequest', () => {
     const body = {
       title: 'Karte',
       genericType: 'INFO',
+      externalId: 'client-controlled-id',
       contentBlocks: [{ body: 'Text' }],
-      payload: { languageCode: 'de', sortWeight: 2 },
+      payload: { languageCode: 'de', sortWeight: 2, openInNewTab: true },
       categories: [{ name: 'Startseite' }],
       mediaContents: [
         { sourceUrl: { url: 'https://example.test/image.jpg' }, contentType: 'image' },
@@ -368,10 +369,14 @@ describe('dispatchSvaMainserverGenericItemsRequest', () => {
         genericItem: expect.objectContaining({ genericType: 'COCKPIT_CARD' }),
       })
     );
+    expect(state.createSvaMainserverGenericItem.mock.calls[0]?.[0]?.genericItem).not.toHaveProperty(
+      'externalId'
+    );
 
     state.getSvaMainserverGenericItem.mockResolvedValue({
       id: 'card-1',
       genericType: 'COCKPIT_CARD',
+      externalId: 'source-card-1',
       payload: { legacy: 'keep', languageCode: 'de', sortWeight: 1 },
     });
     state.updateSvaMainserverGenericItem.mockResolvedValue({ id: 'card-1' });
@@ -386,7 +391,13 @@ describe('dispatchSvaMainserverGenericItemsRequest', () => {
       expect.objectContaining({
         genericItem: expect.objectContaining({
           genericType: 'COCKPIT_CARD',
-          payload: { legacy: 'keep', languageCode: 'de', sortWeight: 2 },
+          externalId: 'source-card-1',
+          payload: {
+            legacy: 'keep',
+            languageCode: 'de',
+            sortWeight: 2,
+            openInNewTab: true,
+          },
         }),
       })
     );

--- a/packages/sva-mainserver/src/server/generic-items-route.ts
+++ b/packages/sva-mainserver/src/server/generic-items-route.ts
@@ -70,6 +70,21 @@ const preserveEditorialAuthor = (
   ...(existing?.author ? { author: existing.author } : {}),
 });
 
+const preserveCockpitCardIdentity = (
+  genericItem: SvaMainserverGenericItemInput,
+  existing: { readonly author?: string; readonly externalId?: string } | null | undefined
+): SvaMainserverGenericItemInput => {
+  const { externalId, ...genericItemWithoutExternalId } = preserveEditorialAuthor(
+    genericItem,
+    existing
+  );
+  void externalId;
+  return {
+    ...genericItemWithoutExternalId,
+    ...(existing?.externalId ? { externalId: existing.externalId } : {}),
+  };
+};
+
 type ContentKind = 'generic-items' | 'faq' | 'cockpit-cards';
 
 type ContentActor = {
@@ -219,7 +234,7 @@ const handleListRequest = async (
     });
   }
   if (cockpitCardsResult)
-    logger.info('Cockpit Cards list upstream pagination completed', {
+    logger.info('Kachel list upstream pagination completed', {
       operation: 'mainserver_cockpit_cards_list_upstream',
       upstream_page_count: cockpitCardsResult.observability.upstreamPageCount,
       matching_item_count: cockpitCardsResult.observability.matchingItemCount,
@@ -256,7 +271,7 @@ const handleDetailRequest = async (
     return errorJson(404, 'not_found', 'FAQ wurde nicht gefunden.');
   }
   if (contentKind === 'cockpit-cards' && data.genericType !== 'COCKPIT_CARD')
-    return errorJson(404, 'not_found', 'Cockpit Card wurde nicht gefunden.');
+    return errorJson(404, 'not_found', 'Kachel wurde nicht gefunden.');
   logSuccess('mainserver_generic-items_detail', itemId);
   return json({ data });
 };
@@ -297,7 +312,7 @@ const handleCreateRequest = async (
           contentKind === 'faq'
             ? { ...withoutEditorialAuthor(genericItem), genericType: 'FAQ' }
             : contentKind === 'cockpit-cards'
-              ? { ...withoutEditorialAuthor(genericItem), genericType: 'COCKPIT_CARD' }
+              ? { ...preserveCockpitCardIdentity(genericItem, null), genericType: 'COCKPIT_CARD' }
               : withoutEditorialAuthor(genericItem),
       });
       const bindingResult = await recordCreatedMainserverDataProvider({
@@ -359,7 +374,7 @@ const handleUpdateRequest = async (
         existingItem &&
         existingItem.genericType !== 'COCKPIT_CARD'
       )
-        return errorJson(404, 'not_found', 'Cockpit Card wurde nicht gefunden.');
+        return errorJson(404, 'not_found', 'Kachel wurde nicht gefunden.');
       const genericItem =
         contentKind === 'faq'
           ? await validateFaqWriteOrResponse(request)
@@ -370,7 +385,7 @@ const handleUpdateRequest = async (
       if (contentKind === 'faq' && !existingItem)
         return errorJson(404, 'not_found', 'FAQ wurde nicht gefunden.');
       if (contentKind === 'cockpit-cards' && !existingItem)
-        return errorJson(404, 'not_found', 'Cockpit Card wurde nicht gefunden.');
+        return errorJson(404, 'not_found', 'Kachel wurde nicht gefunden.');
       const providerAuthorization = await authorizeMainserverExistingContent({
         actor,
         action: pluginActionFor(contentKind, 'update'),
@@ -396,7 +411,7 @@ const handleUpdateRequest = async (
               }
             : contentKind === 'cockpit-cards'
               ? {
-                  ...preserveEditorialAuthor(genericItem, existingItem),
+                  ...preserveCockpitCardIdentity(genericItem, existingItem),
                   genericType: 'COCKPIT_CARD',
                   payload: mergeCockpitCardPayload(existingItem?.payload, genericItem.payload),
                 }
@@ -438,7 +453,7 @@ const handleDeleteRequest = async (
         return errorJson(404, 'not_found', 'FAQ wurde nicht gefunden.');
       }
       if (contentKind === 'cockpit-cards' && existingItem?.genericType !== 'COCKPIT_CARD')
-        return errorJson(404, 'not_found', 'Cockpit Card wurde nicht gefunden.');
+        return errorJson(404, 'not_found', 'Kachel wurde nicht gefunden.');
       const providerAuthorization = await authorizeMainserverExistingContent({
         actor,
         action: pluginActionFor(contentKind, 'delete'),


### PR DESCRIPTION
## Zusammenfassung

- vervollständigt den Kachel-Editor um Linktext und Öffnen-in-neuem-Tab
- erhält `externalId`, unbekannte Payload-Daten und nicht sichtbare Medien-/Linkmetadaten bei Updates
- begrenzt die Kachel-Medienbearbeitung auf Alternativtext, ohne Referenz-, Delivery- oder Berechtigungsverträge zu umgehen
- aktualisiert OpenSpec und arc42-Dokumentation
- ergänzt einen Browser-CRUD-Test mit Kategorie, mehreren Bildern und Link sowie Axe-Prüfung

## Auswirkung

Redakteurinnen und Redakteure können Kacheln mit Überschrift und Kategorie anlegen; Sprache, Text und Bilder bleiben optional. Bestehende Mainserver-Identitäten und unbekannte Daten werden beim Bearbeiten nicht überschrieben.

## Validierung

- gezielte Unit-Tests für Plugin, Shared Media Picker und Mainserver
- Type-Gates für Plugin, Studio UI, Mainserver und App
- Server-Runtime-Guard
- gezielter Playwright-CRUD-E2E inklusive Accessibility-Prüfung
- Lint, i18n, OpenSpec strict und File Placement

Der breite lokale affected-Lauf wurde wegen eines gemessenen Scopes von 14 Projekten zugunsten der GitHub-Gates nicht vorgezogen.