### PR TITLE
refactor(plugin-poi): simplify form serialization

### DIFF
--- a/docs/changelog/entries/pr-1009.json
+++ b/docs/changelog/entries/pr-1009.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1009,
+  "body": "POI-Formulardaten werden übersichtlicher und verlässlich verarbeitet\n\n- Kategorien, Adressen, Kontakte und Standortdaten behalten beim Laden und Speichern ihre bisherige Reihenfolge und ihre Standardwerte.\n- Öffnungszeiten, Preise und Medieninhalte werden weiterhin vollständig validiert und leere Platzhalter zuverlässig ausgefiltert.\n- Zusätzliche Regressionstests sichern ältere POI-Daten, explizite Leerwerte und unveränderte Zusatzdaten ab."
+}

--- a/openspec/changes/refactor-poi-form-contract/design.md
+++ b/openspec/changes/refactor-poi-form-contract/design.md
@@ -1,0 +1,42 @@
+## Context
+
+`mapPoiItemToDetailFormValues` und `mapPoiDetailFormValuesToInput` bilden gemeinsam die produktive Übersetzungsgrenze zwischen Mainserver-POI und Editorformular. Die Änderung muss vorhandene Legacy- und Datenintegritätssemantik erhalten, darf aber wiederholte Normalisierung und verzweigte Orchestrierung lokal reduzieren.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Inbound-Mapping und Serialisierung separat charakterisieren
+  - vorhandene Werte-, Clear-, Reihenfolge-, Fallback- und Filtersemantik erhalten
+  - Komplexität durch fachlich benannte, reine, pluginlokale Transformationen reduzieren
+- Non-Goals:
+  - keine Änderung am Mainserver-, Formular- oder Validierungsvertrag
+  - keine UI-, React- oder Shared-Primitive-Änderung
+  - keine gemeinsame Abstraktion mit Events oder News
+  - keine rein metrische Zerlegung bereits kleiner Mapper
+
+## Decisions
+
+- Decision: Die beiden Transformationsrichtungen bleiben getrennt und pluginlokal.
+  - Rationale: Sie besitzen unterschiedliche Eingabe- und Clear-Semantik; eine gemeinsame Engine würde Ownership und indirekte Verträge vergrößern.
+- Decision: Characterization wird vor jeder produktiven Änderung gegen unveränderte Source ausgeführt.
+  - Rationale: Legacy-Runtime-Werte, Teilobjekte und Referenzverhalten sind nicht vollständig aus den öffentlichen Typen ableitbar.
+- Decision: Kleine Mapper werden nur geändert, wenn dies echte wiederholte Auswertung oder Ownership entfernt.
+  - Rationale: Eine bloße Funktionszerlegung verschiebt den Fallow-Score, ohne Wartungswert zu schaffen.
+
+## Risks / Trade-offs
+
+- Versehentliche Änderung von Leerungs- oder Filtersemantik kann Daten beim Speichern verlieren.
+  - Mitigation: getrennte Characterization-Matrizen für Inbound und Serialisierung sowie Roundtrip-Nachweise.
+- Aktive Editor-Changes berühren dasselbe Paket.
+  - Mitigation: Der Scope bleibt auf Mapping-/Serialisierungs-Source und reine Formvertragstests begrenzt; bei Datei-, Vertrag- oder Testinfrastrukturüberschneidung wird gestoppt.
+
+## Migration Plan
+
+1. Bestehende POI-Unit- und Type-Targets als Baseline ausführen.
+2. Characterization für beide Transformationsrichtungen gegen unveränderte Produktionssource ergänzen und grün ausführen.
+3. Erst nach Review des Changes die produktive Implementierung in kleinen Blöcken umsetzen.
+4. Workspace-Gates, Coverage und exakten Fallow-New-only-Audit ausführen.
+
+## Open Questions
+
+- Keine. Eine notwendige Vertragskorrektur beendet diesen Refactoring-Scope.

--- a/openspec/changes/refactor-poi-form-contract/design.md
+++ b/openspec/changes/refactor-poi-form-contract/design.md
@@ -1,13 +1,14 @@
 ## Context
 
-`mapPoiItemToDetailFormValues` und `mapPoiDetailFormValuesToInput` bilden gemeinsam die produktive Übersetzungsgrenze zwischen Mainserver-POI und Editorformular. Die Änderung muss vorhandene Legacy- und Datenintegritätssemantik erhalten, darf aber wiederholte Normalisierung und verzweigte Orchestrierung lokal reduzieren.
+`mapPoiItemToDetailFormValues` und `mapPoiDetailFormValuesToInput` bilden gemeinsam die produktive Übersetzungsgrenze zwischen Mainserver-POI und Editorformular. Die Änderung muss vorhandene Legacy- und Datenintegritätssemantik erhalten. Das unabhängige Review hat gezeigt, dass nur die Serialisierung im aktuellen Scope wirtschaftlich entflechtet werden kann; der Inbound-Mapper bleibt nach vollständiger Reversion produktiv unverändert.
 
 ## Goals / Non-Goals
 
 - Goals:
   - Inbound-Mapping und Serialisierung separat charakterisieren
   - vorhandene Werte-, Clear-, Reihenfolge-, Fallback- und Filtersemantik erhalten
-  - Komplexität durch fachlich benannte, reine, pluginlokale Transformationen reduzieren
+  - Komplexität der Serialisierung durch fachlich benannte, reine, pluginlokale Transformationen reduzieren
+  - den Inbound-Vertrag charakterisieren und einen unwirtschaftlichen Refactor transparent stoppen
 - Non-Goals:
   - keine Änderung am Mainserver-, Formular- oder Validierungsvertrag
   - keine UI-, React- oder Shared-Primitive-Änderung
@@ -22,6 +23,8 @@
   - Rationale: Legacy-Runtime-Werte, Teilobjekte und Referenzverhalten sind nicht vollständig aus den öffentlichen Typen ableitbar.
 - Decision: Kleine Mapper werden nur geändert, wenn dies echte wiederholte Auswertung oder Ownership entfernt.
   - Rationale: Eine bloße Funktionszerlegung verschiebt den Fallow-Score, ohne Wartungswert zu schaffen.
+- Decision: Der erprobte Inbound-Refactor wird vollständig revertiert und Plan 023 produktiv gestoppt.
+  - Rationale: Die Datei stieg von 11 auf 16 Funktionen und von CC 96 auf 101; fünf Single-use-Mapper verteilten Entscheidungen nur über zusätzliche Grenzen. Die minimale Cognitive-Reduktion von 42 auf 41 rechtfertigt diese Ownership nicht.
 
 ## Risks / Trade-offs
 
@@ -34,8 +37,9 @@
 
 1. Bestehende POI-Unit- und Type-Targets als Baseline ausführen.
 2. Characterization für beide Transformationsrichtungen gegen unveränderte Produktionssource ergänzen und grün ausführen.
-3. Erst nach Review des Changes die produktive Implementierung in kleinen Blöcken umsetzen.
-4. Workspace-Gates, Coverage und exakten Fallow-New-only-Audit ausführen.
+3. Die Serialisierung nach Review in kleinen Blöcken umsetzen.
+4. Den Inbound-Ansatz anhand Datei- und Ownership-Metriken bewerten und bei negativem Nutzen-Aufwand-Verhältnis vollständig revertieren.
+5. Workspace-Gates, Coverage und exakten Fallow-New-only-Audit ausführen.
 
 ## Open Questions
 

--- a/openspec/changes/refactor-poi-form-contract/proposal.md
+++ b/openspec/changes/refactor-poi-form-contract/proposal.md
@@ -1,12 +1,12 @@
-# Change: POI-Formvertrag verhaltensgleich entflechten
+# Change: POI-Serialisierung entflechten und Inbound-Vertrag charakterisieren
 
 ## Why
 
-Das produktive POI-Formular besitzt zwei stark verzweigte Transformationsrichtungen: bestehende Mainserver-Inhalte werden in Formularwerte gemappt und bearbeitete Formularwerte werden wieder in den Mutationsvertrag serialisiert. Die derzeitige Komplexität erschwert die sichere Pflege von Legacy-, Clear-, Reihenfolge- und Fallback-Semantik und erhöht damit das Risiko unbemerkter Datenverluste.
+Das produktive POI-Formular besitzt zwei stark verzweigte Transformationsrichtungen: bestehende Mainserver-Inhalte werden in Formularwerte gemappt und bearbeitete Formularwerte werden wieder in den Mutationsvertrag serialisiert. Die Characterization beider Richtungen schützt Legacy-, Clear-, Reihenfolge- und Fallback-Semantik. Nur die Serialisierung besitzt im geprüften Scope einen Refactoring-Ansatz, dessen Wartungsgewinn die zusätzliche Ownership rechtfertigt.
 
 ## What Changes
 
-- Der bestehende POI-Inbound-Mapper wird durch fachlich benannte, pluginlokale Transformationen vereinfacht.
+- Der bestehende POI-Inbound-Mapper wird umfassend charakterisiert, bleibt produktiv aber unverändert: Ein erprobter Refactor erhöhte Datei-CC und Funktionsanzahl und wurde nach unabhängigem Review vollständig verworfen.
 - Die POI-Serialisierung wird entlang der bestehenden Feldgruppen entkoppelt, ohne den Mainserver- oder Formularvertrag zu verändern.
 - Characterization-Tests sichern Legacy-Daten, explizite Leerungen, ungültige Runtime-Werte, Reihenfolge, Fallbacks und Roundtrips vor der produktiven Änderung ab.
 - UI-Primitives, Validierung, öffentliche Typen und Cross-Plugin-Abstraktionen bleiben unverändert.
@@ -14,6 +14,6 @@ Das produktive POI-Formular besitzt zwei stark verzweigte Transformationsrichtun
 ## Impact
 
 - Affected specs: `content-management`
-- Affected code: `packages/plugin-poi/src/poi.detail-form.mapping.ts`, `packages/plugin-poi/src/poi.detail-form.serialization.ts`, `packages/plugin-poi/tests/poi.detail-form.test.ts`
+- Affected code: `packages/plugin-poi/src/poi.detail-form.serialization.ts`, `packages/plugin-poi/tests/poi.detail-form.test.ts`; `poi.detail-form.mapping.ts` besitzt keinen produktiven Diff
 - Affected arc42 sections: keine; pluginlokales, verhaltensgleiches Refactoring ohne neue Architektur- oder Ownership-Grenze
 - Related changes: `refactor-shared-editor-primitives` bleibt für UI-Sections und Repeater zuständig; `add-studio-data-form-and-test-foundations` bleibt für gemeinsame Formular- und Test-Foundations zuständig

--- a/openspec/changes/refactor-poi-form-contract/proposal.md
+++ b/openspec/changes/refactor-poi-form-contract/proposal.md
@@ -1,0 +1,19 @@
+# Change: POI-Formvertrag verhaltensgleich entflechten
+
+## Why
+
+Das produktive POI-Formular besitzt zwei stark verzweigte Transformationsrichtungen: bestehende Mainserver-Inhalte werden in Formularwerte gemappt und bearbeitete Formularwerte werden wieder in den Mutationsvertrag serialisiert. Die derzeitige Komplexität erschwert die sichere Pflege von Legacy-, Clear-, Reihenfolge- und Fallback-Semantik und erhöht damit das Risiko unbemerkter Datenverluste.
+
+## What Changes
+
+- Der bestehende POI-Inbound-Mapper wird durch fachlich benannte, pluginlokale Transformationen vereinfacht.
+- Die POI-Serialisierung wird entlang der bestehenden Feldgruppen entkoppelt, ohne den Mainserver- oder Formularvertrag zu verändern.
+- Characterization-Tests sichern Legacy-Daten, explizite Leerungen, ungültige Runtime-Werte, Reihenfolge, Fallbacks und Roundtrips vor der produktiven Änderung ab.
+- UI-Primitives, Validierung, öffentliche Typen und Cross-Plugin-Abstraktionen bleiben unverändert.
+
+## Impact
+
+- Affected specs: `content-management`
+- Affected code: `packages/plugin-poi/src/poi.detail-form.mapping.ts`, `packages/plugin-poi/src/poi.detail-form.serialization.ts`, `packages/plugin-poi/tests/poi.detail-form.test.ts`
+- Affected arc42 sections: keine; pluginlokales, verhaltensgleiches Refactoring ohne neue Architektur- oder Ownership-Grenze
+- Related changes: `refactor-shared-editor-primitives` bleibt für UI-Sections und Repeater zuständig; `add-studio-data-form-and-test-foundations` bleibt für gemeinsame Formular- und Test-Foundations zuständig

--- a/openspec/changes/refactor-poi-form-contract/specs/content-management/spec.md
+++ b/openspec/changes/refactor-poi-form-contract/specs/content-management/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: POI-Formtransformationen erhalten den bestehenden Datenvertrag
 
-Das System SHALL beim verhaltensgleichen Refactoring der POI-Formtransformationen die bestehende Übersetzung zwischen Mainserver-Inhalten und Editorformular vollständig erhalten.
+Das System SHALL bei der Characterization des POI-Formvertrags und dem verhaltensgleichen Refactoring der Serialisierung die bestehende Übersetzung zwischen Mainserver-Inhalten und Editorformular vollständig erhalten.
 
 #### Scenario: Bestehender POI wird in Formularwerte gemappt
 
@@ -18,9 +18,9 @@ Das System SHALL beim verhaltensgleichen Refactoring der POI-Formtransformatione
 - **THEN** bleiben Trimming, explizite Leerungen, Deduplikation, Filter, Fallbacks und Listenreihenfolge unverändert
 - **AND** werden falsche numerische Runtime-Werte weiterhin für die nachgelagerte Validierung erkennbar erhalten
 
-#### Scenario: Refactoring verändert keine angrenzenden Verträge
+#### Scenario: Serialisierungsrefactoring verändert keine angrenzenden Verträge
 
-- **GIVEN** die POI-Formtransformationen werden vereinfacht
+- **GIVEN** die POI-Formularserialisierung wird vereinfacht und das Inbound-Mapping bleibt produktiv unverändert
 - **WHEN** die Änderung abgeschlossen wird
 - **THEN** bleiben öffentliche POI-Typen, Mainserver-Vertrag, Validierung und Editor-UI unverändert
 - **AND** entsteht keine neue Cross-Plugin- oder Shared-Package-Ownership-Grenze

--- a/openspec/changes/refactor-poi-form-contract/specs/content-management/spec.md
+++ b/openspec/changes/refactor-poi-form-contract/specs/content-management/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: POI-Formtransformationen erhalten den bestehenden Datenvertrag
+
+Das System SHALL beim verhaltensgleichen Refactoring der POI-Formtransformationen die bestehende Übersetzung zwischen Mainserver-Inhalten und Editorformular vollständig erhalten.
+
+#### Scenario: Bestehender POI wird in Formularwerte gemappt
+
+- **GIVEN** ein POI mit vollständigen, partiellen oder Legacy-Feldern
+- **WHEN** der Inhalt in POI-Formularwerte übersetzt wird
+- **THEN** bleiben Defaults, Kategorienpriorität, Aktivstatus, Listenreihenfolge und Wochentagsnormalisierung unverändert
+- **AND** bleiben nichtendliche Numerik, Payload-Runtime-Shapes und bestehendes Clone- beziehungsweise Referenzverhalten charakterisiert
+
+#### Scenario: Bearbeitete Formularwerte werden serialisiert
+
+- **GIVEN** POI-Formularwerte mit vollständigen, leeren, partiellen oder ungültigen Runtime-Feldern
+- **WHEN** daraus der Mainserver-Mutationsinput erzeugt wird
+- **THEN** bleiben Trimming, explizite Leerungen, Deduplikation, Filter, Fallbacks und Listenreihenfolge unverändert
+- **AND** werden falsche numerische Runtime-Werte weiterhin für die nachgelagerte Validierung erkennbar erhalten
+
+#### Scenario: Refactoring verändert keine angrenzenden Verträge
+
+- **GIVEN** die POI-Formtransformationen werden vereinfacht
+- **WHEN** die Änderung abgeschlossen wird
+- **THEN** bleiben öffentliche POI-Typen, Mainserver-Vertrag, Validierung und Editor-UI unverändert
+- **AND** entsteht keine neue Cross-Plugin- oder Shared-Package-Ownership-Grenze

--- a/openspec/changes/refactor-poi-form-contract/tasks.md
+++ b/openspec/changes/refactor-poi-form-contract/tasks.md
@@ -17,4 +17,4 @@
 - [x] 3.1 POI-Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
 - [x] 3.2 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
 - [x] 3.3 Exakten Fallow-New-only-Audit für `@sva/plugin-poi` ohne eingeführte Findings nachweisen
-- [ ] 3.4 Praktikabilität des gemessenen affected Scopes bewerten und den finalen PR-Gate-Pfad ausführen
+- [x] 3.4 Praktikabilität des gemessenen affected Scopes bewerten und den finalen PR-Gate-Pfad ausführen

--- a/openspec/changes/refactor-poi-form-contract/tasks.md
+++ b/openspec/changes/refactor-poi-form-contract/tasks.md
@@ -15,6 +15,6 @@
 ## 3. Qualitäts- und Abschlussnachweise
 
 - [x] 3.1 POI-Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
-- [ ] 3.2 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
+- [x] 3.2 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
 - [x] 3.3 Exakten Fallow-New-only-Audit für `@sva/plugin-poi` ohne eingeführte Findings nachweisen
 - [ ] 3.4 Praktikabilität des gemessenen affected Scopes bewerten und den finalen PR-Gate-Pfad ausführen

--- a/openspec/changes/refactor-poi-form-contract/tasks.md
+++ b/openspec/changes/refactor-poi-form-contract/tasks.md
@@ -1,0 +1,20 @@
+## 1. Abgrenzung und Characterization
+
+- [x] 1.1 Offene PRs und aktive OpenSpec-Changes auf Source-, Vertrags- und Testinfrastrukturüberschneidungen prüfen
+- [x] 1.2 Bestehende POI-Form-Unit- und Type-Targets gegen unveränderten Altcode grün ausführen
+- [x] 1.3 Eigene Characterization-Matrix für Serialisierung, Clears, Teilobjekte, Filter, Runtime-Werte und Reihenfolge ergänzen
+- [x] 1.4 Eigene Characterization-Matrix für Inbound-Legacywerte, Defaults, Referenzen, Payload und Roundtrip ergänzen
+- [ ] 1.5 Proposal und Characterization-Evidenz reviewen und vor produktiver Umsetzung freigeben
+
+## 2. Produktive Transformationen vereinfachen
+
+- [ ] 2.1 POI-Serialisierung in fachlich benannte, reine Transformationen entflechten, ohne Verhalten oder Vertrag zu ändern
+- [ ] 2.2 `mapPoiContentToFormValues` mit einmalig berechneten fachlichen Zwischenergebnissen vereinfachen
+- [ ] 2.3 Nach jedem produktiven Änderungsblock die gezielten Unit-Tests ausführen
+
+## 3. Qualitäts- und Abschlussnachweise
+
+- [ ] 3.1 POI-Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
+- [ ] 3.2 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
+- [ ] 3.3 Exakten Fallow-New-only-Audit für `@sva/plugin-poi` ohne eingeführte Findings nachweisen
+- [ ] 3.4 Praktikabilität des gemessenen affected Scopes bewerten und den finalen PR-Gate-Pfad ausführen

--- a/openspec/changes/refactor-poi-form-contract/tasks.md
+++ b/openspec/changes/refactor-poi-form-contract/tasks.md
@@ -4,17 +4,17 @@
 - [x] 1.2 Bestehende POI-Form-Unit- und Type-Targets gegen unveränderten Altcode grün ausführen
 - [x] 1.3 Eigene Characterization-Matrix für Serialisierung, Clears, Teilobjekte, Filter, Runtime-Werte und Reihenfolge ergänzen
 - [x] 1.4 Eigene Characterization-Matrix für Inbound-Legacywerte, Defaults, Referenzen, Payload und Roundtrip ergänzen
-- [ ] 1.5 Proposal und Characterization-Evidenz reviewen und vor produktiver Umsetzung freigeben
+- [x] 1.5 Proposal und Characterization-Evidenz reviewen und vor produktiver Umsetzung freigeben
 
 ## 2. Produktive Transformationen vereinfachen
 
-- [ ] 2.1 POI-Serialisierung in fachlich benannte, reine Transformationen entflechten, ohne Verhalten oder Vertrag zu ändern
-- [ ] 2.2 `mapPoiContentToFormValues` mit einmalig berechneten fachlichen Zwischenergebnissen vereinfachen
-- [ ] 2.3 Nach jedem produktiven Änderungsblock die gezielten Unit-Tests ausführen
+- [x] 2.1 POI-Serialisierung in fachlich benannte, reine Transformationen entflechten, ohne Verhalten oder Vertrag zu ändern
+- [x] 2.2 `mapPoiContentToFormValues` mit einmalig berechneten fachlichen Zwischenergebnissen vereinfachen
+- [x] 2.3 Nach jedem produktiven Änderungsblock die gezielten Unit-Tests ausführen
 
 ## 3. Qualitäts- und Abschlussnachweise
 
-- [ ] 3.1 POI-Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
+- [x] 3.1 POI-Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
 - [ ] 3.2 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` grün ausführen
-- [ ] 3.3 Exakten Fallow-New-only-Audit für `@sva/plugin-poi` ohne eingeführte Findings nachweisen
+- [x] 3.3 Exakten Fallow-New-only-Audit für `@sva/plugin-poi` ohne eingeführte Findings nachweisen
 - [ ] 3.4 Praktikabilität des gemessenen affected Scopes bewerten und den finalen PR-Gate-Pfad ausführen

--- a/openspec/changes/refactor-poi-form-contract/tasks.md
+++ b/openspec/changes/refactor-poi-form-contract/tasks.md
@@ -6,10 +6,10 @@
 - [x] 1.4 Eigene Characterization-Matrix für Inbound-Legacywerte, Defaults, Referenzen, Payload und Roundtrip ergänzen
 - [x] 1.5 Proposal und Characterization-Evidenz reviewen und vor produktiver Umsetzung freigeben
 
-## 2. Produktive Transformationen vereinfachen
+## 2. Produktive Serialisierung und wirtschaftliche Schnittkante
 
 - [x] 2.1 POI-Serialisierung in fachlich benannte, reine Transformationen entflechten, ohne Verhalten oder Vertrag zu ändern
-- [x] 2.2 `mapPoiContentToFormValues` mit einmalig berechneten fachlichen Zwischenergebnissen vereinfachen
+- [x] 2.2 Inbound-Refactor bewerten und wegen höherer Datei-CC, zusätzlicher Single-use-Mapper und wachsender Ownership vollständig revertieren
 - [x] 2.3 Nach jedem produktiven Änderungsblock die gezielten Unit-Tests ausführen
 
 ## 3. Qualitäts- und Abschlussnachweise

--- a/packages/plugin-poi/src/poi.detail-form.mapping.ts
+++ b/packages/plugin-poi/src/poi.detail-form.mapping.ts
@@ -68,53 +68,37 @@ const mapPriceToFormValue = (price?: PoiPriceInformation): PoiPriceFormValue => 
   category: price?.category ?? '',
 });
 
-const mapAddressesToFormValues = (item: PoiContentItem) =>
-  item.addresses?.length ? item.addresses.map(mapAddressToFormValue) : [createDefaultAddress()];
-
-const mapOpeningHoursToFormValues = (item: PoiContentItem) =>
-  item.openingHours?.length
+const mapPoiContentToFormValues = (item: PoiContentItem): PoiDetailFormValues['content'] => ({
+  description: item.description ?? '',
+  mobileDescription: item.mobileDescription ?? '',
+  addresses: item.addresses?.length
+    ? item.addresses.map(mapAddressToFormValue)
+    : [createDefaultAddress()],
+  location: mapLocationToFormValue(item.location),
+  contact: mapContactToFormValue(item.contact),
+  openingHours: item.openingHours?.length
     ? item.openingHours.map((entry) => ({
         ...entry,
         weekday: normalizeOpeningHourWeekday(entry.weekday),
       }))
-    : [createDefaultOpeningHour()];
-
-const mapPricesToFormValues = (item: PoiContentItem) =>
-  item.priceInformations?.length
-    ? item.priceInformations.map(mapPriceToFormValue)
-    : [createDefaultPrice()];
-
-const mapAccessibilityInformationToFormValue = (item: PoiContentItem) => ({
-  ...createDefaultAccessibilityInformation(),
-  description: item.accessibilityInformation?.description ?? '',
-  types: item.accessibilityInformation?.types ?? '',
-  urls: item.accessibilityInformation?.urls?.length ? item.accessibilityInformation.urls : [],
-});
-
-const mapCategoryNamesToFormValue = (item: PoiContentItem): string[] => {
-  if (item.categories?.length) {
-    return item.categories.map((category) => category.name);
-  }
-  return item.categoryName ? [item.categoryName] : [];
-};
-
-const mapPoiContentToFormValues = (item: PoiContentItem): PoiDetailFormValues['content'] => ({
-  description: item.description ?? '',
-  mobileDescription: item.mobileDescription ?? '',
-  addresses: mapAddressesToFormValues(item),
-  location: mapLocationToFormValue(item.location),
-  contact: mapContactToFormValue(item.contact),
-  openingHours: mapOpeningHoursToFormValues(item),
+    : [createDefaultOpeningHour()],
   webUrls: item.webUrls?.length ? item.webUrls : [createDefaultWebUrl()],
   operator: {
     name: item.operatingCompany?.name ?? '',
     address: mapAddressToFormValue(item.operatingCompany?.address),
     contact: mapContactToFormValue(item.operatingCompany?.contact),
   },
-  prices: mapPricesToFormValues(item),
+  prices: item.priceInformations?.length
+    ? item.priceInformations.map(mapPriceToFormValue)
+    : [createDefaultPrice()],
   mediaContents: item.mediaContents?.length ? item.mediaContents : [],
   certificates: item.certificates?.length ? item.certificates : [createDefaultCertificate()],
-  accessibilityInformation: mapAccessibilityInformationToFormValue(item),
+  accessibilityInformation: {
+    ...createDefaultAccessibilityInformation(),
+    description: item.accessibilityInformation?.description ?? '',
+    types: item.accessibilityInformation?.types ?? '',
+    urls: item.accessibilityInformation?.urls?.length ? item.accessibilityInformation.urls : [],
+  },
   tagsText: item.tags?.join(', ') ?? '',
   payloadText: JSON.stringify(item.payload === undefined ? {} : item.payload, null, 2),
 });
@@ -122,7 +106,11 @@ const mapPoiContentToFormValues = (item: PoiContentItem): PoiDetailFormValues['c
 export const mapPoiItemToDetailFormValues = (item: PoiContentItem): PoiDetailFormValues => ({
   name: item.name,
   basis: {
-    categories: mapCategoryNamesToFormValue(item),
+    categories: item.categories?.length
+      ? item.categories.map((category) => category.name)
+      : item.categoryName
+        ? [item.categoryName]
+        : [],
     active: item.active !== false,
   },
   content: mapPoiContentToFormValues(item),

--- a/packages/plugin-poi/src/poi.detail-form.mapping.ts
+++ b/packages/plugin-poi/src/poi.detail-form.mapping.ts
@@ -17,8 +17,12 @@ import {
 } from './poi.detail-form.types.js';
 import { normalizeOpeningHourWeekday } from './poi.opening-hours.js';
 
-const mapNumberToString = (value?: number) =>
-  typeof value === 'number' && Number.isFinite(value) ? String(value) : '';
+const mapNumberToString = (value?: number) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return '';
+  }
+  return String(value);
+};
 
 const mapGeoLocationToFormValue = (
   value?: { readonly latitude?: number; readonly longitude?: number } | null
@@ -68,37 +72,53 @@ const mapPriceToFormValue = (price?: PoiPriceInformation): PoiPriceFormValue => 
   category: price?.category ?? '',
 });
 
-const mapPoiContentToFormValues = (item: PoiContentItem): PoiDetailFormValues['content'] => ({
-  description: item.description ?? '',
-  mobileDescription: item.mobileDescription ?? '',
-  addresses: item.addresses?.length
-    ? item.addresses.map(mapAddressToFormValue)
-    : [createDefaultAddress()],
-  location: mapLocationToFormValue(item.location),
-  contact: mapContactToFormValue(item.contact),
-  openingHours: item.openingHours?.length
+const mapAddressesToFormValues = (item: PoiContentItem) =>
+  item.addresses?.length ? item.addresses.map(mapAddressToFormValue) : [createDefaultAddress()];
+
+const mapOpeningHoursToFormValues = (item: PoiContentItem) =>
+  item.openingHours?.length
     ? item.openingHours.map((entry) => ({
         ...entry,
         weekday: normalizeOpeningHourWeekday(entry.weekday),
       }))
-    : [createDefaultOpeningHour()],
+    : [createDefaultOpeningHour()];
+
+const mapPricesToFormValues = (item: PoiContentItem) =>
+  item.priceInformations?.length
+    ? item.priceInformations.map(mapPriceToFormValue)
+    : [createDefaultPrice()];
+
+const mapAccessibilityInformationToFormValue = (item: PoiContentItem) => ({
+  ...createDefaultAccessibilityInformation(),
+  description: item.accessibilityInformation?.description ?? '',
+  types: item.accessibilityInformation?.types ?? '',
+  urls: item.accessibilityInformation?.urls?.length ? item.accessibilityInformation.urls : [],
+});
+
+const mapCategoryNamesToFormValue = (item: PoiContentItem): string[] => {
+  if (item.categories?.length) {
+    return item.categories.map((category) => category.name);
+  }
+  return item.categoryName ? [item.categoryName] : [];
+};
+
+const mapPoiContentToFormValues = (item: PoiContentItem): PoiDetailFormValues['content'] => ({
+  description: item.description ?? '',
+  mobileDescription: item.mobileDescription ?? '',
+  addresses: mapAddressesToFormValues(item),
+  location: mapLocationToFormValue(item.location),
+  contact: mapContactToFormValue(item.contact),
+  openingHours: mapOpeningHoursToFormValues(item),
   webUrls: item.webUrls?.length ? item.webUrls : [createDefaultWebUrl()],
   operator: {
     name: item.operatingCompany?.name ?? '',
     address: mapAddressToFormValue(item.operatingCompany?.address),
     contact: mapContactToFormValue(item.operatingCompany?.contact),
   },
-  prices: item.priceInformations?.length
-    ? item.priceInformations.map(mapPriceToFormValue)
-    : [createDefaultPrice()],
+  prices: mapPricesToFormValues(item),
   mediaContents: item.mediaContents?.length ? item.mediaContents : [],
   certificates: item.certificates?.length ? item.certificates : [createDefaultCertificate()],
-  accessibilityInformation: {
-    ...createDefaultAccessibilityInformation(),
-    description: item.accessibilityInformation?.description ?? '',
-    types: item.accessibilityInformation?.types ?? '',
-    urls: item.accessibilityInformation?.urls?.length ? item.accessibilityInformation.urls : [],
-  },
+  accessibilityInformation: mapAccessibilityInformationToFormValue(item),
   tagsText: item.tags?.join(', ') ?? '',
   payloadText: JSON.stringify(item.payload === undefined ? {} : item.payload, null, 2),
 });
@@ -106,11 +126,7 @@ const mapPoiContentToFormValues = (item: PoiContentItem): PoiDetailFormValues['c
 export const mapPoiItemToDetailFormValues = (item: PoiContentItem): PoiDetailFormValues => ({
   name: item.name,
   basis: {
-    categories: item.categories?.length
-      ? item.categories.map((category) => category.name)
-      : item.categoryName
-        ? [item.categoryName]
-        : [],
+    categories: mapCategoryNamesToFormValue(item),
     active: item.active !== false,
   },
   content: mapPoiContentToFormValues(item),

--- a/packages/plugin-poi/src/poi.detail-form.mapping.ts
+++ b/packages/plugin-poi/src/poi.detail-form.mapping.ts
@@ -17,12 +17,8 @@ import {
 } from './poi.detail-form.types.js';
 import { normalizeOpeningHourWeekday } from './poi.opening-hours.js';
 
-const mapNumberToString = (value?: number) => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return '';
-  }
-  return String(value);
-};
+const mapNumberToString = (value?: number) =>
+  typeof value === 'number' && Number.isFinite(value) ? String(value) : '';
 
 const mapGeoLocationToFormValue = (
   value?: { readonly latitude?: number; readonly longitude?: number } | null

--- a/packages/plugin-poi/src/poi.detail-form.serialization.ts
+++ b/packages/plugin-poi/src/poi.detail-form.serialization.ts
@@ -1,7 +1,12 @@
 import type {
   PoiAccessibilityInformation,
+  PoiAddress,
   PoiContact,
+  PoiLocation,
   PoiMediaContent,
+  PoiOpeningHour,
+  PoiOperatingCompany,
+  PoiPriceInformation,
   PoiWebUrl,
 } from './poi.content.types.js';
 import type { PoiFormInput } from './poi.types.js';
@@ -19,6 +24,15 @@ import {
   serializeTags,
 } from './poi.detail-form.serialization.metadata.js';
 import { normalizeOpeningHourWeekday } from './poi.opening-hours.js';
+
+type MutablePartial<T> = {
+  -readonly [Key in keyof T]?: T[Key];
+};
+
+const withoutUndefined = <T extends Record<string, unknown>>(value: T): MutablePartial<T> =>
+  Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  ) as MutablePartial<T>;
 
 const compactString = (value?: string | null) => {
   const trimmed = value?.trim();
@@ -58,168 +72,161 @@ const compactGeoLocation = (value?: PoiFormGeoLocationValue | null) => {
   return latitude !== undefined || longitude !== undefined ? { latitude, longitude } : undefined;
 };
 
+const compactWebUrl = (entry?: PoiWebUrl | null): PoiWebUrl | undefined => {
+  const url = compactString(entry?.url);
+  if (!url) {
+    return undefined;
+  }
+  const description = compactString(entry?.description);
+  return description ? { url, description } : { url };
+};
+
 const compactWebUrls = (value?: readonly PoiWebUrl[] | null) =>
-  (value ?? [])
-    .map((entry) => ({
-      ...(compactString(entry?.url) ? { url: compactString(entry?.url) as string } : {}),
-      ...(compactString(entry?.description)
-        ? { description: compactString(entry?.description) }
-        : {}),
-    }))
-    .filter((entry): entry is PoiWebUrl => Boolean(entry.url));
+  (value ?? []).map(compactWebUrl).filter((entry): entry is PoiWebUrl => entry !== undefined);
 
 const compactAddress = (value?: PoiAddressFormValue | null) => {
-  const geoLocation = compactGeoLocation(value?.geoLocation);
-  const address = {
-    ...(compactString(value?.addition) ? { addition: compactString(value?.addition) } : {}),
-    ...(compactString(value?.street) ? { street: compactString(value?.street) } : {}),
-    ...(compactString(value?.zip) ? { zip: compactString(value?.zip) } : {}),
-    ...(compactString(value?.city) ? { city: compactString(value?.city) } : {}),
-    ...(compactString(value?.kind) ? { kind: compactString(value?.kind) } : {}),
-    ...(geoLocation ? { geoLocation } : {}),
-  };
+  const address: MutablePartial<PoiAddress> = withoutUndefined({
+    addition: compactString(value?.addition),
+    street: compactString(value?.street),
+    zip: compactString(value?.zip),
+    city: compactString(value?.city),
+    kind: compactString(value?.kind),
+    geoLocation: compactGeoLocation(value?.geoLocation),
+  });
   return Object.keys(address).length > 0 ? address : undefined;
 };
 
 const compactContact = (value?: PoiContact | null) => {
   const webUrls = compactWebUrls(value?.webUrls);
-  const contact = {
-    ...(compactString(value?.firstName) ? { firstName: compactString(value?.firstName) } : {}),
-    ...(compactString(value?.lastName) ? { lastName: compactString(value?.lastName) } : {}),
-    ...(compactString(value?.phone) ? { phone: compactString(value?.phone) } : {}),
-    ...(compactString(value?.fax) ? { fax: compactString(value?.fax) } : {}),
-    ...(compactString(value?.email) ? { email: compactString(value?.email) } : {}),
-    ...(webUrls.length > 0 ? { webUrls } : {}),
-  };
+  const contact: MutablePartial<PoiContact> = withoutUndefined({
+    firstName: compactString(value?.firstName),
+    lastName: compactString(value?.lastName),
+    phone: compactString(value?.phone),
+    fax: compactString(value?.fax),
+    email: compactString(value?.email),
+    webUrls: webUrls.length > 0 ? webUrls : undefined,
+  });
   return Object.keys(contact).length > 0 ? contact : undefined;
 };
 
 const compactLocation = (value?: PoiLocationFormValue | null) => {
-  const geoLocation = compactGeoLocation(value?.geoLocation);
-  const location = {
-    ...(compactString(value?.name) ? { name: compactString(value?.name) } : {}),
-    ...(compactString(value?.department) ? { department: compactString(value?.department) } : {}),
-    ...(compactString(value?.district) ? { district: compactString(value?.district) } : {}),
-    ...(compactString(value?.regionName) ? { regionName: compactString(value?.regionName) } : {}),
-    ...(compactString(value?.state) ? { state: compactString(value?.state) } : {}),
-    ...(geoLocation ? { geoLocation } : {}),
-  };
+  const location: MutablePartial<PoiLocation> = withoutUndefined({
+    name: compactString(value?.name),
+    department: compactString(value?.department),
+    district: compactString(value?.district),
+    regionName: compactString(value?.regionName),
+    state: compactString(value?.state),
+    geoLocation: compactGeoLocation(value?.geoLocation),
+  });
   return Object.keys(location).length > 0 ? location : undefined;
+};
+
+const serializeOpeningHour = (
+  entry: PoiDetailFormValues['content']['openingHours'][number]
+): PoiOpeningHour | undefined => {
+  const weekday = compactString(entry?.weekday);
+  const result: MutablePartial<PoiOpeningHour> = withoutUndefined({
+    weekday: weekday ? normalizeOpeningHourWeekday(weekday) : undefined,
+    dateFrom: compactString(entry?.dateFrom),
+    dateTo: compactString(entry?.dateTo),
+    timeFrom: compactString(entry?.timeFrom),
+    timeTo: compactString(entry?.timeTo),
+    sortNumber: compactFiniteNumber(entry?.sortNumber),
+    open: entry?.open,
+    useYear: entry?.useYear,
+    description: compactString(entry?.description),
+  });
+  return Object.keys(result).length > 0 && hasSubstantiveFields(result, 'open')
+    ? result
+    : undefined;
 };
 
 const serializeOpeningHours = (values: PoiDetailFormValues['content']['openingHours']) =>
   (values ?? [])
-    .map((entry) => ({
-      ...(compactString(entry?.weekday)
-        ? { weekday: normalizeOpeningHourWeekday(compactString(entry?.weekday)) }
-        : {}),
-      ...(compactString(entry?.dateFrom) ? { dateFrom: compactString(entry?.dateFrom) } : {}),
-      ...(compactString(entry?.dateTo) ? { dateTo: compactString(entry?.dateTo) } : {}),
-      ...(compactString(entry?.timeFrom) ? { timeFrom: compactString(entry?.timeFrom) } : {}),
-      ...(compactString(entry?.timeTo) ? { timeTo: compactString(entry?.timeTo) } : {}),
-      ...(compactFiniteNumber(entry?.sortNumber) !== undefined
-        ? { sortNumber: compactFiniteNumber(entry?.sortNumber) }
-        : {}),
-      ...(entry?.open !== undefined ? { open: entry.open } : {}),
-      ...(entry?.useYear !== undefined ? { useYear: entry.useYear } : {}),
-      ...(compactString(entry?.description)
-        ? { description: compactString(entry?.description) }
-        : {}),
-    }))
-    .filter((entry) => {
-      const keys = Object.keys(entry);
-      if (keys.length === 0) {
-        return false;
-      }
+    .map(serializeOpeningHour)
+    .filter((entry): entry is PoiOpeningHour => entry !== undefined);
 
-      return hasSubstantiveFields(entry, 'open');
-    });
+const serializePrice = (
+  entry: PoiDetailFormValues['content']['prices'][number]
+): PoiPriceInformation | undefined => {
+  const result: MutablePartial<PoiPriceInformation> = withoutUndefined({
+    name: compactString(entry?.name),
+    amount: compactValidatedNumber(entry?.amount),
+    groupPrice: entry?.groupPrice,
+    ageFrom: compactFiniteNumber(entry?.ageFrom),
+    ageTo: compactFiniteNumber(entry?.ageTo),
+    minAdultCount: compactFiniteNumber(entry?.minAdultCount),
+    maxAdultCount: compactFiniteNumber(entry?.maxAdultCount),
+    minChildrenCount: compactFiniteNumber(entry?.minChildrenCount),
+    maxChildrenCount: compactFiniteNumber(entry?.maxChildrenCount),
+    description: compactString(entry?.description),
+    category: compactString(entry?.category),
+  });
+  return Object.keys(result).length > 0 && hasSubstantiveFields(result, 'groupPrice')
+    ? result
+    : undefined;
+};
 
 const serializePrices = (values: PoiDetailFormValues['content']['prices']) =>
   (values ?? [])
-    .map((entry) => ({
-      ...(compactString(entry?.name) ? { name: compactString(entry?.name) } : {}),
-      ...(compactValidatedNumber(entry?.amount) !== undefined
-        ? { amount: compactValidatedNumber(entry?.amount) }
-        : {}),
-      ...(entry?.groupPrice !== undefined ? { groupPrice: entry.groupPrice } : {}),
-      ...(compactFiniteNumber(entry?.ageFrom) !== undefined
-        ? { ageFrom: compactFiniteNumber(entry?.ageFrom) }
-        : {}),
-      ...(compactFiniteNumber(entry?.ageTo) !== undefined
-        ? { ageTo: compactFiniteNumber(entry?.ageTo) }
-        : {}),
-      ...(compactFiniteNumber(entry?.minAdultCount) !== undefined
-        ? { minAdultCount: compactFiniteNumber(entry?.minAdultCount) }
-        : {}),
-      ...(compactFiniteNumber(entry?.maxAdultCount) !== undefined
-        ? { maxAdultCount: compactFiniteNumber(entry?.maxAdultCount) }
-        : {}),
-      ...(compactFiniteNumber(entry?.minChildrenCount) !== undefined
-        ? { minChildrenCount: compactFiniteNumber(entry?.minChildrenCount) }
-        : {}),
-      ...(compactFiniteNumber(entry?.maxChildrenCount) !== undefined
-        ? { maxChildrenCount: compactFiniteNumber(entry?.maxChildrenCount) }
-        : {}),
-      ...(compactString(entry?.description)
-        ? { description: compactString(entry?.description) }
-        : {}),
-      ...(compactString(entry?.category) ? { category: compactString(entry?.category) } : {}),
-    }))
-    .filter((entry) => {
-      const keys = Object.keys(entry);
-      if (keys.length === 0) {
-        return false;
-      }
+    .map(serializePrice)
+    .filter((entry): entry is PoiPriceInformation => entry !== undefined);
 
-      return hasSubstantiveFields(entry, 'groupPrice');
-    });
+const serializeMediaContent = (entry: PoiMediaContent): PoiMediaContent | undefined => {
+  const result: MutablePartial<PoiMediaContent> = withoutUndefined({
+    captionText: compactString(entry?.captionText),
+    copyright: compactString(entry?.copyright),
+    height: compactFiniteNumber(entry?.height),
+    width: compactFiniteNumber(entry?.width),
+    contentType: normalizeMediaContentType(entry?.contentType),
+    sourceUrl: compactWebUrl(entry?.sourceUrl),
+  });
+  return Object.keys(result).length > 0 ? result : undefined;
+};
 
 const serializeMediaContents = (values: readonly PoiMediaContent[]) =>
   (values ?? [])
-    .map((entry) => ({
-      ...(compactString(entry?.captionText)
-        ? { captionText: compactString(entry?.captionText) }
-        : {}),
-      ...(compactString(entry?.copyright) ? { copyright: compactString(entry?.copyright) } : {}),
-      ...(compactFiniteNumber(entry?.height) !== undefined
-        ? { height: compactFiniteNumber(entry?.height) }
-        : {}),
-      ...(compactFiniteNumber(entry?.width) !== undefined
-        ? { width: compactFiniteNumber(entry?.width) }
-        : {}),
-      ...(normalizeMediaContentType(entry?.contentType)
-        ? { contentType: normalizeMediaContentType(entry?.contentType) }
-        : {}),
-      ...(entry?.sourceUrl && compactWebUrls([entry.sourceUrl]).length > 0
-        ? { sourceUrl: compactWebUrls([entry.sourceUrl])[0] }
-        : {}),
-    }))
-    .filter((entry) => Object.keys(entry).length > 0);
+    .map(serializeMediaContent)
+    .filter((entry): entry is PoiMediaContent => entry !== undefined);
 
 const serializeAccessibilityInformation = (value: PoiAccessibilityInformation) => {
   const urls = compactWebUrls(value.urls);
-  return {
-    ...(compactString(value.description) ? { description: compactString(value.description) } : {}),
-    ...(compactString(value.types) ? { types: compactString(value.types) } : {}),
-    ...(urls.length > 0 ? { urls } : {}),
-  };
+  return withoutUndefined({
+    description: compactString(value.description),
+    types: compactString(value.types),
+    urls: urls.length > 0 ? urls : undefined,
+  });
+};
+
+const serializeCategories = (values: readonly string[]): Partial<PoiFormInput> => {
+  const categoryNames = compactCategoryNames(values);
+  return categoryNames.length > 0
+    ? {
+        categoryName: categoryNames[0],
+        categories: categoryNames.map((name) => ({ name })),
+      }
+    : {};
+};
+
+const serializeOperator = (
+  value: PoiDetailFormValues['content']['operator']
+): PoiOperatingCompany | undefined => {
+  const operator: MutablePartial<PoiOperatingCompany> = withoutUndefined({
+    name: compactString(value.name),
+    address: compactAddress(value.address),
+    contact: compactContact(value.contact),
+  });
+  return Object.keys(operator).length > 0 ? operator : undefined;
 };
 
 export const mapPoiDetailFormValuesToInput = (
   values: PoiDetailFormValues,
   payload: unknown
 ): PoiFormInput => {
+  const categories = serializeCategories(values.basis.categories);
   const contact = compactContact(values.content.contact);
-  const operatorAddress = compactAddress(values.content.operator.address);
-  const operatorContact = compactContact(values.content.operator.contact);
-  const operator = {
-    ...(compactString(values.content.operator.name)
-      ? { name: compactString(values.content.operator.name) }
-      : {}),
-    ...(operatorAddress ? { address: operatorAddress } : {}),
-    ...(operatorContact ? { contact: operatorContact } : {}),
-  };
+  const location = compactLocation(values.content.location);
+  const operator = serializeOperator(values.content.operator);
 
   return {
     name: values.name.trim(),
@@ -230,22 +237,15 @@ export const mapPoiDetailFormValuesToInput = (
     active: values.basis.active,
     externalId: values.settings.externalId?.trim() ?? '',
     keywords: values.settings.keywords?.trim() ?? '',
-    ...(compactCategoryNames(values.basis.categories).length > 0
-      ? {
-          categoryName: compactCategoryNames(values.basis.categories)[0],
-          categories: compactCategoryNames(values.basis.categories).map((name) => ({ name })),
-        }
-      : {}),
+    ...categories,
     addresses: (values.content.addresses ?? [])
       .map((entry) => compactAddress(entry))
       .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
     ...(contact ? { contact } : {}),
-    ...(compactLocation(values.content.location)
-      ? { location: compactLocation(values.content.location) }
-      : {}),
+    ...(location ? { location } : {}),
     openingHours: serializeOpeningHours(values.content.openingHours),
     webUrls: compactWebUrls(values.content.webUrls),
-    ...(Object.keys(operator).length > 0 ? { operatingCompany: operator } : {}),
+    ...(operator ? { operatingCompany: operator } : {}),
     priceInformations: serializePrices(values.content.prices),
     mediaContents: serializeMediaContents(values.content.mediaContents),
     certificates: serializeCertificates(values.content.certificates),

--- a/packages/plugin-poi/tests/poi.detail-form.test.ts
+++ b/packages/plugin-poi/tests/poi.detail-form.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  createDefaultPoiDetailFormValues,
   mapPoiDetailFormValuesToInput,
   mapPoiItemToDetailFormValues,
+  parsePoiPayloadText,
 } from '../src/poi.detail-form.js';
 import { validatePoiForm } from '../src/poi.validation.js';
 import type { PoiContentItem } from '../src/poi.types.js';
@@ -1019,5 +1021,282 @@ describe('poi.detail-form', () => {
       { contentType: 'attachment' },
       { contentType: 'logo' },
     ]);
+  });
+
+  describe('plan 022 serialization characterization', () => {
+    it('preserves ordered category deduplication and explicit scalar clears', () => {
+      const defaults = createDefaultPoiDetailFormValues();
+      const input = mapPoiDetailFormValuesToInput(
+        {
+          ...defaults,
+          name: '  Bibliothek  ',
+          basis: {
+            active: false,
+            categories: [' Kultur ', '', 'Service', 'Kultur', ' Service '],
+          },
+          content: {
+            ...defaults.content,
+            description: '   ',
+            mobileDescription: '   ',
+            tagsText: ' wissen, , digital, wissen ',
+          },
+          settings: {
+            externalId: '   ',
+            keywords: '',
+          },
+        },
+        undefined
+      );
+
+      expect(input).toMatchObject({
+        name: 'Bibliothek',
+        active: false,
+        categoryName: 'Kultur',
+        categories: [{ name: 'Kultur' }, { name: 'Service' }],
+        mobileDescription: '',
+        externalId: '',
+        keywords: '',
+        tags: ['wissen', 'digital', 'wissen'],
+        payload: undefined,
+      });
+      expect(input).not.toHaveProperty('description');
+    });
+
+    it('keeps partial structures, invalid validation sentinels, and row filtering semantics', () => {
+      const defaults = createDefaultPoiDetailFormValues();
+      const input = mapPoiDetailFormValuesToInput(
+        {
+          ...defaults,
+          content: {
+            ...defaults.content,
+            addresses: [
+              {
+                street: ' Hauptstraße 1 ',
+                geoLocation: { latitude: '52.5', longitude: '' },
+              },
+              {
+                geoLocation: {
+                  latitude: Number.POSITIVE_INFINITY as unknown as string,
+                  longitude: '13.4',
+                },
+              },
+            ],
+            location: {
+              district: ' Mitte ',
+              geoLocation: { latitude: Number.NaN as unknown as string, longitude: '13.41' },
+            },
+            contact: {
+              email: ' info@example.test ',
+              webUrls: [
+                { url: ' ', description: 'entfernt' },
+                { url: ' https://example.test ', description: ' Kontakt ' },
+              ],
+            },
+            openingHours: [
+              { open: false },
+              { weekday: 'Freitag', open: false, useYear: false, sortNumber: '0' },
+            ],
+            operator: {
+              name: ' Betreiber ',
+              address: { city: ' Essen ' },
+              contact: { phone: ' 0201 123 ' },
+            },
+            prices: [
+              { groupPrice: false },
+              { name: ' Frei ', amount: '0', groupPrice: false, ageFrom: '0' },
+            ],
+            mediaContents: [
+              { captionText: ' Ohne Quelle ', contentType: 'image/jpeg' },
+              { sourceUrl: { url: ' ' }, contentType: 'application/pdf' },
+            ],
+          },
+        },
+        {}
+      );
+
+      expect(input.addresses).toEqual([
+        { street: 'Hauptstraße 1', geoLocation: { latitude: 52.5, longitude: undefined } },
+        { geoLocation: { latitude: Number.NaN, longitude: 13.4 } },
+      ]);
+      expect(input.location).toEqual({
+        district: 'Mitte',
+        geoLocation: { latitude: Number.NaN, longitude: 13.41 },
+      });
+      expect(input.contact).toEqual({
+        email: 'info@example.test',
+        webUrls: [{ url: 'https://example.test', description: 'Kontakt' }],
+      });
+      expect(input.openingHours).toEqual([
+        { weekday: 'FR', sortNumber: 0, open: false, useYear: false },
+      ]);
+      expect(input.operatingCompany).toEqual({
+        name: 'Betreiber',
+        address: { city: 'Essen' },
+        contact: { phone: '0201 123' },
+      });
+      expect(input.priceInformations).toEqual([
+        { name: 'Frei', amount: 0, groupPrice: false, ageFrom: 0 },
+      ]);
+      expect(input.mediaContents).toEqual([
+        { captionText: 'Ohne Quelle', contentType: 'image' },
+        { contentType: 'attachment' },
+      ]);
+    });
+
+    it.each([
+      ['undefined', undefined, { payload: undefined }],
+      ['null', null, { payload: null }],
+      ['array', ['legacy'], { payload: ['legacy'] }],
+      ['scalar', 'legacy', { payload: 'legacy' }],
+      ['empty object', {}, {}],
+      ['object', { source: 'legacy' }, { payload: { source: 'legacy' } }],
+    ] as const)('keeps the %s payload serialization contract', (_label, payload, expected) => {
+      const input = mapPoiDetailFormValuesToInput(createDefaultPoiDetailFormValues(), payload);
+
+      if ('payload' in expected) {
+        expect(input).toHaveProperty('payload', expected.payload);
+      } else {
+        expect(input).not.toHaveProperty('payload');
+      }
+    });
+  });
+
+  describe('plan 023 inbound mapping characterization', () => {
+    const item = (overrides: Partial<PoiContentItem> = {}): PoiContentItem => ({
+      id: 'poi-characterization',
+      contentType: 'poi.point-of-interest',
+      status: 'published',
+      createdAt: '2026-06-11T10:00:00.000Z',
+      updatedAt: '2026-06-11T10:00:00.000Z',
+      name: 'Characterization',
+      ...overrides,
+    });
+
+    it('keeps category precedence, active defaults, and empty-list defaults', () => {
+      const explicit = mapPoiItemToDetailFormValues(
+        item({
+          active: false,
+          categoryName: 'Legacy',
+          categories: [{ name: 'Primär' }, { name: 'Sekundär' }],
+          addresses: [],
+          openingHours: [],
+          webUrls: [],
+          priceInformations: [],
+          certificates: [],
+        })
+      );
+      const legacy = mapPoiItemToDetailFormValues(item({ categoryName: 'Legacy' }));
+      const empty = mapPoiItemToDetailFormValues(item({ categories: [], categoryName: '' }));
+
+      expect(explicit.basis).toEqual({ categories: ['Primär', 'Sekundär'], active: false });
+      expect(legacy.basis).toEqual({ categories: ['Legacy'], active: true });
+      expect(empty.basis).toEqual({ categories: [], active: true });
+      expect(explicit.content).toMatchObject({
+        addresses: [{ street: '', city: '' }],
+        openingHours: [{ weekday: '', open: true }],
+        webUrls: [{ url: '' }],
+        prices: [{ amount: '', groupPrice: false }],
+        certificates: [{ name: '' }],
+      });
+    });
+
+    it('maps partial legacy structures, finite numbers, and payload runtime shapes exactly', () => {
+      const mapped = mapPoiItemToDetailFormValues(
+        item({
+          addresses: [
+            { city: 'Essen', geoLocation: { latitude: 0, longitude: Number.POSITIVE_INFINITY } },
+          ],
+          location: { district: 'Mitte', geoLocation: { latitude: -1, longitude: Number.NaN } },
+          contact: { phone: '0201 123' },
+          operatingCompany: { name: 'Betreiber', contact: { email: 'info@example.test' } },
+          priceInformations: [{ amount: 0, ageFrom: -1, ageTo: Number.POSITIVE_INFINITY }],
+          openingHours: [{ weekday: 'Donnerstag', open: false }],
+          payload: null,
+        })
+      );
+
+      expect(mapped.content.addresses).toEqual([
+        {
+          addition: '',
+          street: '',
+          zip: '',
+          city: 'Essen',
+          kind: '',
+          geoLocation: { latitude: '0', longitude: '' },
+        },
+      ]);
+      expect(mapped.content.location).toMatchObject({
+        district: 'Mitte',
+        geoLocation: { latitude: '-1', longitude: '' },
+      });
+      expect(mapped.content.contact).toMatchObject({ phone: '0201 123', webUrls: [] });
+      expect(mapped.content.operator).toMatchObject({
+        name: 'Betreiber',
+        contact: { email: 'info@example.test', webUrls: [] },
+      });
+      expect(mapped.content.prices[0]).toMatchObject({ amount: '0', ageFrom: '-1', ageTo: '' });
+      expect(mapped.content.openingHours).toEqual([{ weekday: 'TH', open: false }]);
+      expect(mapped.content.payloadText).toBe('null');
+      expect(mapPoiItemToDetailFormValues(item({ payload: undefined })).content.payloadText).toBe(
+        '{}'
+      );
+      expect(mapPoiItemToDetailFormValues(item({ payload: ['legacy'] })).content.payloadText).toBe(
+        '[\n  "legacy"\n]'
+      );
+      expect(
+        mapPoiItemToDetailFormValues(item({ payload: { source: 'legacy' } })).content.payloadText
+      ).toBe('{\n  "source": "legacy"\n}');
+      expect(parsePoiPayloadText('{not-json')).toBeUndefined();
+    });
+
+    it('preserves list order and the legacy clone-versus-reference behavior', () => {
+      const addresses = [{ city: 'Erste' }, { city: 'Zweite' }];
+      const openingHours = [
+        { weekday: 'Mittwoch', timeFrom: '09:00' },
+        { weekday: 'Montag', timeFrom: '08:00' },
+      ];
+      const webUrls = [
+        { url: 'https://second.example.test' },
+        { url: 'https://first.example.test' },
+      ];
+      const mediaContents = [{ captionText: 'Zwei' }, { captionText: 'Eins' }];
+      const certificates = [{ name: 'B' }, { name: 'A' }];
+      const mapped = mapPoiItemToDetailFormValues(
+        item({ addresses, openingHours, webUrls, mediaContents, certificates })
+      );
+
+      expect(mapped.content.addresses.map((address) => address.city)).toEqual(['Erste', 'Zweite']);
+      expect(mapped.content.openingHours.map((hour) => hour.weekday)).toEqual(['WE', 'MO']);
+      expect(mapped.content.webUrls).toBe(webUrls);
+      expect(mapped.content.mediaContents).toBe(mediaContents);
+      expect(mapped.content.certificates).toBe(certificates);
+      expect(mapped.content.addresses).not.toBe(addresses);
+      expect(mapped.content.openingHours).not.toBe(openingHours);
+    });
+
+    it('roundtrips stable inbound values without changing list order or legacy payload', () => {
+      const source = item({
+        categories: [{ name: 'Kultur' }, { name: 'Service' }],
+        addresses: [{ city: 'Essen', geoLocation: { latitude: 51.45, longitude: 7.01 } }],
+        openingHours: [{ weekday: 'Montag', timeFrom: '08:00', open: true }],
+        webUrls: [{ url: 'https://example.test', description: 'Website' }],
+        priceInformations: [{ name: 'Frei', amount: 0, groupPrice: false }],
+        payload: { source: 'legacy' },
+      });
+      const mapped = mapPoiItemToDetailFormValues(source);
+      const serialized = mapPoiDetailFormValuesToInput(
+        mapped,
+        parsePoiPayloadText(mapped.content.payloadText)
+      );
+
+      expect(serialized).toMatchObject({
+        categories: [{ name: 'Kultur' }, { name: 'Service' }],
+        addresses: [{ city: 'Essen', geoLocation: { latitude: 51.45, longitude: 7.01 } }],
+        openingHours: [{ weekday: 'MO', timeFrom: '08:00', open: true }],
+        webUrls: [{ url: 'https://example.test', description: 'Website' }],
+        priceInformations: [{ name: 'Frei', amount: 0, groupPrice: false }],
+        payload: { source: 'legacy' },
+      });
+    });
   });
 });

--- a/plans/023-refactor-poi-form-mapping.md
+++ b/plans/023-refactor-poi-form-mapping.md
@@ -7,6 +7,7 @@
 - **Priorität:** P1
 - **Aufwand:** M
 - **Risiko:** MITTEL
+- **Ergebnis:** REJECTED – wirtschaftlicher STOP nach Characterization und unabhängigem Review
 - **Abhängigkeit:** gemeinsam mit Plan 022
 - **Kategorie:** POI-Legacy-Daten, Complexity, CRAP
 - **Geplant auf:** `98e6ca3d7`, 15. August 2026
@@ -15,6 +16,24 @@
 ## Warum und Produktionsreichweite
 
 Das Modul wandelt bestehende Mainserver-POIs in Formularwerte um. Es entscheidet über Legacy-Kategorien, Defaultzeilen, `active !== false`, Numerik und Payload-Text. Der Export läuft über `poi.detail-form.ts` und wird nach `getPoiDetail` vor `react-hook-form reset` in `poi.detail-page.tsx` aufgerufen. Der Hotspot hat sechs Commits, +154/−25 Zeilen und Fan-in 1.
+
+## Ergebnis und wirtschaftlicher STOP
+
+Die separate Characterization für Kategorienpriorität, Defaults, Legacywerte,
+Numerik, Payload, Listenreihenfolge und Referenzverhalten ist grün und bleibt als
+zusätzliche Vertragsabsicherung bestehen. Der anschließend erprobte produktive
+Refactor wurde jedoch vollständig verworfen: Die Datei stieg von 130 auf 146
+Zeilen und von 11 auf 16 Funktionen; Cyclomatic gesamt stieg von 96 auf 101,
+während Cognitive gesamt nur von 42 auf 41 sank. Die fünf neuen Single-use-
+Mapper verteilten bestehende Entscheidungen überwiegend über weitere
+Funktionsgrenzen und erhöhten damit Ownership, statt sie belastbar zu senken.
+
+`packages/plugin-poi/src/poi.detail-form.mapping.ts` wurde deshalb exakt auf die
+Bundle-Basis `884248ef7a33c23e63f01cfaca52d83425f4be4e` zurückgesetzt. Der Zielanker
+`mapPoiContentToFormValues` mit CC 27/Cognitive 14/CRAP 184,5 bleibt transparent
+als Bestandsfinding bestehen. Eine spätere Bearbeitung braucht einen anderen,
+fachlich begründeten Ansatz; bloße Funktionszerlegung erfüllt den Nutzen-
+Aufwand-Schnitt nicht.
 
 ## Scope
 
@@ -49,6 +68,8 @@ Das Modul wandelt bestehende Mainserver-POIs in Formularwerte um. Es entscheidet
 - `git diff --check`
 - Final einmal `pnpm test:pr`, sofern der zuvor gemessene affected Scope praktikabel ist; eine Auslassung mit gemessenem Scope und Ersatzgates dokumentieren.
 - Vor Draft und nach jeder relevanten Source-Revision: `pnpm exec fallow audit --base origin/main --workspace @sva/plugin-poi --explain --format json`. Erwartet: `PASS`, `complexity_introduced: 0`, `dead_code_introduced: 0`, `duplication_introduced: 0`, `styling_introduced: 0` und keine neuen moderaten CRAP-Findings. Coverageabhängiges CRAP mit der vom Coverage-Target erzeugten `coverage-final.json` erneut prüfen.
-- Fertig ist der Plan, wenn der Zielanker `mapPoiContentToFormValues` verschwunden ist und Default-, Legacy-, Reihenfolge- und Payload-Semantik exakt belegt bleibt. Die kleinen Mapper dürfen als Bestandsfindings verbleiben, wenn ihre Änderung nur den Score verschöbe. Der Events-/POI-Clone bleibt unverändert, sofern er nicht allein durch natürliche Vereinfachung verschwindet.
+- Die Characterization ist abgeschlossen. Der produktive Fertig-Pfad wurde durch
+  die dokumentierte STOP-Bedingung beendet; Zielanker und kleine Mapper bleiben
+  als Bestandsfindings erhalten. Der Events-/POI-Clone bleibt unverändert.
 
 STOP bei notwendiger Mainserver-/Formvertragsänderung, bei Konflikt zwischen Roundtrip und bestehender UI-Semantik, bei `any`/Reflection oder bei einer neuen Cross-Plugin-Ownership-Grenze. Vor Start außerdem STOP, wenn `refactor-shared-editor-primitives` oder `add-studio-data-form-and-test-foundations` inzwischen dieselbe Mapping-Source, reine Formvertragstestfälle oder Testinfrastruktur beansprucht.

--- a/plans/README.md
+++ b/plans/README.md
@@ -45,6 +45,8 @@ eigenen Pull Request ausgeliefert.
 | 019 | Public-Waste-App-Zustand und Actions trennen | P1 | L | keine | DONE (#1004, `07d12bb80`) |
 | 020 | Event-Detailformular-Serialisierung modularisieren | P1 | L | keine | DONE (#1005, `6afcd8d52`) |
 | 021 | News-Kompatibilitäts-Snapshot entflechten | P1 | M | keine | DONE (#1006, `1df0515af`) |
+| 022 | POI-Formularserialisierung entflechten | P1 | M–L | Bundle A | IN PROGRESS (#1009) |
+| 023 | POI-Inbound-Mapping charakterisieren und vereinfachen | P1 | M | Bundle A | REJECTED – Characterization grün, produktiver Refactor nach Ownership-Review gestoppt (#1009) |
 
 Statuswerte: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, `REJECTED`.
 
@@ -160,7 +162,7 @@ auf; Dupes endete mit 0. Alle drei Reports waren valides JSON mit `kind`, Schema
 | Kandidat | Ist-Metrik und Trace | Risiko/Wirkung | Aufwand/Testbarkeit | Überschneidung/STOP | Entscheidung |
 |---|---|---|---|---|---|
 | POI-Serialisierung | 6 CRAP-Funde, max. 268,2; produktiver Create/Update-Pfad | POI-Datenintegrität; hoher Wartungsgewinn | M–L; breite Formtests | STOP bei Form-/Mainserver-Vertragsänderung | **ausgewählt, Plan 022** |
-| POI-Inbound-Hauptmapping | `mapPoiContentToFormValues`: CC 27/Cognitive 14/CRAP 184,5; produktiver Detail-Reset | Legacy-/Default-/Reihenfolgedaten | M; derselbe Formtestpfad | kleine Mapper nur charakterisieren, nicht metrisch zerlegen | **ausgewählt, Plan 023** |
+| POI-Inbound-Hauptmapping | `mapPoiContentToFormValues`: CC 27/Cognitive 14/CRAP 184,5; produktiver Detail-Reset | Legacy-/Default-/Reihenfolgedaten | M; Characterization grün | Versuch erhöhte Datei-CC 96→101 und Funktionen 11→16; Source exakt revertiert | **REJECTED nach wirtschaftlichem STOP, Plan 023** |
 | Instance Realm Steps | vier Funde, max. CRAP 299,6; Fan-in 4 | IAM-Status darf nicht falsch erscheinen | M–L; Status-/Fallbackmatrix | STOP bei Backend-/Fixture-Overlap | **ausgewählt, Plan 024** |
 | Instance Primary Action | CC 30/Cognitive 28; produktive Detailseite | sicherheitsrelevante Aktionspriorität | M; kombinatorische Matrix | keine neue Action/Permission | **ausgewählt, Plan 025** |
 | Waste DOI Message | CC 19/Cognitive 18/CRAP 97; Outbox-Pfad | Datenschutz- und Mailvertrag | S–M; fokussierter Unit-Pfad | Token/Secret/SQL explizit out | **ausgewählt, Plan 026** |
@@ -216,7 +218,7 @@ geprüft:
 
 | Bundle | Problempläne | Owner/Workspace | Gemeinsamer Vertrag und Gate-Pfad | Risiko | Aufwand | Abhängigkeiten | Bündelungsgrund |
 |---|---|---|---|---:|---:|---|---|
-| A – POI-Formvertrag | 022, 023 | Plugin POI / `@sva/plugin-poi` | bidirektionales pluginlokales Form-Mapping; `plugin-poi` Unit/Coverage/Types/Lint/Build und Fallow-Audit | mittel | L | Vorstart-Prüfung gegen `refactor-shared-editor-primitives` und `add-studio-data-form-and-test-foundations` | gleicher Owner, dieselbe reine Formvertragstestdatei und derselbe Datenvertrag; UI-/Testinfrastruktur bleibt fremder Scope |
+| A – POI-Formvertrag | 022 produktiv; 023 Characterization mit STOP | Plugin POI / `@sva/plugin-poi` | Serialisierung und abgesicherter Inbound-Vertrag; `plugin-poi` Unit/Coverage/Types/Lint/Build und Fallow-Audit | mittel | M–L | Vorstart-Prüfung gegen `refactor-shared-editor-primitives` und `add-studio-data-form-and-test-foundations` | gleicher Owner und Testpfad; der Inbound-Produktivrefactor wurde wegen zusätzlicher Single-use-Ownership vollständig revertiert |
 | B – Instance-Realm-Operations | 024, 025 | Studio Instance UI / `sva-studio-react` | Realm-Step- und Primäraktionsmodell; gezielte Modelltests, UI-Gates und App-Audit | hoch | L | Vorstart-Prüfung gegen `update-instance-detail-module-tab` | eine Datei, eine Status-/Prioritätsmatrix und Rollback-Grenze; Module-Tab/Journey-Fixtures bleiben fremder Scope |
 | C – Waste DOI Message | 026 | Studio Waste Runtime / `sva-studio-react` | DOI-Maildarstellung; fokussierter Server-Unit-/Type-/Build-Pfad und App-Audit | mittel | S–M | keine | Einzelproblem; Token, Secret, SQL, Datum und Idempotenz bleiben bewusst getrennt |
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -231,8 +231,8 @@ Testdateien. Vor Delegation wird die Delta-/Interaktionsprüfung wiederholt.
 
 | Plan | Titel | Priorität | Aufwand | Bundle | Status |
 |---|---|---:|---:|---|---|
-| 022 | POI-Formularserialisierung entflechten | P1 | M–L | A | TODO |
-| 023 | POI-Inbound-Mapping vereinfachen | P1 | M | A | TODO |
+| 022 | POI-Formularserialisierung entflechten | P1 | M–L | A | IN PROGRESS (#1009) |
+| 023 | POI-Inbound-Mapping vereinfachen | P1 | M | A | REJECTED – Refactor nach Ownership-Review gestoppt (#1009) |
 | 024 | Realm-Operationsschritte entflechten | P1 | M–L | B | TODO |
 | 025 | Instance-Primäraktion explizit priorisieren | P1 | M | B | TODO |
 | 026 | DOI-Versandnachricht entflechten | P1 | S–M | C | TODO |


### PR DESCRIPTION
## Zusammenfassung

- charakterisiert die Serialisierungs- und Inbound-Mapping-Verträge aus den Plänen 022 und 023
- entflechtet ausschließlich die POI-Serialisierung in fachlich benannte reine Transformationen
- dokumentiert den wirtschaftlichen STOP für Plan 023: Der erprobte Inbound-Refactor erhöhte Datei-CC und Funktionsanzahl und wurde vollständig auf die Basis zurückgesetzt

## Nachweise

- Plan 022 produktiv: Serialisierungsdatei CC 197 → 118, Cognitive 85 → 41, CRAP-Findings 6 → 0
- Plan 023 Characterization: Altverhalten abgesichert; produktive Mapping-Datei bytegleich zur Basis, Zielanker bleibt transparent als Bestandsfinding
- POI Unit und Coverage: jeweils 19 Dateien / 127 Tests grün
- POI Types, Lint (0 Fehler), Build grün
- Complexity, OpenSpec strict, File Placement und git diff --check grün
- Fallow New-only Audit mit Coverage: PASS; dead code, complexity, duplication und styling introduced jeweils 0
- `pnpm test:pr` lief vor der vollständigen Mapping-Reversion grün; aufgrund der separaten bytegleichen Dateireversion wurde die Vollsuite nach Reviewentscheidung nicht erneut ausgeführt

## OpenSpec

- `refactor-poi-form-contract`

Der PR bleibt bis Root-Diffreview, unabhängigem Bundle-Review, finaler Evidenz und terminaler CI im Draft.