### PR TITLE
fix(media): linearize base64url padding removal

### DIFF
--- a/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.test.ts
+++ b/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { decodeBucketMediaId, encodeBucketMediaId } from './-media-ui.shared.js';
 
@@ -12,6 +12,48 @@ const mediaUiSharedSourcePath = path.resolve(
 );
 
 describe('bucket media id encoding', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    { label: 'no padding', storageKey: 'abc', encoded: 'YWJj' },
+    { label: 'one padding character', storageKey: 'ab', encoded: 'YWI' },
+    { label: 'two padding characters', storageKey: 'a', encoded: 'YQ' },
+    { label: 'empty input', storageKey: '', encoded: '' },
+    {
+      label: 'Unicode input',
+      storageKey: 'cms_uploads/äöü/straße und café.jpg',
+      encoded: 'Y21zX3VwbG9hZHMvw6TDtsO8L3N0cmHDn2UgdW5kIGNhZsOpLmpwZw',
+    },
+  ])('keeps Node and the browser fallback byte-identical for $label', ({ storageKey, encoded }) => {
+    const nodeMediaId = encodeBucketMediaId(storageKey);
+    expect(nodeMediaId).toBe(`bucket:${encoded}`);
+    expect(decodeBucketMediaId(nodeMediaId)).toBe(storageKey);
+
+    const browserBtoa = vi.fn(globalThis.btoa.bind(globalThis));
+    const browserAtob = vi.fn(globalThis.atob.bind(globalThis));
+    vi.stubGlobal('Buffer', undefined);
+    vi.stubGlobal('btoa', browserBtoa);
+    vi.stubGlobal('atob', browserAtob);
+
+    const browserMediaId = encodeBucketMediaId(storageKey);
+    expect(browserMediaId).toBe(nodeMediaId);
+    expect(decodeBucketMediaId(browserMediaId)).toBe(storageKey);
+    expect(browserBtoa).toHaveBeenCalledOnce();
+    expect(browserAtob).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a very long mixed storage key byte-identical in the browser fallback', () => {
+    const storageKey = `${'cms/._-ä/'.repeat(10_000)}final image.jpg`;
+    const nodeMediaId = encodeBucketMediaId(storageKey);
+
+    vi.stubGlobal('Buffer', undefined);
+
+    expect(encodeBucketMediaId(storageKey)).toBe(nodeMediaId);
+    expect(decodeBucketMediaId(nodeMediaId)).toBe(storageKey);
+  });
+
   it('round-trips non-ascii storage keys', () => {
     const storageKey = 'cms_uploads/äöü/straße und café.jpg';
 
@@ -27,5 +69,6 @@ describe('bucket media id encoding', () => {
     expect(source).not.toContain('.charCodeAt(');
     expect(source).not.toContain('.replace(/\\+/g,');
     expect(source).not.toContain('.replace(/\\//g,');
+    expect(source).not.toContain('.replace(/=+$/g,');
   });
 });

--- a/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.tsx
+++ b/apps/sva-studio-react/src/routes/admin/media/-media-ui.shared.tsx
@@ -23,10 +23,16 @@ const encodeBase64Url = (value: string): string => {
     return Buffer.from(value, 'utf-8').toString('base64url');
   }
 
-  return bytesToBase64(textEncoder.encode(value))
+  const encoded = bytesToBase64(textEncoder.encode(value))
     .replaceAll('+', '-')
-    .replaceAll('/', '_')
-    .replace(/=+$/g, '');
+    .replaceAll('/', '_');
+  if (encoded.endsWith('==')) {
+    return encoded.slice(0, -2);
+  }
+  if (encoded.endsWith('=')) {
+    return encoded.slice(0, -1);
+  }
+  return encoded;
 };
 
 const decodeBase64Url = (value: string): string => {

--- a/docs/changelog/entries/pr-1019.json
+++ b/docs/changelog/entries/pr-1019.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1019,
+  "body": "Bucket-Medienkennungen werden auch bei langen und ungewöhnlichen Dateipfaden zuverlässig erzeugt\n\n- Die Browser-Kodierung entfernt Base64-Padding jetzt mit einer klar begrenzten Operation.\n- Node- und Browser-Ausgaben bleiben für leere, Unicode- und sehr lange Speicherpfade identisch."
+}


### PR DESCRIPTION
## Zusammenfassung
- entfernt den potenziell superlinearen Regex aus dem Browser-Fallback der Bucket-Medien-ID-Kodierung
- bewahrt die Base64url-Ausgabe für null, ein und zwei Padding-Zeichen
- charakterisiert Node- und echten Browser-Fallback mit Unicode sowie sehr langen Eingaben

## SonarCloud
- `AZ7zBUuvKoyPQ8JFyMIq` (`typescript:S8786`)

## Verifikation
- fokussierter Nx-Unit-Test: 8/8 grün
- `sva-studio-react:test:types`, Lint und Build grün
- Fallow PASS; alle Introduced-Zähler 0
- OpenSpec strict, Complexity und File Placement grün
- `pnpm test:pr`: Routes/Types grün, danach PR-fremder Ops-Entrypoint-Fehler für `@sva/data-client`