### PR TITLE
fix(surveys): Principal-Wechsel bei fehlender Bearbeitungsfreigabe ermöglichen

### DIFF
--- a/docs/changelog/entries/pr-976.json
+++ b/docs/changelog/entries/pr-976.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 976,
+  "body": "Principal bei Umfragen trotz fehlender Bearbeitungsfreigabe wechseln\n\n- Die Principal-Auswahl bleibt bedienbar, wenn der aktuell ausgewählte Principal die Umfrage nicht bearbeiten darf.\n- Nutzer können dadurch auf einen berechtigten persönlichen oder organisatorischen Principal wechseln.\n- Die übrigen Umfragefelder und das Speichern bleiben bis zur bestätigten Berechtigung weiterhin gesperrt."
+}

--- a/packages/plugin-surveys/src/surveys.editor.tsx
+++ b/packages/plugin-surveys/src/surveys.editor.tsx
@@ -103,15 +103,15 @@ const SurveyEditorForm = ({
       {!canSave ? (
         <StudioFormSummary kind="error">{pt('messages.updateUnavailable')}</StudioFormSummary>
       ) : null}
+      <SurveyPrincipalControl
+        actingPrincipalType={actingPrincipalType}
+        loadedItem={loadedItem}
+        mode={mode}
+        onChange={onPrincipalChange}
+        principalControl={principalControl}
+        pt={pt}
+      />
       <fieldset className="min-w-0 space-y-5 border-0 p-0" disabled={!canEdit}>
-        <SurveyPrincipalControl
-          actingPrincipalType={actingPrincipalType}
-          loadedItem={loadedItem}
-          mode={mode}
-          onChange={onPrincipalChange}
-          principalControl={principalControl}
-          pt={pt}
-        />
         <StudioDetailTabs
           ariaLabel={pt('tabs.ariaLabel')}
           tabs={tabs}

--- a/packages/plugin-surveys/tests/surveys.editor.page.test.tsx
+++ b/packages/plugin-surveys/tests/surveys.editor.page.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const navigateMock = vi.fn();
 const submitMock = vi.fn();
 const controllerState = vi.hoisted(() => ({
+  actingPrincipalType: 'user' as 'user' | 'organization',
   isLoading: false,
   loadedItem: null as null | { status: 'DRAFT' | 'ACTIVE' | 'ARCHIVED' },
   resourceAccess: {} as Readonly<Record<string, boolean>>,
@@ -100,12 +101,15 @@ vi.mock('@sva/plugin-sdk', () => ({
 
 vi.mock('../src/surveys.editor-logic.js', () => ({
   useSurveyEditorController: ({
+    actingPrincipalType,
     navigateToCreatedDetail,
     onInitialSavedConsumed,
   }: {
+    actingPrincipalType: 'user' | 'organization';
     navigateToCreatedDetail: (contentId: string) => void;
     onInitialSavedConsumed: () => void;
   }) => {
+    controllerState.actingPrincipalType = actingPrincipalType;
     controllerState.onInitialSavedConsumed = onInitialSavedConsumed;
     submitMock.mockImplementation(() => {
       navigateToCreatedDetail('survey-created');
@@ -125,6 +129,7 @@ import { SurveyEditorPage } from '../src/surveys.editor.js';
 describe('SurveyEditorPage', () => {
   afterEach(() => {
     cleanup();
+    controllerState.actingPrincipalType = 'user';
     controllerState.isLoading = false;
     controllerState.loadedItem = null;
     controllerState.resourceAccess = {};
@@ -243,6 +248,38 @@ describe('SurveyEditorPage', () => {
     ).toBe(true);
     fireEvent.submit(document.getElementById('survey-detail-form') as HTMLFormElement);
     expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the principal picker enabled when the selected principal cannot edit', () => {
+    controllerState.loadedItem = { status: 'DRAFT' };
+    accessState.snapshot = {
+      ...accessState.snapshot,
+      unscopedPermissionActions: accessState.snapshot.unscopedPermissionActions.filter(
+        (action) => action !== 'surveys.update'
+      ),
+    };
+    const view = render(
+      <SurveyEditorPage
+        mode="edit"
+        contentId="survey-1"
+        canUpdate
+        principalControl={{
+          kind: 'selectable',
+          value: 'organization',
+          options: [
+            { value: 'user', label: 'Persönlich' },
+            { value: 'organization', label: 'Organisation' },
+          ],
+        }}
+      />
+    );
+
+    const principalSelect = screen.getByLabelText('principal.actAs') as HTMLSelectElement;
+    expect(principalSelect.matches(':disabled')).toBe(false);
+    expect(view.container.querySelector('fieldset')?.matches(':disabled')).toBe(true);
+
+    fireEvent.change(principalSelect, { target: { value: 'user' } });
+    expect(controllerState.actingPrincipalType).toBe('user');
   });
 
   it('keeps fields editable so a denied lifecycle transition can be reverted', () => {


### PR DESCRIPTION
## Zusammenfassung

- hält die Principal-Auswahl außerhalb des deaktivierten Survey-Formularbereichs
- ermöglicht den Wechsel von einem nicht berechtigten auf einen berechtigten Principal
- lässt die eigentlichen Survey-Felder weiterhin fail-closed deaktiviert
- ergänzt einen Regressionstest für Auswahl, Formularsperre und Principal-Wechsel

## Ursache

Die Principal-Auswahl lag im selben deaktivierten `fieldset` wie die Survey-Felder. Wenn der initial ausgewählte Principal keine Bearbeitungsfreigabe hatte, konnte deshalb auch nicht mehr auf einen berechtigten Principal gewechselt werden.

## Validierung

- `pnpm nx run plugin-surveys:test:unit --testFiles=packages/plugin-surveys/tests/surveys.editor.page.test.tsx`
- `pnpm nx run plugin-surveys:test:types`
- `pnpm nx run plugin-surveys:lint` (keine Fehler; bestehende Warnungen)
- `pnpm complexity-gate`
- Prettier und `git diff --check`
