### PR TITLE
test(news): stabilize scheduled publication fixtures

### DIFF
--- a/docs/changelog/entries/pr-988.json
+++ b/docs/changelog/entries/pr-988.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 988,
-  "body": "Zeitgesteuerte News-Prüfungen bleiben dauerhaft stabil\n\n- Automatisierte Tests verwenden wieder eindeutig zukünftige Veröffentlichungszeitpunkte.\n- Produktlogik, Zeitzonenverarbeitung und sichtbares Verhalten bleiben unverändert."
+  "body": "Zeitgesteuerte News bleiben im Editor zuverlässig erkennbar\n\n- Geplante Veröffentlichungen werden weiterhin als zeitgesteuert dargestellt.\n- Der lokale Veröffentlichungszeitpunkt bleibt in der erwarteten Zeitzone sichtbar."
 }

--- a/docs/changelog/entries/pr-988.json
+++ b/docs/changelog/entries/pr-988.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 988,
+  "body": "Zeitgesteuerte News-Prüfungen bleiben dauerhaft stabil\n\n- Automatisierte Tests verwenden wieder eindeutig zukünftige Veröffentlichungszeitpunkte.\n- Produktlogik, Zeitzonenverarbeitung und sichtbares Verhalten bleiben unverändert."
+}

--- a/packages/plugin-news/tests/news.pages.test.tsx
+++ b/packages/plugin-news/tests/news.pages.test.tsx
@@ -1246,7 +1246,7 @@ describe('News editor pages', () => {
       author: 'Editor',
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-02T00:00:00.000Z',
-      publishedAt: '2026-08-14T09:30:00.000Z',
+      publishedAt: '2099-08-14T09:30:00.000Z',
       visible: true,
     });
 
@@ -1257,7 +1257,7 @@ describe('News editor pages', () => {
     const settingsPanel = screen.getByRole('tabpanel', { name: /Einstellungen/ });
 
     await waitFor(() => {
-      expect(screen.getByDisplayValue('2026-08-14T11:30')).toBeTruthy();
+      expect(screen.getByDisplayValue('2099-08-14T11:30')).toBeTruthy();
       expect(within(settingsPanel).getByText('Veröffentlichung')).toBeTruthy();
       expect(within(settingsPanel).getByRole('radio', { name: /Zeitgesteuert/ })).toBeTruthy();
     });
@@ -1643,7 +1643,7 @@ describe('News editor pages', () => {
       author: 'Editor',
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-02T00:00:00.000Z',
-      publishedAt: '2026-08-14T09:30:00.000Z',
+      publishedAt: '2099-08-14T09:30:00.000Z',
       visible: true,
     });
 
@@ -1653,7 +1653,7 @@ describe('News editor pages', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('Zeitpunkt der Veröffentlichung').getAttribute('value')).toBe(
-        '2026-08-14T11:30'
+        '2099-08-14T11:30'
       );
     });
   });


### PR DESCRIPTION
## What

- Verschiebt zwei ausdrücklich zukünftig gemeinte News-Scheduling-Fixtures von 2026 auf 2099.
- Aktualisiert ausschließlich die zugehörigen `datetime-local`-Erwartungen.

## Why

Die Tests klassifizieren geladene News anhand von `publishedAt` relativ zur aktuellen Zeit. Das bisherige Fixture `2026-08-14T09:30:00.000Z` liegt inzwischen in der Vergangenheit und wird von der unveränderten Produktlogik korrekt als bereits veröffentlicht statt zeitgesteuert behandelt. Dadurch scheiterten zwei kalenderabhängige Tests und der Required Unit Check von PR #986.

## Impact

- Keine Produktcode-, Zeitzonen-, Status-, Übersetzungs- oder UX-Änderung.
- Nur zwei Future-Fixtures und ihre beiden sichtbaren Lokalzeit-Erwartungen werden stabilisiert.

## Tests

- `pnpm nx run plugin-news:test:unit --testFiles=tests/news.pages.test.tsx` — 39/39 grün.
- `pnpm nx run plugin-news:test:unit` — 20 Dateien, 152/152 grün.
- `pnpm nx run plugin-news:test:types` — grün.
- `pnpm check:file-placement` — grün.
- Studio-Changelog-Gate in Repo- und PR-Modus — grün; `docs/changelog/entries/pr-988.json` validiert.
- `git diff --check` — grün.
