### PR TITLE
Linearize organization key normalization

### DIFF
--- a/apps/sva-studio-react/src/routes/admin/organizations/-organization-shared.test.tsx
+++ b/apps/sva-studio-react/src/routes/admin/organizations/-organization-shared.test.tsx
@@ -60,8 +60,20 @@ describe('organization shared helpers', () => {
     expect(suggestOrganizationKey('Städtische Werke Köln', [])).toBe('stadtische-werke-koln');
   });
 
+  it.each([
+    ['Unicode NFKD input', '  ÄÖÜ Straße № 12  ', 'aou-stra-e-no-12'],
+    ['separator-only input', ' --- / ___ ', ''],
+    ['edge and repeated separators', '---Alpha___Beta///', 'alpha-beta'],
+  ])('preserves the organization key contract for %s', (_caseName, displayName, expectedKey) => {
+    expect(suggestOrganizationKey(displayName, [])).toBe(expectedKey);
+  });
+
   it('collapses repeated separator runs while generating organization keys', () => {
     expect(suggestOrganizationKey('  Alpha --- Beta / Gamma  ', [])).toBe('alpha-beta-gamma');
+  });
+
+  it('normalizes a very long separator suffix without changing the suggested key', () => {
+    expect(suggestOrganizationKey(`Alpha${'-'.repeat(100_000)}`, [])).toBe('alpha');
   });
 
   it('adds a running suffix when the generated key already exists', () => {
@@ -71,5 +83,36 @@ describe('organization shared helpers', () => {
         { id: 'org-2', displayName: 'Landkreis Alpha', organizationKey: 'landkreis-alpha-2' },
       ])
     ).toBe('landkreis-alpha-3');
+  });
+
+  it('compares existing keys case-insensitively after trimming', () => {
+    expect(
+      suggestOrganizationKey('Landkreis Alpha', [
+        { id: 'org-1', displayName: 'Landkreis Alpha', organizationKey: ' LANDKREIS-ALPHA ' },
+        { id: 'org-2', displayName: 'Landkreis Alpha', organizationKey: 'Landkreis-Alpha-2' },
+      ])
+    ).toBe('landkreis-alpha-3');
+  });
+
+  it('excludes the edited organization before resolving key collisions', () => {
+    expect(
+      suggestOrganizationKey(
+        'Landkreis Alpha',
+        [
+          { id: 'org-1', displayName: 'Landkreis Alpha', organizationKey: 'landkreis-alpha' },
+          { id: 'org-2', displayName: 'Landkreis Alpha', organizationKey: 'landkreis-alpha-2' },
+        ],
+        'org-1'
+      )
+    ).toBe('landkreis-alpha');
+  });
+
+  it('selects the first available suffix in ascending order', () => {
+    expect(
+      suggestOrganizationKey('Landkreis Alpha', [
+        { id: 'org-1', displayName: 'Landkreis Alpha', organizationKey: 'landkreis-alpha' },
+        { id: 'org-3', displayName: 'Landkreis Alpha', organizationKey: 'landkreis-alpha-3' },
+      ])
+    ).toBe('landkreis-alpha-2');
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/organizations/-organization-shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/organizations/-organization-shared.tsx
@@ -88,14 +88,23 @@ export const toOrganizationMutationPayload = (values: OrganizationFormValues) =>
   mainserverApplicationSecret: values.mainserverApplicationSecret.trim() || undefined,
 });
 
-const normalizeOrganizationKeyBase = (value: string): string =>
-  value
+const trimTrailingHyphens = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '-') {
+    end -= 1;
+  }
+  return value.slice(0, end);
+};
+
+const normalizeOrganizationKeyBase = (value: string): string => {
+  const normalized = value
     .normalize('NFKD')
     .replace(/[\u0300-\u036f]/g, '')
     .toLocaleLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+/g, '')
-    .replace(/-+$/g, '');
+    .replace(/^-+/g, '');
+  return trimTrailingHyphens(normalized);
+};
 
 const buildOrganizationKeyCandidate = (baseKey: string, suffix: number): string =>
   suffix <= 1 ? baseKey : `${baseKey}-${suffix}`;

--- a/docs/changelog/entries/pr-1017.json
+++ b/docs/changelog/entries/pr-1017.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1017,
+  "body": "Vorgeschlagene Organisationsschlüssel werden auch aus sehr langen Namen zuverlässig erzeugt\n\n- Bestehende Schlüsselvorschläge und die Reihenfolge automatischer Nummern bleiben unverändert.\n- Unicode-Zeichen, ungewöhnliche Trennzeichen und bereits vergebene Schlüssel sind durch zusätzliche Regressionstests abgesichert."
+}


### PR DESCRIPTION
## Zusammenfassung
- ersetzt das Sonar-S8786-auslösende abschließende Bindestrich-Trimmen durch einen linearen Indexlauf
- erhält Normalisierung, bestehende Key-Erkennung, Exclude-ID und Suffixpriorität unverändert
- charakterisiert Unicode/NFKD, Separatorgrenzen, 100k-Zeichen-Eingabe und Kollisionsfälle

## Abhängigkeit
- Plan 030; vor Ready nach Plan/PR 027 auf den dann aktuellen `origin/main` aktualisieren
- kein offener PR berührt Source oder Fixture; der aktive Organisation-Provisioning-Change bleibt außerhalb dieses Scopes

## Sonar
- `AZ7zBU0TKoyPQ8JFyMIu` (`typescript:S8786`)

## Lokale Evidenz
- fokussierter Routes-Test: 13/13
- `sva-studio-react:test:types`, `lint`, `build`: grün
- Fallow New-only `sva-studio-react`: PASS, 0 neue Complexity/Duplication/Dead Code; ein bestehender Dependency-Befund ist `introduced: false`
- Complexity Gate, OpenSpec strict/all (104/104), File Placement, Changelog, `git diff --check`: grün
- kein Accessibility-Lauf erforderlich, da kein JSX geändert wurde

## Noch offen vor Ready
- Main-Abgleich nach Plan/PR 027 und erneute Gates
- Root- und unabhängiges Review

Draft: nicht Ready, nicht mergen.