### PR TITLE
fix(studio-ui): require crypto UUIDs for media UI IDs

### DIFF
--- a/docs/changelog/entries/pr-1016.json
+++ b/docs/changelog/entries/pr-1016.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1016,
+  "body": "Temporäre Content-Media-Kennungen werden ausschließlich kryptografisch sicher erzeugt\n\n- Neue Medienzuordnungen verwenden die sichere UUID-Funktion des unterstützten Browsers.\n- Ein unsicherer Zufallsfallback kommt nicht mehr zum Einsatz.\n- Fehlt die erforderliche Browserfunktion wider Erwarten, bricht die Erzeugung eindeutig ab, statt eine schwache Kennung zu verwenden."
+}

--- a/packages/studio-ui-react/src/content-media-usage.test.ts
+++ b/packages/studio-ui-react/src/content-media-usage.test.ts
@@ -1,13 +1,35 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   contentMediaUsageToReference,
+  createContentMediaUiId,
   createManualContentMediaUsage,
   isPersistableContentMediaUrl,
   moveContentMediaUsage,
 } from './content-media-usage.js';
 
 describe('content media usage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the Web Crypto UUID as its UI identity', () => {
+    const uiId = '722328a4-8731-47b0-a7ea-b544be7dd527';
+    const randomUUID = vi.fn(() => uiId);
+    vi.stubGlobal('crypto', { randomUUID });
+
+    expect(createContentMediaUiId()).toBe(uiId);
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when the runtime does not provide crypto.randomUUID', () => {
+    vi.stubGlobal('crypto', {});
+
+    expect(() => createContentMediaUiId()).toThrow(
+      'Content media UI IDs require crypto.randomUUID'
+    );
+  });
+
   it('keeps UI identity while normalizing order', () => {
     const first = { ...createManualContentMediaUsage(), uiId: 'first', sortOrder: 0 };
     const second = { ...createManualContentMediaUsage(), uiId: 'second', sortOrder: 1 };

--- a/packages/studio-ui-react/src/content-media-usage.ts
+++ b/packages/studio-ui-react/src/content-media-usage.ts
@@ -24,8 +24,13 @@ export type ContentMediaUsage = Readonly<{
 
 export type ContentMediaUsagePatch = Partial<Omit<ContentMediaUsage, 'uiId'>>;
 
-export const createContentMediaUiId = (): string =>
-  globalThis.crypto?.randomUUID?.() ?? `media-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+export const createContentMediaUiId = (): string => {
+  if (typeof globalThis.crypto?.randomUUID !== 'function') {
+    throw new Error('Content media UI IDs require crypto.randomUUID');
+  }
+
+  return globalThis.crypto.randomUUID();
+};
 
 export const createManualContentMediaUsage = (input?: {
   readonly role?: string;


### PR DESCRIPTION
## Zusammenfassung

- entfernt den unsicheren `Math.random()`-Fallback für Content-Media-UI-IDs
- erzwingt den unterstützten Web-Crypto-Vertrag fail-closed
- charakterisiert UUID-Weitergabe und fehlendes `crypto.randomUUID`

## SonarCloud

- Issue: `AZ_MufJ-6Sn7SUF7x3qN`
- Regel: `typescript:S2245`
- Erwartung nach Main-Scan: Vulnerabilities 1 → 0, New-Code Security Rating C → A

## Lokale Verifikation

- fokussierte Baseline vor Änderung: 3/3 grün
- neue Characterization gegen Altcode: erwarteter Fail-closed-Test rot
- fokussierte Tests nach Fix: 5/5 grün
- `studio-ui-react:test:types`
- `studio-ui-react:lint` (nur 9 bestehende Warnungen außerhalb des Diffs)
- `studio-ui-react:build`
- Fallow New-only: PASS, alle introduced-Zähler 0
- File Placement, OpenSpec strict, Complexity und Studio-Changelog-Repo-Check grün
- breiter `test:pr`: App-Unit inklusive Routes 73 Dateien / 633 Tests grün; verbleibende breite Plugin-Matrix bewusst an PR-CI übergeben

## Scope

Nur `content-media-usage.ts`, der kolokierte Test und der nach PR-Erstellung ergänzte Changelog-Eintrag.