### PR TITLE
Mainserver-Autorendiagnose einklappen und ans Seitenende verschieben

### DIFF
--- a/apps/sva-studio-react/src/routes/content/-content-list-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/content/-content-list-page.test.tsx
@@ -452,6 +452,55 @@ describe('ContentListPage', () => {
     expect(screen.getAllByText('Archiv').length).toBeGreaterThan(0);
   });
 
+  it('places the collapsed author diagnostics after the content table', () => {
+    useContentAccessMock.mockReturnValue({
+      access: {
+        state: 'editable',
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        organizationIds: ['org-1'],
+        sourceKinds: ['direct_role'],
+      },
+      permissionActions: ['content.read', 'iam.monitoring.read'],
+      isLoading: false,
+      error: null,
+    });
+    useContentsMock.mockReturnValue(
+      createContentsApiResult({
+        contents: [
+          {
+            id: 'content-1',
+            contentType: 'generic',
+            title: 'Startseite',
+            createdAt: '2026-03-20T10:00:00.000Z',
+            updatedAt: '2026-03-21T11:00:00.000Z',
+            author: 'Editor',
+            payload: {},
+            status: 'published',
+            access: {
+              state: 'editable',
+              canRead: true,
+              canCreate: true,
+              canUpdate: true,
+              organizationIds: ['org-1'],
+              sourceKinds: ['direct_role'],
+            },
+          },
+        ],
+        pagination: { page: 1, pageSize: 25, total: 1 },
+      })
+    );
+
+    render(<ContentListPage />);
+
+    const table = screen.getByRole('table', { name: 'Inhalte' });
+    const toggle = screen.getByRole('button', { name: 'Mainserver-Autorendiagnose' });
+
+    expect(table.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('does not load contents before content access has resolved', () => {
     renderWithUnresolvedContentAccess();
   });
@@ -1139,9 +1188,9 @@ describe('ContentListPage', () => {
     expect(
       screen.getByRole('button', { name: 'Archivieren (Auswahl)' }).hasAttribute('disabled')
     ).toBe(true);
-    expect(
-      screen.getByRole('button', { name: 'Löschen (Auswahl)' }).hasAttribute('disabled')
-    ).toBe(true);
+    expect(screen.getByRole('button', { name: 'Löschen (Auswahl)' }).hasAttribute('disabled')).toBe(
+      true
+    );
   });
 
   it('uses a sentinel visible type when no readable content types are available', () => {

--- a/apps/sva-studio-react/src/routes/content/-content-list-page.tsx
+++ b/apps/sva-studio-react/src/routes/content/-content-list-page.tsx
@@ -841,10 +841,6 @@ export const ContentListPage = ({
         </Alert>
       ) : null}
 
-      <MainserverAuthoringDiagnosticsPanel
-        enabled={effectivePermissionActions.includes('iam.monitoring.read')}
-      />
-
       <section>
         <StudioDataTable
           ariaLabel={t('content.table.ariaLabel')}
@@ -977,6 +973,10 @@ export const ContentListPage = ({
           )}
         />
       </section>
+
+      <MainserverAuthoringDiagnosticsPanel
+        enabled={effectivePermissionActions.includes('iam.monitoring.read')}
+      />
     </section>
   );
 };

--- a/apps/sva-studio-react/src/routes/content/-mainserver-authoring-diagnostics.test.tsx
+++ b/apps/sva-studio-react/src/routes/content/-mainserver-authoring-diagnostics.test.tsx
@@ -47,6 +47,14 @@ describe('MainserverAuthoringDiagnosticsPanel', () => {
   it('renders the automatic binding, mode-switch, and reconciliation metrics read-only', async () => {
     render(<MainserverAuthoringDiagnosticsPanel enabled />);
 
+    const toggle = screen.getByRole('button', { name: 'Mainserver-Autorendiagnose' });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Bestätigte Bindungen')).toBeNull();
+    expect(state.getDiagnostics).not.toHaveBeenCalled();
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByRole('status').textContent).toContain('Autorendiagnose wird geladen');
     expect(await screen.findByRole('heading', { name: 'Mainserver-Autorendiagnose' })).toBeTruthy();
 
@@ -64,13 +72,18 @@ describe('MainserverAuthoringDiagnosticsPanel', () => {
     expect(screen.getByText('Abgleich erforderlich').nextElementSibling?.textContent).toBe('4');
     expect(screen.getByText('Abgleich fehlgeschlagen').nextElementSibling?.textContent).toBe('1');
     expect(screen.queryByRole('textbox')).toBeNull();
-    expect(screen.queryByRole('button')).toBeNull();
     expect(screen.getByText(/Eine manuelle Zuordnung ist nicht verfügbar/)).toBeTruthy();
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Bestätigte Bindungen')).toBeNull();
   });
 
   it('announces failures and retries only the read operation', async () => {
     state.getDiagnostics.mockRejectedValueOnce(new Error('offline'));
     render(<MainserverAuthoringDiagnosticsPanel enabled />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mainserver-Autorendiagnose' }));
 
     expect(
       await screen.findByText('Die Mainserver-Autorendiagnose konnte nicht geladen werden.')

--- a/apps/sva-studio-react/src/routes/content/-mainserver-authoring-diagnostics.tsx
+++ b/apps/sva-studio-react/src/routes/content/-mainserver-authoring-diagnostics.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ChevronDown } from 'lucide-react';
 
 import { Alert, AlertDescription } from '../../components/ui/alert';
 import { Button } from '../../components/ui/button';
@@ -9,6 +10,11 @@ import {
   CardHeader,
   CardTitle,
 } from '../../components/ui/card';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../../components/ui/collapsible';
 import { t } from '../../i18n';
 import {
   getMainserverAuthoringDiagnostics,
@@ -37,6 +43,7 @@ export type MainserverAuthoringDiagnosticsPanelProps = Readonly<{
 export const MainserverAuthoringDiagnosticsPanel = ({
   enabled,
 }: MainserverAuthoringDiagnosticsPanelProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
   const [diagnostics, setDiagnostics] = React.useState<MainserverAuthoringDiagnostics | null>(null);
   const [error, setError] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);
@@ -44,13 +51,19 @@ export const MainserverAuthoringDiagnosticsPanel = ({
 
   React.useEffect(() => {
     if (!enabled) {
+      setIsOpen(false);
       setDiagnostics(null);
       setError(false);
       setIsLoading(false);
       return;
     }
 
+    if (!isOpen) {
+      return;
+    }
+
     let isActive = true;
+    setDiagnostics(null);
     setIsLoading(true);
     setError(false);
 
@@ -75,7 +88,7 @@ export const MainserverAuthoringDiagnosticsPanel = ({
     return () => {
       isActive = false;
     };
-  }, [enabled, reloadToken]);
+  }, [enabled, isOpen, reloadToken]);
 
   if (!enabled) {
     return null;
@@ -83,92 +96,102 @@ export const MainserverAuthoringDiagnosticsPanel = ({
 
   return (
     <section aria-labelledby="mainserver-authoring-diagnostics-title">
-      <Card>
-        <CardHeader>
-          <CardTitle id="mainserver-authoring-diagnostics-title">
-            {t('content.diagnostics.title')}
-          </CardTitle>
-          <CardDescription>{t('content.diagnostics.description')}</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {isLoading ? (
-            <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
-              {t('content.diagnostics.loading')}
-            </p>
-          ) : null}
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <Card>
+          <CardHeader>
+            <CardTitle id="mainserver-authoring-diagnostics-title">
+              <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 text-left">
+                <span>{t('content.diagnostics.title')}</span>
+                <ChevronDown
+                  aria-hidden="true"
+                  className="h-5 w-5 shrink-0 transition-transform group-data-[state=open]:rotate-180"
+                />
+              </CollapsibleTrigger>
+            </CardTitle>
+          </CardHeader>
+          <CollapsibleContent>
+            <CardContent className="space-y-4">
+              <CardDescription>{t('content.diagnostics.description')}</CardDescription>
+              {isLoading ? (
+                <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+                  {t('content.diagnostics.loading')}
+                </p>
+              ) : null}
 
-          {error ? (
-            <Alert className="border-destructive/40 bg-destructive/5 text-destructive">
-              <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
-                <span>{t('content.diagnostics.loadError')}</span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setReloadToken((value) => value + 1)}
-                >
-                  {t('content.diagnostics.retry')}
-                </Button>
-              </AlertDescription>
-            </Alert>
-          ) : null}
+              {error ? (
+                <Alert className="border-destructive/40 bg-destructive/5 text-destructive">
+                  <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+                    <span>{t('content.diagnostics.loadError')}</span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setReloadToken((value) => value + 1)}
+                    >
+                      {t('content.diagnostics.retry')}
+                    </Button>
+                  </AlertDescription>
+                </Alert>
+              ) : null}
 
-          {diagnostics ? (
-            <>
-              <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.verifiedBindings')}
-                  value={readCount(diagnostics.bindings.byStatus, 'verified')}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.conflicts')}
-                  value={readCount(diagnostics.bindings.byStatus, 'conflict')}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.rotations')}
-                  value={diagnostics.bindings.rotationPrincipalCount}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.compatibility')}
-                  value={readCount(
-                    diagnostics.mutations.byAuthorizationMode,
-                    'credential_visible_compatibility'
-                  )}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.exact')}
-                  value={readCount(diagnostics.mutations.byAuthorizationMode, 'exact')}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.modeSwitches')}
-                  value={diagnostics.mutations.automaticModeSwitchCount}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.shadowEvaluations')}
-                  value={readCount(diagnostics.mutations.byResolverMode, 'shadow')}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.shadowDifferences')}
-                  value={diagnostics.mutations.shadowDifferenceCount}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.reconciliationRequired')}
-                  value={readCount(
-                    diagnostics.mutations.byReconciliationStatus,
-                    'reconciliation_required'
-                  )}
-                />
-                <DiagnosticMetric
-                  label={t('content.diagnostics.metrics.reconciliationFailed')}
-                  value={readCount(diagnostics.mutations.byReconciliationStatus, 'failed')}
-                />
-              </dl>
-              <p className="text-xs text-muted-foreground">
-                {t('content.diagnostics.readOnlyNotice')}
-              </p>
-            </>
-          ) : null}
-        </CardContent>
-      </Card>
+              {diagnostics ? (
+                <>
+                  <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.verifiedBindings')}
+                      value={readCount(diagnostics.bindings.byStatus, 'verified')}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.conflicts')}
+                      value={readCount(diagnostics.bindings.byStatus, 'conflict')}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.rotations')}
+                      value={diagnostics.bindings.rotationPrincipalCount}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.compatibility')}
+                      value={readCount(
+                        diagnostics.mutations.byAuthorizationMode,
+                        'credential_visible_compatibility'
+                      )}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.exact')}
+                      value={readCount(diagnostics.mutations.byAuthorizationMode, 'exact')}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.modeSwitches')}
+                      value={diagnostics.mutations.automaticModeSwitchCount}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.shadowEvaluations')}
+                      value={readCount(diagnostics.mutations.byResolverMode, 'shadow')}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.shadowDifferences')}
+                      value={diagnostics.mutations.shadowDifferenceCount}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.reconciliationRequired')}
+                      value={readCount(
+                        diagnostics.mutations.byReconciliationStatus,
+                        'reconciliation_required'
+                      )}
+                    />
+                    <DiagnosticMetric
+                      label={t('content.diagnostics.metrics.reconciliationFailed')}
+                      value={readCount(diagnostics.mutations.byReconciliationStatus, 'failed')}
+                    />
+                  </dl>
+                  <p className="text-xs text-muted-foreground">
+                    {t('content.diagnostics.readOnlyNotice')}
+                  </p>
+                </>
+              ) : null}
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
     </section>
   );
 };

--- a/docs/changelog/entries/pr-948.json
+++ b/docs/changelog/entries/pr-948.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 948,
+  "body": "Inhalte: Mainserver-Autorendiagnose platzsparend eingeklappt\n\n- Die Autorendiagnose steht jetzt unterhalb der Inhaltstabelle am Ende der Seite.\n- Standardmäßig ist nur die Überschrift sichtbar; die Diagnosewerte werden erst beim Aufklappen geladen."
+}


### PR DESCRIPTION
## Änderung

- verschiebt die Mainserver-Autorendiagnose unter die Inhaltstabelle ans Seitenende
- zeigt standardmäßig nur die als Toggle bedienbare Überschrift
- lädt Diagnosedaten erst beim Öffnen
- erhält Lade-, Fehler- und Retry-Verhalten im aufgeklappten Bereich

## Wirkung

Die selten benötigte Diagnose nimmt im normalen Arbeitsfluss keinen Platz mehr oberhalb der Inhaltsliste ein. Der Toggle ist per Tastatur bedienbar und exponiert seinen Zustand über `aria-expanded`.

## Validierung

- 27/27 fokussierte Route-Unit-Tests
- React-TypeScript-Check
- fokussierter ESLint-Check ohne Fehler
- Prettier-Check
- `git diff --check`

Der breite lokale Nx-Target-Aufruf wurde an der PR-fremden, umgebungsabhängigen `public_waste_config_invalid`-Grenze im abhängigen Public-Waste-Build gestoppt; die betroffenen Route-Tests wurden deshalb über den repository-eigenen Vitest-Wrapper isoliert ausgeführt.