### PR TITLE
refactor(ops): separate Keycloak audit evaluation

### DIFF
--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -735,6 +735,16 @@ Für Waste liest der Agent das kanonische Inventar aus `iam.instance_waste_provi
 - `@sva/data-repositories` materialisiert Definitionen und verwaltete Grants additiv und liefert sichere Änderungszähler.
 - `@sva/instance-registry` bindet denselben Vertrag an Tenant-Bootstrap, Modul-Lifecycle und explizites `seedIamBaseline`.
 
+### Ergänzung 2026-08: Operativer Keycloak-Instanz-Audit
+
+- `scripts/ops/studio-instance-audit/keycloak.ts` besitzt die read-only
+  `kcadm`-Erhebung, die kurzlebige Auth-Konfiguration und deren Cleanup.
+- `scripts/ops/studio-instance-audit/keycloak-evaluation.ts` besitzt den
+  typisierten Snapshot und die reine Ableitung der vierzehn bestehenden
+  Keycloak-Befunde.
+- Die Grenze ist bewusst zweckgebunden: Sie führt weder eine generische Rule
+  Engine noch einen zweiten Provisioning-, Reconcile- oder Mutationspfad ein.
+
 ### Ergänzung 2026-08: DataProvider-gebundene Mainserver-Autorenschaft
 
 - `@sva/auth-runtime` besitzt die instanz- und credential-versionierten Principal-Bindungen, den Shadow-/Automatic-/Compatibility-Resolver, das persistente Mutation-Journal und die read-only Admin-Diagnose.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -1042,3 +1042,25 @@ Vor Schritt 1 ruft `Promote` mit derselben GitHub-OIDC-Grenze `GET /_ops/backup/
 2. Routing beziehungsweise JSON-Fehler transportieren den begrenzten Denial-Kontext additiv. Der Client validiert ihn erneut und verwirft manipulierte oder unbekannte Werte.
 3. Der gemeinsame Formatter löst den lokalisierten Permission-Titel auf und zeigt Titel plus Action-ID in einem bestehenden zugänglichen Alert.
 4. Der Kontext wird nach einem Redirect einmalig aus der URL entfernt. Bei technischem Ausfall oder uneindeutigem fachlichem `403` bleibt die bisherige generische Meldung erhalten.
+
+### Szenario 19: Read-only Keycloak-Instanz-Audit
+
+1. Der operative Audit lädt das aktive Registry-Ziel und die entschlüsselten
+   Vergleichssecrets ausschließlich serverseitig.
+2. Eine temporäre `kcadm`-Konfiguration authentisiert den vorhandenen
+   Provisioner-/Admin-Client.
+3. Die Erhebung liest Realm, Login- und Tenant-Admin-Client, deren Secret-
+   Vergleichswerte, Realm-Rollen, aktiven `system_admin` und die Rollen des
+   Tenant-Admin-Serviceaccounts in fester Reihenfolge.
+4. Fehlt das Realm, endet der Pfad unmittelbar mit dem bisherigen einzelnen
+   Fehlerbefund; nachgelagerte Reads finden nicht statt.
+5. Andernfalls bewertet eine reine Funktion den vollständigen Snapshot und
+   liefert unverändert vierzehn Befunde.
+6. Das `finally`-Cleanup entfernt Config-Datei und temporäres Verzeichnis bei
+   Erfolg und Fehler.
+
+Fehlerpfad:
+
+- Der Audit führt keine Keycloak-Mutation und keinen Plattform-Fallback aus.
+- Fehlende oder abweichende Secrets bleiben Fail-Befunde, ohne Secret-Inhalte
+  in Bericht, Fehler oder Logs zu übernehmen.

--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -735,6 +735,19 @@ Listenparameter werden aus den URL-Search-Params normalisiert. Fachfilter, die d
 - Die `data_provider_id` der Create-Antwort und die Identität aus `/data_provider.json` sind zwei Evidenzwege desselben garantierten Mainserver-Vertrags. Konflikte werden nicht überschrieben, sondern benötigen Reconciliation.
 - Geheimnisse bleiben write-only und verschlüsselt. Read-Models exponieren nur Vorhandensein, Status, Versuchszähler, sicheren Fehlercode und technische IDs.
 
+### Keycloak-Audit und Secret-Grenze
+
+- Der operative Studio-Instanz-Audit trennt read-only Erhebung und reine
+  Bewertung durch einen kleinen typisierten Snapshot.
+- Secret-Werte bleiben kurzlebige interne Vergleichsfakten. Die öffentlichen
+  Befunde unterscheiden ausschließlich verglichen, fehlend und abweichend; sie
+  enthalten weder Klarwerte noch Hashes, Längen oder Teile der Werte.
+- Characterization-Tests verwenden ausschließlich synthetische Marker und
+  prüfen deren Abwesenheit in der Ergebnisevidenz.
+- Check-IDs, Titel, Zusammenfassungen, Detailfelder und Fail-/Warn-/Skip-
+  Statuswerte bleiben gemeinsam mit der `kcadm`-Reihenfolge und dem
+  temporären Cleanup vertraglich stabil.
+
 ### CI-Fast-Feedback und Cache-Vertrauen
 
 - PR-Unit und PR-Coverage planen direkt geänderte Projekte vor dem disjunkten übrigen affected Scope. Nicht sicher zuordenbare Änderungen bleiben im konservativen Restlauf.

--- a/docs/changelog/entries/pr-989.json
+++ b/docs/changelog/entries/pr-989.json
@@ -1,4 +1,4 @@
 {
   "prNumber": 989,
-  "body": "Die Keycloak-Prüfung von Studio-Instanzen bleibt zuverlässig und besser wartbar\n\n- Alle bestehenden Prüfungen für Realm, Clients, Rollen und Zugriffsstatus liefern weiterhin dieselben Ergebnisse.\n- Zugangsdaten werden ausschließlich intern verglichen und nicht in Prüfergebnissen ausgegeben.\n- Zusätzliche Tests sichern auch fehlende oder abweichende Keycloak-Konfigurationen ab."
+  "body": "Die Keycloak-Prüfung meldet Realm-, Client-, Rollen- und Zugriffsabweichungen zuverlässig\n\n- Alle bestehenden Prüfungen für Realm, Clients, Rollen und Zugriffsstatus liefern weiterhin dieselben Ergebnisse.\n- Zugangsdaten werden ausschließlich intern verglichen und nicht in Prüfergebnissen ausgegeben.\n- Fehlende oder abweichende Keycloak-Konfigurationen werden weiterhin eindeutig ausgewiesen."
 }

--- a/docs/changelog/entries/pr-989.json
+++ b/docs/changelog/entries/pr-989.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 989,
+  "body": "Die Keycloak-Prüfung von Studio-Instanzen bleibt zuverlässig und besser wartbar\n\n- Alle bestehenden Prüfungen für Realm, Clients, Rollen und Zugriffsstatus liefern weiterhin dieselben Ergebnisse.\n- Zugangsdaten werden ausschließlich intern verglichen und nicht in Prüfergebnissen ausgegeben.\n- Zusätzliche Tests sichern auch fehlende oder abweichende Keycloak-Konfigurationen ab."
+}

--- a/docs/guides/instance-keycloak-provisioning.md
+++ b/docs/guides/instance-keycloak-provisioning.md
@@ -34,19 +34,19 @@ Wichtig:
 
 Die Instanzverwaltung und der Provisioning-Worker verwenden für den fachlichen Mindestzustand dieselbe kompakte Checkliste. Jeder Punkt muss im Detailstatus und nach dem letzten erfolgreichen Run grün sein.
 
-| Pflichtpunkt | Führende Quelle in Studio/Registry | Zielartefakt in Keycloak | Prüfkriterium | Automatische Aktion |
-| --- | --- | --- | --- | --- |
-| Realm | `realmMode`, `authRealm` | Realm `<authRealm>` | Realm existiert oder darf im Modus `new` erstellt werden | Realm anlegen oder Bestands-Realm validieren |
-| OIDC-Client | `authClientId` | Client `<authClientId>` | Client existiert | Client anlegen oder aktualisieren |
-| Redirect-URIs | `instanceId`, `parentDomain`, `primaryHostname` | `client.redirectUris` | Redirect-Ziele stimmen exakt | Client-URLs abgleichen |
-| Logout-URIs | `instanceId`, `parentDomain`, `primaryHostname` | `client.attributes.post.logout.redirect.uris` | Logout-Ziele stimmen exakt | Client-URLs abgleichen |
-| Web-Origins | `instanceId`, `parentDomain`, `primaryHostname` | `client.webOrigins` | Origins stimmen exakt | Client-URLs abgleichen |
-| `instanceId`-Mapper | `instanceId` | Protocol Mapper `instanceId` | Optionaler Interop-Hinweis; Mapper existiert oder fehlt sichtbar als Warnung | Mapper anlegen oder korrigieren |
-| Tenant-Secret | `authClientSecret` | Client-Secret des Login-Clients | `existing`: Registry-Secret und Keycloak-Secret sind identisch. `new`: Secret wird beim Provisioning erzeugt und danach in die Registry zurückgeschrieben. | Secret setzen, erzeugen, rotieren und Rückschreiben in die Registry |
-| Tenant-Admin | `tenantAdminBootstrap.*` | User `<username>` | User existiert | User anlegen oder aktualisieren |
-| Rolle `system_admin` | `tenantAdminBootstrap.username` | Realm-Rolle auf Tenant-Admin | Rolle vorhanden | Rollen synchronisieren |
-| Ausschluss `instance_registry_admin` | `tenantAdminBootstrap.username` | Realm-Rolle auf Tenant-Admin | Rolle ist nicht zugewiesen | Rollen synchronisieren |
-| User-Attribut `instanceId` | `instanceId`, `tenantAdminBootstrap.username` | `attributes.instanceId` am Tenant-Admin | Optionaler Interop-Hinweis; Attribut entspricht der Instanz-ID oder fehlt sichtbar als Warnung | User-Attribute aktualisieren |
+| Pflichtpunkt                         | Führende Quelle in Studio/Registry              | Zielartefakt in Keycloak                      | Prüfkriterium                                                                                                                                              | Automatische Aktion                                                 |
+| ------------------------------------ | ----------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Realm                                | `realmMode`, `authRealm`                        | Realm `<authRealm>`                           | Realm existiert oder darf im Modus `new` erstellt werden                                                                                                   | Realm anlegen oder Bestands-Realm validieren                        |
+| OIDC-Client                          | `authClientId`                                  | Client `<authClientId>`                       | Client existiert                                                                                                                                           | Client anlegen oder aktualisieren                                   |
+| Redirect-URIs                        | `instanceId`, `parentDomain`, `primaryHostname` | `client.redirectUris`                         | Redirect-Ziele stimmen exakt                                                                                                                               | Client-URLs abgleichen                                              |
+| Logout-URIs                          | `instanceId`, `parentDomain`, `primaryHostname` | `client.attributes.post.logout.redirect.uris` | Logout-Ziele stimmen exakt                                                                                                                                 | Client-URLs abgleichen                                              |
+| Web-Origins                          | `instanceId`, `parentDomain`, `primaryHostname` | `client.webOrigins`                           | Origins stimmen exakt                                                                                                                                      | Client-URLs abgleichen                                              |
+| `instanceId`-Mapper                  | `instanceId`                                    | Protocol Mapper `instanceId`                  | Optionaler Interop-Hinweis; Mapper existiert oder fehlt sichtbar als Warnung                                                                               | Mapper anlegen oder korrigieren                                     |
+| Tenant-Secret                        | `authClientSecret`                              | Client-Secret des Login-Clients               | `existing`: Registry-Secret und Keycloak-Secret sind identisch. `new`: Secret wird beim Provisioning erzeugt und danach in die Registry zurückgeschrieben. | Secret setzen, erzeugen, rotieren und Rückschreiben in die Registry |
+| Tenant-Admin                         | `tenantAdminBootstrap.*`                        | User `<username>`                             | User existiert                                                                                                                                             | User anlegen oder aktualisieren                                     |
+| Rolle `system_admin`                 | `tenantAdminBootstrap.username`                 | Realm-Rolle auf Tenant-Admin                  | Rolle vorhanden                                                                                                                                            | Rollen synchronisieren                                              |
+| Ausschluss `instance_registry_admin` | `tenantAdminBootstrap.username`                 | Realm-Rolle auf Tenant-Admin                  | Rolle ist nicht zugewiesen                                                                                                                                 | Rollen synchronisieren                                              |
+| User-Attribut `instanceId`           | `instanceId`, `tenantAdminBootstrap.username`   | `attributes.instanceId` am Tenant-Admin       | Optionaler Interop-Hinweis; Attribut entspricht der Instanz-ID oder fehlt sichtbar als Warnung                                                             | User-Attribute aktualisieren                                        |
 
 Wichtig:
 
@@ -260,6 +260,25 @@ Ein Tenant gilt erst dann als betriebsbereit, wenn zusätzlich folgende Nachweis
 3. letzter Provisioning-Run ist `succeeded`
 4. Tenant-Login gegen `https://<instanceId>.studio.smart-village.app/auth/login` funktioniert
 5. `/auth/me` liefert den korrekten `instanceId`-Kontext aus Host, Registry und Realm
+
+### Read-only Studio-Instanz-Audit
+
+Der operative Studio-Instanz-Audit ergänzt den Provisioning-Nachweis, ersetzt
+aber weder Preflight noch Plan oder Ausführung. Sein Keycloak-Pfad arbeitet in
+zwei festen Schritten:
+
+1. Die Erhebung authentisiert den vorhandenen Provisioner-/Admin-Client über
+   eine kurzlebige `kcadm`-Konfiguration und liest Realm, Login-Client,
+   Tenant-Admin-Client, Rollen und Serviceaccount-Zustand in fester Reihenfolge.
+2. Eine reine Bewertung leitet aus dem typisierten Snapshot die bestehenden
+   vierzehn Check-Ergebnisse ab. Check-IDs, Titel, Zusammenfassungen, Details
+   und Fail-/Warn-/Skip-Semantik sind ein stabiler Betriebsvertrag.
+
+Der Pfad ist ausschließlich lesend. Ein fehlendes Realm beendet die Erhebung
+fail-closed mit dem einzelnen Realm-Befund. Secret-Werte dienen nur dem
+kurzlebigen Gleichheitsvergleich; Bericht, Fehler und Logs enthalten weiterhin
+nur `tenant secret compared` oder `secret missing`. Die temporäre
+`kcadm`-Konfiguration wird auch bei Fehlern entfernt.
 
 ## Referenzen
 

--- a/openspec/changes/refactor-keycloak-instance-audit-evaluation/design.md
+++ b/openspec/changes/refactor-keycloak-instance-audit-evaluation/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`inspectRealmAndClients` ist ein produktiv erreichbarer read-only Auditpfad. Die
+Funktion authentisiert `kcadm`, liest Realm, Login- und Tenant-Admin-Client,
+Secrets, Realm-Rollen, einen aktiven `system_admin`-Benutzer und dessen Rollen
+sowie die realm-management-Rollen des Tenant-Admin-Serviceaccounts. Anschließend
+bewertet sie vierzehn Befunde. Jede Check-ID samt Titel, Zusammenfassung,
+Detailfeldern und Fail-/Warn-/Skip-Priorität ist operativer Vertrag.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Erhebung und Bewertung durch einen typisierten Snapshot trennen;
+  - die Bewertung rein und vollständig durch Characterization-Tests absichern;
+  - die bestehende `kcadm`-Reihenfolge und das Config-Cleanup beweisen;
+  - Secret-Inhalte außerhalb der kurzlebigen Vergleichsgrenze ausschließen;
+  - den kritischen Komplexitätshotspot ohne Suppression beseitigen.
+- Non-Goals:
+  - neue Checks, Check-IDs, Statuswerte oder Detailfelder;
+  - Keycloak-Mutationen, Reconcile, Rollout oder Konfigurationsänderungen;
+  - ein generisches Regel- oder Audit-Framework.
+
+## Decisions
+
+### Decision: Snapshot bildet nur bereits erhobene Fakten ab
+
+Ein zweckgebundener, unveränderlicher Snapshot enthält genau die Fakten, die der
+bestehende Audit bereits liest. Die `kcadm`-Adapter bleiben in der operativen
+Datei; der Snapshot führt keine zweite I/O- oder Konfigurationsabstraktion ein.
+
+Alternativen considered:
+
+- Generische Check-Definitionen oder eine Rule Engine: verworfen, weil nur ein
+  stabiler Vertrag vorliegt und zusätzliche Abstraktion keine Ownership spart.
+- Einzelne I/O-Aufrufe direkt aus Check-Funktionen: verworfen, weil dadurch
+  Reihenfolge, Mehrfachabfragen und reine Tests schlechter kontrollierbar wären.
+
+### Decision: Secret-Befunde werden als Vergleichsfakten bewertet
+
+Der Snapshot transportiert Secret-Werte nur intern und kurzlebig bis zur reinen
+Bewertung. Die Funktion emittiert ausschließlich die bisherigen Aussagen
+`tenant secret compared` oder `secret missing`; weder Ergebnisse noch
+Testdiagnostik geben die Werte aus. Für Tests werden ausschließlich synthetische
+Marker verwendet und explizit auf Abwesenheit in der Ergebnisevidenz geprüft.
+
+### Decision: Realm-fehlt bleibt ein früher, einzelner Befund
+
+Kann das Realm nicht gelesen werden, bleibt die Erhebung unmittelbar bei dem
+einen bisherigen `keycloak.realm.exists`-Fehler stehen. Der Pfad erzeugt keinen
+künstlichen Vollsnapshot und keine weiteren Checks.
+
+## Risks / Trade-offs
+
+- Status- oder Textdrift durch Extraktion → Vorher ergänzte Characterization-
+  Matrix vergleicht komplette `AuditCheckResult[]`-Objekte.
+- Veränderte `kcadm`-Reihenfolge → Adaptertest fixiert die Aufrufsequenz und
+  das Cleanup der temporären Config.
+- Secret-Leak durch Testfehler → Testevidenz prüft nur synthetische Marker auf
+  Abwesenheit und speichert keine realen Umgebungswerte.
+
+## Migration Plan
+
+1. Characterization-Matrix gegen den bestehenden Monolithen ergänzen und grün
+   ausführen.
+2. Typisierten Snapshot und reine Bewertung extrahieren.
+3. Bestehende Erhebung unverändert an die Bewertung anbinden.
+4. Unit-, Skript-Type-, Complexity-, Fallow-, File-Placement- und PR-Gates
+   ausführen.
+5. Keine Daten-, Realm-, Secret- oder Runtime-Migration ausführen.
+
+## Open Questions
+
+- Keine. Jede erforderliche Auditvertrags- oder Keycloak-Änderung ist eine
+  STOP-Bedingung und benötigt einen separaten Change.

--- a/openspec/changes/refactor-keycloak-instance-audit-evaluation/proposal.md
+++ b/openspec/changes/refactor-keycloak-instance-audit-evaluation/proposal.md
@@ -1,0 +1,34 @@
+# Change: Keycloak-Instanz-Audit in Erhebung und Bewertung trennen
+
+## Why
+
+Der operative Keycloak-Instanz-Audit erhebt Realm-, Client-, Rollen- und
+Secret-Zustände und bewertet gleichzeitig vierzehn Befunde in einer einzigen
+großen Funktion. Dadurch sind der unveränderte Auditvertrag, die
+`kcadm`-Befehlsfolge und die Secret-Grenze unnötig schwer separat nachzuweisen.
+
+## What Changes
+
+- Die bestehende `kcadm`-Erhebung wird in einen kleinen typisierten Snapshot
+  überführt.
+- Eine reine Bewertungsfunktion leitet daraus dieselben vierzehn Check-IDs,
+  Titel, Zusammenfassungen, Details und Statuswerte ab.
+- Characterization-Tests fixieren Realm-, Login-Client-, Tenant-Admin-, Rollen-,
+  `system_admin`-, Mapper- und Bootstrap-Verträge vor der Extraktion.
+- Secret-Werte bleiben auf die Erhebung und reine Gleichheitsbewertung begrenzt;
+  Ergebnisse, Fehler, Logs und Testevidenz enthalten keine Secret-Inhalte.
+- Die `kcadm`-Befehlsfolge, temporäre Konfiguration und deren Cleanup bleiben
+  unverändert.
+
+## Impact
+
+- Affected specs: `instance-provisioning`
+- Affected code: `scripts/ops/studio-instance-audit/keycloak.ts`, neue
+  zweckgebundene Snapshot-/Bewertungsmodule und Vitest-Characterization
+- Affected documentation: betroffene Betriebsdokumentation zum
+  Studio-Instanz-Audit
+- Affected arc42 sections: `docs/architecture/05-building-block-view.md`,
+  `docs/architecture/06-runtime-view.md`,
+  `docs/architecture/08-cross-cutting-concepts.md`
+- Security impact: Keine neue Mutation und keine neue Diagnoseoberfläche; die
+  vorhandene fail-closed Status- und Secret-Semantik wird nur explizit getrennt.

--- a/openspec/changes/refactor-keycloak-instance-audit-evaluation/specs/instance-provisioning/spec.md
+++ b/openspec/changes/refactor-keycloak-instance-audit-evaluation/specs/instance-provisioning/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Operativer Keycloak-Instanz-Audit trennt Erhebung und Bewertung
+
+Das System SHALL den read-only Keycloak-Instanz-Audit als getrennte Erhebungs-
+und Bewertungsgrenzen ausführen. Die Erhebung SHALL den bestehenden Realm-,
+Client-, Secret-, Rollen-, Serviceaccount- und Bootstrap-Zustand in unveränderter
+`kcadm`-Reihenfolge erfassen. Die reine Bewertung SHALL daraus dieselben
+vierzehn Check-IDs, Titel, Zusammenfassungen, Details und Fail-/Warn-/Skip-
+Statuswerte wie der eingeführte Auditvertrag ableiten. Secret-Inhalte MUST aus
+Ergebnissen, Fehlern, Logs und Testevidenz ausgeschlossen bleiben.
+
+#### Scenario: Vollständiger Tenant-Zustand wird unverändert bewertet
+
+- **WHEN** Realm, Login-Client, Tenant-Admin-Client, Secrets, Rollen und aktiver
+  `system_admin`-Benutzer dem bestehenden Soll entsprechen
+- **THEN** liefert der Audit dieselben vierzehn Befunde mit denselben IDs,
+  Titeln, Zusammenfassungen, Details und Statuswerten wie zuvor
+- **AND** enthalten die Ergebnisse keine Secret-Inhalte
+
+#### Scenario: Fehlendes Realm beendet die Erhebung fail-closed
+
+- **WHEN** das konfigurierte Tenant-Realm nicht gelesen werden kann
+- **THEN** liefert der Audit ausschließlich den bestehenden Fehlerbefund
+  `keycloak.realm.exists`
+- **AND** führt er keine nachfolgenden Client-, Rollen- oder Secret-Leseaufrufe
+  aus
+- **AND** räumt er seine temporäre `kcadm`-Konfiguration auf
+
+#### Scenario: Teilzustände behalten Fail-, Warn- und Skip-Semantik
+
+- **WHEN** Login-URLs oder Secrets abweichen, Tenant-Admin-Flags oder Rollen
+  fehlen, kein aktiver `system_admin`-Benutzer existiert oder optionale
+  Mapper-/Bootstrap-Hinweise nicht bestätigt sind
+- **THEN** bleiben alle bisherigen Fail-, Warn- und Skip-Entscheidungen
+  unverändert
+- **AND** führt der Audit keine Keycloak-Mutation und keinen Plattform-Fallback
+  aus

--- a/openspec/changes/refactor-keycloak-instance-audit-evaluation/tasks.md
+++ b/openspec/changes/refactor-keycloak-instance-audit-evaluation/tasks.md
@@ -1,0 +1,32 @@
+## 1. Vertrag charakterisieren
+
+- [x] 1.1 Realm-fehlt und vollständigen Erfolgsfall mit allen vierzehn Check-
+      Ergebnissen vor der Extraktion fixieren.
+- [x] 1.2 Login-URL-/Secret-Abweichungen, Tenant-Admin-Flags/-Secret/-Rollen,
+      `system_admin`-Skip sowie optionale Mapper-/Bootstrap-Hinweise charakterisieren.
+- [x] 1.3 `kcadm`-Befehlsfolge, temporäres Config-Cleanup und Abwesenheit von
+      Secret-Inhalten in Ergebnissen nachweisen.
+
+## 2. Erhebung und Bewertung trennen
+
+- [x] 2.1 Einen kleinen typisierten Snapshot für die bereits erhobenen Fakten
+      einführen.
+- [x] 2.2 Die vierzehn unveränderten Befunde rein aus Snapshot, Ziel und
+      erwarteten Secrets ableiten.
+- [x] 2.3 Den Realm-fehlt-Frühpfad sowie `kcadm`-Aufrufe und Cleanup unverändert
+      erhalten.
+
+## 3. Dokumentation
+
+- [x] 3.1 Relevante deutsche Betriebsdokumentation um die read-only Erhebungs-
+      und Bewertungsgrenze ergänzen.
+- [x] 3.2 Betroffene arc42-Baustein-, Laufzeit- und Security-Sichten aktualisieren.
+
+## 4. Verifikation
+
+- [x] 4.1 Fokussierte Unit-Tests und Skript-Typecheck ausführen.
+- [x] 4.2 Complexity-Gate und Fallow-Vorher-/Nachher-Vergleich ohne Suppression
+      ausführen.
+- [x] 4.3 File-Placement und OpenSpec strict ausführen.
+- [x] 4.4 `pnpm test:pr` vor dem Push ausführen und jeden ausgelassenen breiten
+      Gate-Pfad transparent dokumentieren.

--- a/scripts/ops/studio-instance-audit-keycloak.test.ts
+++ b/scripts/ops/studio-instance-audit-keycloak.test.ts
@@ -1,0 +1,463 @@
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AuditRegistryTarget } from './studio-instance-audit/model.ts';
+
+type KcadmResponse = Readonly<{
+  stderr?: string;
+  stdout: string;
+}>;
+
+const kcadmMock = vi.hoisted(
+  (): {
+    calls: string[][];
+    responder: (args: readonly string[]) => Promise<KcadmResponse>;
+  } => ({
+    calls: [] as string[][],
+    responder: async (): Promise<KcadmResponse> => ({ stdout: '' }),
+  })
+);
+
+vi.mock('node:child_process', () => {
+  const execFileMock = vi.fn();
+  Object.defineProperty(execFileMock, promisify.custom, {
+    value: async (_file: string, args: readonly string[]) => {
+      kcadmMock.calls.push([...args]);
+      return kcadmMock.responder(args);
+    },
+  });
+  return { execFile: execFileMock };
+});
+
+vi.mock('../../packages/auth-runtime/src/runtime-secrets.ts', () => ({
+  getKeycloakAdminClientSecret: () => undefined,
+  getKeycloakProvisionerClientSecret: () => 'synthetic-provisioner-secret',
+}));
+
+const { inspectRealmAndClients } = await import('./studio-instance-audit/keycloak.ts');
+
+const target: AuditRegistryTarget = {
+  authClientSecretConfigured: true,
+  authClientId: 'studio-login',
+  authRealm: 'tenant-realm',
+  displayName: 'Tenant',
+  instanceId: 'tenant',
+  parentDomain: 'studio.example.test',
+  primaryHostname: 'tenant.studio.example.test',
+  status: 'active',
+  tenantAdminClientId: 'tenant-admin',
+  tenantAdminClientSecretConfigured: true,
+  tenantAdminUsername: 'bootstrap-admin',
+};
+
+const loginSecretMarker = 'synthetic-login-secret-marker';
+const tenantAdminSecretMarker = 'synthetic-tenant-admin-secret-marker';
+
+const commandKey = (args: readonly string[]): string => {
+  if (args[0] === 'config') {
+    return 'config credentials';
+  }
+  const configIndex = args.indexOf('--config');
+  return args.slice(0, configIndex).join(' ');
+};
+
+type ScenarioOverrides = Readonly<{
+  loginClient?: Readonly<Record<string, unknown>> | null;
+  loginSecret?: string | null;
+  realmExists?: boolean;
+  realmRoles?: readonly string[];
+  systemAdminRoles?: readonly string[];
+  systemAdminUser?: Readonly<Record<string, unknown>> | null;
+  tenantAdminClient?: Readonly<Record<string, unknown>> | null;
+  tenantAdminSecret?: string | null;
+  tenantAdminServiceRoles?: readonly string[];
+}>;
+
+const configureScenario = (overrides: ScenarioOverrides = {}): void => {
+  const loginClient =
+    overrides.loginClient === undefined
+      ? {
+          attributes: { 'post.logout.redirect.uris': 'https://tenant.studio.example.test/##+' },
+          clientId: 'studio-login',
+          id: 'login-internal-id',
+          redirectUris: ['https://tenant.studio.example.test/auth/callback'],
+          rootUrl: 'https://tenant.studio.example.test',
+          webOrigins: ['https://tenant.studio.example.test'],
+        }
+      : overrides.loginClient;
+  const tenantAdminClient =
+    overrides.tenantAdminClient === undefined
+      ? {
+          clientId: 'tenant-admin',
+          directAccessGrantsEnabled: false,
+          id: 'tenant-admin-internal-id',
+          serviceAccountsEnabled: true,
+          standardFlowEnabled: false,
+        }
+      : overrides.tenantAdminClient;
+  const systemAdminUser =
+    overrides.systemAdminUser === undefined
+      ? { enabled: true, id: 'system-admin-user-id', username: 'system-admin' }
+      : overrides.systemAdminUser;
+  const realmRoles = overrides.realmRoles ?? ['system_admin', 'instance_registry_admin'];
+  const systemAdminRoles = overrides.systemAdminRoles ?? ['system_admin'];
+  const tenantAdminServiceRoles = overrides.tenantAdminServiceRoles ?? [
+    'manage-users',
+    'view-users',
+    'view-realm',
+    'manage-realm',
+    'manage-clients',
+  ];
+
+  kcadmMock.responder = async (args) => {
+    const key = commandKey(args);
+    const responseByCommand: Readonly<Record<string, unknown>> = {
+      'config credentials': '',
+      'get clients -r tenant-realm -q clientId=realm-management': [
+        { clientId: 'realm-management', id: 'realm-management-id' },
+      ],
+      'get clients -r tenant-realm -q clientId=studio-login': loginClient ? [loginClient] : [],
+      'get clients -r tenant-realm -q clientId=tenant-admin': tenantAdminClient
+        ? [tenantAdminClient]
+        : [],
+      'get clients/login-internal-id/client-secret -r tenant-realm': {
+        value: overrides.loginSecret === undefined ? loginSecretMarker : overrides.loginSecret,
+      },
+      'get clients/tenant-admin-internal-id/client-secret -r tenant-realm': {
+        value:
+          overrides.tenantAdminSecret === undefined
+            ? tenantAdminSecretMarker
+            : overrides.tenantAdminSecret,
+      },
+      'get clients/tenant-admin-internal-id/service-account-user -r tenant-realm': {
+        id: 'tenant-admin-service-user-id',
+      },
+      'get realms/tenant-realm': { realm: 'tenant-realm' },
+      'get roles -r tenant-realm': realmRoles.map((name) => ({ id: `${name}-id`, name })),
+      'get roles/system_admin/users -r tenant-realm': systemAdminUser ? [systemAdminUser] : [],
+      'get users/system-admin-user-id/role-mappings/realm -r tenant-realm': systemAdminRoles.map(
+        (name) => ({
+          id: `${name}-id`,
+          name,
+        })
+      ),
+      'get users/tenant-admin-service-user-id/role-mappings/clients/realm-management-id -r tenant-realm':
+        tenantAdminServiceRoles.map((name) => ({ id: `${name}-id`, name })),
+    };
+
+    if (key === 'get realms/tenant-realm' && overrides.realmExists === false) {
+      throw new Error('synthetic realm lookup failure');
+    }
+    if (!(key in responseByCommand)) {
+      throw new Error(`Unexpected kcadm command: ${key}`);
+    }
+    return { stdout: JSON.stringify(responseByCommand[key]) };
+  };
+};
+
+const readConfigPath = (): string => {
+  const configCall = kcadmMock.calls[0] ?? [];
+  const configIndex = configCall.indexOf('--config');
+  const configPath = configCall[configIndex + 1];
+  if (!configPath) {
+    throw new Error('Expected kcadm config path');
+  }
+  return configPath;
+};
+
+describe('inspectRealmAndClients contract', () => {
+  beforeEach(() => {
+    kcadmMock.calls = [];
+    configureScenario();
+    process.env.KEYCLOAK_PROVISIONER_BASE_URL = 'https://keycloak.example.test';
+    process.env.KEYCLOAK_PROVISIONER_REALM = 'root-realm';
+    process.env.KEYCLOAK_PROVISIONER_CLIENT_ID = 'provisioner';
+  });
+
+  it('preserves all fourteen successful and advisory check results without exposing secrets', async () => {
+    const result = await inspectRealmAndClients(target, {
+      authSecret: loginSecretMarker,
+      tenantAdminSecret: tenantAdminSecretMarker,
+    });
+
+    expect(result.checks).toEqual([
+      {
+        checkId: 'keycloak.realm.exists',
+        status: 'pass',
+        summary: 'tenant-realm',
+        title: 'Tenant-Realm existiert',
+      },
+      {
+        checkId: 'keycloak.client.login.exists',
+        status: 'pass',
+        summary: 'studio-login',
+        title: 'Login-Client existiert',
+      },
+      {
+        checkId: 'keycloak.client.login.urls',
+        details: {
+          actualPostLogoutRedirectUris: ['+', 'https://tenant.studio.example.test/'],
+          actualRedirectUris: ['https://tenant.studio.example.test/auth/callback'],
+          actualRootUrl: 'https://tenant.studio.example.test',
+          actualWebOrigins: ['https://tenant.studio.example.test'],
+        },
+        status: 'pass',
+        summary: 'tenant.studio.example.test',
+        title: 'Login-Client-URLs stimmen exakt',
+      },
+      {
+        checkId: 'secrets.login.aligned',
+        status: 'pass',
+        summary: 'tenant secret compared',
+        title: 'Login-Client-Secret ist aligned',
+      },
+      {
+        checkId: 'keycloak.client.tenant_admin.exists',
+        status: 'pass',
+        summary: 'tenant-admin',
+        title: 'Tenant-Admin-Client existiert',
+      },
+      {
+        checkId: 'keycloak.client.tenant_admin.flags',
+        details: {
+          directAccessGrantsEnabled: false,
+          serviceAccountsEnabled: true,
+          standardFlowEnabled: false,
+        },
+        status: 'pass',
+        summary: 'tenant-admin',
+        title: 'Tenant-Admin-Client-Flags stimmen',
+      },
+      {
+        checkId: 'secrets.tenant_admin.aligned',
+        status: 'pass',
+        summary: 'tenant admin secret compared',
+        title: 'Tenant-Admin-Client-Secret ist aligned',
+      },
+      {
+        checkId: 'keycloak.client.tenant_admin.roles',
+        details: {
+          assignedRoles: [
+            'manage-users',
+            'view-users',
+            'view-realm',
+            'manage-realm',
+            'manage-clients',
+          ],
+        },
+        status: 'pass',
+        summary: 'tenant-admin',
+        title: 'Tenant-Admin-Serviceaccount hat realm-management-Rollen',
+      },
+      {
+        checkId: 'keycloak.role.system_admin.exists',
+        status: 'pass',
+        summary: 'system_admin',
+        title: 'Realm-Rolle system_admin existiert',
+      },
+      {
+        checkId: 'keycloak.user.system_admin.exists',
+        details: { username: 'system-admin' },
+        status: 'pass',
+        summary: 'system-admin',
+        title: 'Aktiver system_admin-User existiert',
+      },
+      {
+        checkId: 'keycloak.user.system_admin.not_instance_registry_admin',
+        details: { roles: ['system_admin'] },
+        status: 'pass',
+        summary: 'role set inspected',
+        title: 'system_admin-User trägt nicht instance_registry_admin',
+      },
+      {
+        checkId: 'tenant_iam.access',
+        details: {
+          assignedRoles: [
+            'manage-users',
+            'view-users',
+            'view-realm',
+            'manage-realm',
+            'manage-clients',
+          ],
+        },
+        status: 'pass',
+        summary: 'tenant-admin',
+        title: 'Tenant-IAM-Zugriff ist funktionsfähig',
+      },
+      {
+        checkId: 'keycloak.mapper.instance_id',
+        status: 'warn',
+        summary: 'optional mapper not yet inspected separately',
+        title: 'instanceId-Mapper prüfen',
+      },
+      {
+        checkId: 'keycloak.bootstrap_user.profile',
+        status: 'pass',
+        summary: 'bootstrap-admin',
+        title: 'Bootstrap-Admin-Stammdaten sind gepflegt',
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain(loginSecretMarker);
+    expect(JSON.stringify(result)).not.toContain(tenantAdminSecretMarker);
+    expect(existsSync(readConfigPath())).toBe(false);
+  });
+
+  it('preserves the read-only kcadm command order and config cleanup', async () => {
+    await inspectRealmAndClients(target, {
+      authSecret: loginSecretMarker,
+      tenantAdminSecret: tenantAdminSecretMarker,
+    });
+
+    expect(kcadmMock.calls.map(commandKey)).toEqual([
+      'config credentials',
+      'get realms/tenant-realm',
+      'get clients -r tenant-realm -q clientId=studio-login',
+      'get clients/login-internal-id/client-secret -r tenant-realm',
+      'get clients -r tenant-realm -q clientId=tenant-admin',
+      'get clients/tenant-admin-internal-id/client-secret -r tenant-realm',
+      'get roles -r tenant-realm',
+      'get roles/system_admin/users -r tenant-realm',
+      'get users/system-admin-user-id/role-mappings/realm -r tenant-realm',
+      'get clients -r tenant-realm -q clientId=tenant-admin',
+      'get clients -r tenant-realm -q clientId=realm-management',
+      'get clients/tenant-admin-internal-id/service-account-user -r tenant-realm',
+      'get users/tenant-admin-service-user-id/role-mappings/clients/realm-management-id -r tenant-realm',
+    ]);
+    expect(existsSync(readConfigPath())).toBe(false);
+  });
+
+  it('returns only the established realm failure and still cleans up', async () => {
+    configureScenario({ realmExists: false });
+
+    await expect(inspectRealmAndClients(target)).resolves.toEqual({
+      checks: [
+        {
+          checkId: 'keycloak.realm.exists',
+          status: 'fail',
+          summary: 'realm missing',
+          title: 'Tenant-Realm existiert',
+        },
+      ],
+    });
+    expect(kcadmMock.calls.map(commandKey)).toEqual([
+      'config credentials',
+      'get realms/tenant-realm',
+    ]);
+    expect(existsSync(readConfigPath())).toBe(false);
+  });
+
+  it('preserves fail statuses for URL, secret, tenant-admin flag, and role drift', async () => {
+    configureScenario({
+      loginClient: {
+        attributes: { 'post.logout.redirect.uris': 'https://wrong.example.test/' },
+        clientId: 'studio-login',
+        id: 'login-internal-id',
+        redirectUris: ['https://wrong.example.test/auth/callback'],
+        rootUrl: 'https://wrong.example.test',
+        webOrigins: ['https://wrong.example.test'],
+      },
+      loginSecret: 'synthetic-other-login-secret',
+      tenantAdminClient: {
+        clientId: 'tenant-admin',
+        directAccessGrantsEnabled: true,
+        id: 'tenant-admin-internal-id',
+        serviceAccountsEnabled: false,
+        standardFlowEnabled: true,
+      },
+      tenantAdminSecret: null,
+      tenantAdminServiceRoles: ['view-users'],
+      systemAdminRoles: ['system_admin', 'instance_registry_admin'],
+    });
+
+    const result = await inspectRealmAndClients(target, {
+      authSecret: loginSecretMarker,
+      tenantAdminSecret: tenantAdminSecretMarker,
+    });
+    const byId = new Map(result.checks.map((check) => [check.checkId, check]));
+
+    expect(byId.get('keycloak.client.login.urls')).toMatchObject({ status: 'fail' });
+    expect(byId.get('secrets.login.aligned')).toEqual({
+      checkId: 'secrets.login.aligned',
+      status: 'fail',
+      summary: 'tenant secret compared',
+      title: 'Login-Client-Secret ist aligned',
+    });
+    expect(byId.get('keycloak.client.tenant_admin.flags')).toMatchObject({ status: 'fail' });
+    expect(byId.get('secrets.tenant_admin.aligned')).toMatchObject({
+      status: 'fail',
+      summary: 'secret missing',
+    });
+    expect(byId.get('keycloak.client.tenant_admin.roles')).toMatchObject({ status: 'fail' });
+    expect(byId.get('tenant_iam.access')).toMatchObject({ status: 'fail' });
+    expect(byId.get('keycloak.user.system_admin.not_instance_registry_admin')).toMatchObject({
+      status: 'fail',
+    });
+  });
+
+  it('preserves missing-client failures without attempting client-secret reads', async () => {
+    configureScenario({ loginClient: null, tenantAdminClient: null });
+
+    const result = await inspectRealmAndClients(target, {
+      authSecret: loginSecretMarker,
+      tenantAdminSecret: tenantAdminSecretMarker,
+    });
+    const byId = new Map(result.checks.map((check) => [check.checkId, check]));
+
+    expect(byId.get('keycloak.client.login.exists')).toMatchObject({ status: 'fail' });
+    expect(byId.get('keycloak.client.login.urls')).toMatchObject({
+      details: {
+        actualPostLogoutRedirectUris: [],
+        actualRedirectUris: [],
+        actualRootUrl: undefined,
+        actualWebOrigins: [],
+      },
+      status: 'fail',
+    });
+    expect(byId.get('secrets.login.aligned')).toMatchObject({
+      status: 'fail',
+      summary: 'secret missing',
+    });
+    expect(byId.get('keycloak.client.tenant_admin.exists')).toMatchObject({ status: 'fail' });
+    expect(byId.get('keycloak.client.tenant_admin.flags')).toMatchObject({ status: 'fail' });
+    expect(byId.get('secrets.tenant_admin.aligned')).toMatchObject({
+      status: 'fail',
+      summary: 'secret missing',
+    });
+    expect(kcadmMock.calls.map(commandKey)).not.toContain(
+      'get clients/login-internal-id/client-secret -r tenant-realm'
+    );
+    expect(kcadmMock.calls.map(commandKey)).not.toContain(
+      'get clients/tenant-admin-internal-id/client-secret -r tenant-realm'
+    );
+  });
+
+  it('preserves the system-admin skip and optional warning semantics', async () => {
+    configureScenario({ realmRoles: ['viewer'], systemAdminUser: null });
+
+    const result = await inspectRealmAndClients(
+      { ...target, tenantAdminUsername: undefined },
+      { authSecret: loginSecretMarker, tenantAdminSecret: tenantAdminSecretMarker }
+    );
+    const byId = new Map(result.checks.map((check) => [check.checkId, check]));
+
+    expect(byId.get('keycloak.role.system_admin.exists')).toMatchObject({ status: 'fail' });
+    expect(byId.get('keycloak.user.system_admin.exists')).toMatchObject({
+      status: 'fail',
+      summary: 'no active system_admin user',
+    });
+    expect(byId.get('keycloak.user.system_admin.not_instance_registry_admin')).toEqual({
+      checkId: 'keycloak.user.system_admin.not_instance_registry_admin',
+      details: { roles: [] },
+      status: 'skip',
+      summary: 'no system_admin user',
+      title: 'system_admin-User trägt nicht instance_registry_admin',
+    });
+    expect(byId.get('keycloak.mapper.instance_id')).toMatchObject({ status: 'warn' });
+    expect(byId.get('keycloak.bootstrap_user.profile')).toMatchObject({
+      status: 'warn',
+      summary: 'bootstrap user missing',
+    });
+  });
+});

--- a/scripts/ops/studio-instance-audit-keycloak.test.ts
+++ b/scripts/ops/studio-instance-audit-keycloak.test.ts
@@ -328,6 +328,32 @@ describe('inspectRealmAndClients contract', () => {
     expect(existsSync(readConfigPath())).toBe(false);
   });
 
+  it('redacts credential command failures before they reach the audit report', async () => {
+    const leakedSecretMarker = 'synthetic-secret-that-must-not-leak';
+    kcadmMock.responder = async () => {
+      throw Object.assign(
+        new Error(`Command failed: kcadm.sh --client-secret ${leakedSecretMarker}`),
+        {
+          cmd: `kcadm.sh config credentials --client-secret ${leakedSecretMarker}`,
+          stderr: `authentication failed for ${leakedSecretMarker}`,
+        }
+      );
+    };
+
+    const publicError = await inspectRealmAndClients(target).catch((error: unknown) => error);
+    const auditFailure = {
+      details: publicError instanceof Error ? { message: publicError.message } : undefined,
+      summary: publicError instanceof Error ? publicError.message : String(publicError),
+    };
+
+    expect(publicError).toEqual(new Error('Keycloak authentication failed'));
+    expect(JSON.stringify(publicError, Object.getOwnPropertyNames(publicError))).not.toContain(
+      leakedSecretMarker
+    );
+    expect(JSON.stringify(auditFailure)).not.toContain(leakedSecretMarker);
+    expect(existsSync(readConfigPath())).toBe(false);
+  });
+
   it('returns only the established realm failure and still cleans up', async () => {
     configureScenario({ realmExists: false });
 

--- a/scripts/ops/studio-instance-audit/keycloak-evaluation.ts
+++ b/scripts/ops/studio-instance-audit/keycloak-evaluation.ts
@@ -1,0 +1,314 @@
+import type { AuditCheckResult, AuditRegistryTarget } from './model.ts';
+
+export const REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES = [
+  'manage-users',
+  'view-users',
+  'view-realm',
+  'manage-realm',
+  'manage-clients',
+] as const;
+
+export type KeycloakClientSnapshot = Readonly<{
+  id: string;
+  clientId: string;
+  rootUrl?: string;
+  redirectUris?: readonly string[];
+  webOrigins?: readonly string[];
+  attributes?: Readonly<Record<string, string>>;
+  standardFlowEnabled?: boolean;
+  directAccessGrantsEnabled?: boolean;
+  serviceAccountsEnabled?: boolean;
+}>;
+
+export type KeycloakAuditSnapshot = Readonly<{
+  loginClient: KeycloakClientSnapshot | null;
+  loginSecret: string | null;
+  realmName: string;
+  realmRoles: readonly string[];
+  systemAdminUser: Readonly<{ username?: string }> | null;
+  systemAdminUserRoles: readonly string[];
+  tenantAdminClient: KeycloakClientSnapshot | null;
+  tenantAdminSecret: string | null;
+  tenantAdminServiceRoles: readonly string[];
+}>;
+
+type ExpectedSecrets = Readonly<{
+  authSecret?: string;
+  tenantAdminSecret?: string;
+}>;
+
+const normalizeList = (values: readonly string[] | undefined): string[] =>
+  [...new Set((values ?? []).map((value) => value.trim()).filter(Boolean))].sort((a, b) =>
+    a.localeCompare(b)
+  );
+
+const readPostLogoutUris = (attributes: Readonly<Record<string, string>> | undefined): string[] =>
+  normalizeList(
+    (attributes?.['post.logout.redirect.uris'] ?? '')
+      .split('##')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
+
+const expectedLoginClientConfig = (hostname: string) => {
+  const origin = `https://${hostname}`;
+  return {
+    postLogoutRedirectUris: normalizeList([`${origin}/`, '+']),
+    redirectUris: normalizeList([`${origin}/auth/callback`]),
+    rootUrl: origin,
+    webOrigins: normalizeList([origin]),
+  };
+};
+
+const sameList = (actual: readonly string[], expected: readonly string[]): boolean =>
+  JSON.stringify(actual) === JSON.stringify(expected);
+
+const hasTenantAdminRoles = (roles: readonly string[]): boolean =>
+  REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES.every((roleName) => roles.includes(roleName));
+
+type LoginUrlState = Readonly<{
+  postLogoutRedirectUris: readonly string[];
+  redirectUris: readonly string[];
+  rootUrl?: string;
+  webOrigins: readonly string[];
+}>;
+
+const readLoginUrlState = (client: KeycloakClientSnapshot | null): LoginUrlState => {
+  if (!client) {
+    return { postLogoutRedirectUris: [], redirectUris: [], webOrigins: [] };
+  }
+  return {
+    postLogoutRedirectUris: readPostLogoutUris(client.attributes),
+    redirectUris: normalizeList(client.redirectUris),
+    rootUrl: client.rootUrl,
+    webOrigins: normalizeList(client.webOrigins),
+  };
+};
+
+const loginUrlsAligned = (
+  client: KeycloakClientSnapshot | null,
+  actual: LoginUrlState,
+  expected: LoginUrlState
+): boolean =>
+  client !== null &&
+  [
+    actual.rootUrl === expected.rootUrl,
+    sameList(actual.redirectUris, expected.redirectUris),
+    sameList(actual.webOrigins, expected.webOrigins),
+    sameList(actual.postLogoutRedirectUris, expected.postLogoutRedirectUris),
+  ].every(Boolean);
+
+const buildLoginUrlCheck = (
+  target: AuditRegistryTarget,
+  client: KeycloakClientSnapshot | null
+): AuditCheckResult => {
+  const actual = readLoginUrlState(client);
+  const expected = expectedLoginClientConfig(target.primaryHostname);
+  return {
+    checkId: 'keycloak.client.login.urls',
+    details: {
+      actualPostLogoutRedirectUris: actual.postLogoutRedirectUris,
+      actualRedirectUris: actual.redirectUris,
+      actualRootUrl: actual.rootUrl,
+      actualWebOrigins: actual.webOrigins,
+    },
+    status: loginUrlsAligned(client, actual, expected) ? 'pass' : 'fail',
+    summary: target.primaryHostname,
+    title: 'Login-Client-URLs stimmen exakt',
+  };
+};
+
+const buildLoginSecretCheck = (
+  expectedSecret: string | undefined,
+  actualSecret: string | null
+): AuditCheckResult => {
+  if (!expectedSecret || !actualSecret) {
+    return {
+      checkId: 'secrets.login.aligned',
+      status: 'fail',
+      summary: 'secret missing',
+      title: 'Login-Client-Secret ist aligned',
+    };
+  }
+  return {
+    checkId: 'secrets.login.aligned',
+    status: expectedSecret === actualSecret ? 'pass' : 'fail',
+    summary: 'tenant secret compared',
+    title: 'Login-Client-Secret ist aligned',
+  };
+};
+
+const buildLoginChecks = (
+  target: AuditRegistryTarget,
+  snapshot: KeycloakAuditSnapshot,
+  secrets: ExpectedSecrets
+): readonly AuditCheckResult[] => {
+  const client = snapshot.loginClient;
+  return [
+    {
+      checkId: 'keycloak.client.login.exists',
+      status: client ? 'pass' : 'fail',
+      summary: target.authClientId,
+      title: 'Login-Client existiert',
+    },
+    buildLoginUrlCheck(target, client),
+    buildLoginSecretCheck(secrets.authSecret, snapshot.loginSecret),
+  ];
+};
+
+const tenantAdminFlagsAligned = (client: KeycloakClientSnapshot | null): boolean =>
+  client !== null &&
+  [
+    client.directAccessGrantsEnabled === false,
+    client.serviceAccountsEnabled === true,
+    client.standardFlowEnabled === false,
+  ].every(Boolean);
+
+const buildTenantAdminSecretCheck = (
+  expectedSecret: string | undefined,
+  actualSecret: string | null
+): AuditCheckResult => {
+  if (!expectedSecret || !actualSecret) {
+    return {
+      checkId: 'secrets.tenant_admin.aligned',
+      status: 'fail',
+      summary: 'secret missing',
+      title: 'Tenant-Admin-Client-Secret ist aligned',
+    };
+  }
+  return {
+    checkId: 'secrets.tenant_admin.aligned',
+    status: expectedSecret === actualSecret ? 'pass' : 'fail',
+    summary: 'tenant admin secret compared',
+    title: 'Tenant-Admin-Client-Secret ist aligned',
+  };
+};
+
+const buildTenantAdminExistenceCheck = (
+  target: AuditRegistryTarget,
+  client: KeycloakClientSnapshot | null
+): AuditCheckResult => ({
+  checkId: 'keycloak.client.tenant_admin.exists',
+  status: client ? 'pass' : 'fail',
+  summary: target.tenantAdminClientId,
+  title: 'Tenant-Admin-Client existiert',
+});
+
+const buildTenantAdminFlagsCheck = (
+  target: AuditRegistryTarget,
+  client: KeycloakClientSnapshot | null
+): AuditCheckResult => ({
+  checkId: 'keycloak.client.tenant_admin.flags',
+  details: {
+    directAccessGrantsEnabled: client?.directAccessGrantsEnabled,
+    serviceAccountsEnabled: client?.serviceAccountsEnabled,
+    standardFlowEnabled: client?.standardFlowEnabled,
+  },
+  status: tenantAdminFlagsAligned(client) ? 'pass' : 'fail',
+  summary: target.tenantAdminClientId,
+  title: 'Tenant-Admin-Client-Flags stimmen',
+});
+
+const buildTenantAdminRolesCheck = (
+  target: AuditRegistryTarget,
+  roles: readonly string[]
+): AuditCheckResult => ({
+  checkId: 'keycloak.client.tenant_admin.roles',
+  details: { assignedRoles: roles },
+  status: hasTenantAdminRoles(roles) ? 'pass' : 'fail',
+  summary: target.tenantAdminClientId,
+  title: 'Tenant-Admin-Serviceaccount hat realm-management-Rollen',
+});
+
+const buildTenantAdminChecks = (
+  target: AuditRegistryTarget,
+  snapshot: KeycloakAuditSnapshot,
+  secrets: ExpectedSecrets
+): readonly AuditCheckResult[] => {
+  const client = snapshot.tenantAdminClient;
+  return [
+    buildTenantAdminExistenceCheck(target, client),
+    buildTenantAdminFlagsCheck(target, client),
+    buildTenantAdminSecretCheck(secrets.tenantAdminSecret, snapshot.tenantAdminSecret),
+    buildTenantAdminRolesCheck(target, snapshot.tenantAdminServiceRoles),
+  ];
+};
+
+const buildSystemAdminRoleCheck = (realmRoles: readonly string[]): AuditCheckResult => ({
+  checkId: 'keycloak.role.system_admin.exists',
+  status: realmRoles.includes('system_admin') ? 'pass' : 'fail',
+  summary: 'system_admin',
+  title: 'Realm-Rolle system_admin existiert',
+});
+
+const buildSystemAdminUserCheck = (
+  user: KeycloakAuditSnapshot['systemAdminUser']
+): AuditCheckResult => ({
+  checkId: 'keycloak.user.system_admin.exists',
+  details: { username: user?.username },
+  status: user ? 'pass' : 'fail',
+  summary: user?.username ?? 'no active system_admin user',
+  title: 'Aktiver system_admin-User existiert',
+});
+
+const buildSystemAdminRoleSeparationCheck = (
+  user: KeycloakAuditSnapshot['systemAdminUser'],
+  roles: readonly string[]
+): AuditCheckResult => ({
+  checkId: 'keycloak.user.system_admin.not_instance_registry_admin',
+  details: { roles },
+  status: user ? (roles.includes('instance_registry_admin') ? 'fail' : 'pass') : 'skip',
+  summary: user ? 'role set inspected' : 'no system_admin user',
+  title: 'system_admin-User trägt nicht instance_registry_admin',
+});
+
+const buildSystemAdminChecks = (snapshot: KeycloakAuditSnapshot): readonly AuditCheckResult[] => {
+  const user = snapshot.systemAdminUser;
+  return [
+    buildSystemAdminRoleCheck(snapshot.realmRoles),
+    buildSystemAdminUserCheck(user),
+    buildSystemAdminRoleSeparationCheck(user, snapshot.systemAdminUserRoles),
+  ];
+};
+
+const buildTenantIamAccessCheck = (
+  target: AuditRegistryTarget,
+  roles: readonly string[]
+): AuditCheckResult => ({
+  checkId: 'tenant_iam.access',
+  details: { assignedRoles: roles },
+  status: hasTenantAdminRoles(roles) ? 'pass' : 'fail',
+  summary: target.tenantAdminClientId,
+  title: 'Tenant-IAM-Zugriff ist funktionsfähig',
+});
+
+const buildBootstrapProfileCheck = (target: AuditRegistryTarget): AuditCheckResult => ({
+  checkId: 'keycloak.bootstrap_user.profile',
+  status: target.tenantAdminUsername ? 'pass' : 'warn',
+  summary: target.tenantAdminUsername ?? 'bootstrap user missing',
+  title: 'Bootstrap-Admin-Stammdaten sind gepflegt',
+});
+
+export const evaluateKeycloakAuditChecks = (
+  target: AuditRegistryTarget,
+  snapshot: KeycloakAuditSnapshot,
+  secrets: ExpectedSecrets
+): readonly AuditCheckResult[] => [
+  {
+    checkId: 'keycloak.realm.exists',
+    status: snapshot.realmName === target.authRealm ? 'pass' : 'fail',
+    summary: snapshot.realmName,
+    title: 'Tenant-Realm existiert',
+  },
+  ...buildLoginChecks(target, snapshot, secrets),
+  ...buildTenantAdminChecks(target, snapshot, secrets),
+  ...buildSystemAdminChecks(snapshot),
+  buildTenantIamAccessCheck(target, snapshot.tenantAdminServiceRoles),
+  {
+    checkId: 'keycloak.mapper.instance_id',
+    status: 'warn',
+    summary: 'optional mapper not yet inspected separately',
+    title: 'instanceId-Mapper prüfen',
+  },
+  buildBootstrapProfileCheck(target),
+];

--- a/scripts/ops/studio-instance-audit/keycloak.ts
+++ b/scripts/ops/studio-instance-audit/keycloak.ts
@@ -9,28 +9,9 @@ import {
   getKeycloakProvisionerClientSecret,
 } from '../../../packages/auth-runtime/src/runtime-secrets.ts';
 import type { AuditCheckResult, AuditRegistryTarget } from './model.ts';
+import { evaluateKeycloakAuditChecks, type KeycloakClientSnapshot } from './keycloak-evaluation.ts';
 
 const execFileAsync = promisify(execFile);
-
-const REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES = [
-  'manage-users',
-  'view-users',
-  'view-realm',
-  'manage-realm',
-  'manage-clients',
-] as const;
-
-type KeycloakClientRepresentation = Readonly<{
-  id: string;
-  clientId: string;
-  rootUrl?: string;
-  redirectUris?: readonly string[];
-  webOrigins?: readonly string[];
-  attributes?: Readonly<Record<string, string>>;
-  standardFlowEnabled?: boolean;
-  directAccessGrantsEnabled?: boolean;
-  serviceAccountsEnabled?: boolean;
-}>;
 
 type KeycloakUserRepresentation = Readonly<{
   id: string;
@@ -43,56 +24,24 @@ type KeycloakRoleRepresentation = Readonly<{
   name: string;
 }>;
 
-const normalizeList = (values: readonly string[] | undefined): string[] =>
-  [...new Set((values ?? []).map((value) => value.trim()).filter(Boolean))].sort((a, b) => a.localeCompare(b));
-
-const readPostLogoutUris = (attributes: Readonly<Record<string, string>> | undefined): string[] =>
-  normalizeList(
-    (attributes?.['post.logout.redirect.uris'] ?? '')
-      .split('##')
-      .map((entry) => entry.trim())
-      .filter(Boolean),
-  );
-
-const expectedOrigin = (hostname: string) => `https://${hostname}`;
-
-const expectedLoginClientConfig = (hostname: string) => {
-  const origin = expectedOrigin(hostname);
-  return {
-    postLogoutRedirectUris: normalizeList([`${origin}/`, '+']),
-    redirectUris: normalizeList([`${origin}/auth/callback`]),
-    rootUrl: origin,
-    webOrigins: normalizeList([origin]),
-  };
-};
-
-const expectedTenantAdminClientFlags = {
-  directAccessGrantsEnabled: false,
-  serviceAccountsEnabled: true,
-  standardFlowEnabled: false,
-} as const;
-
-const ensureEnv = (key: string): string => {
-  const value = process.env[key]?.trim();
-  if (!value) {
-    throw new Error(`Missing required env: ${key}`);
-  }
-  return value;
-};
-
 const withKcadmConfig = async <T>(work: (configPath: string) => Promise<T>): Promise<T> => {
-  const configPath = join(mkdtempSync(join(tmpdir(), 'studio-instance-audit-kcadm-')), 'kcadm.config');
+  const configPath = join(
+    mkdtempSync(join(tmpdir(), 'studio-instance-audit-kcadm-')),
+    'kcadm.config'
+  );
   try {
     const clientSecret = getKeycloakProvisionerClientSecret() ?? getKeycloakAdminClientSecret();
     if (!clientSecret) {
       throw new Error('Missing Keycloak admin client secret');
     }
-    const baseUrl = process.env.KEYCLOAK_PROVISIONER_BASE_URL?.trim()
-      || process.env.KEYCLOAK_ADMIN_BASE_URL?.trim();
-    const realm = process.env.KEYCLOAK_PROVISIONER_REALM?.trim()
-      || process.env.KEYCLOAK_ADMIN_REALM?.trim();
-    const clientId = process.env.KEYCLOAK_PROVISIONER_CLIENT_ID?.trim()
-      || process.env.KEYCLOAK_ADMIN_CLIENT_ID?.trim();
+    const baseUrl =
+      process.env.KEYCLOAK_PROVISIONER_BASE_URL?.trim() ||
+      process.env.KEYCLOAK_ADMIN_BASE_URL?.trim();
+    const realm =
+      process.env.KEYCLOAK_PROVISIONER_REALM?.trim() || process.env.KEYCLOAK_ADMIN_REALM?.trim();
+    const clientId =
+      process.env.KEYCLOAK_PROVISIONER_CLIENT_ID?.trim() ||
+      process.env.KEYCLOAK_ADMIN_CLIENT_ID?.trim();
     if (!baseUrl || !realm || !clientId) {
       throw new Error('Missing Keycloak provisioner/admin configuration');
     }
@@ -128,7 +77,7 @@ const runKcadmJson = async <T>(configPath: string, args: readonly string[]): Pro
 const findRealmRoleUser = async (
   configPath: string,
   realm: string,
-  roleName: string,
+  roleName: string
 ): Promise<KeycloakUserRepresentation | null> => {
   const users = await runKcadmJson<readonly KeycloakUserRepresentation[]>(configPath, [
     'get',
@@ -142,7 +91,7 @@ const findRealmRoleUser = async (
 const listUserRealmRoles = async (
   configPath: string,
   realm: string,
-  userId: string,
+  userId: string
 ): Promise<readonly string[]> => {
   const roles = await runKcadmJson<readonly KeycloakRoleRepresentation[]>(configPath, [
     'get',
@@ -156,9 +105,9 @@ const listUserRealmRoles = async (
 const listTenantAdminServiceRoles = async (
   configPath: string,
   realm: string,
-  clientId: string,
+  clientId: string
 ): Promise<readonly string[]> => {
-  const tenantAdminClients = await runKcadmJson<readonly KeycloakClientRepresentation[]>(configPath, [
+  const tenantAdminClients = await runKcadmJson<readonly KeycloakClientSnapshot[]>(configPath, [
     'get',
     'clients',
     '-r',
@@ -170,7 +119,7 @@ const listTenantAdminServiceRoles = async (
   if (!tenantAdminClient?.id) {
     return [];
   }
-  const realmManagementClients = await runKcadmJson<readonly KeycloakClientRepresentation[]>(configPath, [
+  const realmManagementClients = await runKcadmJson<readonly KeycloakClientSnapshot[]>(configPath, [
     'get',
     'clients',
     '-r',
@@ -201,14 +150,19 @@ const listTenantAdminServiceRoles = async (
 };
 
 const listRealmRoles = async (configPath: string, realm: string): Promise<readonly string[]> => {
-  const roles = await runKcadmJson<readonly KeycloakRoleRepresentation[]>(configPath, ['get', 'roles', '-r', realm]);
+  const roles = await runKcadmJson<readonly KeycloakRoleRepresentation[]>(configPath, [
+    'get',
+    'roles',
+    '-r',
+    realm,
+  ]);
   return roles.map((role) => role.name);
 };
 
 const readKeycloakClientSecret = async (
   configPath: string,
   realm: string,
-  clientId: string,
+  clientId: string
 ): Promise<string | null> => {
   const secret = await runKcadmJson<{ value?: string }>(configPath, [
     'get',
@@ -219,19 +173,88 @@ const readKeycloakClientSecret = async (
   return secret?.value ?? null;
 };
 
+const readClientAndSecret = async (
+  configPath: string,
+  realm: string,
+  clientId: string
+): Promise<Readonly<{ client: KeycloakClientSnapshot | null; secret: string | null }>> => {
+  const clients = await runKcadmJson<readonly KeycloakClientSnapshot[]>(configPath, [
+    'get',
+    'clients',
+    '-r',
+    realm,
+    '-q',
+    `clientId=${clientId}`,
+  ]);
+  const client = clients[0] ?? null;
+  const secret = client?.id ? await readKeycloakClientSecret(configPath, realm, client.id) : null;
+  return { client, secret };
+};
+
+const readOptionalClientAndSecret = async (
+  configPath: string,
+  realm: string,
+  clientId: string | undefined
+): ReturnType<typeof readClientAndSecret> =>
+  clientId ? readClientAndSecret(configPath, realm, clientId) : { client: null, secret: null };
+
+const readSystemAdminState = async (
+  configPath: string,
+  realm: string,
+  realmRoles: readonly string[]
+): Promise<
+  Readonly<{
+    systemAdminUser: KeycloakUserRepresentation | null;
+    systemAdminUserRoles: readonly string[];
+  }>
+> => {
+  if (!realmRoles.includes('system_admin')) {
+    return { systemAdminUser: null, systemAdminUserRoles: [] };
+  }
+  const systemAdminUser = await findRealmRoleUser(configPath, realm, 'system_admin');
+  const systemAdminUserRoles = systemAdminUser?.id
+    ? await listUserRealmRoles(configPath, realm, systemAdminUser.id)
+    : [];
+  return { systemAdminUser, systemAdminUserRoles };
+};
+
+const collectKeycloakAuditSnapshot = async (configPath: string, target: AuditRegistryTarget) => {
+  const login = await readClientAndSecret(configPath, target.authRealm, target.authClientId);
+  const tenantAdmin = await readOptionalClientAndSecret(
+    configPath,
+    target.authRealm,
+    target.tenantAdminClientId
+  );
+  const realmRoles = await listRealmRoles(configPath, target.authRealm);
+  const systemAdmin = await readSystemAdminState(configPath, target.authRealm, realmRoles);
+  const tenantAdminServiceRoles = target.tenantAdminClientId
+    ? await listTenantAdminServiceRoles(configPath, target.authRealm, target.tenantAdminClientId)
+    : [];
+
+  return {
+    loginClient: login.client,
+    loginSecret: login.secret,
+    realmRoles,
+    systemAdminUser: systemAdmin.systemAdminUser,
+    systemAdminUserRoles: systemAdmin.systemAdminUserRoles,
+    tenantAdminClient: tenantAdmin.client,
+    tenantAdminSecret: tenantAdmin.secret,
+    tenantAdminServiceRoles,
+  };
+};
+
 export const inspectRealmAndClients = async (
   target: AuditRegistryTarget,
   deps: {
     authSecret?: string;
     tenantAdminSecret?: string;
-  } = {},
+  } = {}
 ): Promise<{ checks: readonly AuditCheckResult[] }> => {
-  const expectedLogin = expectedLoginClientConfig(target.primaryHostname);
-
   return withKcadmConfig(async (configPath) => {
-    const realm = await runKcadmJson<{ realm: string }>(configPath, ['get', `realms/${target.authRealm}`]).catch(
-      () => null,
-    );
+    const realm = await runKcadmJson<{ realm: string }>(configPath, [
+      'get',
+      `realms/${target.authRealm}`,
+    ]).catch(() => null);
     if (!realm) {
       return {
         checks: [
@@ -244,167 +267,17 @@ export const inspectRealmAndClients = async (
         ],
       };
     }
-    const loginClients = await runKcadmJson<readonly KeycloakClientRepresentation[]>(configPath, [
-      'get',
-      'clients',
-      '-r',
-      target.authRealm,
-      '-q',
-      `clientId=${target.authClientId}`,
-    ]);
-    const loginClient = loginClients[0] ?? null;
-    const loginSecret = loginClient?.id
-      ? await readKeycloakClientSecret(configPath, target.authRealm, loginClient.id)
-      : null;
-    const tenantAdminClients = target.tenantAdminClientId
-      ? await runKcadmJson<readonly KeycloakClientRepresentation[]>(configPath, [
-          'get',
-          'clients',
-          '-r',
-          target.authRealm,
-          '-q',
-          `clientId=${target.tenantAdminClientId}`,
-        ])
-      : [];
-    const tenantAdminClient = tenantAdminClients[0] ?? null;
-    const tenantAdminSecret = tenantAdminClient?.id
-      ? await readKeycloakClientSecret(configPath, target.authRealm, tenantAdminClient.id)
-      : null;
-    const realmRoles = await listRealmRoles(configPath, target.authRealm);
-    const systemAdminUser = realmRoles.includes('system_admin')
-      ? await findRealmRoleUser(configPath, target.authRealm, 'system_admin')
-      : null;
-    const systemAdminUserRoles = systemAdminUser?.id
-      ? await listUserRealmRoles(configPath, target.authRealm, systemAdminUser.id)
-      : [];
-    const tenantAdminServiceRoles = target.tenantAdminClientId
-      ? await listTenantAdminServiceRoles(configPath, target.authRealm, target.tenantAdminClientId)
-      : [];
+    const snapshot = await collectKeycloakAuditSnapshot(configPath, target);
 
-    const checks: AuditCheckResult[] = [
-      {
-        checkId: 'keycloak.realm.exists',
-        status: realm?.realm === target.authRealm ? 'pass' : 'fail',
-        summary: realm?.realm ?? 'realm missing',
-        title: 'Tenant-Realm existiert',
-      },
-      {
-        checkId: 'keycloak.client.login.exists',
-        status: loginClient ? 'pass' : 'fail',
-        summary: target.authClientId,
-        title: 'Login-Client existiert',
-      },
-      {
-        checkId: 'keycloak.client.login.urls',
-        details: {
-          actualPostLogoutRedirectUris: loginClient ? readPostLogoutUris(loginClient.attributes) : [],
-          actualRedirectUris: loginClient ? normalizeList(loginClient.redirectUris) : [],
-          actualRootUrl: loginClient?.rootUrl,
-          actualWebOrigins: loginClient ? normalizeList(loginClient.webOrigins) : [],
+    return {
+      checks: evaluateKeycloakAuditChecks(
+        target,
+        {
+          ...snapshot,
+          realmName: realm.realm,
         },
-        status:
-          loginClient
-          && loginClient.rootUrl === expectedLogin.rootUrl
-          && JSON.stringify(normalizeList(loginClient.redirectUris)) === JSON.stringify(expectedLogin.redirectUris)
-          && JSON.stringify(normalizeList(loginClient.webOrigins)) === JSON.stringify(expectedLogin.webOrigins)
-          && JSON.stringify(readPostLogoutUris(loginClient.attributes)) === JSON.stringify(expectedLogin.postLogoutRedirectUris)
-            ? 'pass'
-            : 'fail',
-        summary: target.primaryHostname,
-        title: 'Login-Client-URLs stimmen exakt',
-      },
-      {
-        checkId: 'secrets.login.aligned',
-        status: deps.authSecret && loginSecret ? (deps.authSecret === loginSecret ? 'pass' : 'fail') : 'fail',
-        summary: deps.authSecret && loginSecret ? 'tenant secret compared' : 'secret missing',
-        title: 'Login-Client-Secret ist aligned',
-      },
-      {
-        checkId: 'keycloak.client.tenant_admin.exists',
-        status: tenantAdminClient ? 'pass' : 'fail',
-        summary: target.tenantAdminClientId,
-        title: 'Tenant-Admin-Client existiert',
-      },
-      {
-        checkId: 'keycloak.client.tenant_admin.flags',
-        details: {
-          directAccessGrantsEnabled: tenantAdminClient?.directAccessGrantsEnabled,
-          serviceAccountsEnabled: tenantAdminClient?.serviceAccountsEnabled,
-          standardFlowEnabled: tenantAdminClient?.standardFlowEnabled,
-        },
-        status:
-          tenantAdminClient
-          && tenantAdminClient.directAccessGrantsEnabled === expectedTenantAdminClientFlags.directAccessGrantsEnabled
-          && tenantAdminClient.serviceAccountsEnabled === expectedTenantAdminClientFlags.serviceAccountsEnabled
-          && tenantAdminClient.standardFlowEnabled === expectedTenantAdminClientFlags.standardFlowEnabled
-            ? 'pass'
-            : 'fail',
-        summary: target.tenantAdminClientId,
-        title: 'Tenant-Admin-Client-Flags stimmen',
-      },
-      {
-        checkId: 'secrets.tenant_admin.aligned',
-        status:
-          deps.tenantAdminSecret && tenantAdminSecret
-            ? deps.tenantAdminSecret === tenantAdminSecret ? 'pass' : 'fail'
-            : 'fail',
-        summary: deps.tenantAdminSecret && tenantAdminSecret ? 'tenant admin secret compared' : 'secret missing',
-        title: 'Tenant-Admin-Client-Secret ist aligned',
-      },
-      {
-        checkId: 'keycloak.client.tenant_admin.roles',
-        details: { assignedRoles: tenantAdminServiceRoles },
-        status: REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES.every((roleName) => tenantAdminServiceRoles.includes(roleName))
-          ? 'pass'
-          : 'fail',
-        summary: target.tenantAdminClientId,
-        title: 'Tenant-Admin-Serviceaccount hat realm-management-Rollen',
-      },
-      {
-        checkId: 'keycloak.role.system_admin.exists',
-        status: realmRoles.includes('system_admin') ? 'pass' : 'fail',
-        summary: 'system_admin',
-        title: 'Realm-Rolle system_admin existiert',
-      },
-      {
-        checkId: 'keycloak.user.system_admin.exists',
-        details: { username: systemAdminUser?.username },
-        status: systemAdminUser ? 'pass' : 'fail',
-        summary: systemAdminUser?.username ?? 'no active system_admin user',
-        title: 'Aktiver system_admin-User existiert',
-      },
-      {
-        checkId: 'keycloak.user.system_admin.not_instance_registry_admin',
-        details: { roles: systemAdminUserRoles },
-        status: systemAdminUser
-          ? systemAdminUserRoles.includes('instance_registry_admin') ? 'fail' : 'pass'
-          : 'skip',
-        summary: systemAdminUser ? 'role set inspected' : 'no system_admin user',
-        title: 'system_admin-User trägt nicht instance_registry_admin',
-      },
-      {
-        checkId: 'tenant_iam.access',
-        details: { assignedRoles: tenantAdminServiceRoles },
-        status: REQUIRED_TENANT_ADMIN_CLIENT_ROLE_NAMES.every((roleName) => tenantAdminServiceRoles.includes(roleName))
-          ? 'pass'
-          : 'fail',
-        summary: target.tenantAdminClientId,
-        title: 'Tenant-IAM-Zugriff ist funktionsfähig',
-      },
-      {
-        checkId: 'keycloak.mapper.instance_id',
-        status: 'warn',
-        summary: 'optional mapper not yet inspected separately',
-        title: 'instanceId-Mapper prüfen',
-      },
-      {
-        checkId: 'keycloak.bootstrap_user.profile',
-        status: target.tenantAdminUsername ? 'pass' : 'warn',
-        summary: target.tenantAdminUsername ?? 'bootstrap user missing',
-        title: 'Bootstrap-Admin-Stammdaten sind gepflegt',
-      },
-    ];
-
-    return { checks };
+        deps
+      ),
+    };
   });
 };

--- a/scripts/ops/studio-instance-audit/keycloak.ts
+++ b/scripts/ops/studio-instance-audit/keycloak.ts
@@ -24,6 +24,33 @@ type KeycloakRoleRepresentation = Readonly<{
   name: string;
 }>;
 
+const authenticateKcadm = async (
+  configPath: string,
+  baseUrl: string,
+  realm: string,
+  clientId: string,
+  clientSecret: string
+): Promise<void> => {
+  try {
+    await execFileAsync('kcadm.sh', [
+      'config',
+      'credentials',
+      '--server',
+      baseUrl,
+      '--realm',
+      realm,
+      '--client',
+      clientId,
+      '--client-secret',
+      clientSecret,
+      '--config',
+      configPath,
+    ]);
+  } catch {
+    throw new Error('Keycloak authentication failed');
+  }
+};
+
 const withKcadmConfig = async <T>(work: (configPath: string) => Promise<T>): Promise<T> => {
   const configPath = join(
     mkdtempSync(join(tmpdir(), 'studio-instance-audit-kcadm-')),
@@ -46,20 +73,7 @@ const withKcadmConfig = async <T>(work: (configPath: string) => Promise<T>): Pro
       throw new Error('Missing Keycloak provisioner/admin configuration');
     }
 
-    await execFileAsync('kcadm.sh', [
-      'config',
-      'credentials',
-      '--server',
-      baseUrl,
-      '--realm',
-      realm,
-      '--client',
-      clientId,
-      '--client-secret',
-      clientSecret,
-      '--config',
-      configPath,
-    ]);
+    await authenticateKcadm(configPath, baseUrl, realm, clientId, clientSecret);
     return await work(configPath);
   } finally {
     rmSync(configPath, { force: true });

--- a/tooling/quality/complexity-policy.json
+++ b/tooling/quality/complexity-policy.json
@@ -2848,24 +2848,6 @@
       "status": "open",
       "summary": "Lange Keycloak-Audit-Orchestrierung in kleinere Check- und Aggregationsschritte aufteilen (packages/instance-registry/src/service-audit-keycloak.ts)"
     },
-    "ops-scripts:scripts/ops/studio-instance-audit/keycloak.ts:cyclomaticComplexity": {
-      "ticketId": "QUAL-STUDIO-AUDIT-001",
-      "ticketSystem": "backlog",
-      "status": "open",
-      "summary": "Keycloak-Audit-Verzweigungen in kleinere Client-, Realm- und Check-Bausteine zerlegen (scripts/ops/studio-instance-audit/keycloak.ts)"
-    },
-    "ops-scripts:scripts/ops/studio-instance-audit/keycloak.ts:fileLines": {
-      "ticketId": "QUAL-STUDIO-AUDIT-001",
-      "ticketSystem": "backlog",
-      "status": "open",
-      "summary": "Keycloak-Audit-Datei in kleinere Auth-, Fetch- und Bewertungsmodule splitten (scripts/ops/studio-instance-audit/keycloak.ts)"
-    },
-    "ops-scripts:scripts/ops/studio-instance-audit/keycloak.ts:functionLines": {
-      "ticketId": "QUAL-STUDIO-AUDIT-001",
-      "ticketSystem": "backlog",
-      "status": "open",
-      "summary": "Lange Keycloak-Audit-Funktionen in kleinere Request-, Parse- und Summary-Schritte aufteilen (scripts/ops/studio-instance-audit/keycloak.ts)"
-    },
     "packages-default:packages/plugin-events/src/events.detail-content-tab.tsx:cyclomaticComplexity": {
       "ticketId": "QUAL-PLUGIN-EVENTS-DETAIL-001",
       "ticketSystem": "backlog",

--- a/tooling/testing/vitest.config.ts
+++ b/tooling/testing/vitest.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
       '../../scripts/ops/runtime/remote-verification.test.ts',
       '../../scripts/ops/runtime/smoke.test.ts',
       '../../scripts/ops/runtime/studio-image-verify-evidence.test.ts',
+      '../../scripts/ops/studio-instance-audit-keycloak.test.ts',
       '../../scripts/ops/tenant-ingress-audit.test.ts',
       '../../deploy/backup-agent/agent.test.ts',
       '../../deploy/backup-agent-stack.test.ts',


### PR DESCRIPTION
## Was geändert wurde

- trennt die read-only Keycloak-Erhebung des Studio-Instanz-Audits von der reinen Bewertung der 14 bestehenden Audit-Checks
- fixiert Check-IDs, Status, Zusammenfassungen, Details, `kcadm`-Befehlsfolge und Config-Cleanup durch Characterization-Tests
- hält Secret-Werte aus Ergebnissen und Testevidenz heraus
- entfernt die erledigten Complexity-Baselines `QUAL-STUDIO-AUDIT-001`
- ergänzt OpenSpec, Betriebsdokumentation und die betroffenen arc42-Sichten

## Warum

Der bisherige Audit-Callback vermischte Keycloak-I/O, Secret-Vergleiche und Check-Aggregation in einem kritischen Hotspot mit CC 57, COG 43, 179 Funktionszeilen und CRAP 3306. Die Trennung senkt das Änderungsrisiko, ohne den operativen Auditvertrag oder Keycloak zu verändern.

## Verifikation

- `pnpm exec vitest run scripts/ops/studio-instance-audit.test.ts scripts/ops/studio-instance-audit-keycloak.test.ts` (2 Dateien, 12 Tests)
- `pnpm exec tsc -p tsconfig.scripts.json --noEmit`
- targeted ESLint für Implementierung und Characterization-Test
- `pnpm complexity-gate`
- `pnpm check:file-placement`
- `pnpm exec openspec validate refactor-keycloak-instance-audit-evaluation --strict`
- `pnpm nx run data-client:build` und `pnpm test:ops:critical` (11 + 36 + 4 Tests)
- `pnpm nx run sva-studio-react:test:unit`
- `pnpm test:pr`

Fallow bestätigt, dass der kritische 57/43/179/3306-Hotspot entfallen ist und keine neuen Dead-Code-Funde eingeführt wurden. `fallow audit --gate new-only` bleibt wegen neun geerbten Repository-Dependency-Funden mit `introduced: false` rot; die geänderte Produktionslogik erreicht höchstens CC 5, COG 2 und CRAP 30.
