### PR TITLE
Linearize Waste tenant database identifier trimming

### DIFF
--- a/docs/changelog/entries/pr-1014.json
+++ b/docs/changelog/entries/pr-1014.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1014,
+  "body": "Waste-Tenant-Datenbankkennungen werden auch bei sehr langen Instanznamen zuverlässig abgeleitet\n\n- Bestehende Datenbank- und Rollennamen bleiben unverändert.\n- Die Verarbeitung ungewöhnlicher Trennzeichen, Unicode-Zeichen und leerer Werte ist durch zusätzliche Regressionstests abgesichert."
+}

--- a/packages/server-runtime/src/waste/tenant-database-identifiers.server.test.ts
+++ b/packages/server-runtime/src/waste/tenant-database-identifiers.server.test.ts
@@ -2,11 +2,38 @@ import { describe, expect, it } from 'vitest';
 
 import { deriveWasteTenantDatabaseNames } from './tenant-database-identifiers.server.js';
 
+const namesForBase = (base: string) => ({
+  database: `${base}_db`,
+  ownerRole: `${base}_owner`,
+  migratorRole: `${base}_migrator`,
+  appRole: `${base}_app`,
+  publicAppRole: `${base}_public`,
+});
+
 describe('Waste tenant database identifiers', () => {
   it('derives stable, bounded and tenant-specific names', () => {
     const names = deriveWasteTenantDatabaseNames('bb-prignitz');
-    expect(names.database).toBe('sva_w_bb_prignitz_4fc528d5be47_db');
+    expect(names).toEqual(namesForBase('sva_w_bb_prignitz_4fc528d5be47'));
     expect(Object.values(names).every((name) => /^[a-z][a-z0-9_]{0,62}$/u.test(name))).toBe(true);
     expect(names.database).not.toBe(deriveWasteTenantDatabaseNames('bb-guben').database);
+  });
+
+  it.each([
+    ['ASCII separators', 'BB Prignitz__West', 'sva_w_bb_prignitz_west_f36ac2426242'],
+    ['Unicode NFKD input', '  ÄÖÜ Straße № 12  ', 'sva_w_a_o_u_stra_e_no_12_33af1e752912'],
+    ['separator-only input', '---___...', 'sva_w_tenant_e81773dbc284'],
+    ['edge separators', '__bb-prignitz__', 'sva_w_bb_prignitz_28c143c3b0bb'],
+    ['digit-leading input', '123-tenant', 'sva_w_t_123_tenant_fa322dc764a7'],
+    ['empty input', '', 'sva_w_tenant_e3b0c44298fc'],
+  ])('preserves exact names for %s', (_caseName, instanceId, expectedBase) => {
+    expect(deriveWasteTenantDatabaseNames(instanceId)).toEqual(namesForBase(expectedBase));
+  });
+
+  it('preserves exact bounded names for a very long separator suffix', () => {
+    const names = deriveWasteTenantDatabaseNames(`a${'-'.repeat(100_000)}`);
+
+    expect(names).toEqual(namesForBase('sva_w_a_97113d83bdf9'));
+    expect(Object.values(names).every((name) => name.length <= 63)).toBe(true);
+    expect(Object.values(names).every((name) => /^[a-z][a-z0-9_]{0,62}$/u.test(name))).toBe(true);
   });
 });

--- a/packages/server-runtime/src/waste/tenant-database-identifiers.server.ts
+++ b/packages/server-runtime/src/waste/tenant-database-identifiers.server.ts
@@ -2,6 +2,20 @@ import { createHash } from 'node:crypto';
 
 const identifierPattern = /^[a-z][a-z0-9_]{0,62}$/u;
 
+const trimBoundaryUnderscores = (value: string): string => {
+  let start = 0;
+  while (value[start] === '_') {
+    start += 1;
+  }
+
+  let end = value.length;
+  while (end > start && value[end - 1] === '_') {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+};
+
 export type WasteTenantDatabaseNames = Readonly<{
   database: string;
   ownerRole: string;
@@ -14,9 +28,9 @@ export const deriveWasteTenantDatabaseNames = (instanceId: string): WasteTenantD
   const normalized = instanceId
     .normalize('NFKD')
     .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, '_')
-    .replace(/^_+|_+$/gu, '') || 'tenant';
-  const safeSlug = /^[a-z]/u.test(normalized) ? normalized : `t_${normalized}`;
+    .replace(/[^a-z0-9]+/gu, '_');
+  const normalizedSlug = trimBoundaryUnderscores(normalized) || 'tenant';
+  const safeSlug = /^[a-z]/u.test(normalizedSlug) ? normalizedSlug : `t_${normalizedSlug}`;
   const hash = createHash('sha256').update(instanceId).digest('hex').slice(0, 12);
   const base = `sva_w_${safeSlug.slice(0, 25)}_${hash}`;
   const names = {


### PR DESCRIPTION
## Zusammenfassung
- ersetzt das Sonar-S8786-auslösende Rand-Trimmen durch lineare Indexläufe
- hält Hash, Präfixe, Suffixe und alle abgeleiteten Datenbank-/Rollennamen bytegleich
- charakterisiert ASCII, Unicode/NFKD, Leer-/Trennzeichen-, Ziffern- und sehr lange Eingaben

## Abhängigkeit
- Plan 029; vor Ready nach Plan/PR 027 auf den dann aktuellen `origin/main` aktualisieren
- keine Source-, Vertrags- oder Fixture-Überschneidung mit #983/#984

## Sonar
- `AZ_DlvT3UItUTMcRH3zS` (`typescript:S8786`)

## Lokale Evidenz
- `server-runtime:test:unit`: 133/133
- `server-runtime:test:coverage`: 95,34 % Lines, 84,22 % Branches
- `server-runtime:test:types`, `lint`, `build`, `check:runtime`: grün
- `pnpm check:server-runtime`: grün
- Fallow New-only `@sva/server-runtime`: PASS, 0 neue Complexity/Dead Code/Duplication
- Complexity Gate, OpenSpec strict/all (104/104), File Placement, Changelog, `git diff --check`: grün

## Noch offen vor Ready
- Rebase nach Plan/PR 027 und erneute Gates
- Root- und unabhängiges Review

Draft: nicht Ready, nicht mergen.