### PR TITLE
test(waste-management): restore repository branch coverage

### DIFF
--- a/docs/changelog/entries/pr-947.json
+++ b/docs/changelog/entries/pr-947.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 947,
-  "body": "Waste Management: Repository-Tests für Tour-Gültigkeit vervollständigt\n\n- Zusätzliche Randfälle für Tour-Gültigkeiten und Standort–Tour-Zuordnungen sichern die neue Repository-Logik ab.\n- Der vollständige Coverage-Gate-Lauf bleibt damit auch nach der Erweiterung stabil grün."
+  "body": "Waste Management: Randfälle bei Tour-Gültigkeiten abgesichert\n\n- Leere oder fehlende Gültigkeitsangaben und Standort–Tour-Zuordnungen werden weiterhin zuverlässig verarbeitet.\n- Gemeinsame Gültigkeitsänderungen sind für alle unterstützten Datumsvarianten abgesichert."
 }

--- a/docs/changelog/entries/pr-947.json
+++ b/docs/changelog/entries/pr-947.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 947,
+  "body": "Waste Management: Repository-Tests für Tour-Gültigkeit vervollständigt\n\n- Zusätzliche Randfälle für Tour-Gültigkeiten und Standort–Tour-Zuordnungen sichern die neue Repository-Logik ab.\n- Der vollständige Coverage-Gate-Lauf bleibt damit auch nach der Erweiterung stabil grün."
+}

--- a/packages/data-repositories/src/waste-management/master-data.test.ts
+++ b/packages/data-repositories/src/waste-management/master-data.test.ts
@@ -1038,6 +1038,42 @@ describe('waste master data repository', () => {
       /SET first_date = CASE[\s\S]*?WHEN 'clear' THEN NULL[\s\S]*?end_date = CASE/
     );
     expect(database.statements[1]?.values).toEqual([['tour-1'], 'unchanged', null, 'clear', null]);
+
+    const nullableTour = createExecutor([
+      {
+        id: 'tour-2',
+        recurrence: null,
+        custom_recurrence_id: 'preset-14',
+        first_date: null,
+        end_date: null,
+      },
+    ]);
+
+    await expect(
+      createWasteMasterDataRepository(nullableTour.executor).lockWasteToursByIds(['tour-2'])
+    ).resolves.toEqual([
+      {
+        id: 'tour-2',
+        recurrence: null,
+        customRecurrenceId: 'preset-14',
+        firstDate: undefined,
+        endDate: undefined,
+      },
+    ]);
+
+    expect(
+      wasteMasterDataStatements.updateWasteTourValidityBulk({
+        tourIds: ['tour-1', 'tour-2'],
+        firstDate: { mode: 'set', value: '2027-01-01' },
+        endDate: { mode: 'set', value: '2027-12-31' },
+      }).values
+    ).toEqual([
+      ['tour-1', 'tour-2'],
+      'set',
+      '2027-01-01',
+      'set',
+      '2027-12-31',
+    ]);
   });
 
   it('lists, reads and upserts custom recurrence presets', async () => {
@@ -1203,6 +1239,19 @@ describe('waste master data repository', () => {
     expect(write.statements[0]?.values).toEqual(['link-3', 'location-3', 'tour-3']);
     expect(write.statements[0]?.text).not.toContain('start_date');
     expect(write.statements[0]?.text).not.toContain('end_date');
+
+    const unfilteredStatement = wasteMasterDataStatements.listWasteLocationTourLinks({
+      locationId: ' ',
+      tourId: ' ',
+    });
+    expect(unfilteredStatement.values).toEqual([]);
+    expect(unfilteredStatement.text).not.toContain('WHERE');
+
+    await expect(
+      createWasteMasterDataRepository(createExecutor().executor).getWasteLocationTourLinkById(
+        'missing-link'
+      )
+    ).resolves.toBeNull();
   });
 
   it('lists, reads and upserts location-tour pickup dates idempotently by location, tour and pickup date', async () => {


### PR DESCRIPTION
## Was wurde geändert?

- ergänzt Branch-Tests für nullable Tour-Gültigkeitswerte und beide `set`-Pfade des Bulk-Updates
- deckt whitespace-leere Standort-/Tourfilter sowie den fehlenden Location-Tour-Link ab

## Warum?

Der vollständige Main-Coverage-Lauf nach PR #946 war rot, weil die Branch-Coverage von `data-repositories` um 0,59 Prozentpunkte sank; erlaubt sind 0,50 Prozentpunkte. Das Coverage-Artefakt zeigte die fehlenden Pfade direkt in der neuen Waste-Repository-Logik.

## Auswirkung

Keine Runtime-Änderung. Der PR stellt ausschließlich die fehlende Testabdeckung für die mit #946 eingeführten Randfälle her.

## Verifikation

- `pnpm nx run data-repositories:test:unit --testFiles=src/waste-management/master-data.test.ts` (22/22)
- `pnpm nx run data-repositories:test:coverage --skipNxCache` (162/162; Branches 85,12 % statt 84,43 %)
- `pnpm nx run-many -t test:types lint -p data-repositories --skipNxCache`
