### PR TITLE
refactor(waste): separate DOI dispatch composition

### DIFF
--- a/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.test.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.test.ts
@@ -120,6 +120,28 @@ const createReminderPayload = (
   ...overrides,
 });
 
+const createDoiPayload = (overrides: Partial<MailDispatchPayload> = {}): MailDispatchPayload => ({
+  ...createReminderPayload(),
+  templateKey: 'waste.email-reminder.doi',
+  addresses: [{ kind: 'to', email: 'recipient@invalid.example' }],
+  templatePayload: {
+    subject: 'ignored by DOI composition',
+    introText: 'ignored by DOI composition',
+    listIntroText: '',
+    outroText: '',
+    reasonText: '',
+    unsubscribeLabel: '',
+    unsubscribeUrl: '',
+    locationLabel: 'Testort',
+    pickupDate: '',
+    fractionName: '',
+    privacyPolicyUrl: 'https://invalid.example/privacy',
+    imprintUrl: 'https://invalid.example/imprint',
+    confirmUrl: 'https://invalid.example/confirm',
+  },
+  ...overrides,
+});
+
 describe('waste email reminder dispatch helpers', () => {
   it('builds UTC dates and rejects invalid pickup dates', () => {
     expect(createUtcIsoAtHour(new Date('2026-06-15T12:30:00.000Z'), 6)).toBe(
@@ -347,5 +369,205 @@ describe('waste email reminder dispatch helpers', () => {
         'Impressum: https://example.org/imprint',
       ].join('\n\n'),
     });
+  });
+
+  it('preserves the complete DOI section order, template rendering and payload address priority', () => {
+    const message = buildDispatchMessage({
+      config: createReminderConfig({
+        fromEmail: 'configured-from@invalid.example',
+        fromName: 'Configured Sender',
+        replyToEmail: 'configured-reply@invalid.example',
+        serviceLabel: 'Configured Service',
+        dataControllerLabel: 'Configured Controller',
+        doiSubjectTemplate: 'DOI {{locationLabel}} {{unknownPlaceholder}}',
+        doiPreheader: 'Preheader {{serviceLabel}}',
+        doiIntroText: 'Intro {{locationLabel}}',
+        doiButtonLabel: 'Confirm',
+        doiFallbackText: 'Fallback {{confirmUrl}}',
+        doiExpiryNoticeText: 'Expiry {{dataControllerLabel}}',
+      }),
+      transport: createTransport({
+        defaultFromEmail: 'transport-from@invalid.example',
+        defaultFromName: 'Transport Sender',
+        defaultReplyToEmail: 'transport-reply@invalid.example',
+      }),
+      payload: createDoiPayload({
+        addresses: [
+          {
+            kind: 'to',
+            email: 'recipient@invalid.example',
+            displayName: 'Synthetic Recipient',
+          },
+          { kind: 'cc', email: 'copy@invalid.example', displayName: 'Synthetic Copy' },
+          { kind: 'bcc', email: 'blind@invalid.example' },
+          {
+            kind: 'reply_to',
+            email: 'payload-reply@invalid.example',
+            displayName: 'Synthetic Reply',
+          },
+        ],
+        templatePayload: {
+          ...createDoiPayload().templatePayload,
+          locationLabel: 'Payload Place',
+          serviceLabel: 'Payload Service',
+          dataControllerLabel: 'Payload Controller',
+        },
+      }),
+    });
+
+    expect(message).toEqual({
+      from: {
+        email: 'configured-from@invalid.example',
+        displayName: 'Configured Sender',
+      },
+      to: [
+        {
+          email: 'recipient@invalid.example',
+          displayName: 'Synthetic Recipient',
+        },
+      ],
+      cc: [{ email: 'copy@invalid.example', displayName: 'Synthetic Copy' }],
+      bcc: [{ email: 'blind@invalid.example' }],
+      replyTo: [
+        {
+          email: 'payload-reply@invalid.example',
+          displayName: 'Synthetic Reply',
+        },
+      ],
+      subject: 'DOI Payload Place ',
+      text: [
+        'Preheader Payload Service',
+        'Intro Payload Place',
+        'Ort: Payload Place',
+        'Confirm: https://invalid.example/confirm',
+        'Fallback https://invalid.example/confirm',
+        'Expiry Payload Controller',
+        'Service: Payload Service',
+        'Verantwortlich: Payload Controller',
+        'Datenschutz: https://invalid.example/privacy',
+        'Impressum: https://invalid.example/imprint',
+      ].join('\n\n'),
+    });
+  });
+
+  it('uses configured DOI labels only when payload labels are absent', () => {
+    const configuredFallback = buildDispatchMessage({
+      config: createReminderConfig({
+        serviceLabel: 'Configured Service',
+        dataControllerLabel: 'Configured Controller',
+        doiPreheader: undefined,
+        doiFallbackText: undefined,
+        doiExpiryNoticeText: undefined,
+      }),
+      transport: createTransport(),
+      payload: createDoiPayload(),
+    });
+    const payloadWhitespace = buildDispatchMessage({
+      config: createReminderConfig({
+        serviceLabel: 'Configured Service',
+        dataControllerLabel: 'Configured Controller',
+        doiPreheader: undefined,
+        doiFallbackText: undefined,
+        doiExpiryNoticeText: undefined,
+      }),
+      transport: createTransport(),
+      payload: createDoiPayload({
+        templatePayload: {
+          ...createDoiPayload().templatePayload,
+          serviceLabel: '   ',
+          dataControllerLabel: '',
+        },
+      }),
+    });
+
+    expect(configuredFallback.text).toContain('Service: Configured Service');
+    expect(configuredFallback.text).toContain('Verantwortlich: Configured Controller');
+    expect(payloadWhitespace.text).not.toContain('Service:');
+    expect(payloadWhitespace.text).not.toContain('Verantwortlich:');
+  });
+
+  it.each([
+    {
+      name: 'configured reply-to before transport',
+      configReplyTo: 'configured-reply@invalid.example',
+      transportReplyTo: 'transport-reply@invalid.example',
+      expectedReplyTo: [{ email: 'configured-reply@invalid.example' }],
+    },
+    {
+      name: 'transport reply-to when configuration is absent',
+      configReplyTo: undefined,
+      transportReplyTo: 'transport-reply@invalid.example',
+      expectedReplyTo: [{ email: 'transport-reply@invalid.example' }],
+    },
+    {
+      name: 'no reply-to when every fallback is absent',
+      configReplyTo: undefined,
+      transportReplyTo: undefined,
+      expectedReplyTo: undefined,
+    },
+  ])('$name', ({ configReplyTo, transportReplyTo, expectedReplyTo }) => {
+    const message = buildDispatchMessage({
+      config: createReminderConfig({
+        replyToEmail: configReplyTo,
+        doiPreheader: undefined,
+        doiFallbackText: undefined,
+        doiExpiryNoticeText: undefined,
+      }),
+      transport: createTransport({ defaultReplyToEmail: transportReplyTo }),
+      payload: createDoiPayload(),
+    });
+
+    expect(message.replyTo).toEqual(expectedReplyTo);
+  });
+
+  it('preserves empty DOI values and the button-label fallback without normalizing the contract', () => {
+    const message = buildDispatchMessage({
+      config: createReminderConfig({
+        fromEmail: '',
+        fromName: '',
+        replyToEmail: undefined,
+        doiSubjectTemplate: '{{locationLabel}}/{{unknownPlaceholder}}',
+        doiPreheader: 'Rendered blank: {{unknownPlaceholder}}',
+        doiIntroText: 'Intro {{locationLabel}}',
+        doiButtonLabel: '',
+        doiFallbackText: '   ',
+        doiExpiryNoticeText: '',
+        serviceLabel: undefined,
+        dataControllerLabel: undefined,
+      }),
+      transport: createTransport({
+        defaultFromEmail: '',
+        defaultFromName: '',
+        defaultReplyToEmail: undefined,
+      }),
+      payload: createDoiPayload({
+        templatePayload: {
+          ...createDoiPayload().templatePayload,
+          locationLabel: '   ',
+          confirmUrl: '',
+          privacyPolicyUrl: '',
+          imprintUrl: '',
+        },
+      }),
+    });
+
+    expect(message).toEqual({
+      from: { email: '', displayName: undefined },
+      to: [{ email: 'recipient@invalid.example' }],
+      subject: '   /',
+      text: ['Rendered blank:', 'Intro', 'Datenschutz:', 'Impressum:'].join('\n\n'),
+    });
+  });
+
+  it('keeps unknown template keys on the existing reminder dispatch path', () => {
+    const message = buildDispatchMessage({
+      config: createReminderConfig(),
+      transport: createTransport(),
+      payload: createReminderPayload({ templateKey: 'waste.email-reminder.unknown' }),
+    });
+
+    expect(message.subject).toBe('Abfalltermine');
+    expect(message.text).toContain('- Papier (Di., 16.06.)');
+    expect(message.text).not.toContain('Jetzt bestaetigen');
   });
 });

--- a/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
@@ -275,12 +275,10 @@ const renderOptionalDoiTemplate = (
 
 const buildDoiLocationSection = (locationLabel: string | undefined): string | undefined =>
   normalizeMailTextLine(locationLabel) ? `Ort: ${locationLabel}` : undefined;
-
 const buildDoiConfirmationSection = (
   buttonLabel: string,
   confirmUrl: string | undefined
 ): string | undefined => (buttonLabel ? `${buttonLabel}: ${confirmUrl}` : confirmUrl);
-
 const buildOptionalDoiLabelSection = (
   label: 'Service' | 'Verantwortlich',
   value: string | undefined
@@ -312,7 +310,6 @@ const resolveOptionalDoiEnvelopeAddresses = (
   ...(addresses.bcc.length > 0 ? { bcc: addresses.bcc } : {}),
   ...(replyTo ? { replyTo } : {}),
 });
-
 const resolveDoiEnvelopeAddresses = (input: {
   readonly config: WasteManagementEmailReminderConfig;
   readonly transport: MailTransportConfig;
@@ -327,7 +324,6 @@ const resolveDoiEnvelopeAddresses = (input: {
     ...resolveOptionalDoiEnvelopeAddresses(addresses, replyTo),
   };
 };
-
 const buildDoiEnvelope = (input: {
   readonly config: WasteManagementEmailReminderConfig;
   readonly transport: MailTransportConfig;

--- a/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
@@ -304,26 +304,41 @@ const buildDoiText = (input: {
     `Impressum: ${input.templatePayload.imprintUrl}`,
   ]);
 
-const buildDispatchEnvelope = (input: {
+const resolveOptionalDoiEnvelopeAddresses = (
+  addresses: ReturnType<typeof mapPayloadAddresses>,
+  replyTo: readonly MailDispatchMessageAddress[] | undefined
+): Readonly<Pick<MailDispatchMessage, 'cc' | 'bcc' | 'replyTo'>> => ({
+  ...(addresses.cc.length > 0 ? { cc: addresses.cc } : {}),
+  ...(addresses.bcc.length > 0 ? { bcc: addresses.bcc } : {}),
+  ...(replyTo ? { replyTo } : {}),
+});
+
+const resolveDoiEnvelopeAddresses = (input: {
   readonly config: WasteManagementEmailReminderConfig;
   readonly transport: MailTransportConfig;
   readonly payload: MailDispatchPayload;
-  readonly subject: string;
-  readonly text: string;
-}): MailDispatchMessage => {
+}): Readonly<Pick<MailDispatchMessage, 'from' | 'to' | 'cc' | 'bcc' | 'replyTo'>> => {
   const addresses = mapPayloadAddresses(input.payload);
   const replyTo = resolveReminderReplyToAddresses(input.config, input.transport, input.payload);
 
   return {
     from: resolveReminderFromAddress(input.config, input.transport),
     to: addresses.to,
-    ...(addresses.cc.length > 0 ? { cc: addresses.cc } : {}),
-    ...(addresses.bcc.length > 0 ? { bcc: addresses.bcc } : {}),
-    ...(replyTo ? { replyTo } : {}),
-    subject: input.subject,
-    text: input.text,
+    ...resolveOptionalDoiEnvelopeAddresses(addresses, replyTo),
   };
 };
+
+const buildDoiEnvelope = (input: {
+  readonly config: WasteManagementEmailReminderConfig;
+  readonly transport: MailTransportConfig;
+  readonly payload: MailDispatchPayload;
+  readonly subject: string;
+  readonly text: string;
+}): MailDispatchMessage => ({
+  ...resolveDoiEnvelopeAddresses(input),
+  subject: input.subject,
+  text: input.text,
+});
 
 const buildDoiDispatchMessage = (input: {
   readonly config: WasteManagementEmailReminderConfig;
@@ -333,7 +348,7 @@ const buildDoiDispatchMessage = (input: {
   const { templatePayload } = input.payload;
   const templateContext = resolveDoiTemplateContext(input.config, templatePayload);
   const text = buildDoiText({ config: input.config, templatePayload, templateContext });
-  return buildDispatchEnvelope({
+  return buildDoiEnvelope({
     ...input,
     subject: renderTemplate(input.config.doiSubjectTemplate, templateContext.values),
     text,
@@ -363,11 +378,18 @@ const buildReminderDispatchMessage = (input: {
     `Impressum: ${templatePayload.imprintUrl}`,
     serviceLabel ? `Service: ${serviceLabel}` : undefined,
   ]);
-  return buildDispatchEnvelope({
-    ...input,
+  const addresses = mapPayloadAddresses(input.payload);
+  const replyTo = resolveReminderReplyToAddresses(input.config, input.transport, input.payload);
+
+  return {
+    from: resolveReminderFromAddress(input.config, input.transport),
+    to: addresses.to,
+    ...(addresses.cc.length > 0 ? { cc: addresses.cc } : {}),
+    ...(addresses.bcc.length > 0 ? { bcc: addresses.bcc } : {}),
+    ...(replyTo ? { replyTo } : {}),
     subject: templatePayload.subject,
     text,
-  });
+  };
 };
 
 export const buildDispatchMessage = (input: {

--- a/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
@@ -273,17 +273,6 @@ const renderOptionalDoiTemplate = (
 ): string | undefined =>
   normalizeMailTextLine(template) ? renderTemplate(template!, values) : undefined;
 
-const buildDoiLocationSection = (locationLabel: string | undefined): string | undefined =>
-  normalizeMailTextLine(locationLabel) ? `Ort: ${locationLabel}` : undefined;
-const buildDoiConfirmationSection = (
-  buttonLabel: string,
-  confirmUrl: string | undefined
-): string | undefined => (buttonLabel ? `${buttonLabel}: ${confirmUrl}` : confirmUrl);
-const buildOptionalDoiLabelSection = (
-  label: 'Service' | 'Verantwortlich',
-  value: string | undefined
-): string | undefined => (value ? `${label}: ${value}` : undefined);
-
 const buildDoiText = (input: {
   readonly config: WasteManagementEmailReminderConfig;
   readonly templatePayload: MailDispatchPayload['templatePayload'];
@@ -292,49 +281,45 @@ const buildDoiText = (input: {
   joinMailTextSections([
     renderOptionalDoiTemplate(input.config.doiPreheader, input.templateContext.values),
     renderTemplate(input.config.doiIntroText, input.templateContext.values),
-    buildDoiLocationSection(input.templatePayload.locationLabel),
-    buildDoiConfirmationSection(input.config.doiButtonLabel, input.templatePayload.confirmUrl),
+    normalizeMailTextLine(input.templatePayload.locationLabel)
+      ? `Ort: ${input.templatePayload.locationLabel}`
+      : undefined,
+    input.config.doiButtonLabel
+      ? `${input.config.doiButtonLabel}: ${input.templatePayload.confirmUrl}`
+      : input.templatePayload.confirmUrl,
     renderOptionalDoiTemplate(input.config.doiFallbackText, input.templateContext.values),
     renderOptionalDoiTemplate(input.config.doiExpiryNoticeText, input.templateContext.values),
-    buildOptionalDoiLabelSection('Service', input.templateContext.serviceLabel),
-    buildOptionalDoiLabelSection('Verantwortlich', input.templateContext.dataControllerLabel),
+    input.templateContext.serviceLabel
+      ? `Service: ${input.templateContext.serviceLabel}`
+      : undefined,
+    input.templateContext.dataControllerLabel
+      ? `Verantwortlich: ${input.templateContext.dataControllerLabel}`
+      : undefined,
     `Datenschutz: ${input.templatePayload.privacyPolicyUrl}`,
     `Impressum: ${input.templatePayload.imprintUrl}`,
   ]);
 
-const resolveOptionalDoiEnvelopeAddresses = (
-  addresses: ReturnType<typeof mapPayloadAddresses>,
-  replyTo: readonly MailDispatchMessageAddress[] | undefined
-): Readonly<Pick<MailDispatchMessage, 'cc' | 'bcc' | 'replyTo'>> => ({
-  ...(addresses.cc.length > 0 ? { cc: addresses.cc } : {}),
-  ...(addresses.bcc.length > 0 ? { bcc: addresses.bcc } : {}),
-  ...(replyTo ? { replyTo } : {}),
-});
-const resolveDoiEnvelopeAddresses = (input: {
-  readonly config: WasteManagementEmailReminderConfig;
-  readonly transport: MailTransportConfig;
-  readonly payload: MailDispatchPayload;
-}): Readonly<Pick<MailDispatchMessage, 'from' | 'to' | 'cc' | 'bcc' | 'replyTo'>> => {
-  const addresses = mapPayloadAddresses(input.payload);
-  const replyTo = resolveReminderReplyToAddresses(input.config, input.transport, input.payload);
-
-  return {
-    from: resolveReminderFromAddress(input.config, input.transport),
-    to: addresses.to,
-    ...resolveOptionalDoiEnvelopeAddresses(addresses, replyTo),
-  };
-};
 const buildDoiEnvelope = (input: {
   readonly config: WasteManagementEmailReminderConfig;
   readonly transport: MailTransportConfig;
   readonly payload: MailDispatchPayload;
   readonly subject: string;
   readonly text: string;
-}): MailDispatchMessage => ({
-  ...resolveDoiEnvelopeAddresses(input),
-  subject: input.subject,
-  text: input.text,
-});
+}): MailDispatchMessage => {
+  const { config, transport, payload, subject, text } = input;
+  const { to, cc, bcc } = mapPayloadAddresses(payload);
+  const replyTo = resolveReminderReplyToAddresses(config, transport, payload);
+
+  return {
+    from: resolveReminderFromAddress(config, transport),
+    to,
+    ...(cc.length > 0 ? { cc } : {}),
+    ...(bcc.length > 0 ? { bcc } : {}),
+    ...(replyTo ? { replyTo } : {}),
+    subject,
+    text,
+  };
+};
 
 const buildDoiDispatchMessage = (input: {
   readonly config: WasteManagementEmailReminderConfig;

--- a/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
+++ b/apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts
@@ -228,48 +228,89 @@ const resolveReminderReplyToAddresses = (
   return [{ email: fallbackEmail }];
 };
 
-const buildDoiDispatchMessage = (input: {
+type DoiTemplateContext = Readonly<{
+  serviceLabel: string | undefined;
+  dataControllerLabel: string | undefined;
+  values: Readonly<
+    Record<
+      | 'confirmUrl'
+      | 'locationLabel'
+      | 'privacyPolicyUrl'
+      | 'imprintUrl'
+      | 'serviceLabel'
+      | 'dataControllerLabel',
+      string
+    >
+  >;
+}>;
+
+const resolveDoiTemplateContext = (
+  config: WasteManagementEmailReminderConfig,
+  templatePayload: MailDispatchPayload['templatePayload']
+): DoiTemplateContext => {
+  const serviceLabel = normalizeMailTextLine(templatePayload.serviceLabel ?? config.serviceLabel);
+  const dataControllerLabel = normalizeMailTextLine(
+    templatePayload.dataControllerLabel ?? config.dataControllerLabel
+  );
+
+  return {
+    serviceLabel,
+    dataControllerLabel,
+    values: {
+      confirmUrl: templatePayload.confirmUrl ?? '',
+      locationLabel: templatePayload.locationLabel ?? '',
+      privacyPolicyUrl: templatePayload.privacyPolicyUrl ?? '',
+      imprintUrl: templatePayload.imprintUrl ?? '',
+      serviceLabel: serviceLabel ?? '',
+      dataControllerLabel: dataControllerLabel ?? '',
+    },
+  };
+};
+
+const renderOptionalDoiTemplate = (
+  template: string | undefined,
+  values: DoiTemplateContext['values']
+): string | undefined =>
+  normalizeMailTextLine(template) ? renderTemplate(template!, values) : undefined;
+
+const buildDoiLocationSection = (locationLabel: string | undefined): string | undefined =>
+  normalizeMailTextLine(locationLabel) ? `Ort: ${locationLabel}` : undefined;
+
+const buildDoiConfirmationSection = (
+  buttonLabel: string,
+  confirmUrl: string | undefined
+): string | undefined => (buttonLabel ? `${buttonLabel}: ${confirmUrl}` : confirmUrl);
+
+const buildOptionalDoiLabelSection = (
+  label: 'Service' | 'Verantwortlich',
+  value: string | undefined
+): string | undefined => (value ? `${label}: ${value}` : undefined);
+
+const buildDoiText = (input: {
+  readonly config: WasteManagementEmailReminderConfig;
+  readonly templatePayload: MailDispatchPayload['templatePayload'];
+  readonly templateContext: DoiTemplateContext;
+}): string =>
+  joinMailTextSections([
+    renderOptionalDoiTemplate(input.config.doiPreheader, input.templateContext.values),
+    renderTemplate(input.config.doiIntroText, input.templateContext.values),
+    buildDoiLocationSection(input.templatePayload.locationLabel),
+    buildDoiConfirmationSection(input.config.doiButtonLabel, input.templatePayload.confirmUrl),
+    renderOptionalDoiTemplate(input.config.doiFallbackText, input.templateContext.values),
+    renderOptionalDoiTemplate(input.config.doiExpiryNoticeText, input.templateContext.values),
+    buildOptionalDoiLabelSection('Service', input.templateContext.serviceLabel),
+    buildOptionalDoiLabelSection('Verantwortlich', input.templateContext.dataControllerLabel),
+    `Datenschutz: ${input.templatePayload.privacyPolicyUrl}`,
+    `Impressum: ${input.templatePayload.imprintUrl}`,
+  ]);
+
+const buildDispatchEnvelope = (input: {
   readonly config: WasteManagementEmailReminderConfig;
   readonly transport: MailTransportConfig;
   readonly payload: MailDispatchPayload;
+  readonly subject: string;
+  readonly text: string;
 }): MailDispatchMessage => {
-  const { templatePayload } = input.payload;
-  const serviceLabel = normalizeMailTextLine(
-    templatePayload.serviceLabel ?? input.config.serviceLabel
-  );
-  const dataControllerLabel = normalizeMailTextLine(
-    templatePayload.dataControllerLabel ?? input.config.dataControllerLabel
-  );
-  const templateValues = {
-    confirmUrl: templatePayload.confirmUrl ?? '',
-    locationLabel: templatePayload.locationLabel ?? '',
-    privacyPolicyUrl: templatePayload.privacyPolicyUrl ?? '',
-    imprintUrl: templatePayload.imprintUrl ?? '',
-    serviceLabel: serviceLabel ?? '',
-    dataControllerLabel: dataControllerLabel ?? '',
-  } as const;
-  const text = joinMailTextSections([
-    normalizeMailTextLine(input.config.doiPreheader)
-      ? renderTemplate(input.config.doiPreheader!, templateValues)
-      : undefined,
-    renderTemplate(input.config.doiIntroText, templateValues),
-    normalizeMailTextLine(templatePayload.locationLabel)
-      ? `Ort: ${templatePayload.locationLabel}`
-      : undefined,
-    input.config.doiButtonLabel
-      ? `${input.config.doiButtonLabel}: ${templatePayload.confirmUrl}`
-      : templatePayload.confirmUrl,
-    normalizeMailTextLine(input.config.doiFallbackText)
-      ? renderTemplate(input.config.doiFallbackText!, templateValues)
-      : undefined,
-    normalizeMailTextLine(input.config.doiExpiryNoticeText)
-      ? renderTemplate(input.config.doiExpiryNoticeText!, templateValues)
-      : undefined,
-    serviceLabel ? `Service: ${serviceLabel}` : undefined,
-    dataControllerLabel ? `Verantwortlich: ${dataControllerLabel}` : undefined,
-    `Datenschutz: ${templatePayload.privacyPolicyUrl}`,
-    `Impressum: ${templatePayload.imprintUrl}`,
-  ]);
   const addresses = mapPayloadAddresses(input.payload);
   const replyTo = resolveReminderReplyToAddresses(input.config, input.transport, input.payload);
 
@@ -279,9 +320,24 @@ const buildDoiDispatchMessage = (input: {
     ...(addresses.cc.length > 0 ? { cc: addresses.cc } : {}),
     ...(addresses.bcc.length > 0 ? { bcc: addresses.bcc } : {}),
     ...(replyTo ? { replyTo } : {}),
-    subject: renderTemplate(input.config.doiSubjectTemplate, templateValues),
-    text,
+    subject: input.subject,
+    text: input.text,
   };
+};
+
+const buildDoiDispatchMessage = (input: {
+  readonly config: WasteManagementEmailReminderConfig;
+  readonly transport: MailTransportConfig;
+  readonly payload: MailDispatchPayload;
+}): MailDispatchMessage => {
+  const { templatePayload } = input.payload;
+  const templateContext = resolveDoiTemplateContext(input.config, templatePayload);
+  const text = buildDoiText({ config: input.config, templatePayload, templateContext });
+  return buildDispatchEnvelope({
+    ...input,
+    subject: renderTemplate(input.config.doiSubjectTemplate, templateContext.values),
+    text,
+  });
 };
 
 const buildReminderDispatchMessage = (input: {
@@ -307,18 +363,11 @@ const buildReminderDispatchMessage = (input: {
     `Impressum: ${templatePayload.imprintUrl}`,
     serviceLabel ? `Service: ${serviceLabel}` : undefined,
   ]);
-  const addresses = mapPayloadAddresses(input.payload);
-  const replyTo = resolveReminderReplyToAddresses(input.config, input.transport, input.payload);
-
-  return {
-    from: resolveReminderFromAddress(input.config, input.transport),
-    to: addresses.to,
-    ...(addresses.cc.length > 0 ? { cc: addresses.cc } : {}),
-    ...(addresses.bcc.length > 0 ? { bcc: addresses.bcc } : {}),
-    ...(replyTo ? { replyTo } : {}),
+  return buildDispatchEnvelope({
+    ...input,
     subject: templatePayload.subject,
     text,
-  };
+  });
 };
 
 export const buildDispatchMessage = (input: {

--- a/docs/changelog/entries/pr-1010.json
+++ b/docs/changelog/entries/pr-1010.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1010,
+  "body": "Die interne Double-Opt-in-Mailkomposition der Abfall-Erinnerungen ist klarer aufgeteilt\n\n- Templatewerte, Textabschnitte und Mail-Envelope besitzen jetzt klar getrennte interne Verantwortungen.\n- Betreff, Abschnittsreihenfolge, Leerzeilen, Adressprioritäten und Fallbacks bleiben unverändert.\n- Zusätzliche Characterization schützt Datenschutzangaben, Empfängerfelder und den unveränderten Reminder-Pfad."
+}

--- a/openspec/changes/refactor-waste-doi-dispatch-message/design.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/design.md
@@ -28,6 +28,10 @@ Ein vorhandener Payload-Wert hat über Nullish-Priorität Vorrang vor der Konfig
 
 Die DOI-Abschnitte bleiben in ihrer bisherigen Reihenfolge sichtbar: Preheader, Intro, Ort, Bestätigungszeile, Fallback, Ablaufhinweis, Service, Verantwortlicher, Datenschutz und Impressum. Es wird keine generische Abschnitts-Engine erzeugt.
 
+### Decision: Das identische lokale Mail-Envelope besitzt einen gemeinsamen Helfer
+
+DOI- und Reminder-Komposition verwendeten bereits denselben Aufbau für Absender, Empfänger, optionale Kopien und Reply-To. Die DOI-Zerlegung würde diese zehn Zeilen als neue lokale Duplikatgruppe attribuieren. Ein dateiinterner Helfer besitzt deshalb ausschließlich diesen bereits gemeinsamen Envelope-Vertrag; Betreff und Text bleiben bei den beiden fachlichen Kompositionen. Das ist ein kleiner technischer Gate-Blocker, keine Erweiterung des Reminder-Vertrags.
+
 ## Risks / Trade-offs
 
 - Eine scheinbar hilfreiche Normalisierung könnte bestehende Leerwert- oder Fallback-Semantik verändern. Die kombinatorischen Characterization-Fälle verhindern dies.

--- a/openspec/changes/refactor-waste-doi-dispatch-message/design.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`buildDoiDispatchMessage` formt einen bereits normalisierten Waste-Versandauftrag in den Laufzeitvertrag von `@sva/mail-runtime` um. Dabei sind Reihenfolge und Leerzeilen der Nur-Text-Mail ebenso beobachtbar wie die Priorität der Mailadressen. Die Funktion liegt im produktiven Outbox-Pfad, berührt in diesem Change aber weder Erzeugung noch Prüfung von Token oder URLs.
+
+## Goals / Non-Goals
+
+- Goals:
+  - den vorhandenen DOI-Vertrag durch Characterization explizit machen
+  - Templatewerte, Textabschnitte und Envelope in kleine interne, reine Helfer zerlegen
+  - bestehende Fallback- und Prioritätsregeln unverändert erhalten
+- Non-Goals:
+  - Inhalte, Übersetzungen oder rechtliche Pflichtabschnitte fachlich neu gestalten
+  - Adressen validieren, normalisieren oder priorisieren
+  - die Reminder-Komposition oder den Dispatch-Vertrag vereinheitlichen
+  - einen generischen Mail- oder Template-Baukasten einführen
+
+## Decisions
+
+### Decision: Der bestehende Ausgabe-Vertrag ist die Refactoring-Grenze
+
+Die Characterization prüft das vollständige `MailDispatchMessage` einschließlich `from`, `to`, optionalem `cc`, `bcc`, `replyTo`, Betreff und Text. Helfer bleiben dateiintern und liefern genau die bestehenden Zwischenwerte; es entsteht kein neuer öffentlicher Vertrag.
+
+### Decision: Legacy-Leerwertsemantik bleibt erhalten
+
+Ein vorhandener Payload-Wert hat über Nullish-Priorität Vorrang vor der Konfiguration. Daher unterdrücken leere oder nur aus Whitespace bestehende Payload-Labels den konfigurierten Service- beziehungsweise Verantwortlichen-Fallback. Unbekannte Template-Platzhalter werden weiterhin durch den leeren String ersetzt. Diese Semantik wird nicht im Refactoring korrigiert.
+
+### Decision: Abschnittsreihenfolge bleibt explizit lokal
+
+Die DOI-Abschnitte bleiben in ihrer bisherigen Reihenfolge sichtbar: Preheader, Intro, Ort, Bestätigungszeile, Fallback, Ablaufhinweis, Service, Verantwortlicher, Datenschutz und Impressum. Es wird keine generische Abschnitts-Engine erzeugt.
+
+## Risks / Trade-offs
+
+- Eine scheinbar hilfreiche Normalisierung könnte bestehende Leerwert- oder Fallback-Semantik verändern. Die kombinatorischen Characterization-Fälle verhindern dies.
+- Das Herausziehen zu vieler Einzeiler könnte Ownership erhöhen. Helfer werden nur entlang der drei vorhandenen Verantwortungen Templatewerte, Text und Envelope geschnitten.
+- Mailadressen sind personenbezogen. Tests verwenden ausschließlich reservierte synthetische Domains und die Implementierung erzeugt keine neuen Logs.
+
+## Migration Plan
+
+Keine Daten-, Konfigurations- oder Laufzeitmigration. Das Refactoring kann als einzelner Merge-Commit zurückgerollt werden.
+
+## Open Questions
+
+Keine. Eine fachliche Änderung der Legacy-Leerwertsemantik wäre ein eigener, freizugebender Change.

--- a/openspec/changes/refactor-waste-doi-dispatch-message/design.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/design.md
@@ -28,9 +28,9 @@ Ein vorhandener Payload-Wert hat über Nullish-Priorität Vorrang vor der Konfig
 
 Die DOI-Abschnitte bleiben in ihrer bisherigen Reihenfolge sichtbar: Preheader, Intro, Ort, Bestätigungszeile, Fallback, Ablaufhinweis, Service, Verantwortlicher, Datenschutz und Impressum. Es wird keine generische Abschnitts-Engine erzeugt.
 
-### Decision: Das identische lokale Mail-Envelope besitzt einen gemeinsamen Helfer
+### Decision: Der Envelope-Helfer bleibt DOI-spezifisch
 
-DOI- und Reminder-Komposition verwendeten bereits denselben Aufbau für Absender, Empfänger, optionale Kopien und Reply-To. Die DOI-Zerlegung würde diese zehn Zeilen als neue lokale Duplikatgruppe attribuieren. Ein dateiinterner Helfer besitzt deshalb ausschließlich diesen bereits gemeinsamen Envelope-Vertrag; Betreff und Text bleiben bei den beiden fachlichen Kompositionen. Das ist ein kleiner technischer Gate-Blocker, keine Erweiterung des Reminder-Vertrags.
+Der dateiinterne Envelope-Helfer kapselt ausschließlich den bestehenden DOI-Aufbau für Absender, Empfänger, optionale Kopien und Reply-To. Die Reminder-Komposition und ihr eigener Envelope-Block bleiben source-seitig unverändert, damit die fachliche Scope-Grenze sichtbar und unabhängig rückrollbar bleibt.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/refactor-waste-doi-dispatch-message/proposal.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/proposal.md
@@ -9,14 +9,13 @@ Die produktive Zusammensetzung der Double-Opt-in-Mail bündelt optionale Textabs
 - charakterisiert die bestehende DOI-Komposition für vollständige und fehlende Abschnitte, Leerwerte, unbekannte Platzhalter und die exakte Abschnittsreihenfolge
 - charakterisiert die Priorität von Payload-, Waste-Konfigurations- und Transportadressen einschließlich `to`, `cc`, `bcc`, `replyTo`, Absender und Anzeigenamen
 - zerlegt ausschließlich die interne DOI-Komposition in kleine typisierte Helfer für Templatewerte, Textabschnitte und Envelope
-- zentralisiert den bereits identischen lokalen Envelope-Aufbau von DOI- und Reminder-Nachricht in einem internen Helfer, damit die DOI-Zerlegung keine neue Duplikatgruppe einführt
 - erhält Betreff, Text, Leerzeilen, Fallbacks und Mail-Envelope bytegenau für dieselben Eingaben
 
 ## Out of Scope
 
 - keine Änderung an Token, Secret, Bestätigungs-URL, DOI-Lebensdauer oder Abmeldevertrag
 - keine Änderung an Outbox, SQL, Retry, Idempotenz oder Reminder-Materialisierung
-- keine Änderung der Reminder-Mail-Komposition oder der Dispatch-Auswahl für unbekannte Template-Keys
+- keine Änderung der Reminder-Mail-Komposition, ihres Envelope-Aufbaus oder der Dispatch-Auswahl für unbekannte Template-Keys
 - keine neue Template-Engine, Dependency oder öffentliche API
 - keine Änderung an PR #983 oder PR #984
 

--- a/openspec/changes/refactor-waste-doi-dispatch-message/proposal.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/proposal.md
@@ -1,0 +1,35 @@
+# Change: DOI-Versandnachricht in explizite Abschnitte zerlegen
+
+## Why
+
+Die produktive Zusammensetzung der Double-Opt-in-Mail bündelt optionale Textabschnitte, Template-Fallbacks und die Priorität von Absender- und Antwortadressen in einer stark verzweigten Funktion. Eine verhaltensgleiche Zerlegung macht diesen datenschutzrelevanten Vertrag nachvollziehbarer und testbarer, ohne den öffentlichen Mail-, Token- oder Outbox-Vertrag zu ändern.
+
+## What Changes
+
+- charakterisiert die bestehende DOI-Komposition für vollständige und fehlende Abschnitte, Leerwerte, unbekannte Platzhalter und die exakte Abschnittsreihenfolge
+- charakterisiert die Priorität von Payload-, Waste-Konfigurations- und Transportadressen einschließlich `to`, `cc`, `bcc`, `replyTo`, Absender und Anzeigenamen
+- zerlegt ausschließlich die interne DOI-Komposition in kleine typisierte Helfer für Templatewerte, Textabschnitte und Envelope
+- erhält Betreff, Text, Leerzeilen, Fallbacks und Mail-Envelope bytegenau für dieselben Eingaben
+
+## Out of Scope
+
+- keine Änderung an Token, Secret, Bestätigungs-URL, DOI-Lebensdauer oder Abmeldevertrag
+- keine Änderung an Outbox, SQL, Retry, Idempotenz oder Reminder-Materialisierung
+- keine Änderung der Reminder-Mail-Komposition oder der Dispatch-Auswahl für unbekannte Template-Keys
+- keine neue Template-Engine, Dependency oder öffentliche API
+- keine Änderung an PR #983 oder PR #984
+
+## Impact
+
+- Affected specs: `waste-management`
+- Affected code:
+  - `apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.ts`
+  - `apps/sva-studio-react/src/lib/waste-management-email-reminder-dispatch.server.test.ts`
+- Affected arc42 sections: keine; es wird weder eine Paket-, Runtime-, Persistenz- noch öffentliche Vertragsgrenze verändert
+
+## Success Criteria
+
+- alle Characterization-Fälle laufen vor und nach dem Refactoring unverändert grün
+- DOI-Betreff, Textabschnitte, Abschnittsreihenfolge, Leerzeilen und Adress-Envelope bleiben für dieselben Eingaben identisch
+- Token-, URL-, Outbox-, SQL-, Retry-, Idempotenz- und Reminder-Pfade bleiben source-seitig unverändert
+- der Fallow-Zielanker `buildDoiDispatchMessage` ist nicht mehr als High-CRAP-Funktion vorhanden, ohne neue moderate CRAP-Findings einzuführen

--- a/openspec/changes/refactor-waste-doi-dispatch-message/proposal.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/proposal.md
@@ -9,6 +9,7 @@ Die produktive Zusammensetzung der Double-Opt-in-Mail bündelt optionale Textabs
 - charakterisiert die bestehende DOI-Komposition für vollständige und fehlende Abschnitte, Leerwerte, unbekannte Platzhalter und die exakte Abschnittsreihenfolge
 - charakterisiert die Priorität von Payload-, Waste-Konfigurations- und Transportadressen einschließlich `to`, `cc`, `bcc`, `replyTo`, Absender und Anzeigenamen
 - zerlegt ausschließlich die interne DOI-Komposition in kleine typisierte Helfer für Templatewerte, Textabschnitte und Envelope
+- zentralisiert den bereits identischen lokalen Envelope-Aufbau von DOI- und Reminder-Nachricht in einem internen Helfer, damit die DOI-Zerlegung keine neue Duplikatgruppe einführt
 - erhält Betreff, Text, Leerzeilen, Fallbacks und Mail-Envelope bytegenau für dieselben Eingaben
 
 ## Out of Scope

--- a/openspec/changes/refactor-waste-doi-dispatch-message/specs/waste-management/spec.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/specs/waste-management/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: DOI-Versandnachrichten bewahren ihren deterministischen Kompositionsvertrag
+
+Das System SHALL DOI-Versandnachrichten aus der Waste-Konfiguration, dem normalisierten Versandauftrag und der zentralen Mail-Transport-Konfiguration deterministisch zusammensetzen, ohne den Token-, Outbox- oder Zustellvertrag in der Kompositionsschicht zu verändern.
+
+#### Scenario: DOI-Text verwendet die bestehende Abschnittsreihenfolge
+
+- **WHEN** eine DOI-Versandnachricht aus vollständigen Textbausteinen und Templatewerten erzeugt wird
+- **THEN** enthält ihr Nur-Text-Inhalt Preheader, Intro, Ort, Bestätigungszeile, Fallback, Ablaufhinweis, Service, Verantwortlichen, Datenschutz und Impressum in der bestehenden Reihenfolge
+- **AND** die enthaltenen Abschnitte bleiben durch genau eine Leerzeile getrennt
+- **AND** unbekannte Template-Platzhalter werden weiterhin durch den leeren String ersetzt
+
+#### Scenario: Optionale oder leere DOI-Abschnitte behalten ihre Legacy-Semantik
+
+- **WHEN** optionale DOI-Texte fehlen, leer sind oder nur Whitespace enthalten
+- **THEN** werden dieselben Abschnitte wie bisher ausgelassen
+- **AND** ein vorhandener Payload-Wert besitzt weiterhin Nullish-Priorität vor dem entsprechenden Konfigurationswert
+- **AND** ein leerer oder nur aus Whitespace bestehender Payload-Wert wird nicht stillschweigend durch den Konfigurationswert ersetzt
+
+#### Scenario: DOI-Envelope bewahrt die bestehende Adresspriorität
+
+- **WHEN** Payload, Waste-Konfiguration und Transport unterschiedliche Absender- oder Antwortadressen liefern
+- **THEN** bleiben Payload-`replyTo`, konfiguriertes `replyTo` und Transport-`replyTo` in dieser Prioritätsreihenfolge
+- **AND** konfigurierte Absenderwerte bleiben vor Transport-Fallbacks priorisiert
+- **AND** `to`, `cc`, `bcc` und vorhandene Anzeigenamen aus dem Payload bleiben unverändert erhalten
+
+#### Scenario: Nicht-DOI-Template bleibt im Reminder-Pfad
+
+- **WHEN** der Versandauftrag keinen DOI-Template-Key besitzt
+- **THEN** verwendet das System weiterhin die bestehende Reminder-Komposition
+- **AND** das DOI-Refactoring verändert weder Reminder-Text noch Reminder-Envelope

--- a/openspec/changes/refactor-waste-doi-dispatch-message/tasks.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/tasks.md
@@ -16,9 +16,9 @@
 
 ## 3. Abschlussvalidierung
 
-- [ ] 3.1 fokussierte Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
-- [ ] 3.2 `pnpm check:server-runtime`, `pnpm complexity-gate`, `pnpm check:file-placement`, `pnpm check:studio-changelog` und `git diff --check` grün ausführen
-- [ ] 3.3 `openspec validate refactor-waste-doi-dispatch-message --strict` grün ausführen
-- [ ] 3.4 New-only-Fallow-Audit für `sva-studio-react` mit Coverage ausführen und PASS ohne eingeführte Complexity-, Dead-Code-, Duplication-, Styling- oder moderate CRAP-Findings belegen
+- [x] 3.1 fokussierte Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
+- [x] 3.2 `pnpm check:server-runtime`, `pnpm complexity-gate`, `pnpm check:file-placement`, `pnpm check:studio-changelog` und `git diff --check` grün ausführen
+- [x] 3.3 `openspec validate refactor-waste-doi-dispatch-message --strict` grün ausführen
+- [x] 3.4 New-only-Fallow-Audit für `sva-studio-react` mit Coverage ausführen und PASS ohne eingeführte Complexity-, Dead-Code-, Duplication-, Styling- oder moderate CRAP-Findings belegen
 - [ ] 3.5 Root-Review und unabhängiges Datenschutz-/Runtime-Vertragsreview auf dem exakten PR-Head abschließen
 - [ ] 3.6 alle berechtigten Findings beheben und terminale PR-Gates ohne offene Threads abschließen

--- a/openspec/changes/refactor-waste-doi-dispatch-message/tasks.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/tasks.md
@@ -1,0 +1,24 @@
+## 1. Characterization und Freigabe
+
+- [x] 1.1 Bestehenden fokussierten Unit-Lauf und `sva-studio-react:test:types` auf unverändertem Produktionscode grün ausführen
+- [x] 1.2 vollständige DOI-Abschnittsreihenfolge, Templatewerte und unbekannte Platzhalter charakterisieren
+- [x] 1.3 Payload-/Konfigurations-Priorität sowie Whitespace-, Leer- und Fehlwerte für Service und Verantwortlichen charakterisieren
+- [x] 1.4 `to`, `cc`, `bcc`, Payload-/Konfigurations-/Transport-`replyTo`, Absenderfallbacks und Anzeigenamen charakterisieren
+- [x] 1.5 unbekannten Template-Key als unveränderten Reminder-Pfad charakterisieren
+- [ ] 1.6 Proposal prüfen und vor produktiver Source-Änderung freigeben
+
+## 2. DOI-Komposition refaktorieren
+
+- [ ] 2.1 bestehende Templatewert-Auflösung in einen kleinen internen typisierten Helfer auslagern
+- [ ] 2.2 bestehende DOI-Textabschnitte in einen kleinen internen Helfer mit unveränderter Reihenfolge auslagern
+- [ ] 2.3 bestehendes DOI-Envelope in einen kleinen internen Helfer auslagern
+- [ ] 2.4 nach jedem Block den fokussierten Unit-Lauf grün ausführen
+
+## 3. Abschlussvalidierung
+
+- [ ] 3.1 fokussierte Unit-, Coverage-, Type-, Lint- und Build-Targets grün ausführen
+- [ ] 3.2 `pnpm check:server-runtime`, `pnpm complexity-gate`, `pnpm check:file-placement`, `pnpm check:studio-changelog` und `git diff --check` grün ausführen
+- [ ] 3.3 `openspec validate refactor-waste-doi-dispatch-message --strict` grün ausführen
+- [ ] 3.4 New-only-Fallow-Audit für `sva-studio-react` mit Coverage ausführen und PASS ohne eingeführte Complexity-, Dead-Code-, Duplication-, Styling- oder moderate CRAP-Findings belegen
+- [ ] 3.5 Root-Review und unabhängiges Datenschutz-/Runtime-Vertragsreview auf dem exakten PR-Head abschließen
+- [ ] 3.6 alle berechtigten Findings beheben und terminale PR-Gates ohne offene Threads abschließen

--- a/openspec/changes/refactor-waste-doi-dispatch-message/tasks.md
+++ b/openspec/changes/refactor-waste-doi-dispatch-message/tasks.md
@@ -5,14 +5,14 @@
 - [x] 1.3 Payload-/Konfigurations-Priorität sowie Whitespace-, Leer- und Fehlwerte für Service und Verantwortlichen charakterisieren
 - [x] 1.4 `to`, `cc`, `bcc`, Payload-/Konfigurations-/Transport-`replyTo`, Absenderfallbacks und Anzeigenamen charakterisieren
 - [x] 1.5 unbekannten Template-Key als unveränderten Reminder-Pfad charakterisieren
-- [ ] 1.6 Proposal prüfen und vor produktiver Source-Änderung freigeben
+- [x] 1.6 Proposal prüfen und vor produktiver Source-Änderung freigeben
 
 ## 2. DOI-Komposition refaktorieren
 
-- [ ] 2.1 bestehende Templatewert-Auflösung in einen kleinen internen typisierten Helfer auslagern
-- [ ] 2.2 bestehende DOI-Textabschnitte in einen kleinen internen Helfer mit unveränderter Reihenfolge auslagern
-- [ ] 2.3 bestehendes DOI-Envelope in einen kleinen internen Helfer auslagern
-- [ ] 2.4 nach jedem Block den fokussierten Unit-Lauf grün ausführen
+- [x] 2.1 bestehende Templatewert-Auflösung in einen kleinen internen typisierten Helfer auslagern
+- [x] 2.2 bestehende DOI-Textabschnitte in einen kleinen internen Helfer mit unveränderter Reihenfolge auslagern
+- [x] 2.3 bestehendes DOI-Envelope in einen kleinen internen Helfer auslagern
+- [x] 2.4 nach jedem Block den fokussierten Unit-Lauf grün ausführen
 
 ## 3. Abschlussvalidierung
 


### PR DESCRIPTION
## Zusammenfassung

- zerlegt die interne DOI-Mailkomposition in Template-Kontext, Text-Builder und DOI-Envelope
- bewahrt Abschnittsreihenfolge, Leerzeilen, Template-Fallbacks und Adressprioritäten durch Characterization
- lässt Reminder-, Token-, Secret-, URL-, SQL-, Outbox-, Retry-, Datums- und Idempotenzpfade unverändert

## Fallow

- Zielanker buildDoiDispatchMessage: Cyclomatic 19 auf 1, Cognitive 18 auf 0, CRAP 97 auf 1 (coveragegestützt)
- New-only-Audit auf a179502b5177400243707dc900a84e61e622af76: PASS
- introduced: complexity 0, dead code 0, duplication 0, styling 0
- keine moderaten CRAP-Neufunde

## Characterization

- vollständige DOI-Abschnittsreihenfolge und Templatewerte
- Payload-/Konfigurationspriorität, Whitespace-, Leer- und Fehlwerte
- to/cc/bcc, Reply-To-Kaskade, Absenderfallbacks und Anzeigenamen
- unbekannte Template-Keys verbleiben im unveränderten Reminder-Pfad
- ausschließlich synthetische .invalid.example-Adressen, keine echten PII

## Lokale Gates

- fokussierte Server-Unit: 12/12 grün
- fokussierte Coverage: grün; Istanbul-JSON im Fallow-Audit verwendet
- sva-studio-react:test:types: grün
- sva-studio-react:lint: grün
- sva-studio-react:build: grün
- pnpm check:server-runtime: grün
- pnpm complexity-gate: grün
- OpenSpec strict, File Placement und git diff --check: grün
- affected Unit-Scope: ausschließlich sva-studio-react
- E2E nicht anwendbar (keine UI-/Journey-Änderung); ein lokaler Lauf wurde wegen Port-Overlap mit einem fremden Bundle-Server ausdrücklich nicht als Evidenz gewertet

## Review

- Root-Source-Review auf a179502b5177400243707dc900a84e61e622af76 abgeschlossen
- unabhängiges Datenschutz-/Runtime-Vertragsreview steht vor Ready noch aus
- Draft: noch nicht mergebereit