### PR TITLE
docs(plans): add SonarCloud risk round

### DIFF
--- a/docs/changelog/entries/pr-1013.json
+++ b/docs/changelog/entries/pr-1013.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1013,
+  "body": "Die nächste SonarCloud-Verbesserungsrunde ist mit risikoorientierten, getrennt ausführbaren Arbeitspaketen dokumentiert."
+}

--- a/plans/027-require-cryptographic-content-media-ui-ids.md
+++ b/plans/027-require-cryptographic-content-media-ui-ids.md
@@ -1,0 +1,48 @@
+# Plan 027: Kryptografisch sichere Content-Media-UI-IDs erzwingen
+
+> **Executor**: Arbeite ausschließlich im angegebenen Scope. Führe Baseline und neue Characterization zuerst gegen den Altcode aus. STOP-Bedingungen haben Vorrang vor Improvisation.
+
+## Status
+
+- **Priorität**: P0
+- **Aufwand**: S
+- **Risiko**: mittel
+- **Abhängigkeit**: keine; separat zuerst mergen
+- **Kategorie**: Security
+- **Geplant auf**: `960955af8`, 15. August 2026
+- **Sonar**: `AZ_MufJ-6Sn7SUF7x3qN`, `typescript:S2245`, BLOCKER/Vulnerability
+
+## Warum das wichtig ist
+
+`createContentMediaUiId` fällt bei fehlendem `crypto.randomUUID` auf `Math.random()` zurück. Die ID ist zwar UI-lokal, aber der unsichere Fallback erzeugt die einzige offene Vulnerability und hält das Main-Quality-Gate über New-Code Security Rating C rot. Der Vertrag soll klar fail-closed auf Web Crypto beruhen, ohne einen zweiten selbstgebauten Zufallsgenerator.
+
+## Aktueller Zustand
+
+- `packages/studio-ui-react/src/content-media-usage.ts:25-26`: `globalThis.crypto?.randomUUID?.() ?? media-${Date.now()}-${Math.random()...}`.
+- `packages/studio-ui-react/src/content-media-usage.test.ts`: prüft Reihenfolge, URLs und Referenzen, aber nicht den Runtime-Vertrag der ID-Erzeugung.
+- Workspace: `studio-ui-react`; vorhandene Targets: `test:unit`, `test:types`, `lint`, `build`.
+
+## Scope
+
+**In Scope**: die beiden oben genannten Dateien; falls nötig eine vorhandene deutsche Fach-Dokumentation oder Changelog-Entry nach Repository-Konvention.
+
+**Out of Scope**: persistierte Asset-IDs, Media-Upload, URL-Sicherheitslogik, Crypto-Polyfills, Sonar-Transition/Suppression, Quality-Profile.
+
+## Schritte und Characterization
+
+1. Baseline: `pnpm nx run studio-ui-react:test:unit --testFiles=src/content-media-usage.test.ts` muss grün sein.
+2. Tests zuerst: eindeutige Rückgabe von `crypto.randomUUID`; fehlendes `crypto.randomUUID` muss den expliziten Runtime-Vertrag zeigen (kein stiller schwacher Fallback). Neue Tests gegen Altcode ausführen und den erwarteten roten Fall dokumentieren.
+3. Minimal implementieren: Web-Crypto-Vertrag direkt und typsicher verwenden; keine lokale Zufallslogik und keine ID-Verhaltensänderung außerhalb dieses Konstruktors.
+4. Gates: fokussierte Unit-Tests, `pnpm nx run studio-ui-react:test:types`, `pnpm nx run studio-ui-react:lint`, `pnpm nx run studio-ui-react:build`, `pnpm exec fallow audit --base origin/main --workspace studio-ui-react --explain --format json`, `pnpm check:file-placement`, `pnpm test:changelog:pr`, `pnpm exec openspec validate --all --strict`, `git diff --check`.
+
+## Erwartete Wirkung
+
+- Sonar: Ziel-Key verschwindet; Vulnerabilities 1→0, New-Code Security C→A, Gate ERROR→OK nach Main-Scan.
+- Fallow: PASS; keine eingeführte Complexity, Dead Code oder Duplikation; keine moderate neue CRAP-Stelle.
+
+## STOP-Bedingungen
+
+- Ein unterstützter Produktionsruntime besitzt nachweislich kein `crypto.randomUUID` und ein Polyfill wäre erforderlich.
+- Der Fix müsste persistierte oder serverseitig interpretierte IDs ändern.
+- Baseline rot oder aktive Source-/Vertragsüberschneidung.
+

--- a/plans/028-linearize-organization-technical-identity-normalization.md
+++ b/plans/028-linearize-organization-technical-identity-normalization.md
@@ -1,0 +1,40 @@
+# Plan 028: Organisationstechnische Identitäten linear normalisieren
+
+## Status
+
+- **Priorität**: P1
+- **Aufwand**: S–M
+- **Risiko**: hoch
+- **Abhängigkeit**: Plan 027 gemergt; danach auf neuen Main rebasen
+- **Kategorie**: algorithmische Security / IAM
+- **Geplant auf**: `960955af8`, 15. August 2026
+- **Sonar**: `AZ_xm2LjTJR08C9EVXIk`, `AZ_xm2LjTJR08C9EVXIl`; 2 × `typescript:S8786`
+
+## Warum das wichtig ist
+
+`normalizeAsciiSegment` verarbeitet organisationskontrollierte Anzeigenamen in einem produktiven Provisioning-Pfad. Zwei Regex-Schritte besitzen laut Sonar superlineares Backtracking. Die Ausgabe, Kollisionsbehandlung und maximale Länge sind Teil der technischen Account-Identität und dürfen nicht driften.
+
+## Aktueller Zustand und Scope
+
+- `packages/auth-runtime/src/iam-organizations/organization-mainserver-technical-account.ts:22-38`: Separator-Kollaps und Randpunkt-Trim über Regex.
+- `packages/auth-runtime/src/iam-organizations/organization-mainserver-provisioning.test.ts:157-180`: bestehende Identitätsfälle.
+- Workspace `auth-runtime`; Node-ESM-Regeln und `check:runtime` gelten.
+- In Scope nur diese Source- und Testdatei sowie zwingende deutschsprachige Doku/Changelog-Datei. Out of Scope: Keycloak-Aufrufe, Provisioning-State, SQL, Kollisionspriorität, E-Mail-Domain und Account-Persistenz.
+
+## Characterization und Umsetzung
+
+1. Bestehenden fokussierten Unit-Test als Baseline grün ausführen.
+2. Vor Source-Änderung eine Matrix für Umlaute/ß, nur Separatoren, führende/abschließende Separatoren, sehr lange gleichartige und adversarial geformte Eingaben, leere Werte, Fallback und collision-safe Suffix ergänzen. Keine konkrete Missbrauchs-Payload dokumentieren. Neue Performancegrenze mit großzügigem deterministischem Zeitbudget gegen Altcode messen; funktionale Tests müssen die exakten Alt-Ausgaben festhalten.
+3. Die beiden riskanten Regex-Schritte durch linear begrenzte Plattform-/Kontrollflusslogik ersetzen, ohne neue Abstraktionsschicht.
+4. Gates: fokussierte Unit, `auth-runtime:test:types`, `auth-runtime:lint`, `auth-runtime:build`, `auth-runtime:check:runtime`, `pnpm check:server-runtime`, Fallow-New-only für `auth-runtime`, OpenSpec strict/all, File Placement, Changelog, `git diff --check`.
+
+## Erwartete Wirkung
+
+2 S8786 verschwinden; Identitätsbytes bleiben für alle charakterisierten Fälle gleich. Fallow PASS ohne neue Complexity/CRAP/Duplikation.
+
+## STOP-Bedingungen
+
+- Bestehende Normalisierung erzeugt bei gleicher Eingabe nicht deterministische oder bereits persistiert abweichende Identitäten.
+- Änderung verlangt Provisioning-, Keycloak-, SQL- oder OpenSpec-Vertragsänderung.
+- Aktiver Branch berührt dieselben Source-/Fixture-Verträge.
+

--- a/plans/029-linearize-waste-tenant-database-identifiers.md
+++ b/plans/029-linearize-waste-tenant-database-identifiers.md
@@ -1,0 +1,39 @@
+# Plan 029: Waste-Tenant-Datenbankkennungen linear ableiten
+
+## Status
+
+- **Priorität**: P1
+- **Aufwand**: S
+- **Risiko**: hoch
+- **Abhängigkeit**: Plan 027; keine Source-Überschneidung mit #983/#984 vor Start erneut belegen
+- **Kategorie**: Datenintegrität / algorithmische Security
+- **Geplant auf**: `960955af8`, 15. August 2026
+- **Sonar**: `AZ_DlvT3UItUTMcRH3zS`, `typescript:S8786`
+
+## Warum das wichtig ist
+
+Die Normalisierung von `instanceId` bestimmt unveränderliche PostgreSQL-Datenbank- und Rollenkennungen. Ein semantischer Drift könnte bestehende Tenant-Datenbanken unerreichbar machen; zugleich darf sehr lange Eingabe nicht superlinear laufen.
+
+## Aktueller Zustand und Scope
+
+- `packages/server-runtime/src/waste/tenant-database-identifiers.server.ts:15-21`: Nicht-Alphanumerik wird gruppiert ersetzt und Rand-Unterstriche werden per Alternationsregex entfernt.
+- `packages/server-runtime/src/waste/tenant-database-identifiers.server.test.ts`: nur ein normaler Stabilitätsfall.
+- In Scope ausschließlich diese Source-/Testdatei plus zwingende Doku/Changelog. Out of Scope: Provisioner, Migrationen, Compose, Schema, Rollenrechte, Hashalgorithmus, Namenlängen.
+
+## Characterization und Umsetzung
+
+1. Baseline des fokussierten `server-runtime`-Tests grün.
+2. Exakte Ausgaben für ASCII, Unicode/NFKD, nur Trennzeichen, führende/abschließende Trennzeichen, digit-start, leere und sehr lange/adversarial geformte Eingaben charakterisieren; Längen und Identifier-Pattern für alle fünf Namen prüfen. Neue Tests zuerst am Altcode ausführen.
+3. Nur den S8786-Auslöser linear ersetzen; Hash, Präfixe, Suffixe und `identifierPattern` unverändert lassen.
+4. Gates: fokussierte Unit, Types, Lint, Build, `server-runtime:check:runtime`, `pnpm check:server-runtime`, Fallow-New-only `server-runtime`, OpenSpec strict/all, File Placement, Changelog, `git diff --check`.
+
+## Erwartete Wirkung
+
+1 S8786 verschwindet; alle abgeleiteten DB-/Rollennamen bleiben bytegleich. Fallow PASS ohne neue Findings.
+
+## STOP-Bedingungen
+
+- Ein charakterisierter Name unterscheidet sich nach dem Refactor.
+- #983/#984 oder ein aktiver OpenSpec berührt die Kennungsableitung oder Fixtures.
+- Schema-/Provisioneränderung wird nötig.
+

--- a/plans/030-linearize-organization-key-normalization.md
+++ b/plans/030-linearize-organization-key-normalization.md
@@ -1,0 +1,33 @@
+# Plan 030: Organisation-Keys linear normalisieren
+
+## Status
+
+- **Priorität**: P1
+- **Aufwand**: S
+- **Risiko**: mittel
+- **Abhängigkeit**: Plan 027
+- **Kategorie**: Eingabevalidierung / algorithmische Security
+- **Geplant auf**: `960955af8`, 15. August 2026
+- **Sonar**: `AZ7zBU0TKoyPQ8JFyMIu`, `typescript:S8786`
+
+## Kontext, Scope und Vertrag
+
+`apps/sva-studio-react/src/routes/admin/organizations/-organization-shared.tsx:92-101` erzeugt aus eingegebenen Anzeigenamen vorgeschlagene eindeutige Organisation-Keys. Der Randtrim-Regex ist als superlinear markiert. In Scope sind diese Datei und `-organization-shared.test.tsx`; Out of Scope sind Mutation-Payload, Backendvalidierung, Organisationspersistenz, Mainserver-Credentials und UI-Layout.
+
+## Characterization und Umsetzung
+
+1. Vorhandenen fokussierten Test als Baseline ausführen.
+2. Tests für Unicode/NFKD, nur Separatoren, Rand-/Mehrfachseparatoren, sehr lange/adversarial geformte Werte, bestehende Keys, Exclude-ID und Suffixreihenfolge zuerst hinzufügen und am Altcode ausführen.
+3. Ausschließlich den riskanten Trim-Schritt linear formulieren; resultierende Keys und Kollisionspriorität exakt erhalten.
+4. Gates: fokussierte Unit, `sva-studio-react:test:types`, `sva-studio-react:lint`, relevanter Build, Fallow-New-only `sva-studio-react`, Accessibility nur falls JSX geändert wird, OpenSpec strict/all, File Placement, Changelog, `git diff --check`.
+
+## Erwartete Wirkung
+
+1 S8786 verschwindet; keine Änderung gespeicherter oder vorgeschlagener Keys; Fallow PASS.
+
+## STOP-Bedingungen
+
+- Normalisierungs- oder Kollisionsvertrag müsste fachlich geändert werden.
+- Aktive Organisation-Provisioning-Arbeit berührt Source oder dieselbe Fixture.
+- Änderung zieht Backend/API/DB-Scope nach sich.
+

--- a/plans/031-linearize-studio-changelog-html-detection.md
+++ b/plans/031-linearize-studio-changelog-html-detection.md
@@ -1,0 +1,27 @@
+# Plan 031: Changelog-HTML-Erkennung linear begrenzen
+
+## Status
+
+- **Priorität**: P1
+- **Aufwand**: S–M
+- **Risiko**: mittel
+- **Abhängigkeit**: Plan 027
+- **Kategorie**: Eingabevalidierung / algorithmische Security
+- **Geplant auf**: `960955af8`, 15. August 2026
+- **Sonar**: `AZ9CFgkRsdqj1ar76p4t`, `typescript:S8786`
+
+## Kontext und Scope
+
+`apps/sva-studio-react/src/lib/studio-changelog.shared.ts:5` erkennt rohes HTML in repositorykontrollierten Changelog-Bodies mit einem potenziell superlinearen Regex. Obwohl der Angreiferradius kleiner als bei Runtime-Formularen ist, läuft der Parser in Build/Runtime-Ladepfaden und soll lange fehlerhafte Einträge zuverlässig begrenzen. In Scope: diese Source und `studio-changelog.shared.test.ts`; Out of Scope: Markdown-Renderer, Katalogpfade, Fehlermeldungstexte, Changelog-Schema.
+
+## Characterization und Umsetzung
+
+1. Fokussierte Baseline grün.
+2. Erlaubte Vergleichs-/Textzeichen, echte Start-/End-/Self-closing-Tags, Attribute, unvollständige Tags, sehr lange und adversarial geformte Eingaben charakterisieren. Exakte Accept/Reject-Semantik vor Änderung festhalten.
+3. Riskanten Regex durch eine lineare, lokal verständliche Erkennung ersetzen; keinen Voll-HTML-Parser und keine neue Dependency ohne belegten Semantikbedarf.
+4. Gates: fokussierte Unit, App Types/Lint/Build, Fallow-New-only App, Changelog-Gate, OpenSpec strict/all, File Placement, `git diff --check`.
+
+## Erwartete Wirkung und STOP
+
+1 S8786 verschwindet, Accept/Reject-Matrix bleibt gleich, Fallow PASS. STOP bei erforderlicher Änderung der erlaubten Changelog-Syntax, Nutzertexten/i18n oder gemeinsamem Markdown-Sanitizing-Vertrag.
+

--- a/plans/032-linearize-media-base64url-padding.md
+++ b/plans/032-linearize-media-base64url-padding.md
@@ -1,0 +1,27 @@
+# Plan 032: Media-Base64url-Padding linear entfernen
+
+## Status
+
+- **Priorität**: P2
+- **Aufwand**: S
+- **Risiko**: mittel
+- **Abhängigkeit**: Plan 027
+- **Kategorie**: Eingabevalidierung / algorithmische Security
+- **Geplant auf**: `960955af8`, 15. August 2026
+- **Sonar**: `AZ7zBUuvKoyPQ8JFyMIq`, `typescript:S8786`
+
+## Kontext und Scope
+
+`apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.tsx:19-31` entfernt Base64-Padding im Browser-Fallback mit `/=+$/g`. Storage-Keys können lang und extern geprägt sein; Node- und Browserpfad müssen exakt dieselbe Base64url-Ausgabe und Roundtrip-Semantik behalten. In Scope sind diese Source und `-media-ui.shared.test.ts`; Out of Scope: Media-ID-Präfix, Storage-Key-Schema, Upload, Asset-API, globale Base64-Helfer.
+
+## Characterization und Umsetzung
+
+1. Fokussierte Baseline grün.
+2. Node- und Browser-Fallback für Paddinglängen 0/1/2, Unicode, leere und sehr lange/adversarial geformte Storage-Keys charakterisieren; Altcodeausgabe und Roundtrip festhalten. Bestehenden Source-Shape-Test nicht als alleinigen Beleg verwenden.
+3. Nur das Padding linear/konstant begrenzt entfernen; keine neue Utility-Abstraktion.
+4. Gates: fokussierte Unit, App Types/Lint/Build, Fallow-New-only App, OpenSpec strict/all, File Placement, Changelog, `git diff --check`.
+
+## Erwartete Wirkung und STOP
+
+1 S8786 verschwindet; Node-/Browser-Ausgabe bleibt bytegleich; Fallow PASS. STOP, wenn Browser-Fallback im Test nicht realistisch isolierbar ist oder eine gemeinsame Encoding-Vertragsänderung nötig wird.
+

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,5 +1,52 @@
 # Implementierungspläne zur Fallow-Sanierung
 
+## SonarCloud-Runde 1 – Live-Baseline und Ausführung
+
+Die SonarCloud-Runde wurde am 15. August 2026 auf dem live gefetchten
+`origin/main` `960955af8e356554e605eecc1c591924a3aaaff4` geplant. Die jüngste
+Sonar-Analyse vom `2026-08-15T18:26:07+0000` trägt exakt dieselbe Revision.
+
+- Quality Gate: `ERROR`; allein rot ist New-Code Security Rating `3/C` bei
+  erlaubtem Wert `1/A`.
+- 969 offene Issues: 1 Vulnerability, 0 Bugs, 968 Code Smells; 0 ungeprüfte
+  Security Hotspots.
+- Severity: 1 Blocker, 108 Critical, 416 Major, 444 Minor.
+- Debt: 6.545 Minuten (109 h 05 min); Coverage 88,0 %, Line Coverage 92,0 %,
+  Branch Coverage 81,7 %, globale Duplikation 1,9 %, New-Code-Duplikation 1,0 %.
+- Bestätigte Hauptgruppen: S3358 241, S1874 127, S3776 91, S4782 52,
+  S7763 41, S3863 34, S6478 30, S6551 28, S6571 24, S3735 16,
+  S6819 15, S9020 15 und S8786 6.
+
+### Gewählte Bündel und Reihenfolge
+
+| Plan | Titel | Priorität | Sonar vorher | Abhängigkeit | Status |
+|---|---|---:|---:|---|---|
+| 027 | Kryptografisch sichere Content-Media-UI-IDs | P0 | S2245: 1 | keine | TODO |
+| 028 | Organisationstechnische Identitäten linear normalisieren | P1 | S8786: 2 | 027 | TODO |
+| 029 | Waste-Tenant-Datenbankkennungen linear ableiten | P1 | S8786: 1 | 027, Konfliktprüfung #983/#984 | TODO |
+| 030 | Organisation-Keys linear normalisieren | P1 | S8786: 1 | 027 | TODO |
+| 031 | Changelog-HTML-Erkennung linear begrenzen | P1 | S8786: 1 | 027 | TODO |
+| 032 | Media-Base64url-Padding linear entfernen | P2 | S8786: 1 | 027 | TODO |
+
+Plan 027 wird separat zuerst gemergt und über den Main-Sonar-Scan abgenommen.
+Danach dürfen 028–032 bei disjunkten Source-/Vertragsgrenzen parallel laufen.
+Die sechs S8786-Befunde sind absichtlich nach Ownership und Testpfad getrennt;
+eine gemeinsame Regex-Sammel-PR wäre fachlich nicht reviewbar.
+
+### Zurückgestellt nach Live-Prüfung
+
+- S6551 in Waste-Masterdaten besitzt echte `FormDataEntryValue`-/Datei- und
+  Datenintegritätsrelevanz, überschneidet sich aber fachlich mit PR #983 und
+  dem Postal-Code-Backfill. Nach dessen terminalem Zustand neu bewerten.
+- Auth-/IAM-S3776, Sidebar/Content und Mainserver-Routen bleiben wegen aktiver
+  Principal-/Scoped-Access- beziehungsweise Service-Internals-OpenSpecs aus
+  dieser konfliktarmen ersten Sonar-Runde heraus.
+- S1874 ist keine reine React-Event-Migration: die Gruppe enthält auch Zod,
+  TanStack Table, OpenTelemetry und Browser-API-Deprecations. Sie wird später
+  nach API-Ownern geplant, nicht global ersetzt.
+- S3358/S4782/S7763/S3863/S6571 werden erst nach den produktionsriskanteren
+  Security-, Datenintegritäts- und Accessibility-Paketen mechanisch abgebaut.
+
 Erste Runde erstellt am 14. August 2026. Die zweite Runde wurde am
 15. August 2026 auf dem live gefetchten `origin/main`-Commit `067e7a8e6`
 geplant.


### PR DESCRIPTION
## Zusammenfassung
- dokumentiert die vollständige Live-Sonar-Baseline auf 960955af8
- priorisiert den Security-Gate-Fix und alle sechs S8786-Befunde nach Ownership
- hält Konflikte, Characterization, Fallow- und STOP-Gates je Paket fest

## Validierung
- git diff --check
- pnpm check:file-placement
- pnpm exec openspec validate --all --strict

Nur Planungsunterlagen; keine produktive Source-Änderung.