### PR TITLE
docs(plans): plan third Fallow improvement round

### DIFF
--- a/docs/changelog/entries/pr-1008.json
+++ b/docs/changelog/entries/pr-1008.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1008,
+  "body": "Die dritte wirtschaftliche Fallow-Verbesserungsrunde ist geplant\n\n- Die Live-Baseline auf dem neuesten origin/main dokumentiert Health, produktiven Dead Code, Dependencies, Boundaries und Duplikation.\n- Fünf produktiv erreichbare Zielprobleme sind nach Risiko und Wirtschaftlichkeit ausgewählt und in drei kohärente Arbeitspakete gebündelt.\n- Jeder Problemplan enthält Characterization, exakte Gates, Fallow-Abnahme und harte STOP-Bedingungen."
+}

--- a/plans/022-refactor-poi-form-serialization.md
+++ b/plans/022-refactor-poi-form-serialization.md
@@ -1,0 +1,60 @@
+# Plan 022: POI-Formularserialisierung entflechten
+
+> **Executor-Anweisung:** Arbeite nur im zugewiesenen Worktree. Führe vor jeder produktiven Änderung die Baseline und neue Characterization-Tests gegen den unveränderten Altcode aus. Bei einer STOP-Bedingung nicht improvisieren.
+
+## Status
+
+- **Priorität:** P1
+- **Aufwand:** M–L
+- **Risiko:** MITTEL
+- **Abhängigkeit:** gemeinsam mit Plan 023 in Bundle A
+- **Kategorie:** POI-Datenintegrität, Complexity, CRAP
+- **Geplant auf:** `98e6ca3d7`, 15. August 2026
+- **Fallow vorher:** `poi.detail-form.serialization.ts` hat 259 Zeilen, 27 Funktionen, Cyclomatic gesamt 197, Cognitive gesamt 85, MI 69,4, Complexity-Dichte 0,76 und sechs CRAP-Findings. Kritisch sind die Mapper ab Zeile 140 mit CC 33/CRAP 268,2 und ab Zeile 112 mit CC 26/CRAP 172; `compactAddress`, `compactContact`, `compactLocation` und der Medienmapper liegen jeweils bei CC 19/CRAP 97.
+
+## Warum und Produktionsreichweite
+
+Das Modul übersetzt das bearbeitete POI-Formular in den Mainserver-Mutationsvertrag. Fehler verlieren explizite Leerungen, verändern Koordinaten, Öffnungszeiten, Preise, Medien oder die Reihenfolge von Kategorien. Der Export läuft über `poi.detail-form.ts`, wird in `poi.detail-page.tsx` vor Create/Update aufgerufen und ist damit produktiv erreichbar. Der Hotspot-Score beträgt 15,9 bei 15 Commits, +365/−107 Zeilen und Fan-in 1.
+
+## Scope
+
+**In Scope:** `packages/plugin-poi/src/poi.detail-form.serialization.ts`, bei belegtem Bedarf ein minimales pluginlokales Helper-Modul, `packages/plugin-poi/tests/poi.detail-form.test.ts`, gemeinsamer OpenSpec-Change und Changelog für Bundle A.
+
+**Out of Scope:** Events-/News-Module, Mainserver-Vertrag, öffentliche POI-Typen, Validierung, neue Shared-Package-Grenze, Clone `dup:9b9f8261`, funktionale Korrekturen.
+
+**Aktive-Abgrenzung:** `refactor-shared-editor-primitives` besitzt POI-UI-
+Sections und Repeater, erklärt Mapping/Validierung/Speichern aber ausdrücklich
+als pluginlokal. `add-studio-data-form-and-test-foundations` setzt seine
+Referenzimplementierung außerhalb des POI-Mappings um. Dieser Plan ändert weder
+UI-Primitives noch Shared-Testinfrastruktur. Vor Start beide aktiven Changes und
+Branch-Deltas erneut prüfen; bei Datei-, Testinfrastruktur- oder
+Vertragsüberschneidung STOP.
+
+## Characterization vor Refactoring
+
+1. Baseline: `pnpm nx run plugin-poi:test:unit --testFiles=tests/poi.detail-form.test.ts` und `pnpm nx run plugin-poi:test:types`; beide müssen grün sein.
+2. Gegen Altcode ergänzen und grün ausführen: `null`/`undefined`/Whitespace; leere und teilweise Adresse, Kontakt, Location; Latitude/Longitude einzeln, `NaN`, Infinity und numerischer String; Kategorien-Deduplikation und Reihenfolge; Öffnungszeiten mit Boolean-only-/Platzhalterzeilen; Preise einschließlich `0` und `false`; Medien ohne URL bzw. mit MIME-Normalisierung; Operator leer/teilweise; explizite Clears für Mobile Description, External ID, Keywords und Tags; Payload `undefined`, Objekt und falscher Runtime-Typ.
+3. Für jedes neue Testset den unveränderten Produktionsdiff mit `git diff -- packages/plugin-poi/src` prüfen: vor dem Refactor darf dort keine Änderung stehen.
+
+## Umsetzung
+
+1. Wiederholte Normalisierung genau einmal pro Feld auswerten und fachlich benannte kleine Mapper verwenden. Keine Reflection, keine generische Pfad-Engine und kein `any`.
+2. Öffnungszeiten, Preise und Medien in jeweils klaren, reinen Transformationen halten; Fallback-, Filter- und Reihenfolgesemantik unverändert lassen.
+3. Erst nach grüner Characterization produktiven Code ändern. Nach jedem Block den gezielten Unit-Run wiederholen.
+4. Gemeinsam mit Plan 023 OpenSpec `refactor-poi-form-contract` strikt validieren.
+
+## Gates und Fertig-Kriterien
+
+- `pnpm nx run plugin-poi:test:unit --testFiles=tests/poi.detail-form.test.ts`
+- `pnpm nx run plugin-poi:test:coverage --testFiles=tests/poi.detail-form.test.ts`
+- `pnpm nx run plugin-poi:test:types`, `pnpm nx run plugin-poi:lint`, `pnpm nx run plugin-poi:build`
+- `pnpm complexity-gate`, `pnpm exec openspec validate refactor-poi-form-contract --strict`, `pnpm check:file-placement`, `pnpm check:studio-changelog`, `git diff --check`
+- Final einmal `pnpm test:pr`, sofern der gemessene affected Scope praktikabel ist; Abweichung dokumentieren.
+- Vor Draft und nach Source-Revision: `pnpm exec fallow audit --base origin/main --workspace @sva/plugin-poi --explain --format json`; PASS mit Complexity/Dead Code/Duplication/Styling introduced 0 und ohne moderate CRAP-Neufunde, bei Bedarf mit echter Coverage wiederholen.
+- Zielanker und alle berührten Serialization-Findings sind verschwunden; öffentliche Shapes, Werte, Reihenfolge und Clears bleiben byte-/deep-equal zur Characterization.
+
+## STOP
+
+- STOP, wenn Mainserver-Feldvertrag, Validierung oder öffentliche POI-Typen geändert werden müssten.
+- STOP, wenn Altcode-Tests widersprüchliche Clear-, Fallback- oder Reihenfolgesemantik zeigen.
+- STOP bei aktiver Source-/Testüberschneidung oder wenn eine Cross-Plugin-Abstraktion nötig erscheint.

--- a/plans/023-refactor-poi-form-mapping.md
+++ b/plans/023-refactor-poi-form-mapping.md
@@ -1,0 +1,54 @@
+# Plan 023: POI-Inbound-Mapping charakterisieren und vereinfachen
+
+> **Executor-Anweisung:** Dieser Plan ist das zweite eigenständige Zielproblem in Bundle A. Seine Characterization-Evidenz muss separat erkennbar bleiben, auch wenn dieselbe Testdatei wie Plan 022 verwendet wird.
+
+## Status
+
+- **Priorität:** P1
+- **Aufwand:** M
+- **Risiko:** MITTEL
+- **Abhängigkeit:** gemeinsam mit Plan 022
+- **Kategorie:** POI-Legacy-Daten, Complexity, CRAP
+- **Geplant auf:** `98e6ca3d7`, 15. August 2026
+- **Fallow vorher:** `poi.detail-form.mapping.ts` hat 130 Zeilen, 11 Funktionen, CC gesamt 96, Cognitive gesamt 42, MI 70,6 und Dichte 0,74. Zielanker ist `mapPoiContentToFormValues` mit CC 27/Cognitive 14/CRAP 184,5. `mapPriceToFormValue` liegt bei CC 16/CRAP 71,3; die bereits kleinen Kontakt-, Adress- und Location-Mapper liegen zwischen CRAP 43,1 und 49,5 und sind Characterization-, nicht zwingend Refactoring-Ziele.
+
+## Warum und Produktionsreichweite
+
+Das Modul wandelt bestehende Mainserver-POIs in Formularwerte um. Es entscheidet über Legacy-Kategorien, Defaultzeilen, `active !== false`, Numerik und Payload-Text. Der Export läuft über `poi.detail-form.ts` und wird nach `getPoiDetail` vor `react-hook-form reset` in `poi.detail-page.tsx` aufgerufen. Der Hotspot hat sechs Commits, +154/−25 Zeilen und Fan-in 1.
+
+## Scope
+
+**In Scope:** `mapPoiContentToFormValues` in `packages/plugin-poi/src/poi.detail-form.mapping.ts`, nur bei fachlichem Bedarf unmittelbar verwendete pluginlokale Mapper, `packages/plugin-poi/tests/poi.detail-form.test.ts`, gemeinsamer OpenSpec-/Changelog-Scope.
+
+**Out of Scope:** rein metrisches Zerlegen der bereits 8–13 Zeilen kleinen Kontakt-, Adress- und Location-Mapper, Events-Mapper, der kleine Clone `dup:9b9f8261`, Mainserver-Snapshots, neue Defaultwerte, Änderung öffentlicher Formtypen oder UI-Komponenten.
+
+## Characterization vor Refactoring
+
+1. Baseline: `pnpm nx run plugin-poi:test:unit --testFiles=tests/poi.detail-form.test.ts` und `pnpm nx run plugin-poi:test:types`; beide müssen grün sein.
+2. Eigene Tests für: Kategorienliste gewinnt vor `categoryName`; Fallback auf `categoryName`; leere Kategorien; `active` true/false/fehlend; fehlende vs. leere Adressen, Web-URLs, Öffnungszeiten, Preise und Zertifikate; Kontakt/Location/Operator teilweise; `0`, negative und nichtendliche Zahlen; Payload `undefined`, `null`, Array und Objekt; Wochentagsnormalisierung; Eingabelistenreihenfolge und Referenz-/Clone-Verhalten.
+3. Roundtrip-Fälle Mapping → Serialisierung getrennt von den reinen Inbound-Erwartungen halten.
+4. Neue Fälle auf unverändertem Produktionscode grün ausführen und mit `git diff -- packages/plugin-poi/src` nachweisen, dass vor dem Refactor kein Source-Diff besteht.
+
+## Umsetzung
+
+1. Die verzweigte Orchestrierung in `mapPoiContentToFormValues` durch einmalig berechnete, fachlich benannte Zwischenergebnisse vereinfachen; vorhandene kleine Mapper nur ändern, wenn dies echte doppelte Ownership entfernt.
+2. Keine gemeinsame Events-/News-Abstraktion und keine generische Feld-Engine einführen.
+3. Nach jedem Block gezielte Unit-Tests; Plan-022- und Plan-023-Fälle müssen gemeinsam grün bleiben.
+
+## Gates und Fertig-Kriterien
+
+- `pnpm nx run plugin-poi:test:unit --testFiles=tests/poi.detail-form.test.ts`
+- `pnpm nx run plugin-poi:test:coverage --testFiles=tests/poi.detail-form.test.ts`
+- `pnpm nx run plugin-poi:test:types`
+- `pnpm nx run plugin-poi:lint`
+- `pnpm nx run plugin-poi:build`
+- `pnpm complexity-gate`
+- `pnpm exec openspec validate refactor-poi-form-contract --strict`
+- `pnpm check:file-placement`
+- `pnpm check:studio-changelog`
+- `git diff --check`
+- Final einmal `pnpm test:pr`, sofern der zuvor gemessene affected Scope praktikabel ist; eine Auslassung mit gemessenem Scope und Ersatzgates dokumentieren.
+- Vor Draft und nach jeder relevanten Source-Revision: `pnpm exec fallow audit --base origin/main --workspace @sva/plugin-poi --explain --format json`. Erwartet: `PASS`, `complexity_introduced: 0`, `dead_code_introduced: 0`, `duplication_introduced: 0`, `styling_introduced: 0` und keine neuen moderaten CRAP-Findings. Coverageabhängiges CRAP mit der vom Coverage-Target erzeugten `coverage-final.json` erneut prüfen.
+- Fertig ist der Plan, wenn der Zielanker `mapPoiContentToFormValues` verschwunden ist und Default-, Legacy-, Reihenfolge- und Payload-Semantik exakt belegt bleibt. Die kleinen Mapper dürfen als Bestandsfindings verbleiben, wenn ihre Änderung nur den Score verschöbe. Der Events-/POI-Clone bleibt unverändert, sofern er nicht allein durch natürliche Vereinfachung verschwindet.
+
+STOP bei notwendiger Mainserver-/Formvertragsänderung, bei Konflikt zwischen Roundtrip und bestehender UI-Semantik, bei `any`/Reflection oder bei einer neuen Cross-Plugin-Ownership-Grenze. Vor Start außerdem STOP, wenn `refactor-shared-editor-primitives` oder `add-studio-data-form-and-test-foundations` inzwischen dieselbe Mapping-Source, reine Formvertragstestfälle oder Testinfrastruktur beansprucht.

--- a/plans/024-refactor-instance-realm-operation-steps.md
+++ b/plans/024-refactor-instance-realm-operation-steps.md
@@ -1,0 +1,67 @@
+# Plan 024: Realm-Operationsschritte deklarativ und semantikgleich aufbauen
+
+> **Executor-Anweisung:** IAM-/Realm-Zustände sind sicherheitsrelevant. Vor dem Refactor muss eine kombinatorische Status-, Prioritäts-, Fallback- und Negativmatrix gegen Altcode grün sein.
+
+## Status
+
+- **Priorität:** P1
+- **Aufwand:** M–L
+- **Risiko:** HOCH
+- **Abhängigkeit:** gemeinsam mit Plan 025 in Bundle B
+- **Kategorie:** IAM-UI-Vertrag, Datenintegrität, Complexity, CRAP
+- **Geplant auf:** `98e6ca3d7`, 15. August 2026
+- **Fallow vorher:** `-instances-shared.tsx` hat 778 Zeilen, 39 Funktionen, Fan-in 4, CC gesamt 232, Cognitive gesamt 171, MI 79,6, fünf CRAP-Findings und Hotspot-Score 5,6 bei 22 Commits. Zielgruppe: `buildExistingRealmAssessmentSteps` CC 35/Cognitive 41/CRAP 299,6; `buildNewRealmArtifactSteps` 28/22/197,3; `buildNewRealmLeadSteps` 20/19/106,4; `buildWorkerPreflightStep` 17/29/79,4.
+
+## Warum und Produktionsreichweite
+
+Die Builder bestimmen, welche Realm-Vertrags-, Preflight-, Provisionierungs-, Drift-, Reconcile- und Abschlusszustände Administratoren sehen und welche Aktion angeboten wird. Die Datei wird produktiv von Detail-Page-Helpers, Doctor-Modell und Detailseite konsumiert. Eine Prioritäts- oder Fallbackänderung kann einen fehlerhaften IAM-Zustand als bereit darstellen oder notwendige Reparatur verdecken.
+
+## Scope
+
+**In Scope:** die vier genannten Builder in `apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx`, ein minimales internes Modul im selben Route-Cluster, `-instances-shared.test.tsx` und `-instance-detail-models.test.ts`, OpenSpec `refactor-instance-realm-operations`, Changelog.
+
+**Out of Scope:** Keycloak-/Registry-Backend, API-Aufrufe, Mutationswerte aus Plan 017/PR #1001, neue Actions, Übersetzungsinhalte, Realm-Vertragskorrekturen, `instance-interfaces*`, PR #983/#984.
+
+**Aktive-Abgrenzung:** `update-instance-detail-module-tab` besitzt Module-Tab,
+Navigation, Module-Workspace und deren Journey-/UI-Fixtures. Dieser Plan besitzt
+nur das bestehende Realm-Operationsmodell und die zwei benannten Modelltests.
+Vor Start den aktiven Change und Branch-Delta erneut prüfen; bei Datei-, Fixture-
+oder Vertragsüberschneidung STOP.
+
+## Characterization vor Refactoring
+
+1. Baseline: `pnpm nx run sva-studio-react:test:unit --testFiles=src/routes/admin/instances/-instances-shared.test.tsx --testFiles=src/routes/admin/instances/-instance-detail-models.test.ts` sowie `pnpm nx run sva-studio-react:test:types` müssen grün sein.
+2. New Realm: Vertrag vollständig/unvollständig; Preflight fehlt/ready/blocked inklusive `realm_mode`-Summary-Fallback; Plan fehlt/ready/blocked; Run planned/running/succeeded/failed; jedes Keycloak-Artefakt einzeln erfüllt/nicht erfüllt; Secret-Ausrichtung teilweise; finaler Status; exakte Schrittreihenfolge, Evidence Source, Timestamp, Request-ID und Action.
+3. Existing Realm: Keycloak-Status fehlt/vorhanden; Drift ja/nein; letzter Run fehlt/failed/sonstig; Contract Repair; Reconcile-Bereitschaft; Result Validation; alle Summary-/Action-Prioritäten.
+4. Falsche/fehlende optionale Runtime-Daten müssen fail-closed zur bisherigen Ausgabe führen.
+5. Neue Matrixfälle auf unverändertem Produktionscode grün ausführen und mit `git diff -- apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx` den fehlenden Source-Diff vor dem Refactor belegen.
+
+## Umsetzung
+
+1. Wiederholte Step-Metadaten und Statusauflösung in fachlich benannte typed Helper/Descriptoren innerhalb des Route-Owners ziehen.
+2. Status- und Summary-Entscheidungen getrennt lesbar halten; keine generische Workflow-Engine, keine neue öffentliche API.
+3. Reihenfolge und Action-Priorität aus Characterization exakt bewahren. Nach jedem Builder-Block gezielte Tests ausführen.
+
+## Gates und Fertig-Kriterien
+
+- `pnpm nx run sva-studio-react:test:unit --testFiles=src/routes/admin/instances/-instances-shared.test.tsx --testFiles=src/routes/admin/instances/-instance-detail-models.test.ts`
+- `pnpm nx run sva-studio-react:test:coverage --testFiles=src/routes/admin/instances/-instances-shared.test.tsx --testFiles=src/routes/admin/instances/-instance-detail-models.test.ts`
+- `pnpm nx run sva-studio-react:test:types`
+- `pnpm nx run sva-studio-react:lint`
+- `pnpm nx run sva-studio-react:build`
+- `pnpm nx run sva-studio-react:test:a11y`; erwartet grün, weil das Bundle die sichtbare Admin-Statusdarstellung berührt. Ein gesondertes E2E-Journey-Target ist nicht erforderlich, da weder Navigation noch Interaktion geändert wird; die exakten sichtbaren Modelle werden in den beiden Unit-Dateien geprüft.
+- `pnpm complexity-gate`
+- `pnpm exec openspec validate refactor-instance-realm-operations --strict`
+- `pnpm check:file-placement`
+- `pnpm check:studio-changelog`
+- `git diff --check`
+- Final einmal `pnpm test:pr`, wenn der zuvor gemessene affected Scope praktikabel ist; Auslassung und Ersatzgates dokumentieren.
+- `pnpm exec fallow audit --base origin/main --workspace sva-studio-react --explain --format json`; erwartet `PASS`, `complexity_introduced: 0`, `dead_code_introduced: 0`, `duplication_introduced: 0`, `styling_introduced: 0` und keine moderaten CRAP-Neufunde. Coverageabhängiges CRAP mit der vom Coverage-Target erzeugten `coverage-final.json` erneut prüfen.
+- Root-Review und unabhängiges IAM-/Semantikreview auf exaktem HEAD.
+- Zielgruppe verschwindet, ohne Schritt, Reihenfolge, Status, Summary, Evidence, Timestamp, Request-ID oder Action zu ändern.
+
+## STOP
+
+- STOP, wenn Backend-, Registry-, Keycloak- oder öffentlicher UI-Vertrag geändert werden müsste.
+- STOP bei Source-, Typ- oder Testfixture-Überschneidung mit einem aktiven Worktree/PR.
+- STOP, wenn Legacy-Fallbacks nicht eindeutig charakterisierbar sind oder eine generische Workflow-Engine nötig würde.

--- a/plans/025-refactor-instance-primary-action-priority.md
+++ b/plans/025-refactor-instance-primary-action-priority.md
@@ -1,0 +1,50 @@
+# Plan 025: Primäraktion der Instance-Operationsmodelle explizit priorisieren
+
+> **Executor-Anweisung:** Dieser Plan ist ein eigenes Zielproblem in Bundle B. Seine Prioritätsmatrix muss vor jeder Source-Änderung gegen Altcode belegt sein.
+
+## Status
+
+- **Priorität:** P1
+- **Aufwand:** M
+- **Risiko:** HOCH
+- **Abhängigkeit:** gemeinsam mit Plan 024
+- **Kategorie:** IAM-UI-Aktionspriorität, CRAP
+- **Geplant auf:** `98e6ca3d7`, 15. August 2026
+- **Fallow vorher:** `buildOperationsPrimaryAction` in `-instances-shared.tsx:619` hat CC 30, Cognitive 28, 131 Zeilen und CRAP 33 bei geschätzter hoher Coverage; lokaler Clone `dup:a9825bed` umfasst 16 Zeilen.
+
+## Warum und Produktionsreichweite
+
+Die Funktion wählt aus Realm-Modell, Schrittzuständen, erlaubten Aktionen und Mutationsfehlern genau eine primäre Admin-Aktion. Verdeckte Prioritätsänderungen können gefährliche oder wirkungslose IAM-Aktionen hervorheben. Sie teilt Owner, Datei, Tests und Rollback-Grenze mit Plan 024, ist aber separat zu charakterisieren.
+
+## Scope
+
+**In Scope:** `buildOperationsPrimaryAction`, unmittelbar benötigte interne typed Helper, dieselben beiden Testdateien sowie gemeinsamer OpenSpec-/Changelog-Scope.
+
+**Out of Scope:** neue Actions, Berechtigungsprüfung, Mutationseffekte, Übersetzungen, Backend, Änderung des `RealmOperationsModel`.
+
+## Characterization und Umsetzung
+
+1. Baseline: `pnpm nx run sva-studio-react:test:unit --testFiles=src/routes/admin/instances/-instances-shared.test.tsx --testFiles=src/routes/admin/instances/-instance-detail-models.test.ts` und `pnpm nx run sva-studio-react:test:types`; beide müssen grün sein.
+2. Matrix gegen Altcode: kein möglicher Schritt; mehrere mögliche Schritte; blockierte, laufende, bereite und erfolgreiche Schritte; `focus_configuration`, Preflight, Plan, Provisionierung, Statusprüfung, Reconcile und Aktivierung; MutationError vorhanden/fehlend; New-/Existing-Realm; Follow-up-Actions; gleiche Priorität und Reihenfolge; `null`/`undefined`-Optionals.
+3. Neue Fälle auf unverändertem Produktionscode grün ausführen und mit `git diff -- apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx` den fehlenden Source-Diff vor dem Refactor belegen.
+4. Prioritätsentscheidung als kleine explizite, typisierte Kandidaten-/Auswahlfunktion ausdrücken. Kein frei konfigurierbares Ruleset und keine Reflection.
+5. Bestehende Action-ID, Label-, Disabled-, Reason- und Navigation-Semantik unverändert lassen.
+
+## Gates und Fertig-Kriterien
+
+- `pnpm nx run sva-studio-react:test:unit --testFiles=src/routes/admin/instances/-instances-shared.test.tsx --testFiles=src/routes/admin/instances/-instance-detail-models.test.ts`
+- `pnpm nx run sva-studio-react:test:coverage --testFiles=src/routes/admin/instances/-instances-shared.test.tsx --testFiles=src/routes/admin/instances/-instance-detail-models.test.ts`
+- `pnpm nx run sva-studio-react:test:types`
+- `pnpm nx run sva-studio-react:lint`
+- `pnpm nx run sva-studio-react:build`
+- `pnpm nx run sva-studio-react:test:a11y`; erwartet grün. Ein eigenes E2E-Journey-Target ist nicht anwendbar, weil Navigation und Interaktion unverändert bleiben und die Auswahlmatrix vollständig auf Modellebene charakterisiert wird.
+- `pnpm complexity-gate`
+- `pnpm exec openspec validate refactor-instance-realm-operations --strict`
+- `pnpm check:file-placement`
+- `pnpm check:studio-changelog`
+- `git diff --check`
+- Final einmal `pnpm test:pr`, wenn der zuvor gemessene affected Scope praktikabel ist; Auslassung und Ersatzgates dokumentieren.
+- Vor Draft und nach jeder relevanten Source-Revision: `pnpm exec fallow audit --base origin/main --workspace sva-studio-react --explain --format json`. Erwartet: `PASS`, `complexity_introduced: 0`, `dead_code_introduced: 0`, `duplication_introduced: 0`, `styling_introduced: 0` und keine neuen moderaten CRAP-Findings. Coverageabhängiges CRAP mit echter `coverage-final.json` wiederholen.
+- Fertig ist der Plan, wenn der Zielanker und der natürlich berührte lokale Clone verschwunden sind, ohne Änderung irgendeiner Matrixausgabe.
+
+STOP bei unklarer Priorität, notwendiger Action-/Permission-Vertragsänderung, aktiver Source-/Testüberschneidung oder Bedarf an einer generischen Rules Engine. Vor Start außerdem STOP, wenn `update-instance-detail-module-tab` inzwischen `-instances-shared.tsx`, die zwei Modelltests oder dieselben Realm-Aktionsfixtures beansprucht.

--- a/plans/026-refactor-waste-doi-dispatch-message.md
+++ b/plans/026-refactor-waste-doi-dispatch-message.md
@@ -1,0 +1,62 @@
+# Plan 026: DOI-Versandnachricht in explizite Abschnitte zerlegen
+
+> **Executor-Anweisung:** E-Mail-Adressen und DOI-Inhalte sind produktive Datenschutzverträge. Vor Refactoring alle Adress-, Fallback- und Abschnittskombinationen gegen Altcode charakterisieren; keine echten personenbezogenen Daten in Tests oder Logs verwenden.
+
+## Status
+
+- **Priorität:** P1
+- **Aufwand:** S–M
+- **Risiko:** MITTEL
+- **Abhängigkeit:** keine; Bundle C
+- **Kategorie:** Waste-DOI, Datenschutz, Complexity, CRAP
+- **Geplant auf:** `98e6ca3d7`, 15. August 2026
+- **Fallow vorher:** `buildDoiDispatchMessage` in `waste-management-email-reminder-dispatch.server.ts:231` hat CC 19, Cognitive 18, 55 Zeilen und CRAP 97 (High). Die Datei hat 332 Zeilen, Fan-in 2, MI 87 und keine Dead-Code-Quote.
+
+## Warum und Produktionsreichweite
+
+Die Funktion erzeugt Betreff, Textabschnitte, Absender sowie To/CC/BCC/Reply-To für die produktive Double-Opt-in-Mail. Sie wird über `buildDispatchMessage` vom E-Mail-Outbox-Prozessor erreicht. Heute liegen optionale Templateabschnitte, Fallbacks und Adressprioritäten in einer verzweigten Funktion; Drift kann Pflichtinformationen entfernen oder Reply-To falsch wählen.
+
+## Scope
+
+**In Scope:** `apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts`, `apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.test.ts`, minimaler interner typed Helper, OpenSpec `refactor-waste-doi-dispatch-message`, Changelog.
+
+**Out of Scope:** Tokenerzeugung, Secret-Auswahl, Datums-/Location-Matching, Reminder-Mail, Outbox/SQL/Retry/Idempotenz, Templates/Übersetzungswerte, öffentliche Mail- oder Waste-Verträge, PR #983/#984.
+
+## Characterization vor Refactoring
+
+1. Baseline: `pnpm nx run sva-studio-react:test:unit --testFiles=src/lib/waste-management-email-reminder-dispatch.server.test.ts` und `pnpm nx run sva-studio-react:test:types`; beide müssen grün sein.
+2. DOI-Matrix: Payload-/Config-ServiceLabel und DataController-Priorität; Whitespace/leer/fehlend; Preheader, Intro, Ort, Buttonlabel mit/ohne Confirm-URL, Fallback, Expiry, Datenschutz und Impressum; exakte Abschnittsreihenfolge und Leerzeilen; Subject-Platzhalter unbekannt/gesetzt.
+3. Adressen: To/CC/BCC, Payload-Reply-To vor Config vor Transport, fehlende Fallbacks, DisplayName und From-Priorität. Keine Secrets im Snapshot.
+4. Negativfall: falscher Template-Key bleibt im unveränderten Reminder-Pfad; DOI-Refactor darf ihn nicht berühren.
+5. Neue DOI-Fälle auf unverändertem Produktionscode grün ausführen und mit `git diff -- apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts` den fehlenden Source-Diff vor dem Refactor belegen.
+
+## Umsetzung
+
+1. Templatewerte, optionale Textabschnitte und Address Envelope in kleine reine interne Funktionen teilen.
+2. Reihenfolge, Trimming, Fallbacks und Rückgabeform exakt bewahren; keine Template-Engine oder neue Dependency einführen.
+3. Nach jedem Block gezielten Unit-Run ausführen.
+
+## Gates und Fertig-Kriterien
+
+- `pnpm nx run sva-studio-react:test:unit --testFiles=src/lib/waste-management-email-reminder-dispatch.server.test.ts`
+- `pnpm nx run sva-studio-react:test:coverage --testFiles=src/lib/waste-management-email-reminder-dispatch.server.test.ts`
+- `pnpm nx run sva-studio-react:test:types`
+- `pnpm nx run sva-studio-react:lint`
+- `pnpm nx run sva-studio-react:build`
+- `pnpm check:server-runtime`
+- `pnpm complexity-gate`
+- `pnpm exec openspec validate refactor-waste-doi-dispatch-message --strict`
+- `pnpm check:file-placement`
+- `pnpm check:studio-changelog`
+- `git diff --check`
+- Accessibility-/E2E-Gates sind nicht anwendbar, weil ausschließlich serverseitige Mailmodellierung ohne UI oder Journey geändert wird.
+- Final einmal `pnpm test:pr`, sofern der zuvor gemessene affected Scope praktikabel ist; Auslassung und Ersatzgates dokumentieren.
+- `pnpm exec fallow audit --base origin/main --workspace sva-studio-react --explain --format json`; erwartet `PASS`, `complexity_introduced: 0`, `dead_code_introduced: 0`, `duplication_introduced: 0`, `styling_introduced: 0` und keine moderaten CRAP-Neufunde. Coverageabhängiges CRAP mit der vom Coverage-Target erzeugten `coverage-final.json` erneut prüfen.
+- Root-Review und unabhängiges Datenschutz-/Runtime-Vertragsreview.
+- Zielanker verschwunden; Subject, Text, Reihenfolge und Envelope sind für jede Characterization exakt gleich.
+
+## STOP
+
+- STOP bei notwendiger Änderung an Token, Secret, URL-, Outbox-, SQL-, Retry- oder Idempotenzvertrag.
+- STOP bei aktiver Überschneidung derselben Source-/Testdatei oder widersprüchlicher Altsemantik.
+- STOP, wenn eine neue generische Template-Engine oder öffentliche API erforderlich würde.

--- a/plans/README.md
+++ b/plans/README.md
@@ -109,7 +109,133 @@ aus Plan 020. Der bei der Planung ausdrücklich ausgegrenzte Events-/POI-Clone
 Clone `dup:9b9f8261` betrifft nur einen sechszeiligen Number-to-String-Mapper
 und wurde nicht durch eine Shared- oder Metrikabstraktion kaschiert.
 
-Die Gesamtrepository ist damit nicht findingfrei. Insbesondere verbleiben 924
+## Dritte wirtschaftliche Runde – Live-Analyse
+
+Die dritte Runde wurde am 15. August 2026 auf einem neuen sauberen detached
+Worktree des live gefetchten `origin/main`-Commits
+`98e6ca3d79f7df23674f26c5c8c8307b9da8cd82` geplant. Fallow ist im Root-
+Manifest auf `3.10.0` gepinnt; die ausgeführte signierte Binary meldete ebenfalls
+`fallow 3.10.0`. Das JSON-Report-Schema ist Version 7.
+
+Die unveränderte `.fallowrc.json` hat SHA-256
+`4ea365cbdc2b24f2407f16d483d8ea86440a26cbd123608c7cb9b965f8fcee40`.
+Sie definiert die eingecheckten Test-/Script-/Server-Entries, drei dynamische
+Entries, drei bekannte unresolved Runtime-Artefakte, vier Ignore-Patterns und
+sieben Boundary-Zonen (`app`, `routing`, `server-runtime`, `auth-runtime`,
+`iam-admin`, `instance-registry`, `integration`) mit den dort hinterlegten
+Allow-Regeln. Es wurde weder eine Suppression noch ein Schwellenwert verändert.
+
+Verwendete Baseline-Befehle, jeweils mit JSON, `--quiet`, `--explain`, getrenntem
+stderr und Exitcode-Prüfung:
+
+```bash
+fallow health --format json --quiet --explain
+fallow dead-code --production --format json --quiet --explain
+fallow dupes --format json --quiet --explain
+fallow dead-code --trace-file <kandidat> --format json --quiet --explain
+fallow dead-code --trace-dependency <paket> --format json --quiet --explain
+```
+
+Exitcode 1 trat bei Health und Production Dead Code als normaler Finding-Zustand
+auf; Dupes endete mit 0. Alle drei Reports waren valides JSON mit `kind`, Schema
+7 und `_meta`. Kein Analyzerlauf endete mit Exitcode 2.
+
+| Metrik | Live-Baseline |
+|---|---:|
+| Dateien / Funktionen | 3.452 / 43.269 |
+| Health-Findings | 924 |
+| Critical / High / Moderate | 163 / 277 / 484 |
+| Maintainability | 90,9 |
+| Production Dead Code/Dependencies | 798 |
+| Unused files / exports / types | 58 / 533 / 141 |
+| Unused / unlisted Dependencies | 3 / 14 |
+| Unresolved Imports / Dev-in-Production | 3 / 1 |
+| Importzyklen / Re-export-Zyklen | 0 / 0 |
+| Boundary / Coverage / Call | 0 / 0 / 0 |
+| Duplikatgruppen / Instanzen | 686 / 1.526 |
+| Duplizierte Zeilen / Quote | 27.400 / 8,30 % |
+
+## Kandidatenentscheidung der dritten Runde
+
+| Kandidat | Ist-Metrik und Trace | Risiko/Wirkung | Aufwand/Testbarkeit | Überschneidung/STOP | Entscheidung |
+|---|---|---|---|---|---|
+| POI-Serialisierung | 6 CRAP-Funde, max. 268,2; produktiver Create/Update-Pfad | POI-Datenintegrität; hoher Wartungsgewinn | M–L; breite Formtests | STOP bei Form-/Mainserver-Vertragsänderung | **ausgewählt, Plan 022** |
+| POI-Inbound-Hauptmapping | `mapPoiContentToFormValues`: CC 27/Cognitive 14/CRAP 184,5; produktiver Detail-Reset | Legacy-/Default-/Reihenfolgedaten | M; derselbe Formtestpfad | kleine Mapper nur charakterisieren, nicht metrisch zerlegen | **ausgewählt, Plan 023** |
+| Instance Realm Steps | vier Funde, max. CRAP 299,6; Fan-in 4 | IAM-Status darf nicht falsch erscheinen | M–L; Status-/Fallbackmatrix | STOP bei Backend-/Fixture-Overlap | **ausgewählt, Plan 024** |
+| Instance Primary Action | CC 30/Cognitive 28; produktive Detailseite | sicherheitsrelevante Aktionspriorität | M; kombinatorische Matrix | keine neue Action/Permission | **ausgewählt, Plan 025** |
+| Waste DOI Message | CC 19/Cognitive 18/CRAP 97; Outbox-Pfad | Datenschutz- und Mailvertrag | S–M; fokussierter Unit-Pfad | Token/Secret/SQL explizit out | **ausgewählt, Plan 026** |
+| Auth Permission Store | 17 Importer, zentraler Permissionpfad | höchster Blast Radius | M–L, HIGH | aktive OpenSpecs `use-mainserver-data-provider-as-content-author` und `centralize-scoped-ui-access` verändern Principal-, Permission- und UI-Zugriffsverträge | **zurückgestellt** |
+| Media `completeUpload` | CC 22/CRAP 126,5; produktiver Uploadpfad | Storage-/Idempotenzintegrität | M, gute Tests | aktive Media-OpenSpecs | **zurückgestellt** |
+| Header | CC 26/CRAP 172; AppShell | produktive Shell | M, UI/A11y | `add-account-credential-self-service` nennt Datei | **zurückgestellt** |
+| Interface Healthcheck/Server | max. CRAP 367,5; produktive Interfaces | Secrets/SQL/Netzwerk | M–L | direkte PR-#983-Sourceüberschneidung | **zurückgestellt** |
+| Content Projection/Sidebar | hohe Hotspots und Reichweite | IAM/Content | L | aktive DataProvider-/Scoped-Access-Verträge | **zurückgestellt** |
+| Mainserver Event/News/POI | mehrere Critical/High und große Clones | öffentlicher Runtimevertrag | M–L | aktiver Service-Internals-Change; PR #1005/#1006 frisch | **zurückgestellt** |
+| Root-/Deploy-Dependencies | 3 unused, 14 unlisted, 1 dev-in-production | mögliche Ownership-Lücke | S–M | kein kanonischer Workspace-Audit; Traces überwiegend Script/Debug | **verworfen** |
+| Radix-/sanitize-html-Doppeldeklaration | je ein bereits korrekt besitzender Zielworkspace | geringe Ownership-Bereinigung | S, gut prüfbar | eigener PR-/CI-Aufwand überwiegt Nutzen | **verworfen** |
+| große Cross-Plugin-Clones | bis 926 Zeilen nominell | unterschiedliche Fachverträge | L/unklar | neue Shared-Ownership, >2 Workspaces | **verworfen** |
+| verbleibender Dead Code | 798 Findings, überwiegend nicht produktiv erreichbar | kein belegter Runtime-Nutzen | variabel | Production-Reachability fehlt | **verworfen für diese Runde** |
+
+Die Schnittkante liegt hinter Plan 026: Auch dieses Ziel ist noch wirtschaftlich,
+weil ein klarer produktiver DOI-Vertrag, ein einzelner Owner und ein kompakter
+Test-/Rollback-Pfad vorliegen. Der fachlich stärkere nächste Auth-Kandidat ist
+wegen der aktiven OpenSpecs `use-mainserver-data-provider-as-content-author`
+und `centralize-scoped-ui-access` aktuell nicht unabhängig reviewbar: Beide
+verändern Principal-/Permission- beziehungsweise darauf aufbauende UI-
+Zugriffsverträge mit demselben Konsumentenradius. Kleinere Dependency- oder
+Moderate-Funde rechtfertigen keinen zusätzlichen PR- und CI-Zyklus.
+
+## Abgrenzung zu aktiven Änderungen
+
+Die Auswahl wurde nicht allein über Domänennamen abgegrenzt, sondern gegen die
+aktiven OpenSpec-Aufgaben und die beim Analysebeginn vorhandenen Branch-Deltas
+geprüft:
+
+- `refactor-shared-editor-primitives` migriert POI-UI-Section- und Repeater-
+  Primitives. Der Change erklärt Mapping, Validierung und Speichern ausdrücklich
+  als pluginlokal. Bundle A beansprucht nur
+  `poi.detail-form.serialization.ts`, `poi.detail-form.mapping.ts` und die
+  reinen Formvertragsfälle in `poi.detail-form.test.ts`; UI-Komponenten,
+  Repeater und deren Tests sind ausgeschlossen.
+- `add-studio-data-form-and-test-foundations` inventarisiert POI als Konsument,
+  setzt seine Referenzimplementierung jedoch in Admin-Users, -Roles und Content
+  um. Bundle A ändert keine Testinfrastruktur, keinen Form-Provider und keine
+  Shared-Testutility. Eine spätere Änderung dieser Ownership ist eine harte
+  STOP-Bedingung.
+- `update-instance-detail-module-tab` besitzt den neuen Module-Tab und dessen
+  Journey-/UI-Vertrag. Bundle B besitzt ausschließlich die bestehenden Realm-
+  Operationsmodelle in `-instances-shared.tsx` und deren Modelltests; Tab,
+  Navigation, Module-Workspace und dessen Fixtures sind ausgeschlossen.
+- Die zu Analysebeginn vorhandenen Deltas der Principal-, Mainserver-, Content-
+  und Instance-Module-Branches (`f6b72e7`, `8b3c6e4`, `6db1dfa`, `b2110b7`)
+  enthielten keine der für Bundle A oder B ausgewählten Source-Dateien. Vor
+  Delegation wird dieselbe Datei-/Vertragsprüfung gegen die dann live aktiven
+  Branches, PRs und OpenSpec-Aufgaben wiederholt; bei Treffer wird das Bundle
+  zurückgestellt, nicht parallel gestartet.
+
+## Bundle-Matrix der dritten Runde
+
+| Bundle | Problempläne | Owner/Workspace | Gemeinsamer Vertrag und Gate-Pfad | Risiko | Aufwand | Abhängigkeiten | Bündelungsgrund |
+|---|---|---|---|---:|---:|---|---|
+| A – POI-Formvertrag | 022, 023 | Plugin POI / `@sva/plugin-poi` | bidirektionales pluginlokales Form-Mapping; `plugin-poi` Unit/Coverage/Types/Lint/Build und Fallow-Audit | mittel | L | Vorstart-Prüfung gegen `refactor-shared-editor-primitives` und `add-studio-data-form-and-test-foundations` | gleicher Owner, dieselbe reine Formvertragstestdatei und derselbe Datenvertrag; UI-/Testinfrastruktur bleibt fremder Scope |
+| B – Instance-Realm-Operations | 024, 025 | Studio Instance UI / `sva-studio-react` | Realm-Step- und Primäraktionsmodell; gezielte Modelltests, UI-Gates und App-Audit | hoch | L | Vorstart-Prüfung gegen `update-instance-detail-module-tab` | eine Datei, eine Status-/Prioritätsmatrix und Rollback-Grenze; Module-Tab/Journey-Fixtures bleiben fremder Scope |
+| C – Waste DOI Message | 026 | Studio Waste Runtime / `sva-studio-react` | DOI-Maildarstellung; fokussierter Server-Unit-/Type-/Build-Pfad und App-Audit | mittel | S–M | keine | Einzelproblem; Token, Secret, SQL, Datum und Idempotenz bleiben bewusst getrennt |
+
+Alle Bundles starten unabhängig auf dem dann aktuellen `origin/main`, aber A
+und B erst nach der oben benannten erneuten Ownership-Prüfung. Bundle B und C
+teilen zwar den kanonischen Workspace, aber weder Source, Vertrag noch
+Testdateien. Vor Delegation wird die Delta-/Interaktionsprüfung wiederholt.
+
+## Reihenfolge und Status – dritte Runde
+
+| Plan | Titel | Priorität | Aufwand | Bundle | Status |
+|---|---|---:|---:|---|---|
+| 022 | POI-Formularserialisierung entflechten | P1 | M–L | A | TODO |
+| 023 | POI-Inbound-Mapping vereinfachen | P1 | M | A | TODO |
+| 024 | Realm-Operationsschritte entflechten | P1 | M–L | B | TODO |
+| 025 | Instance-Primäraktion explizit priorisieren | P1 | M | B | TODO |
+| 026 | DOI-Versandnachricht entflechten | P1 | S–M | C | TODO |
+
+Das Gesamtrepository ist damit nicht findingfrei. Insbesondere verbleiben 924
 globale Health-Findings. In `news.detail-form.ts` sind zwei nachweislich
 unveränderte, fachfremde High-Findings vorhanden; das Zielfinding
 `syncSnapshotFromCompatibilityValues` aus Plan 021 ist dagegen beseitigt.


### PR DESCRIPTION
## Summary

- records the live Fallow 3.10.0 baseline on `origin/main` `98e6ca3d7`
- selects five bounded production risks and groups them into three coherent bundles
- documents per-problem characterization, exact gates, STOP conditions, OpenSpec overlap, and the economic cut line

## Review evidence

- Root diff review: approved on `710107a06`
- Independent plausibility review: APPROVE after one correction round
- Scope: planning documents only; no production source changes

## Local gates

- `git diff --check`
- `check-file-placement.ts` (6,392 files)
- `openspec validate --all --strict` (101 passed)

The changelog entry will be added after GitHub assigns the PR number.