### PR TITLE
fix(studio-ui): type missing crypto runtime errors

### DIFF
--- a/docs/changelog/entries/pr-1020.json
+++ b/docs/changelog/entries/pr-1020.json
@@ -1,0 +1,4 @@
+{
+  "prNumber": 1020,
+  "body": "Fehlende Browser-Kryptografie wird bei neuen Medienzuordnungen eindeutig als Laufzeit-Typfehler gemeldet."
+}

--- a/packages/studio-ui-react/src/content-media-usage.test.ts
+++ b/packages/studio-ui-react/src/content-media-usage.test.ts
@@ -25,6 +25,7 @@ describe('content media usage', () => {
   it('fails closed when the runtime does not provide crypto.randomUUID', () => {
     vi.stubGlobal('crypto', {});
 
+    expect(() => createContentMediaUiId()).toThrow(TypeError);
     expect(() => createContentMediaUiId()).toThrow(
       'Content media UI IDs require crypto.randomUUID'
     );

--- a/packages/studio-ui-react/src/content-media-usage.ts
+++ b/packages/studio-ui-react/src/content-media-usage.ts
@@ -26,7 +26,7 @@ export type ContentMediaUsagePatch = Partial<Omit<ContentMediaUsage, 'uiId'>>;
 
 export const createContentMediaUiId = (): string => {
   if (typeof globalThis.crypto?.randomUUID !== 'function') {
-    throw new Error('Content media UI IDs require crypto.randomUUID');
+    throw new TypeError('Content media UI IDs require crypto.randomUUID');
   }
 
   return globalThis.crypto.randomUUID();


### PR DESCRIPTION
## Zusammenfassung
- wirft bei fehlendem `crypto.randomUUID` einen spezifischen `TypeError`
- bewahrt Fail-closed-Verhalten und Fehlermeldung unverändert
- charakterisiert die Fehlerklasse vor der Source-Änderung

## SonarCloud
- `AaAHHfjRRXPx87p88P3F` (`typescript:S7786`)

## Verifikation
- neue Characterization war gegen den Altcode gezielt rot (`Error` statt `TypeError`)
- fokussierter Nx-Test 5/5 grün
- Package Types, Lint und Build grün
- Fallow PASS; alle Introduced-Zähler 0
- Complexity, OpenSpec strict, File Placement und diff-check grün
- affected Unit-Scope umfasst 12 Projekte; breite Suite bleibt CI vorbehalten