### PR TITLE
Projekte zuverlässig anzeigen und physisch löschen

### DIFF
--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -3306,6 +3306,30 @@ describe('content list projection', () => {
     ]);
   });
 
+  it('archives the bound GenericItem reference after deleting a project', async () => {
+    await refreshProjectedContentsForMainserverMutation({
+      contentType: 'projects.project',
+      instanceId: 'de-musterhausen',
+      keycloakSubject: 'kc-user-1',
+      actorAccountId: 'account-1',
+      actorDisplayName: 'Redaktion',
+      mutationRef: 'project-delete-operation-1',
+      organizationId: 'org-1',
+      operation: 'delete',
+      entityId: 'project-delete-1',
+    });
+
+    expect(state.recordSuccessfulExternalContentDeletion).toHaveBeenCalledWith({
+      instanceId: 'de-musterhausen',
+      actorAccountId: 'account-1',
+      actorDisplayName: 'Redaktion',
+      mutationRef: 'project-delete-operation-1',
+      sourceSystem: 'mainserver',
+      sourceEntityType: 'GenericItem',
+      sourceEntityId: 'project-delete-1',
+    });
+  });
+
   it('continues project refresh after filtered pages and projects every payload variant', async () => {
     state.resolveEffectivePermissions.mockResolvedValue({
       ok: true,
@@ -3609,7 +3633,7 @@ describe('content list projection', () => {
       actorDisplayName: 'Redaktion',
       mutationRef: 'operation-delete-1',
       sourceSystem: 'mainserver',
-      sourceEntityType: 'generic-items.generic-item',
+      sourceEntityType: 'GenericItem',
       sourceEntityId: 'generic-delete-1',
     });
   });

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -3313,6 +3313,15 @@ describe('content list projection', () => {
       sourceEntityType: 'GenericItem',
       sourceEntityId: 'project-delete-1',
     });
+    expect(state.recordSuccessfulExternalContentDeletion).toHaveBeenCalledWith({
+      instanceId: 'de-musterhausen',
+      actorAccountId: 'account-1',
+      actorDisplayName: 'Redaktion',
+      mutationRef: 'project-delete-operation-1',
+      sourceSystem: 'mainserver',
+      sourceEntityType: 'projects.project',
+      sourceEntityId: 'project-delete-1',
+    });
   });
 
   it('continues project refresh after filtered pages and projects every payload variant', async () => {

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -3618,7 +3618,7 @@ describe('content list projection', () => {
       actorDisplayName: 'Redaktion',
       mutationRef: 'operation-delete-1',
       sourceSystem: 'mainserver',
-      sourceEntityType: 'GenericItem',
+      sourceEntityType: 'generic-items.generic-item',
       sourceEntityId: 'generic-delete-1',
     });
   });

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -294,21 +294,6 @@ describe('content list projection', () => {
       );
     }
 
-    if (text.includes("projection.payload_json->>'deleted' = 'true'")) {
-      rows = rows.filter((row) => {
-        if (row.content_type !== 'projects.project') return true;
-        const payload =
-          row.payload_json &&
-          typeof row.payload_json === 'object' &&
-          !Array.isArray(row.payload_json)
-            ? (row.payload_json as Record<string, unknown>)
-            : {};
-        return (
-          payload.deleted !== undefined && payload.deleted !== null && payload.deleted !== true
-        );
-      });
-    }
-
     return rows;
   };
 

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.test.ts
@@ -294,6 +294,21 @@ describe('content list projection', () => {
       );
     }
 
+    if (text.includes("projection.payload_json->>'deleted' = 'true'")) {
+      rows = rows.filter((row) => {
+        if (row.content_type !== 'projects.project') return true;
+        const payload =
+          row.payload_json &&
+          typeof row.payload_json === 'object' &&
+          !Array.isArray(row.payload_json)
+            ? (row.payload_json as Record<string, unknown>)
+            : {};
+        return (
+          payload.deleted !== undefined && payload.deleted !== null && payload.deleted !== true
+        );
+      });
+    }
+
     return rows;
   };
 
@@ -3291,7 +3306,7 @@ describe('content list projection', () => {
     ]);
   });
 
-  it('continues project refresh after filtered pages and excludes soft-deleted projects', async () => {
+  it('continues project refresh after filtered pages and projects every payload variant', async () => {
     state.resolveEffectivePermissions.mockResolvedValue({
       ok: true,
       permissions: [{ action: 'projects.read', resourceType: 'projects' }],
@@ -3342,6 +3357,28 @@ describe('content list projection', () => {
         content_type: 'projects.project',
         source_entity_id: 'project-active',
       }),
+      expect.objectContaining({
+        content_type: 'projects.project',
+        source_entity_id: 'project-deleted',
+      }),
+    ]);
+
+    const listResponse = await listProjectedContents(ctx, {
+      page: 1,
+      pageSize: 25,
+      type: 'projects.project',
+      visibleTypes: ['projects.project'],
+      sortBy: 'updatedAt',
+      sortDirection: 'desc',
+    });
+    const listPayload = (await listResponse.json()) as {
+      data: Array<{ id: string }>;
+      pagination: { total: number };
+    };
+    expect(listPayload.pagination.total).toBe(2);
+    expect(listPayload.data.map((item) => item.id).sort()).toEqual([
+      'project-active',
+      'project-deleted',
     ]);
   });
 

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -1829,13 +1829,7 @@ const mainserverProjectionPageLoaders: Record<
           ...result,
           data: result.data.filter(
             (item) =>
-              resolveGenericItemProjectionContentType(item.genericType) === target.contentType &&
-              !(
-                item.payload &&
-                typeof item.payload === 'object' &&
-                !Array.isArray(item.payload) &&
-                (item.payload as Record<string, unknown>).deleted === true
-              )
+              resolveGenericItemProjectionContentType(item.genericType) === target.contentType
           ),
         },
         pagingResult: result,
@@ -3177,11 +3171,7 @@ LEFT JOIN LATERAL (
     AND reference.reconciliation_status = 'bound'
   LIMIT 1
 ) AS project_reference ON TRUE
-${whereClause}
-  AND NOT (
-    projection.content_type = 'projects.project'
-    AND projection.payload_json->>'deleted' = 'true'
-  );
+${whereClause};
       `,
         params
       );

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -2701,7 +2701,10 @@ const refreshGenericItemSiblingProjections = async (input: {
       actorDisplayName: input.target.actorDisplayName,
       mutationRef: input.target.mutationRef,
       sourceSystem: 'mainserver',
-      sourceEntityType: 'GenericItem',
+      sourceEntityType:
+        input.target.contentType === 'projects.project'
+          ? 'GenericItem'
+          : input.target.contentType,
       sourceEntityId: input.entityId,
     });
   }

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -2701,7 +2701,7 @@ const refreshGenericItemSiblingProjections = async (input: {
       actorDisplayName: input.target.actorDisplayName,
       mutationRef: input.target.mutationRef,
       sourceSystem: 'mainserver',
-      sourceEntityType: input.target.contentType,
+      sourceEntityType: 'GenericItem',
       sourceEntityId: input.entityId,
     });
   }

--- a/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
+++ b/apps/sva-studio-react/src/lib/iam-content-list-projection.server.ts
@@ -2695,18 +2695,21 @@ const refreshGenericItemSiblingProjections = async (input: {
     input.target.actorDisplayName &&
     input.target.mutationRef
   ) {
-    await recordSuccessfulExternalContentDeletion({
-      instanceId: input.target.instanceId,
-      actorAccountId: input.target.actorAccountId,
-      actorDisplayName: input.target.actorDisplayName,
-      mutationRef: input.target.mutationRef,
-      sourceSystem: 'mainserver',
-      sourceEntityType:
-        input.target.contentType === 'projects.project'
-          ? 'GenericItem'
-          : input.target.contentType,
-      sourceEntityId: input.entityId,
-    });
+    const sourceEntityTypes =
+      input.target.contentType === 'projects.project'
+        ? ['GenericItem', 'projects.project']
+        : [input.target.contentType];
+    for (const sourceEntityType of sourceEntityTypes) {
+      await recordSuccessfulExternalContentDeletion({
+        instanceId: input.target.instanceId,
+        actorAccountId: input.target.actorAccountId,
+        actorDisplayName: input.target.actorDisplayName,
+        mutationRef: input.target.mutationRef,
+        sourceSystem: 'mainserver',
+        sourceEntityType,
+        sourceEntityId: input.entityId,
+      });
+    }
   }
   let item: Awaited<ReturnType<typeof getSvaMainserverGenericItem>> | undefined;
   try {

--- a/docs/changelog/entries/pr-949.json
+++ b/docs/changelog/entries/pr-949.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 949,
+  "body": "Projekte: Bestehende Einträge wieder sichtbar und Löschen korrigiert\n\n- Alle vorhandenen Projekte erscheinen unabhängig von älteren technischen Löschmarkierungen in der Inhaltsübersicht.\n- Beim Löschen wird das Projekt jetzt vollständig aus dem Mainserver entfernt."
+}

--- a/docs/guides/featured-projects.md
+++ b/docs/guides/featured-projects.md
@@ -14,7 +14,7 @@ Der Editor gliedert sich in die Bereiche „Basis“, „Inhalt“ und „Einste
 - „Inhalt“ enthält Rich Text und eine optionale, geordnete Bildergalerie. URL und Alternativtext sind je Bild verpflichtend; Bildunterschrift und Bildnachweis sind optional. Das erste Bild ist Titel- und Vorschaubild.
 - „Einstellungen“ enthält Status und genau einen sichtbaren Autor als Organisation oder Person. Veröffentlichungszeitpunkt und technische Metadaten sind nur lesbar.
 
-Der lokale Content-Core ist für Status, Veröffentlichungsmetadaten und Autorenschaft führend. Der Adapter spiegelt den Status für die Mainserver-Kompatibilität nach `payload.status` und setzt `visible` nur bei `published` auf `true`. Ein vorhandenes Mainserver-GenericItem mit `genericType: "FeaturedProject"` wird unabhängig von einem älteren Payload-Feld `deleted` als Projekt behandelt und im Studio angezeigt. Ein Löschvorgang entfernt das GenericItem physisch aus dem Mainserver; neue oder aktualisierte Projekte schreiben keinen eigenen `deleted`-Projektzustand.
+Der lokale Content-Core ist für Status, Veröffentlichungsmetadaten und Autorenschaft führend. Der Adapter spiegelt den Status für die Mainserver-Kompatibilität nach `payload.status` und setzt `visible` nur bei `published` auf `true`. Ein vorhandenes Mainserver-GenericItem mit `genericType: "FeaturedProject"` wird unabhängig von einem älteren Payload-Feld `deleted` als Projekt behandelt und im Studio angezeigt. Ein Löschvorgang entfernt das GenericItem physisch aus dem Mainserver. Neue oder aktualisierte Projekte setzen selbst keinen `deleted`-Projektzustand; unbekannte bestehende Payload-Schlüssel bleiben bei Aktualisierungen unverändert erhalten.
 
 ## Konsistenz und Wiederholung
 

--- a/docs/guides/featured-projects.md
+++ b/docs/guides/featured-projects.md
@@ -14,7 +14,7 @@ Der Editor gliedert sich in die Bereiche „Basis“, „Inhalt“ und „Einste
 - „Inhalt“ enthält Rich Text und eine optionale, geordnete Bildergalerie. URL und Alternativtext sind je Bild verpflichtend; Bildunterschrift und Bildnachweis sind optional. Das erste Bild ist Titel- und Vorschaubild.
 - „Einstellungen“ enthält Status und genau einen sichtbaren Autor als Organisation oder Person. Veröffentlichungszeitpunkt und technische Metadaten sind nur lesbar.
 
-Der lokale Content-Core ist für Status, Veröffentlichungsmetadaten und Autorenschaft führend. Der Adapter spiegelt den Status für die Mainserver-Kompatibilität nach `payload.status` und setzt `visible` nur bei `published` auf `true`. Ein Löschvorgang markiert das Mainserver-Payload mit `deleted: true` und entfernt das Projekt aus aktiven Studio-Listen.
+Der lokale Content-Core ist für Status, Veröffentlichungsmetadaten und Autorenschaft führend. Der Adapter spiegelt den Status für die Mainserver-Kompatibilität nach `payload.status` und setzt `visible` nur bei `published` auf `true`. Ein vorhandenes Mainserver-GenericItem mit `genericType: "FeaturedProject"` wird unabhängig von einem älteren Payload-Feld `deleted` als Projekt behandelt und im Studio angezeigt. Ein Löschvorgang entfernt das GenericItem physisch aus dem Mainserver; neue oder aktualisierte Projekte schreiben keinen eigenen `deleted`-Projektzustand.
 
 ## Konsistenz und Wiederholung
 

--- a/packages/plugin-projects/README.md
+++ b/packages/plugin-projects/README.md
@@ -1,4 +1,3 @@
 # `@sva/plugin-projects`
 
-Redaktionelles Studio-Plugin für freie `Project`-Inhalte auf Basis des Mainserver-Typs `Project`.
-
+Redaktionelles Studio-Plugin für Projektinhalte auf Basis von Mainserver-GenericItems mit `genericType: "FeaturedProject"`. Bestehende Payload-Felder namens `deleted` beeinflussen die Anzeige nicht; beim Löschen wird das GenericItem physisch aus dem Mainserver entfernt.

--- a/packages/plugin-projects/src/projects.api-types.ts
+++ b/packages/plugin-projects/src/projects.api-types.ts
@@ -28,7 +28,6 @@ export type ProjectContentItem = ProjectFormInput &
     id: string;
     published: boolean;
     publishedAt?: string;
-    deleted: boolean;
     createdAt: string;
     updatedAt: string;
     author: ProjectAuthor;

--- a/packages/plugin-projects/tests/projects.pages.test.tsx
+++ b/packages/plugin-projects/tests/projects.pages.test.tsx
@@ -125,7 +125,6 @@ const project = {
   published: true,
   publishedAt: '2026-08-03T10:00:00.000Z',
   author: { type: 'organization' as const, id: 'org-1', displayName: 'Stadt' },
-  deleted: false,
   createdAt: '2026-08-03T09:00:00.000Z',
   updatedAt: '2026-08-03T10:00:00.000Z',
 };

--- a/packages/sva-mainserver/src/server/projects-contract.test.ts
+++ b/packages/sva-mainserver/src/server/projects-contract.test.ts
@@ -252,6 +252,7 @@ describe('projects contract', () => {
         payload: {
           ...existing.payload,
           author: { type: 'person', id: 'person-1', displayName: 'Ursprünglich' },
+          deleted: true,
         },
       },
     });
@@ -259,7 +260,7 @@ describe('projects contract', () => {
     expect(merged.payload).toEqual(
       expect.objectContaining({
         author: { type: 'person', id: 'person-1', displayName: 'Ursprünglich' },
-        deleted: false,
+        deleted: true,
       })
     );
   });

--- a/packages/sva-mainserver/src/server/projects-contract.test.ts
+++ b/packages/sva-mainserver/src/server/projects-contract.test.ts
@@ -168,7 +168,6 @@ describe('projects contract', () => {
         payload: {
           language: 'de',
           status: 'published',
-          deleted: false,
         },
         contentBlocks: [{ intro: 'Kurz', body: '<p>Text</p>' }],
         mediaContents: [
@@ -245,7 +244,7 @@ describe('projects contract', () => {
     ]);
   });
 
-  it('preserves an existing legacy author when soft-deleting', () => {
+  it('preserves legacy payload markers without interpreting them', () => {
     const merged = mergeProjectIntoGenericItem({
       project,
       existing: {
@@ -255,13 +254,12 @@ describe('projects contract', () => {
           author: { type: 'person', id: 'person-1', displayName: 'Ursprünglich' },
         },
       },
-      deleted: true,
     });
 
     expect(merged.payload).toEqual(
       expect.objectContaining({
         author: { type: 'person', id: 'person-1', displayName: 'Ursprünglich' },
-        deleted: true,
+        deleted: false,
       })
     );
   });
@@ -323,7 +321,6 @@ describe('projects contract', () => {
       published: true,
       publishedAt: '2026-01-03T00:00:00.000Z',
       author: { type: 'organization', id: 'org-1', displayName: 'Gemeinde' },
-      deleted: false,
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-02T00:00:00.000Z',
     });

--- a/packages/sva-mainserver/src/server/projects-contract.ts
+++ b/packages/sva-mainserver/src/server/projects-contract.ts
@@ -155,7 +155,6 @@ export const mergeProjectIntoGenericItem = (input: {
   readonly existing?: SvaMainserverGenericItem;
   readonly externalId?: string;
   readonly publishedAt?: string;
-  readonly deleted?: boolean;
 }): SvaMainserverGenericItemInput => {
   const existing = input.existing;
   const existingPayload = payloadRecord(existing?.payload);
@@ -189,7 +188,6 @@ export const mergeProjectIntoGenericItem = (input: {
       ...existingPayload,
       language: input.project.language.trim(),
       status: input.project.status,
-      deleted: input.deleted ?? existingPayload.deleted === true,
     },
     contentBlocks:
       input.project.description.trim() || fullText || firstBlock || remainingBlocks.length > 0
@@ -262,7 +260,6 @@ export const mapGenericItemToProject = (item: SvaMainserverGenericItem): SvaMain
     ...(item.publishedAt ? { publishedAt: item.publishedAt } : {}),
     author: projectAuthor(item, payload),
     ...(item.dataProvider ? { dataProvider: item.dataProvider } : {}),
-    deleted: payload.deleted === true,
     createdAt: item.createdAt,
     updatedAt: item.updatedAt,
   };

--- a/packages/sva-mainserver/src/server/projects-listing.ts
+++ b/packages/sva-mainserver/src/server/projects-listing.ts
@@ -4,14 +4,6 @@ import type { listSvaMainserverGenericItems } from './service.js';
 const MAX_UPSTREAM_PAGES = 500;
 type GenericItem = Awaited<ReturnType<typeof listSvaMainserverGenericItems>>['data'][number];
 
-const isDeleted = (item: GenericItem): boolean => {
-  const payload =
-    item.payload && typeof item.payload === 'object' && !Array.isArray(item.payload)
-      ? (item.payload as Record<string, unknown>)
-      : {};
-  return payload.deleted === true;
-};
-
 export const listAllActiveProjectItems = async (
   input: Parameters<typeof listSvaMainserverGenericItems>[0],
   listItems: typeof listSvaMainserverGenericItems
@@ -34,9 +26,7 @@ export const listAllActiveProjectItems = async (
     page += 1;
   }
 
-  const data = upstreamItems.filter(
-    (item) => item.genericType === 'FeaturedProject' && !isDeleted(item)
-  );
+  const data = upstreamItems.filter((item) => item.genericType === 'FeaturedProject');
   return {
     data,
     observability: {

--- a/packages/sva-mainserver/src/server/projects-route.test.ts
+++ b/packages/sva-mainserver/src/server/projects-route.test.ts
@@ -22,6 +22,7 @@ const state = vi.hoisted(() => ({
   withLock: vi.fn(),
   changeVisibility: vi.fn(),
   createGenericItem: vi.fn(),
+  deleteGenericItem: vi.fn(),
   getGenericItem: vi.fn(),
   listGenericItems: vi.fn(),
   updateGenericItem: vi.fn(),
@@ -74,6 +75,7 @@ vi.mock('@sva/server-runtime', async () => {
 vi.mock('./service.js', () => ({
   changeSvaMainserverGenericItemVisibility: state.changeVisibility,
   createSvaMainserverGenericItem: state.createGenericItem,
+  deleteSvaMainserverGenericItem: state.deleteGenericItem,
   getSvaMainserverGenericItem: state.getGenericItem,
   listSvaMainserverGenericItems: state.listGenericItems,
   updateSvaMainserverGenericItem: state.updateGenericItem,
@@ -225,7 +227,7 @@ describe('projects route', () => {
     vi.resetAllMocks();
   });
 
-  it('reads every upstream page before filtering and paginating Mainserver projects', async () => {
+  it('reads every upstream page and lists every existing FeaturedProject regardless of payload markers', async () => {
     prepareDefaults();
     state.listReferences.mockResolvedValue([reference]);
     state.loadCore.mockResolvedValue(core);
@@ -245,8 +247,11 @@ describe('projects route', () => {
 
     expect(response?.status).toBe(200);
     await expect(response?.json()).resolves.toEqual({
-      data: [expect.objectContaining({ id: contentId, title: 'Projekt' })],
-      pagination: { page: 1, pageSize: 25, hasNextPage: false, total: 1 },
+      data: [
+        expect.objectContaining({ id: contentId, title: 'Projekt' }),
+        expect.objectContaining({ id: 'deleted', title: 'Projekt' }),
+      ],
+      pagination: { page: 1, pageSize: 25, hasNextPage: false, total: 2 },
     });
     expect(state.listGenericItems).toHaveBeenCalledTimes(2);
   });
@@ -580,7 +585,7 @@ describe('projects route', () => {
     expect(state.completeIdempotency).not.toHaveBeenCalled();
   });
 
-  it('read-merges hidden fields on serialized updates and soft deletes via payload marker', async () => {
+  it('read-merges hidden fields on serialized updates and physically deletes the GenericItem', async () => {
     prepareDefaults();
     state.loadReferenceByContentId.mockResolvedValue(reference);
     state.getGenericItem.mockResolvedValue(genericItem);
@@ -599,24 +604,19 @@ describe('projects route', () => {
     expect(state.updateCore).toHaveBeenCalledWith(
       expect.objectContaining({ contentId, status: 'published' })
     );
+    const visibilityCallsAfterUpdate = state.changeVisibility.mock.calls.length;
 
     const deleteResponse = await dispatchSvaMainserverProjectsRequest(
       request(`/api/v1/mainserver/projects/${contentId}`, { method: 'DELETE' })
     );
     expect(deleteResponse?.status).toBe(200);
-    expect(state.updateGenericItem).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        genericItem: expect.objectContaining({
-          payload: expect.objectContaining({ deleted: true }),
-        }),
-      })
+    expect(state.deleteGenericItem).toHaveBeenCalledWith(
+      expect.objectContaining({ genericItemId: 'external-1' })
     );
-    expect(state.changeVisibility).toHaveBeenLastCalledWith(
-      expect.objectContaining({ visible: false })
-    );
+    expect(state.changeVisibility).toHaveBeenCalledTimes(visibilityCallsAfterUpdate);
   });
 
-  it('updates and soft-deletes externally created Mainserver projects without a local core', async () => {
+  it('updates and physically deletes externally created Mainserver projects without a local core', async () => {
     prepareDefaults();
     state.loadReferenceByContentId.mockResolvedValue(undefined);
     state.getGenericItem.mockResolvedValue(genericItem);
@@ -646,13 +646,8 @@ describe('projects route', () => {
 
     expect(deleteResponse?.status).toBe(200);
     await expect(deleteResponse?.json()).resolves.toEqual({ data: { id: 'external-1' } });
-    expect(state.updateGenericItem).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        genericItemId: 'external-1',
-        genericItem: expect.objectContaining({
-          payload: expect.objectContaining({ deleted: true }),
-        }),
-      })
+    expect(state.deleteGenericItem).toHaveBeenCalledWith(
+      expect.objectContaining({ genericItemId: 'external-1' })
     );
   });
 
@@ -669,7 +664,7 @@ describe('projects route', () => {
     expect(response?.status).toBe(405);
   });
 
-  it('loads a project detail and enforces missing, deleted and unauthorized contexts', async () => {
+  it('loads a project detail regardless of payload markers and enforces missing and unauthorized contexts', async () => {
     prepareDefaults();
     state.loadCore.mockResolvedValue(core);
     state.loadReferenceByContentId.mockResolvedValue(reference);
@@ -712,10 +707,10 @@ describe('projects route', () => {
       ...genericItem,
       payload: { ...genericItem.payload, deleted: true },
     });
-    const deleted = await dispatchSvaMainserverProjectsRequest(
+    const legacyPayloadMarker = await dispatchSvaMainserverProjectsRequest(
       request(`/api/v1/mainserver/projects/${contentId}`)
     );
-    expect(deleted?.status).toBe(404);
+    expect(legacyPayloadMarker?.status).toBe(200);
 
     state.authorize.mockResolvedValueOnce({
       ok: false,
@@ -892,7 +887,7 @@ describe('projects route', () => {
     );
 
     state.updateCore.mockResolvedValue(undefined);
-    state.updateGenericItem.mockRejectedValueOnce(new Error('provider_lost'));
+    state.deleteGenericItem.mockRejectedValueOnce(new Error('provider_lost'));
     const deletion = await dispatchSvaMainserverProjectsRequest(
       request(`/api/v1/mainserver/projects/${contentId}`, { method: 'DELETE' })
     );
@@ -900,7 +895,7 @@ describe('projects route', () => {
     expect(state.updateReconciliation).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'reconciliation_required',
-        errorCode: 'soft_delete_finalize_failed',
+        errorCode: 'provider_delete_failed',
       })
     );
   });

--- a/packages/sva-mainserver/src/server/projects-route.test.ts
+++ b/packages/sva-mainserver/src/server/projects-route.test.ts
@@ -824,9 +824,8 @@ describe('projects route', () => {
     );
   });
 
-  it('rebinds a recreated project after its previously bound provider item was deleted', async () => {
+  it('replays the completed create without recreating a physically deleted project', async () => {
     prepareDefaults();
-    const recreatedItem = { ...genericItem, id: 'external-2' };
     state.loadReferenceByOperation.mockResolvedValue(reference);
     state.getGenericItem.mockRejectedValue(
       new SvaMainserverError({
@@ -835,8 +834,11 @@ describe('projects route', () => {
         statusCode: 404,
       })
     );
-    state.createGenericItem.mockResolvedValue(recreatedItem);
-    state.bindReference.mockResolvedValue({ ...reference, sourceEntityId: recreatedItem.id });
+    state.reserveIdempotency.mockResolvedValue({
+      status: 'replay',
+      responseBody: { data: { id: contentId } },
+      responseStatus: 201,
+    });
 
     const response = await dispatchSvaMainserverProjectsRequest(
       request('/api/v1/mainserver/projects', {
@@ -847,12 +849,10 @@ describe('projects route', () => {
     );
 
     expect(response?.status).toBe(201);
-    expect(state.createGenericItem).toHaveBeenCalledTimes(1);
-    expect(state.bindReference).toHaveBeenCalledWith({
-      instanceId: 'tenant-1',
-      referenceId,
-      sourceEntityId: 'external-2',
-    });
+    await expect(response?.json()).resolves.toEqual({ data: { id: contentId } });
+    expect(state.reserveIdempotency).toHaveBeenCalledTimes(1);
+    expect(state.createGenericItem).not.toHaveBeenCalled();
+    expect(state.bindReference).not.toHaveBeenCalled();
   });
 
   it('preserves provider create success when local create follow-up is unavailable', async () => {

--- a/packages/sva-mainserver/src/server/projects-route.test.ts
+++ b/packages/sva-mainserver/src/server/projects-route.test.ts
@@ -824,6 +824,37 @@ describe('projects route', () => {
     );
   });
 
+  it('rebinds a recreated project after its previously bound provider item was deleted', async () => {
+    prepareDefaults();
+    const recreatedItem = { ...genericItem, id: 'external-2' };
+    state.loadReferenceByOperation.mockResolvedValue(reference);
+    state.getGenericItem.mockRejectedValue(
+      new SvaMainserverError({
+        code: 'not_found',
+        message: 'GenericItem wurde nicht gefunden.',
+        statusCode: 404,
+      })
+    );
+    state.createGenericItem.mockResolvedValue(recreatedItem);
+    state.bindReference.mockResolvedValue({ ...reference, sourceEntityId: recreatedItem.id });
+
+    const response = await dispatchSvaMainserverProjectsRequest(
+      request('/api/v1/mainserver/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Idempotency-Key': 'operation-1' },
+        body: JSON.stringify(input),
+      })
+    );
+
+    expect(response?.status).toBe(201);
+    expect(state.createGenericItem).toHaveBeenCalledTimes(1);
+    expect(state.bindReference).toHaveBeenCalledWith({
+      instanceId: 'tenant-1',
+      referenceId,
+      sourceEntityId: 'external-2',
+    });
+  });
+
   it('preserves provider create success when local create follow-up is unavailable', async () => {
     prepareDefaults();
     state.loadReferenceByOperation.mockResolvedValue(undefined);

--- a/packages/sva-mainserver/src/server/projects-route.test.ts
+++ b/packages/sva-mainserver/src/server/projects-route.test.ts
@@ -855,6 +855,37 @@ describe('projects route', () => {
     expect(state.bindReference).not.toHaveBeenCalled();
   });
 
+  it('completes a new reservation when a deleted project idempotency record expired', async () => {
+    prepareDefaults();
+    state.loadReferenceByOperation.mockResolvedValue(reference);
+    state.getGenericItem.mockRejectedValue(
+      new SvaMainserverError({
+        code: 'not_found',
+        message: 'GenericItem wurde nicht gefunden.',
+        statusCode: 404,
+      })
+    );
+    state.reserveIdempotency.mockResolvedValue({ status: 'reserved' });
+
+    const response = await dispatchSvaMainserverProjectsRequest(
+      request('/api/v1/mainserver/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Idempotency-Key': 'operation-1' },
+        body: JSON.stringify(input),
+      })
+    );
+
+    expect(response?.status).toBe(409);
+    expect(state.completeIdempotency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: 'operation-1',
+        responseStatus: 409,
+        status: 'FAILED',
+      })
+    );
+    expect(state.createGenericItem).not.toHaveBeenCalled();
+  });
+
   it('preserves provider create success when local create follow-up is unavailable', async () => {
     prepareDefaults();
     state.loadReferenceByOperation.mockResolvedValue(undefined);

--- a/packages/sva-mainserver/src/server/projects-route.ts
+++ b/packages/sva-mainserver/src/server/projects-route.ts
@@ -376,6 +376,14 @@ const createProject = async (
   if (isResponse(project)) return project;
   const actorInfo = await actorInfoOrResponse(request, ctx);
   if (isResponse(actorInfo)) return actorInfo;
+  const reserveCreateIdempotency = () =>
+    reserveIdempotency({
+      instanceId: actor.instanceId,
+      actorAccountId: actorInfo.actorAccountId,
+      endpoint: CREATE_ENDPOINT,
+      idempotencyKey: key,
+      payloadHash: createHash('sha256').update(rawBody).digest('hex'),
+    });
   const principalAuthorization = await authorizeMainserverCreateForPrincipal({
     actor,
     action: 'projects.create',
@@ -438,15 +446,35 @@ const createProject = async (
       return projectMutationJson(responseBody, existing.id, 201);
     }
 
+    if (reference?.sourceEntityId) {
+      try {
+        const reserved = await reserveCreateIdempotency();
+        if (reserved.status === 'replay')
+          return json(reserved.responseBody, reserved.responseStatus);
+        return errorJson(
+          409,
+          'idempotency_key_reuse',
+          reserved.status === 'conflict'
+            ? reserved.message
+            : 'Idempotency-Key verweist auf ein gelöschtes Projekt.'
+        );
+      } catch (error) {
+        logger.warn('Project create replay could not verify its deleted provider binding', {
+          operation: 'mainserver_projects_local_follow_up',
+          instance_id: actor.instanceId,
+          error_code: error instanceof Error ? error.name : 'idempotency_unavailable',
+        });
+        return errorJson(
+          503,
+          'idempotency_unavailable',
+          'Projektwiederholung konnte nicht geprüft werden.'
+        );
+      }
+    }
+
     if (!reference)
       try {
-        const reserved = await reserveIdempotency({
-          instanceId: actor.instanceId,
-          actorAccountId: actorInfo.actorAccountId,
-          endpoint: CREATE_ENDPOINT,
-          idempotencyKey: key,
-          payloadHash: createHash('sha256').update(rawBody).digest('hex'),
-        });
+        const reserved = await reserveCreateIdempotency();
         if (reserved.status === 'replay')
           return json(reserved.responseBody, reserved.responseStatus);
         if (reserved.status === 'conflict')
@@ -523,7 +551,7 @@ const createProject = async (
         });
         reference = prepared.reference;
       }
-      if (reference.sourceEntityId !== created.id) {
+      if (!reference.sourceEntityId) {
         reference = await bindExternalContentReference({
           instanceId: actor.instanceId,
           referenceId: reference.id,

--- a/packages/sva-mainserver/src/server/projects-route.ts
+++ b/packages/sva-mainserver/src/server/projects-route.ts
@@ -53,6 +53,7 @@ import { listAllActiveProjectItems } from './projects-listing.js';
 import {
   changeSvaMainserverGenericItemVisibility,
   createSvaMainserverGenericItem,
+  deleteSvaMainserverGenericItem,
   getSvaMainserverGenericItem,
   listSvaMainserverGenericItems,
   updateSvaMainserverGenericItem,
@@ -113,10 +114,9 @@ const idempotencyKeyOrResponse = (request: Request): string | Response => {
     : errorJson(400, 'idempotency_key_required', 'Header Idempotency-Key ist erforderlich.');
 };
 
-const projectPayload = (input: SvaMainserverProjectInput, deleted = false) => ({
+const projectPayload = (input: SvaMainserverProjectInput) => ({
   language: input.language,
   status: input.status,
-  deleted,
 });
 
 const publishedAtFor = (input: SvaMainserverProjectInput, current?: string): string | undefined =>
@@ -212,11 +212,6 @@ const loadProjectContext = async (
   }
   if (!item) return undefined;
   if (item.genericType !== PROJECTS_GENERIC_TYPE) return undefined;
-  const payload =
-    item.payload && typeof item.payload === 'object' && !Array.isArray(item.payload)
-      ? (item.payload as Record<string, unknown>)
-      : {};
-  if (payload.deleted === true) return undefined;
   return { core, reference, item };
 };
 
@@ -772,50 +767,15 @@ const deleteProject = async (
           item: freshItem,
         });
         if (isResponse(providerAuthorization)) return providerAuthorization;
-        const freshProject = mapAndValidate(freshItem);
-        await updateSvaMainserverGenericItem({
+        await deleteSvaMainserverGenericItem({
           ...actor,
           genericItemId: freshItem.id,
-          genericItem: mergeProjectIntoGenericItem({
-            project: freshProject,
-            existing: freshItem,
-            deleted: true,
-            publishedAt: freshItem.publishedAt,
-          }),
         });
-        await changeSvaMainserverGenericItemVisibility({
-          ...actor,
-          genericItemId: freshItem.id,
-          visible: false,
-        });
-        let localFollowUpFailed = false;
-        if (context.core && context.reference) {
-          await Promise.resolve(
-            updateExternalContentCore({
-              ...actorInfo,
-              actorDisplayName: ctx.user.displayName ?? ctx.user.username ?? ctx.user.id,
-              contentId: context.reference.contentId,
-              title: freshItem.title,
-              payload: { ...projectPayload(freshProject, true) },
-              status: freshProject.status,
-              publishedAt: freshItem.publishedAt,
-              authorDisplayMode: actor.mutationPrincipalContext.actingPrincipalType,
-              authorDisplayName: ctx.user.displayName ?? ctx.user.username ?? ctx.user.id,
-            })
-          ).catch((error: unknown) => {
-            localFollowUpFailed = true;
-            logger.warn('Project local follow-up failed after provider delete', {
-              operation: 'mainserver_projects_local_follow_up',
-              instance_id: instanceId,
-              error_code: error instanceof Error ? error.name : 'local_finalize_failed',
-            });
-          });
-        }
         await finalizeMainserverMutation({
           actor,
           providerOutcome: 'succeeded',
-          reconciliationStatus: localFollowUpFailed ? 'reconciliation_required' : 'complete',
-          completedSteps: ['provider_write', 'soft_delete'],
+          reconciliationStatus: 'complete',
+          completedSteps: ['provider_write', 'tombstone'],
           contentId: freshItem.id,
           observedDataProviderId: freshItem.dataProvider?.id,
         });
@@ -833,7 +793,7 @@ const deleteProject = async (
           instanceId,
           referenceId: context.reference.id,
           status: 'reconciliation_required',
-          errorCode: 'soft_delete_finalize_failed',
+          errorCode: 'provider_delete_failed',
         })
       ).catch(() => undefined);
     return toMainserverErrorResponse(error, 'Projekt konnte nicht gelöscht werden.');

--- a/packages/sva-mainserver/src/server/projects-route.ts
+++ b/packages/sva-mainserver/src/server/projects-route.ts
@@ -451,13 +451,22 @@ const createProject = async (
         const reserved = await reserveCreateIdempotency();
         if (reserved.status === 'replay')
           return json(reserved.responseBody, reserved.responseStatus);
-        return errorJson(
-          409,
-          'idempotency_key_reuse',
+        const message =
           reserved.status === 'conflict'
             ? reserved.message
-            : 'Idempotency-Key verweist auf ein gelöschtes Projekt.'
-        );
+            : 'Idempotency-Key verweist auf ein gelöschtes Projekt.';
+        const responseBody = { error: 'idempotency_key_reuse', message };
+        if (reserved.status === 'reserved') {
+          await completeCreate({
+            instanceId: actor.instanceId,
+            actorAccountId: actorInfo.actorAccountId,
+            idempotencyKey: key,
+            responseBody,
+            responseStatus: 409,
+            status: 'FAILED',
+          });
+        }
+        return json(responseBody, 409);
       } catch (error) {
         logger.warn('Project create replay could not verify its deleted provider binding', {
           operation: 'mainserver_projects_local_follow_up',

--- a/packages/sva-mainserver/src/server/projects-route.ts
+++ b/packages/sva-mainserver/src/server/projects-route.ts
@@ -523,7 +523,7 @@ const createProject = async (
         });
         reference = prepared.reference;
       }
-      if (!reference.sourceEntityId) {
+      if (reference.sourceEntityId !== created.id) {
         reference = await bindExternalContentReference({
           instanceId: actor.instanceId,
           referenceId: reference.id,

--- a/packages/sva-mainserver/src/server/service-internals/projection-filtered-pagination.ts
+++ b/packages/sva-mainserver/src/server/service-internals/projection-filtered-pagination.ts
@@ -31,15 +31,7 @@ const matchesProjectionContentType = (
     ? genericTypeOwnership[record.genericType]
     : undefined;
   const resolvedContentType = ownedContentType ?? 'generic-items.generic-item';
-  if (resolvedContentType !== contentType) return false;
-  if (contentType !== 'projects.project') return true;
-  const payload = record.payload;
-  return !(
-    payload !== null &&
-    typeof payload === 'object' &&
-    !Array.isArray(payload) &&
-    (payload as Record<string, unknown>).deleted === true
-  );
+  return resolvedContentType === contentType;
 };
 
 export const loadFilteredGenericItemProjectionPage = async (input: {

--- a/packages/sva-mainserver/src/server/service-internals/projection-list-operations.test.ts
+++ b/packages/sva-mainserver/src/server/service-internals/projection-list-operations.test.ts
@@ -287,6 +287,11 @@ describe('projection list operations', () => {
         contentType: 'projects.project',
         title: 'Projekt',
       }),
+      expect.objectContaining({
+        id: 'deleted-project',
+        contentType: 'projects.project',
+        title: 'Gelöscht',
+      }),
     ]);
   });
 

--- a/packages/sva-mainserver/src/types.ts
+++ b/packages/sva-mainserver/src/types.ts
@@ -640,7 +640,6 @@ export type SvaMainserverProject = SvaMainserverProjectInput &
     id: string;
     published: boolean;
     publishedAt?: string;
-    deleted: boolean;
     createdAt: string;
     updatedAt: string;
     author: SvaMainserverProjectAuthor;


### PR DESCRIPTION
## Was wurde geändert?

- Vorhandene `FeaturedProject`-GenericItems werden unabhängig von einem älteren `payload.deleted` angezeigt.
- Die Studio-Projektion filtert Projekte nicht mehr anhand dieses Legacy-Felds.
- Das Löschen eines Projekts entfernt das GenericItem physisch aus dem Mainserver.
- `deleted` wurde aus dem Projekt-API-Vertrag entfernt und die Dokumentation angepasst.

## Ursache

Der SQL-Filter behandelte ein fehlendes JSON-Feld mit SQL-Dreiwertlogik als `NULL`. Dadurch wurden auch Projekte ohne `payload.deleted` aus der Studio-Liste ausgeschlossen. Zusätzlich verwendete der Projekt-Endpunkt bisher einen Soft-Delete-Marker statt der vorhandenen Mainserver-Delete-Mutation.

## Auswirkungen

Bestehende Projekte erscheinen wieder vollständig im Studio. Neue Löschvorgänge entfernen das zugehörige Mainserver-GenericItem tatsächlich.

## Verifikation

- `pnpm nx affected --target=test:unit --base=origin/main`
- `pnpm nx run-many --target=test:types --projects=sva-mainserver,plugin-projects,sva-studio-react`
- `pnpm nx run sva-mainserver:check:runtime`
- `pnpm nx run-many --target=lint --projects=sva-mainserver,plugin-projects,sva-studio-react`
- `pnpm check:file-placement`
- `git diff --check`

Kein OpenSpec-Change gemäß ausdrücklicher Scope-Entscheidung.