### PR TITLE
feat(news): improve waste push target selection

### DIFF
--- a/docs/changelog/entries/pr-982.json
+++ b/docs/changelog/entries/pr-982.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 982,
+  "body": "Abholorte für Push-Nachrichten lassen sich übersichtlicher auswählen\n\n- Die Auswahl zeigt jederzeit, wie viele Abholorte insgesamt ausgewählt sind.\n- Änderungen an den Suchfiltern beginnen mit einer neuen, eindeutigen Auswahl.\n- Große Auswahllisten lassen sich ein- und ausklappen und seitenweise durchsehen.\n- Verbesserte Statusmeldungen unterstützen die Bedienung mit Screenreadern."
+}

--- a/docs/changelog/entries/pr-982.json
+++ b/docs/changelog/entries/pr-982.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 982,
-  "body": "Abholorte für Push-Nachrichten lassen sich übersichtlicher auswählen\n\n- Die Auswahl zeigt jederzeit, wie viele Abholorte insgesamt ausgewählt sind.\n- Änderungen an den Suchfiltern beginnen mit einer neuen, eindeutigen Auswahl.\n- Große Auswahllisten lassen sich ein- und ausklappen und seitenweise durchsehen.\n- Verbesserte Statusmeldungen unterstützen die Bedienung mit Screenreadern."
+  "body": "Abholorte für Push-Nachrichten lassen sich übersichtlicher auswählen\n\n- Die Auswahl zeigt jederzeit, wie viele Abholorte im aktuellen Filter ausgewählt sind.\n- Ausgeblendete Auswahlen bleiben beim Filtern vorgemerkt und werden erst beim Erweitern des Filters wieder wirksam.\n- Beim Übernehmen werden nur die aktuell wirksamen Abholorte berücksichtigt.\n- Große Auswahllisten lassen sich ein- und ausklappen und seitenweise durchsehen.\n- Verbesserte Statusmeldungen unterstützen die Bedienung mit Screenreadern."
 }

--- a/openspec/changes/add-news-waste-location-targeting/design.md
+++ b/openspec/changes/add-news-waste-location-targeting/design.md
@@ -16,7 +16,7 @@ Der Mainserver kann Nachrichten-Payloads mit `wasteLocationKeys` an bereits vorb
 - Städte erhalten dafür im mandantenspezifischen Waste-Schema die optionale Spalte `postal_code`. Neu auswählbar sind nur aktive Abholorte mit vollständigem Stadt-, PLZ- und Straßenbezug; eine Hausnummer ist optional.
 - Formzustand und Mutation führen das vollständige bestehende Payload mit. Nur `wasteLocationKeys` wird ersetzt oder bei globalem Versand entfernt.
 - Nicht auflösbare gespeicherte Schlüssel bleiben als veraltete Ziele sichtbar und erhalten.
-- Der Dialog bearbeitet eine temporäre Auswahl. Erst „Auswahl übernehmen“ verändert das Formular.
+- Der Dialog bearbeitet eine temporär vorgemerkte Auswahl. Filter grenzen nur deren wirksame Schnittmenge mit den aktuellen Treffern ein: Angezeigt, gezählt und übernommen werden die aktuell passenden Ziele, während ausgeblendete gültige Ziele für ein späteres Erweitern des Filters vorgemerkt bleiben. Nicht auflösbare gespeicherte Schlüssel bleiben unabhängig davon erhalten. Erst „Auswahl übernehmen“ verändert das Formular.
 - Nach einer bestätigten Push-Zustellung ist die Zielauswahl schreibgeschützt, damit das gespeicherte Payload die historische Empfängergruppe weiterhin beschreibt.
 - Stadt-Updates verwenden feldselektive PATCH-Semantik bis zur SQL-Anweisung. Ausgelassene Felder bleiben unverändert; nur ein explizites `null` entfernt PLZ oder Region.
 

--- a/openspec/changes/add-news-waste-location-targeting/specs/content-management/spec.md
+++ b/openspec/changes/add-news-waste-location-targeting/specs/content-management/spec.md
@@ -10,6 +10,21 @@ Der News-Editor MUST berechtigten Redakteuren erlauben, Ziel-Abholorte unabhäng
 - **THEN** zeigt der Zielgruppenbereich den deduplizierten gezielten Modus und die ausgewählten Adressen
 - **AND** gehen vorherige Auswahlen durch Filtern oder Seitenwechsel nicht verloren
 
+#### Scenario: Redaktion schränkt eine vorgemerkte Auswahl ein
+
+- **GIVEN** die Redaktion hat mehrere Filtertreffer vorgemerkt
+- **WHEN** sie den Filter weiter einschränkt
+- **THEN** zeigt und zählt der Editor nur die Schnittmenge aus vorgemerkter Auswahl und aktuellen Treffern
+- **AND** erscheinen die zuvor vorgemerkten Treffer beim erneuten Erweitern des Filters wieder als ausgewählt
+- **AND** entfernt ein manuelles Abwählen den Treffer dauerhaft aus der vorgemerkten Auswahl
+
+#### Scenario: Redaktion übernimmt eine gefilterte Auswahl
+
+- **GIVEN** ein Filter blendet einen Teil der vorgemerkten gültigen Ziele aus
+- **WHEN** die Redaktion die Auswahl übernimmt
+- **THEN** ersetzt nur die wirksame Schnittmenge die bisherigen gültigen Zielschlüssel
+- **AND** bleiben vorhandene nicht auflösbare Zielschlüssel erhalten, bis die Redaktion sie ausdrücklich entfernt
+
 #### Scenario: Vorhandenes Ziel kann nicht aufgelöst werden
 
 - **WHEN** ein vorhandener Abholortschlüssel nicht mehr anhand der aktuellen Waste-Stammdaten aufgelöst werden kann

--- a/openspec/changes/add-news-waste-location-targeting/tasks.md
+++ b/openspec/changes/add-news-waste-location-targeting/tasks.md
@@ -9,6 +9,7 @@
 - [x] 2.2 Zielgruppenbereich in den Push-Einstellungen mit Status, Zusammenfassung und veralteten Zielen ergänzen
 - [x] 2.3 Barrierefreies Auswahl-Overlay mit Hierarchiefiltern, Suche und seitenübergreifender Auswahl ergänzen
 - [x] 2.4 Globalen Push beim auslösenden Speichern bestätigen
+- [x] 2.5 Vorgemerkte und wirksame Auswahl über ein filterabhängiges Schnittmengenmodell trennen
 
 ## 3. Qualität und Dokumentation
 
@@ -18,3 +19,4 @@
 - [x] 3.4 City-Updates atomar auf feldselektive PATCH-Semantik härten
 - [x] 3.5 Zielauswahl lazy laden, dynamische Ergebnisse barrierefrei ankündigen und versendete Ziele sperren
 - [x] 3.6 Neue Tests modulnah platzieren und Review-Regressionen abdecken
+- [x] 3.7 Lokalisierte Seitennavigation, sichtbare veraltete Ziele und das Schnittmengenmodell absichern

--- a/packages/plugin-news/src/news.detail-targeting-dialog.parts.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-dialog.parts.tsx
@@ -189,12 +189,14 @@ export function TargetingTable({
 
 export function TargetingPagination({
   resultCount,
+  selectedCount,
   page,
   pageCount,
   pt,
   setPage,
 }: Readonly<{
   resultCount: number;
+  selectedCount: number;
   page: number;
   pageCount: number;
   pt: NewsTargetingTranslator;
@@ -203,9 +205,22 @@ export function TargetingPagination({
   return (
     <div className="flex items-center justify-between text-sm">
       <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-        {pt('targeting.table.status', { count: resultCount, page, pageCount })}
+        {pt('targeting.table.selectionStatus', {
+          count: resultCount,
+          selectedCount,
+          page,
+          pageCount,
+        })}
       </span>
-      <span>{pt('targeting.table.resultCount', { count: resultCount })}</span>
+      <div className="flex items-center gap-2">
+        <span>{pt('targeting.table.resultCount', { count: resultCount })}</span>
+        <span aria-hidden="true" className="text-muted-foreground">
+          ·
+        </span>
+        <span className="font-medium">
+          {pt('targeting.table.selectedCount', { count: selectedCount })}
+        </span>
+      </div>
       <div className="flex items-center gap-2">
         <Button
           type="button"

--- a/packages/plugin-news/src/news.detail-targeting-dialog.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-dialog.tsx
@@ -49,7 +49,7 @@ export function NewsDetailTargetingDialog({
     return `${street?.name}, ${cityContextLabel(street?.cityId ?? '')}`;
   };
   const applySelection = () => {
-    onApply(editor.draft);
+    onApply(editor.appliedDraft);
     editor.setOpen(false);
   };
   const openEditor = async () => {
@@ -103,7 +103,7 @@ export function NewsDetailTargetingDialog({
           />
           <TargetingPagination
             resultCount={editor.filtered.length}
-            selectedCount={editor.selectedIds.size}
+            selectedCount={editor.effectiveSelectedCount}
             page={editor.page}
             pageCount={editor.pageCount}
             pt={pt}

--- a/packages/plugin-news/src/news.detail-targeting-dialog.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-dialog.tsx
@@ -103,6 +103,7 @@ export function NewsDetailTargetingDialog({
           />
           <TargetingPagination
             resultCount={editor.filtered.length}
+            selectedCount={editor.selectedIds.size}
             page={editor.page}
             pageCount={editor.pageCount}
             pt={pt}

--- a/packages/plugin-news/src/news.detail-targeting-state.ts
+++ b/packages/plugin-news/src/news.detail-targeting-state.ts
@@ -87,6 +87,19 @@ export const useNewsTargetingEditor = (
   );
   const filtered = React.useMemo(() => filterTargetOptions(options, filters), [filters, options]);
   const selectedIds = React.useMemo(() => new Set(draft.map(wasteLocationKeyId)), [draft]);
+  const optionIds = React.useMemo(() => new Set(options.map((option) => option.id)), [options]);
+  const effectiveDraft = React.useMemo(
+    () => filtered.filter((option) => selectedIds.has(option.id)).map((option) => option.key),
+    [filtered, selectedIds]
+  );
+  const staleDraft = React.useMemo(
+    () => draft.filter((entry) => !optionIds.has(wasteLocationKeyId(entry))),
+    [draft, optionIds]
+  );
+  const appliedDraft = React.useMemo(
+    () => [...staleDraft, ...effectiveDraft],
+    [effectiveDraft, staleDraft]
+  );
   const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
   const currentPage = Math.min(page, pageCount);
   const visible = filtered.slice((currentPage - 1) * pageSize, currentPage * pageSize);
@@ -96,7 +109,6 @@ export const useNewsTargetingEditor = (
   React.useEffect(() => setPage(1), [filters]);
 
   const updateFilters = (next: Partial<TargetingFilters>) => {
-    setDraft([]);
     setFilters((current) => ({ ...current, ...next }));
   };
   const openEditor = () => {
@@ -127,7 +139,8 @@ export const useNewsTargetingEditor = (
     open,
     setOpen,
     openEditor,
-    draft,
+    appliedDraft,
+    effectiveSelectedCount: effectiveDraft.length,
     filters,
     updateFilters,
     citiesById,

--- a/packages/plugin-news/src/news.detail-targeting-state.ts
+++ b/packages/plugin-news/src/news.detail-targeting-state.ts
@@ -38,6 +38,20 @@ const filterTargetOptions = (
   );
 };
 
+const deriveTargetingSelection = (
+  options: readonly NewsWasteTargetOption[],
+  filtered: readonly NewsWasteTargetOption[],
+  draft: readonly WasteLocationKey[]
+) => {
+  const selectedIds = new Set(draft.map(wasteLocationKeyId));
+  const optionIds = new Set(options.map((option) => option.id));
+  const effectiveDraft = filtered
+    .filter((option) => selectedIds.has(option.id))
+    .map((option) => option.key);
+  const staleDraft = draft.filter((entry) => !optionIds.has(wasteLocationKeyId(entry)));
+  return { selectedIds, effectiveDraft, appliedDraft: [...staleDraft, ...effectiveDraft] };
+};
+
 export const useNewsTargetingEditor = (
   overview: WasteManagementMasterDataOverview,
   options: readonly NewsWasteTargetOption[],
@@ -86,19 +100,9 @@ export const useNewsTargetingEditor = (
     [citiesById, filters, overview.houseNumbers, streetsById]
   );
   const filtered = React.useMemo(() => filterTargetOptions(options, filters), [filters, options]);
-  const selectedIds = React.useMemo(() => new Set(draft.map(wasteLocationKeyId)), [draft]);
-  const optionIds = React.useMemo(() => new Set(options.map((option) => option.id)), [options]);
-  const effectiveDraft = React.useMemo(
-    () => filtered.filter((option) => selectedIds.has(option.id)).map((option) => option.key),
-    [filtered, selectedIds]
-  );
-  const staleDraft = React.useMemo(
-    () => draft.filter((entry) => !optionIds.has(wasteLocationKeyId(entry))),
-    [draft, optionIds]
-  );
-  const appliedDraft = React.useMemo(
-    () => [...staleDraft, ...effectiveDraft],
-    [effectiveDraft, staleDraft]
+  const { selectedIds, effectiveDraft, appliedDraft } = React.useMemo(
+    () => deriveTargetingSelection(options, filtered, draft),
+    [draft, filtered, options]
   );
   const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
   const currentPage = Math.min(page, pageCount);
@@ -112,6 +116,8 @@ export const useNewsTargetingEditor = (
     setFilters((current) => ({ ...current, ...next }));
   };
   const openEditor = () => {
+    setFilters(initialFilters);
+    setPage(1);
     setDraft(selected);
     setOpen(true);
   };

--- a/packages/plugin-news/src/news.detail-targeting-state.ts
+++ b/packages/plugin-news/src/news.detail-targeting-state.ts
@@ -96,6 +96,7 @@ export const useNewsTargetingEditor = (
   React.useEffect(() => setPage(1), [filters]);
 
   const updateFilters = (next: Partial<TargetingFilters>) => {
+    setDraft([]);
     setFilters((current) => ({ ...current, ...next }));
   };
   const openEditor = () => {

--- a/packages/plugin-news/src/news.detail-targeting-tab.test.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-tab.test.tsx
@@ -231,6 +231,35 @@ describe('NewsDetailTargetingTab', () => {
     expect(screen.getByText('targeting.mode.targeted:1')).toBeTruthy();
   });
 
+  it('resets restrictive filters before reopening and applying the selection', () => {
+    const initialTargets = houseNumbers.map((houseNumber) => ({
+      street: `Hauptstraße ${houseNumber.number}`,
+      zip: '12345',
+      city: 'Musterstadt',
+    }));
+    render(<Subject initialTargets={initialTargets} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
+    fireEvent.change(screen.getByLabelText('targeting.filters.street'), {
+      target: { value: 's1' },
+    });
+    fireEvent.change(screen.getByLabelText('targeting.filters.houseNumber'), {
+      target: { value: 'h1' },
+    });
+    expect(screen.getByText('targeting.table.selectedCount:1')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'actions.cancel' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
+    expect((screen.getByLabelText('targeting.filters.street') as HTMLSelectElement).value).toBe('');
+    expect(
+      (screen.getByLabelText('targeting.filters.houseNumber') as HTMLSelectElement).value
+    ).toBe('');
+    expect(screen.getByText('targeting.table.selectedCount:26')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.apply' }));
+
+    expect(screen.getByText('targeting.mode.targeted:26')).toBeTruthy();
+  });
+
   it('exposes visible filter labels and announces filtered result changes', () => {
     render(<Subject />);
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));

--- a/packages/plugin-news/src/news.detail-targeting-tab.test.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-tab.test.tsx
@@ -45,8 +45,19 @@ const overview = {
   locationTourLinks: [],
 } as const;
 
-const translate = (key: string, variables?: Readonly<Record<string, string | number>>) =>
-  variables?.count === undefined ? key : `${key}:${variables.count}`;
+const translate = (key: string, variables?: Readonly<Record<string, string | number>>) => {
+  if (
+    key === 'targeting.summary.pageStatus' &&
+    variables?.page !== undefined &&
+    variables.pageCount !== undefined
+  ) {
+    return `${key}:${variables.page}:${variables.pageCount}`;
+  }
+  if (variables?.count === undefined) return key;
+  return variables.selectedCount === undefined
+    ? `${key}:${variables.count}`
+    : `${key}:${variables.count}:${variables.selectedCount}`;
+};
 
 function Subject({
   masterData = overview,
@@ -78,7 +89,11 @@ describe('NewsDetailTargetingTab', () => {
     render(<Subject />);
 
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
+    expect(screen.getByText('targeting.table.selectedCount:0')).toBeTruthy();
+    expect(screen.getByRole('status').textContent).toBe('targeting.table.selectionStatus:26:0');
     fireEvent.click(screen.getByLabelText('targeting.actions.selectAll'));
+    expect(screen.getByText('targeting.table.selectedCount:26')).toBeTruthy();
+    expect(screen.getByRole('status').textContent).toBe('targeting.table.selectionStatus:26:26');
     fireEvent.click(screen.getByRole('button', { name: 'actions.cancel' }));
     expect(screen.getByText('targeting.mode.global')).toBeTruthy();
     expect(screen.getByTestId('dirty-state').textContent).toBe('clean');
@@ -86,12 +101,26 @@ describe('NewsDetailTargetingTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
     fireEvent.click(screen.getByLabelText('targeting.actions.selectAll'));
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.next' }));
+    expect(screen.getByText('targeting.table.selectedCount:26')).toBeTruthy();
     expect((screen.getByLabelText('targeting.actions.selectAll') as HTMLInputElement).checked).toBe(
       true
     );
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.apply' }));
 
-    expect(screen.getByText('targeting.mode.targeted:26')).toBeTruthy();
+    const selectionSummary = screen.getByText('targeting.mode.targeted:26');
+    const selectionDetails = selectionSummary.closest('details');
+    expect(selectionDetails?.open).toBe(false);
+    fireEvent.click(selectionSummary);
+    expect(selectionDetails?.open).toBe(true);
+    expect(screen.getAllByRole('button', { name: 'targeting.actions.removeTarget' })).toHaveLength(
+      25
+    );
+    expect(screen.getByText('1 / 2')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.next' }));
+    expect(screen.getAllByRole('button', { name: 'targeting.actions.removeTarget' })).toHaveLength(
+      1
+    );
+    expect(screen.getByText('2 / 2')).toBeTruthy();
     expect(screen.getByTestId('dirty-state').textContent).toBe('dirty');
   });
 
@@ -161,6 +190,22 @@ describe('NewsDetailTargetingTab', () => {
     expect(houseNumberOptions).not.toContain('9 — Parkweg, 54321 Südstadt');
   });
 
+  it('clears the draft selection when the filters change', () => {
+    render(<Subject />);
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
+    fireEvent.change(screen.getByLabelText('targeting.filters.region'), {
+      target: { value: 'r1' },
+    });
+    fireEvent.click(screen.getByLabelText('targeting.actions.selectAll'));
+    expect(screen.getByText('targeting.table.selectedCount:26')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('targeting.filters.city'), {
+      target: { value: 'c1' },
+    });
+
+    expect(screen.getByText('targeting.table.selectedCount:0')).toBeTruthy();
+  });
+
   it('exposes visible filter labels and announces filtered result changes', () => {
     render(<Subject />);
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
@@ -170,7 +215,7 @@ describe('NewsDetailTargetingTab', () => {
     expect(screen.getByText('targeting.filters.city')).toBeTruthy();
     expect(screen.getByText('targeting.filters.street')).toBeTruthy();
     expect(screen.getByText('targeting.filters.houseNumber')).toBeTruthy();
-    expect(screen.getByRole('status').textContent).toContain('targeting.table.status');
+    expect(screen.getByRole('status').textContent).toContain('targeting.table.selectionStatus');
   });
 
   it('filters down to a house number and applies an individually selected target', () => {
@@ -202,6 +247,30 @@ describe('NewsDetailTargetingTab', () => {
     expect(screen.getByTestId('dirty-state').textContent).toBe('dirty');
   });
 
+  it('navigates from the displayed page after removing the last item on a late page', () => {
+    const initialTargets = Array.from({ length: 126 }, (_, index) => ({
+      street: `Teststraße ${index + 1}`,
+      zip: '12345',
+      city: 'Musterstadt',
+    }));
+    render(<Subject initialTargets={initialTargets} />);
+    fireEvent.click(screen.getByText('targeting.mode.targeted:126'));
+    expect(screen.getByText('targeting.summary.pageStatus:1:6')).toBeTruthy();
+
+    const nextButton = screen.getByRole('button', { name: 'targeting.actions.next' });
+    for (let page = 1; page < 6; page += 1) {
+      fireEvent.click(nextButton);
+    }
+    expect(screen.getByText('6 / 6')).toBeTruthy();
+    expect(screen.getByText('targeting.summary.pageStatus:6:6')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.removeTarget' }));
+    expect(screen.getByText('5 / 5')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.previous' }));
+
+    expect(screen.getByText('4 / 5')).toBeTruthy();
+  });
+
   it('keeps recipients read-only after the Push has been sent', () => {
     const target = { street: 'Hauptstraße 1', zip: '12345', city: 'Musterstadt' };
     render(<Subject initialTargets={[target]} readOnly />);
@@ -228,6 +297,7 @@ describe('NewsDetailTargetingTab', () => {
     expect(screen.getByText(/targeting\.stale/)).toBeTruthy();
     expect(screen.getByTestId('dirty-state').textContent).toBe('clean');
 
+    fireEvent.click(screen.getByText('targeting.mode.targeted:1'));
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.removeTarget' }));
 
     expect(screen.getByText('targeting.mode.global')).toBeTruthy();

--- a/packages/plugin-news/src/news.detail-targeting-tab.test.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-tab.test.tsx
@@ -115,12 +115,12 @@ describe('NewsDetailTargetingTab', () => {
     expect(screen.getAllByRole('button', { name: 'targeting.actions.removeTarget' })).toHaveLength(
       25
     );
-    expect(screen.getByText('1 / 2')).toBeTruthy();
+    expect(screen.getByText('targeting.summary.pageStatus:1:2')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.next' }));
     expect(screen.getAllByRole('button', { name: 'targeting.actions.removeTarget' })).toHaveLength(
       1
     );
-    expect(screen.getByText('2 / 2')).toBeTruthy();
+    expect(screen.getByText('targeting.summary.pageStatus:2:2')).toBeTruthy();
     expect(screen.getByTestId('dirty-state').textContent).toBe('dirty');
   });
 
@@ -190,7 +190,7 @@ describe('NewsDetailTargetingTab', () => {
     expect(houseNumberOptions).not.toContain('9 — Parkweg, 54321 Südstadt');
   });
 
-  it('clears the draft selection when the filters change', () => {
+  it('remembers filtered-out selections but only applies the effective intersection', () => {
     render(<Subject />);
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
     fireEvent.change(screen.getByLabelText('targeting.filters.region'), {
@@ -199,11 +199,36 @@ describe('NewsDetailTargetingTab', () => {
     fireEvent.click(screen.getByLabelText('targeting.actions.selectAll'));
     expect(screen.getByText('targeting.table.selectedCount:26')).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText('targeting.filters.city'), {
-      target: { value: 'c1' },
+    fireEvent.change(screen.getByLabelText('targeting.filters.street'), {
+      target: { value: 's1' },
+    });
+    fireEvent.change(screen.getByLabelText('targeting.filters.houseNumber'), {
+      target: { value: 'h1' },
     });
 
-    expect(screen.getByText('targeting.table.selectedCount:0')).toBeTruthy();
+    expect(screen.getByText('targeting.table.selectedCount:1')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('targeting.filters.houseNumber'), {
+      target: { value: '' },
+    });
+    expect(screen.getByText('targeting.table.selectedCount:26')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('targeting.filters.houseNumber'), {
+      target: { value: 'h1' },
+    });
+    fireEvent.click(screen.getByLabelText('Hauptstraße 1, 12345 Musterstadt'));
+    fireEvent.change(screen.getByLabelText('targeting.filters.houseNumber'), {
+      target: { value: '' },
+    });
+    expect(screen.getByText('targeting.table.selectedCount:25')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('targeting.filters.houseNumber'), {
+      target: { value: 'h2' },
+    });
+    expect(screen.getByText('targeting.table.selectedCount:1')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.apply' }));
+
+    expect(screen.getByText('targeting.mode.targeted:1')).toBeTruthy();
   });
 
   it('exposes visible filter labels and announces filtered result changes', () => {
@@ -261,14 +286,13 @@ describe('NewsDetailTargetingTab', () => {
     for (let page = 1; page < 6; page += 1) {
       fireEvent.click(nextButton);
     }
-    expect(screen.getByText('6 / 6')).toBeTruthy();
     expect(screen.getByText('targeting.summary.pageStatus:6:6')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.removeTarget' }));
-    expect(screen.getByText('5 / 5')).toBeTruthy();
+    expect(screen.getByText('targeting.summary.pageStatus:5:5')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.previous' }));
 
-    expect(screen.getByText('4 / 5')).toBeTruthy();
+    expect(screen.getByText('targeting.summary.pageStatus:4:5')).toBeTruthy();
   });
 
   it('keeps recipients read-only after the Push has been sent', () => {
@@ -294,14 +318,33 @@ describe('NewsDetailTargetingTab', () => {
 
     render(<Subject initialTargets={[staleTarget]} />);
 
-    expect(screen.getByText(/targeting\.stale/)).toBeTruthy();
+    expect(screen.getByText('targeting.summary.staleCount:1')).toBeTruthy();
     expect(screen.getByTestId('dirty-state').textContent).toBe('clean');
 
     fireEvent.click(screen.getByText('targeting.mode.targeted:1'));
+    expect(screen.getByText('targeting.stale')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.removeTarget' }));
 
     expect(screen.getByText('targeting.mode.global')).toBeTruthy();
     expect(screen.getByTestId('dirty-state').textContent).toBe('dirty');
     expect(screen.queryByText('Alte Straße 7, 12345 Musterstadt')).toBeNull();
+  });
+
+  it('retains stale targets when applying an effective filtered selection', () => {
+    const staleTarget = { street: 'Alte Straße 7', zip: '12345', city: 'Musterstadt' };
+    const validTarget = { street: 'Hauptstraße 1', zip: '12345', city: 'Musterstadt' };
+    render(<Subject initialTargets={[staleTarget, validTarget]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.edit' }));
+    fireEvent.change(screen.getByLabelText('targeting.filters.street'), {
+      target: { value: 's1' },
+    });
+    fireEvent.change(screen.getByLabelText('targeting.filters.houseNumber'), {
+      target: { value: 'h1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'targeting.actions.apply' }));
+
+    expect(screen.getByText('targeting.mode.targeted:2')).toBeTruthy();
+    expect(screen.getByText('targeting.summary.staleCount:1')).toBeTruthy();
   });
 });

--- a/packages/plugin-news/src/news.detail-targeting-tab.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-tab.tsx
@@ -34,44 +34,85 @@ type TargetingSummaryProps = Readonly<{
   onRemove?: (key: WasteLocationKey) => void;
 }>;
 
+const targetingSummaryPageSize = 25;
+
 function TargetingSummary({ selected, staleIds, pt, onRemove }: TargetingSummaryProps) {
+  const [page, setPage] = React.useState(1);
+  const pageCount = Math.max(1, Math.ceil(selected.length / targetingSummaryPageSize));
+  const currentPage = Math.min(page, pageCount);
+  const visible = selected.slice(
+    (currentPage - 1) * targetingSummaryPageSize,
+    currentPage * targetingSummaryPageSize
+  );
+
   if (selected.length === 0) {
     return <p className="text-sm text-muted-foreground">{pt('targeting.globalHint')}</p>;
   }
 
   return (
-    <ul className="divide-y divide-border/60 rounded-lg border border-border/60 bg-background">
-      {selected.map((key) => {
-        const targetId = wasteLocationKeyId(key);
-        const targetLabel = `${key.street}, ${key.zip} ${key.city}`;
-        return (
-          <li
-            key={targetId}
-            className="flex flex-wrap items-center justify-between gap-3 px-3 py-2"
-          >
-            <span className="flex min-w-0 flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              <span>{targetLabel}</span>
-              {staleIds.has(targetId) ? (
-                <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
-                  {pt('targeting.stale')}
-                </span>
+    <div className="space-y-3">
+      <ul className="divide-y divide-border/60 rounded-lg border border-border/60 bg-background">
+        {visible.map((key) => {
+          const targetId = wasteLocationKeyId(key);
+          const targetLabel = `${key.street}, ${key.zip} ${key.city}`;
+          return (
+            <li
+              key={targetId}
+              className="flex flex-wrap items-center justify-between gap-3 px-3 py-2"
+            >
+              <span className="flex min-w-0 flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                <span>{targetLabel}</span>
+                {staleIds.has(targetId) ? (
+                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                    {pt('targeting.stale')}
+                  </span>
+                ) : null}
+              </span>
+              {onRemove ? (
+                <Button
+                  type="button"
+                  variant="tertiary"
+                  size="sm"
+                  aria-label={pt('targeting.actions.removeTarget', { address: targetLabel })}
+                  onClick={() => onRemove(key)}
+                >
+                  {pt('actions.remove')}
+                </Button>
               ) : null}
-            </span>
-            {onRemove ? (
-              <Button
-                type="button"
-                variant="tertiary"
-                size="sm"
-                aria-label={pt('targeting.actions.removeTarget', { address: targetLabel })}
-                onClick={() => onRemove(key)}
-              >
-                {pt('actions.remove')}
-              </Button>
-            ) : null}
-          </li>
-        );
-      })}
-    </ul>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="flex items-center justify-end text-sm">
+        <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+          {pt('targeting.summary.pageStatus', {
+            page: currentPage,
+            pageCount,
+          })}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={currentPage <= 1}
+            onClick={() => setPage(currentPage - 1)}
+          >
+            {pt('targeting.actions.previous')}
+          </Button>
+          <span>
+            {currentPage} / {pageCount}
+          </span>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={currentPage >= pageCount}
+            onClick={() => setPage(currentPage + 1)}
+          >
+            {pt('targeting.actions.next')}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -130,17 +171,26 @@ export function NewsDetailTargetingSection({
         ) : null}
       </div>
       <div className="space-y-4 rounded-xl border border-border/60 bg-muted/10 p-4">
-        <p className="text-sm font-medium">
-          {selected.length === 0
-            ? pt('targeting.mode.global')
-            : pt('targeting.mode.targeted', { count: selected.length })}
-        </p>
-        <TargetingSummary
-          selected={selected}
-          staleIds={staleIds}
-          pt={pt}
-          onRemove={readOnly ? undefined : removeSelectedTarget}
-        />
+        {selected.length === 0 ? (
+          <>
+            <p className="text-sm font-medium">{pt('targeting.mode.global')}</p>
+            <TargetingSummary selected={selected} staleIds={staleIds} pt={pt} />
+          </>
+        ) : (
+          <details className="group rounded-lg border border-border/60 bg-background">
+            <summary className="cursor-pointer select-none px-3 py-3 text-sm font-medium marker:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring">
+              {pt('targeting.mode.targeted', { count: selected.length })}
+            </summary>
+            <div className="border-t border-border/60 p-3">
+              <TargetingSummary
+                selected={selected}
+                staleIds={staleIds}
+                pt={pt}
+                onRemove={readOnly ? undefined : removeSelectedTarget}
+              />
+            </div>
+          </details>
+        )}
         {readOnly ? null : (
           <NewsDetailTargetingDialog
             overview={resolvedOverview}

--- a/packages/plugin-news/src/news.detail-targeting-tab.tsx
+++ b/packages/plugin-news/src/news.detail-targeting-tab.tsx
@@ -84,12 +84,6 @@ function TargetingSummary({ selected, staleIds, pt, onRemove }: TargetingSummary
         })}
       </ul>
       <div className="flex items-center justify-end text-sm">
-        <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-          {pt('targeting.summary.pageStatus', {
-            page: currentPage,
-            pageCount,
-          })}
-        </span>
         <div className="flex items-center gap-2">
           <Button
             type="button"
@@ -99,8 +93,11 @@ function TargetingSummary({ selected, staleIds, pt, onRemove }: TargetingSummary
           >
             {pt('targeting.actions.previous')}
           </Button>
-          <span>
-            {currentPage} / {pageCount}
+          <span role="status" aria-live="polite" aria-atomic="true">
+            {pt('targeting.summary.pageStatus', {
+              page: currentPage,
+              pageCount,
+            })}
           </span>
           <Button
             type="button"
@@ -179,7 +176,14 @@ export function NewsDetailTargetingSection({
         ) : (
           <details className="group rounded-lg border border-border/60 bg-background">
             <summary className="cursor-pointer select-none px-3 py-3 text-sm font-medium marker:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring">
-              {pt('targeting.mode.targeted', { count: selected.length })}
+              <span className="inline-flex flex-wrap items-center gap-2">
+                <span>{pt('targeting.mode.targeted', { count: selected.length })}</span>
+                {staleIds.size > 0 ? (
+                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                    {pt('targeting.summary.staleCount', { count: staleIds.size })}
+                  </span>
+                ) : null}
+              </span>
             </summary>
             <div className="border-t border-border/60 p-3">
               <TargetingSummary

--- a/packages/plugin-news/src/plugin.translations.ts
+++ b/packages/plugin-news/src/plugin.translations.ts
@@ -176,7 +176,10 @@ const newsTranslationsDe = createNewsLocaleTranslations({
     },
     stale: 'veraltet',
     loadError: 'Die Abholorte konnten nicht geladen werden. Versuchen Sie es erneut.',
-    summary: { pageStatus: 'Seite {{page}} von {{pageCount}}' },
+    summary: {
+      pageStatus: 'Seite {{page}} von {{pageCount}}',
+      staleCount: '{{count}} veraltet',
+    },
     dialog: {
       title: 'Abholorte auswählen',
       description: 'Filtern und wählen Sie aktive, vollständig adressierte Abholorte.',
@@ -620,7 +623,10 @@ const newsTranslationsEn = createNewsLocaleTranslations({
     },
     stale: 'stale',
     loadError: 'The collection locations could not be loaded. Please try again.',
-    summary: { pageStatus: 'Page {{page}} of {{pageCount}}' },
+    summary: {
+      pageStatus: 'Page {{page}} of {{pageCount}}',
+      staleCount: '{{count}} stale',
+    },
     dialog: {
       title: 'Select collection locations',
       description: 'Filter and select active, fully addressed collection locations.',

--- a/packages/plugin-news/src/plugin.translations.ts
+++ b/packages/plugin-news/src/plugin.translations.ts
@@ -176,6 +176,7 @@ const newsTranslationsDe = createNewsLocaleTranslations({
     },
     stale: 'veraltet',
     loadError: 'Die Abholorte konnten nicht geladen werden. Versuchen Sie es erneut.',
+    summary: { pageStatus: 'Seite {{page}} von {{pageCount}}' },
     dialog: {
       title: 'Abholorte auswählen',
       description: 'Filtern und wählen Sie aktive, vollständig adressierte Abholorte.',
@@ -201,7 +202,9 @@ const newsTranslationsDe = createNewsLocaleTranslations({
       emptyValue: '–',
       empty: 'Keine passenden Abholorte gefunden.',
       resultCount: '{{count}} Treffer',
-      status: '{{count}} Treffer, Seite {{page}} von {{pageCount}}',
+      selectedCount: '{{count}} ausgewählt',
+      selectionStatus:
+        '{{count}} Treffer, {{selectedCount}} ausgewählt, Seite {{page}} von {{pageCount}}',
     },
     actions: {
       edit: 'Auswahl bearbeiten',
@@ -617,6 +620,7 @@ const newsTranslationsEn = createNewsLocaleTranslations({
     },
     stale: 'stale',
     loadError: 'The collection locations could not be loaded. Please try again.',
+    summary: { pageStatus: 'Page {{page}} of {{pageCount}}' },
     dialog: {
       title: 'Select collection locations',
       description: 'Filter and select active, fully addressed collection locations.',
@@ -642,7 +646,9 @@ const newsTranslationsEn = createNewsLocaleTranslations({
       emptyValue: '–',
       empty: 'No matching collection locations found.',
       resultCount: '{{count}} results',
-      status: '{{count}} results, page {{page}} of {{pageCount}}',
+      selectedCount: '{{count}} selected',
+      selectionStatus:
+        '{{count}} results, {{selectedCount}} selected, page {{page}} of {{pageCount}}',
     },
     actions: {
       edit: 'Edit selection',


### PR DESCRIPTION
Diese Änderung verbessert die Auswahl von Abholorten für gezielte Push-Benachrichtigungen bei News.

## Änderungen

- Gesamtzahl der im aktuellen Filter ausgewählten Abholorte im Auswahldialog ergänzt
- Vorgemerkte Auswahl beim Einschränken von Suche und Filtern erhalten
- Anzeige, Zählung und Übernahme auf die wirksame Schnittmenge mit den aktuellen Filtertreffern begrenzt
- Restriktive Dialogfilter beim erneuten Öffnen zurückgesetzt
- Übernommene Abholorte standardmäßig zusammengeklappt
- Veraltete Abholortziele bereits in der zusammengeklappten Übersicht gekennzeichnet
- Übernommene Abholorte mit 25 Einträgen pro Seite paginiert
- Seitennavigation nach dem Entfernen von Einträgen stabilisiert und vollständig lokalisiert
- Redundante Auswahlzahl unter der übernommenen Liste entfernt
- Screenreader-Status für Trefferzahl, Auswahlzahl und aktuelle Seite ergänzt
- Deutsche und englische Übersetzungen ergänzt

## Begründung

Bei großen Datenbeständen konnten zahlreiche Abholorte gleichzeitig ausgewählt werden. Dadurch wurden sowohl der Auswahldialog als auch die anschließend dargestellte Liste unübersichtlich und erzeugten sehr lange Seiten.

Das Schnittmengenmodell hält frühere Auswahlen beim Filtern vorgemerkt, zeigt und übernimmt jedoch nur die aktuell wirksamen Treffer. Beim erneuten Öffnen beginnt der Dialog ohne alte Filter, damit eine unbemerkte Einschränkung keine Empfänger entfernt. Die paginierte und einklappbare Darstellung begrenzt zugleich die sichtbare Länge der übernommenen Liste.

## Tests

- Plugin-News-Unit-Tests einschließlich Auswahl-, Filter-, Pagination- und A11y-Regressionen
- TypeScript- und ESLint-Gate für `plugin-news`
- Complexity-Gate gegen `origin/main`

Alle 151 Plugin-News-Unit-Tests, das TypeScript-Gate und der Complexity-Gate sind grün. ESLint meldet lediglich eine bereits bestehende Warnung außerhalb der geänderten Stellen.
