### PR TITLE
refactor(news): simplify compatibility snapshot sync

### DIFF
--- a/docs/architecture/08-cross-cutting-concepts.md
+++ b/docs/architecture/08-cross-cutting-concepts.md
@@ -772,3 +772,7 @@ Listenparameter werden aus den URL-Search-Params normalisiert. Fachfilter, die d
 - Geo-Unit-Freigaben haben weiterhin Vorrang vor dem Legacy-Geo-Scope-Fallback. Über-Mitternacht-Zeitfenster bleiben zulässig; ungültige vollständige Zeitfenster verweigern den Zugriff.
 - Restriktionen sind grantbezogen: Ein anderer passender und zulässiger Allow-Grant kann weiterhin erlauben. Es existiert weder eine generische Rule-Registry noch ein zweiter Authorize-Pfad.
 - Characterization-Tests sichern kollidierende Regeln, Provenance und das bestehende Force-Deny-Verhalten ohne permissiven Fallback ab.
+
+### News-Kompatibilitäts-Snapshot
+
+Der News-Editor hält historische Mainserver-Felder in einem internen Legacy-Snapshot: Nur ausdrücklich berührte Compatibility-Aliase mit passendem Laufzeittyp aktualisieren diesen Snapshot, während vereinfachte redaktionelle Felder und die bestehenden Publication-, Push- und ContentBlocks-Prioritäten führend bleiben.

--- a/docs/changelog/entries/pr-1006.json
+++ b/docs/changelog/entries/pr-1006.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1006,
+  "body": "Der News-Editor bewahrt ältere Kompatibilitätsfelder übersichtlicher\n\n- Redaktionelle Inhalte und Legacy-Felder behalten ihre bisherige Priorität.\n- Geplante Veröffentlichung, Push-Benachrichtigung und Ortsbezug werden weiterhin nur nach einer tatsächlichen Änderung übernommen.\n- Umfangreiche Regressionstests sichern Create- und Edit-Vorgänge sowie ungültige Kompatibilitätswerte ab."
+}

--- a/openspec/changes/refactor-news-compatibility-snapshot/design.md
+++ b/openspec/changes/refactor-news-compatibility-snapshot/design.md
@@ -1,0 +1,23 @@
+## Context
+
+Der News-Editor führt vereinfachte redaktionelle Formularfelder und interne Compatibility-Aliase für historische Mainserver-Felder zusammen. Nur als `touched` markierte Aliase dürfen den bestehenden Snapshot aktualisieren; mehrere Felder besitzen zusätzliche fachliche Regeln.
+
+## Goals / Non-Goals
+
+- Goals: unveränderte Touched- und Laufzeittypprüfung, unveränderte Publication- und Payload-Priorität, kleinere einzeln prüfbare Synchronisationsschritte.
+- Non-Goals: neue Legacy-Felder, öffentliche Formtypen, Scheduling-Korrekturen, API- oder Mainserver-Änderungen.
+
+## Decisions
+
+- Nur gleichförmige String- und Boolean-Felder werden in expliziten, vollständig typisierten Feldgruppen beschrieben.
+- `publishedAt`, `publicationDate`, `pushNotification`, `address` und `contentBlocks` bleiben benannte Sonderfunktionen, damit Reihenfolge und Seiteneffekte sichtbar bleiben.
+- Der bestehende Snapshot wird weiterhin in-place aktualisiert; Objekt- und Arrayreferenzen werden nicht zusätzlich geklont.
+
+## Risks / Trade-offs
+
+- Eine falsche Feldgruppenzuordnung könnte Laufzeittypen verändern. Die tabellengetriebene Altcode-Characterization prüft deshalb jedes Feld mit true/false/fehlendem Touched-Marker und passendem/falschem Typ.
+- Eine veränderte Sonderfallreihenfolge könnte Scheduling oder redaktionelle Inhalte überschreiben. Die Sonderpfade bleiben in derselben Aufrufreihenfolge und erhalten gezielte Konflikttests.
+
+## Migration Plan
+
+Kein Daten- oder API-Migrationsschritt. Das Refactoring wird durch Characterization, Nx-Gates und statischen sowie coveragegestützten New-only-Audit abgesichert.

--- a/openspec/changes/refactor-news-compatibility-snapshot/proposal.md
+++ b/openspec/changes/refactor-news-compatibility-snapshot/proposal.md
@@ -1,0 +1,17 @@
+# Change: News-Kompatibilitäts-Snapshot entflechten
+
+## Why
+
+Die Synchronisation historischer News-Felder bündelt gleichförmige Feldübernahmen und fachliche Sonderfälle in einer hochkomplexen Funktion. Eine explizit typisierte Zerlegung soll den laufenden Legacy-Datenvertrag prüfbar erhalten und das Risiko unbeabsichtigter Überschreibungen reduzieren.
+
+## What Changes
+
+- Gleichförmige String- und Boolean-Übernahmen werden über interne, typisierte Feldgruppen synchronisiert.
+- Publication-, Push-, Address- und ContentBlocks-Sonderfälle bleiben getrennt und behalten ihre bestehende Priorität.
+- Eine vollständige Characterization-Matrix belegt Touched-, Laufzeittyp-, Konflikt-, Referenz- und Create/Edit-Semantik.
+
+## Impact
+
+- Affected specs: `content-management`
+- Affected code: `packages/plugin-news/src/news.detail-form.ts`, zugehörige Tests
+- Affected arc42 sections: `08-cross-cutting-concepts`

--- a/openspec/changes/refactor-news-compatibility-snapshot/specs/content-management/spec.md
+++ b/openspec/changes/refactor-news-compatibility-snapshot/specs/content-management/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: News-Kompatibilitätsfelder bleiben snapshotbasiert und verlustfrei
+
+Der News-Editor MUST historische Compatibility-Aliaswerte nur bei einem ausdrücklich gesetzten Touched-Marker und passendem Laufzeittyp in den bestehenden Legacy-Snapshot übernehmen. Vereinfachte redaktionelle Felder MUST bei der Mutation führend bleiben; Publication-, Push-, Address- und ContentBlocks-Sonderregeln MUST ihre bestehende Priorität behalten.
+
+#### Scenario: Unberührter oder typfalscher Alias wird ignoriert
+
+- **WHEN** ein Compatibility-Alias keinen Touched-Marker besitzt, ausdrücklich unberührt ist oder einen falschen Laufzeittyp trägt
+- **THEN** bleibt der vorhandene Snapshotwert unverändert
+- **AND** die Mutation übernimmt keinen typfalschen Aliaswert
+
+#### Scenario: Mehrere gültige Aliase werden gemeinsam übernommen
+
+- **WHEN** mehrere Compatibility-Aliase als berührt markiert sind und passende Laufzeittypen tragen
+- **THEN** aktualisiert der Editor alle zugehörigen Snapshotwerte
+- **AND** nicht berührte bestehende Snapshotwerte bleiben erhalten
+
+#### Scenario: Vereinfachte redaktionelle Felder widersprechen Legacy-Inhalten
+
+- **WHEN** vereinfachte Titel-, Intro-, Body- oder Medienwerte gleichzeitig widersprüchliche Compatibility-ContentBlocks begleiten
+- **THEN** schreibt die Create- oder Edit-Mutation die vereinfachten redaktionellen Werte
+- **AND** die Compatibility-Werte ändern keine öffentliche Form- oder API-Semantik

--- a/openspec/changes/refactor-news-compatibility-snapshot/tasks.md
+++ b/openspec/changes/refactor-news-compatibility-snapshot/tasks.md
@@ -14,6 +14,6 @@
 ## 3. Dokumentation und Qualität
 
 - [x] 3.1 arc42 Abschnitt 08 um den snapshotbasierten Compatibility-Vertrag ergänzen
-- [ ] 3.2 Studio-Changelog-Eintrag für die tatsächliche PR-Nummer ergänzen
-- [ ] 3.3 Unit, Types, Lint, Build, Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
-- [ ] 3.4 Statischen und coveragegestützten New-only-Audit mit allen introduced Attributionen 0 ausführen
+- [x] 3.2 Studio-Changelog-Eintrag für die tatsächliche PR-Nummer ergänzen
+- [x] 3.3 Unit, Types, Lint, Build, Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
+- [x] 3.4 Statischen und coveragegestützten New-only-Audit mit allen introduced Attributionen 0 ausführen

--- a/openspec/changes/refactor-news-compatibility-snapshot/tasks.md
+++ b/openspec/changes/refactor-news-compatibility-snapshot/tasks.md
@@ -1,0 +1,19 @@
+## 1. Characterization
+
+- [x] 1.1 Gezielte Unit-Baseline und Types gegen den Altcode ausführen
+- [x] 1.2 Alle Compatibility-Felder für Touched true/false/fehlend und passende/falsche Laufzeittypen charakterisieren
+- [x] 1.3 Publication-, Mehrfachänderungs-, Referenz-/Clone-, Push- und Create/Edit-Konfliktfälle charakterisieren
+- [x] 1.4 Neue Characterization mit unveränderter Altcode-Source grün bestätigen
+
+## 2. Implementierung
+
+- [x] 2.1 Gleichförmige String- und Boolean-Feldübernahmen intern typisiert gruppieren
+- [x] 2.2 Publication-, Push-, Address- und ContentBlocks-Sonderfälle getrennt erhalten
+- [x] 2.3 Vollständige Characterization nach dem Refactoring unverändert grün bestätigen
+
+## 3. Dokumentation und Qualität
+
+- [x] 3.1 arc42 Abschnitt 08 um den snapshotbasierten Compatibility-Vertrag ergänzen
+- [ ] 3.2 Studio-Changelog-Eintrag für die tatsächliche PR-Nummer ergänzen
+- [ ] 3.3 Unit, Types, Lint, Build, Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
+- [ ] 3.4 Statischen und coveragegestützten New-only-Audit mit allen introduced Attributionen 0 ausführen

--- a/packages/plugin-news/src/news.detail-form.ts
+++ b/packages/plugin-news/src/news.detail-form.ts
@@ -671,41 +671,97 @@ const normalizeEditorialValues = (values: NewsDetailFormValues): NewsDetailFormV
   return values;
 };
 
-const syncSnapshotFromCompatibilityValues = (values: NewsDetailFormValues) => {
-  const compatibilityValues = values as CompatibilityFormValues;
-  const snapshot = ensureLegacySnapshot(values);
-  const touched = ensureCompatibilityTouched(values);
+type StringCompatibilitySnapshotField =
+  | 'keywords'
+  | 'externalId'
+  | 'newsType'
+  | 'charactersToBeShown'
+  | 'pointOfInterestId';
 
-  if (touched.keywords && typeof compatibilityValues.keywords === 'string') {
-    snapshot.keywords = compatibilityValues.keywords;
+type BooleanCompatibilitySnapshotField = 'fullVersion' | 'showPublishDate';
+
+const METADATA_STRING_COMPATIBILITY_FIELDS = [
+  'keywords',
+  'externalId',
+  'newsType',
+  'charactersToBeShown',
+] as const satisfies readonly StringCompatibilitySnapshotField[];
+
+const POINT_OF_INTEREST_COMPATIBILITY_FIELD = [
+  'pointOfInterestId',
+] as const satisfies readonly StringCompatibilitySnapshotField[];
+
+const BOOLEAN_COMPATIBILITY_FIELDS = [
+  'fullVersion',
+  'showPublishDate',
+] as const satisfies readonly BooleanCompatibilitySnapshotField[];
+
+const syncStringCompatibilityFields = (
+  compatibilityValues: CompatibilityFormValues,
+  snapshot: MutableLegacyCompatibilitySnapshot,
+  touched: NonNullable<NewsDetailEditorialFormValues['__compatibilityTouched']>,
+  fields: readonly StringCompatibilitySnapshotField[]
+) => {
+  for (const field of fields) {
+    const nextValue = compatibilityValues[field];
+    if (touched[field] && typeof nextValue === 'string') {
+      snapshot[field] = nextValue;
+    }
   }
-  if (touched.externalId && typeof compatibilityValues.externalId === 'string') {
-    snapshot.externalId = compatibilityValues.externalId;
+};
+
+const syncBooleanCompatibilityFields = (
+  compatibilityValues: CompatibilityFormValues,
+  snapshot: MutableLegacyCompatibilitySnapshot,
+  touched: NonNullable<NewsDetailEditorialFormValues['__compatibilityTouched']>
+) => {
+  for (const field of BOOLEAN_COMPATIBILITY_FIELDS) {
+    const nextValue = compatibilityValues[field];
+    if (touched[field] && typeof nextValue === 'boolean') {
+      snapshot[field] = nextValue;
+    }
   }
-  if (touched.newsType && typeof compatibilityValues.newsType === 'string') {
-    snapshot.newsType = compatibilityValues.newsType;
-  }
-  if (touched.charactersToBeShown && typeof compatibilityValues.charactersToBeShown === 'string') {
-    snapshot.charactersToBeShown = compatibilityValues.charactersToBeShown;
-  }
-  if (touched.fullVersion && typeof compatibilityValues.fullVersion === 'boolean') {
-    snapshot.fullVersion = compatibilityValues.fullVersion;
-  }
-  if (touched.showPublishDate && typeof compatibilityValues.showPublishDate === 'boolean') {
-    snapshot.showPublishDate = compatibilityValues.showPublishDate;
-  }
+};
+
+const syncPushNotificationCompatibilityValue = (
+  values: NewsDetailFormValues,
+  compatibilityValues: CompatibilityFormValues,
+  touched: NonNullable<NewsDetailEditorialFormValues['__compatibilityTouched']>
+) => {
   if (touched.pushNotification && typeof compatibilityValues.pushNotification === 'boolean') {
     values.pushNotificationEnabled = compatibilityValues.pushNotification;
   }
+};
+
+const syncPublishedAtCompatibilityValue = (
+  values: NewsDetailFormValues,
+  compatibilityValues: CompatibilityFormValues,
+  snapshot: MutableLegacyCompatibilitySnapshot,
+  touched: NonNullable<NewsDetailEditorialFormValues['__compatibilityTouched']>
+) => {
   if (touched.publishedAt && typeof compatibilityValues.publishedAt === 'string') {
     snapshot.publishedAt = compatibilityValues.publishedAt;
     if (values.publicationMode === 'draft' && values.scheduledPublicationAt.trim().length === 0) {
       syncPublicationModeFromPublishedAt(values, compatibilityValues.publishedAt);
     }
   }
+};
+
+const syncPublicationDateCompatibilityValue = (
+  compatibilityValues: CompatibilityFormValues,
+  snapshot: MutableLegacyCompatibilitySnapshot,
+  touched: NonNullable<NewsDetailEditorialFormValues['__compatibilityTouched']>
+) => {
   if (touched.publicationDate && typeof compatibilityValues.publicationDate === 'string') {
     snapshot.publicationDate = compatibilityValues.publicationDate;
   }
+};
+
+const syncAddressCompatibilityValue = (
+  compatibilityValues: CompatibilityFormValues,
+  snapshot: MutableLegacyCompatibilitySnapshot,
+  touched: NonNullable<NewsDetailEditorialFormValues['__compatibilityTouched']>
+) => {
   if (
     touched.address &&
     compatibilityValues.address &&
@@ -713,12 +769,41 @@ const syncSnapshotFromCompatibilityValues = (values: NewsDetailFormValues) => {
   ) {
     snapshot.address = compatibilityValues.address;
   }
-  if (touched.pointOfInterestId && typeof compatibilityValues.pointOfInterestId === 'string') {
-    snapshot.pointOfInterestId = compatibilityValues.pointOfInterestId;
-  }
+};
+
+const syncContentBlocksCompatibilityValue = (
+  compatibilityValues: CompatibilityFormValues,
+  snapshot: MutableLegacyCompatibilitySnapshot,
+  touched: NonNullable<NewsDetailEditorialFormValues['__compatibilityTouched']>
+) => {
   if (touched.contentBlocks && Array.isArray(compatibilityValues.contentBlocks)) {
     snapshot.legacyContentBlocks = compatibilityValues.contentBlocks;
   }
+};
+
+const syncSnapshotFromCompatibilityValues = (values: NewsDetailFormValues) => {
+  const compatibilityValues = values as CompatibilityFormValues;
+  const snapshot = ensureLegacySnapshot(values);
+  const touched = ensureCompatibilityTouched(values);
+
+  syncStringCompatibilityFields(
+    compatibilityValues,
+    snapshot,
+    touched,
+    METADATA_STRING_COMPATIBILITY_FIELDS
+  );
+  syncBooleanCompatibilityFields(compatibilityValues, snapshot, touched);
+  syncPushNotificationCompatibilityValue(values, compatibilityValues, touched);
+  syncPublishedAtCompatibilityValue(values, compatibilityValues, snapshot, touched);
+  syncPublicationDateCompatibilityValue(compatibilityValues, snapshot, touched);
+  syncAddressCompatibilityValue(compatibilityValues, snapshot, touched);
+  syncStringCompatibilityFields(
+    compatibilityValues,
+    snapshot,
+    touched,
+    POINT_OF_INTEREST_COMPATIBILITY_FIELD
+  );
+  syncContentBlocksCompatibilityValue(compatibilityValues, snapshot, touched);
 };
 
 export const mapNewsDetailFormValuesToMutation = (

--- a/packages/plugin-news/tests/news.detail-form.test.ts
+++ b/packages/plugin-news/tests/news.detail-form.test.ts
@@ -8,7 +8,13 @@ import {
   mapNewsItemToDetailFormValues,
   newsDetailFormSchema,
 } from '../src/news.detail-form.js';
-import type { NewsContentBlockFormValue, NewsContentItem } from '../src/news.types.js';
+import type {
+  NewsContentBlockFormValue,
+  NewsContentItem,
+  NewsDetailCompatibilityField,
+  NewsDetailFormValues,
+  NewsFormInput,
+} from '../src/news.types.js';
 
 const sampleItem: NewsContentItem = {
   id: 'news-1',
@@ -47,6 +53,119 @@ const sampleItem: NewsContentItem = {
   createdAt: '2026-05-20T09:00:00.000Z',
   updatedAt: '2026-05-22T09:00:00.000Z',
 };
+
+type CompatibilityTouchRuntime = true | false | undefined;
+
+const defineCompatibilityRuntimeInput = (
+  values: NewsDetailFormValues,
+  key: NewsDetailCompatibilityField,
+  value: unknown,
+  touched: CompatibilityTouchRuntime
+) => {
+  Object.defineProperty(values, key, {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value,
+  });
+
+  if (touched === undefined) {
+    delete (values as unknown as Record<string, unknown>).__compatibilityTouched;
+    return;
+  }
+
+  Object.defineProperty(values, '__compatibilityTouched', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: { [key]: touched },
+  });
+};
+
+const readMutationField = (mutation: NewsFormInput, key: string): unknown =>
+  (mutation as unknown as Record<string, unknown>)[key];
+
+const compatibilityFieldCases = [
+  {
+    key: 'keywords',
+    mutationKey: 'keywords',
+    validValue: 'Neue Schlagwörter',
+    invalidValue: 42,
+    initialValue: 'Rathaus, Termin',
+    updatedValue: 'Neue Schlagwörter',
+  },
+  {
+    key: 'externalId',
+    mutationKey: 'externalId',
+    validValue: 'ext-new',
+    invalidValue: false,
+    initialValue: 'ext-42',
+    updatedValue: 'ext-new',
+  },
+  {
+    key: 'newsType',
+    mutationKey: 'newsType',
+    validValue: 'warnung',
+    invalidValue: [],
+    initialValue: 'meldung',
+    updatedValue: 'warnung',
+  },
+  {
+    key: 'charactersToBeShown',
+    mutationKey: 'charactersToBeShown',
+    validValue: '240',
+    invalidValue: 240,
+    initialValue: 180,
+    updatedValue: 240,
+  },
+  {
+    key: 'fullVersion',
+    mutationKey: 'fullVersion',
+    validValue: false,
+    invalidValue: 'false',
+    initialValue: true,
+    updatedValue: false,
+  },
+  {
+    key: 'showPublishDate',
+    mutationKey: 'showPublishDate',
+    validValue: true,
+    invalidValue: 1,
+    initialValue: false,
+    updatedValue: true,
+  },
+  {
+    key: 'pushNotification',
+    mutationKey: 'pushNotification',
+    validValue: true,
+    invalidValue: 'true',
+    initialValue: false,
+    updatedValue: true,
+  },
+  {
+    key: 'pointOfInterestId',
+    mutationKey: 'pointOfInterestId',
+    validValue: 'poi-new',
+    invalidValue: null,
+    initialValue: 'poi-1',
+    updatedValue: 'poi-new',
+  },
+  {
+    key: 'address',
+    mutationKey: 'address',
+    validValue: { street: 'Neue Straße 2', zip: '54321', city: 'Neustadt' },
+    invalidValue: 'Neue Straße 2',
+    initialValue: { street: 'Marktplatz 1', zip: '12345', city: 'Musterstadt' },
+    updatedValue: { street: 'Neue Straße 2', zip: '54321', city: 'Neustadt' },
+  },
+] as const satisfies readonly {
+  key: NewsDetailCompatibilityField;
+  mutationKey: string;
+  validValue: unknown;
+  invalidValue: unknown;
+  initialValue: unknown;
+  updatedValue: unknown;
+}[];
 
 describe('news.detail-form', () => {
   it('backs compatibility aliases with the hidden snapshot instead of standalone public state', () => {
@@ -198,6 +317,123 @@ describe('news.detail-form', () => {
     expect(mutation).not.toHaveProperty('charactersToBeShown');
   });
 
+  it.each(compatibilityFieldCases)(
+    'applies touched $key compatibility values with their matching runtime type',
+    ({ key, mutationKey, validValue, updatedValue }) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      defineCompatibilityRuntimeInput(values, key, validValue, true);
+
+      const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+      expect(readMutationField(mutation, mutationKey)).toEqual(updatedValue);
+    }
+  );
+
+  it.each(compatibilityFieldCases)(
+    'ignores explicitly untouched $key compatibility values',
+    ({ key, mutationKey, validValue, initialValue }) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      defineCompatibilityRuntimeInput(values, key, validValue, false);
+
+      const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+      expect(readMutationField(mutation, mutationKey)).toEqual(initialValue);
+    }
+  );
+
+  it.each(compatibilityFieldCases)(
+    'ignores $key compatibility values when the touched marker is missing',
+    ({ key, mutationKey, validValue, initialValue }) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      defineCompatibilityRuntimeInput(values, key, validValue, undefined);
+
+      const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+      expect(readMutationField(mutation, mutationKey)).toEqual(initialValue);
+    }
+  );
+
+  it.each(compatibilityFieldCases)(
+    'ignores touched $key compatibility values with a mismatching runtime type',
+    ({ key, mutationKey, invalidValue, initialValue }) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      defineCompatibilityRuntimeInput(values, key, invalidValue, true);
+
+      const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+      expect(readMutationField(mutation, mutationKey)).toEqual(initialValue);
+    }
+  );
+
+  it('applies multiple touched compatibility fields without losing the existing snapshot', () => {
+    const values = mapNewsItemToDetailFormValues(sampleItem);
+    values.keywords = 'Mehrfach';
+    values.externalId = 'ext-multi';
+    values.fullVersion = false;
+    values.address = { street: 'Nebenstraße 4', zip: '77777', city: 'Anderswo' };
+
+    expect(mapNewsDetailFormValuesToMutation(values, 'edit')).toMatchObject({
+      keywords: 'Mehrfach',
+      externalId: 'ext-multi',
+      fullVersion: false,
+      newsType: 'meldung',
+      pointOfInterestId: 'poi-1',
+      address: { street: 'Nebenstraße 4', zip: '77777', city: 'Anderswo' },
+    });
+  });
+
+  it.each([true, false, undefined] as const)(
+    'stores compatibility content blocks only when touched is %s',
+    (touched) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      const blocks: NewsContentBlockFormValue[] = [
+        {
+          title: 'Compatibility-Titel',
+          intro: 'Compatibility-Intro',
+          body: '<p>Compatibility-Body</p>',
+          mediaContents: [],
+        },
+      ];
+      defineCompatibilityRuntimeInput(values, 'contentBlocks', blocks, touched);
+
+      const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+      if (touched === true) {
+        expect(values.__legacySnapshot?.legacyContentBlocks).toBe(blocks);
+      } else {
+        expect(values.__legacySnapshot?.legacyContentBlocks).not.toBe(blocks);
+      }
+      expect(mutation.contentBlocks?.[0]).toMatchObject({
+        title: 'Rathaus informiert',
+        intro: 'Kurzer Einstieg',
+        body: '<p>Ausfuehrlicher Inhalt</p>',
+      });
+      expect(mutation.contentBlocks).not.toBe(blocks);
+    }
+  );
+
+  it('ignores touched content blocks with a mismatching runtime type', () => {
+    const values = mapNewsItemToDetailFormValues(sampleItem);
+    const existingBlocks = values.__legacySnapshot?.legacyContentBlocks;
+    defineCompatibilityRuntimeInput(values, 'contentBlocks', { title: 'Kein Array' }, true);
+
+    mapNewsDetailFormValuesToMutation(values, 'edit');
+
+    expect(values.__legacySnapshot?.legacyContentBlocks).toBe(existingBlocks);
+  });
+
+  it('retains compatibility object references in the snapshot and clones mutation values', () => {
+    const values = mapNewsItemToDetailFormValues(sampleItem);
+    const address = { street: 'Referenzweg 1', zip: '10101', city: 'Klonstadt' };
+    defineCompatibilityRuntimeInput(values, 'address', address, true);
+
+    const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+    expect(values.__legacySnapshot?.address).toBe(address);
+    expect(mutation.address).toEqual(address);
+    expect(mutation.address).not.toBe(address);
+  });
+
   it('preserves bullet lists, ordered lists, and links in serialized editor HTML', () => {
     const values = createDefaultNewsDetailFormValues('Redaktion');
     const formattedHtml =
@@ -251,6 +487,117 @@ describe('news.detail-form', () => {
     });
   });
 
+  it.each([true, false, undefined] as const)(
+    'updates publicationDate independently when touched is %s',
+    (touched) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      defineCompatibilityRuntimeInput(
+        values,
+        'publicationDate',
+        '2026-07-01T08:15:00.000Z',
+        touched
+      );
+
+      const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+      expect(mutation.publicationDate).toBe(
+        touched === true ? '2026-07-01T08:15:00.000Z' : '2026-05-24T09:00:00.000Z'
+      );
+      expect(mutation.publishedAt).toBe('2026-05-24T09:00:00.000Z');
+    }
+  );
+
+  it('ignores a touched publicationDate with a mismatching runtime type', () => {
+    const values = mapNewsItemToDetailFormValues(sampleItem);
+    defineCompatibilityRuntimeInput(values, 'publicationDate', 1_780_300_000_000, true);
+
+    const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+    expect(mutation.publicationDate).toBe('2026-05-24T08:00:00.000Z');
+    expect(values.__legacySnapshot?.publicationDate).toBe('2026-05-24T08:00:00.000Z');
+  });
+
+  it.each([false, undefined] as const)(
+    'ignores a matching publishedAt value when touched is %s',
+    (touched) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      defineCompatibilityRuntimeInput(values, 'publishedAt', '2026-07-02T09:30', touched);
+
+      const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+      expect(mutation.publishedAt).toBe('2026-05-24T09:00:00.000Z');
+      expect(values.publicationMode).toBe('immediate');
+    }
+  );
+
+  it('ignores a touched publishedAt value with a mismatching runtime type', () => {
+    const values = mapNewsItemToDetailFormValues(sampleItem);
+    defineCompatibilityRuntimeInput(values, 'publishedAt', { iso: '2026-07-02T09:30' }, true);
+
+    const mutation = mapNewsDetailFormValuesToMutation(values, 'edit');
+
+    expect(mutation.publishedAt).toBe('2026-05-24T09:00:00.000Z');
+    expect(values.__legacySnapshot?.publishedAt).toBe('2026-05-24T09:00:00.000Z');
+  });
+
+  it('synchronizes a touched publishedAt only for a draft without a scheduled value', () => {
+    const eligibleDraft = mapNewsItemToDetailFormValues(sampleItem);
+    eligibleDraft.publicationMode = 'draft';
+    eligibleDraft.scheduledPublicationAt = '';
+    defineCompatibilityRuntimeInput(eligibleDraft, 'publishedAt', '2026-07-02T09:30', true);
+
+    const occupiedDraft = mapNewsItemToDetailFormValues(sampleItem);
+    occupiedDraft.publicationMode = 'draft';
+    occupiedDraft.scheduledPublicationAt = '2026-07-03T10:45';
+    defineCompatibilityRuntimeInput(occupiedDraft, 'publishedAt', '2026-07-02T09:30', true);
+
+    const scheduled = mapNewsItemToDetailFormValues(sampleItem);
+    scheduled.publicationMode = 'scheduled';
+    scheduled.scheduledPublicationAt = '2026-07-04T11:00';
+    defineCompatibilityRuntimeInput(scheduled, 'publishedAt', '2026-07-02T09:30', true);
+
+    expect(mapNewsDetailFormValuesToMutation(eligibleDraft, 'edit')).toMatchObject({
+      publishedAt: '2026-07-02T09:30',
+      publicationDate: '2026-05-24T08:00:00.000Z',
+    });
+    expect(eligibleDraft).toMatchObject({ publicationMode: 'draft', scheduledPublicationAt: '' });
+
+    expect(mapNewsDetailFormValuesToMutation(occupiedDraft, 'edit').publishedAt).toBe(
+      '2026-07-02T09:30'
+    );
+    expect(occupiedDraft).toMatchObject({
+      publicationMode: 'draft',
+      scheduledPublicationAt: '2026-07-03T10:45',
+    });
+
+    expect(mapNewsDetailFormValuesToMutation(scheduled, 'edit').publishedAt).toBe(
+      '2026-07-04T11:00'
+    );
+    expect(scheduled).toMatchObject({
+      publicationMode: 'scheduled',
+      scheduledPublicationAt: '2026-07-04T11:00',
+    });
+  });
+
+  it('keeps blank publishedAt handling distinct for draft and scheduled values', () => {
+    const draft = mapNewsItemToDetailFormValues(sampleItem);
+    draft.publicationMode = 'draft';
+    draft.scheduledPublicationAt = '';
+    defineCompatibilityRuntimeInput(draft, 'publishedAt', '', true);
+
+    const scheduled = mapNewsItemToDetailFormValues(sampleItem);
+    scheduled.publicationMode = 'scheduled';
+    scheduled.scheduledPublicationAt = '2026-07-04T11:00';
+    defineCompatibilityRuntimeInput(scheduled, 'publishedAt', '', true);
+
+    const draftMutation = mapNewsDetailFormValuesToMutation(draft, 'edit');
+    const scheduledMutation = mapNewsDetailFormValuesToMutation(scheduled, 'edit');
+
+    expect(draft).toMatchObject({ publicationMode: 'draft', scheduledPublicationAt: '' });
+    expect(Number.isNaN(new Date(draftMutation.publishedAt).getTime())).toBe(false);
+    expect(scheduledMutation.publishedAt).toBe('2026-07-04T11:00');
+  });
+
   it('serializes edit payloads from the simplified fields even when compatibility data disagrees', () => {
     const values = mapNewsItemToDetailFormValues(sampleItem);
 
@@ -290,6 +637,44 @@ describe('news.detail-form', () => {
         }),
       ],
     });
+  });
+
+  it.each(['create', 'edit'] as const)(
+    'keeps simplified editorial values ahead of contradictory compatibility blocks in %s mode',
+    (mode) => {
+      const values = mapNewsItemToDetailFormValues(sampleItem);
+      const compatibilityBlocks: NewsContentBlockFormValue[] = [
+        {
+          title: 'Legacy-Titel',
+          intro: 'Legacy-Intro',
+          body: '<p>Legacy-Body</p>',
+          mediaContents: [],
+        },
+      ];
+      values.title = 'Führender Titel';
+      values.contentIntro = 'Führendes Intro';
+      values.contentBody = '<p>Führender Body</p>';
+      defineCompatibilityRuntimeInput(values, 'contentBlocks', compatibilityBlocks, true);
+
+      expect(mapNewsDetailFormValuesToMutation(values, mode).contentBlocks?.[0]).toMatchObject({
+        title: 'Führender Titel',
+        intro: 'Führendes Intro',
+        body: '<p>Führender Body</p>',
+      });
+    }
+  );
+
+  it('keeps push inclusion distinct for create and previously notified edits', () => {
+    const values = mapNewsItemToDetailFormValues({
+      ...sampleItem,
+      pushNotificationsSentAt: '2026-05-24T09:01:00.000Z',
+    });
+    defineCompatibilityRuntimeInput(values, 'pushNotification', true, true);
+
+    expect(mapNewsDetailFormValuesToMutation(values, 'create').pushNotification).toBe(true);
+    expect(mapNewsDetailFormValuesToMutation(values, 'edit')).not.toHaveProperty(
+      'pushNotification'
+    );
   });
 
   it('validates the compatibility-only schema branches for legacy fields and invalid urls', async () => {


### PR DESCRIPTION
## Zusammenfassung

- entflechtet die interne Compatibility-Snapshot-Synchronisierung in typisierte Feldgruppen und klar benannte Sonderpfade
- bewahrt Publication-, Push-, Address-, ContentBlocks- und Create/Edit-Semantik ohne öffentlichen Vertragswechsel
- ergänzt 54 Altcode-Characterizations sowie OpenSpec und arc42-Dokumentation

## Fallow

- vorher: `syncSnapshotFromCompatibilityValues` CC 28, Cognitive 27, CRAP 197,3 (critical)
- nachher: Ziel-Finding entfernt
- statischer New-only-Audit auf `ed29951ac98d965874df38b33924f27a560861a3`: PASS; complexity/dead_code/duplication/styling introduced jeweils 0
- Coverage-Audit mit echter Nx-Coverage auf demselben HEAD: PASS; keine Complexity-Findings, alle introduced jeweils 0

## Tests und Gates

- Altcode-Characterization: 72/72 gezielte Tests grün, bevor Source geändert wurde
- `plugin-news:test:coverage`: 201/201, Statements 93,58 %, Branches 85,39 %, Functions 93,97 %, Lines 93,94 %
- Unit, Types, Lint, Build, Complexity, OpenSpec strict, File Placement, Server Runtime, Changelog, `git diff --check`: grün
- `pnpm test:pr`: grün inklusive Studio-Unit, Build und E2E (47 passed, 8 skipped)

## Reviews

- Root-Diffreview auf `ed29951ac98d965874df38b33924f27a560861a3`: NO FINDINGS; Feldpriorität, Sonderfall-Reihenfolge, Fallbacks und Referenzsemantik bestätigt
- unabhängiges risikoorientiertes Review auf `ed29951ac98d965874df38b33924f27a560861a3`: NO FINDINGS; Semantikparität, Datenintegrität, Fallow/CRAP und Testabdeckung bestätigt

OpenSpec: `refactor-news-compatibility-snapshot`