### PR TITLE
feat(studio): Dashboard-Aktionen übersichtlicher gestalten

### DIFF
--- a/apps/sva-studio-react/e2e/media-management.spec.ts
+++ b/apps/sva-studio-react/e2e/media-management.spec.ts
@@ -1,7 +1,11 @@
 import { expect, test } from '@playwright/test';
 import type { Page, Route } from '@playwright/test';
 
-import { navigateClientSide, registerSharedIamRoutes } from './studio-shell.helpers';
+import {
+  expectAppShellReady,
+  navigateClientSide,
+  registerSharedIamRoutes,
+} from './studio-shell.helpers';
 
 type MediaAssetRecord = {
   readonly id: string;
@@ -77,25 +81,6 @@ const permissionPayload = {
   evaluatedAt: '2026-04-29T12:00:00.000Z',
 };
 
-const expectInterfacesShellReady = async (page: Page, timeout = 20_000) => {
-  await expect
-    .poll(
-      async () => {
-        const headingVisible = await page.getByRole('heading', { name: 'Schnittstellen' }).isVisible().catch(() => false);
-        if (headingVisible) {
-          return true;
-        }
-
-        return page
-          .getByText('Schnittstellen werden geladen ...')
-          .isVisible()
-          .catch(() => false);
-      },
-      { timeout }
-    )
-    .toBe(true);
-};
-
 const mockSharedShellRequests = async (page: Page) => {
   await page.route('**/auth/me**', async (route) => {
     await route.fulfill({
@@ -161,7 +146,11 @@ const routeMediaRequests = async (
   }
 
   if (path === '/api/v1/iam/media/upload-sessions' && method === 'POST') {
-    const body = request.postDataJSON() as { mimeType: string; byteSize: number; visibility?: 'public' | 'protected' };
+    const body = request.postDataJSON() as {
+      mimeType: string;
+      byteSize: number;
+      visibility?: 'public' | 'protected';
+    };
     const asset: MediaAssetRecord = {
       id: 'asset-1',
       instanceId: 'de-musterhausen',
@@ -302,7 +291,11 @@ const routeMediaRequests = async (
     return;
   }
 
-  await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not_found' }) });
+  await route.fulfill({
+    status: 404,
+    contentType: 'application/json',
+    body: JSON.stringify({ error: 'not_found' }),
+  });
 };
 
 test.describe('media management', () => {
@@ -310,7 +303,9 @@ test.describe('media management', () => {
     await mockSharedShellRequests(page);
   });
 
-  test('uploads a file from the media library and opens the detail workspace afterwards', async ({ page }) => {
+  test('uploads a file from the media library and opens the detail workspace afterwards', async ({
+    page,
+  }) => {
     const state: {
       assets: MediaAssetRecord[];
       usageByAssetId: Record<string, MediaUsageRecord>;
@@ -331,7 +326,7 @@ test.describe('media management', () => {
     });
 
     await page.goto('/interfaces');
-    await expectInterfacesShellReady(page);
+    await expectAppShellReady(page);
     await navigateClientSide(page, '/admin/media');
     await expect(page.getByRole('heading', { name: 'Medienbibliothek' })).toBeVisible();
     await page.locator('[data-testid="media-upload-input"]').setInputFiles({
@@ -349,7 +344,9 @@ test.describe('media management', () => {
 
     await page.getByRole('button', { name: 'Medium löschen' }).click();
 
-    await expect(page.getByText('Die Medienaktion konnte wegen eines Konflikts nicht abgeschlossen werden.')).toBeVisible();
+    await expect(
+      page.getByText('Die Medienaktion konnte wegen eines Konflikts nicht abgeschlossen werden.')
+    ).toBeVisible();
     await expect(page.getByText('Aktive Referenzen: 1')).toBeVisible();
   });
 
@@ -370,7 +367,7 @@ test.describe('media management', () => {
     });
 
     await page.goto('/interfaces');
-    await expectInterfacesShellReady(page);
+    await expectAppShellReady(page);
     await navigateClientSide(page, '/admin/media');
     await expect(page.getByRole('heading', { name: 'Medienbibliothek' })).toBeVisible();
 

--- a/apps/sva-studio-react/e2e/smoke.spec.ts
+++ b/apps/sva-studio-react/e2e/smoke.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
 import {
+  expectAppShellReady,
   gotoHomeAsAuthenticatedUser,
   navigateClientSide,
   registerSharedIamRoutes,
@@ -30,9 +31,12 @@ const captureServerFnResponses = (page: Page) => {
     };
     responses.push(entry);
 
-    void response.text().then((body) => {
-      entry.body = body;
-    }).catch(() => undefined);
+    void response
+      .text()
+      .then((body) => {
+        entry.body = body;
+      })
+      .catch(() => undefined);
   });
 
   return responses;
@@ -50,7 +54,8 @@ const resolvePlaywrightServerPort = () => {
     return process.env.PLAYWRIGHT_PORT;
   }
 
-  const configuredBaseUrl = process.env.PLAYWRIGHT_DE_MUSTERHAUSEN_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL;
+  const configuredBaseUrl =
+    process.env.PLAYWRIGHT_DE_MUSTERHAUSEN_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL;
 
   if (!configuredBaseUrl) {
     return '4173';
@@ -58,10 +63,6 @@ const resolvePlaywrightServerPort = () => {
 
   const parsedBaseUrl = new URL(configuredBaseUrl);
   return parsedBaseUrl.port || (parsedBaseUrl.protocol === 'https:' ? '443' : '80');
-};
-
-const expectInterfacesShellReady = async (page: Page, timeout = 20_000) => {
-  await expect(page.getByRole('heading', { name: 'Schnittstellen', exact: true })).toBeVisible({ timeout });
 };
 
 const mockAuthenticatedPluginShell = async (page: Page) => {
@@ -192,7 +193,7 @@ test('authenticated client navigation renders /interfaces', async ({ page }) => 
   await mockAuthenticatedPluginShell(page);
   await gotoHomeAsAuthenticatedUser(page);
   await navigateClientSide(page, '/interfaces');
-  await expectInterfacesShellReady(page);
+  await expectAppShellReady(page);
 });
 
 test('interfaces page uses the real /_server transport during overview load', async ({ page }) => {
@@ -230,14 +231,13 @@ test('interfaces page uses the real /_server transport during overview load', as
 
   await gotoHomeAsAuthenticatedUser(page);
   await navigateClientSide(page, '/interfaces');
-  await expect(
-    page.getByRole('heading', { name: 'Schnittstellen', exact: true })
-  ).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByRole('heading', { name: 'Schnittstellen', exact: true })).toBeVisible({
+    timeout: 20_000,
+  });
   await expect
-    .poll(
-      () => serverFnResponses.find((response) => response.method === 'GET')?.status,
-      { timeout: 20_000 }
-    )
+    .poll(() => serverFnResponses.find((response) => response.method === 'GET')?.status, {
+      timeout: 20_000,
+    })
     .toBe(200);
 
   const loadResponse = serverFnResponses.find((response) => response.method === 'GET');
@@ -246,7 +246,9 @@ test('interfaces page uses the real /_server transport during overview load', as
   expect(pageErrors).toEqual([]);
 });
 
-test('authenticated client navigation to /admin/content renders the host-owned content route', async ({ page }) => {
+test('authenticated client navigation to /admin/content renders the host-owned content route', async ({
+  page,
+}) => {
   const pageErrors: string[] = [];
   const consoleErrors: string[] = [];
   const requestFailures: string[] = [];
@@ -263,7 +265,9 @@ test('authenticated client navigation to /admin/content renders the host-owned c
     }
   });
   page.on('requestfailed', (request) => {
-    requestFailures.push(`${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? 'unknown'}`);
+    requestFailures.push(
+      `${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? 'unknown'}`
+    );
   });
   page.on('request', (request) => {
     observedRequests.push(`${request.resourceType()} ${request.method()} ${request.url()}`);
@@ -275,7 +279,7 @@ test('authenticated client navigation to /admin/content renders the host-owned c
   const response = await page.goto('/interfaces');
   expect(response).not.toBeNull();
   expect(response?.status()).toBeLessThan(400);
-  await expectInterfacesShellReady(page);
+  await expectAppShellReady(page);
   await expect(page.locator('html')).toHaveAttribute('data-theme', /.+/);
   await navigateClientSide(page, '/admin/content');
   await expect(page).toHaveURL(/\/admin\/content(?:\?.*)?$/);
@@ -298,20 +302,27 @@ test('GET /auth/login returns redirect response', async ({ request }) => {
   });
 });
 
-test('tenant-host login fails closed when canonical auth redirect prerequisites are unavailable', async ({ request }) => {
+test('tenant-host login fails closed when canonical auth redirect prerequisites are unavailable', async ({
+  request,
+}) => {
   const playwrightPort = resolvePlaywrightServerPort();
-  const tenantLoginUrl = process.env.PLAYWRIGHT_TENANT_LOGIN_URL
-    ?? `http://demo2.studio.localhost:${playwrightPort}/auth/login?returnTo=%2Fadmin%2Finstances`;
+  const tenantLoginUrl =
+    process.env.PLAYWRIGHT_TENANT_LOGIN_URL ??
+    `http://demo2.studio.localhost:${playwrightPort}/auth/login?returnTo=%2Fadmin%2Finstances`;
   const parsedTenantLoginUrl = new URL(tenantLoginUrl);
-  const tenantRequestPort = parsedTenantLoginUrl.port
-    || (parsedTenantLoginUrl.hostname === 'demo2.studio.localhost'
+  const tenantRequestPort =
+    parsedTenantLoginUrl.port ||
+    (parsedTenantLoginUrl.hostname === 'demo2.studio.localhost'
       ? playwrightPort
       : parsedTenantLoginUrl.protocol === 'https:'
         ? '443'
         : '80');
   const requestUrl =
     parsedTenantLoginUrl.hostname === 'demo2.studio.localhost'
-      ? new URL(`${parsedTenantLoginUrl.pathname}${parsedTenantLoginUrl.search}`, `http://127.0.0.1:${tenantRequestPort}`).toString()
+      ? new URL(
+          `${parsedTenantLoginUrl.pathname}${parsedTenantLoginUrl.search}`,
+          `http://127.0.0.1:${tenantRequestPort}`
+        ).toString()
       : tenantLoginUrl;
 
   const response = await request.get(requestUrl, {
@@ -353,7 +364,9 @@ test('router keeps the shell active during client-side navigation', async ({ pag
     }
   });
   page.on('requestfailed', (request) => {
-    requestFailures.push(`${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? 'unknown'}`);
+    requestFailures.push(
+      `${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? 'unknown'}`
+    );
   });
   page.on('request', (request) => {
     observedRequests.push(`${request.resourceType()} ${request.method()} ${request.url()}`);
@@ -363,12 +376,12 @@ test('router keeps the shell active during client-side navigation', async ({ pag
   });
 
   await page.goto('/interfaces');
-  await expectInterfacesShellReady(page);
+  await expectAppShellReady(page);
   await expect(page.locator('html')).toHaveAttribute('data-theme', /.+/);
   await navigateClientSide(page, '/admin/content');
   await expect(page.getByRole('heading', { name: 'Inhalte', exact: true })).toBeVisible();
   await navigateClientSide(page, '/interfaces');
   await expect(page).toHaveURL(/\/interfaces$/);
-  await expectInterfacesShellReady(page);
+  await expectAppShellReady(page);
   expect(pageErrors).toEqual([]);
 });

--- a/apps/sva-studio-react/e2e/studio-shell.helpers.ts
+++ b/apps/sva-studio-react/e2e/studio-shell.helpers.ts
@@ -40,6 +40,12 @@ export const gotoHomeAsAuthenticatedUser = async (page: Page, expectedUserName =
   await expect(page.getByRole('button', { name: expectedTriggerPattern })).toBeVisible();
 };
 
+export const expectAppShellReady = async (page: Page, timeout = 20_000) => {
+  const mainContent = page.locator('main#main-content');
+  await expect(mainContent).toBeVisible({ timeout });
+  await expect(mainContent).toHaveAttribute('aria-busy', 'false', { timeout });
+};
+
 export const navigateClientSide = async (page: Page, targetPath: string) => {
   const routerAvailable = await page
     .waitForFunction(

--- a/apps/sva-studio-react/src/components/Sidebar.test.tsx
+++ b/apps/sva-studio-react/src/components/Sidebar.test.tsx
@@ -349,6 +349,7 @@ describe('Sidebar', () => {
     expect(screen.queryByRole('link', { name: 'News' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Medien' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Benutzer' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Inhalt erstellen' })).toBeNull();
   });
 
   it('rendert im Loading-Zustand keine interaktiven Links', () => {
@@ -468,6 +469,54 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: 'Orte' }).getAttribute('href')).toBe(
       '/admin/content?type=poi.point-of-interest&page=1'
     );
+  });
+
+  it('zeigt den primären Erstellen-Einstieg vor der Übersicht bei mindestens einem anlegbaren Inhaltstyp', () => {
+    enableRegisteredContentTypes();
+    renderSidebar({
+      user: createSidebarUser({ assignedModules: ['news'] }),
+      contentAccess: createContentAccessState({
+        access: defaultEditableAccessState,
+        permissionActions: ['news.read', 'news.create'],
+      }),
+    });
+
+    const dataManagementSection = screen.getByText('Datenverwaltung').closest('section');
+    expect(dataManagementSection).toBeTruthy();
+    const links = within(dataManagementSection as HTMLElement).getAllByRole('link');
+    expect(links[0]?.textContent).toContain('Inhalt erstellen');
+    expect(links[0]?.getAttribute('href')).toBe('/admin/content/new');
+    expect(links[1]?.textContent).toContain('Übersicht');
+    expect(links[0]?.className).toContain('bg-action-primary');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Seitenleiste einklappen' }));
+    const collapsedCreateLink = screen.getByRole('link', { name: 'Inhalt erstellen' });
+    expect(collapsedCreateLink.getAttribute('title')).toBe('Inhalt erstellen');
+    expect(collapsedCreateLink.className).toContain('min-w-11');
+  });
+
+  it('blendet den Erstellen-Einstieg ohne passende Permission oder Modulzuweisung aus', () => {
+    enableRegisteredContentTypes();
+    const { rerender } = renderSidebar({
+      user: createSidebarUser({ assignedModules: ['news'] }),
+      contentAccess: createContentAccessState({
+        access: defaultReadOnlyAccessState,
+        permissionActions: ['news.read'],
+      }),
+    });
+
+    expect(screen.queryByRole('link', { name: 'Inhalt erstellen' })).toBeNull();
+
+    setupSidebarSession({
+      user: createSidebarUser({ assignedModules: [] }),
+      contentAccess: createContentAccessState({
+        access: defaultEditableAccessState,
+        permissionActions: ['news.read', 'news.create'],
+      }),
+    });
+    rerender(<Sidebar />);
+
+    expect(screen.queryByRole('link', { name: 'Inhalt erstellen' })).toBeNull();
   });
 
   it('zeigt hosteigene Inhaltstypen ohne fiktive Content-Modulzuweisung', () => {

--- a/apps/sva-studio-react/src/components/Sidebar.tsx
+++ b/apps/sva-studio-react/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   IconPackages,
   IconPhoto,
   IconPlugConnected,
+  IconPlus,
   IconShieldCheck,
   IconShieldLock,
   IconUserSquareRounded,
@@ -88,6 +89,7 @@ type SidebarLeafItem = {
   readonly search?: (current: Readonly<Record<string, unknown>>) => Record<string, unknown>;
   readonly contentType?: string | null;
   readonly activePathPrefixes?: readonly string[];
+  readonly appearance?: 'default' | 'primary';
 };
 
 type SidebarGroupItem = {
@@ -291,6 +293,29 @@ const SidebarLeafLink = ({
   );
 
   if (item.to) {
+    if (item.appearance === 'primary') {
+      return (
+        <Button
+          asChild
+          className={`h-11 rounded-lg font-semibold shadow-sm ${
+            isCollapsed ? 'w-11 justify-center px-0' : 'w-full justify-start gap-3 px-3'
+          }`}
+        >
+          <Link
+            activeOptions={item.exact ? { exact: true } : undefined}
+            to={item.to}
+            search={item.search}
+            aria-current={isActive ? 'page' : undefined}
+            aria-label={isCollapsed ? item.label : undefined}
+            title={isCollapsed ? item.label : undefined}
+            onClick={onClick}
+          >
+            {content}
+          </Link>
+        </Button>
+      );
+    }
+
     return (
       <Link
         activeOptions={item.exact ? { exact: true } : undefined}
@@ -857,8 +882,8 @@ export default function Sidebar({
         hasPermissionAction(
           MODULES_READ_PERMISSION,
           contentAccessApi.permissionActions,
-           contentAccessApi.isLoading
-         )));
+          contentAccessApi.isLoading
+        )));
   const canAccessApplicationLink =
     canAccessWorkspace &&
     canAccessExperimentalFeatures &&
@@ -936,17 +961,24 @@ export default function Sidebar({
       (item) => item.section === 'applications'
     );
     const pluginSystemItems = pluginNavigationItems.filter((item) => item.section === 'system');
-    const readableContentTypes = studioContentTypes.filter(
-      (definition) => {
-        const moduleId = definition.requiredReadAction.startsWith('content.')
-          ? null
-          : definition.requiredReadAction.split('.')[0];
-        return (
-          contentAccessApi.permissionActions.includes(definition.requiredReadAction) &&
-          isModuleAssignedToUser(moduleId, user)
-        );
-      }
-    );
+    const readableContentTypes = studioContentTypes.filter((definition) => {
+      const moduleId = definition.requiredReadAction.startsWith('content.')
+        ? null
+        : definition.requiredReadAction.split('.')[0];
+      return (
+        contentAccessApi.permissionActions.includes(definition.requiredReadAction) &&
+        isModuleAssignedToUser(moduleId, user)
+      );
+    });
+    const creatableContentTypes = studioContentTypes.filter((definition) => {
+      const moduleId = definition.requiredCreateAction.startsWith('content.')
+        ? null
+        : definition.requiredCreateAction.split('.')[0];
+      return (
+        contentAccessApi.permissionActions.includes(definition.requiredCreateAction) &&
+        isModuleAssignedToUser(moduleId, user)
+      );
+    });
     const contentChildren: SidebarLeafItem[] = [
       ...(canAccessContent || readableContentTypes.length > 0
         ? [
@@ -981,6 +1013,19 @@ export default function Sidebar({
     ];
 
     const dataManagementItems: SidebarItem[] = [
+      ...(canAccessWorkspace && creatableContentTypes.length > 0
+        ? [
+            {
+              kind: 'link' as const,
+              id: 'create-content',
+              to: '/admin/content/new',
+              label: t('shell.sidebar.createContent'),
+              icon: IconPlus,
+              exact: true,
+              appearance: 'primary' as const,
+            },
+          ]
+        : []),
       {
         kind: 'link',
         id: 'overview',

--- a/apps/sva-studio-react/src/i18n/resources/de/home.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/home.resources.ts
@@ -9,35 +9,27 @@ export const homeDEResources = {
     openSourceSuffix: 'in Bad Belzig',
     subtitle: 'Smart Village App Self-Service Plattform für Inhalte, Module und Erweiterungen.',
     body: 'Verwalten Sie Inhalte, Kontokontext und angeschlossene Module in einer gemeinsamen Oberfläche mit serverseitig abgesicherter Authentifizierung und Berechtigungsprüfung.',
-    primaryAction: 'Inhalte öffnen',
-    secondaryAction: 'Konto öffnen',
   },
   session: {
     loading: 'Sitzung wird geladen ...',
   },
-  sections: {
-    overviewTitle: 'Direkte Einstiege',
-    overviewBody:
-      'Nutzen Sie die wichtigsten Bereiche direkt aus der Startseite. Details zu Rollen, Guards und technischen Entscheidungen bleiben in den jeweiligen Fachbereichen verankert.',
-  },
   cards: {
-    content: {
-      title: 'Inhalte',
+    news: {
+      title: 'Nachricht erstellen',
       description:
-        'Pflegen Sie redaktionelle Inhalte, Metadaten und Veröffentlichungsstände in der zentralen Inhaltsverwaltung.',
-      action: 'Inhalte öffnen',
+        'Verfassen Sie eine neue Nachricht und bereiten Sie diese für die Veröffentlichung vor.',
     },
-    account: {
-      title: 'Konto',
-      description:
-        'Prüfen Sie Ihr Profil, Ihren Datenschutzkontext und weitere selbstbedienbare Kontofunktionen.',
-      action: 'Konto öffnen',
+    events: {
+      title: 'Veranstaltung anlegen',
+      description: 'Erfassen Sie eine neue Veranstaltung mit Termin, Ort und weiteren Angaben.',
     },
-    interfaces: {
-      title: 'Schnittstellen',
-      description:
-        'Überblicken Sie angebundene Integrationen und öffnen Sie die verwalteten Schnittstellenbereiche.',
-      action: 'Schnittstellen öffnen',
+    media: {
+      title: 'Medium hochladen',
+      description: 'Laden Sie ein neues Bild oder Dokument in die zentrale Mediathek hoch.',
+    },
+    users: {
+      title: 'Benutzerverwaltung öffnen',
+      description: 'Verwalten Sie Benutzerkonten und deren Zugriff auf das Studio.',
     },
   },
   changelog: {

--- a/apps/sva-studio-react/src/i18n/resources/de/shell.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/de/shell.resources.ts
@@ -120,6 +120,7 @@ export const shellDEResources = {
       system: 'System',
     },
     overview: 'Übersicht',
+    createContent: 'Inhalt erstellen',
     content: 'Inhalte',
     contentAll: 'Alle',
     media: 'Medien',

--- a/apps/sva-studio-react/src/i18n/resources/en/home.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/home.resources.ts
@@ -9,34 +9,26 @@ export const homeENResources = {
     openSourceSuffix: 'in Bad Belzig',
     subtitle: 'Smart Village App self-service platform for content, modules, and extensions.',
     body: 'Manage content, account context, and connected modules in one shared interface with server-side authentication and authorization checks.',
-    primaryAction: 'Open content',
-    secondaryAction: 'Open account',
   },
   session: {
     loading: 'Session is loading ...',
   },
-  sections: {
-    overviewTitle: 'Direct entry points',
-    overviewBody:
-      'Use the key areas directly from the home page. Details about roles, guards, and technical decisions remain within their dedicated feature areas.',
-  },
   cards: {
-    content: {
-      title: 'Content',
-      description:
-        'Manage editorial content, metadata, and publication states in the central content area.',
-      action: 'Open content',
+    news: {
+      title: 'Create news item',
+      description: 'Write a new news item and prepare it for publication.',
     },
-    account: {
-      title: 'Account',
-      description:
-        'Review your profile, privacy context, and other self-service account capabilities.',
-      action: 'Open account',
+    events: {
+      title: 'Create event',
+      description: 'Add a new event with its date, location, and further details.',
     },
-    interfaces: {
-      title: 'Interfaces',
-      description: 'Review connected integrations and open the managed interface sections.',
-      action: 'Open interfaces',
+    media: {
+      title: 'Upload media',
+      description: 'Upload a new image or document to the central media library.',
+    },
+    users: {
+      title: 'Open user management',
+      description: 'Manage user accounts and their access to Studio.',
     },
   },
   changelog: {

--- a/apps/sva-studio-react/src/i18n/resources/en/shell.resources.ts
+++ b/apps/sva-studio-react/src/i18n/resources/en/shell.resources.ts
@@ -117,6 +117,7 @@ export const shellENResources = {
       system: 'System',
     },
     overview: 'Overview',
+    createContent: 'Create content',
     content: 'Content',
     contentAll: 'All',
     media: 'Media',

--- a/apps/sva-studio-react/src/routes/-home-action-cards.tsx
+++ b/apps/sva-studio-react/src/routes/-home-action-cards.tsx
@@ -1,0 +1,125 @@
+import { Link } from '@tanstack/react-router';
+import { CalendarDays, ImageUp, Newspaper, Users, type LucideIcon } from 'lucide-react';
+
+import { Card, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { useContentAccess } from '../hooks/use-content-access';
+import { t } from '../i18n';
+import {
+  hasPlatformInstanceAdminAccess,
+  hasUserAdminAccess,
+  isIamAdminEnabled,
+} from '../lib/iam-admin-access';
+import { studioContentTypes } from '../lib/plugins';
+import type { useAuth } from '../providers/auth-provider';
+
+type HomeActionCard = {
+  readonly description: string;
+  readonly icon: LucideIcon;
+  readonly id: string;
+  readonly title: string;
+  readonly to: string;
+};
+
+const findCreatePath = (requiredAction: string) =>
+  studioContentTypes.find((definition) => definition.requiredCreateAction === requiredAction)
+    ?.createPath;
+
+const resolveHomeActionCards = (
+  user: ReturnType<typeof useAuth>['user'],
+  permissionActions: readonly string[]
+): HomeActionCard[] => {
+  const cards: HomeActionCard[] = [];
+  const accessUser = user ? { ...user, permissionActions } : null;
+  const hasModulePermission = (moduleId: string, action: string) =>
+    user?.assignedModules?.includes(moduleId) === true && permissionActions.includes(action);
+  const addContentCard = (id: string, moduleId: string, action: string, icon: LucideIcon) => {
+    const to = findCreatePath(action);
+    if (to && hasModulePermission(moduleId, action)) {
+      cards.push({
+        id,
+        to,
+        title: t(`home.cards.${id}.title`),
+        description: t(`home.cards.${id}.description`),
+        icon,
+      });
+    }
+  };
+
+  addContentCard('news', 'news', 'news.create', Newspaper);
+  addContentCard('events', 'events', 'events.create', CalendarDays);
+
+  if (hasModulePermission('media', 'media.create')) {
+    cards.push({
+      id: 'media',
+      to: '/admin/media/new',
+      title: t('home.cards.media.title'),
+      description: t('home.cards.media.description'),
+      icon: ImageUp,
+    });
+  }
+
+  if (
+    isIamAdminEnabled() &&
+    (hasUserAdminAccess(accessUser) || hasPlatformInstanceAdminAccess(accessUser))
+  ) {
+    cards.push({
+      id: 'users',
+      to: '/admin/users',
+      title: t('home.cards.users.title'),
+      description: t('home.cards.users.description'),
+      icon: Users,
+    });
+  }
+
+  return cards;
+};
+
+const resolveDesktopGridClass = (cardCount: number) => {
+  if (cardCount >= 4) return 'lg:grid-cols-4';
+  if (cardCount === 3) return 'lg:grid-cols-3';
+  if (cardCount === 2) return 'lg:grid-cols-2';
+  return 'lg:grid-cols-1';
+};
+
+export const HomeActionCards = ({
+  user,
+}: {
+  readonly user: ReturnType<typeof useAuth>['user'];
+}) => {
+  const { permissionActions } = useContentAccess();
+  const cards = resolveHomeActionCards(user, permissionActions);
+  const mediumGridClass = cards.length >= 2 ? 'md:grid-cols-2' : 'md:grid-cols-1';
+
+  if (cards.length === 0) return null;
+
+  return (
+    <div className={`grid gap-4 ${mediumGridClass} ${resolveDesktopGridClass(cards.length)}`}>
+      {cards.map((card) => {
+        const Icon = card.icon;
+        return (
+          <Card
+            key={card.id}
+            className="h-full border-border/80 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+          >
+            <Link
+              to={card.to}
+              className="block h-full rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <CardHeader className="h-full space-y-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <Icon aria-hidden="true" className="h-6 w-6" />
+                </div>
+                <div className="space-y-2">
+                  <CardTitle>{card.title}</CardTitle>
+                  <CardDescription className="text-sm leading-6">
+                    {card.description}
+                  </CardDescription>
+                </div>
+              </CardHeader>
+            </Link>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/sva-studio-react/src/routes/-home-page.test.tsx
+++ b/apps/sva-studio-react/src/routes/-home-page.test.tsx
@@ -5,11 +5,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const useAuthMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, to }: { readonly children: ReactNode; readonly to: string }) => <a href={to}>{children}</a>,
+  Link: ({ children, to }: { readonly children: ReactNode; readonly to: string }) => (
+    <a href={to}>{children}</a>
+  ),
 }));
 
 vi.mock('../providers/auth-provider', () => ({
   useAuth: () => useAuthMock(),
+}));
+
+vi.mock('../hooks/use-content-access', () => ({
+  useContentAccess: () => ({ permissionActions: [] }),
 }));
 
 import { HomePage } from './-home-page';
@@ -95,7 +101,9 @@ describe('HomePage', () => {
     render(<HomePage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Die letzten Änderungen konnten gerade nicht geladen werden.')).toBeTruthy();
+      expect(
+        screen.getByText('Die letzten Änderungen konnten gerade nicht geladen werden.')
+      ).toBeTruthy();
     });
   });
 });

--- a/apps/sva-studio-react/src/routes/-home-page.tsx
+++ b/apps/sva-studio-react/src/routes/-home-page.tsx
@@ -1,27 +1,19 @@
 import React from 'react';
-import { Link } from '@tanstack/react-router';
-import { CalendarDays, Heart, ImageUp, Newspaper, Users } from 'lucide-react';
+import { Heart } from 'lucide-react';
 
 import { t } from '../i18n';
-import { useContentAccess } from '../hooks/use-content-access';
 import { readLatestAuthDiagnosticSnapshot } from '../lib/auth-diagnostics';
 import { createLoginHref, sanitizeReturnTo } from '../lib/auth-navigation';
-import {
-  hasPlatformInstanceAdminAccess,
-  hasUserAdminAccess,
-  isIamAdminEnabled,
-} from '../lib/iam-admin-access';
 import {
   formatPermissionDenialMessage,
   readPermissionDenialFromSearch,
 } from '../lib/permission-denial-presentation';
 import { resolvePermissionTitle } from '../lib/permission-labels';
-import { studioContentTypes } from '../lib/plugins';
 import { type StudioChangelogState } from '../lib/studio-changelog-state';
 import { useAuth } from '../providers/auth-provider';
 import { Alert, AlertDescription } from '../components/ui/alert';
 import { Button } from '@sva/studio-ui-react';
-import { Card, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { HomeActionCards } from './-home-action-cards';
 import { loadStudioChangelogState, StudioChangelogSection } from './-home-page-studio-changelog';
 
 type HomeRouteState = {
@@ -182,106 +174,9 @@ const AuthenticatedHomeOverview = ({
   readonly changelogState: StudioChangelogState;
   readonly user: ReturnType<typeof useAuth>['user'];
 }) => {
-  const contentAccessApi = useContentAccess();
-  const permissionActions = contentAccessApi.permissionActions;
-  const accessUser = user ? { ...user, permissionActions } : null;
-  const isModuleAssigned = (moduleId: string) => user?.assignedModules?.includes(moduleId) === true;
-  const findCreatePath = (requiredAction: string) =>
-    studioContentTypes.find((definition) => definition.requiredCreateAction === requiredAction)
-      ?.createPath;
-  const newsCreatePath = findCreatePath('news.create');
-  const eventsCreatePath = findCreatePath('events.create');
-  const cards = [
-    ...(newsCreatePath && isModuleAssigned('news') && permissionActions.includes('news.create')
-      ? [
-          {
-            id: 'news',
-            to: newsCreatePath,
-            title: t('home.cards.news.title'),
-            description: t('home.cards.news.description'),
-            icon: Newspaper,
-          },
-        ]
-      : []),
-    ...(eventsCreatePath &&
-    isModuleAssigned('events') &&
-    permissionActions.includes('events.create')
-      ? [
-          {
-            id: 'events',
-            to: eventsCreatePath,
-            title: t('home.cards.events.title'),
-            description: t('home.cards.events.description'),
-            icon: CalendarDays,
-          },
-        ]
-      : []),
-    ...(isModuleAssigned('media') && permissionActions.includes('media.create')
-      ? [
-          {
-            id: 'media',
-            to: '/admin/media/new',
-            title: t('home.cards.media.title'),
-            description: t('home.cards.media.description'),
-            icon: ImageUp,
-          },
-        ]
-      : []),
-    ...(isIamAdminEnabled() &&
-    (hasUserAdminAccess(accessUser) || hasPlatformInstanceAdminAccess(accessUser))
-      ? [
-          {
-            id: 'users',
-            to: '/admin/users',
-            title: t('home.cards.users.title'),
-            description: t('home.cards.users.description'),
-            icon: Users,
-          },
-        ]
-      : []),
-  ];
-  const desktopGridClass =
-    cards.length >= 4
-      ? 'lg:grid-cols-4'
-      : cards.length === 3
-        ? 'lg:grid-cols-3'
-        : cards.length === 2
-          ? 'lg:grid-cols-2'
-          : 'lg:grid-cols-1';
-  const mediumGridClass = cards.length >= 2 ? 'md:grid-cols-2' : 'md:grid-cols-1';
-
   return (
     <section className="mx-auto w-full max-w-6xl px-6 py-12">
-      {cards.length > 0 ? (
-        <div className={`grid gap-4 ${mediumGridClass} ${desktopGridClass}`}>
-          {cards.map((card) => {
-            const Icon = card.icon;
-            return (
-              <Card
-                key={card.id}
-                className="h-full border-border/80 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
-              >
-                <Link
-                  to={card.to}
-                  className="block h-full rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                >
-                  <CardHeader className="h-full space-y-4">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                      <Icon aria-hidden="true" className="h-6 w-6" />
-                    </div>
-                    <div className="space-y-2">
-                      <CardTitle>{card.title}</CardTitle>
-                      <CardDescription className="text-sm leading-6">
-                        {card.description}
-                      </CardDescription>
-                    </div>
-                  </CardHeader>
-                </Link>
-              </Card>
-            );
-          })}
-        </div>
-      ) : null}
+      <HomeActionCards user={user} />
 
       <StudioChangelogSection changelogState={changelogState} />
     </section>

--- a/apps/sva-studio-react/src/routes/-home-page.tsx
+++ b/apps/sva-studio-react/src/routes/-home-page.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
 import { Link } from '@tanstack/react-router';
-import { Heart } from 'lucide-react';
+import { CalendarDays, Heart, ImageUp, Newspaper, Users } from 'lucide-react';
 
 import { t } from '../i18n';
+import { useContentAccess } from '../hooks/use-content-access';
 import { readLatestAuthDiagnosticSnapshot } from '../lib/auth-diagnostics';
 import { createLoginHref, sanitizeReturnTo } from '../lib/auth-navigation';
+import {
+  hasPlatformInstanceAdminAccess,
+  hasUserAdminAccess,
+  isIamAdminEnabled,
+} from '../lib/iam-admin-access';
 import {
   formatPermissionDenialMessage,
   readPermissionDenialFromSearch,
 } from '../lib/permission-denial-presentation';
 import { resolvePermissionTitle } from '../lib/permission-labels';
+import { studioContentTypes } from '../lib/plugins';
 import { type StudioChangelogState } from '../lib/studio-changelog-state';
 import { useAuth } from '../providers/auth-provider';
 import { Alert, AlertDescription } from '../components/ui/alert';
 import { Button } from '@sva/studio-ui-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Card, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { loadStudioChangelogState, StudioChangelogSection } from './-home-page-studio-changelog';
 
 type HomeRouteState = {
@@ -88,22 +95,7 @@ const clearConsumedHomeAuthSearch = (): void => {
   window.history.replaceState(window.history.state, '', nextHref);
 };
 
-const AuthenticatedHeroActions = () => (
-  <div className="flex flex-wrap gap-3">
-    <Button asChild>
-      <Link to="/admin/content">{t('home.hero.primaryAction')}</Link>
-    </Button>
-    <Button asChild variant="secondary">
-      <Link to="/account">{t('home.hero.secondaryAction')}</Link>
-    </Button>
-  </div>
-);
-
-const AnonymousHeroActions = ({
-  loginHref,
-}: {
-  readonly loginHref: string;
-}) => (
+const AnonymousHeroActions = ({ loginHref }: { readonly loginHref: string }) => (
   <div className="flex w-full max-w-xl flex-col items-center gap-3 sm:flex-row sm:justify-center">
     <Button asChild className="h-12 min-w-48 rounded-full px-8 text-base">
       <a href={loginHref}>{t('shell.header.login')}</a>
@@ -120,7 +112,10 @@ const HomeOpenSourceClaim = () => (
       className="inline-flex items-center gap-1 underline-offset-4 transition-colors hover:text-foreground hover:underline"
     >
       <span>{`${t('home.hero.openSourcePrefix')} `}</span>
-      <span aria-label={t('home.hero.openSourceLoveLabel')} className="inline-flex items-center text-rose-500">
+      <span
+        aria-label={t('home.hero.openSourceLoveLabel')}
+        className="inline-flex items-center text-rose-500"
+      >
         <Heart aria-hidden="true" className="h-4 w-4 fill-current" strokeWidth={1.8} />
         <span className="sr-only">{t('home.hero.openSourceLoveLabel')}</span>
       </span>
@@ -143,7 +138,9 @@ const DevAuthPrompt = ({
     <Button type="button" onClick={() => void loginWithDevAuth()}>
       {t('shell.header.devLogin')}
     </Button>
-    {showDevLoginPrompt ? <span className="text-sm text-muted-foreground">{t('home.devAuth.prompt')}</span> : null}
+    {showDevLoginPrompt ? (
+      <span className="text-sm text-muted-foreground">{t('home.devAuth.prompt')}</span>
+    ) : null}
   </div>
 );
 
@@ -160,10 +157,14 @@ const HomeAuthErrorBanner = ({
     <AlertDescription>{authError}</AlertDescription>
     <div className="flex flex-col items-start gap-2 sm:items-end">
       {authDiagnosticSnapshot.requestId ? (
-        <span>{t('home.authError.requestId', { requestId: authDiagnosticSnapshot.requestId })}</span>
+        <span>
+          {t('home.authError.requestId', { requestId: authDiagnosticSnapshot.requestId })}
+        </span>
       ) : null}
       {authDiagnosticSnapshot.authFlowId ? (
-        <span>{t('home.authError.authFlowId', { authFlowId: authDiagnosticSnapshot.authFlowId })}</span>
+        <span>
+          {t('home.authError.authFlowId', { authFlowId: authDiagnosticSnapshot.authFlowId })}
+        </span>
       ) : null}
       {authErrorLoginHref ? (
         <Button asChild size="sm" variant="secondary">
@@ -176,59 +177,120 @@ const HomeAuthErrorBanner = ({
 
 const AuthenticatedHomeOverview = ({
   changelogState,
+  user,
 }: {
   readonly changelogState: StudioChangelogState;
-}) => (
-  <section className="mx-auto max-w-6xl px-6 py-12">
-    <div className="mb-6 flex flex-col gap-2">
-      <h2 className="text-2xl font-semibold tracking-tight">{t('home.sections.overviewTitle')}</h2>
-      <p className="max-w-3xl text-sm text-muted-foreground">{t('home.sections.overviewBody')}</p>
-    </div>
+  readonly user: ReturnType<typeof useAuth>['user'];
+}) => {
+  const contentAccessApi = useContentAccess();
+  const permissionActions = contentAccessApi.permissionActions;
+  const accessUser = user ? { ...user, permissionActions } : null;
+  const isModuleAssigned = (moduleId: string) => user?.assignedModules?.includes(moduleId) === true;
+  const findCreatePath = (requiredAction: string) =>
+    studioContentTypes.find((definition) => definition.requiredCreateAction === requiredAction)
+      ?.createPath;
+  const newsCreatePath = findCreatePath('news.create');
+  const eventsCreatePath = findCreatePath('events.create');
+  const cards = [
+    ...(newsCreatePath && isModuleAssigned('news') && permissionActions.includes('news.create')
+      ? [
+          {
+            id: 'news',
+            to: newsCreatePath,
+            title: t('home.cards.news.title'),
+            description: t('home.cards.news.description'),
+            icon: Newspaper,
+          },
+        ]
+      : []),
+    ...(eventsCreatePath &&
+    isModuleAssigned('events') &&
+    permissionActions.includes('events.create')
+      ? [
+          {
+            id: 'events',
+            to: eventsCreatePath,
+            title: t('home.cards.events.title'),
+            description: t('home.cards.events.description'),
+            icon: CalendarDays,
+          },
+        ]
+      : []),
+    ...(isModuleAssigned('media') && permissionActions.includes('media.create')
+      ? [
+          {
+            id: 'media',
+            to: '/admin/media/new',
+            title: t('home.cards.media.title'),
+            description: t('home.cards.media.description'),
+            icon: ImageUp,
+          },
+        ]
+      : []),
+    ...(isIamAdminEnabled() &&
+    (hasUserAdminAccess(accessUser) || hasPlatformInstanceAdminAccess(accessUser))
+      ? [
+          {
+            id: 'users',
+            to: '/admin/users',
+            title: t('home.cards.users.title'),
+            description: t('home.cards.users.description'),
+            icon: Users,
+          },
+        ]
+      : []),
+  ];
+  const desktopGridClass =
+    cards.length >= 4
+      ? 'lg:grid-cols-4'
+      : cards.length === 3
+        ? 'lg:grid-cols-3'
+        : cards.length === 2
+          ? 'lg:grid-cols-2'
+          : 'lg:grid-cols-1';
+  const mediumGridClass = cards.length >= 2 ? 'md:grid-cols-2' : 'md:grid-cols-1';
 
-    <div className="grid gap-4 md:grid-cols-3">
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('home.cards.content.title')}</CardTitle>
-          <CardDescription>{t('home.cards.content.description')}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button asChild variant="secondary">
-            <Link to="/admin/content">{t('home.cards.content.action')}</Link>
-          </Button>
-        </CardContent>
-      </Card>
+  return (
+    <section className="mx-auto w-full max-w-6xl px-6 py-12">
+      {cards.length > 0 ? (
+        <div className={`grid gap-4 ${mediumGridClass} ${desktopGridClass}`}>
+          {cards.map((card) => {
+            const Icon = card.icon;
+            return (
+              <Card
+                key={card.id}
+                className="h-full border-border/80 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+              >
+                <Link
+                  to={card.to}
+                  className="block h-full rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <CardHeader className="h-full space-y-4">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                      <Icon aria-hidden="true" className="h-6 w-6" />
+                    </div>
+                    <div className="space-y-2">
+                      <CardTitle>{card.title}</CardTitle>
+                      <CardDescription className="text-sm leading-6">
+                        {card.description}
+                      </CardDescription>
+                    </div>
+                  </CardHeader>
+                </Link>
+              </Card>
+            );
+          })}
+        </div>
+      ) : null}
 
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('home.cards.account.title')}</CardTitle>
-          <CardDescription>{t('home.cards.account.description')}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button asChild variant="secondary">
-            <Link to="/account">{t('home.cards.account.action')}</Link>
-          </Button>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('home.cards.interfaces.title')}</CardTitle>
-          <CardDescription>{t('home.cards.interfaces.description')}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button asChild variant="secondary">
-            <Link to="/interfaces">{t('home.cards.interfaces.action')}</Link>
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-
-    <StudioChangelogSection changelogState={changelogState} />
-  </section>
-);
+      <StudioChangelogSection changelogState={changelogState} />
+    </section>
+  );
+};
 
 export const HomePage = () => {
   const {
+    user,
     isAuthenticated,
     isLoading,
     error,
@@ -272,7 +334,8 @@ export const HomePage = () => {
     routeError ??
     (sessionRecoveryFailed ? t('home.authError.sessionExpired') : null) ??
     (error ? t('home.authError.sessionLoadFailed') : null);
-  const authErrorLoginHref = !isAuthenticated && authError ? createLoginHref(authReturnTo ?? undefined) : null;
+  const authErrorLoginHref =
+    !isAuthenticated && authError ? createLoginHref(authReturnTo ?? undefined) : null;
   const heroLoginHref = createLoginHref(authReturnTo ?? undefined);
   const isAnonymousHome = !isAuthenticated;
   const [changelogState, setChangelogState] = React.useState<StudioChangelogState>({
@@ -299,7 +362,7 @@ export const HomePage = () => {
   }, [isAuthenticated]);
 
   return (
-    <div className="min-h-full bg-background text-foreground">
+    <div className="flex min-h-full flex-col bg-background text-foreground">
       <section className="bg-[radial-gradient(circle_at_top,_rgba(0,90,158,0.18),_transparent_34%),linear-gradient(to_bottom,_rgba(241,246,252,0.98),_rgba(255,255,255,0.99)_44%,_rgb(var(--background))_100%)] dark:bg-[radial-gradient(circle_at_top,_rgba(74,132,188,0.22),_transparent_30%),linear-gradient(to_bottom,_rgba(10,16,24,1),_rgba(13,20,30,0.98)_38%,_rgb(var(--background))_100%)]">
         <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-16 pt-16 sm:pb-20 sm:pt-20">
           <div
@@ -318,7 +381,9 @@ export const HomePage = () => {
               </h1>
               {isAuthenticated ? (
                 <>
-                  <p className="max-w-2xl text-lg text-muted-foreground">{t('home.hero.subtitle')}</p>
+                  <p className="max-w-2xl text-lg text-muted-foreground">
+                    {t('home.hero.subtitle')}
+                  </p>
                   <p className="max-w-2xl text-sm text-muted-foreground">{t('home.hero.body')}</p>
                 </>
               ) : (
@@ -327,14 +392,20 @@ export const HomePage = () => {
                     Die gemeinsame Oberfläche für Inhalte, Module und Organisationen.
                   </p>
                   <p className="mx-auto max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
-                    Melden Sie sich an, um Inhalte zu verwalten, Fachmodule zu öffnen und in Ihrem Arbeitskontext direkt weiterzuarbeiten.
+                    Melden Sie sich an, um Inhalte zu verwalten, Fachmodule zu öffnen und in Ihrem
+                    Arbeitskontext direkt weiterzuarbeiten.
                   </p>
                 </>
               )}
             </div>
-            {isAuthenticated ? <AuthenticatedHeroActions /> : !isLoading ? <AnonymousHeroActions loginHref={heroLoginHref} /> : null}
+            {!isAuthenticated && !isLoading ? (
+              <AnonymousHeroActions loginHref={heroLoginHref} />
+            ) : null}
             {isAnonymousHome && !isLoading && isDevAuthAvailable ? (
-              <DevAuthPrompt showDevLoginPrompt={showDevLoginPrompt} loginWithDevAuth={loginWithDevAuth} />
+              <DevAuthPrompt
+                showDevLoginPrompt={showDevLoginPrompt}
+                loginWithDevAuth={loginWithDevAuth}
+              />
             ) : null}
             {authError ? (
               <HomeAuthErrorBanner
@@ -343,7 +414,6 @@ export const HomePage = () => {
                 authErrorLoginHref={authErrorLoginHref}
               />
             ) : null}
-            <HomeOpenSourceClaim />
           </div>
         </div>
       </section>
@@ -353,8 +423,12 @@ export const HomePage = () => {
           <p className="text-sm text-muted-foreground">{t('home.session.loading')}</p>
         </section>
       ) : isAuthenticated ? (
-        <AuthenticatedHomeOverview changelogState={changelogState} />
+        <AuthenticatedHomeOverview changelogState={changelogState} user={user} />
       ) : null}
+
+      <footer className="mt-auto flex justify-center px-6 py-8">
+        <HomeOpenSourceClaim />
+      </footer>
     </div>
   );
 };

--- a/apps/sva-studio-react/src/routes/-index.test.tsx
+++ b/apps/sva-studio-react/src/routes/-index.test.tsx
@@ -5,6 +5,20 @@ import React from 'react';
 import { HomePage } from './-home-page';
 
 const useAuthMock = vi.fn();
+type HomeContentAccessMockState = {
+  access: { canRead: boolean; canCreate: boolean } | null;
+  permissionActions: string[];
+  unscopedPermissionActions: string[];
+  isLoading: boolean;
+  error: Error | null;
+};
+const useContentAccessMock = vi.fn<() => HomeContentAccessMockState>(() => ({
+  access: { canRead: true, canCreate: true },
+  permissionActions: ['news.create', 'events.create', 'media.create', 'iam.user.read'],
+  unscopedPermissionActions: [],
+  isLoading: false,
+  error: null,
+}));
 const readLatestAuthDiagnosticSnapshotMock = vi.fn(() => ({}));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -24,6 +38,28 @@ vi.mock('../providers/auth-provider', () => ({
   useAuth: () => useAuthMock(),
 }));
 
+vi.mock('../hooks/use-content-access', () => ({
+  useContentAccess: () => useContentAccessMock(),
+}));
+
+vi.mock('../lib/plugins', () => ({
+  studioBuildTimeRegistry: {
+    pluginPermissionRegistry: new Map(),
+  },
+  studioContentTypes: [
+    {
+      contentType: 'news.article',
+      requiredCreateAction: 'news.create',
+      createPath: '/admin/news/new',
+    },
+    {
+      contentType: 'events.event-record',
+      requiredCreateAction: 'events.create',
+      createPath: '/admin/events/new',
+    },
+  ],
+}));
+
 vi.mock('../lib/auth-diagnostics', () => ({
   readLatestAuthDiagnosticSnapshot: () => readLatestAuthDiagnosticSnapshotMock(),
 }));
@@ -35,6 +71,14 @@ describe('HomePage', () => {
     readLatestAuthDiagnosticSnapshotMock.mockReset();
     readLatestAuthDiagnosticSnapshotMock.mockReturnValue({});
     useAuthMock.mockReset();
+    useContentAccessMock.mockReset();
+    useContentAccessMock.mockReturnValue({
+      access: { canRead: true, canCreate: true },
+      permissionActions: ['news.create', 'events.create', 'media.create', 'iam.user.read'],
+      unscopedPermissionActions: [],
+      isLoading: false,
+      error: null,
+    });
   });
 
   it('shows authenticated session summary without raw demo messaging', () => {
@@ -43,6 +87,7 @@ describe('HomePage', () => {
         id: 'user-1',
         roles: ['editor', 'system_admin'],
         instanceId: 'de-musterhausen',
+        assignedModules: ['news', 'events', 'media'],
       },
       isAuthenticated: true,
       isLoading: false,
@@ -58,14 +103,11 @@ describe('HomePage', () => {
 
     expect(screen.queryByText('Demo Session')).toBeNull();
     expect(screen.queryByText('IAM-Authorize (Modulpfad)')).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Inhalte öffnen' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Konto öffnen' })).toBeNull();
     expect(
-      screen
-        .getAllByRole('link', { name: 'Inhalte öffnen' })
-        .some((link) => link.getAttribute('href') === '/admin/content')
-    ).toBe(true);
-    expect(screen.getByRole('heading', { name: 'SVA Studio' }).closest('section')?.className).toContain(
-      'rgba(0,90,158,0.18)'
-    );
+      screen.getByRole('heading', { name: 'SVA Studio' }).closest('section')?.className
+    ).toContain('rgba(0,90,158,0.18)');
   });
 
   it('shows signed-out copy without exposing role diagnostics', () => {
@@ -88,10 +130,14 @@ describe('HomePage', () => {
     expect(screen.queryByText('Anmeldung erforderlich')).toBeNull();
     expect(screen.queryByRole('link', { name: 'Zum Login' })).toBeNull();
     expect(
-      screen.getByRole('link', { name: 'Open Source Software made with love in Bad Belzig' }).getAttribute('href')
+      screen
+        .getByRole('link', { name: 'Open Source Software made with love in Bad Belzig' })
+        .getAttribute('href')
     ).toBe('https://github.com/smart-village-solutions/sva-studio');
     expect(
-      screen.getByRole('link', { name: 'Open Source Software made with love in Bad Belzig' }).getAttribute('rel')
+      screen
+        .getByRole('link', { name: 'Open Source Software made with love in Bad Belzig' })
+        .getAttribute('rel')
     ).toBe('noopener noreferrer');
     expect(screen.getByLabelText('love')).toBeTruthy();
     expect(screen.queryByText('Direkte Einstiege')).toBeNull();
@@ -119,12 +165,13 @@ describe('HomePage', () => {
     expect(screen.getByText('Sitzung wird geladen ...')).toBeTruthy();
   });
 
-  it('shows direct entry points instead of debug cards', () => {
+  it('shows all permitted actions as four equally sized desktop cards', () => {
     useAuthMock.mockReturnValue({
       user: {
         id: 'user-1',
         roles: ['editor'],
         instanceId: 'de-musterhausen',
+        assignedModules: ['news', 'events', 'media'],
       },
       isAuthenticated: true,
       isLoading: false,
@@ -138,20 +185,109 @@ describe('HomePage', () => {
 
     render(<HomePage />);
 
-    expect(screen.getByText('Direkte Einstiege')).toBeTruthy();
-    expect(
-      screen
-        .getAllByRole('link', { name: 'Inhalte öffnen' })
-        .some((link) => link.getAttribute('href') === '/admin/content')
-    ).toBe(true);
-    expect(
-      screen
-        .getAllByRole('link', { name: 'Konto öffnen' })
-        .some((link) => link.getAttribute('href') === '/account')
-    ).toBe(true);
-    expect(screen.getByRole('link', { name: 'Schnittstellen öffnen' }).getAttribute('href')).toBe(
-      '/interfaces'
+    expect(screen.queryByText('Direkte Einstiege')).toBeNull();
+    expect(screen.getByRole('link', { name: /Nachricht erstellen/ }).getAttribute('href')).toBe(
+      '/admin/news/new'
     );
+    expect(screen.getByRole('link', { name: /Veranstaltung anlegen/ }).getAttribute('href')).toBe(
+      '/admin/events/new'
+    );
+    expect(screen.getByRole('link', { name: /Medium hochladen/ }).getAttribute('href')).toBe(
+      '/admin/media/new'
+    );
+    const usersLink = screen.getByRole('link', { name: /Benutzerverwaltung öffnen/ });
+    expect(usersLink.getAttribute('href')).toBe('/admin/users');
+    expect(usersLink.closest('.grid')?.className).toContain('lg:grid-cols-4');
+  });
+
+  it('shows only actions allowed by permissions and assigned modules', () => {
+    useContentAccessMock.mockReturnValue({
+      access: { canRead: true, canCreate: true },
+      permissionActions: ['news.create', 'media.create'],
+      unscopedPermissionActions: [],
+      isLoading: false,
+      error: null,
+    });
+    useAuthMock.mockReturnValue({
+      user: {
+        id: 'user-1',
+        roles: ['editor'],
+        instanceId: 'de-musterhausen',
+        assignedModules: ['news'],
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      logout: vi.fn(),
+      refreshSession: vi.fn(),
+      hasResolvedSession: true,
+      isRecoveringSession: false,
+    });
+
+    render(<HomePage />);
+
+    const newsLink = screen.getByRole('link', { name: /Nachricht erstellen/ });
+    expect(newsLink).toBeTruthy();
+    expect(newsLink.closest('.grid')?.className).toContain('lg:grid-cols-1');
+    expect(screen.queryByRole('link', { name: /Veranstaltung anlegen/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Medium hochladen/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Benutzerverwaltung öffnen/ })).toBeNull();
+  });
+
+  it('keeps dashboard actions fail-closed while permissions are loading', () => {
+    useContentAccessMock.mockReturnValue({
+      access: null,
+      permissionActions: [],
+      unscopedPermissionActions: [],
+      isLoading: true,
+      error: null,
+    });
+    useAuthMock.mockReturnValue({
+      user: {
+        id: 'user-1',
+        roles: ['editor'],
+        instanceId: 'de-musterhausen',
+        assignedModules: ['news', 'events', 'media'],
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      logout: vi.fn(),
+      refreshSession: vi.fn(),
+      hasResolvedSession: true,
+      isRecoveringSession: false,
+    });
+
+    render(<HomePage />);
+
+    expect(screen.queryByRole('link', { name: /Nachricht erstellen/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Veranstaltung anlegen/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Medium hochladen/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Benutzerverwaltung öffnen/ })).toBeNull();
+  });
+
+  it('places the open-source claim in the page footer', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      logout: vi.fn(),
+      refreshSession: vi.fn(),
+      hasResolvedSession: true,
+      isRecoveringSession: false,
+    });
+
+    render(<HomePage />);
+
+    expect(
+      screen
+        .getByRole('link', { name: 'Open Source Software made with love in Bad Belzig' })
+        .closest('footer')
+    ).toBeTruthy();
   });
 
   it('shows a helpful message after insufficient role redirect', () => {
@@ -265,7 +401,9 @@ describe('HomePage', () => {
     render(<HomePage />);
 
     expect(screen.queryByText('Login fehlgeschlagen. Bitte erneut versuchen.')).toBeNull();
-    expect(screen.queryByText('Login abgebrochen oder abgelaufen. Bitte erneut anmelden.')).toBeNull();
+    expect(
+      screen.queryByText('Login abgebrochen oder abgelaufen. Bitte erneut anmelden.')
+    ).toBeNull();
   });
 
   it('starts a full-document login redirect from the home route when auth=login is present', () => {

--- a/docs/changelog/entries/pr-979.json
+++ b/docs/changelog/entries/pr-979.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 979,
+  "body": "Dashboard-Aktionen schneller und übersichtlicher erreichen\n\n- Die Startseite zeigt abhängig von Berechtigungen und aktiven Modulen direkte Aktionen für Nachrichten, Veranstaltungen, Medien und Benutzerverwaltung.\n- Die Aktionskarten passen ihre Breite automatisch an die Anzahl verfügbarer Einstiege an und nutzen auf großen Bildschirmen bis zu vier Spalten.\n- Der einleitende Schnellzugriffs-Text sowie die bisherigen Buttons für Inhalte und Konto entfallen.\n- Der Open-Source-Hinweis steht nun am Ende der Startseite.\n- In der Seitenleiste führt ein hervorgehobener Einstieg vor der Übersicht direkt zur Erstellung eines neuen Inhalts."
+}


### PR DESCRIPTION
## Was ändert sich?

- Entfernt die bisherigen Hero-Aktionen „Inhalte öffnen“ und „Konto öffnen“ sowie den erklärenden Schnellzugriffs-Text.
- Zeigt stattdessen permission- und modulabhängige Cards für Nachrichten, Veranstaltungen, Medien und Benutzerverwaltung.
- Passt die Card-Breite responsiv an die Anzahl sichtbarer Aktionen an, mit bis zu vier Cards pro Desktop-Zeile.
- Verschiebt den Open-Source-Hinweis ans Ende der Startseite.
- Ergänzt in der Seitenleiste vor „Übersicht“ den primären, permission-gesteuerten Einstieg „Inhalt erstellen“.
- Aktualisiert deutsche und englische Übersetzungen sowie Regressionstests.

## Warum?

Die Startseite soll die tatsächlich nutzbaren Kernaktionen klarer priorisieren und nur Einstiege anbieten, die im aktuellen Modul- und Berechtigungskontext verfügbar sind.

Closes #967

## Auswirkungen

Nutzer sehen je nach effektiven Berechtigungen und zugewiesenen Modulen zwischen null und vier Schnellaktionen. Ungelöste oder fehlerhafte Berechtigungsstände bleiben fail-closed.

## Validierung

- `pnpm nx run sva-studio-react:test:unit:routes --testFiles=src/routes/-index.test.tsx --skipNxCache`
- `pnpm nx run sva-studio-react:test:unit:ui --testFiles=src/components/Sidebar.test.tsx --skipNxCache`
- `pnpm nx run sva-studio-react:test:types --skipNxCache`
- `pnpm nx run-many -t check:i18n lint -p sva-studio-react --skipNxCache --nxBail`
- `pnpm nx run sva-studio-react:test:a11y --skipNxCache`
- `pnpm nx run sva-studio-react:build --skipNxCache`
- `pnpm check:file-placement`
- `pnpm check:studio-changelog`
- `git diff --check`