### PR TITLE
fix(studio): linearize changelog HTML detection

### DIFF
--- a/apps/sva-studio-react/src/lib/studio-changelog.shared.test.ts
+++ b/apps/sva-studio-react/src/lib/studio-changelog.shared.test.ts
@@ -21,9 +21,41 @@ describe('studio-changelog.shared', () => {
     expect(assertStudioChangelogBody('entry.json', '  Nutzertext  ')).toBe('Nutzertext');
   });
 
-  it('rejects empty or raw-html bodies', () => {
+  it.each([
+    'Vergleich: 2 < 3 und 5 > 4',
+    'Ein unvollständiger Verweis <section',
+    'Kontakt <redaktion@example.org>',
+    'Text mit <é> bleibt normaler Inhalt',
+    'Text mit <p/foo> bleibt normaler Inhalt',
+  ])('preserves non-html text containing angle brackets: %s', (body) => {
+    expect(assertStudioChangelogBody('entry.json', body)).toBe(body);
+  });
+
+  it.each([
+    '<p>Absatz</p>',
+    'Text mit </p>',
+    'Zeilenumbruch<br/>',
+    '<section data-kind="notice">Hinweis</section>',
+    '<x-y aria-label="Hinweis">Inhalt</x-y>',
+    '<p\nclass="notice">Inhalt</p>',
+    '<p / >',
+    'Text <<p>>',
+    '<ſ>Unicode-Faltung</ſ>',
+    '<K>Unicode-Faltung</K>',
+  ])('rejects raw-html tag syntax: %s', (body) => {
+    expect(() => assertStudioChangelogBody('entry.json', body)).toThrow(/rohes HTML/);
+  });
+
+  it('handles very long and adversarially shaped non-html text', () => {
+    const longPlainText = `Hinweis ${'inhalt '.repeat(30_000)}<section ${'attribut '.repeat(30_000)}Ende`;
+    const manyIncompleteCandidates = `${'<a attribut '.repeat(20_000)}Ende`;
+
+    expect(assertStudioChangelogBody('entry.json', longPlainText)).toBe(longPlainText);
+    expect(assertStudioChangelogBody('entry.json', manyIncompleteCandidates)).toBe(manyIncompleteCandidates);
+  });
+
+  it('rejects empty bodies', () => {
     expect(() => assertStudioChangelogBody('entry.json', '   ')).toThrow(/nicht leer/);
-    expect(() => assertStudioChangelogBody('entry.json', 'Text mit </p>')).toThrow(/rohes HTML/);
   });
 
   it('parses valid entry documents', () => {

--- a/apps/sva-studio-react/src/lib/studio-changelog.shared.test.ts
+++ b/apps/sva-studio-react/src/lib/studio-changelog.shared.test.ts
@@ -27,6 +27,7 @@ describe('studio-changelog.shared', () => {
     'Kontakt <redaktion@example.org>',
     'Text mit <é> bleibt normaler Inhalt',
     'Text mit <p/foo> bleibt normaler Inhalt',
+    'Text mit <p/ > bleibt normaler Inhalt',
   ])('preserves non-html text containing angle brackets: %s', (body) => {
     expect(assertStudioChangelogBody('entry.json', body)).toBe(body);
   });

--- a/apps/sva-studio-react/src/lib/studio-changelog.shared.ts
+++ b/apps/sva-studio-react/src/lib/studio-changelog.shared.ts
@@ -2,7 +2,7 @@ export const STUDIO_CHANGELOG_ENTRY_DIRECTORY = 'docs/changelog/entries';
 export const STUDIO_CHANGELOG_ENTRY_PATTERN = /^docs\/changelog\/entries\/pr-(\d+)\.json$/u;
 export const STUDIO_CHANGELOG_ARTIFACT_RELATIVE_PATH = 'generated/studio-changelog.json';
 export const STUDIO_CHANGELOG_ENTRY_LIMIT = 20;
-const STUDIO_CHANGELOG_RAW_HTML_PATTERN = /<\/?[a-z][\w-]*(?:\s[^<>]*)?\s*\/?>/iu;
+const STUDIO_CHANGELOG_RAW_HTML_PATTERN = /<\/?[a-z][\w-]*(?:\/?>|\s[^<>]*>)/iu;
 
 export type StudioChangelogEntry = {
   readonly prNumber: number;

--- a/docs/changelog/entries/pr-1018.json
+++ b/docs/changelog/entries/pr-1018.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1018,
+  "body": "Die HTML-Erkennung für Studio-Changelog-Einträge verarbeitet auch sehr lange und unvollständige Eingaben mit linear begrenzter Laufzeit."
+}


### PR DESCRIPTION
## Summary
- replace the ambiguous raw-HTML regex suffix with disjoint linear alternatives
- characterize accepted angle-bracket text and rejected tag forms
- cover very long and adversarially shaped incomplete input

## Sonar
- Plan 031
- `AZ9CFgkRsdqj1ar76p4t` (`typescript:S8786`)

## Validation
- focused characterization on the unchanged implementation: PASS
- `pnpm nx run sva-studio-react:test:unit`: PASS (73 files, 633 tests)
- `pnpm nx run sva-studio-react:test:types`: PASS
- `pnpm nx run sva-studio-react:lint`: PASS
- `pnpm nx run sva-studio-react:build`: PASS
- Fallow New-only `sva-studio-react`: PASS, 0 introduced complexity/dead code/duplication
- `pnpm complexity-gate`: PASS
- `pnpm check:file-placement`: PASS
- `pnpm exec openspec validate --all --strict --no-interactive`: PASS
- `git diff --check`: PASS

Draft pending root review and final rebase onto the security-gate merge.