### PR TITLE
refactor(instances): simplify realm operation models

### DIFF
--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx
@@ -14,6 +14,8 @@ import {
   buildOperationsPrimaryAction,
   getErrorMessage,
   getOperationsEvidenceSourceLabel,
+  type OperationsStepModel,
+  type RealmOperationsModel,
 } from './-instances-shared';
 import {
   createEmptyCreateForm,
@@ -1379,5 +1381,568 @@ describe('instances shared helpers', () => {
     expect(model.currentRun?.id).toBe('run-success');
     expect(model.historicalRuns.map((run) => run.id)).toEqual(['run-failed']);
     expect(model.hasHistoricalMismatchHint).toBe(true);
+  });
+});
+
+const createOperationsStepFixture = (
+  key: OperationsStepModel['key'],
+  status: OperationsStepModel['status']
+): OperationsStepModel => ({
+  key,
+  status,
+  title: key,
+  summary: `${key}:${status}`,
+  evidenceSource: 'history',
+});
+
+const createOperationsModelFixture = (
+  mode: RealmOperationsModel['mode'],
+  steps: readonly OperationsStepModel[],
+  overrides: Partial<RealmOperationsModel> = {}
+): RealmOperationsModel => ({
+  mode,
+  status: 'degraded',
+  summary: 'characterization',
+  steps,
+  followUpActions: [],
+  signals: {
+    modeConflict: false,
+    hasDrift: false,
+  },
+  ...overrides,
+});
+
+const incompleteKeycloakStatus = {
+  realmExists: false,
+  clientExists: false,
+  tenantAdminClientExists: false,
+  tenantAdminExists: false,
+  tenantAdminHasSystemAdmin: false,
+  systemAdminRoleExists: false,
+  redirectUrisMatch: false,
+  logoutUrisMatch: false,
+  webOriginsMatch: false,
+  clientSecretConfigured: false,
+  tenantClientSecretReadable: false,
+  clientSecretAligned: false,
+  tenantAdminClientSecretConfigured: false,
+  tenantAdminClientSecretReadable: false,
+  tenantAdminClientSecretAligned: false,
+  runtimeSecretSource: 'platform',
+} as const;
+
+const completeKeycloakStatus = {
+  ...incompleteKeycloakStatus,
+  realmExists: true,
+  clientExists: true,
+  tenantAdminClientExists: true,
+  tenantAdminExists: true,
+  tenantAdminHasSystemAdmin: true,
+  systemAdminRoleExists: true,
+  redirectUrisMatch: true,
+  logoutUrisMatch: true,
+  webOriginsMatch: true,
+  clientSecretConfigured: true,
+  tenantClientSecretReadable: true,
+  clientSecretAligned: true,
+  tenantAdminClientSecretConfigured: true,
+  tenantAdminClientSecretReadable: true,
+  tenantAdminClientSecretAligned: true,
+  runtimeSecretSource: 'tenant',
+} as const;
+
+const createProvisioningRunFixture = (
+  overallStatus: 'planned' | 'running' | 'succeeded' | 'failed'
+) => ({
+  id: `run-${overallStatus}`,
+  instanceId: 'demo',
+  intent: 'provision' as const,
+  mode: 'new' as const,
+  overallStatus,
+  driftSummary: `Run ${overallStatus}`,
+  requestId: `request-${overallStatus}`,
+  createdAt: '2026-08-15T09:00:00.000Z',
+  updatedAt: '2026-08-15T09:05:00.000Z',
+  steps: [],
+});
+
+describe('realm operations step characterization', () => {
+  it.each([
+    {
+      name: 'incomplete contract keeps preflight and plan pending',
+      overrides: { displayName: '' },
+      expected: {
+        registry_contract: { status: 'fehlgeschlagen', action: 'focus_configuration' },
+        worker_preflight: { status: 'offen', action: undefined },
+        worker_plan: { status: 'offen', action: undefined },
+      },
+    },
+    {
+      name: 'complete contract offers preflight before a plan exists',
+      overrides: {},
+      expected: {
+        registry_contract: { status: 'erfolgreich', action: undefined },
+        worker_preflight: { status: 'bereit', action: 'check_preflight' },
+        worker_plan: { status: 'bereit', action: undefined },
+      },
+    },
+    {
+      name: 'blocked realm-mode preflight preserves its diagnostic summary',
+      overrides: {
+        keycloakPreflight: {
+          overallStatus: 'blocked',
+          checkedAt: '2026-08-15T08:00:00.000Z',
+          checks: [
+            {
+              checkKey: 'realm_mode',
+              status: 'blocked',
+              title: 'Realm mode',
+              summary: 'Live realm already exists.',
+              details: {},
+            },
+          ],
+        },
+      },
+      expected: {
+        registry_contract: { status: 'erfolgreich', action: undefined },
+        worker_preflight: {
+          status: 'fehlgeschlagen',
+          action: undefined,
+          summary: 'Live realm already exists.',
+          checkedAt: '2026-08-15T08:00:00.000Z',
+        },
+        worker_plan: { status: 'offen', action: 'plan_provisioning' },
+      },
+    },
+    {
+      name: 'ready preflight offers plan generation',
+      overrides: {
+        keycloakPreflight: {
+          overallStatus: 'ready',
+          checkedAt: '2026-08-15T08:00:00.000Z',
+          checks: [],
+        },
+      },
+      expected: {
+        registry_contract: { status: 'erfolgreich', action: undefined },
+        worker_preflight: {
+          status: 'erfolgreich',
+          action: undefined,
+          checkedAt: '2026-08-15T08:00:00.000Z',
+        },
+        worker_plan: { status: 'bereit', action: 'plan_provisioning' },
+      },
+    },
+    {
+      name: 'blocked plan preserves worker drift evidence',
+      overrides: {
+        keycloakPreflight: {
+          overallStatus: 'ready',
+          checkedAt: '2026-08-15T08:00:00.000Z',
+          checks: [],
+        },
+        keycloakPlan: {
+          mode: 'new',
+          overallStatus: 'blocked',
+          generatedAt: '2026-08-15T08:05:00.000Z',
+          driftSummary: 'Plan cannot reconcile the target realm.',
+          steps: [],
+        },
+      },
+      expected: {
+        registry_contract: { status: 'erfolgreich', action: undefined },
+        worker_preflight: { status: 'erfolgreich', action: undefined },
+        worker_plan: {
+          status: 'fehlgeschlagen',
+          action: undefined,
+          summary: 'Plan cannot reconcile the target realm.',
+          checkedAt: '2026-08-15T08:05:00.000Z',
+        },
+      },
+    },
+  ])('keeps new-realm lead-step semantics when $name', ({ overrides, expected }) => {
+    const model = buildNewRealmOperationsModel(createDetailFixture(overrides), null);
+
+    for (const [key, stepExpectation] of Object.entries(expected)) {
+      expect(model.steps.find((step) => step.key === key)).toMatchObject(stepExpectation);
+    }
+  });
+
+  it.each([
+    { runStatus: undefined, artifactStatus: 'offen', finalStatus: 'offen' },
+    { runStatus: 'planned', artifactStatus: 'läuft', finalStatus: 'läuft' },
+    { runStatus: 'running', artifactStatus: 'läuft', finalStatus: 'läuft' },
+    { runStatus: 'failed', artifactStatus: 'fehlgeschlagen', finalStatus: 'fehlgeschlagen' },
+    { runStatus: 'succeeded', artifactStatus: 'fehlgeschlagen', finalStatus: 'fehlgeschlagen' },
+  ] as const)(
+    'maps a $runStatus worker run to $artifactStatus artifacts and $finalStatus validation',
+    ({ runStatus, artifactStatus, finalStatus }) => {
+      const run = runStatus ? createProvisioningRunFixture(runStatus) : undefined;
+      const model = buildNewRealmOperationsModel(
+        createDetailFixture({
+          latestKeycloakProvisioningRun: run,
+          keycloakProvisioningRuns: run ? [run] : [],
+        }),
+        null
+      );
+
+      expect(model.steps.find((step) => step.key === 'realm')).toMatchObject({
+        status: artifactStatus,
+        evidenceSource: 'keycloak_run',
+        checkedAt: run?.updatedAt,
+        requestId: run?.requestId,
+      });
+      expect(model.steps.find((step) => step.key === 'final_validation')).toMatchObject({
+        status: finalStatus,
+        evidenceSource: 'final_validation',
+        checkedAt: '2026-01-01T00:00:00.000Z',
+        requestId: run?.requestId,
+      });
+    }
+  );
+
+  it.each([
+    ['realm', { realmExists: true }],
+    [
+      'login_client',
+      {
+        clientExists: true,
+        redirectUrisMatch: true,
+        logoutUrisMatch: true,
+        webOriginsMatch: true,
+      },
+    ],
+    ['tenant_admin_client', { tenantAdminClientExists: true }],
+    ['realm_roles', { tenantAdminHasSystemAdmin: true }],
+    ['tenant_admin', { tenantAdminExists: true }],
+    [
+      'secret_sync',
+      {
+        clientSecretAligned: true,
+        tenantAdminClientSecretAligned: true,
+      },
+    ],
+  ] as const)(
+    'marks only satisfied %s artifact evidence successful',
+    (stepKey, statusOverrides) => {
+      const run = createProvisioningRunFixture('running');
+      const model = buildNewRealmOperationsModel(
+        createDetailFixture({
+          keycloakStatus: {
+            ...incompleteKeycloakStatus,
+            ...statusOverrides,
+          },
+          latestKeycloakProvisioningRun: run,
+          keycloakProvisioningRuns: [run],
+        }),
+        null
+      );
+
+      expect(model.steps.find((step) => step.key === stepKey)).toMatchObject({
+        status: 'erfolgreich',
+        evidenceSource: 'final_validation',
+        checkedAt: run.updatedAt,
+        requestId: run.requestId,
+      });
+    }
+  );
+
+  it.each([
+    {
+      name: 'missing contract and evidence',
+      overrides: { displayName: '', tenantAdminClient: null, keycloakPreflight: null },
+      expected: {
+        registry_contract: { status: 'fehlgeschlagen', action: 'focus_configuration' },
+        worker_preflight: { status: 'offen', action: undefined },
+        live_status: { status: 'bereit', action: 'check_keycloak_status' },
+        drift_analysis: { status: 'offen' },
+        contract_repair: { status: 'fehlgeschlagen', action: 'focus_configuration' },
+        reconcile: { status: 'offen', action: undefined },
+        result_validation: { status: 'offen' },
+      },
+    },
+    {
+      name: 'blocked preflight without live status',
+      overrides: {
+        realmMode: 'existing',
+        authClientSecretConfigured: true,
+        keycloakPreflight: {
+          overallStatus: 'blocked',
+          checkedAt: '2026-08-15T10:00:00.000Z',
+          checks: [],
+        },
+      },
+      expected: {
+        worker_preflight: {
+          status: 'fehlgeschlagen',
+          checkedAt: '2026-08-15T10:00:00.000Z',
+        },
+        live_status: { status: 'offen', action: 'check_keycloak_status' },
+        drift_analysis: { status: 'offen' },
+        reconcile: { status: 'offen' },
+        result_validation: { status: 'offen' },
+      },
+    },
+    {
+      name: 'complete live status without drift',
+      overrides: {
+        realmMode: 'existing',
+        authClientSecretConfigured: true,
+        keycloakStatus: completeKeycloakStatus,
+      },
+      expected: {
+        live_status: { status: 'erfolgreich', evidenceSource: 'final_validation' },
+        drift_analysis: { status: 'erfolgreich', evidenceSource: 'final_validation' },
+        reconcile: {
+          status: 'erfolgreich',
+          action: undefined,
+          evidenceSource: 'final_validation',
+        },
+        result_validation: { status: 'erfolgreich' },
+      },
+    },
+    {
+      name: 'drift with a failed latest run',
+      overrides: {
+        realmMode: 'existing',
+        authClientSecretConfigured: true,
+        keycloakStatus: {
+          ...completeKeycloakStatus,
+          logoutUrisMatch: false,
+        },
+        latestKeycloakProvisioningRun: {
+          ...createProvisioningRunFixture('failed'),
+          mode: 'existing',
+        },
+      },
+      expected: {
+        drift_analysis: { status: 'fehlgeschlagen' },
+        reconcile: {
+          status: 'fehlgeschlagen',
+          action: 'reconcileKeycloak',
+          evidenceSource: 'keycloak_run',
+          checkedAt: '2026-08-15T09:05:00.000Z',
+          requestId: 'request-failed',
+        },
+        result_validation: { status: 'fehlgeschlagen' },
+      },
+    },
+  ])('keeps existing-realm assessment semantics for $name', ({ overrides, expected }) => {
+    const model = buildExistingRealmOperationsModel(createDetailFixture(overrides) as never, null);
+
+    for (const [key, stepExpectation] of Object.entries(expected)) {
+      expect(model.steps.find((step) => step.key === key)).toMatchObject(stepExpectation);
+    }
+  });
+
+  it('ignores mutation errors in both operation-model projections', () => {
+    const mutationError = {
+      name: 'IamHttpError',
+      status: 409,
+      code: 'conflict',
+      message: 'legacy mutation error',
+    } as const;
+
+    expect(buildNewRealmOperationsModel(createDetailFixture(), mutationError)).toEqual(
+      buildNewRealmOperationsModel(createDetailFixture(), null)
+    );
+    expect(
+      buildExistingRealmOperationsModel(
+        createDetailFixture({ realmMode: 'existing', authClientSecretConfigured: true }),
+        mutationError
+      )
+    ).toEqual(
+      buildExistingRealmOperationsModel(
+        createDetailFixture({ realmMode: 'existing', authClientSecretConfigured: true }),
+        null
+      )
+    );
+  });
+});
+
+describe('realm operations primary-action priority characterization', () => {
+  it.each([
+    {
+      name: 'contract failure beats every later candidate',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'fehlgeschlagen'),
+        createOperationsStepFixture('worker_preflight', 'fehlgeschlagen'),
+        createOperationsStepFixture('worker_plan', 'bereit'),
+        createOperationsStepFixture('realm', 'fehlgeschlagen'),
+      ],
+      overrides: { signals: { modeConflict: true, hasDrift: false } },
+      expected: { action: 'focus_configuration', reason: 'missing_contract' },
+    },
+    {
+      name: 'mode conflict beats a blocked preflight',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'fehlgeschlagen'),
+      ],
+      overrides: { signals: { modeConflict: true, hasDrift: false } },
+      expected: { action: 'check_preflight', reason: 'mode_conflict' },
+    },
+    {
+      name: 'blocked preflight beats worker planning',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'fehlgeschlagen'),
+        createOperationsStepFixture('worker_plan', 'bereit'),
+      ],
+      expected: { action: 'check_preflight', reason: 'preflight_blocked' },
+    },
+    {
+      name: 'completed validation exposes the first follow-up before stale plan evidence',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('final_validation', 'erfolgreich'),
+        createOperationsStepFixture('worker_plan', 'bereit'),
+      ],
+      overrides: { followUpActions: ['activate_instance', 'probeTenantIamAccess'] as const },
+      expected: { action: 'activate_instance', reason: 'follow_up' },
+    },
+    {
+      name: 'worker planning beats failed artifacts',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('worker_plan', 'bereit'),
+        createOperationsStepFixture('realm', 'fehlgeschlagen'),
+      ],
+      expected: { action: 'plan_provisioning', reason: 'follow_up' },
+    },
+    {
+      name: 'failed worker plan is replanned before execution retry',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('worker_plan', 'fehlgeschlagen'),
+        createOperationsStepFixture('realm', 'fehlgeschlagen'),
+      ],
+      expected: { action: 'plan_provisioning', reason: 'follow_up' },
+    },
+    {
+      name: 'failed provisioning artifact requests an execution retry',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('worker_plan', 'erfolgreich'),
+        createOperationsStepFixture('realm', 'fehlgeschlagen'),
+        createOperationsStepFixture('final_validation', 'fehlgeschlagen'),
+      ],
+      expected: { action: 'execute_provisioning', reason: 'run_retry' },
+    },
+    {
+      name: 'failed secret sync retains the legacy run-retry reason',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('worker_plan', 'erfolgreich'),
+        createOperationsStepFixture('secret_sync', 'fehlgeschlagen'),
+      ],
+      expected: { action: 'execute_provisioning', reason: 'run_retry' },
+    },
+    {
+      name: 'open provisioning artifact starts worker execution',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('worker_plan', 'erfolgreich'),
+        createOperationsStepFixture('tenant_admin', 'offen'),
+      ],
+      expected: { action: 'execute_provisioning', reason: 'run_retry' },
+    },
+    {
+      name: 'failed final validation refreshes live status',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('worker_plan', 'erfolgreich'),
+        createOperationsStepFixture('final_validation', 'fehlgeschlagen'),
+      ],
+      expected: { action: 'check_keycloak_status', reason: 'final_validation' },
+    },
+    {
+      name: 'follow-up remains available without final-validation evidence',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+      ],
+      overrides: { followUpActions: ['probeTenantIamAccess'] as const },
+      expected: { action: 'probeTenantIamAccess', reason: 'follow_up' },
+    },
+    {
+      name: 'missing optional steps fail closed to status validation',
+      steps: [],
+      expected: { action: 'check_keycloak_status', reason: 'final_validation' },
+    },
+  ])('keeps new-realm priority when $name', ({ steps, overrides, expected }) => {
+    expect(
+      buildOperationsPrimaryAction(createOperationsModelFixture('new', steps, overrides))
+    ).toMatchObject(expected);
+  });
+
+  it.each([
+    {
+      name: 'contract repair beats preflight and drift',
+      steps: [
+        createOperationsStepFixture('contract_repair', 'fehlgeschlagen'),
+        createOperationsStepFixture('worker_preflight', 'fehlgeschlagen'),
+        createOperationsStepFixture('reconcile', 'fehlgeschlagen'),
+      ],
+      overrides: { signals: { modeConflict: false, hasDrift: true } },
+      expected: { action: 'focus_configuration', reason: 'missing_contract' },
+    },
+    {
+      name: 'preflight blocker beats missing live status',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'fehlgeschlagen'),
+        createOperationsStepFixture('live_status', 'bereit'),
+      ],
+      expected: { action: 'check_preflight', reason: 'preflight_blocked' },
+    },
+    {
+      name: 'missing live status beats drift reconciliation',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('live_status', 'bereit'),
+        createOperationsStepFixture('reconcile', 'fehlgeschlagen'),
+      ],
+      overrides: { signals: { modeConflict: false, hasDrift: true } },
+      expected: { action: 'check_keycloak_status', reason: 'final_validation' },
+    },
+    {
+      name: 'drift requests reconcile',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('live_status', 'erfolgreich'),
+        createOperationsStepFixture('reconcile', 'bereit'),
+      ],
+      overrides: { signals: { modeConflict: false, hasDrift: true } },
+      expected: { action: 'reconcileKeycloak', reason: 'run_retry' },
+    },
+    {
+      name: 'failed reconcile retries even without a drift signal',
+      steps: [
+        createOperationsStepFixture('registry_contract', 'erfolgreich'),
+        createOperationsStepFixture('worker_preflight', 'erfolgreich'),
+        createOperationsStepFixture('live_status', 'erfolgreich'),
+        createOperationsStepFixture('reconcile', 'fehlgeschlagen'),
+      ],
+      expected: { action: 'reconcileKeycloak', reason: 'run_retry' },
+    },
+    {
+      name: 'missing optional steps fail closed to status validation',
+      steps: [],
+      expected: { action: 'check_keycloak_status', reason: 'final_validation' },
+    },
+  ])('keeps existing-realm priority when $name', ({ steps, overrides, expected }) => {
+    expect(
+      buildOperationsPrimaryAction(createOperationsModelFixture('existing', steps, overrides))
+    ).toMatchObject(expected);
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx
@@ -80,6 +80,29 @@ const EXISTING_REALM_STEP_TITLES: Record<
   result_validation: 'admin.instances.operations.existing.steps.resultValidation',
 };
 
+const WORKER_PREFLIGHT_COPY = {
+  new: {
+    title: NEW_REALM_STEP_TITLES.worker_preflight,
+    summary: {
+      offen: 'admin.instances.operations.new.stepSummaries.workerPreflightPending',
+      fehlgeschlagen: 'admin.instances.operations.new.stepSummaries.workerPreflightFailed',
+      erfolgreich: 'admin.instances.operations.new.stepSummaries.workerPreflightReady',
+      bereit: 'admin.instances.operations.new.stepSummaries.workerPreflightReadyToRun',
+    },
+  },
+  existing: {
+    title: EXISTING_REALM_STEP_TITLES.worker_preflight,
+    summary: {
+      offen: 'admin.instances.operations.existing.stepSummaries.workerPreflightPending',
+      fehlgeschlagen: 'admin.instances.operations.existing.stepSummaries.workerPreflightFailed',
+      erfolgreich: 'admin.instances.operations.existing.stepSummaries.workerPreflightReady',
+      bereit: 'admin.instances.operations.existing.stepSummaries.workerPreflightReadyToRun',
+    },
+  },
+} as const;
+
+type WorkerPreflightStatus = keyof (typeof WORKER_PREFLIGHT_COPY)['new']['summary'];
+
 const readLatestKeycloakRun = (instance: IamInstanceDetail) =>
   instance.latestKeycloakProvisioningRun ?? instance.keycloakProvisioningRuns[0];
 
@@ -174,65 +197,54 @@ const deriveOperationsModelStatus = (steps: OperationsStepModel[]): RealmOperati
   return 'unknown';
 };
 
+const readWorkerPreflightStatus = (
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight']
+): WorkerPreflightStatus => {
+  if (!contractComplete) {
+    return 'offen';
+  }
+  if (preflight?.overallStatus === 'blocked') {
+    return 'fehlgeschlagen';
+  }
+  return preflight ? 'erfolgreich' : 'bereit';
+};
+
+const readWorkerPreflightSummary = (
+  mode: 'new' | 'existing',
+  status: WorkerPreflightStatus,
+  preflight: IamInstanceDetail['keycloakPreflight']
+) => {
+  const copy = WORKER_PREFLIGHT_COPY[mode];
+  if (mode === 'new' && status === 'fehlgeschlagen') {
+    return findPreflightCheck(preflight, 'realm_mode')?.summary ?? t(copy.summary.fehlgeschlagen);
+  }
+  return t(copy.summary[status]);
+};
+
 const buildWorkerPreflightStep = (
   mode: 'new' | 'existing',
   contractComplete: boolean,
   preflight: IamInstanceDetail['keycloakPreflight'],
 ): OperationsStepModel => {
-  const blocked = preflight?.overallStatus === 'blocked';
-  const pending = !contractComplete;
-  const ready = Boolean(preflight);
+  const status = readWorkerPreflightStatus(contractComplete, preflight);
+  const copy = WORKER_PREFLIGHT_COPY[mode];
 
   return createOperationStep({
     key: 'worker_preflight',
-    title: t(
-      mode === 'new'
-        ? NEW_REALM_STEP_TITLES.worker_preflight
-        : EXISTING_REALM_STEP_TITLES.worker_preflight
-    ),
-    status: pending
-      ? 'offen'
-      : blocked
-        ? 'fehlgeschlagen'
-        : ready
-          ? 'erfolgreich'
-          : 'bereit',
-    summary: pending
-      ? t(
-        mode === 'new'
-          ? 'admin.instances.operations.new.stepSummaries.workerPreflightPending'
-          : 'admin.instances.operations.existing.stepSummaries.workerPreflightPending'
-      )
-      : blocked
-        ? (
-          mode === 'new'
-            ? findPreflightCheck(preflight, 'realm_mode')?.summary
-              ?? t('admin.instances.operations.new.stepSummaries.workerPreflightFailed')
-            : t('admin.instances.operations.existing.stepSummaries.workerPreflightFailed')
-        )
-        : ready
-          ? t(
-            mode === 'new'
-              ? 'admin.instances.operations.new.stepSummaries.workerPreflightReady'
-              : 'admin.instances.operations.existing.stepSummaries.workerPreflightReady'
-          )
-          : t(
-            mode === 'new'
-              ? 'admin.instances.operations.new.stepSummaries.workerPreflightReadyToRun'
-              : 'admin.instances.operations.existing.stepSummaries.workerPreflightReadyToRun'
-          ),
+    title: t(copy.title),
+    status,
+    summary: readWorkerPreflightSummary(mode, status, preflight),
     evidenceSource: 'worker_preflight',
     checkedAt: readPreflightTimestamp(preflight),
-    action: contractComplete && !preflight ? 'check_preflight' : undefined,
+    action: status === 'bereit' ? 'check_preflight' : undefined,
   });
 };
 
-const buildNewRealmLeadSteps = (
+const buildNewRealmRegistryContractStep = (
   instance: IamInstanceDetail,
-  contractComplete: boolean,
-  preflight: IamInstanceDetail['keycloakPreflight'],
-  plan: IamInstanceDetail['keycloakPlan'],
-): OperationsStepModel[] => [
+  contractComplete: boolean
+): OperationsStepModel =>
   createOperationStep({
     key: 'registry_contract',
     title: t(NEW_REALM_STEP_TITLES.registry_contract),
@@ -243,29 +255,78 @@ const buildNewRealmLeadSteps = (
     evidenceSource: 'registry_contract',
     checkedAt: instance.updatedAt,
     action: contractComplete ? undefined : 'focus_configuration',
-  }),
-  buildWorkerPreflightStep('new', contractComplete, preflight),
+  });
+
+const readNewRealmWorkerPlanState = (
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+  plan: IamInstanceDetail['keycloakPlan']
+): Pick<OperationsStepModel, 'status' | 'summary' | 'action'> => {
+  const action = readNewRealmWorkerPlanAction(contractComplete, preflight, plan);
+  if (!contractComplete) {
+    return {
+      status: 'offen',
+      summary: t('admin.instances.operations.new.stepSummaries.workerPlanPending'),
+      action,
+    };
+  }
+  if (preflight?.overallStatus === 'blocked') {
+    return {
+      status: 'offen',
+      summary: t('admin.instances.operations.new.stepSummaries.workerPlanPending'),
+      action,
+    };
+  }
+  if (plan?.overallStatus === 'blocked') {
+    return { status: 'fehlgeschlagen', summary: plan.driftSummary, action };
+  }
+  if (plan) {
+    return {
+      status: 'erfolgreich',
+      summary: t('admin.instances.operations.new.stepSummaries.workerPlanReady'),
+      action,
+    };
+  }
+  return {
+    status: 'bereit',
+    summary: t('admin.instances.operations.new.stepSummaries.workerPlanReadyToRun'),
+    action,
+  };
+};
+
+function readNewRealmWorkerPlanAction(
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+  plan: IamInstanceDetail['keycloakPlan']
+): OperationsStepModel['action'] {
+  if (!contractComplete || !preflight) {
+    return undefined;
+  }
+  return plan ? undefined : 'plan_provisioning';
+}
+
+const buildNewRealmWorkerPlanStep = (
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+  plan: IamInstanceDetail['keycloakPlan']
+): OperationsStepModel =>
   createOperationStep({
     key: 'worker_plan',
     title: t(NEW_REALM_STEP_TITLES.worker_plan),
-    status: !contractComplete || preflight?.overallStatus === 'blocked'
-      ? 'offen'
-      : plan?.overallStatus === 'blocked'
-        ? 'fehlgeschlagen'
-        : plan
-          ? 'erfolgreich'
-          : 'bereit',
-    summary: !contractComplete || preflight?.overallStatus === 'blocked'
-      ? t('admin.instances.operations.new.stepSummaries.workerPlanPending')
-      : plan?.overallStatus === 'blocked'
-        ? plan.driftSummary
-        : plan
-          ? t('admin.instances.operations.new.stepSummaries.workerPlanReady')
-          : t('admin.instances.operations.new.stepSummaries.workerPlanReadyToRun'),
     evidenceSource: 'worker_plan',
     checkedAt: plan?.generatedAt,
-    action: contractComplete && preflight && !plan ? 'plan_provisioning' : undefined,
-  }),
+    ...readNewRealmWorkerPlanState(contractComplete, preflight, plan),
+  });
+
+const buildNewRealmLeadSteps = (
+  instance: IamInstanceDetail,
+  contractComplete: boolean,
+  preflight: IamInstanceDetail['keycloakPreflight'],
+  plan: IamInstanceDetail['keycloakPlan'],
+): OperationsStepModel[] => [
+  buildNewRealmRegistryContractStep(instance, contractComplete),
+  buildWorkerPreflightStep('new', contractComplete, preflight),
+  buildNewRealmWorkerPlanStep(contractComplete, preflight, plan),
 ];
 
 const buildNewRealmOperationsSummary = (
@@ -303,156 +364,218 @@ const buildNewRealmFollowUpActions = (
     ? ['activate_instance']
     : [];
 
+type NewRealmArtifactContext = {
+  instance: IamInstanceDetail;
+  latestRun: IamInstanceDetail['latestKeycloakProvisioningRun'];
+  runState: ReturnType<typeof readProvisioningRunState>;
+};
+
+const readNewRealmArtifactState = (
+  satisfied: boolean,
+  runState: ReturnType<typeof readProvisioningRunState>,
+  failedSummaryKey: string,
+  readySummaryKey: string,
+): Pick<OperationsStepModel, 'status' | 'summary'> => {
+  if (satisfied) {
+    return { status: 'erfolgreich', summary: t(readySummaryKey) };
+  }
+  if (runState.failed || runState.succeeded) {
+    return { status: 'fehlgeschlagen', summary: t(failedSummaryKey) };
+  }
+  if (runState.running || runState.planned) {
+    return {
+      status: 'läuft',
+      summary: t('admin.instances.operations.new.stepSummaries.awaitingCurrentRun'),
+    };
+  }
+  return {
+    status: 'offen',
+    summary: t('admin.instances.operations.new.stepSummaries.pendingWorkerExecution'),
+  };
+};
+
+const buildNewRealmRealmStep = ({
+  instance,
+  latestRun,
+  runState,
+}: NewRealmArtifactContext): OperationsStepModel => createOperationStep({
+  key: 'realm',
+  title: t(NEW_REALM_STEP_TITLES.realm),
+  evidenceSource: instance.keycloakStatus ? 'final_validation' : 'keycloak_run',
+  checkedAt: readRunTimestamp(latestRun),
+  requestId: latestRun?.requestId,
+  ...readNewRealmArtifactState(
+    Boolean(instance.keycloakStatus?.realmExists),
+    runState,
+    'admin.instances.operations.new.stepSummaries.realmFailed',
+    'admin.instances.operations.new.stepSummaries.realmReady',
+  ),
+});
+
+const buildNewRealmLoginClientStep = ({
+  instance,
+  latestRun,
+  runState,
+}: NewRealmArtifactContext): OperationsStepModel => createOperationStep({
+  key: 'login_client',
+  title: t(NEW_REALM_STEP_TITLES.login_client),
+  evidenceSource: instance.keycloakStatus ? 'final_validation' : 'keycloak_run',
+  checkedAt: readRunTimestamp(latestRun),
+  requestId: latestRun?.requestId,
+  ...readNewRealmArtifactState(
+    Boolean(
+      instance.keycloakStatus?.clientExists
+        && instance.keycloakStatus.redirectUrisMatch
+        && instance.keycloakStatus.logoutUrisMatch
+        && instance.keycloakStatus.webOriginsMatch
+    ),
+    runState,
+    'admin.instances.operations.new.stepSummaries.loginClientFailed',
+    'admin.instances.operations.new.stepSummaries.loginClientReady',
+  ),
+});
+
+const buildNewRealmTenantAdminClientStep = ({
+  instance,
+  latestRun,
+  runState,
+}: NewRealmArtifactContext): OperationsStepModel => createOperationStep({
+  key: 'tenant_admin_client',
+  title: t(NEW_REALM_STEP_TITLES.tenant_admin_client),
+  evidenceSource: instance.keycloakStatus ? 'final_validation' : 'keycloak_run',
+  checkedAt: readRunTimestamp(latestRun),
+  requestId: latestRun?.requestId,
+  ...readNewRealmArtifactState(
+    Boolean(instance.keycloakStatus?.tenantAdminClientExists),
+    runState,
+    'admin.instances.operations.new.stepSummaries.tenantAdminClientFailed',
+    'admin.instances.operations.new.stepSummaries.tenantAdminClientReady',
+  ),
+});
+
+const buildNewRealmRolesStep = ({
+  instance,
+  latestRun,
+  runState,
+}: NewRealmArtifactContext): OperationsStepModel => createOperationStep({
+  key: 'realm_roles',
+  title: t(NEW_REALM_STEP_TITLES.realm_roles),
+  evidenceSource: instance.keycloakStatus ? 'final_validation' : 'keycloak_run',
+  checkedAt: readRunTimestamp(latestRun),
+  requestId: latestRun?.requestId,
+  ...readNewRealmArtifactState(
+    Boolean(instance.keycloakStatus?.tenantAdminHasSystemAdmin),
+    runState,
+    'admin.instances.operations.new.stepSummaries.realmRolesFailed',
+    'admin.instances.operations.new.stepSummaries.realmRolesReady',
+  ),
+});
+
+const buildNewRealmTenantAdminStep = ({
+  instance,
+  latestRun,
+  runState,
+}: NewRealmArtifactContext): OperationsStepModel => createOperationStep({
+  key: 'tenant_admin',
+  title: t(NEW_REALM_STEP_TITLES.tenant_admin),
+  evidenceSource: instance.keycloakStatus ? 'final_validation' : 'keycloak_run',
+  checkedAt: readRunTimestamp(latestRun),
+  requestId: latestRun?.requestId,
+  ...readNewRealmArtifactState(
+    Boolean(instance.keycloakStatus?.tenantAdminExists),
+    runState,
+    'admin.instances.operations.new.stepSummaries.tenantAdminFailed',
+    'admin.instances.operations.new.stepSummaries.tenantAdminReady',
+  ),
+});
+
+const buildNewRealmSecretSyncStep = ({
+  instance,
+  latestRun,
+  runState,
+}: NewRealmArtifactContext): OperationsStepModel => createOperationStep({
+  key: 'secret_sync',
+  title: t(NEW_REALM_STEP_TITLES.secret_sync),
+  evidenceSource: instance.keycloakStatus ? 'final_validation' : 'keycloak_run',
+  checkedAt: readRunTimestamp(latestRun),
+  requestId: latestRun?.requestId,
+  ...readNewRealmArtifactState(
+    Boolean(
+      instance.keycloakStatus?.clientSecretAligned
+        && instance.keycloakStatus.tenantAdminClientSecretAligned
+    ),
+    runState,
+    'admin.instances.operations.new.stepSummaries.secretSyncFailed',
+    'admin.instances.operations.new.stepSummaries.secretSyncReady',
+  ),
+});
+
+const readNewRealmFinalValidationStatus = (
+  instance: IamInstanceDetail,
+  runState: ReturnType<typeof readProvisioningRunState>,
+): OperationsStepModel['status'] => {
+  if (isFinalKeycloakStateSatisfied(instance)) {
+    return 'erfolgreich';
+  }
+  if (runState.failed || runState.succeeded) {
+    return 'fehlgeschlagen';
+  }
+  return runState.running || runState.planned ? 'läuft' : 'offen';
+};
+
+const buildNewRealmFinalValidationStep = (
+  instance: IamInstanceDetail,
+  runState: ReturnType<typeof readProvisioningRunState>,
+  requestId: string | undefined,
+): OperationsStepModel => {
+  const status = readNewRealmFinalValidationStatus(instance, runState);
+  return createOperationStep({
+    key: 'final_validation',
+    title: t(NEW_REALM_STEP_TITLES.final_validation),
+    evidenceSource: 'final_validation',
+    checkedAt: instance.updatedAt,
+    requestId,
+    status,
+    summary: status === 'erfolgreich'
+      ? t('admin.instances.operations.new.stepSummaries.finalValidationReady')
+      : status === 'fehlgeschlagen'
+        ? t('admin.instances.operations.new.stepSummaries.finalValidationFailed')
+        : t('admin.instances.operations.new.stepSummaries.finalValidationPending'),
+  });
+};
+
+const buildNewRealmBootstrapCompleteStep = (
+  instance: IamInstanceDetail,
+  requestId: string | undefined,
+): OperationsStepModel => {
+  const complete = isFinalKeycloakStateSatisfied(instance);
+  return createOperationStep({
+    key: 'realm_bootstrap_complete',
+    title: t(NEW_REALM_STEP_TITLES.realm_bootstrap_complete),
+    evidenceSource: 'final_validation',
+    checkedAt: instance.updatedAt,
+    requestId,
+    status: complete ? 'erfolgreich' : 'offen',
+    summary: complete
+      ? t('admin.instances.operations.new.stepSummaries.bootstrapCompleteReady')
+      : t('admin.instances.operations.new.stepSummaries.bootstrapCompletePending'),
+  });
+};
+
 const buildNewRealmArtifactSteps = (instance: IamInstanceDetail): OperationsStepModel[] => {
   const latestRun = readLatestKeycloakRun(instance);
   const runState = readProvisioningRunState(latestRun);
-  const checkedAt = readRunTimestamp(latestRun);
+  const context = { instance, latestRun, runState };
   const requestId = latestRun?.requestId;
-  const keycloakStatus = instance.keycloakStatus;
-
-  const artifactState = (
-    satisfied: boolean,
-    failedSummaryKey: string,
-    readySummaryKey: string
-  ): Pick<OperationsStepModel, 'status' | 'summary'> => {
-    if (satisfied) {
-      return {
-        status: 'erfolgreich',
-        summary: t(readySummaryKey),
-      };
-    }
-    if (runState.failed) {
-      return {
-        status: 'fehlgeschlagen',
-        summary: t(failedSummaryKey),
-      };
-    }
-    if (runState.running || runState.planned) {
-      return {
-        status: 'läuft',
-        summary: t('admin.instances.operations.new.stepSummaries.awaitingCurrentRun'),
-      };
-    }
-    if (runState.succeeded) {
-      return {
-        status: 'fehlgeschlagen',
-        summary: t(failedSummaryKey),
-      };
-    }
-    return {
-      status: 'offen',
-      summary: t('admin.instances.operations.new.stepSummaries.pendingWorkerExecution'),
-    };
-  };
-
   return [
-    createOperationStep({
-      key: 'realm',
-      title: t(NEW_REALM_STEP_TITLES.realm),
-      evidenceSource: keycloakStatus ? 'final_validation' : 'keycloak_run',
-      checkedAt,
-      requestId,
-      ...artifactState(
-        Boolean(keycloakStatus?.realmExists),
-        'admin.instances.operations.new.stepSummaries.realmFailed',
-        'admin.instances.operations.new.stepSummaries.realmReady'
-      ),
-    }),
-    createOperationStep({
-      key: 'login_client',
-      title: t(NEW_REALM_STEP_TITLES.login_client),
-      evidenceSource: keycloakStatus ? 'final_validation' : 'keycloak_run',
-      checkedAt,
-      requestId,
-      ...artifactState(
-        Boolean(
-          keycloakStatus?.clientExists
-            && keycloakStatus.redirectUrisMatch
-            && keycloakStatus.logoutUrisMatch
-            && keycloakStatus.webOriginsMatch
-        ),
-        'admin.instances.operations.new.stepSummaries.loginClientFailed',
-        'admin.instances.operations.new.stepSummaries.loginClientReady'
-      ),
-    }),
-    createOperationStep({
-      key: 'tenant_admin_client',
-      title: t(NEW_REALM_STEP_TITLES.tenant_admin_client),
-      evidenceSource: keycloakStatus ? 'final_validation' : 'keycloak_run',
-      checkedAt,
-      requestId,
-      ...artifactState(
-        Boolean(keycloakStatus?.tenantAdminClientExists),
-        'admin.instances.operations.new.stepSummaries.tenantAdminClientFailed',
-        'admin.instances.operations.new.stepSummaries.tenantAdminClientReady'
-      ),
-    }),
-    createOperationStep({
-      key: 'realm_roles',
-      title: t(NEW_REALM_STEP_TITLES.realm_roles),
-      evidenceSource: keycloakStatus ? 'final_validation' : 'keycloak_run',
-      checkedAt,
-      requestId,
-      ...artifactState(
-        Boolean(keycloakStatus?.tenantAdminHasSystemAdmin),
-        'admin.instances.operations.new.stepSummaries.realmRolesFailed',
-        'admin.instances.operations.new.stepSummaries.realmRolesReady'
-      ),
-    }),
-    createOperationStep({
-      key: 'tenant_admin',
-      title: t(NEW_REALM_STEP_TITLES.tenant_admin),
-      evidenceSource: keycloakStatus ? 'final_validation' : 'keycloak_run',
-      checkedAt,
-      requestId,
-      ...artifactState(
-        Boolean(keycloakStatus?.tenantAdminExists),
-        'admin.instances.operations.new.stepSummaries.tenantAdminFailed',
-        'admin.instances.operations.new.stepSummaries.tenantAdminReady'
-      ),
-    }),
-    createOperationStep({
-      key: 'secret_sync',
-      title: t(NEW_REALM_STEP_TITLES.secret_sync),
-      evidenceSource: keycloakStatus ? 'final_validation' : 'keycloak_run',
-      checkedAt,
-      requestId,
-      ...artifactState(
-        Boolean(keycloakStatus?.clientSecretAligned && keycloakStatus.tenantAdminClientSecretAligned),
-        'admin.instances.operations.new.stepSummaries.secretSyncFailed',
-        'admin.instances.operations.new.stepSummaries.secretSyncReady'
-      ),
-    }),
-    createOperationStep({
-      key: 'final_validation',
-      title: t(NEW_REALM_STEP_TITLES.final_validation),
-      evidenceSource: 'final_validation',
-      checkedAt: instance.updatedAt,
-      requestId,
-      status: isFinalKeycloakStateSatisfied(instance)
-        ? 'erfolgreich'
-        : runState.failed || runState.succeeded
-          ? 'fehlgeschlagen'
-          : runState.running || runState.planned
-            ? 'läuft'
-            : 'offen',
-      summary: isFinalKeycloakStateSatisfied(instance)
-        ? t('admin.instances.operations.new.stepSummaries.finalValidationReady')
-        : runState.failed || runState.succeeded
-            ? t('admin.instances.operations.new.stepSummaries.finalValidationFailed')
-            : t('admin.instances.operations.new.stepSummaries.finalValidationPending'),
-    }),
-    createOperationStep({
-      key: 'realm_bootstrap_complete',
-      title: t(NEW_REALM_STEP_TITLES.realm_bootstrap_complete),
-      evidenceSource: 'final_validation',
-      checkedAt: instance.updatedAt,
-      requestId,
-      status: isFinalKeycloakStateSatisfied(instance) ? 'erfolgreich' : 'offen',
-      summary: isFinalKeycloakStateSatisfied(instance)
-        ? t('admin.instances.operations.new.stepSummaries.bootstrapCompleteReady')
-        : t('admin.instances.operations.new.stepSummaries.bootstrapCompletePending'),
-    }),
+    buildNewRealmRealmStep(context),
+    buildNewRealmLoginClientStep(context),
+    buildNewRealmTenantAdminClientStep(context),
+    buildNewRealmRolesStep(context),
+    buildNewRealmTenantAdminStep(context),
+    buildNewRealmSecretSyncStep(context),
+    buildNewRealmFinalValidationStep(instance, runState, requestId),
+    buildNewRealmBootstrapCompleteStep(instance, requestId),
   ];
 };
 
@@ -490,7 +613,20 @@ const buildExistingRealmAssessmentSteps = (
   latestRun: IamInstanceDetail['latestKeycloakProvisioningRun'],
   hasDrift: boolean,
 ): OperationsStepModel[] => [
-  createOperationStep({
+  buildExistingRealmRegistryContractStep(instance, contractComplete),
+  buildWorkerPreflightStep('existing', contractComplete, preflight),
+  buildExistingRealmLiveStatusStep(instance, preflight),
+  buildExistingRealmDriftAnalysisStep(instance, hasDrift),
+  buildExistingRealmContractRepairStep(instance, contractComplete),
+  buildExistingRealmReconcileStep(instance, latestRun, hasDrift),
+  buildExistingRealmResultValidationStep(instance, hasDrift),
+];
+
+function buildExistingRealmRegistryContractStep(
+  instance: IamInstanceDetail,
+  contractComplete: boolean
+): OperationsStepModel {
+  return createOperationStep({
     key: 'registry_contract',
     title: t(EXISTING_REALM_STEP_TITLES.registry_contract),
     status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
@@ -500,40 +636,59 @@ const buildExistingRealmAssessmentSteps = (
     evidenceSource: 'registry_contract',
     checkedAt: instance.updatedAt,
     action: contractComplete ? undefined : 'focus_configuration',
-  }),
-  buildWorkerPreflightStep('existing', contractComplete, preflight),
-  createOperationStep({
+  });
+}
+
+function buildExistingRealmLiveStatusStep(
+  instance: IamInstanceDetail,
+  preflight: IamInstanceDetail['keycloakPreflight']
+): OperationsStepModel {
+  const liveStatusAvailable = Boolean(instance.keycloakStatus);
+  return createOperationStep({
     key: 'live_status',
     title: t(EXISTING_REALM_STEP_TITLES.live_status),
-    status: instance.keycloakStatus
+    status: liveStatusAvailable
       ? 'erfolgreich'
       : preflight?.overallStatus === 'blocked'
         ? 'offen'
         : 'bereit',
-    summary: instance.keycloakStatus
+    summary: liveStatusAvailable
       ? t('admin.instances.operations.existing.stepSummaries.liveStatusReady')
       : t('admin.instances.operations.existing.stepSummaries.liveStatusPending'),
-    evidenceSource: instance.keycloakStatus ? 'final_validation' : 'worker_preflight',
+    evidenceSource: liveStatusAvailable ? 'final_validation' : 'worker_preflight',
     checkedAt: instance.updatedAt,
-    action: instance.keycloakStatus ? undefined : 'check_keycloak_status',
-  }),
-  createOperationStep({
+    action: liveStatusAvailable ? undefined : 'check_keycloak_status',
+  });
+}
+
+function buildExistingRealmDriftAnalysisStep(
+  instance: IamInstanceDetail,
+  hasDrift: boolean
+): OperationsStepModel {
+  const liveStatusAvailable = Boolean(instance.keycloakStatus);
+  return createOperationStep({
     key: 'drift_analysis',
     title: t(EXISTING_REALM_STEP_TITLES.drift_analysis),
-    status: !instance.keycloakStatus
+    status: !liveStatusAvailable
       ? 'offen'
       : hasDrift
         ? 'fehlgeschlagen'
         : 'erfolgreich',
-    summary: !instance.keycloakStatus
+    summary: !liveStatusAvailable
       ? t('admin.instances.operations.existing.stepSummaries.driftAnalysisPending')
       : hasDrift
         ? t('admin.instances.operations.existing.stepSummaries.driftAnalysisFailed')
         : t('admin.instances.operations.existing.stepSummaries.driftAnalysisReady'),
-    evidenceSource: instance.keycloakStatus ? 'final_validation' : 'history',
+    evidenceSource: liveStatusAvailable ? 'final_validation' : 'history',
     checkedAt: instance.updatedAt,
-  }),
-  createOperationStep({
+  });
+}
+
+function buildExistingRealmContractRepairStep(
+  instance: IamInstanceDetail,
+  contractComplete: boolean
+): OperationsStepModel {
+  return createOperationStep({
     key: 'contract_repair',
     title: t(EXISTING_REALM_STEP_TITLES.contract_repair),
     status: contractComplete ? 'erfolgreich' : 'fehlgeschlagen',
@@ -543,46 +698,78 @@ const buildExistingRealmAssessmentSteps = (
     evidenceSource: 'registry_contract',
     checkedAt: instance.updatedAt,
     action: contractComplete ? undefined : 'focus_configuration',
-  }),
-  createOperationStep({
+  });
+}
+
+function buildExistingRealmReconcileStep(
+  instance: IamInstanceDetail,
+  latestRun: IamInstanceDetail['latestKeycloakProvisioningRun'],
+  hasDrift: boolean
+): OperationsStepModel {
+  const liveStatusAvailable = Boolean(instance.keycloakStatus);
+  const latestRunFailed = latestRun?.overallStatus === 'failed';
+  return createOperationStep({
     key: 'reconcile',
     title: t(EXISTING_REALM_STEP_TITLES.reconcile),
-    status: !instance.keycloakStatus
-      ? 'offen'
-      : latestRun?.overallStatus === 'failed'
-        ? 'fehlgeschlagen'
-        : hasDrift
-          ? 'bereit'
-          : 'erfolgreich',
-    summary: !instance.keycloakStatus
-      ? t('admin.instances.operations.existing.stepSummaries.reconcilePending')
-      : latestRun?.overallStatus === 'failed'
-        ? t('admin.instances.operations.existing.stepSummaries.reconcileFailed')
-        : hasDrift
-          ? t('admin.instances.operations.existing.stepSummaries.reconcileReadyToRun')
-          : t('admin.instances.operations.existing.stepSummaries.reconcileReady'),
+    ...readExistingRealmReconcileState(liveStatusAvailable, latestRunFailed, hasDrift),
     evidenceSource: latestRun ? 'keycloak_run' : 'final_validation',
     checkedAt: readRunTimestamp(latestRun) ?? instance.updatedAt,
     requestId: latestRun?.requestId,
-    action: instance.keycloakStatus && hasDrift ? 'reconcileKeycloak' : undefined,
-  }),
-  createOperationStep({
+    action: liveStatusAvailable && hasDrift ? 'reconcileKeycloak' : undefined,
+  });
+}
+
+function readExistingRealmReconcileState(
+  liveStatusAvailable: boolean,
+  latestRunFailed: boolean,
+  hasDrift: boolean
+): Pick<OperationsStepModel, 'status' | 'summary'> {
+  if (!liveStatusAvailable) {
+    return {
+      status: 'offen',
+      summary: t('admin.instances.operations.existing.stepSummaries.reconcilePending'),
+    };
+  }
+  if (latestRunFailed) {
+    return {
+      status: 'fehlgeschlagen',
+      summary: t('admin.instances.operations.existing.stepSummaries.reconcileFailed'),
+    };
+  }
+  if (hasDrift) {
+    return {
+      status: 'bereit',
+      summary: t('admin.instances.operations.existing.stepSummaries.reconcileReadyToRun'),
+    };
+  }
+  return {
+    status: 'erfolgreich',
+    summary: t('admin.instances.operations.existing.stepSummaries.reconcileReady'),
+  };
+}
+
+function buildExistingRealmResultValidationStep(
+  instance: IamInstanceDetail,
+  hasDrift: boolean
+): OperationsStepModel {
+  const liveStatusAvailable = Boolean(instance.keycloakStatus);
+  return createOperationStep({
     key: 'result_validation',
     title: t(EXISTING_REALM_STEP_TITLES.result_validation),
-    status: !instance.keycloakStatus
+    status: !liveStatusAvailable
       ? 'offen'
       : hasDrift
         ? 'fehlgeschlagen'
         : 'erfolgreich',
-    summary: !instance.keycloakStatus
+    summary: !liveStatusAvailable
       ? t('admin.instances.operations.existing.stepSummaries.resultValidationPending')
       : hasDrift
         ? t('admin.instances.operations.existing.stepSummaries.resultValidationFailed')
         : t('admin.instances.operations.existing.stepSummaries.resultValidationReady'),
     evidenceSource: 'final_validation',
     checkedAt: instance.updatedAt,
-  }),
-];
+  });
+}
 
 export const buildExistingRealmOperationsModel = (
   instance: IamInstanceDetail,
@@ -616,137 +803,119 @@ export const buildExistingRealmOperationsModel = (
   };
 };
 
-export const buildOperationsPrimaryAction = (model: RealmOperationsModel): OperationsPrimaryAction => {
-  if (model.mode === 'new') {
-    const contractStep = model.steps.find((step) => step.key === 'registry_contract');
-    if (contractStep?.status === 'fehlgeschlagen') {
-      return {
-        action: 'focus_configuration',
-        label: getOperationsActionLabel('focus_configuration'),
-        reason: 'missing_contract',
-      };
-    }
-    const preflightStep = model.steps.find((step) => step.key === 'worker_preflight');
-    if (model.signals.modeConflict) {
-      return {
-        action: 'check_preflight',
-        label: getOperationsActionLabel('check_preflight'),
-        reason: 'mode_conflict',
-      };
-    }
-    if (preflightStep?.status === 'fehlgeschlagen') {
-      return {
-        action: 'check_preflight',
-        label: getOperationsActionLabel('check_preflight'),
-        reason: 'preflight_blocked',
-      };
-    }
-    const finalValidationStep = model.steps.find((step) => step.key === 'final_validation');
-    const followUpAction = model.followUpActions[0];
-    if (finalValidationStep?.status === 'erfolgreich' && followUpAction) {
-      return {
-        action: followUpAction,
-        label: getOperationsActionLabel(followUpAction),
-        reason: 'follow_up',
-      };
-    }
-    const workerPlanStep = model.steps.find((step) => step.key === 'worker_plan');
-    if (workerPlanStep?.status === 'bereit' || workerPlanStep?.status === 'fehlgeschlagen') {
-      return {
-        action: 'plan_provisioning',
-        label: getOperationsActionLabel('plan_provisioning'),
-        reason: 'follow_up',
-      };
-    }
-    const latestFailure = model.steps.find((step) =>
-      isNewRealmProvisioningStep(step.key)
-      && step.status === 'fehlgeschlagen'
-    );
-    if (latestFailure) {
-      return {
-        action: 'execute_provisioning',
-        label: getOperationsActionLabel('execute_provisioning'),
-        reason: 'run_retry',
-      };
-    }
-    const secretSyncStep = model.steps.find((step) => step.key === 'secret_sync');
-    if (secretSyncStep?.status === 'fehlgeschlagen') {
-      return {
-        action: 'execute_provisioning',
-        label: getOperationsActionLabel('execute_provisioning'),
-        reason: 'secret_sync',
-      };
-    }
-    const pendingArtifactStep = model.steps.find((step) =>
-      isNewRealmProvisioningStep(step.key)
-      && step.status === 'offen'
-    );
-    if (pendingArtifactStep) {
-      return {
-        action: 'execute_provisioning',
-        label: getOperationsActionLabel('execute_provisioning'),
-        reason: 'run_retry',
-      };
-    }
-    if (finalValidationStep?.status === 'fehlgeschlagen') {
-      return {
-        action: 'check_keycloak_status',
-        label: getOperationsActionLabel('check_keycloak_status'),
-        reason: 'final_validation',
-      };
-    }
-    if (followUpAction) {
-      return {
-        action: followUpAction,
-        label: getOperationsActionLabel(followUpAction),
-        reason: 'follow_up',
-      };
-    }
-    return {
-      action: 'check_keycloak_status',
-      label: getOperationsActionLabel('check_keycloak_status'),
-      reason: 'final_validation',
-    };
-  }
+const createOperationsPrimaryAction = (
+  action: OperationsPrimaryAction['action'],
+  reason: OperationsPrimaryAction['reason']
+): OperationsPrimaryAction => ({
+  action,
+  label: getOperationsActionLabel(action),
+  reason,
+});
 
-  const contractStep = model.steps.find((step) => step.key === 'registry_contract' || step.key === 'contract_repair');
-  if (contractStep?.status === 'fehlgeschlagen') {
-    return {
-      action: 'focus_configuration',
-      label: getOperationsActionLabel('focus_configuration'),
-      reason: 'missing_contract',
-    };
+const findOperationsStep = (model: RealmOperationsModel, key: OperationsStepKey) =>
+  model.steps.find((step) => step.key === key);
+
+const buildNewRealmPrerequisiteAction = (
+  model: RealmOperationsModel
+): OperationsPrimaryAction | undefined => {
+  if (findOperationsStep(model, 'registry_contract')?.status === 'fehlgeschlagen') {
+    return createOperationsPrimaryAction('focus_configuration', 'missing_contract');
   }
-  const preflightStep = model.steps.find((step) => step.key === 'worker_preflight');
-  if (preflightStep?.status === 'fehlgeschlagen') {
-    return {
-      action: 'check_preflight',
-      label: getOperationsActionLabel('check_preflight'),
-      reason: 'preflight_blocked',
-    };
+  if (model.signals.modeConflict) {
+    return createOperationsPrimaryAction('check_preflight', 'mode_conflict');
   }
-  const liveStatusStep = model.steps.find((step) => step.key === 'live_status');
-  if (liveStatusStep?.status === 'bereit') {
-    return {
-      action: 'check_keycloak_status',
-      label: getOperationsActionLabel('check_keycloak_status'),
-      reason: 'final_validation',
-    };
+  if (findOperationsStep(model, 'worker_preflight')?.status === 'fehlgeschlagen') {
+    return createOperationsPrimaryAction('check_preflight', 'preflight_blocked');
   }
-  const reconcileStep = model.steps.find((step) => step.key === 'reconcile');
-  if (model.signals.hasDrift || reconcileStep?.status === 'fehlgeschlagen') {
-    return {
-      action: 'reconcileKeycloak',
-      label: getOperationsActionLabel('reconcileKeycloak'),
-      reason: 'run_retry',
-    };
-  }
-  return {
-    action: 'check_keycloak_status',
-    label: getOperationsActionLabel('check_keycloak_status'),
-    reason: 'final_validation',
-  };
+  return undefined;
 };
+
+const buildCompletedNewRealmFollowUpAction = (
+  model: RealmOperationsModel
+): OperationsPrimaryAction | undefined => {
+  const followUpAction = model.followUpActions[0];
+  return findOperationsStep(model, 'final_validation')?.status === 'erfolgreich' && followUpAction
+    ? createOperationsPrimaryAction(followUpAction, 'follow_up')
+    : undefined;
+};
+
+const buildNewRealmWorkerAction = (
+  model: RealmOperationsModel
+): OperationsPrimaryAction | undefined => {
+  const workerPlanStatus = findOperationsStep(model, 'worker_plan')?.status;
+  if (workerPlanStatus === 'bereit' || workerPlanStatus === 'fehlgeschlagen') {
+    return createOperationsPrimaryAction('plan_provisioning', 'follow_up');
+  }
+  const failedArtifact = model.steps.find((step) =>
+    isNewRealmProvisioningStep(step.key) && step.status === 'fehlgeschlagen'
+  );
+  if (failedArtifact) {
+    return createOperationsPrimaryAction('execute_provisioning', 'run_retry');
+  }
+  const pendingArtifact = model.steps.find((step) =>
+    isNewRealmProvisioningStep(step.key) && step.status === 'offen'
+  );
+  return pendingArtifact
+    ? createOperationsPrimaryAction('execute_provisioning', 'run_retry')
+    : undefined;
+};
+
+const buildNewRealmFinalAction = (model: RealmOperationsModel): OperationsPrimaryAction => {
+  if (findOperationsStep(model, 'final_validation')?.status === 'fehlgeschlagen') {
+    return createOperationsPrimaryAction('check_keycloak_status', 'final_validation');
+  }
+  const followUpAction = model.followUpActions[0];
+  return followUpAction
+    ? createOperationsPrimaryAction(followUpAction, 'follow_up')
+    : createOperationsPrimaryAction('check_keycloak_status', 'final_validation');
+};
+
+const buildNewRealmPrimaryAction = (model: RealmOperationsModel): OperationsPrimaryAction => {
+  const prerequisiteAction = buildNewRealmPrerequisiteAction(model);
+  if (prerequisiteAction) {
+    return prerequisiteAction;
+  }
+  const completedFollowUpAction = buildCompletedNewRealmFollowUpAction(model);
+  if (completedFollowUpAction) {
+    return completedFollowUpAction;
+  }
+  return buildNewRealmWorkerAction(model) ?? buildNewRealmFinalAction(model);
+};
+
+const buildExistingRealmPrerequisiteAction = (
+  model: RealmOperationsModel
+): OperationsPrimaryAction | undefined => {
+  const contractStep = model.steps.find(
+    (step) => step.key === 'registry_contract' || step.key === 'contract_repair'
+  );
+  if (contractStep?.status === 'fehlgeschlagen') {
+    return createOperationsPrimaryAction('focus_configuration', 'missing_contract');
+  }
+  return findOperationsStep(model, 'worker_preflight')?.status === 'fehlgeschlagen'
+    ? createOperationsPrimaryAction('check_preflight', 'preflight_blocked')
+    : undefined;
+};
+
+const buildExistingRealmPrimaryAction = (model: RealmOperationsModel): OperationsPrimaryAction => {
+  const prerequisiteAction = buildExistingRealmPrerequisiteAction(model);
+  if (prerequisiteAction) {
+    return prerequisiteAction;
+  }
+  if (findOperationsStep(model, 'live_status')?.status === 'bereit') {
+    return createOperationsPrimaryAction('check_keycloak_status', 'final_validation');
+  }
+  if (model.signals.hasDrift || findOperationsStep(model, 'reconcile')?.status === 'fehlgeschlagen') {
+    return createOperationsPrimaryAction('reconcileKeycloak', 'run_retry');
+  }
+  return createOperationsPrimaryAction('check_keycloak_status', 'final_validation');
+};
+
+export const buildOperationsPrimaryAction = (
+  model: RealmOperationsModel
+): OperationsPrimaryAction =>
+  model.mode === 'new'
+    ? buildNewRealmPrimaryAction(model)
+    : buildExistingRealmPrimaryAction(model);
 
 export const buildHistoryWorkspaceModel = (
   instance: IamInstanceDetail,

--- a/docs/changelog/entries/pr-1011.json
+++ b/docs/changelog/entries/pr-1011.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1011,
+  "body": "Die Realm-Operationsanzeige priorisiert Verwaltungsaktionen intern übersichtlicher\n\n- Realm-Vertrag, Preflight, Provisionierung, Drift und Reconcile behalten ihre bisherigen Status, Hinweise und Reihenfolgen.\n- Auch ungewöhnliche Legacy-Prioritäten und fehlende optionale Laufzeitdaten bleiben unverändert fail-closed.\n- Kombinatorische Regressionstests sichern die sichtbaren Schritte und die genau eine primäre Folgeaktion ab."
+}

--- a/openspec/changes/refactor-instance-realm-operations/design.md
+++ b/openspec/changes/refactor-instance-realm-operations/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`-instances-shared.tsx` projiziert Registry-, Preflight-, Plan-, Run- und
+Keycloak-Evidenz in ein sichtbares Realm-Operationsmodell. Dieselbe Datei wählt
+aus diesem Modell genau eine primäre Admin-Aktion. Beide Entscheidungen sind
+produktiv erreichbar und IAM-relevant, sollen aber ohne Verhaltensänderung
+intern lesbarer werden.
+
+Der aktive Change `update-instance-detail-module-tab` betrifft denselben
+Route-Cluster, aber einen anderen Vertrag: Modulzuweisung, Modul-Workspace,
+Tab-Navigation und zugehörige Page-/UI-Tests. Die Realm-Operationsquelle und die
+beiden Modelltests dieses Changes werden dort nicht benannt. Offene PRs #983
+und #984 betreffen ausschließlich Waste-Verträge. Diese Abgrenzung wird vor der
+Implementierung erneut geprüft.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Realm-Schritte anhand fachlich benannter, typisierter Entscheidungen
+    aufbauen
+  - Primäraktionspriorität isoliert und in unveränderter Reihenfolge ausdrücken
+  - bestehende New-/Existing-, Fehler-, Reihenfolge-, Fallback- und
+    Metadaten-Semantik vollständig bewahren
+- Non-Goals:
+  - öffentliche Typen oder Action-IDs ändern
+  - Backend-, Keycloak-, Registry-, Permission- oder Mutationslogik ändern
+  - Übersetzungen, Navigation, Modul-Tab oder sichtbare Interaktion ändern
+  - eine konfigurierbare Workflow- oder Rules-Engine einführen
+
+## Decisions
+
+- Decision: Characterization wird in zwei getrennten Blöcken geführt:
+  Realm-Schrittprojektion und Primäraktionspriorität.
+  - Reason: Jedes Zielproblem erhält eigenständige Evidenz und kann bei einem
+    Review separat gegen den Altcode verglichen werden.
+- Decision: Neue Helper bleiben intern im vorhandenen Route-Owner und werden
+  nur eingeführt, wenn sie eine fachliche Entscheidung benennen.
+  - Reason: Eine neue Paket- oder öffentliche Ownership-Grenze wäre für den
+    lokalen Vertrag unverhältnismäßig.
+- Decision: Die Characterization bewahrt auch überraschende Legacy-Semantik,
+  darunter die vorhandene Action-Attribution bei blockiertem Preflight und den
+  aktuellen `run_retry`-Reason für fehlgeschlagenen Secret-Sync.
+  - Reason: Diese Runde ist ein verhaltensgleicher Refactor; Korrekturen
+    benötigen einen eigenen freigegebenen Vertrag.
+
+## Risks / Trade-offs
+
+- Verdeckte Prioritätsänderung kann eine falsche IAM-Aktion hervorheben.
+  - Mitigation: konkurrierende Kandidaten werden kombinatorisch getestet; der
+    exakte erste Treffer bleibt verbindlich.
+- Falsch zugeordnete Evidence oder Zeitstempel können Betrieb und Diagnose
+  täuschen.
+  - Mitigation: Characterization prüft `evidenceSource`, `checkedAt` und
+    `requestId` für Run- und Final-Validation-Pfade.
+- Gemeinsamer Route-Cluster mit dem Modul-Tab-Change kann Konflikte erzeugen.
+  - Mitigation: datei-, Fixture- und vertragsscharfe Prüfung vor Source-Arbeit;
+    bei echter Überschneidung STOP.
+- Zusätzliche Helper könnten nur Metriken verschieben.
+  - Mitigation: keine generische Engine und keine Abstraktion ohne benannte
+    Realm-Fachentscheidung; New-only-Fallow-Audit auf dem kanonischen Workspace.
+
+## Migration Plan
+
+1. Baseline und neue Characterization gegen unveränderte Produktionssource
+   grün nachweisen.
+2. OpenSpec und Characterization durch Root-Agent prüfen und freigeben lassen.
+3. Builder blockweise intern strukturieren und nach jedem Block gezielt testen.
+4. Lokale Gates, Coverage, Fallow New-only und risikoorientiertes Review auf dem
+   exakten PR-Head ausführen.
+5. Bei Semantikabweichung den jeweiligen Refactorblock zurücknehmen; keine
+   Datenmigration oder Runtime-Rollback ist erforderlich.
+
+## Open Questions
+
+- Keine. Eine notwendige Vertragskorrektur beendet diesen Change und wird nicht
+  still in den Refactor aufgenommen.

--- a/openspec/changes/refactor-instance-realm-operations/proposal.md
+++ b/openspec/changes/refactor-instance-realm-operations/proposal.md
@@ -1,0 +1,36 @@
+# Change: Realm-Operationsmodell intern und semantikgleich vereinfachen
+
+## Why
+
+Die Realm-Schrittprojektion und die Auswahl der primären Admin-Aktion liegen in
+wenigen stark verzweigten Buildern. Dadurch sind sicherheitsrelevante Status-,
+Fallback- und Prioritätsregeln schwer isoliert prüfbar, obwohl sie produktiv den
+nächsten IAM-Operationsschritt bestimmen.
+
+## What Changes
+
+- Charakterisiert die vollständige New-/Existing-Realm-Schrittmatrix vor jeder
+  produktiven Änderung.
+- Charakterisiert die Primäraktionspriorität getrennt von der Schritterzeugung.
+- Strukturiert ausschließlich interne Builder und typisierte Auswahlhelfer im
+  bestehenden Route-Owner neu.
+- Bewahrt Reihenfolge, Status, Summary, Evidence Source, Timestamp, Request-ID,
+  Action-ID, Label, Reason und Follow-up-Verhalten unverändert.
+- Führt keine neue Workflow-Engine, öffentliche API, Mutation, Berechtigung oder
+  Übersetzung ein.
+
+## Impact
+
+- Affected specs: `instance-provisioning`
+- Affected code:
+  - `apps/sva-studio-react/src/routes/admin/instances/-instances-shared.tsx`
+  - optional ein internes, nicht öffentliches Helper-Modul im selben Route-Owner
+  - `apps/sva-studio-react/src/routes/admin/instances/-instances-shared.test.tsx`
+  - `apps/sva-studio-react/src/routes/admin/instances/-instance-detail-models.test.ts`
+- Affected arc42 sections: keine normative Architekturwirkung; Owner,
+  Paketgrenze, öffentliche Verträge und Runtime-Flows bleiben unverändert
+- Active-change boundary: `update-instance-detail-module-tab` besitzt
+  Modul-Workspace, Tab-Integration und Page-/UI-Flows. Dieser Change besitzt
+  ausschließlich Realm-Operationsprojektion, Primäraktionsauswahl und die zwei
+  benannten Modelltests. Bei Source-, Fixture- oder Vertragsüberschneidung wird
+  die Umsetzung gestoppt.

--- a/openspec/changes/refactor-instance-realm-operations/specs/instance-provisioning/spec.md
+++ b/openspec/changes/refactor-instance-realm-operations/specs/instance-provisioning/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Interne Realm-Operationsprojektion bleibt bei Refactorings semantikgleich
+
+Das System SHALL bei internen Refactorings der Instanz-Detailprojektion die
+bestehende Realm-Schritt- und Primäraktionssemantik vollständig bewahren. Eine
+interne Zerlegung darf weder öffentliche Verträge noch die sichtbare
+Entscheidungsreihenfolge ändern.
+
+#### Scenario: New-Realm-Schritte bewahren Zustand und Evidenz
+
+- **WHEN** Registry-Vertrag, Preflight, Plan, Provisioning-Run und einzelne Keycloak-Artefakte in vollständigen, fehlenden, laufenden, blockierten, fehlgeschlagenen oder erfolgreichen Kombinationen vorliegen
+- **THEN** bleiben Reihenfolge, Status, Summary und Action jedes New-Realm-Schritts unverändert
+- **AND** bleiben `evidenceSource`, `checkedAt` und `requestId` derselben Registry-, Preflight-, Plan-, Run- oder Final-Validation-Evidenz zugeordnet
+
+#### Scenario: Existing-Realm-Schritte bewahren Drift- und Reconcile-Semantik
+
+- **WHEN** Live-Status fehlt oder vorliegt, Drift vorhanden oder abwesend ist und der letzte Run fehlt, fehlschlägt oder anderweitig abgeschlossen ist
+- **THEN** bleiben Registry-Vertrag, Preflight, Live-Status, Driftanalyse, Vertragsreparatur, Reconcile und Ergebnisvalidierung in derselben Reihenfolge und mit denselben Statuswerten erhalten
+- **AND** bleiben Reconcile-Action, Evidence Source, Timestamp und Request-ID unverändert zugeordnet
+
+#### Scenario: Primäraktion bewahrt die feste Prioritätsreihenfolge
+
+- **WHEN** mehrere mögliche New- oder Existing-Realm-Aktionen gleichzeitig aus Schrittzuständen, Signalen und Follow-up-Aktionen ableitbar sind
+- **THEN** wählt die Instanz-Detailprojektion dieselbe erste Aktion mit derselben Action-ID, demselben Label und demselben Reason wie vor dem Refactoring
+- **AND** bleiben Konfigurations-, Moduskonflikt-, Preflight-, Plan-, Execute-, Status-, Reconcile- und Follow-up-Prioritäten unverändert
+
+#### Scenario: Fehlende oder Legacy-Evidenz bleibt fail-closed
+
+- **WHEN** optionale Schritte, Preflight-, Plan-, Run- oder Keycloak-Evidenz `null`, `undefined`, unvollständig oder widersprüchlich vorliegt
+- **THEN** bleibt die bisherige offene, blockierte oder statusprüfende Fallback-Ausgabe erhalten
+- **AND** führt die interne Strukturierung keine optimistische Erfolgsannahme und keine neue Mutation ein

--- a/openspec/changes/refactor-instance-realm-operations/tasks.md
+++ b/openspec/changes/refactor-instance-realm-operations/tasks.md
@@ -5,20 +5,20 @@
 - [x] 1.3 Betroffene Unit- und Type-Baseline gegen unveränderte Source grün ausführen
 - [x] 1.4 Kombinatorische Characterization der New-/Existing-Realm-Schritte ergänzen
 - [x] 1.5 Getrennte Characterization der Primäraktionspriorität ergänzen
-- [ ] 1.6 Proposal und Characterization durch den Root-Agent prüfen und freigeben lassen
+- [x] 1.6 Proposal und Characterization durch den Root-Agent prüfen und freigeben lassen
 
 ## 2. Implementierung
 
-- [ ] 2.1 Worker-Preflight-, New-Realm-Lead- und Artefaktschritte intern semantikgleich strukturieren
-- [ ] 2.2 Existing-Realm-Assessment intern semantikgleich strukturieren
-- [ ] 2.3 Primäraktionsauswahl als kleine explizite, typisierte Prioritätsentscheidung ausdrücken
-- [ ] 2.4 Nach jedem Refactorblock die gezielten Modelltests ausführen
+- [x] 2.1 Worker-Preflight-, New-Realm-Lead- und Artefaktschritte intern semantikgleich strukturieren
+- [x] 2.2 Existing-Realm-Assessment intern semantikgleich strukturieren
+- [x] 2.3 Primäraktionsauswahl als kleine explizite, typisierte Prioritätsentscheidung ausdrücken
+- [x] 2.4 Nach jedem Refactorblock die gezielten Modelltests ausführen
 
 ## 3. Dokumentation und Qualität
 
 - [ ] 3.1 Studio-Changelog ergänzen und Planstatus aktualisieren
-- [ ] 3.2 Unit, Coverage, Types, Lint, Build und Accessibility ausführen
+- [x] 3.2 Unit, Coverage, Types, Lint, Build und Accessibility ausführen
 - [ ] 3.3 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` ausführen
-- [ ] 3.4 Fallow New-only für `sva-studio-react` mit echter Coverage ausführen
+- [x] 3.4 Fallow New-only für `sva-studio-react` mit echter Coverage ausführen
 - [ ] 3.5 Root-Review und unabhängiges IAM-/Semantikreview auf dem exakten Head abschließen
 - [ ] 3.6 Terminale CI, null offene Threads und Mergeability nachweisen

--- a/openspec/changes/refactor-instance-realm-operations/tasks.md
+++ b/openspec/changes/refactor-instance-realm-operations/tasks.md
@@ -16,9 +16,9 @@
 
 ## 3. Dokumentation und Qualität
 
-- [ ] 3.1 Studio-Changelog ergänzen und Planstatus aktualisieren
+- [x] 3.1 Studio-Changelog ergänzen und Planstatus aktualisieren
 - [x] 3.2 Unit, Coverage, Types, Lint, Build und Accessibility ausführen
-- [ ] 3.3 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` ausführen
+- [x] 3.3 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` ausführen
 - [x] 3.4 Fallow New-only für `sva-studio-react` mit echter Coverage ausführen
 - [ ] 3.5 Root-Review und unabhängiges IAM-/Semantikreview auf dem exakten Head abschließen
 - [ ] 3.6 Terminale CI, null offene Threads und Mergeability nachweisen

--- a/openspec/changes/refactor-instance-realm-operations/tasks.md
+++ b/openspec/changes/refactor-instance-realm-operations/tasks.md
@@ -1,0 +1,24 @@
+## 1. Scope und Characterization
+
+- [x] 1.1 Live-Basis, offene PRs und aktive OpenSpec-Changes prüfen
+- [x] 1.2 `update-instance-detail-module-tab` datei-, Fixture- und vertragsscharf abgrenzen
+- [x] 1.3 Betroffene Unit- und Type-Baseline gegen unveränderte Source grün ausführen
+- [x] 1.4 Kombinatorische Characterization der New-/Existing-Realm-Schritte ergänzen
+- [x] 1.5 Getrennte Characterization der Primäraktionspriorität ergänzen
+- [ ] 1.6 Proposal und Characterization durch den Root-Agent prüfen und freigeben lassen
+
+## 2. Implementierung
+
+- [ ] 2.1 Worker-Preflight-, New-Realm-Lead- und Artefaktschritte intern semantikgleich strukturieren
+- [ ] 2.2 Existing-Realm-Assessment intern semantikgleich strukturieren
+- [ ] 2.3 Primäraktionsauswahl als kleine explizite, typisierte Prioritätsentscheidung ausdrücken
+- [ ] 2.4 Nach jedem Refactorblock die gezielten Modelltests ausführen
+
+## 3. Dokumentation und Qualität
+
+- [ ] 3.1 Studio-Changelog ergänzen und Planstatus aktualisieren
+- [ ] 3.2 Unit, Coverage, Types, Lint, Build und Accessibility ausführen
+- [ ] 3.3 Complexity, OpenSpec strict, File Placement, Changelog und `git diff --check` ausführen
+- [ ] 3.4 Fallow New-only für `sva-studio-react` mit echter Coverage ausführen
+- [ ] 3.5 Root-Review und unabhängiges IAM-/Semantikreview auf dem exakten Head abschließen
+- [ ] 3.6 Terminale CI, null offene Threads und Mergeability nachweisen

--- a/plans/024-refactor-instance-realm-operation-steps.md
+++ b/plans/024-refactor-instance-realm-operation-steps.md
@@ -11,6 +11,8 @@
 - **Kategorie:** IAM-UI-Vertrag, Datenintegrität, Complexity, CRAP
 - **Geplant auf:** `98e6ca3d7`, 15. August 2026
 - **Fallow vorher:** `-instances-shared.tsx` hat 778 Zeilen, 39 Funktionen, Fan-in 4, CC gesamt 232, Cognitive gesamt 171, MI 79,6, fünf CRAP-Findings und Hotspot-Score 5,6 bei 22 Commits. Zielgruppe: `buildExistingRealmAssessmentSteps` CC 35/Cognitive 41/CRAP 299,6; `buildNewRealmArtifactSteps` 28/22/197,3; `buildNewRealmLeadSteps` 20/19/106,4; `buildWorkerPreflightStep` 17/29/79,4.
+- **Umsetzung:** Draft-PR #1011; Characterization und Source-Diff durch Root-Review freigegeben.
+- **Fallow nachher:** Die vier Zielanker sind aus den Complexity-/CRAP-Findings verschwunden. Die Datei hat 947 Zeilen, 63 kleine fachlich benannte Funktionen, CC gesamt 245, Cognitive gesamt 120, MI 80,8 und CRAP-Maximum 16,1; New-only meldet für Complexity, Dead Code, Duplikation und Styling jeweils 0 eingeführte Befunde.
 
 ## Warum und Produktionsreichweite
 

--- a/plans/025-refactor-instance-primary-action-priority.md
+++ b/plans/025-refactor-instance-primary-action-priority.md
@@ -11,6 +11,8 @@
 - **Kategorie:** IAM-UI-Aktionspriorität, CRAP
 - **Geplant auf:** `98e6ca3d7`, 15. August 2026
 - **Fallow vorher:** `buildOperationsPrimaryAction` in `-instances-shared.tsx:619` hat CC 30, Cognitive 28, 131 Zeilen und CRAP 33 bei geschätzter hoher Coverage; lokaler Clone `dup:a9825bed` umfasst 16 Zeilen.
+- **Umsetzung:** Draft-PR #1011; die getrennte Prioritätsmatrix und der Source-Diff sind durch Root-Review freigegeben.
+- **Fallow nachher:** `buildOperationsPrimaryAction` ist nur noch der typisierte New-/Existing-Dispatcher; der Zielanker und sein lokaler Clone sind aus den Findings verschwunden. Der Coverage-gebundene New-only-Audit meldet keine eingeführte Complexity, keinen moderaten CRAP-Befund und keine eingeführte Duplikation.
 
 ## Warum und Produktionsreichweite
 


### PR DESCRIPTION
## Zusammenfassung

- strukturiert die Realm-Operationsschritte in fachlich benannte, typisierte Builder
- macht die New-/Existing-Realm-Prioritätsentscheidung explizit und erhält alle Legacy-Prioritäten
- sichert Schritt-, Fehler-, Fallback- und Prioritätssemantik durch 39 neue Characterization-Fälle

## Scope

Bundle B der Fallow-Runde 3: Pläne 024 und 025. Keine Änderung an öffentlicher API, Actions, Permissions, Navigation oder Module-Tab-Vertrag.

## Evidenz

- Root-Diffreview auf `e3ee29ded798ea65d5a806f961fd67b66d68c429`: freigegeben, keine offenen Source-Findings
- gezielte Unit-Tests: 70/70
- gezielte Coverage: Statements 86,01 %, Branches 73,14 %, Functions 85,04 %, Lines 86,11 %
- `pnpm test:pr`: grün; Routes 633/633, Ops 51/51, E2E 47 bestanden / 8 erwartbar übersprungen
- Types, Lint, Build, A11y 6/6, Complexity, OpenSpec strict, File Placement und `git diff --check`: grün
- Fallow Audit Schema 7 mit echter Coverage: PASS; `dead_code_introduced`, `complexity_introduced`, `duplication_introduced`, `styling_introduced` jeweils 0; keine Complexity-/CRAP-Neufunde

## OpenSpec

`refactor-instance-realm-operations`
